### PR TITLE
Remove asserts from Kroxylicious

### DIFF
--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/DecodedFrame.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/DecodedFrame.java
@@ -81,7 +81,6 @@ public abstract class DecodedFrame<H extends ApiMessage, B extends ApiMessage>
     @Override
     public final int estimateEncodedSize() {
         if (headerAndBodyEncodedLength != -1) {
-            assert serializationCache != null;
             return FRAME_SIZE_LENGTH + headerAndBodyEncodedLength;
         }
         var headerVersion = headerVersion();
@@ -105,12 +104,10 @@ public abstract class DecodedFrame<H extends ApiMessage, B extends ApiMessage>
                     getClass().getSimpleName(), encodedSize, header, body, out);
         }
         out.ensureWritable(encodedSize);
-        final int initialIndex = out.writerIndex();
         out.writeInt(headerAndBodyEncodedLength);
         final ObjectSerializationCache cache = serializationCache;
         header.write(out, cache, headerVersion());
         body.write(out, cache, apiVersion());
-        assert (out.writerIndex() - initialIndex) == encodedSize;
     }
 
     @Override

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyBackendHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyBackendHandler.java
@@ -36,7 +36,7 @@ public class KafkaProxyBackendHandler extends ChannelInboundHandlerAdapter {
 
     public void inboundChannelWritabilityChanged(ChannelHandlerContext inboundCtx) {
         if (inboundCtx != this.inboundCtx) {
-            LOGGER.warn("Inbound Channel writability change notification for inappropriate context. {} received notification for {}", this.inboundCtx, inboundCtx);
+            throw new IllegalArgumentException("Inbound Channel writability change notification for inappropriate context. " + this.inboundCtx + " received notification for " + this.inboundCtx);
         }
         final ChannelHandlerContext outboundCtx = blockedOutboundCtx;
         if (outboundCtx != null && inboundCtx.channel().isWritable()) {

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyBackendHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyBackendHandler.java
@@ -35,7 +35,9 @@ public class KafkaProxyBackendHandler extends ChannelInboundHandlerAdapter {
     }
 
     public void inboundChannelWritabilityChanged(ChannelHandlerContext inboundCtx) {
-        assert inboundCtx == this.inboundCtx;
+        if (inboundCtx != this.inboundCtx) {
+            LOGGER.warn("Inbound Channel write ability change notification for inappropriate context. {} received notification for {}", this.inboundCtx, inboundCtx);
+        }
         final ChannelHandlerContext outboundCtx = blockedOutboundCtx;
         if (outboundCtx != null && inboundCtx.channel().isWritable()) {
             blockedOutboundCtx = null;
@@ -53,7 +55,6 @@ public class KafkaProxyBackendHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void channelRead(final ChannelHandlerContext ctx, Object msg) {
-        assert blockedOutboundCtx == null;
         LOGGER.trace("Channel read {}", msg);
         final Channel inboundChannel = inboundCtx.channel();
         if (inboundChannel.isWritable()) {

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyBackendHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyBackendHandler.java
@@ -36,7 +36,7 @@ public class KafkaProxyBackendHandler extends ChannelInboundHandlerAdapter {
 
     public void inboundChannelWritabilityChanged(ChannelHandlerContext inboundCtx) {
         if (inboundCtx != this.inboundCtx) {
-            LOGGER.warn("Inbound Channel write ability change notification for inappropriate context. {} received notification for {}", this.inboundCtx, inboundCtx);
+            LOGGER.warn("Inbound Channel writability change notification for inappropriate context. {} received notification for {}", this.inboundCtx, inboundCtx);
         }
         final ChannelHandlerContext outboundCtx = blockedOutboundCtx;
         if (outboundCtx != null && inboundCtx.channel().isWritable()) {

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -141,7 +141,7 @@ public class KafkaProxyFrontendHandler extends ChannelInboundHandlerAdapter {
 
     public void outboundWritabilityChanged(ChannelHandlerContext outboundCtx) {
         if (this.outboundCtx != outboundCtx) {
-            LOGGER.warn("Outbound Channel writability change notification for inappropriate context. {} received notification for {}", this.outboundCtx, outboundCtx);
+            throw new IllegalArgumentException("Outbound Channel writability change notification for inappropriate context. " + this.outboundCtx + " received notification for " + outboundCtx);
         }
         final ChannelHandlerContext inboundCtx = blockedInboundCtx;
         if (inboundCtx != null && outboundCtx.channel().isWritable()) {

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -140,7 +140,9 @@ public class KafkaProxyFrontendHandler extends ChannelInboundHandlerAdapter {
     }
 
     public void outboundWritabilityChanged(ChannelHandlerContext outboundCtx) {
-        LOGGER.warn("Outbound Channel write ability change notification for inappropriate context. {} received notification for {}", this.outboundCtx, outboundCtx);
+        if (this.outboundCtx != outboundCtx) {
+            LOGGER.warn("Outbound Channel writability change notification for inappropriate context. {} received notification for {}", this.outboundCtx, outboundCtx);
+        }
         final ChannelHandlerContext inboundCtx = blockedInboundCtx;
         if (inboundCtx != null && outboundCtx.channel().isWritable()) {
             blockedInboundCtx = null;

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -140,7 +140,7 @@ public class KafkaProxyFrontendHandler extends ChannelInboundHandlerAdapter {
     }
 
     public void outboundWritabilityChanged(ChannelHandlerContext outboundCtx) {
-        assert this.outboundCtx == outboundCtx;
+        LOGGER.warn("Outbound Channel write ability change notification for inappropriate context. {} received notification for {}", this.outboundCtx, outboundCtx);
         final ChannelHandlerContext inboundCtx = blockedInboundCtx;
         if (inboundCtx != null && outboundCtx.channel().isWritable()) {
             blockedInboundCtx = null;
@@ -149,7 +149,7 @@ public class KafkaProxyFrontendHandler extends ChannelInboundHandlerAdapter {
     }
 
     @Override
-    public void channelReadComplete(final ChannelHandlerContext ctx) throws Exception {
+    public void channelReadComplete(final ChannelHandlerContext ctx) {
         if (outboundCtx == null) {
             LOGGER.trace("Outbound is not active");
             return;


### PR DESCRIPTION
Partial fix for #45 as I think it makes sense to introduce checkstyle and associated rules separately. 

I've generally sided with removing the asserts as they are on the hot-path for the proxy. However I kept the channel handler context checks as I think they are invoked less often and would point to genuine "wiring" issues, but I can't quite convince myself that the checks are cheep enough to keep enough on that execution path.   

Fixes #45 