### PR TITLE
Add micrometer metrics and optional scrape endpoint

### DIFF
--- a/integrationtests/src/test/java/io/kroxylicious/proxy/KroxyConfigBuilder.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/KroxyConfigBuilder.java
@@ -34,9 +34,18 @@ public class KroxyConfigBuilder {
     public record Filter(String type, @JsonInclude(NON_EMPTY) Map<String, Object> config) {
     }
 
+    public record AdminHttp(Endpoints endpoints) {
+    }
+
+    public record Endpoints(@JsonGetter("prometheus") @JsonInclude(NON_NULL) Map<String, String> prometheusEndpointConfig) {
+    }
+
     private Proxy proxy;
     private final Map<String, Cluster> clusters = new LinkedHashMap<>();
     private final List<Filter> filters = new ArrayList<>();
+
+    @JsonInclude(NON_NULL)
+    private AdminHttp adminHttp = null;
 
     public KroxyConfigBuilder(String proxyAddress) {
         proxy = new Proxy(proxyAddress, null, null);
@@ -54,6 +63,11 @@ public class KroxyConfigBuilder {
     public KroxyConfigBuilder withKeyStoreConfig(String keystoreFile, String keyPassword) {
         String address = proxy == null ? null : proxy.address;
         proxy = new Proxy(address, keystoreFile, keyPassword);
+        return this;
+    }
+
+    public KroxyConfigBuilder withPrometheusEndpoint() {
+        adminHttp = new AdminHttp(new Endpoints(Map.of()));
         return this;
     }
 
@@ -78,6 +92,10 @@ public class KroxyConfigBuilder {
 
     public Proxy getProxy() {
         return proxy;
+    }
+
+    public AdminHttp getAdminHttp() {
+        return adminHttp;
     }
 
     public Map<String, Cluster> getClusters() {

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/KroxyConfigBuilderTest.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/KroxyConfigBuilderTest.java
@@ -67,6 +67,16 @@ public class KroxyConfigBuilderTest {
         assertTextField(filterConfig, "a", "b");
     }
 
+    @Test
+    public void testPrometheusEndpointConfig() throws IOException {
+        ObjectNode deserializedConfig = serializeAndDeserialize(new KroxyConfigBuilder("localhost:9192")
+                .withPrometheusEndpoint());
+        ObjectNode adminHttp = assertObjectField(deserializedConfig, "adminHttp");
+        ObjectNode endpoints = assertObjectField(adminHttp, "endpoints");
+        ObjectNode prometheus = assertObjectField(endpoints, "prometheus");
+        assertTrue(prometheus.isEmpty(), "expect prometheus endpoint to have an empty object serialized");
+    }
+
     private static ObjectNode serializeAndDeserialize(KroxyConfigBuilder builder) throws IOException {
         String config = builder.build();
         return OBJECT_MAPPER.reader().readValue(config, ObjectNode.class);

--- a/kroxylicious/example-proxy-config.yml
+++ b/kroxylicious/example-proxy-config.yml
@@ -9,6 +9,9 @@ proxy:
   address: localhost:9192
   logNetwork: true
   logFrames: true
+adminHttp:
+  endpoints:
+    prometheus: {}
 clusters:
   demo:
     bootstrap_servers: localhost:9092

--- a/kroxylicious/pom.xml
+++ b/kroxylicious/pom.xml
@@ -34,8 +34,17 @@
             <artifactId>netty-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -78,7 +87,6 @@
             <artifactId>netty-codec-haproxy</artifactId>
             <version>${netty.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -8,20 +8,29 @@ package io.kroxylicious.proxy.config;
 import java.util.List;
 import java.util.Map;
 
+import io.kroxylicious.proxy.config.admin.AdminHttpConfiguration;
+
 public class Configuration {
 
     private final ProxyConfig proxy;
+
+    private final AdminHttpConfiguration adminHttp;
     private final Map<String, Cluster> clusters;
     private final List<FilterDefinition> filters;
 
-    public Configuration(ProxyConfig proxy, Map<String, Cluster> clusters, List<FilterDefinition> filters) {
+    public Configuration(ProxyConfig proxy, AdminHttpConfiguration adminHttp, Map<String, Cluster> clusters, List<FilterDefinition> filters) {
         this.proxy = proxy;
+        this.adminHttp = adminHttp;
         this.clusters = clusters;
         this.filters = filters;
     }
 
     public ProxyConfig proxy() {
         return proxy;
+    }
+
+    public AdminHttpConfiguration adminHttpConfig() {
+        return adminHttp;
     }
 
     public Map<String, Cluster> clusters() {

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/config/admin/AdminHttpConfiguration.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/config/admin/AdminHttpConfiguration.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.config.admin;
+
+public class AdminHttpConfiguration {
+    private final String host;
+    private final Integer port;
+    private final EndpointsConfiguration endpoints;
+
+    public AdminHttpConfiguration(String host, Integer port, EndpointsConfiguration endpoints) {
+        this.host = host == null ? "0.0.0.0" : host;
+        this.port = port == null ? 9193 : port;
+        this.endpoints = endpoints == null ? new EndpointsConfiguration(null) : endpoints;
+    }
+
+    public EndpointsConfiguration getEndpoints() {
+        return endpoints;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public String getHost() {
+        return host;
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/config/admin/EndpointsConfiguration.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/config/admin/EndpointsConfiguration.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.config.admin;
+
+import java.util.Optional;
+
+public class EndpointsConfiguration {
+    private final PrometheusMetricsConfig prometheus;
+
+    public EndpointsConfiguration(PrometheusMetricsConfig prometheus) {
+        this.prometheus = prometheus;
+    }
+
+    public Optional<PrometheusMetricsConfig> maybePrometheus() {
+        return Optional.ofNullable(prometheus);
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/config/admin/PrometheusMetricsConfig.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/config/admin/PrometheusMetricsConfig.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.config.admin;
+
+public class PrometheusMetricsConfig {
+
+    public PrometheusMetricsConfig() {
+
+    }
+
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/MeterRegistries.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/MeterRegistries.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal;
+
+import java.util.Optional;
+
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+
+public class MeterRegistries {
+    private final PrometheusMeterRegistry prometheusMeterRegistry;
+
+    public MeterRegistries() {
+        this.prometheusMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        Metrics.addRegistry(prometheusMeterRegistry);
+    }
+
+    /**
+     * Offers up a prometheus registry if available. Currently, we always have a prometheus registry but in
+     * future we may wish to use a different micrometer backend. Clients should use the global
+     * io.micrometer.core.instrument.Metrics static methods to record metrics, not this implementation. This is used to
+     * support specialisations like scraping the prometheus metrics.
+     */
+    public Optional<PrometheusMeterRegistry> maybePrometheusMeterRegistry() {
+        return Optional.ofNullable(prometheusMeterRegistry);
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/admin/AdminHttpInitializer.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/admin/AdminHttpInitializer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.admin;
+
+import io.kroxylicious.proxy.config.admin.AdminHttpConfiguration;
+import io.kroxylicious.proxy.internal.MeterRegistries;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.HttpServerExpectContinueHandler;
+
+public class AdminHttpInitializer extends ChannelInitializer<SocketChannel> {
+
+    private final MeterRegistries registries;
+    private final AdminHttpConfiguration adminHttpConfiguration;
+
+    public AdminHttpInitializer(MeterRegistries registries, AdminHttpConfiguration adminHttpConfiguration) {
+        this.registries = registries;
+        this.adminHttpConfiguration = adminHttpConfiguration;
+    }
+
+    @Override
+    public void initChannel(SocketChannel ch) {
+        ChannelPipeline p = ch.pipeline();
+        p.addLast(new HttpServerCodec());
+        p.addLast(new HttpServerExpectContinueHandler());
+        RoutingHttpServer.RoutingHttpServerBuilder builder = RoutingHttpServer.builder();
+        adminHttpConfiguration.getEndpoints().maybePrometheus().ifPresent(prometheusMetricsConfig -> {
+            builder.withRoute(PrometheusMetricsEndpoint.PATH, new PrometheusMetricsEndpoint(registries));
+        });
+        p.addLast(builder.build());
+    }
+
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/admin/PrometheusMetricsEndpoint.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/admin/PrometheusMetricsEndpoint.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.admin;
+
+import java.util.function.Function;
+
+import io.kroxylicious.proxy.internal.MeterRegistries;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+
+public class PrometheusMetricsEndpoint implements Function<HttpRequest, HttpResponse> {
+
+    public static String PATH = "/metrics";
+
+    private final PrometheusMeterRegistry registry;
+
+    public PrometheusMetricsEndpoint(MeterRegistries registries) {
+        if (registries.maybePrometheusMeterRegistry().isEmpty()) {
+            throw new IllegalStateException("Attempting to configure a prometheus endpoint but no Prometheus registry available");
+        }
+        this.registry = registries.maybePrometheusMeterRegistry().get();
+    }
+
+    @Override
+    public HttpResponse apply(HttpRequest httpRequest) {
+        return RoutingHttpServer.responseWithBody(httpRequest, OK, registry.scrape());
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/admin/RoutingHttpServer.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/admin/RoutingHttpServer.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.admin;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaderNames.CONTENT_LENGTH;
+import static io.netty.handler.codec.http.HttpHeaderValues.CLOSE;
+import static io.netty.handler.codec.http.HttpHeaderValues.KEEP_ALIVE;
+import static io.netty.handler.codec.http.HttpHeaderValues.TEXT_PLAIN;
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static io.netty.handler.codec.rtsp.RtspHeaderNames.CONTENT_TYPE;
+
+public class RoutingHttpServer extends SimpleChannelInboundHandler<HttpObject> {
+
+    private final Map<String, Function<HttpRequest, HttpResponse>> routes;
+    private static final Logger LOGGER = LoggerFactory.getLogger(RoutingHttpServer.class);
+
+    public RoutingHttpServer(Map<String, Function<HttpRequest, HttpResponse>> routes) {
+        this.routes = routes;
+    }
+
+    public static RoutingHttpServerBuilder builder() {
+        return new RoutingHttpServerBuilder();
+    }
+
+    @Override
+    public void channelReadComplete(ChannelHandlerContext ctx) {
+        ctx.flush();
+    }
+
+    @Override
+    public void channelRead0(ChannelHandlerContext ctx, HttpObject msg) {
+        if (msg instanceof HttpRequest) {
+            HttpRequest req = (HttpRequest) msg;
+            boolean keepAlive = HttpUtil.isKeepAlive(req);
+
+            HttpResponse response = getResponse(req);
+
+            if (keepAlive) {
+                if (!req.protocolVersion().isKeepAliveDefault()) {
+                    response.headers().set(CONNECTION, KEEP_ALIVE);
+                }
+            }
+            else {
+                // Tell the client we're going to close the connection.
+                response.headers().set(CONNECTION, CLOSE);
+            }
+
+            ChannelFuture f = ctx.write(response);
+
+            if (!keepAlive) {
+                f.addListener(ChannelFutureListener.CLOSE);
+            }
+        }
+    }
+
+    private HttpResponse getResponse(HttpRequest req) {
+        if (routes.containsKey(req.uri())) {
+            try {
+                return routes.get(req.uri()).apply(req);
+            }
+            catch (Exception e) {
+                LOGGER.error("exception while invoking endpoint for route {}", req.uri(), e);
+                return responseWithStatus(req, INTERNAL_SERVER_ERROR);
+            }
+        }
+        else {
+            return responseWithStatus(req, NOT_FOUND);
+        }
+    }
+
+    public static FullHttpResponse responseWithStatus(HttpRequest req, HttpResponseStatus status) {
+        return responseWithBody(req, status, status.reasonPhrase());
+    }
+
+    public static FullHttpResponse responseWithBody(HttpRequest req, HttpResponseStatus status, String content) {
+        FullHttpResponse response = new DefaultFullHttpResponse(req.protocolVersion(), status,
+                Unpooled.wrappedBuffer(content.getBytes(StandardCharsets.UTF_8)));
+        response.headers()
+                .set(CONTENT_TYPE, TEXT_PLAIN)
+                .setInt(CONTENT_LENGTH, response.content().readableBytes());
+        return response;
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        LOGGER.error("exception caught in MetricsServer", cause);
+        ctx.close();
+    }
+
+    static class RoutingHttpServerBuilder {
+
+        private final Map<String, Function<HttpRequest, HttpResponse>> routes = new HashMap<>();
+
+        RoutingHttpServerBuilder withRoute(String path, Function<HttpRequest, HttpResponse> responseFunction) {
+            routes.put(path, responseFunction);
+            return this;
+        }
+
+        RoutingHttpServer build() {
+            return new RoutingHttpServer(routes);
+        }
+
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <mockito-core.version>4.6.1</mockito-core.version>
         <slf4j-api.version>1.7.36</slf4j-api.version>
         <zookeeper.version>3.6.3</zookeeper.version>
+        <micrometer.version>1.10.2</micrometer.version>
     </properties>
 
     <name>Kroxylicious Parent</name>
@@ -98,6 +99,13 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
                 <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-bom</artifactId>
+                <version>${micrometer.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Users can now optionally add configuration like:
```
adminHttp:
  host: localhost
  port: 9193
  endpoints:
    prometheus: {}
```
to offer http prometheus metrics on `/metrics`

A prometheus implementation of MeterRegistry is wired into the global registry so filter classes can use micrometer's static methods to configure metrics for the global registry.

Why:
Users will want to observe what the proxy is doing