### PR TITLE
draft: Otel filter

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -8,18 +8,17 @@
         <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
         <outputRelativeToContentRoot value="true" />
         <module name="kroxylicious-multitenant" />
-        <module name="kroxylicious.main" />
         <module name="integrationtests.main" />
         <module name="kroxylicious-test-tools" />
         <module name="kroxylicious-api" />
+        <module name="kroxylicious-unit-test" />
         <module name="kroxylicious" />
         <module name="integrationtests" />
         <module name="integrationtests.test" />
-        <module name="kroxylicious-krpc-plugin.main" />
-        <module name="kroxylicious.test" />
+        <module name="kroxylicious-schema-validation" />
         <module name="kroxylicious-filter-api" />
         <module name="kroxylicious-krpc-plugin" />
-        <module name="kroxylicious-krpc-plugin.test" />
+        <module name="performance-tests" />
       </profile>
     </annotationProcessing>
   </component>
@@ -36,9 +35,12 @@
       <module name="kroxylicious-krpc-plugin.test" options="-parameters" />
       <module name="kroxylicious-multitenant" options="-parameters" />
       <module name="kroxylicious-parent" options="-parameters" />
+      <module name="kroxylicious-schema-validation" options="-parameters" />
       <module name="kroxylicious-test-tools" options="-parameters" />
+      <module name="kroxylicious-unit-test" options="-parameters" />
       <module name="kroxylicious.main" options="-parameters" />
       <module name="kroxylicious.test" options="-parameters" />
+      <module name="performance-tests" options="-parameters" />
     </option>
   </component>
 </project>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -10,15 +10,21 @@
     <file url="file://$PROJECT_DIR$/integrationtests/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious-multitenant/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious-multitenant/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/kroxylicious-schema-validation/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/kroxylicious-schema-validation/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious-test-tools/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious-test-tools/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious-test-tools/target/generated-sources/krpc" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/kroxylicious-unit-test/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/kroxylicious-unit-test/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious/src/main/templates" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious/target/generated-sources/krpc" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/krpc-code-gen/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/krpc-code-gen/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/performance-tests/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/performance-tests/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
   </component>

--- a/kroxylicious/example-proxy-config.yml
+++ b/kroxylicious/example-proxy-config.yml
@@ -20,6 +20,10 @@ virtualClusters:
     logFrames: false
 filters:
 - type: ApiVersions
+- type: BrokerAddress
+- type: OtelTracingFilter
+  config:
+    transformation: io.kroxylicious.proxy.internal.filter.ProduceRequestTransformationFilter$UpperCasing
 #- type: ProduceRequestTransformation
 #  config:
 #    transformation: io.kroxylicious.proxy.internal.filter.ProduceRequestTransformationFilter$UpperCasing

--- a/kroxylicious/kroxylicious.main.iml
+++ b/kroxylicious/kroxylicious.main.iml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="CheckStyle-IDEA-Module" serialisationVersion="2">
+    <option name="activeLocationsIds" />
+  </component>
+</module>

--- a/kroxylicious/pom.xml
+++ b/kroxylicious/pom.xml
@@ -179,6 +179,30 @@
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+<!--            <scope>runtime</scope>-->
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-jaeger</artifactId>
+<!--            <scope>runtime</scope>-->
+        </dependency>
+
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+            <version>1.20.0-alpha</version>
+<!--            <scope>runtime</scope>-->
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+            <version>1.20.0-alpha</version>
+<!--            <scope>runtime</scope>-->
+        </dependency>
     </dependencies>
 
     <build>

--- a/kroxylicious/pom.xml
+++ b/kroxylicious/pom.xml
@@ -127,6 +127,10 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/OtelTracingFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/OtelTracingFilter.java
@@ -1,0 +1,19 @@
+package io.kroxylicious.proxy.internal.filter;
+
+import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.ProduceRequestFilter;
+import io.kroxylicious.proxy.filter.ProduceResponseFilter;
+import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.message.ProduceResponseData;
+
+public class OtelTracingFilter implements ProduceRequestFilter, ProduceResponseFilter {
+    @Override
+    public void onProduceRequest(ProduceRequestData request, KrpcFilterContext context) {
+        ;
+    }
+
+    @Override
+    public void onProduceResponse(ProduceResponseData response, KrpcFilterContext context) {
+
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/OtelTracingFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/OtelTracingFilter.java
@@ -1,19 +1,94 @@
 package io.kroxylicious.proxy.internal.filter;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import io.kroxylicious.proxy.filter.KrpcFilterContext;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
 import io.kroxylicious.proxy.filter.ProduceResponseFilter;
+import io.kroxylicious.proxy.internal.util.NettyMemoryRecords;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.ProduceResponseData;
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.MemoryRecordsBuilder;
+import org.apache.kafka.common.record.TimestampType;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 public class OtelTracingFilter implements ProduceRequestFilter, ProduceResponseFilter {
+
+    private final TextMapPropagator textMapPropagator;
+    //TODO inject? Configure?
+    private static final Tracer tracer = GlobalOpenTelemetry.getTracer("kroxylicious", "0.0.1");
+
+    public OtelTracingFilter() {
+        textMapPropagator = W3CTraceContextPropagator.getInstance();
+    }
+
     @Override
-    public void onProduceRequest(ProduceRequestData request, KrpcFilterContext context) {
-        ;
+    public void onProduceRequest(ProduceRequestData request, KrpcFilterContext filterContext) {
+        //TODO not convinced creating a span here
+        try (Scope ignored = configureSpanDefaults("ProduceRequest", filterContext)
+                .startSpan()
+                .makeCurrent()) {
+            //TODO only take action if we are tracing the request
+            if (Span.current().isRecording()) {
+                request.topicData().stream()
+                        .flatMap(topicProduceData -> topicProduceData.partitionData().stream())
+                        .forEach(partitionProduceData -> {
+                            MemoryRecords records = (MemoryRecords) partitionProduceData.records();
+                            try(MemoryRecordsBuilder newRecords = NettyMemoryRecords.builder(filterContext.allocate((records).sizeInBytes()),
+                                    CompressionType.NONE,
+                                    TimestampType.CREATE_TIME,
+                                    0)) {
+                                records.batches().forEach(batchRecord -> batchRecord.forEach(record -> {
+                                    final Scope recordScope = configureSpanDefaults("Record", filterContext)
+                                            .setParent(Context.current())
+                                            .startSpan()
+                                            .makeCurrent();
+                                    final List<Header> headers = new ArrayList<>(Arrays.asList(record.headers().clone()));
+                                    textMapPropagator.inject(Context.current(),
+                                            record,
+                                            (carrier, key, value) -> headers.add(new RecordHeader("kroxy_" + key, value.getBytes(StandardCharsets.UTF_8))));
+                                    newRecords.append(record.timestamp(), record.key(), record.value(), headers.toArray(new Header[0]));
+                                    recordScope.close();
+                                }));
+                                partitionProduceData.setRecords(newRecords.build());
+                            }
+                        });
+            }
+        }
+    }
+
+    private static SpanBuilder configureSpanDefaults(String spanName, KrpcFilterContext filterContext) {
+        return tracer.spanBuilder(spanName)
+                .setSpanKind(SpanKind.PRODUCER)
+                .setAttribute("KroxyliciousCluster", "testing")
+                .setAttribute("Channel", filterContext.channelDescriptor());
     }
 
     @Override
     public void onProduceResponse(ProduceResponseData response, KrpcFilterContext context) {
 
     }
+
+    public static class OtelTracingFilterConfig extends FilterConfig {
+        @JsonCreator
+        public OtelTracingFilterConfig() {
+        }
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,13 @@
                 <version>${sundr-builder-annotations.version}</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>1.20.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Initial cut of a filter to allow the proxy to start injecting OpenTelemetry traces into kafka message headers. 