### PR TITLE
Enforce maven minimum version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -433,6 +433,9 @@
                                 </goals>
                                 <configuration>
                                     <rules>
+                                        <requireMavenVersion>
+                                            <version>[3.5.0,)</version>
+                                        </requireMavenVersion>
                                         <requireJavaVersion>
                                             <version>[${java.version},)</version>
                                         </requireJavaVersion>


### PR DESCRIPTION
Why:
We have plugins that require >= 3.5.0