### PR TITLE
build.directory is deprecated switch to project.build.directory

### DIFF
--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -106,7 +106,7 @@
                         <TESTCONTAINERS_RYUK_DISABLED>true</TESTCONTAINERS_RYUK_DISABLED>
                     </environmentVariables>
                     <systemProperties>
-                        <container.logs.dir>${build.directory}/container-logs/</container.logs.dir>
+                        <container.logs.dir>${project.build.directory}/container-logs/</container.logs.dir>
                     </systemProperties>
                 </configuration>
                 <executions>


### PR DESCRIPTION
Fixes:

```
~kroxylicious │ main  mvn clean verify                                                                                                                    ✔ │ system  │ 16:01:10 
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for io.kroxylicious:integrationtests:jar:1.0-SNAPSHOT
[WARNING] The expression ${build.directory} is deprecated. Please use ${project.build.directory} instead.
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```