### PR TITLE
Generate krpc-plugin descriptor on compile

### DIFF
--- a/krpc-code-gen/pom.xml
+++ b/krpc-code-gen/pom.xml
@@ -95,6 +95,20 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- We need to ensure that the descriptor is generated at compile phase -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-descriptor</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>descriptor</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Execute maven-plugin-plugin:descriptor on krpc-plugin compile phase

The default-descriptor goal is bound to the process-class phase which is the phase following the compile phase. This means that `mvn compile` by default won't generate the krpc-plugin descriptor.

And since Kroxylicious module can't get compiled without the descriptor of krpc-plugin, running `mvn compile` would ultimatly fail for Kroxylicious module without this change.