### PR TITLE
Add Dockerfile for a development purposes container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# This docker file is only intended for development purposes
+ARG BUILD_IMAGE=maven:3.8-openjdk-17
+ARG RUNTIME_IMAGE=openjdk:11-jdk-slim
+LABEL org.opencontainers.image.source="https://github.com/kroxylicious/kroxylicious.git"
+
+# Maven dependencies stage. Allows for caching pulled deps.
+FROM ${BUILD_IMAGE} AS dependencies
+
+WORKDIR /build
+
+COPY etc etc
+COPY pom.xml pom.xml
+COPY krpc-code-gen/pom.xml krpc-code-gen/pom.xml
+COPY kroxylicious/pom.xml kroxylicious/pom.xml
+COPY integrationtests/pom.xml integrationtests/pom.xml
+
+RUN mvn -q -ntp -B -pl krpc-code-gen -am dependency:go-offline
+
+RUN mvn -q -ntp -B -pl kroxylicious -am dependency:go-offline
+
+# Kroxylicious jars stage.
+FROM ${BUILD_IMAGE} AS build
+
+WORKDIR /build
+
+COPY --from=dependencies /root/.m2 /root/.m2
+
+COPY etc etc
+COPY pom.xml pom.xml
+COPY krpc-code-gen/ krpc-code-gen
+COPY kroxylicious/ kroxylicious
+COPY integrationtests/pom.xml integrationtests/pom.xml
+
+RUN mvn -q -ntp -B -pl krpc-code-gen install
+
+RUN mvn -q -ntp -Pdist -Dquick -B -pl krpc-code-gen,kroxylicious package
+
+# Final runtime stage
+FROM ${RUNTIME_IMAGE}
+
+WORKDIR /app
+
+COPY --from=build /build/kroxylicious/target/kroxylicious-1.0-SNAPSHOT-jar-with-dependencies.jar kroxylicious-1.0-SNAPSHOT.jar
+COPY --from=build /build/kroxylicious/example-proxy-config.yml proxy-config.yml
+
+ENTRYPOINT ["java", "-jar", "kroxylicious-1.0-SNAPSHOT.jar"]
+CMD ["-c", "proxy-config.yml"]

--- a/kroxylicious/pom.xml
+++ b/kroxylicious/pom.xml
@@ -116,13 +116,12 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
         </dependency>
-
-        <!-- Test dependencies -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <scope>test</scope>
         </dependency>
+
+        <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
@@ -146,6 +145,16 @@
     </dependencies>
 
     <build>
+        <!-- Without this extension, the os arch and name can't be detected
+         while building from inside a Docker build and maven can't find the artifact
+          for io.netty:netty-transport-native-unix-common:jar -->
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.0</version>
+            </extension>
+        </extensions>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -269,8 +278,38 @@
                                     <classpathPrefix>${libs.dir}/</classpathPrefix>
                                     <mainClass>io.kroxylicious.proxy.Kroxylicious</mainClass>
                                 </manifest>
+                                <manifestEntries>
+                                    <Multi-Release>true</Multi-Release>
+                                </manifestEntries>
                             </archive>
                         </configuration>
+                    </plugin>
+                    <plugin>
+                        <!-- Needed to build a fat jar for the container -->
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>3.4.2</version>
+                        <configuration>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                            <archive>
+                                <manifestEntries>
+                                    <Multi-Release>true</Multi-Release>
+                                </manifestEntries>
+                                <manifest>
+                                    <mainClass>io.kroxylicious.proxy.Kroxylicious</mainClass>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>make-assembly</id>
+                                <phase>package</phase> 
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/kroxylicious/src/main/resources/log4j2.properties
+++ b/kroxylicious/src/main/resources/log4j2.properties
@@ -11,7 +11,7 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} <%t> %-5p %c:%L - %m%n
 
-rootLogger.level = WARN
+rootLogger.level = INFO
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false


### PR DESCRIPTION
This introduces the following changes
    
- Add support for building a kroxylicious fat jar in the pom file
- Change root logger level to INFO
- Adding a multi-stage Dockerfile which runs a minimal JRE + the fat jar for the development purposes only