### PR TITLE
Enable configuration of micrometer global registry

### DIFF
--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -108,6 +108,7 @@
                     <systemProperties>
                         <container.logs.dir>${project.build.directory}/container-logs/</container.logs.dir>
                     </systemProperties>
+                    <runOrder>random</runOrder>
                 </configuration>
                 <executions>
                     <execution>

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
@@ -5,16 +5,11 @@
  */
 package io.kroxylicious.proxy;
 
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 
 import org.apache.kafka.clients.CommonClientConfigs;
@@ -38,9 +33,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-import io.micrometer.core.instrument.Metrics;
-import io.netty.handler.codec.http.HttpResponseStatus;
-
 import io.kroxylicious.proxy.config.ConfigParser;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.internal.filter.ByteBufferTransformation;
@@ -48,7 +40,6 @@ import io.kroxylicious.proxy.testkafkacluster.KafkaClusterConfig;
 import io.kroxylicious.proxy.testkafkacluster.KafkaClusterFactory;
 import io.kroxylicious.proxy.testkafkacluster.KeytoolCertificateGenerator;
 
-import static java.net.http.HttpResponse.BodyHandlers.ofString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -158,33 +149,6 @@ public class KrpcFilterIT {
                 assertEquals("Hello, world!", records.iterator().next().value());
             }
 
-            // shutdown the proxy
-            proxy.shutdown();
-
-        }
-
-    }
-
-    @Test
-    public void shouldOfferPrometheusMetricsScrapeEndpoint() throws Exception {
-        String proxyAddress = "localhost:9192";
-
-        try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder().testInfo(testInfo).build())) {
-            cluster.start();
-
-            String config = baseConfigBuilder(proxyAddress, cluster.getBootstrapServers())
-                    .withPrometheusEndpoint().build();
-
-            var proxy = startProxy(config);
-
-            String counter_name = "test_metric_" + Math.abs(new Random().nextLong()) + "_total";
-            Metrics.counter(counter_name).increment();
-            HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost:9193/metrics")).GET().build();
-            HttpResponse<String> response = HttpClient.newHttpClient().send(request, ofString());
-            assertTrue(response.body().contains(counter_name + " 1.0"));
-            HttpRequest notFoundReq = HttpRequest.newBuilder(URI.create("http://localhost:9193/nonexistant")).GET().build();
-            HttpResponse<String> notFoundResp = HttpClient.newHttpClient().send(notFoundReq, ofString());
-            assertEquals(notFoundResp.statusCode(), HttpResponseStatus.NOT_FOUND.code());
             // shutdown the proxy
             proxy.shutdown();
 

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/MetricsIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/MetricsIT.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+import io.kroxylicious.proxy.config.ConfigParser;
+import io.kroxylicious.proxy.config.Configuration;
+import io.kroxylicious.proxy.config.micrometer.MicrometerConfigurationHook;
+import io.kroxylicious.proxy.testkafkacluster.KafkaClusterConfig;
+import io.kroxylicious.proxy.testkafkacluster.KafkaClusterFactory;
+
+import static java.net.http.HttpResponse.BodyHandlers.ofString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MetricsIT {
+
+    public static final String PROXY_ADDRESS = "localhost:9192";
+    private TestInfo testInfo;
+    private KafkaProxy proxy;
+
+    @BeforeEach
+    public void beforeEach(TestInfo testInfo) {
+        this.testInfo = testInfo;
+        Metrics.globalRegistry.clear();
+    }
+    @AfterEach
+    public void teardown() {
+        if(proxy != null){
+            try {
+                proxy.shutdown();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public static class ConfigHook implements MicrometerConfigurationHook {
+
+        @Override
+        public void configure(MeterRegistry targetRegistry) {
+            new JvmThreadMetrics().bindTo(targetRegistry);
+        }
+    }
+
+    @Test
+    public void shouldOfferPrometheusMetricsScrapeEndpoint() throws Exception {
+        try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder().testInfo(testInfo).build())) {
+            cluster.start();
+
+            String config = baseConfigBuilder(PROXY_ADDRESS, cluster.getBootstrapServers())
+                    .withPrometheusEndpoint().build();
+
+            startProxy(config);
+
+            String counter_name = "test_metric_" + Math.abs(new Random().nextLong()) + "_total";
+            Metrics.counter(counter_name).increment();
+            HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost:9193/metrics")).GET().build();
+            HttpResponse<String> response = HttpClient.newHttpClient().send(request, ofString());
+            assertResponseBodyContainsMeter(response, counter_name, "1.0");
+            HttpRequest notFoundReq = HttpRequest.newBuilder(URI.create("http://localhost:9193/nonexistant")).GET().build();
+            HttpResponse<String> notFoundResp = HttpClient.newHttpClient().send(notFoundReq, ofString());
+            assertEquals(notFoundResp.statusCode(), HttpResponseStatus.NOT_FOUND.code());
+        }
+    }
+
+    @Test
+    public void shouldOfferPrometheusMetricsWithNamedBinder() throws Exception {
+        try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder().testInfo(testInfo).build())) {
+            cluster.start();
+
+            String config = baseConfigBuilder(PROXY_ADDRESS, cluster.getBootstrapServers())
+                    .withMicrometerBinder("JvmGcMetrics")
+                    .withPrometheusEndpoint().build();
+
+            startProxy(config);
+            HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost:9193/metrics")).GET().build();
+            HttpResponse<String> response = HttpClient.newHttpClient().send(request, ofString());
+            assertResponseBodyContainsMeter(response, "jvm_gc_memory_allocated_bytes_total");
+        }
+
+    }
+
+    @Test
+    public void shouldOfferPrometheusMetricsWithCommonTags() throws Exception {
+        try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder().testInfo(testInfo).build())) {
+            cluster.start();
+
+            String config = baseConfigBuilder(PROXY_ADDRESS, cluster.getBootstrapServers())
+                    .withMicrometerCommonTag("a", "b")
+                    .withPrometheusEndpoint().build();
+
+            startProxy(config);
+
+            String counter_name = "test_metric_" + Math.abs(new Random().nextLong()) + "_total";
+            Metrics.counter(counter_name).increment();
+            HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost:9193/metrics")).GET().build();
+            HttpResponse<String> response = HttpClient.newHttpClient().send(request, ofString());
+            assertResponseBodyContainsMeterWithTag(response, counter_name, "a", "b");
+        }
+    }
+
+    @Test
+    public void shouldOfferPrometheusMetricsWithConfigHook() throws Exception {
+        try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder().testInfo(testInfo).build())) {
+            cluster.start();
+
+            String config = baseConfigBuilder(PROXY_ADDRESS, cluster.getBootstrapServers())
+                    .withMicrometerConfigHook(ConfigHook.class.getTypeName())
+                    .withPrometheusEndpoint().build();
+
+            startProxy(config);
+            HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost:9193/metrics")).GET().build();
+            HttpResponse<String> response = HttpClient.newHttpClient().send(request, ofString());
+            assertResponseBodyContainsMeter(response, "jvm_threads_live_threads");
+        }
+    }
+
+    @Test
+    public void shouldOfferPrometheusMetricsWithFullyQualifiedBinder() throws Exception {
+        try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder().testInfo(testInfo).build())) {
+            cluster.start();
+
+            String config = baseConfigBuilder(PROXY_ADDRESS, cluster.getBootstrapServers())
+                    .withMicrometerBinder("io.micrometer.core.instrument.binder.system.UptimeMetrics")
+                    .withPrometheusEndpoint().build();
+
+            startProxy(config);
+            HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost:9193/metrics")).GET().build();
+            HttpResponse<String> response = HttpClient.newHttpClient().send(request, ofString());
+            assertResponseBodyContainsMeter(response, "process_uptime_seconds");
+        }
+    }
+
+    private static void assertResponseBodyContainsMeter(HttpResponse<String> response, String meterName, String meterValue) {
+        assertResponseBodyContainsMeter(response, meterName, "\\{*.*\\}*", Pattern.quote(meterValue));
+    }
+
+    private static void assertResponseBodyContainsMeter(HttpResponse<String> response, String meterName) {
+        assertResponseBodyContainsMeter(response, meterName, "\\{*.*\\}*", "[0-9\\.E]+");
+    }
+
+    private static void assertResponseBodyContainsMeterWithTag(HttpResponse<String> response, String meterName, String tagKey, String tagValue) {
+        assertResponseBodyContainsMeter(response, meterName, "\\{" + Pattern.quote(tagKey) + "=\"" + Pattern.quote(tagValue) + "\",\\}", "[0-9\\.E]+");
+    }
+
+    private static void assertResponseBodyContainsMeter(HttpResponse<String> response, String meterName, String labelRegex, String valueRegex) {
+        assertTrue(Arrays.stream(response.body().split("\n")).anyMatch(it -> it.matches(meterName + labelRegex + " " + valueRegex)));
+    }
+
+    private static KroxyConfigBuilder baseConfigBuilder(String proxyAddress, String bootstrapServers) {
+        return new KroxyConfigBuilder(proxyAddress)
+                .withDefaultCluster(bootstrapServers)
+                .addFilter("ApiVersions")
+                .addFilter("BrokerAddress");
+    }
+
+    private void startProxy(String config) throws InterruptedException {
+        Configuration proxyConfig = new ConfigParser().parseConfiguration(config);
+
+        KafkaProxy kafkaProxy = new KafkaProxy(proxyConfig);
+        kafkaProxy.startup();
+
+        proxy = kafkaProxy;
+    }
+
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -44,6 +44,7 @@ import io.netty.incubator.channel.uring.IOUringServerSocketChannel;
 import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.admin.AdminHttpConfiguration;
+import io.kroxylicious.proxy.config.micrometer.MicrometerConfiguration;
 import io.kroxylicious.proxy.internal.KafkaProxyInitializer;
 import io.kroxylicious.proxy.internal.MeterRegistries;
 import io.kroxylicious.proxy.internal.admin.AdminHttpInitializer;
@@ -62,6 +63,7 @@ public final class KafkaProxy {
     private final boolean useIoUring;
     private final FilterChainFactory filterChainFactory;
     private final AdminHttpConfiguration adminHttpConfig;
+    private final MicrometerConfiguration micrometerConfig;
     private EventLoopGroup bossGroup;
     private EventLoopGroup workerGroup;
     private Channel acceptorChannel;
@@ -85,7 +87,7 @@ public final class KafkaProxy {
         this.logFrames = config.proxy().logFrames();
         this.useIoUring = config.proxy().useIoUring();
         this.adminHttpConfig = config.adminHttpConfig();
-
+        this.micrometerConfig = config.micrometerConfig();
         this.filterChainFactory = new FilterChainFactory(config);
 
         this.keyStoreFile = config.proxy().keyStoreFile().map(File::new);
@@ -183,7 +185,7 @@ public final class KafkaProxy {
             channelClass = NioServerSocketChannel.class;
         }
 
-        MeterRegistries meterRegistries = new MeterRegistries();
+        MeterRegistries meterRegistries = new MeterRegistries(micrometerConfig);
         maybeStartMetricsListener(bossGroup, workerGroup, channelClass, meterRegistries);
 
         ServerBootstrap serverBootstrap = new ServerBootstrap().group(bossGroup, workerGroup)

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/classloader/ClassloaderUtils.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/classloader/ClassloaderUtils.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.classloader;
+
+import java.util.Optional;
+
+public class ClassloaderUtils {
+    public static <T> Optional<Class<? extends T>> loadClassIfPresent(Class<T> superClass, String targetClassName) {
+        try {
+            Class<?> targetClass = ClassloaderUtils.class.getClassLoader().loadClass(targetClassName);
+            if (superClass.isAssignableFrom(targetClass)) {
+                return Optional.of(targetClass.asSubclass(superClass));
+            }
+            else {
+                throw new RuntimeException("class " + targetClass.getSimpleName() + " is not assignable to " + superClass);
+            }
+        }
+        catch (ClassNotFoundException e) {
+            return Optional.empty();
+        }
+    }
+
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -9,18 +9,25 @@ import java.util.List;
 import java.util.Map;
 
 import io.kroxylicious.proxy.config.admin.AdminHttpConfiguration;
+import io.kroxylicious.proxy.config.micrometer.MicrometerConfiguration;
 
 public class Configuration {
 
     private final ProxyConfig proxy;
 
     private final AdminHttpConfiguration adminHttp;
+    private final MicrometerConfiguration micrometer;
     private final Map<String, Cluster> clusters;
     private final List<FilterDefinition> filters;
 
-    public Configuration(ProxyConfig proxy, AdminHttpConfiguration adminHttp, Map<String, Cluster> clusters, List<FilterDefinition> filters) {
+    public Configuration(ProxyConfig proxy,
+                         AdminHttpConfiguration adminHttp,
+                         MicrometerConfiguration micrometer,
+                         Map<String, Cluster> clusters,
+                         List<FilterDefinition> filters) {
         this.proxy = proxy;
         this.adminHttp = adminHttp;
+        this.micrometer = micrometer;
         this.clusters = clusters;
         this.filters = filters;
     }
@@ -39,5 +46,9 @@ public class Configuration {
 
     public List<FilterDefinition> filters() {
         return filters;
+    }
+
+    public MicrometerConfiguration micrometerConfig() {
+        return micrometer == null ? MicrometerConfiguration.empty() : micrometer;
     }
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/config/micrometer/MicrometerConfiguration.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/config/micrometer/MicrometerConfiguration.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.config.micrometer;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+import io.kroxylicious.proxy.classloader.ClassloaderUtils;
+
+public class MicrometerConfiguration {
+
+    private static final MicrometerConfiguration EMPTY = new MicrometerConfiguration(null, null, null);
+    private static final List<String> BINDER_PACKAGES = getBinderPackages();
+
+    private final List<Class<? extends MeterBinder>> binders;
+    private final Optional<Class<? extends MicrometerConfigurationHook>> configurationHook;
+    private final List<Tag> commonTags;
+
+    private static List<String> getBinderPackages() {
+        String binderPackage = "io.micrometer.core.instrument.binder";
+        return List.of(binderPackage + ".jvm", binderPackage + ".system");
+    }
+
+    public MicrometerConfiguration(List<String> binders, String configurationHookClass, Map<String, String> commonTags) {
+        this.binders = configureBinders(binders);
+        this.configurationHook = loadConfigurationHookClass(configurationHookClass);
+        this.commonTags = toTags(commonTags);
+    }
+
+    public static MicrometerConfiguration empty() {
+        return EMPTY;
+    }
+
+    private List<Tag> toTags(Map<String, String> commonTags) {
+        if (commonTags == null) {
+            return List.of();
+        }
+        return commonTags.entrySet().stream().map(entry -> Tag.of(entry.getKey(), entry.getValue())).collect(Collectors.toList());
+    }
+
+    private Optional<Class<? extends MicrometerConfigurationHook>> loadConfigurationHookClass(String configurationHookClass) {
+        if (configurationHookClass == null) {
+            return Optional.empty();
+        }
+        Class<? extends MicrometerConfigurationHook> clazz = ClassloaderUtils.loadClassIfPresent(MicrometerConfigurationHook.class, configurationHookClass)
+                .orElseThrow(() -> new IllegalArgumentException("could not load micrometer configuration hook: " + configurationHookClass));
+        return Optional.ofNullable(clazz);
+    }
+
+    private List<Class<? extends MeterBinder>> configureBinders(List<String> binders) {
+        if (binders == null) {
+            return List.of();
+        }
+        return binders.stream().map(this::toBinderClass).collect(Collectors.toList());
+    }
+
+    private Class<? extends MeterBinder> toBinderClass(String binder) {
+        Stream<String> literalCandidate = Stream.of(binder);
+        Stream<String> packageClassCandidates = BINDER_PACKAGES.stream().map(binderPackage -> binderPackage + "." + binder);
+        return Stream.concat(literalCandidate, packageClassCandidates)
+                .map(candidateClassName -> ClassloaderUtils.loadClassIfPresent(MeterBinder.class, candidateClassName))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst().orElseThrow(() -> new IllegalArgumentException("could not locate binder class for " + binder));
+    }
+
+    public List<Class<? extends MeterBinder>> getBinders() {
+        return binders;
+    }
+
+    public Optional<Class<? extends MicrometerConfigurationHook>> loadConfigurationHookClass() {
+        return configurationHook;
+    }
+
+    public List<Tag> getCommonTags() {
+        return commonTags;
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/config/micrometer/MicrometerConfigurationHook.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/config/micrometer/MicrometerConfigurationHook.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.config.micrometer;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+public interface MicrometerConfigurationHook {
+    void configure(MeterRegistry targetRegistry);
+
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/MeterRegistries.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/MeterRegistries.java
@@ -5,18 +5,67 @@
  */
 package io.kroxylicious.proxy.internal;
 
+import java.lang.reflect.Constructor;
 import java.util.Optional;
 
 import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
+
+import io.kroxylicious.proxy.config.micrometer.MicrometerConfiguration;
+import io.kroxylicious.proxy.config.micrometer.MicrometerConfigurationHook;
 
 public class MeterRegistries {
     private final PrometheusMeterRegistry prometheusMeterRegistry;
 
-    public MeterRegistries() {
+    public MeterRegistries(MicrometerConfiguration micrometerConfig) {
+        configureMicrometer(micrometerConfig);
         this.prometheusMeterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
         Metrics.addRegistry(prometheusMeterRegistry);
+    }
+
+    private void configureMicrometer(MicrometerConfiguration micrometerConfig) {
+        CompositeMeterRegistry globalRegistry = Metrics.globalRegistry;
+        configureCommonTags(micrometerConfig, globalRegistry);
+        configureBinders(micrometerConfig, globalRegistry);
+        callConfigurationHook(micrometerConfig, globalRegistry);
+    }
+
+    private void configureCommonTags(MicrometerConfiguration micrometerConfig, CompositeMeterRegistry targetRegistry) {
+        targetRegistry.config().commonTags(micrometerConfig.getCommonTags());
+    }
+
+    private static void callConfigurationHook(MicrometerConfiguration micrometerConfig, CompositeMeterRegistry targetRegistry) {
+        Optional<Class<? extends MicrometerConfigurationHook>> configurationHookClass = micrometerConfig.loadConfigurationHookClass();
+        if (configurationHookClass.isPresent()) {
+            Class<? extends MicrometerConfigurationHook> clazz = configurationHookClass.get();
+            MicrometerConfigurationHook micrometerConfigurationHook = instantiateWithNoArgs(clazz);
+            micrometerConfigurationHook.configure(targetRegistry);
+        }
+    }
+
+    private static void configureBinders(MicrometerConfiguration micrometerConfig, CompositeMeterRegistry targetRegistry) {
+        for (Class<? extends MeterBinder> binder : micrometerConfig.getBinders()) {
+            MeterBinder meterBinder = instantiateWithNoArgs(binder);
+            try {
+                meterBinder.bindTo(targetRegistry);
+            }
+            catch (Exception e) {
+                throw new RuntimeException("failed to bind metrics with " + binder.getSimpleName(), e);
+            }
+        }
+    }
+
+    private static <T> T instantiateWithNoArgs(Class<? extends T> binder) {
+        try {
+            Constructor<? extends T> declaredConstructor = binder.getDeclaredConstructor();
+            return declaredConstructor.newInstance();
+        }
+        catch (Exception e) {
+            throw new IllegalArgumentException("failed to instantiate " + binder.getSimpleName(), e);
+        }
     }
 
     /**

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/config/micrometer/MicrometerConfigurationTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/config/micrometer/MicrometerConfigurationTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.config.micrometer;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.system.UptimeMetrics;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MicrometerConfigurationTest {
+
+    public static class TestHook implements MicrometerConfigurationHook {
+        @Override
+        public void configure(MeterRegistry targetRegistry) {
+
+        }
+    }
+
+    @Test
+    public void testLocatesJvmBinder() {
+        MicrometerConfiguration config = new MicrometerConfiguration(List.of("JvmGcMetrics"), null, null);
+        List<Class<? extends MeterBinder>> binders = config.getBinders();
+        assertThat(binders).contains(JvmGcMetrics.class);
+    }
+
+    @Test
+    public void testNullBinderList() {
+        MicrometerConfiguration config = new MicrometerConfiguration(null, null, null);
+        List<Class<? extends MeterBinder>> binders = config.getBinders();
+        assertThat(binders).isEmpty();
+    }
+
+    @Test
+    public void testNonExistentBinder() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new MicrometerConfiguration(List.of("non.existent.Binder"), null, null);
+        });
+    }
+
+    @Test
+    public void testEmptyBinderList() {
+        MicrometerConfiguration config = new MicrometerConfiguration(List.of(), null, null);
+        List<Class<? extends MeterBinder>> binders = config.getBinders();
+        assertThat(binders).isEmpty();
+    }
+
+    @Test
+    public void testLocatesMicrometerHook() {
+        MicrometerConfiguration config = new MicrometerConfiguration(null, TestHook.class.getTypeName(), null);
+        Optional<Class<? extends MicrometerConfigurationHook>> hookClass = config.loadConfigurationHookClass();
+        assertTrue(hookClass.isPresent(), "configuration hook class optional should be present");
+        assertEquals(TestHook.class, hookClass.get());
+    }
+
+    @Test
+    public void testNonExistentMicrometerHook() {
+        assertThrows(RuntimeException.class, () -> {
+            new MicrometerConfiguration(null, "bad.class.DoesntExist", null);
+        });
+    }
+
+    @Test
+    public void testConfigHookEmptyIfNoClassnameProvided() {
+        MicrometerConfiguration config = new MicrometerConfiguration(null, null, null);
+        Optional<Class<? extends MicrometerConfigurationHook>> hookClass = config.loadConfigurationHookClass();
+        assertThat(hookClass).describedAs("configuration hook class optional").isEmpty();
+    }
+
+    @Test
+    public void testLocatesSystemBinder() {
+        MicrometerConfiguration config = new MicrometerConfiguration(List.of("JvmGcMetrics"), null, null);
+        List<Class<? extends MeterBinder>> binders = config.getBinders();
+        assertThat(binders).contains(JvmGcMetrics.class);
+    }
+
+    @Test
+    public void testLocatesBinderUsingFullPackage() {
+        MicrometerConfiguration config = new MicrometerConfiguration(List.of("io.micrometer.core.instrument.binder.system.UptimeMetrics"), null, null);
+        List<Class<? extends MeterBinder>> binders = config.getBinders();
+        assertThat(binders).contains(UptimeMetrics.class);
+    }
+
+    @Test
+    public void testNullCommonTags() {
+        MicrometerConfiguration config = new MicrometerConfiguration(null, null, null);
+        assertThat(config.getCommonTags()).isEmpty();
+    }
+
+    @Test
+    public void testEmptyCommonTags() {
+        MicrometerConfiguration config = new MicrometerConfiguration(null, null, Map.of());
+        assertThat(config.getCommonTags()).isEmpty();
+    }
+
+    @Test
+    public void testNonEmptyCommonTags() {
+        MicrometerConfiguration config = new MicrometerConfiguration(null, null, Map.of("a", "b"));
+        assertThat(config.getCommonTags()).contains(Tag.of("a", "b"));
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -323,6 +323,7 @@
                     <version>3.0.0-M5</version>
                     <configuration>
                         <skipTests>${skipUTs}</skipTests>
+                        <runOrder>random</runOrder>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Implements #111 

This enables configuration of some key micrometer features:
1. common tags to add to all metrics (labels in prometheus-speak)
2. binders (components that can provide common metrics like jvm or system metrics)

and adds a configurable hook so you could apply arbitrary configuration to the global registry.

You can configure common tags to add to all metrics by adding configuration like this to the kroxy yaml:

```
micrometer:
  commonTags:
    zone: euc-1a
```

You can configure binders to bind to the global registry by adding configuration like this to the kroxy yaml:

```
micrometer:
  binders:
    - JvmGcMetrics
    - io.micrometer.core.instrument.binder.jvm.JvmHeapPressureMetrics
```

First we check if there is a class that can be loaded directly using the string as a type name, otherwise we will try to load it from these packages:

* io.micrometer.core.instrument.binder.jvm
* io.micrometer.core.instrument.binder.system

Note it is assumed that the binder implementations have a no-arg constructor if you need something more complex you could use the configuration hook.

You can specify a MicrometerConfigurationHook implementation as a way to perform arbitrary configuration of the global MeterRegistry by adding configuration like this to the kroxy yaml:

```
micrometer:
  configurationHookClass: your.custom.HookClass
```

This hook will be called after the `binders` and `common tags` are configured