### PR TITLE
Fix #128: Add some skeleton docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ Failed to load class org.slf4j.impl.StaticLoggerBinder
 
 Make sure to follow the [suggestions here](https://www.slf4j.org/codes.html#StaticLoggerBinder) to include one (and only one) of the suggested jars on the classpath.
 
+## Rendering documentation
+
+The `docs` directory has some user documentation written in [AsciiDoc](https://docs.asciidoctor.org/asciidoc/latest/) format.
+You can render it to HTML using:
+
+```
+./mvnw org.asciidoctor:asciidoctor-maven-plugin:process-asciidoc@convert-to-html
+```
+
+The output will be in `target/html/master.html`. 
+
 ## Performance Testing
 
 See [benchmarking.md](benchmarking.md) for information on running basic performance tests for this proxy.

--- a/docs/available-filters.adoc
+++ b/docs/available-filters.adoc
@@ -7,6 +7,6 @@ Only a few built in filters are provided.
 // TODO list them and describe them
 
 
-== 3rd party filters
-
-TODO
+// == 3rd party filters
+//
+// TODO

--- a/docs/available-filters.adoc
+++ b/docs/available-filters.adoc
@@ -1,0 +1,12 @@
+= Filters
+
+== Built-in filters
+
+Only a few built in filters are provided.
+
+// TODO list them and describe them
+
+
+== 3rd party filters
+
+TODO

--- a/docs/custom-filters.adoc
+++ b/docs/custom-filters.adoc
@@ -1,0 +1,57 @@
+= Custom filters
+
+Custom filters can be written in the Java programming language.
+Knowledge of the Kafka protocol is generally required to write a protocol filter.
+
+As explained in the overview, there are two kinds of filter:
+
+Net filters:: allow customisation over how Kafka client connections are handled.
+Protocol filters:: allow customisation of how protocol messages are handled on their way to, or from, the Kafka cluster.
+
+The following sections explain in more detail how to write your own filters.
+
+== API docs
+TODO Link to the API docs
+
+== Dependencies
+
+How filter classes are loaded is not currently defined by the filter contract.
+In other words, filters might be loaded using a classloaded-per-filter model,
+or using a single class loader.
+This doesn't really make a difference to filter authors except where they want to make use of other libraries.
+Because those dependencies might be loaded by the same classloader as the dependencies of other filters there is the possibility of collision.
+
+For common things like logging and metric facade APIs it is recommended to use the facade APIs which are also used by the proxy core.
+
+// TODO Maven dependency
+// TODO Gradle dependency
+
+== Net filters
+
+== An example net filter
+
+== Protocol filters
+
+A protocol filter is a `public` top-level, concrete class with a particular public constructor and which implements
+one or more protocol filter interfaces.
+
+=== The protocol filter lifecycle
+
+Instances of the filter class are created on demand when a protocol message is first sent by a client.
+Instances are specific to the channel between a single client and a single broker.
+
+It exists while the client remains connected.
+
+=== Handling state
+
+The simplest way of managing per-client state is to use member fields.
+The proxy guarantees that all methods of a given filter instance will always be invoked on the same thread.
+Therefore there is no need to use synchronization when accessing such fields.
+
+=== An example protocol filter
+
+// TODO
+
+== Packaging filters
+
+Filters are packaged as standard `.jar` files.

--- a/docs/custom-filters.adoc
+++ b/docs/custom-filters.adoc
@@ -5,9 +5,9 @@ Knowledge of the Kafka protocol is generally required to write a protocol filter
 
 As explained in the overview, there are two kinds of filter:
 
-Net filters:: allow customisation over how Kafka client connections are handled.
+Net filters:: Allow customisation over how Kafka client connections are handled.
 
-Protocol filters:: allow customisation of how protocol messages are handled on their way to, or from, the Kafka cluster.
+Protocol filters:: Allow customisation of how protocol messages are handled on their way to, or from, the Kafka cluster.
 
 The following sections explain in more detail how to write your own filters.
 

--- a/docs/custom-filters.adoc
+++ b/docs/custom-filters.adoc
@@ -6,29 +6,32 @@ Knowledge of the Kafka protocol is generally required to write a protocol filter
 As explained in the overview, there are two kinds of filter:
 
 Net filters:: allow customisation over how Kafka client connections are handled.
+
 Protocol filters:: allow customisation of how protocol messages are handled on their way to, or from, the Kafka cluster.
 
 The following sections explain in more detail how to write your own filters.
 
 == API docs
-TODO Link to the API docs
+// TODO Link to the API docs
 
 == Dependencies
 
 How filter classes are loaded is not currently defined by the filter contract.
-In other words, filters might be loaded using a classloaded-per-filter model,
+In other words, filters might be loaded using a classloader-per-filter model,
 or using a single class loader.
-This doesn't really make a difference to filter authors except where they want to make use of other libraries.
-Because those dependencies might be loaded by the same classloader as the dependencies of other filters there is the possibility of collision.
+This doesn't really make a difference to filter authors except where they want to make use of libraries as dependencies.
+Because those dependencies might be loaded by the same classloader as the dependencies of other filters there is the possibility of collision. Filter A and Filter B might both want to use Library C, and they might want to use different versions of Library C.
 
 For common things like logging and metric facade APIs it is recommended to use the facade APIs which are also used by the proxy core.
 
 // TODO Maven dependency
 // TODO Gradle dependency
 
+// TODO recommend BOM usage
+
 == Net filters
 
-== An example net filter
+=== An example net filter
 
 == Protocol filters
 
@@ -55,3 +58,5 @@ Therefore there is no need to use synchronization when accessing such fields.
 == Packaging filters
 
 Filters are packaged as standard `.jar` files.
+
+// TODO

--- a/docs/deploying.adoc
+++ b/docs/deploying.adoc
@@ -5,7 +5,7 @@ Topologies etc
 == Selecting plugins
 Put the filter jars in some directory
 
-== Providing implementations for façades
+== Providing implementations for facades
 
 
 

--- a/docs/deploying.adoc
+++ b/docs/deploying.adoc
@@ -1,0 +1,19 @@
+= Deploying proxies
+
+Topologies etc
+
+== Selecting plugins
+Put the filter jars in some directory
+
+== Providing implementations for façades
+
+
+
+== Configuring the proxy networking
+
+YAML
+Proxy level configuration
+SSL
+
+== Configuring proxy plugins
+Filter level configuration

--- a/docs/master.adoc
+++ b/docs/master.adoc
@@ -1,0 +1,11 @@
+= Kroxylicious Proxy
+
+include::overview.adoc[leveloffset=1]
+
+include::available-filters.adoc[leveloffset=1]
+
+include::custom-filters.adoc[leveloffset=1]
+
+include::deploying.adoc[leveloffset=1]
+
+include::operating.adoc[leveloffset=1]

--- a/docs/operating.adoc
+++ b/docs/operating.adoc
@@ -2,6 +2,8 @@
 
 == Logging
 
+== Configuring TLS
+
 == Reconfiguration
 
 == Monitoring and observability

--- a/docs/operating.adoc
+++ b/docs/operating.adoc
@@ -1,0 +1,7 @@
+= Operating proxies
+
+== Logging
+
+== Reconfiguration
+
+== Monitoring and observability

--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -43,7 +43,7 @@ When the broker returns a response (such as a `Produce` response) the protocol f
 
 An important principal for the protocol filter API is that filters should _compose_ nicely.
 That means that filters generally don't know what other filters might be present in the chain, and what they might be doing to messages.
-When a filter forwards a request or response it doesn't know whether the message be being sent to the next filter in the chain, or straight back to the client.
+When a filter forwards a request or response it doesn't know whether the message is being sent to the next filter in the chain, or straight back to the client.
 
 Such composition is important because it means a _proxy user_ can configure multiple filters (possibly written by several _filter authors_) and expect to get the combined effect of all of them.
 
@@ -53,7 +53,7 @@ In practice they will often need to understand what each filter does in some det
 == Implementation
 
 The proxy is written in Java, on top of https://netty.io[Netty].
-The usual https://netty.io/4.1/api/io/netty/channel/ChannelHandler.html[`ChannelHandlers`] provided by the Netty project are used where appropriate (e.g. SSL support uses https://netty.io/4.1/api/io/netty/handler/ssl/SslHandler.html[`SslHandler`]), and Kroxy provides Kafka-specific handlers of its own.
+The usual https://netty.io/4.1/api/io/netty/channel/ChannelHandler.html[`ChannelHandlers`] provided by the Netty project are used where appropriate (e.g. SSL support uses https://netty.io/4.1/api/io/netty/handler/ssl/SslHandler.html[`SslHandler`]), and Kroxylicious provides Kafka-specific handlers of its own.
 
 The Kafka-aware parts use the Apache Kafka project's own classes for serialization and deserialization.
 
@@ -61,12 +61,12 @@ Protocol filters get executed using a handler-per-filter model.
 
 == Deployment topologies
 
-The proxy supports a range of possibly deployment topologies.
+The proxy supports a range of possible deployment topologies.
 Which style is used depends on what the proxy is meant to _achieve_, architecturally speaking.
 Broadly speaking a proxy instance can be deployed:
 
 As a forward proxy::
-proxying the access of one or more clients to a particular cluster/broker that might also accessible (to other clients) directly.
+Proxying the access of one or more clients to a particular cluster/broker that might also accessible (to other clients) directly.
 +
 // TODO include a diagram
 +
@@ -74,7 +74,7 @@ Topic-level encryption provides one example use case for a forward proxy-style d
 This might be applicable when using clients that don't support interceptors, or if an organisation wants to apply the same encryption policy in a single place, securing access to the keys within their network.
 
 As a reverse proxy::
-proxying access for all clients trying to reach a particular cluster/broker.
+Proxying access for all clients trying to reach a particular cluster/broker.
 +
 // TODO include a diagram
 +
@@ -93,6 +93,7 @@ Proxy-per-broker::
 This is probably the simplest way to deploy a proxy.
 +
 If you control the Kafka cluster you can use the https://kafka.apache.org/documentation.html#brokerconfigs_advertised.listeners[`advertised.listeners`] broker config to ensure all access to the cluster happens via the proxy.
+When the Kafka cluster is running on Kubernetes proxy-per-broker can be achived using the side-car pattern.
 +
 If you do not control the Kafka cluster you can use a protocol filter to rewrite  `Metadata` (and a few other responses) sent to clients so that they only discover proxy-fronted brokers, and therefore only connect via proxies.
 

--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -1,0 +1,84 @@
+= Overview
+
+== What is Kroxylicious Proxy?
+
+Kroxylicous Proxy provides a pluggable, protocol-aware ("Layer 7") proxy for Apache Kafka brokers and clusters, together with an API for conveniently implementing custom logic within such a proxy.
+
+== Why?
+
+Proxies are a powerful and flexible architectural pattern.
+For Kafka they can be used to add functionality to Kafka clusters which is not available out-of-the-box with Apache Kafka.
+In an ideal world, such functionality would be implemented directly in Apache Kafka. But there are numerous practical reasons that prevent this, for example:
+
+* Organizations having very niche requirements which unsuitable for implementation directly in Apache Kafka.
+* Functionality which requires an plugin API in Apache Kafka which doesn't currently exist, and the Apache Kafka project is unwilling to implement.
+* Experimental functionality which might end up being implemented in Apache Kafka eventually.
+For example using Kroxylicious proxy it's easier to experiment with alternative transport protocols, such as Quic, or operating system APIs, such as io_uring, because there is already support for this in Netty, the networking framework on which Kroxylicious is built.
+
+== How it works
+
+// TODO include a diagram
+
+When a Kafka protocol client (typically a producer, consumer or admin client) connects to a proxy instance it is first handled by a pluggable _network filter_
+This handles things like:
+
+* SSL
+* Possibly initial client requests such as `ApiVersions`, `SaslHandshake` and `SaslAuthenticate`
+
+The network filter then
+
+1. determines which broker to connect the client to
+1. instantiates a chain of protocol filters for processing all further messages.
+1. removes itself from the further processing
+
+A _filter chain_ consists of one or more pluggable _protocol filters_.
+Kafka protocol messages (such as `Produce` requests and `Fetch` responses) pass  sequentially through each of the protocol filters in the chain before being forwarded to the broker.
+A  _protocol filter_ implements some logic for intercepting, inspecting and/or manipulating Kafka protocol messages.
+
+== Implementation
+
+The proxy is written in Java, on top of Netty.
+Standard Netty handlers are used where appropriate (e.g. SSL).
+The Kafka-aware parts use the Apache Kafka project's own classes for serialization and deserialization.
+Protocol filters get executed using a handler-per-filter model.
+
+== Deployment topologies
+
+The proxy supports a range of possibly deployment topologies.
+Which style is used depends on what the proxy is meant to _achieve_, architecturally speaking.
+Broadly speaking a proxy instance can be deployed:
+
+As a forward proxy::
+proxying the access of one or more clients to a particular cluster/broker that might also accessible (to other clients) directly.
++
+// TODO include a diagram
++
+Topic-level encryption provides one example use case for a forward proxy.
+This might be applicable for a client that doesn't support interceptors, or an organisation wanting to apply the same encryption policy in a single place while  securing access to the keys.
+
+As a reverse proxy::
+proxying access for all clients trying to reach a particular cluster/broker.
++
+// TODO include a diagram
++
+Transparent multi-tenancy provides an example use case for a reverse proxy.
+While Apache Kafka itself has some features that enable multi-tenancy they rely on topic name prefixing as the primary mechanism for ensuring isolation.
+Tenants have to adhere to the naming policy and so know they're a tenant of a larger shared cluster.
++
+_Transparent_ multi-tenancy means each tenant has the illusion of having their own cluster, with almost complete freedom over topic and group naming, while still actually sharing a cluster.
+
+// TODO we probably don't need the level of detail below, just summarize
+// and provide the detail in the deploying section
+
+We can further classify deployment topologies in how many proxy instances are used. For example:
+
+Proxy-per-broker::
+This is probably the simplest way to deploy a proxy.
+If you control the Kafka cluster you can use the `advertized.listeners` broker config to ensure all access to the cluster happens via the proxy.
+If you do not control the Kafka cluster you can use a protocol filter to rewrite  `Metadata` and other responses sent to clients so that they will only connect to brokers via proxies
+
+Single proxy instance::
+
+Proxy cluster::
+
+== More about filters

--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -2,16 +2,18 @@
 
 == What is Kroxylicious Proxy?
 
-Kroxylicous Proxy provides a pluggable, protocol-aware ("Layer 7") proxy for Apache Kafka brokers and clusters, together with an API for conveniently implementing custom logic within such a proxy.
+Kroxylicous Proxy provides a pluggable, protocol-aware ("Layer 7") proxy for https://kafka.apache.org[Apache Kafka(R)] brokers and clusters, together with an API for conveniently implementing custom logic within such a proxy.
 
 == Why?
 
 Proxies are a powerful and flexible architectural pattern.
 For Kafka they can be used to add functionality to Kafka clusters which is not available out-of-the-box with Apache Kafka.
-In an ideal world, such functionality would be implemented directly in Apache Kafka. But there are numerous practical reasons that prevent this, for example:
+In an ideal world, such functionality would be implemented directly in Apache Kafka.
+But there are numerous practical reasons that can prevent this, for example:
 
-* Organizations having very niche requirements which unsuitable for implementation directly in Apache Kafka.
-* Functionality which requires an plugin API in Apache Kafka which doesn't currently exist, and the Apache Kafka project is unwilling to implement.
+* Organizations having very niche requirements which are unsuitable for implementation directly in Apache Kafka.
+* Functionality which requires changes to Kafka's public API and which the Apache Kafka project is unwilling to implement.
+  This is the case for https://lists.apache.org/thread/x1p119hkpoy01vq9ck3d0ql67jtvm875[broker interceptors], for example.
 * Experimental functionality which might end up being implemented in Apache Kafka eventually.
 For example using Kroxylicious proxy it's easier to experiment with alternative transport protocols, such as Quic, or operating system APIs, such as io_uring, because there is already support for this in Netty, the networking framework on which Kroxylicious is built.
 
@@ -27,19 +29,34 @@ This handles things like:
 
 The network filter then
 
-1. determines which broker to connect the client to
-1. instantiates a chain of protocol filters for processing all further messages.
-1. removes itself from the further processing
+. determines which broker to connect the client to
+. instantiates a chain of protocol filters for processing all further messages.
+. removes itself from the further processing
 
 A _filter chain_ consists of one or more pluggable _protocol filters_.
-Kafka protocol messages (such as `Produce` requests and `Fetch` responses) pass  sequentially through each of the protocol filters in the chain before being forwarded to the broker.
 A  _protocol filter_ implements some logic for intercepting, inspecting and/or manipulating Kafka protocol messages.
+Kafka protocol requests (such as `Produce` requests) pass sequentially through each of the protocol filters in the chain before being forwarded to the broker.
+
+When the broker returns a response (such as a `Produce` response) the protocol filters in the chain are invoked in the reverse order, each having the opportunity to inspecting and/or manipulating the response. Eventually a response is returned to the client.
+
+=== Filter composition
+
+An important principal for the protocol filter API is that filters should _compose_ nicely.
+That means that filters generally don't know what other filters might be present in the chain, and what they might be doing to messages.
+When a filter forwards a request or response it doesn't know whether the message be being sent to the next filter in the chain, or straight back to the client.
+
+Such composition is important because it means a _proxy user_ can configure multiple filters (possibly written by several _filter authors_) and expect to get the combined effect of all of them.
+
+It's never quite that simple, of course.
+In practice they will often need to understand what each filter does in some detail in order to be able to operate their proxy properly, for example by understanding whatever metrics each filter is emitting.
 
 == Implementation
 
-The proxy is written in Java, on top of Netty.
-Standard Netty handlers are used where appropriate (e.g. SSL).
+The proxy is written in Java, on top of https://netty.io[Netty].
+The usual https://netty.io/4.1/api/io/netty/channel/ChannelHandler.html[`ChannelHandlers`] provided by the Netty project are used where appropriate (e.g. SSL support uses https://netty.io/4.1/api/io/netty/handler/ssl/SslHandler.html[`SslHandler`]), and Kroxy provides Kafka-specific handlers of its own.
+
 The Kafka-aware parts use the Apache Kafka project's own classes for serialization and deserialization.
+
 Protocol filters get executed using a handler-per-filter model.
 
 == Deployment topologies
@@ -53,8 +70,8 @@ proxying the access of one or more clients to a particular cluster/broker that m
 +
 // TODO include a diagram
 +
-Topic-level encryption provides one example use case for a forward proxy.
-This might be applicable for a client that doesn't support interceptors, or an organisation wanting to apply the same encryption policy in a single place while  securing access to the keys.
+Topic-level encryption provides one example use case for a forward proxy-style deployment.
+This might be applicable when using clients that don't support interceptors, or if an organisation wants to apply the same encryption policy in a single place, securing access to the keys within their network.
 
 As a reverse proxy::
 proxying access for all clients trying to reach a particular cluster/broker.
@@ -62,8 +79,8 @@ proxying access for all clients trying to reach a particular cluster/broker.
 // TODO include a diagram
 +
 Transparent multi-tenancy provides an example use case for a reverse proxy.
-While Apache Kafka itself has some features that enable multi-tenancy they rely on topic name prefixing as the primary mechanism for ensuring isolation.
-Tenants have to adhere to the naming policy and so know they're a tenant of a larger shared cluster.
+While Apache Kafka itself has some features that enable multi-tenancy, they rely on topic name prefixing as the primary mechanism for ensuring namespace isolation.
+Tenants have to adhere to the naming policy and know they're a tenant of a larger shared cluster.
 +
 _Transparent_ multi-tenancy means each tenant has the illusion of having their own cluster, with almost complete freedom over topic and group naming, while still actually sharing a cluster.
 
@@ -74,8 +91,10 @@ We can further classify deployment topologies in how many proxy instances are us
 
 Proxy-per-broker::
 This is probably the simplest way to deploy a proxy.
-If you control the Kafka cluster you can use the `advertized.listeners` broker config to ensure all access to the cluster happens via the proxy.
-If you do not control the Kafka cluster you can use a protocol filter to rewrite  `Metadata` and other responses sent to clients so that they will only connect to brokers via proxies
++
+If you control the Kafka cluster you can use the https://kafka.apache.org/documentation.html#brokerconfigs_advertised.listeners[`advertised.listeners`] broker config to ensure all access to the cluster happens via the proxy.
++
+If you do not control the Kafka cluster you can use a protocol filter to rewrite  `Metadata` (and a few other responses) sent to clients so that they only discover proxy-fronted brokers, and therefore only connect via proxies.
 
 Single proxy instance::
 

--- a/pom.xml
+++ b/pom.xml
@@ -375,6 +375,33 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctor-maven-plugin</artifactId>
+                <version>2.2.2</version>
+                <executions>
+                    <execution>
+                        <id>convert-to-html</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/html</outputDirectory>
+                            <attributes>
+                                <source-highlighter>coderay</source-highlighter>
+                                <imagesdir>./images</imagesdir>
+                                <toc>left</toc>
+                                <icons>font</icons>
+                            </attributes>
+                            <sourceDirectory>docs</sourceDirectory>
+                            <sourceDocumentName>master.adoc</sourceDocumentName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -383,7 +383,6 @@
                 <executions>
                     <execution>
                         <id>convert-to-html</id>
-                        <phase>generate-resources</phase>
                         <goals>
                             <goal>process-asciidoc</goal>
                         </goals>


### PR DESCRIPTION
This PR adds a skeleton for some user docs, using asciidoc as the format, and rendering them using maven.

I'm not intending to flesh out all the `TODOs` in this PR, as a lot of what we're documenting is poorly defined right now. Instead the idea is to put something in place so that, as people contribute filters, we can start documenting how they're supposed to be used at the same time. If we delay adding this we're just building up debt which will need to be paid in the future when we have to go back and document the features we've already implemented. 

Once this PR is merged we can:

* [ ] open issues for the missing pieces which we can immediately improve (e.g. generating the filter API Javadocs and linking to it from the main docs)
* [ ] add a PR template so that PR authors are reminded of the need to provide docs for new features, or review the continuing correctness of any existing user docs. 
* [ ] In due course arrange for the website to include the docs. Exactly how to do this is yet to be determined. We might want to move some of the content and generation to the website repo at that point. But there is likely to always be some version-dependent content, the source for which belongs in this repo.