### PR TITLE
Generate javadoc jars as part of build

### DIFF
--- a/integrationtests/src/test/java/io/kroxylicious/proxy/MetricsIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/MetricsIT.java
@@ -44,12 +44,14 @@ public class MetricsIT {
         this.testInfo = testInfo;
         Metrics.globalRegistry.clear();
     }
+
     @AfterEach
     public void teardown() {
-        if(proxy != null){
+        if (proxy != null) {
             try {
                 proxy.shutdown();
-            } catch (InterruptedException e) {
+            }
+            catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
         }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/filter/package-info.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/filter/package-info.java
@@ -16,18 +16,18 @@
  * <p>filter chain is instantiated by a {@link io.kroxylicious.proxy.bootstrap.FilterChainFactory}
  * when a connection is made by a client.</p>
  *
- * <h3 id='assumptions'>Important facts about the Kafka protocol</h3>
+ * <h2 id='assumptions'>Important facts about the Kafka protocol</h2>
  *
- * <h4 id='pipelining'>Pipelining</h4>
+ * <h3 id='pipelining'>Pipelining</h3>
  * <p>The Kafka protocol supports pipelining (meaning a client can send multiple requests,
  * before getting a response for any of them). Therefore when writing a filter implementation
  * do not assume you won't see multiple requests before seeing any corresponding responses.</p>
  *
- * <h4 id='ordering'>Ordering</h4>
+ * <h3 id='ordering'>Ordering</h3>
  * <p>A broker does not, in general, send responses in the same order as it receives requests.
  * Therefore when writing a filter implementation do not assume ordering.</p>
  *
- * <h4 id='local_view'>Local view</h4>
+ * <h3 id='local_view'>Local view</h3>
  * <p>A client may obtain information from one broker in a cluster and use it to interact with other
  * brokers in the cluster (or the same broker, but on a different connection, and therefore a different
  * channel and filter chain). A classic example would
@@ -36,7 +36,7 @@
  *
  * <p>So although your filter
  * <em>implementation</em> might intercept both {@code Metadata} and {@code Produce} request/response
- * (for example), those requests will not pass through the same <emp>instance</emp> of your filter
+ * (for example), those requests will not pass through the same <em>instance</em> of your filter
  * implementation. Therefore it is incorrect, in general, to assume your filter has a global view of
  * the communication between the client and broker.</p>
  *

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/Frame.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/Frame.java
@@ -5,8 +5,6 @@
  */
 package io.kroxylicious.proxy.frame;
 
-import io.netty.buffer.ByteBuf;
-
 /**
  * A frame in the Kafka protocol, which may or may not be fully decoded.
  */
@@ -14,7 +12,7 @@ public interface Frame {
 
     /**
      * Estimate the expected encoded size in bytes of this {@code Frame}.<br>
-     * In particular, written data by {@link #encode(ByteBuf)} should be the same as reported by this method.
+     * In particular, written data by {@link #encode(ByteBufAccessor)} should be the same as reported by this method.
      */
     int estimateEncodedSize();
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/future/CompositeFuture.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/future/CompositeFuture.java
@@ -26,9 +26,8 @@ import io.kroxylicious.proxy.internal.future.CompositeFutureImpl;
 public interface CompositeFuture extends Future<CompositeFuture> {
 
     /**
-     * Return a composite future, succeeded when all futures are succeeded, failed when any future is failed.
-     * <p/>
-     * The returned future fails as soon as one of {@code f1} or {@code f2} fails.
+     * <p>Return a composite future, succeeded when all futures are succeeded, failed when any future is failed.</p>
+     * <p>The returned future fails as soon as one of {@code f1} or {@code f2} fails.</p>
      *
      * @param f1 future
      * @param f2 future
@@ -76,9 +75,8 @@ public interface CompositeFuture extends Future<CompositeFuture> {
     }
 
     /**
-     * Return a composite future, succeeded when any futures is succeeded, failed when all futures are failed.
-     * <p/>
-     * The returned future succeeds as soon as one of {@code f1} or {@code f2} succeeds.
+     * <p>Return a composite future, succeeded when any futures is succeeded, failed when all futures are failed.</p>
+     * <p>The returned future succeeds as soon as one of {@code f1} or {@code f2} succeeds.</p>
      *
      * @param f1 future
      * @param f2 future
@@ -126,9 +124,8 @@ public interface CompositeFuture extends Future<CompositeFuture> {
     }
 
     /**
-     * Return a composite future, succeeded when all futures are succeeded, failed when any future is failed.
-     * <p/>
-     * It always wait until all its futures are completed and will not fail as soon as one of {@code f1} or {@code f2} fails.
+     * <p>Return a composite future, succeeded when all futures are succeeded, failed when any future is failed.</p>
+     * <p>It always wait until all its futures are completed and will not fail as soon as one of {@code f1} or {@code f2} fails.</p>
      *
      * @param f1 future
      * @param f2 future

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/future/Promise.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/future/Promise.java
@@ -51,9 +51,8 @@ public interface Promise<T> extends Handler<AsyncResult<T>> {
     }
 
     /**
-     * Set the result. Any handler will be called, if there is one, and the promise will be marked as completed.
-     * <p/>
-     * Any handler set on the associated promise will be called.
+     * <p>Set the result. Any handler will be called, if there is one, and the promise will be marked as completed.</p>
+     * <p>Any handler set on the associated promise will be called.</p>
      *
      * @param result  the result
      * @throws IllegalStateException when the promise is already completed

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaAuthnHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaAuthnHandler.java
@@ -195,19 +195,19 @@ import io.kroxylicious.proxy.tag.VisibleForTesting;
  * an {@link AuthenticationEvent} to upstream handlers, specifically {@link KafkaProxyFrontendHandler}, to use in
  * deciding how the connection to an upstream connection should be made.</p>
  *
- * @see "<a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=51809888">KIP-12: Kafka Sasl/Kerberos and SSL implementation</a>
+ * @see <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=51809888">KIP-12: Kafka Sasl/Kerberos and SSL implementation</a>
  * added support for Kerberos authentication"
- * @see "<a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-43%3A+Kafka+SASL+enhancements">KIP-43: Kafka SASL enhancements</a>
+ * @see <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-43%3A+Kafka+SASL+enhancements">KIP-43: Kafka SASL enhancements</a>
  * added the SaslHandshake RPC in Kafka 0.10.0.0"
- * @see "<a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-84%3A+Support+SASL+SCRAM+mechanisms">KIP-84: Support SASL SCRAM mechanisms</a>
+ * @see <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-84%3A+Support+SASL+SCRAM+mechanisms">KIP-84: Support SASL SCRAM mechanisms</a>
  * added support for the SCRAM-SHA-256 and SCRAM-SHA-512 mechanisms"
- * @see "<a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-152+-+Improve+diagnostics+for+SASL+authentication+failures">KIP-152: Improve diagnostics for SASL authentication failures</a>
+ * @see <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-152+-+Improve+diagnostics+for+SASL+authentication+failures">KIP-152: Improve diagnostics for SASL authentication failures</a>
  * added support for the SaslAuthenticate RPC (previously the auth bytes were not encapsulated in a Kafka frame"
- * @see "<a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=75968876">KIP-255: OAuth Authentication via SASL/OAUTHBEARER</a>
+ * @see <a href="https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=75968876">KIP-255: OAuth Authentication via SASL/OAUTHBEARER</a>
  * added support for OAUTH authentication"
- * @see "<a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-368%3A+Allow+SASL+Connections+to+Periodically+Re-Authenticate">KIP-365: Allow SASL Connections to Periodically Re-Authenticate</a>
+ * @see <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-368%3A+Allow+SASL+Connections+to+Periodically+Re-Authenticate">KIP-365: Allow SASL Connections to Periodically Re-Authenticate</a>
  * added time-based reauthentication requirements for clients"
- * @see "<a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-684+-+Support+mutual+TLS+authentication+on+SASL_SSL+listeners">KIP-684: Support mTLS authentication on SASL_SSL listeners</a>
+ * @see <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-684+-+Support+mutual+TLS+authentication+on+SASL_SSL+listeners">KIP-684: Support mTLS authentication on SASL_SSL listeners</a>
  * added support for mutual TLS authentication even on SASL_SSL listeners (which was previously ignored)"
  */
 public class KafkaAuthnHandler extends ChannelInboundHandlerAdapter {

--- a/kroxylicious/src/main/templates/Kproxy/Filter.ftl
+++ b/kroxylicious/src/main/templates/Kproxy/Filter.ftl
@@ -44,8 +44,6 @@ public interface ${filterClass} extends KrpcFilter {
      *
      * @param ${msgType} The KRPC message to handle.
      * @param context The context.
-     * @return the {@code ${msgType}} to be passed to the next filter.
-     * If null is returned then the given {@code ${msgType}} will be used.
      */
     public void on${messageSpec.name}(${dataClass} ${msgType}, KrpcFilterContext context);
 

--- a/kroxylicious/src/main/templates/Kproxy/KrpcFilter.ftl
+++ b/kroxylicious/src/main/templates/Kproxy/KrpcFilter.ftl
@@ -41,12 +41,12 @@ import io.kroxylicious.proxy.frame.DecodedResponseFrame;
  * the {@code on*Request} method(s), unless your filter can avoid deserialization in which case
  * you can override {@link #shouldDeserializeRequest(ApiKeys, short)} as well.</p>
  *
- * <h3>Guarantees</h3>
+ * <h2>Guarantees</h2>
  * <p>Implementors of this API may assume the following:</p>
  * <ol>
  *     <li>That each instance of the filter is associated with a single channel</li>
  *     <li>That {@link #shouldDeserializeRequest(ApiKeys, short)} and
- *     {@link #apply(DecodedRequestFrame, KrpcFilterContext)} (or {@code on*Request} as appropriate)
+ *     {@link #onRequest(DecodedRequestFrame, KrpcFilterContext)} (or {@code on*Request} as appropriate)
  *     will always be invoked on the same thread.</li>
  *     <li>That filters are applied in the order they were configured.</li>
  * </ol>
@@ -85,7 +85,6 @@ public /* sealed */ interface KrpcFilter /* TODO permits ... */ {
      * Apply the filter to the given {@code decodedFrame} using the given {@code filterContext}.
      * @param decodedFrame The response frame.
      * @param filterContext The filter context.
-     * @return The state of the filter.
      */
     public default void onResponse(DecodedResponseFrame<?> decodedFrame,
                                    KrpcFilterContext filterContext) {
@@ -112,8 +111,8 @@ public /* sealed */ interface KrpcFilter /* TODO permits ... */ {
      *     <li>{@code shouldDeserializeRequest} on request A</li>
      *     <li>{@code shouldDeserializeRequest} on request B</li>
      *     <li>{@code shouldDeserializeRequest} on request A</li>
-     *     <li>{@code apply} on request A</li>
-     *     <li>{@code apply} on request B</li>
+     *     <li>{@code onRequest} on request A</li>
+     *     <li>{@code onRequest} on request B</li>
      * </ol>
      * @param apiKey The API key
      * @param apiVersion The API version

--- a/krpc-code-gen/src/test/resources/Kproxy/KrpcRequestFilter.ftl
+++ b/krpc-code-gen/src/test/resources/Kproxy/KrpcRequestFilter.ftl
@@ -45,7 +45,7 @@ import io.kroxylicious.proxy.codec.DecodedRequestFrame;
  * <p>When extending {@link KrpcGenericRequestFilter} you need to override {@link #apply(DecodedRequestFrame, KrpcFilterContext)},
  * and may override {@link #shouldDeserializeRequest(ApiKeys, short)} as well.</p>
  *
- * <h3>Guarantees</h3>
+ * <h2>Guarantees</h2>
  * <p>Implementors of this API may assume the following:</p>
  * <ol>
  *     <li>That each instance of the filter is associated with a single channel</li>

--- a/pom.xml
+++ b/pom.xml
@@ -378,6 +378,19 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
                 <version>2.2.2</version>


### PR DESCRIPTION
Also including fixes to the javadoc to enable the JDK tooling to process our docs (still emits a lot of warnings)

Why:
When we release to maven central if we push up `*-javadoc.jar` files then we should have javadoc made available for us on https://javadoc.io This would save us having to check in 8MB of generated javadoc HTML somewhere and deal with updating it, we could link to javadoc.io from our asciidoc.