### PR TITLE
Load Filters reflectively

### DIFF
--- a/integrationtests/src/test/java/io/kroxylicious/proxy/MetricsIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/MetricsIT.java
@@ -44,12 +44,14 @@ public class MetricsIT {
         this.testInfo = testInfo;
         Metrics.globalRegistry.clear();
     }
+
     @AfterEach
     public void teardown() {
-        if(proxy != null){
+        if (proxy != null) {
             try {
                 proxy.shutdown();
-            } catch (InterruptedException e) {
+            }
+            catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
         }

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/PrefixingFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/PrefixingFilter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.MemoryRecordsBuilder;
+import org.apache.kafka.common.record.MutableRecordBatch;
+import org.apache.kafka.common.record.Record;
+import org.apache.kafka.common.record.TimestampType;
+
+import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.ProduceRequestFilter;
+import io.kroxylicious.proxy.internal.filter.FilterConfig;
+import io.kroxylicious.proxy.internal.filter.FilterCreator;
+import io.kroxylicious.proxy.internal.util.NettyMemoryRecords;
+
+public class PrefixingFilter implements ProduceRequestFilter {
+
+    private final String prefix;
+
+    public static class PrefixingConfig extends FilterConfig {
+        private final String prefix;
+
+        public PrefixingConfig(String prefix) {
+            this.prefix = prefix;
+        }
+
+        public String getPrefix() {
+            return prefix;
+        }
+    }
+
+    @FilterCreator
+    public PrefixingFilter(PrefixingConfig config) {
+        this.prefix = config.getPrefix();
+    }
+
+    @Override
+    public void onProduceRequest(ProduceRequestData req, KrpcFilterContext ctx) {
+        req.topicData().forEach(topicData -> {
+            for (ProduceRequestData.PartitionProduceData partitionData : topicData.partitionData()) {
+                MemoryRecords records = (MemoryRecords) partitionData.records();
+                try (MemoryRecordsBuilder newRecords = NettyMemoryRecords.builder(ctx.allocate(records.sizeInBytes()), CompressionType.NONE,
+                        TimestampType.CREATE_TIME, 0)) {
+
+                    for (MutableRecordBatch batch : records.batches()) {
+                        for (Record batchRecord : batch) {
+                            String prefixed = prefix + new String(StandardCharsets.UTF_8.decode(batchRecord.value()).array());
+                            ByteBuffer prefixedBuffer = ByteBuffer.wrap(prefixed.getBytes(StandardCharsets.UTF_8));
+                            newRecords.append(batchRecord.timestamp(), batchRecord.key(), prefixedBuffer);
+                        }
+                    }
+
+                    partitionData.setRecords(newRecords.build());
+                }
+            }
+        });
+        ctx.forwardRequest(req);
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ApiVersionsFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ApiVersionsFilter.java
@@ -21,9 +21,6 @@ public class ApiVersionsFilter implements ApiVersionsResponseFilter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ApiVersionsFilter.class);
 
-    public static class ApiVersionsFilterConfig extends FilterConfig {
-    }
-
     private static void intersectApiVersions(String channel, ApiVersionsResponseData resp) {
         for (var key : resp.apiKeys()) {
             short apiId = key.apiKey();
@@ -37,9 +34,10 @@ public class ApiVersionsFilter implements ApiVersionsResponseFilter {
     /**
      * Update the given {@code key}'s max and min versions so that the client uses APIs versions mutually
      * understood by both the proxy and the broker.
+     *
      * @param channel The channel.
-     * @param key The key data from an upstream API_VERSIONS response.
-     * @param apiKey The proxy's API key for this API.
+     * @param key     The key data from an upstream API_VERSIONS response.
+     * @param apiKey  The proxy's API key for this API.
      */
     private static void intersectApiVersion(String channel, ApiVersionsResponseData.ApiVersion key, ApiKeys apiKey) {
         short mutualMin = (short) Math.max(

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilter.java
@@ -32,9 +32,6 @@ public class BrokerAddressFilter implements MetadataResponseFilter, FindCoordina
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BrokerAddressFilter.class);
 
-    public static class BrokerAddressFilterConfig extends FilterConfig {
-    }
-
     public interface AddressMapping {
         String downstreamHost(String upstreamHost, int upstreamPort);
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BuiltinFilterContributor.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BuiltinFilterContributor.java
@@ -5,45 +5,141 @@
  */
 package io.kroxylicious.proxy.internal.filter;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.kroxylicious.proxy.classloader.ClassloaderUtils;
 import io.kroxylicious.proxy.config.ProxyConfig;
 import io.kroxylicious.proxy.filter.FilterContributor;
 import io.kroxylicious.proxy.filter.KrpcFilter;
-import io.kroxylicious.proxy.internal.filter.ApiVersionsFilter.ApiVersionsFilterConfig;
-import io.kroxylicious.proxy.internal.filter.BrokerAddressFilter.BrokerAddressFilterConfig;
-import io.kroxylicious.proxy.internal.filter.FetchResponseTransformationFilter.FetchResponseTransformationFilterConfig;
-import io.kroxylicious.proxy.internal.filter.ProduceRequestTransformationFilter.ProduceRequestTransformationFilterConfig;
 
 public class BuiltinFilterContributor implements FilterContributor {
 
     @Override
-    public Class<? extends FilterConfig> getConfigType(String shortName) {
-        switch (shortName) {
-            case "ApiVersions":
-                return ApiVersionsFilterConfig.class;
-            case "BrokerAddress":
-                return BrokerAddressFilterConfig.class;
-            case "ProduceRequestTransformation":
-                return ProduceRequestTransformationFilterConfig.class;
-            case "FetchResponseTransformation":
-                return FetchResponseTransformationFilterConfig.class;
-            default:
-                return null;
-        }
+    public Class<? extends FilterConfig> getConfigType(String name) {
+        Optional<Class<? extends KrpcFilter>> clazz = findFilterClass(name);
+        return clazz.map(this::lookupConfigFromClasspath).orElse(null);
     }
 
     @Override
-    public KrpcFilter getFilter(String shortName, ProxyConfig proxyConfig, FilterConfig filterConfig) {
-        switch (shortName) {
+    public KrpcFilter getFilter(String name, ProxyConfig proxyConfig, FilterConfig filterConfig) {
+        Optional<Class<? extends KrpcFilter>> clazz = findFilterClass(name);
+        return clazz.map(aClass -> maybeLoadFilterReflectively(proxyConfig, filterConfig, aClass)).orElse(null);
+    }
+
+    private Optional<Class<? extends KrpcFilter>> findFilterClass(String name) {
+        return builtinClass(name).or(() -> ClassloaderUtils.loadClassIfPresent(KrpcFilter.class, name));
+    }
+
+    public Optional<Class<? extends KrpcFilter>> builtinClass(String name) {
+        switch (name) {
             case "ApiVersions":
-                return new ApiVersionsFilter();
+                return Optional.of(ApiVersionsFilter.class);
             case "BrokerAddress":
-                return new BrokerAddressFilter(proxyConfig);
+                return Optional.of(BrokerAddressFilter.class);
             case "ProduceRequestTransformation":
-                return new ProduceRequestTransformationFilter((ProduceRequestTransformationFilterConfig) filterConfig);
+                return Optional.of(ProduceRequestTransformationFilter.class);
             case "FetchResponseTransformation":
-                return new FetchResponseTransformationFilter((FetchResponseTransformationFilterConfig) filterConfig);
+                return Optional.of(FetchResponseTransformationFilter.class);
             default:
-                return null;
+                return Optional.empty();
         }
     }
+
+    private Class<? extends FilterConfig> lookupConfigFromClasspath(Class<? extends KrpcFilter> clazz) {
+        return maybeGetFilterConfigClassFromConstructor(clazz);
+    }
+
+    private static Class<? extends FilterConfig> maybeGetFilterConfigClassFromConstructor(Class<? extends KrpcFilter> aClass) {
+        Optional<Constructor<? extends KrpcFilter>> maybeConstructor = getFilterConstructor(aClass);
+        Optional<Class<? extends FilterConfig>> aClass1 = maybeConstructor.map(targetConstructor -> {
+            List<Class<?>> filterConfigParams = Arrays.stream(targetConstructor.getParameterTypes()).filter(FilterConfig.class::isAssignableFrom)
+                    .collect(Collectors.toList());
+            if (filterConfigParams.size() > 1) {
+                throw new IllegalArgumentException("constructor " + targetConstructor + " had more than one parameter that was a FilterConfig, expecting zero or one");
+            }
+            if (filterConfigParams.isEmpty()) {
+                // empty config
+                return FilterConfig.class;
+            }
+            else {
+                return filterConfigParams.get(0).asSubclass(FilterConfig.class);
+            }
+        });
+        return aClass1.orElse(null);
+    }
+
+    private static Optional<Constructor<? extends KrpcFilter>> getFilterConstructor(Class<? extends KrpcFilter> aClass) {
+        return getTargetConstructor(aClass).or(() -> getOnlyConstructor(aClass));
+    }
+
+    private static Optional<? extends Constructor<? extends KrpcFilter>> getOnlyConstructor(Class<? extends KrpcFilter> aClass) {
+        Constructor<?>[] constructors = aClass.getConstructors();
+        if (constructors.length != 1) {
+            throw new IllegalArgumentException("more than one constructor found on a class with no FilterCreator annotated constructor");
+        }
+        else {
+            try {
+                return Optional.of(aClass.getConstructor(constructors[0].getParameterTypes()));
+            }
+            catch (NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private KrpcFilter maybeLoadFilterReflectively(ProxyConfig proxyConfig, final FilterConfig filterConfig, Class<? extends KrpcFilter> clazz) {
+        Optional<Constructor<? extends KrpcFilter>> tc = getFilterConstructor(clazz);
+        return tc.map(onlyConstructor -> {
+            Object[] args = createArguments(proxyConfig, filterConfig, onlyConstructor);
+            try {
+                return onlyConstructor.newInstance(args);
+            }
+            catch (InvocationTargetException | InstantiationException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }).orElse(null);
+
+    }
+
+    private static Object[] createArguments(ProxyConfig proxyConfig, FilterConfig filterConfig, Constructor<? extends KrpcFilter> onlyConstructor) {
+        return Arrays.stream(onlyConstructor.getParameterTypes()).map(aClass -> {
+            if (aClass == ProxyConfig.class) {
+                return proxyConfig;
+            }
+            else if (FilterConfig.class.isAssignableFrom(aClass)) {
+                return filterConfig;
+            }
+            else {
+                throw new IllegalArgumentException("cannot handle Filter constructor parameter of type: " + aClass);
+            }
+        }).toArray(Object[]::new);
+    }
+
+    private static Optional<Constructor<? extends KrpcFilter>> getTargetConstructor(Class<? extends KrpcFilter> aClass) {
+        Stream<Constructor<?>> constructorStream = Arrays.stream(aClass.getConstructors())
+                .filter(constructor -> constructor.getAnnotation(FilterCreator.class) != null);
+        List<Constructor<?>> collect = constructorStream.collect(Collectors.toList());
+        if (collect.size() > 1) {
+            throw new IllegalArgumentException("found >1 constructors annotated with FilterCreator on " + aClass.getName());
+        }
+        else if (collect.isEmpty()) {
+            return Optional.empty();
+        }
+        else {
+            try {
+                Constructor<? extends KrpcFilter> constructor = aClass.getConstructor(collect.get(0).getParameterTypes());
+                return Optional.of(constructor);
+            }
+            catch (NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterCreator.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterCreator.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.filter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.CONSTRUCTOR)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface FilterCreator {
+}


### PR DESCRIPTION
With this change you can supply the full classname of a Filter and it will be loaded. The FilterConfig class is inferred from a constructor of the KrpcFilter implementation

To select the constructor of the KrpcFilter implementation we look for:
1. A constructor annotated with FilterCreator
2. The only constructor if none are annotated (includes the implicit 0-arg constructor if you don't define one)

Then, we allow that constructor to contain a single parameter that extends FilterConfig. We select that subclass as the Filter's config class.

When constructing the Filter we then fill in the config parameter, and can also optionally fill the ProxyConfig as an argument. If we find any other parameters of unexpected types we throw an error.

Note that for compatibility we can still refer to the existing builtin filters by a shortname and this is mapped to the matching filter class. So kroxy can make it more readable to load some core filters.

Why:
We want to enable FilterAuthors to use their newly minted filters without having to modify the BuiltinFilterContributor.