### PR TITLE
Correct Intellij license.

### DIFF
--- a/.idea/copyright/Kroxylicious.xml
+++ b/.idea/copyright/Kroxylicious.xml
@@ -1,6 +1,6 @@
 <component name="CopyrightManager">
   <copyright>
-    <option name="notice" value="/*&#10; * Copyright Kroxylicious Authors.&#10; *&#10; * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0&#10; */&#10;&#10;" />
+    <option name="notice" value="Copyright Kroxylicious Authors.&#10;&#10;Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0" />
     <option name="myName" value="Kroxylicious" />
   </copyright>
 </component>


### PR DESCRIPTION
The license body is plain text, the tooling includes the correct comment chars for the type of file being worked.