### PR TITLE
Refactor KrpcFilterContext to offer MemoryRecordsBuilder not netty By…

### DIFF
--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/filter/KrpcFilterContext.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/filter/KrpcFilterContext.java
@@ -8,8 +8,9 @@ package io.kroxylicious.proxy.filter;
 import java.util.concurrent.CompletionStage;
 
 import org.apache.kafka.common.protocol.ApiMessage;
-
-import io.netty.buffer.ByteBuf;
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.record.MemoryRecordsBuilder;
+import org.apache.kafka.common.record.TimestampType;
 
 /**
  * A context to allow filters to interact with other filters and the pipeline.
@@ -21,12 +22,17 @@ public interface KrpcFilterContext {
     String channelDescriptor();
 
     /**
-     * Allocate a ByteBuffer of the given capacity.
-     * The buffer will be deallocated when the request processing is completed
-     * @param initialCapacity The initial capacity of the buffer.
-     * @return The allocated buffer
+     * Creates a MemoryRecordsBuilder of the given capacity.
+     * @param initialCapacity The initial capacity of the backing buffer in bytes.
+     * @param compressionType The compression type.
+     * @param timestampType The timestamp type.
+     * @param baseOffset The bash offset.
+     * @return The created MemoryRecordsBuilder
      */
-    ByteBuf allocate(int initialCapacity);
+    MemoryRecordsBuilder memoryRecordsBuilder(int initialCapacity,
+                                              CompressionType compressionType,
+                                              TimestampType timestampType,
+                                              long baseOffset);
 
     /**
      * @return the SNI hostname provided by the client.  Will be null if the client is

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FetchResponseTransformationFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FetchResponseTransformationFilter.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 import io.kroxylicious.proxy.filter.FetchResponseFilter;
 import io.kroxylicious.proxy.filter.KrpcFilterContext;
 import io.kroxylicious.proxy.future.Future;
-import io.kroxylicious.proxy.internal.util.NettyMemoryRecords;
 
 /**
  * An filter for modifying the key/value/header/topic of {@link ApiKeys#FETCH} responses.
@@ -107,7 +106,7 @@ public class FetchResponseTransformationFilter implements FetchResponseFilter {
         for (FetchableTopicResponse topicData : responseData.responses()) {
             for (PartitionData partitionData : topicData.partitions()) {
                 MemoryRecords records = (MemoryRecords) partitionData.records();
-                MemoryRecordsBuilder newRecords = NettyMemoryRecords.builder(context.allocate(records.sizeInBytes()), CompressionType.NONE,
+                MemoryRecordsBuilder newRecords = context.memoryRecordsBuilder(records.sizeInBytes(), CompressionType.NONE,
                         TimestampType.CREATE_TIME, 0);
 
                 for (MutableRecordBatch batch : records.batches()) {

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ProduceRequestTransformationFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ProduceRequestTransformationFilter.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.record.TimestampType;
 
 import io.kroxylicious.proxy.filter.KrpcFilterContext;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
-import io.kroxylicious.proxy.internal.util.NettyMemoryRecords;
 
 /**
  * An filter for modifying the key/value/header/topic of {@link ApiKeys#PRODUCE} requests.
@@ -77,7 +76,7 @@ public class ProduceRequestTransformationFilter implements ProduceRequestFilter 
         req.topicData().forEach(topicData -> {
             for (PartitionProduceData partitionData : topicData.partitionData()) {
                 MemoryRecords records = (MemoryRecords) partitionData.records();
-                MemoryRecordsBuilder newRecords = NettyMemoryRecords.builder(ctx.allocate(records.sizeInBytes()), CompressionType.NONE,
+                MemoryRecordsBuilder newRecords = ctx.memoryRecordsBuilder(records.sizeInBytes(), CompressionType.NONE,
                         TimestampType.CREATE_TIME, 0);
 
                 for (MutableRecordBatch batch : records.batches()) {


### PR DESCRIPTION
…teBuf

Why:
We are working towards extracting a filter-api to enable Filter Authors to write custom filters. We want to remove the netty dependency from this API.