### PR TITLE
refactor to introduce a generic Contributor interface

### DIFF
--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/config/BaseConfig.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/config/BaseConfig.java
@@ -3,13 +3,18 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.kroxylicious.proxy.internal.filter;
+package io.kroxylicious.proxy.config;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 /**
- * Base class for all filter-specific configuration types.
+ * <p>
+ * Base class for all configuration types. Users ar able to create arbitrary jackson
+ * deserializable config classes that can be integrated With the Kroxylicious configuration file.
+ * </p>
+ * <p>
  * Subclasses should be immutable and have a constructor annotated with {@link JsonCreator}.
+ * </p>
  */
-public class FilterConfig {
+public class BaseConfig {
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/config/FilterDefinition.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/config/FilterDefinition.java
@@ -9,16 +9,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 
-import io.kroxylicious.proxy.internal.filter.FilterConfig;
-
 public class FilterDefinition {
 
     private final String type;
-    private final FilterConfig config;
+    private final BaseConfig config;
 
     @JsonCreator
     public FilterDefinition(String type,
-                            @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "type") @JsonTypeIdResolver(FilterConfigTypeIdResolver.class) FilterConfig config) {
+                            @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "type") @JsonTypeIdResolver(FilterConfigTypeIdResolver.class) BaseConfig config) {
         this.type = type;
         this.config = config;
     }
@@ -27,7 +25,7 @@ public class FilterDefinition {
         return type;
     }
 
-    public FilterConfig config() {
+    public BaseConfig config() {
         return config;
     }
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/filter/FilterContributor.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/filter/FilterContributor.java
@@ -5,12 +5,7 @@
  */
 package io.kroxylicious.proxy.filter;
 
-import io.kroxylicious.proxy.config.ProxyConfig;
-import io.kroxylicious.proxy.internal.filter.FilterConfig;
+import io.kroxylicious.proxy.service.Contributor;
 
-public interface FilterContributor {
-
-    Class<? extends FilterConfig> getConfigType(String shortName);
-
-    KrpcFilter getFilter(String shortName, ProxyConfig proxyConfig, FilterConfig filterConfig);
+public interface FilterContributor extends Contributor<KrpcFilter> {
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilter.java
@@ -50,7 +50,6 @@ import io.kroxylicious.proxy.filter.OffsetForLeaderEpochRequestFilter;
 import io.kroxylicious.proxy.filter.OffsetForLeaderEpochResponseFilter;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
 import io.kroxylicious.proxy.filter.ProduceResponseFilter;
-import io.kroxylicious.proxy.internal.filter.FilterConfig;
 
 /**
  * Simple multi-tenant filter.
@@ -72,10 +71,6 @@ public class MultiTenantTransformationFilter
         OffsetFetchRequestFilter, OffsetFetchResponseFilter,
         OffsetCommitRequestFilter, OffsetCommitResponseFilter,
         OffsetForLeaderEpochRequestFilter, OffsetForLeaderEpochResponseFilter {
-
-    public static class MultiTenantTransformationFilterConfig extends FilterConfig {
-    }
-
     private static final Logger LOGGER = LoggerFactory.getLogger(MultiTenantTransformationFilter.class);
 
     @Override

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ApiVersionsFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ApiVersionsFilter.java
@@ -22,9 +22,6 @@ public class ApiVersionsFilter implements ApiVersionsResponseFilter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ApiVersionsFilter.class);
 
-    public static class ApiVersionsFilterConfig extends FilterConfig {
-    }
-
     private static void intersectApiVersions(String channel, ApiVersionsResponseData resp) {
         for (var key : resp.apiKeys()) {
             short apiId = key.apiKey();

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilter.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.message.ResponseHeaderData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.kroxylicious.proxy.config.BaseConfig;
 import io.kroxylicious.proxy.config.ProxyConfig;
 import io.kroxylicious.proxy.filter.DescribeClusterResponseFilter;
 import io.kroxylicious.proxy.filter.FindCoordinatorResponseFilter;
@@ -34,11 +35,11 @@ public class BrokerAddressFilter implements MetadataResponseFilter, FindCoordina
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BrokerAddressFilter.class);
 
-    public static class BrokerAddressFilterConfig extends FilterConfig {
+    public static class BrokerAddressConfig extends BaseConfig {
 
         private final Class<? extends AddressMapping> addressMapperClazz;
 
-        public BrokerAddressFilterConfig(String addressMapper) {
+        public BrokerAddressConfig(String addressMapper) {
             try {
                 this.addressMapperClazz = addressMapper == null ? null : (Class<? extends AddressMapping>) Class.forName(addressMapper);
                 ;
@@ -55,7 +56,7 @@ public class BrokerAddressFilter implements MetadataResponseFilter, FindCoordina
 
     private final AddressMapping mapping;
 
-    public BrokerAddressFilter(ProxyConfig all, BrokerAddressFilterConfig config) {
+    public BrokerAddressFilter(ProxyConfig all, BrokerAddressConfig config) {
 
         try {
             this.mapping = config == null || config.addressMapperClazz == null ? new FixedAddressMapping(all)

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BuiltinFilterContributor.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BuiltinFilterContributor.java
@@ -5,51 +5,24 @@
  */
 package io.kroxylicious.proxy.internal.filter;
 
-import io.kroxylicious.proxy.config.ProxyConfig;
 import io.kroxylicious.proxy.filter.FilterContributor;
 import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.filter.multitenant.MultiTenantTransformationFilter;
-import io.kroxylicious.proxy.filter.multitenant.MultiTenantTransformationFilter.MultiTenantTransformationFilterConfig;
-import io.kroxylicious.proxy.internal.filter.ApiVersionsFilter.ApiVersionsFilterConfig;
-import io.kroxylicious.proxy.internal.filter.BrokerAddressFilter.BrokerAddressFilterConfig;
-import io.kroxylicious.proxy.internal.filter.FetchResponseTransformationFilter.FetchResponseTransformationFilterConfig;
-import io.kroxylicious.proxy.internal.filter.ProduceRequestTransformationFilter.ProduceRequestTransformationFilterConfig;
+import io.kroxylicious.proxy.internal.filter.BrokerAddressFilter.BrokerAddressConfig;
+import io.kroxylicious.proxy.internal.filter.FetchResponseTransformationFilter.FetchResponseTransformationConfig;
+import io.kroxylicious.proxy.internal.filter.ProduceRequestTransformationFilter.ProduceRequestTransformationConfig;
+import io.kroxylicious.proxy.service.BaseContributor;
 
-public class BuiltinFilterContributor implements FilterContributor {
+public class BuiltinFilterContributor extends BaseContributor<KrpcFilter> implements FilterContributor {
 
-    @Override
-    public Class<? extends FilterConfig> getConfigType(String shortName) {
-        switch (shortName) {
-            case "ApiVersions":
-                return ApiVersionsFilterConfig.class;
-            case "BrokerAddress":
-                return BrokerAddressFilterConfig.class;
-            case "ProduceRequestTransformation":
-                return ProduceRequestTransformationFilterConfig.class;
-            case "FetchResponseTransformation":
-                return FetchResponseTransformationFilterConfig.class;
-            case "MultiTenant":
-                return MultiTenantTransformationFilterConfig.class;
-            default:
-                return null;
-        }
-    }
+    public static final BaseContributorBuilder<KrpcFilter> FILTERS = BaseContributor.<KrpcFilter> builder()
+            .add("ApiVersions", ApiVersionsFilter::new)
+            .add("BrokerAddress", BrokerAddressConfig.class, BrokerAddressFilter::new)
+            .add("ProduceRequestTransformation", ProduceRequestTransformationConfig.class, ProduceRequestTransformationFilter::new)
+            .add("FetchResponseTransformation", FetchResponseTransformationConfig.class, FetchResponseTransformationFilter::new)
+            .add("MultiTenant", MultiTenantTransformationFilter::new);
 
-    @Override
-    public KrpcFilter getFilter(String shortName, ProxyConfig proxyConfig, FilterConfig filterConfig) {
-        switch (shortName) {
-            case "ApiVersions":
-                return new ApiVersionsFilter();
-            case "BrokerAddress":
-                return new BrokerAddressFilter(proxyConfig, ((BrokerAddressFilterConfig) filterConfig));
-            case "ProduceRequestTransformation":
-                return new ProduceRequestTransformationFilter((ProduceRequestTransformationFilterConfig) filterConfig);
-            case "FetchResponseTransformation":
-                return new FetchResponseTransformationFilter((FetchResponseTransformationFilterConfig) filterConfig);
-            case "MultiTenant":
-                return new MultiTenantTransformationFilter();
-            default:
-                return null;
-        }
+    public BuiltinFilterContributor() {
+        super(FILTERS);
     }
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FetchResponseTransformationFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FetchResponseTransformationFilter.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.record.TimestampType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.kroxylicious.proxy.config.BaseConfig;
 import io.kroxylicious.proxy.filter.FetchResponseFilter;
 import io.kroxylicious.proxy.filter.KrpcFilterContext;
 import io.kroxylicious.proxy.future.Future;
@@ -38,11 +39,11 @@ import io.kroxylicious.proxy.internal.util.NettyMemoryRecords;
  */
 public class FetchResponseTransformationFilter implements FetchResponseFilter {
 
-    public static class FetchResponseTransformationFilterConfig extends FilterConfig {
+    public static class FetchResponseTransformationConfig extends BaseConfig {
 
         private final String transformation;
 
-        public FetchResponseTransformationFilterConfig(String transformation) {
+        public FetchResponseTransformationConfig(String transformation) {
             this.transformation = transformation;
         }
 
@@ -60,7 +61,7 @@ public class FetchResponseTransformationFilter implements FetchResponseFilter {
 
     // TODO: add transformation support for key/header/topic
 
-    public FetchResponseTransformationFilter(FetchResponseTransformationFilterConfig config) {
+    public FetchResponseTransformationFilter(FetchResponseTransformationConfig config) {
         try {
             this.valueTransformation = (ByteBufferTransformation) Class.forName(config.transformation()).getConstructor().newInstance();
         }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterContributorManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterContributorManager.java
@@ -8,6 +8,7 @@ package io.kroxylicious.proxy.internal.filter;
 import java.util.Iterator;
 import java.util.ServiceLoader;
 
+import io.kroxylicious.proxy.config.BaseConfig;
 import io.kroxylicious.proxy.config.ProxyConfig;
 import io.kroxylicious.proxy.filter.FilterContributor;
 import io.kroxylicious.proxy.filter.KrpcFilter;
@@ -26,11 +27,11 @@ public class FilterContributorManager {
         return INSTANCE;
     }
 
-    public Class<? extends FilterConfig> getConfigType(String shortName) {
+    public Class<? extends BaseConfig> getConfigType(String shortName) {
         Iterator<FilterContributor> it = contributors.iterator();
         while (it.hasNext()) {
             FilterContributor contributor = it.next();
-            Class<? extends FilterConfig> configType = contributor.getConfigType(shortName);
+            Class<? extends BaseConfig> configType = contributor.getConfigType(shortName);
             if (configType != null) {
                 return configType;
             }
@@ -39,11 +40,11 @@ public class FilterContributorManager {
         throw new IllegalArgumentException("No filter found for name '" + shortName + "'");
     }
 
-    public KrpcFilter getFilter(String shortName, ProxyConfig proxyConfig, FilterConfig filterConfig) {
+    public KrpcFilter getFilter(String shortName, ProxyConfig proxyConfig, BaseConfig filterConfig) {
         Iterator<FilterContributor> it = contributors.iterator();
         while (it.hasNext()) {
             FilterContributor contributor = it.next();
-            KrpcFilter filter = contributor.getFilter(shortName, proxyConfig, filterConfig);
+            KrpcFilter filter = contributor.getInstance(shortName, proxyConfig, filterConfig);
             if (filter != null) {
                 return filter;
             }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ProduceRequestTransformationFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ProduceRequestTransformationFilter.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.record.MutableRecordBatch;
 import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.record.TimestampType;
 
+import io.kroxylicious.proxy.config.BaseConfig;
 import io.kroxylicious.proxy.filter.KrpcFilterContext;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
 import io.kroxylicious.proxy.internal.util.NettyMemoryRecords;
@@ -38,11 +39,11 @@ public class ProduceRequestTransformationFilter implements ProduceRequestFilter 
         }
     }
 
-    public static class ProduceRequestTransformationFilterConfig extends FilterConfig {
+    public static class ProduceRequestTransformationConfig extends BaseConfig {
 
         private final String transformation;
 
-        public ProduceRequestTransformationFilterConfig(String transformation) {
+        public ProduceRequestTransformationConfig(String transformation) {
             this.transformation = transformation;
         }
 
@@ -58,7 +59,7 @@ public class ProduceRequestTransformationFilter implements ProduceRequestFilter 
 
     // TODO: add transformation support for key/header/topic
 
-    public ProduceRequestTransformationFilter(ProduceRequestTransformationFilterConfig config) {
+    public ProduceRequestTransformationFilter(ProduceRequestTransformationConfig config) {
         try {
             this.valueTransformation = (ByteBufferTransformation) Class.forName(config.transformation()).getConstructor().newInstance();
         }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.config.ProxyConfig;
+
+/**
+ * A convenience base class for creating concrete contributor subclasses using a typesafe builder
+ */
+public abstract class BaseContributor<L> implements Contributor<L> {
+
+    private final Map<String, InstanceBuilder<? extends BaseConfig, L>> shortNameToInstanceBuilder;
+
+    public BaseContributor(BaseContributorBuilder<L> builder) {
+        shortNameToInstanceBuilder = builder.build();
+    }
+
+    @Override
+    public Class<? extends BaseConfig> getConfigType(String shortName) {
+        InstanceBuilder<?, L> instanceBuilder = shortNameToInstanceBuilder.get(shortName);
+        return instanceBuilder == null ? null : instanceBuilder.configClass;
+    }
+
+    @Override
+    public L getInstance(String shortName, ProxyConfig proxyConfig, BaseConfig config) {
+        InstanceBuilder<? extends BaseConfig, L> instanceBuilder = shortNameToInstanceBuilder.get(shortName);
+        return instanceBuilder == null ? null : instanceBuilder.construct(proxyConfig, config);
+    }
+
+    private static class InstanceBuilder<T extends BaseConfig, L> {
+
+        private final Class<T> configClass;
+        private final BiFunction<ProxyConfig, T, L> instanceFunction;
+
+        public InstanceBuilder(Class<T> configClass, BiFunction<ProxyConfig, T, L> instanceFunction) {
+            this.configClass = configClass;
+            this.instanceFunction = instanceFunction;
+        }
+
+        L construct(ProxyConfig proxyConfig, BaseConfig config) {
+            if (config == null) {
+                // tests pass in a null config, which some instance functions can tolerate
+                return instanceFunction.apply(proxyConfig, null);
+            }
+            else if (configClass.isAssignableFrom(config.getClass())) {
+                return instanceFunction.apply(proxyConfig, configClass.cast(config));
+            }
+            else {
+                throw new IllegalArgumentException("config has the wrong type, expected "
+                        + configClass.getName() + ", got " + config.getClass().getName());
+            }
+        }
+    }
+
+    public static class BaseContributorBuilder<L> {
+
+        private BaseContributorBuilder() {
+        }
+
+        private final Map<String, InstanceBuilder<?, L>> shortNameToInstanceBuilder = new HashMap<>();
+
+        public <T extends BaseConfig> BaseContributorBuilder<L> add(String shortName, Class<T> configClass, BiFunction<ProxyConfig, T, L> instanceFunction) {
+            if (shortNameToInstanceBuilder.containsKey(shortName)) {
+                throw new IllegalArgumentException(shortName + " already registered");
+            }
+            shortNameToInstanceBuilder.put(shortName, new InstanceBuilder<>(configClass, instanceFunction));
+            return this;
+        }
+
+        public BaseContributorBuilder<L> add(String shortName, Function<ProxyConfig, L> instanceFunction) {
+            add(shortName, BaseConfig.class, (proxyConfig, config) -> instanceFunction.apply(proxyConfig));
+            return this;
+        }
+
+        public <T extends BaseConfig> BaseContributorBuilder<L> add(String shortName, Class<T> configClass, Function<T, L> instanceFunction) {
+            add(shortName, configClass, (proxyConfig, config) -> instanceFunction.apply(config));
+            return this;
+        }
+
+        public BaseContributorBuilder<L> add(String shortName, Supplier<L> instanceFunction) {
+            add(shortName, BaseConfig.class, (proxyConfig, config) -> instanceFunction.get());
+            return this;
+        }
+
+        public Map<String, InstanceBuilder<?, L>> build() {
+            return Map.copyOf(shortNameToInstanceBuilder);
+        }
+    }
+
+    public static <L> BaseContributorBuilder<L> builder() {
+        return new BaseContributorBuilder<>();
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/service/Contributor.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/service/Contributor.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.service;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.config.ProxyConfig;
+
+/**
+ * Support loading an Instance of a service, optionally providing it with configuration obtained
+ * from the Kroxylicious configuration file.
+ */
+public interface Contributor<T> {
+
+    Class<? extends BaseConfig> getConfigType(String shortName);
+
+    T getInstance(String shortName, ProxyConfig proxyConfig, BaseConfig config);
+}


### PR DESCRIPTION
Why:
We want to re-use the contributor mechanism to load other services that require some configuration from the Kroxy YAML. This change paves the way for further `Contributor` sub-interfaces and adds a `BaseContributor` abstract class that gives users a type-safe way to create their concrete contributor.

Spun off of https://github.com/kroxylicious/kroxylicious/pull/138