### PR TITLE
Remove CNAME

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-kroxylicious.io


### PR DESCRIPTION
Why:
The domains have been sorted by naming the kroxylicious organisation repository <orgname>.github.io per the docs. Now all the repositories pick up the custom domain. Adding a CNAME here causes a potential conflict.