### PR TITLE
Refactor KrpcFilterContext to offer ByteBufferOutputStream not netty …

### DIFF
--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/filter/KrpcFilterContext.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/filter/KrpcFilterContext.java
@@ -8,8 +8,7 @@ package io.kroxylicious.proxy.filter;
 import java.util.concurrent.CompletionStage;
 
 import org.apache.kafka.common.protocol.ApiMessage;
-
-import io.netty.buffer.ByteBuf;
+import org.apache.kafka.common.utils.ByteBufferOutputStream;
 
 /**
  * A context to allow filters to interact with other filters and the pipeline.
@@ -21,12 +20,12 @@ public interface KrpcFilterContext {
     String channelDescriptor();
 
     /**
-     * Allocate a ByteBuffer of the given capacity.
-     * The buffer will be deallocated when the request processing is completed
+     * Create a ByteBufferOutputStream of the given capacity.
+     * The backing buffer will be deallocated when the request processing is completed
      * @param initialCapacity The initial capacity of the buffer.
-     * @return The allocated buffer
+     * @return The allocated ByteBufferOutputStream
      */
-    ByteBuf allocate(int initialCapacity);
+    ByteBufferOutputStream createByteBufferOutputStream(int initialCapacity);
 
     /**
      * @return the SNI hostname provided by the client.  Will be null if the client is

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/DefaultFilterContext.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/DefaultFilterContext.java
@@ -13,6 +13,7 @@ import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +25,7 @@ import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.filter.KrpcFilterContext;
 import io.kroxylicious.proxy.frame.DecodedFrame;
 import io.kroxylicious.proxy.future.Promise;
+import io.kroxylicious.proxy.internal.util.ByteBufOutputStream;
 
 /**
  * Implementation of {@link KrpcFilterContext}.
@@ -63,18 +65,16 @@ class DefaultFilterContext implements KrpcFilterContext {
     }
 
     /**
-     * Allocate a buffer with the given {@code initialCapacity}.
-     * The returned buffer will be released automatically
-     * TODO when?
+     * Create a ByteBufferOutputStream of the given capacity.
+     * The backing buffer will be deallocated when the request processing is completed
      * @param initialCapacity The initial capacity of the buffer.
-     * @return The allocated buffer.
+     * @return The allocated ByteBufferOutputStream
      */
     @Override
-    public ByteBuf allocate(int initialCapacity) {
+    public ByteBufferOutputStream createByteBufferOutputStream(int initialCapacity) {
         final ByteBuf buffer = channelContext.alloc().heapBuffer(initialCapacity);
         decodedFrame.add(buffer);
-
-        return buffer;
+        return new ByteBufOutputStream(buffer);
     }
 
     @Override

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FetchResponseTransformationFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FetchResponseTransformationFilter.java
@@ -32,7 +32,7 @@ import io.kroxylicious.proxy.config.BaseConfig;
 import io.kroxylicious.proxy.filter.FetchResponseFilter;
 import io.kroxylicious.proxy.filter.KrpcFilterContext;
 import io.kroxylicious.proxy.future.Future;
-import io.kroxylicious.proxy.internal.util.NettyMemoryRecords;
+import io.kroxylicious.proxy.internal.util.MemoryRecordsHelper;
 
 /**
  * An filter for modifying the key/value/header/topic of {@link ApiKeys#FETCH} responses.
@@ -109,7 +109,7 @@ public class FetchResponseTransformationFilter implements FetchResponseFilter {
         for (FetchableTopicResponse topicData : responseData.responses()) {
             for (PartitionData partitionData : topicData.partitions()) {
                 MemoryRecords records = (MemoryRecords) partitionData.records();
-                MemoryRecordsBuilder newRecords = NettyMemoryRecords.builder(context.allocate(records.sizeInBytes()), CompressionType.NONE,
+                MemoryRecordsBuilder newRecords = MemoryRecordsHelper.builder(context.createByteBufferOutputStream(records.sizeInBytes()), CompressionType.NONE,
                         TimestampType.CREATE_TIME, 0);
 
                 for (MutableRecordBatch batch : records.batches()) {

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ProduceRequestTransformationFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ProduceRequestTransformationFilter.java
@@ -24,7 +24,7 @@ import org.apache.kafka.common.record.TimestampType;
 import io.kroxylicious.proxy.config.BaseConfig;
 import io.kroxylicious.proxy.filter.KrpcFilterContext;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
-import io.kroxylicious.proxy.internal.util.NettyMemoryRecords;
+import io.kroxylicious.proxy.internal.util.MemoryRecordsHelper;
 
 /**
  * An filter for modifying the key/value/header/topic of {@link ApiKeys#PRODUCE} requests.
@@ -79,7 +79,7 @@ public class ProduceRequestTransformationFilter implements ProduceRequestFilter 
         req.topicData().forEach(topicData -> {
             for (PartitionProduceData partitionData : topicData.partitionData()) {
                 MemoryRecords records = (MemoryRecords) partitionData.records();
-                MemoryRecordsBuilder newRecords = NettyMemoryRecords.builder(ctx.allocate(records.sizeInBytes()), CompressionType.NONE,
+                MemoryRecordsBuilder newRecords = MemoryRecordsHelper.builder(ctx.createByteBufferOutputStream(records.sizeInBytes()), CompressionType.NONE,
                         TimestampType.CREATE_TIME, 0);
 
                 for (MutableRecordBatch batch : records.batches()) {

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/util/ByteBufOutputStream.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/util/ByteBufOutputStream.java
@@ -14,7 +14,7 @@ import io.netty.buffer.ByteBuf;
 /**
  * This class has been introduced as a work-around to allow using pooled {@link ByteBuf} instances
  * that are allowed to grow on demand while used on {@link org.apache.kafka.common.record.MemoryRecordsBuilder}
- * to create records (using {@link NettyMemoryRecords} factory methods).<br>
+ * to create records (using {@link MemoryRecordsHelper} factory methods).<br>
  */
 public class ByteBufOutputStream extends ByteBufferOutputStream {
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/util/MemoryRecordsHelper.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/util/MemoryRecordsHelper.java
@@ -9,31 +9,23 @@ import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.MemoryRecordsBuilder;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.TimestampType;
-
-import io.netty.buffer.ByteBuf;
+import org.apache.kafka.common.utils.ByteBufferOutputStream;
 
 /**
  * This is introduces additional factory builder methods then {@link org.apache.kafka.common.record.MemoryRecords#builder} ones,
  * in order to use {@link ByteBufOutputStream}<br>
  *
  */
-public class NettyMemoryRecords {
+public class MemoryRecordsHelper {
 
-    public static MemoryRecordsBuilder builder(ByteBuf buffer,
+    public static MemoryRecordsBuilder builder(ByteBufferOutputStream stream,
                                                CompressionType compressionType,
                                                TimestampType timestampType,
                                                long baseOffset) {
-        return builder(new ByteBufOutputStream(buffer), RecordBatch.CURRENT_MAGIC_VALUE, compressionType, timestampType, baseOffset);
-    }
-
-    private static MemoryRecordsBuilder builder(ByteBufOutputStream stream,
-                                                CompressionType compressionType,
-                                                TimestampType timestampType,
-                                                long baseOffset) {
         return builder(stream, RecordBatch.CURRENT_MAGIC_VALUE, compressionType, timestampType, baseOffset);
     }
 
-    private static MemoryRecordsBuilder builder(ByteBufOutputStream stream,
+    private static MemoryRecordsBuilder builder(ByteBufferOutputStream stream,
                                                 byte magic,
                                                 CompressionType compressionType,
                                                 TimestampType timestampType,
@@ -46,7 +38,7 @@ public class NettyMemoryRecords {
                 RecordBatch.NO_PARTITION_LEADER_EPOCH);
     }
 
-    private static MemoryRecordsBuilder builder(ByteBufOutputStream stream,
+    private static MemoryRecordsBuilder builder(ByteBufferOutputStream stream,
                                                 byte magic,
                                                 CompressionType compressionType,
                                                 TimestampType timestampType,
@@ -61,7 +53,7 @@ public class NettyMemoryRecords {
                 logAppendTime, producerId, producerEpoch, baseSequence, isTransactional, false, partitionLeaderEpoch);
     }
 
-    private static MemoryRecordsBuilder builder(ByteBufOutputStream stream,
+    private static MemoryRecordsBuilder builder(ByteBufferOutputStream stream,
                                                 byte magic,
                                                 CompressionType compressionType,
                                                 TimestampType timestampType,


### PR DESCRIPTION
…ByteBuf

Why:
We are working towards extracting a filter-api to enable Filter Authors to write custom filters. We want to remove the netty dependency from this API.

This is an alternative to #145

The MemoryRecordsBuilder has quite a large primary constructor, it felt wrong to expose only some of the paramters of it as we'd then have to update the public KrpcFilterContext if we wanted to pass through more args. With this change we make the context return a kafka ByteBufferOutputStream that can then be used by the kroxy internals to build the MemoryRecordsBuilder however it wants.