### PR TITLE
Fix maven warnings related to license and test properties.

### DIFF
--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -105,9 +105,9 @@
                         <!-- https://github.com/containers/podman/issues/7927#issuecomment-731525556 - required for testcontainers/podman support -->
                         <TESTCONTAINERS_RYUK_DISABLED>true</TESTCONTAINERS_RYUK_DISABLED>
                     </environmentVariables>
-                    <systemProperties>
+                    <systemPropertyVariables>
                         <container.logs.dir>${project.build.directory}/container-logs/</container.logs.dir>
-                    </systemProperties>
+                    </systemPropertyVariables>
                     <runOrder>random</runOrder>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -221,15 +221,21 @@
                     <version>4.1</version>
                     <configuration>
                         <!--suppress MavenModelInspection -->
-                        <header>${rootdir}/etc/license.txt</header>
                         <strictCheck>true</strictCheck>
-                        <excludes>
-                            <exclude>LICENSE.txt</exclude>
-                            <exclude>**/.dontdelete</exclude>
-                            <!-- Need to keep original copyright for Vert.x classes -->
-                            <exclude>src/main/java/io/kroxylicious/proxy/future/**</exclude>
-                            <exclude>src/main/java/io/kroxylicious/proxy/internal/future/**</exclude>
-                        </excludes>
+                        <licenseSets>
+                            <licenseSet>
+                                <header>${rootdir}/etc/license.txt</header>
+                                <excludes>
+                                    <exclude>LICENSE.txt</exclude>
+                                    <exclude>**/.dontdelete</exclude>
+                                    <exclude>docs/**</exclude>
+                                    <!-- Need to keep original copyright for Vert.x classes -->
+                                    <exclude>src/main/java/io/kroxylicious/proxy/future/**</exclude>
+                                    <exclude>src/main/java/io/kroxylicious/proxy/internal/future/**</exclude>
+                                    <exclude>**/.dontdelete</exclude>
+                                </excludes>
+                            </licenseSet>
+                        </licenseSets>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Fixes: 

```
[WARNING] Parameter 'systemProperties' is deprecated: Use systemPropertyVariables instead.
[WARNING] Parameter 'legacyConfigExcludes' (user property 'license.excludes') is deprecated: use {@link LicenseSet#excludes}
[WARNING] Parameter 'legacyConfigHeader' (user property 'license.header') is deprecated: use {@link LicenseSet#header}[WARNING] Unknown file extension: /Users/kwall/src/kroxylicious/docs/index.adoc
```