### PR TITLE
Change performance tests results branch to performance-results

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -88,7 +88,7 @@ jobs:
           name: kafka producer perf test Benchmark
           tool: 'customSmallerIsBetter'
           output-file-path: output.json
-          gh-pages-branch: gh-pages
+          gh-pages-branch: performance-results
           benchmark-data-dir-path: .benchmark
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
@@ -155,7 +155,7 @@ jobs:
           name: kafka producer perf test Benchmark
           tool: 'customSmallerIsBetter'
           output-file-path: output.json
-          gh-pages-branch: gh-pages
+          gh-pages-branch: performance-results
           benchmark-data-dir-path: .benchmark
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true


### PR DESCRIPTION
### Type of change
- Bugfix

### Description

Change the performance test output branch to performance-results instead of gh-pages

### Additional Context

_Why are you making this pull request?_

Performance benchmark results are wiped from the gh-pages branch by the asciidoc
action when commits are pushed to main. The asciidoctor-ghpages-action action
rebases the branch down to a single commit and blows away other changes. So commits
from the performance tests are lost.

By writing to the performance-results branch we will keep historical results but the
nice graphs won't be available in github pages. We can check them out locally to view
them.

Closes #177
