### PR TITLE
Support running performance tests against a PR originating from a Fork

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -32,13 +32,10 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: xt0rted/pull-request-comment-branch@v1
-        id: comment-branch
-
       - name: 'Check out repository'
         uses: actions/checkout@v3
         with:
-          ref: ${{ steps.comment-branch.outputs.head_ref }}
+          ref: refs/pull/${{ github.event.issue.number }}/head
           submodules: 'true'
 
       - name: 'Set up Java'


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Changes the performance test workflow on PR comment to checkout a PR ref so that it works with PRs from Forks. Fixes #182

### Additional Context

Currently the action fails if you comment `/perf` on a PR from a remote fork because the checkout action can't checkout the ref we get from the pull-request-comment-branch action. It tries to checkout the branch from `origin` where it doesn't exist. Luckily github creates refs for the PR head locally that we can use in our checkout.

https://www.jvt.me/posts/2019/01/19/git-ref-github-pull-requests

github creates two refs in the base repository for each PR: 
refs/pull/123/head
refs/pull/123/merge

We can checkout refs/pull/123/head instead of using the github API to lookup the ref associated with the PR

Solution found via https://github.com/actions/checkout/issues/331#issuecomment-1438220926 :heart: 
