### PR TITLE
Use java 19 everywhere

### DIFF
--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -19,10 +19,6 @@
     <artifactId>integrationtests</artifactId>
     <description>Integration tests where Kroxylicious is tested end-to-end with a real Kafka cluster.</description>
 
-    <properties>
-        <java.version>19</java.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>io.kroxylicious</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>19</java.version>
         <java.test.version>19</java.test.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven.compiler.release>${java.version}</maven.compiler.release>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Use java 19 as target and language level.

### Additional Context

Software currency. We know there is some performance issue with netty 4 and JDK 17, this PR is to test the waters and see if there is anything that leaps out in our performance benchmark.