### PR TITLE
Always execute maven plugin to calculate rootdir

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -398,6 +398,22 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.commonjava.maven.plugins</groupId>
+                <artifactId>directory-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>resolve-rootdir</id>
+                        <goals>
+                            <goal>highest-basedir</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                        <configuration>
+                            <property>rootdir</property>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -502,22 +518,6 @@
                                              <phases>clean,deploy,site</phases>
                                         </requirePluginVersions>
                                     </rules>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.commonjava.maven.plugins</groupId>
-                        <artifactId>directory-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>resolve-rootdir</id>
-                                <goals>
-                                    <goal>highest-basedir</goal>
-                                </goals>
-                                <phase>initialize</phase>
-                                <configuration>
-                                    <property>rootdir</property>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION


### Type of change

- Bugfix

### Description

Always execute maven plugin to calculate rootdir

### Additional Context

When running `mvn clean verify -Dquick` the rootdir resolver plugin was excluded due to the `quick` property but the `formatter` plugin config depends on `rootdir` being made available.

This prevented performance tests running as it uses `mvn -B clean verify -Pdist -Dquick` to build.
