### PR TITLE
Set language level to 17, 19 for integration tests

### DIFF
--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -21,6 +21,7 @@
 
     <properties>
         <java.version>19</java.version>
+        <java.test.version>19</java.test.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
 
     <properties>
         <kroxyliciousApi.version>0.1.0-SNAPSHOT</kroxyliciousApi.version>
-        <java.version>11</java.version>
-        <java.test.version>19</java.test.version>
+        <java.version>17</java.version>
+        <java.test.version>17</java.test.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <maven.compiler.testRelease>${java.test.version}</maven.compiler.testRelease>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Sets the language level to 17 for `main` and `test` in all modules except `integrationtests`. `integrationtests` relies on an 18+ feature to configure in a custom `InetAddressResolver` so test clients can resolve `foo.multitenant.kafka:9192` and `bar.multitenant.kafka:9192` to a localhost ip.

### Additional Context

The split language levels across test and main sources has been a pain for development, several of us use IDEA and it doesn't work smoothly having different language levels for `main` and `test`. It hungs together in an experimental maven import mode but recently we [found an issue](https://github.com/kroxylicious/kroxylicious/pull/171#issuecomment-1470346027) where test resources were not on the classpath when running some new unit tests. Moving to a more conventional setup with the same language level for test/main per maven module should make it smoother.

We want to target a LTS java version as a minimum runtime version.