### PR TITLE
Use direct buffers when available.

### DIFF
--- a/kroxylicious/pom.xml
+++ b/kroxylicious/pom.xml
@@ -297,5 +297,15 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>debug</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/DefaultFilterContext.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/DefaultFilterContext.java
@@ -72,7 +72,7 @@ class DefaultFilterContext implements KrpcFilterContext {
      */
     @Override
     public ByteBufferOutputStream createByteBufferOutputStream(int initialCapacity) {
-        final ByteBuf buffer = channelContext.alloc().heapBuffer(initialCapacity);
+        final ByteBuf buffer = channelContext.alloc().ioBuffer(initialCapacity);
         decodedFrame.add(buffer);
         return new ByteBufOutputStream(buffer);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,11 @@
                 <version>${slf4j-api.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-simple</artifactId>
+                <version>${slf4j-api.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
                 <version>${lombok.version}</version>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description
Take advantage of direct buffers for more efficient checksum implementations and reduced pressure on the garbage collector. 

While we want to use `DirectBuffers` there can be issue with the availability of the API's used to manage them so we leave it up to Netty to determine if available by calling `Allocator.ioBuffer` rather than going directly to `Allocator.directBuffer`.   

### Additional Context

I've tried profiling this change however I haven't found a combination of filters or load which generates enough GC pressure or checksum  usage to produce a difference in runs that isn't entirely drowned out by the variations between benchmark runs.

Closes: https://github.com/kroxylicious/kroxylicious/issues/76 
