### PR TITLE
Multitenant - Group mapping - consumer manual assign use-case

### DIFF
--- a/integrationtests/src/test/java/io/kroxylicious/proxy/multitenant/MultiTenantIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/multitenant/MultiTenantIT.java
@@ -192,18 +192,18 @@ public class MultiTenantIT {
     public void tenantGroupIsolation(KafkaCluster cluster) throws Exception {
         String config = getConfig(PROXY_ADDRESS, cluster);
         try (var proxy = startProxy(config)) {
-            //tenant 1 - creates topic
+            // tenant 1 - creates topic
             createTopics(TENANT1_PROXY_ADDRESS, List.of(NEW_TOPIC_1));
-            //tenant 1 - creates a consumer
+            // tenant 1 - creates a consumer
             createConsumerWithGroup(TENANT1_PROXY_ADDRESS, "Tenant1Group", NEW_TOPIC_1);
-            //tenant 1 - uses kafka admin api to check consumer groups
+            // tenant 1 - uses kafka admin api to check consumer groups
             verifyConsumerGroups(TENANT1_PROXY_ADDRESS, "Tenant1Group");
 
-            //tenant 2 - creates a topic
+            // tenant 2 - creates a topic
             createTopics(TENANT2_PROXY_ADDRESS, List.of(NEW_TOPIC_1));
-            //tenant 2 - creates a consumer
+            // tenant 2 - creates a consumer
             createConsumerWithGroup(TENANT2_PROXY_ADDRESS, "Tenant2Group", NEW_TOPIC_1);
-            //tenant 2 - uses kafka admin api to check consumer groups, and it will fail because it can see tenant 1 also
+            // tenant 2 - uses kafka admin api to check consumer groups, and it will fail because it can see tenant 1 also
             verifyConsumerGroups(TENANT2_PROXY_ADDRESS, "Tenant2Group");
         }
     }

--- a/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilter.java
+++ b/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilter.java
@@ -150,14 +150,21 @@ public class MultiTenantTransformationFilter
     @Override
     public void onOffsetFetchRequest(RequestHeaderData data, OffsetFetchRequestData request, KrpcFilterContext context) {
         request.topics().forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, false));
-        request.groups().forEach(requestGroup -> requestGroup.topics().forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, false)));
+        request.groups().forEach(requestGroup -> {
+            applyTenantPrefix(context, requestGroup::groupId, requestGroup::setGroupId, false);
+            requestGroup.topics().forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, false));
+        });
+
         context.forwardRequest(request);
     }
 
     @Override
     public void onOffsetFetchResponse(ResponseHeaderData data, OffsetFetchResponseData response, KrpcFilterContext context) {
         response.topics().forEach(topic -> removeTenantPrefix(context, topic::name, topic::setName, false));
-        response.groups().forEach(responseGroup -> responseGroup.topics().forEach(topic -> removeTenantPrefix(context, topic::name, topic::setName, false)));
+        response.groups().forEach(responseGroup -> {
+            removeTenantPrefix(context, responseGroup::groupId, responseGroup::setGroupId, false);
+            responseGroup.topics().forEach(topic -> removeTenantPrefix(context, topic::name, topic::setName, false));
+        });
         context.forwardResponse(response);
     }
 

--- a/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilter.java
+++ b/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilter.java
@@ -245,7 +245,7 @@ public class MultiTenantTransformationFilter
 
     private String applyTenantPrefix(KrpcFilterContext context, String clientSideName) {
         var tenantPrefix = getTenantPrefix(context);
-        return tenantPrefix + "-" + clientSideName;
+        return tenantPrefix + clientSideName;
     }
 
     private void removeTenantPrefix(KrpcFilterContext context, Supplier<String> getter, Consumer<String> setter, boolean ignoreEmpty) {
@@ -259,7 +259,7 @@ public class MultiTenantTransformationFilter
 
     private String removeTenantPrefix(KrpcFilterContext context, String brokerSideName) {
         var tenantPrefix = getTenantPrefix(context);
-        return brokerSideName.substring(tenantPrefix.length() + 1);
+        return brokerSideName.substring(tenantPrefix.length());
     }
 
     private static String getTenantPrefix(KrpcFilterContext context) {
@@ -272,7 +272,7 @@ public class MultiTenantTransformationFilter
         if (dot < 1) {
             throw new IllegalStateException("Unexpected SNI hostname formation. SNI hostname : " + sniHostname);
         }
-        return sniHostname.substring(0, dot);
+        return sniHostname.substring(0, dot) + "-";
     }
 
     public MultiTenantTransformationFilter() {

--- a/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilter.java
+++ b/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilter.java
@@ -182,6 +182,7 @@ public class MultiTenantTransformationFilter
 
     @Override
     public void onOffsetCommitRequest(RequestHeaderData data, OffsetCommitRequestData request, KrpcFilterContext context) {
+        applyTenantPrefix(context, request::groupId, request::setGroupId, false);
         request.topics().forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, false));
         context.forwardRequest(request);
     }

--- a/kroxylicious-multitenant/src/test/resources/io/kroxylicious/proxy/filter/multitenant/FindCoordinator.test.yaml
+++ b/kroxylicious-multitenant/src/test/resources/io/kroxylicious/proxy/filter/multitenant/FindCoordinator.test.yaml
@@ -1,0 +1,34 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+- apiMessageType: FIND_COORDINATOR
+  version: 4
+  request:
+    payload:
+      keyType: 0
+      coordinatorKeys:
+        - test-group
+      timeoutMs: 0
+      validateOnly: false
+    diff:
+      - op: replace
+        path: /coordinatorKeys/0
+        value: tenant1-test-group
+  response:
+    payload:
+      throttleTimeMs: 0
+      coordinators:
+        - key: tenant1-test-group
+          nodeId: 0
+          host: localhost
+          port: 12345
+          errorCode: 0
+          errorMessage:
+    diff:
+      - op: replace
+        path: "/coordinators/0/key"
+        value: test-group
+  disabled: false

--- a/kroxylicious-multitenant/src/test/resources/io/kroxylicious/proxy/filter/multitenant/ListGroups.test.yaml
+++ b/kroxylicious-multitenant/src/test/resources/io/kroxylicious/proxy/filter/multitenant/ListGroups.test.yaml
@@ -1,0 +1,46 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+- apiMessageType: LIST_GROUPS
+  description: Group mapping
+  version: 4
+  request:
+    payload:
+      statesFilter: []
+    diff: []
+  response:
+    payload:
+      throttleTimeMs: 0
+      errorCode: 0
+      groups:
+        - groupId: tenant1-mygroup
+          protocolType: consumer
+          groupState: stable
+    diff:
+      - op: replace
+        path: "/groups/0/groupId"
+        value: mygroup
+  disabled: false
+
+- apiMessageType: LIST_GROUPS
+  description: Group filtering
+  version: 4
+  request:
+    payload:
+      statesFilter: [ ]
+    diff: [ ]
+  response:
+    payload:
+      throttleTimeMs: 0
+      errorCode: 0
+      groups:
+        - groupId: tenant2-mygroup
+          protocolType: consumer
+          groupState: stable
+    diff:
+      - op: remove
+        path: "/groups/0"
+  disabled: false

--- a/kroxylicious-multitenant/src/test/resources/io/kroxylicious/proxy/filter/multitenant/OffsetCommit.test.yaml
+++ b/kroxylicious-multitenant/src/test/resources/io/kroxylicious/proxy/filter/multitenant/OffsetCommit.test.yaml
@@ -21,6 +21,9 @@
               committedMetadata: null
     diff:
       - op: replace
+        path: "/groupId"
+        value: tenant1-mygroup
+      - op: replace
         path: "/topics/0/name"
         value: tenant1-foo
   response:

--- a/kroxylicious-multitenant/src/test/resources/io/kroxylicious/proxy/filter/multitenant/OffsetFetch.test.yaml
+++ b/kroxylicious-multitenant/src/test/resources/io/kroxylicious/proxy/filter/multitenant/OffsetFetch.test.yaml
@@ -16,12 +16,15 @@
       requireStable: false
     diff:
       - op: replace
+        path: "/groups/0/groupId"
+        value: tenant1-mygroup
+      - op: replace
         path: "/groups/0/topics/0/name"
         value: tenant1-foo
   response:
     payload:
       groups:
-        - groupId: mygroup
+        - groupId: tenant1-mygroup
           topics:
             - name: tenant1-foo
               partitions:
@@ -33,6 +36,9 @@
           errorCode: 0
       throttleTimeMs: 0
     diff:
+      - op: replace
+        path: "/groups/0/groupId"
+        value: mygroup
       - op: replace
         path: "/groups/0/topics/0/name"
         value: foo


### PR DESCRIPTION
This is the first part of #190 which covers the use case of a consumer using #assign() method.  The desire is to commit this, then build on top of it to implement the other group mapping use-cases (#subscribe) etc.


