### PR TITLE
Avoid long poll in multi-tenant tests that use subscribe

### DIFF
--- a/integrationtests/integrationtests.iml
+++ b/integrationtests/integrationtests.iml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="CheckStyle-IDEA-Module" serialisationVersion="2">
+    <option name="activeLocationsIds" />
+  </component>
+</module>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description


`runConsumerInOrderToCreateGroup` on the SUBSCRIBE path is weak.  It uses a poll with a long timeout and hopes that the consumer will have been assigned a partition.  This approach is slow and could give rise to spurious failures.   This change alters the code to explicitly await the assignment. It also avoids the long poll, so the tests should run a bit quicker. 

### Additional Context

_Why are you making this pull request?_
