### PR TITLE
Add links to slack to issue templates and README

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-_Please use this to only for bug reports_. For questions or when you need help, you can use the [GitHub Discussions](https://github.com/kroxylicious/kroxylicious/discussions)
+_Please use this to only for bug reports_. For questions or when you need help, you can use the [GitHub Discussions](https://github.com/kroxylicious/kroxylicious/discussions) or use the [community Slack](https://kroxylicious.slack.com) chat.
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -6,6 +6,7 @@ labels: documentation
 assignees: ''
 
 ---
+If you have questions before creating this documentation issue, you can use the [GitHub Discussions](https://github.com/kroxylicious/kroxylicious/discussions) or use the [community Slack](https://kroxylicious.slack.com) chat.
 
 **Suggestion / Problem**
 Describe your problem or suggestion

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,6 +6,7 @@ labels: enhancement
 assignees: ''
 
 ---
+If you have questions before creating this feature request, you can use the [GitHub Discussions](https://github.com/kroxylicious/kroxylicious/discussions) or use the [community Slack](https://kroxylicious.slack.com) chat.
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 Kroxylicious is an exploration for building a Kafka protocol proxy,
 addressing use cases such as multi-tenancy, schema validation, or encryption.
 
+## Quick Links
+- [kroxylicious.io](https://www.kroxylicious.io)
+- [Documentation](https://www.kroxylicious.io/kroxylicious)
+- [GitHub design and discussion](https://github.com/kroxylicious/design)
+- [Community Slack chat](https://kroxylicious.slack.com/)
+
 ## Build
 
 JDK version 19 or newer, and Apache Maven are required for building this project.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Add links to slack from issue templates and add Quick Links near the top of the `README.md` to link off to documentation, slack and design discussion.
