### PR TITLE
Export GPG_KEY var so its accessible in the subshell

### DIFF
--- a/scripts/release-api.sh
+++ b/scripts/release-api.sh
@@ -10,10 +10,10 @@ set -o nounset -e
 RELEASE_API_VERSION=${1}
 API_MODULES=':kroxylicious-api,:kroxylicious-filter-api'
 
-if [[ -z "${GPG_KEY}" ]]; then
-    echo "GPG_KEY not set unable to sign the release. Please export GPG_KEY" 1>&2
-    exit 1
-fi
+#if [[ -z "${GPG_KEY}" ]]; then
+#    echo "GPG_KEY not set unable to sign the release. Please export GPG_KEY" 1>&2
+#    exit 1
+#fi
 
 if [[ -z ${RELEASE_API_VERSION} ]]; then
   echo "no api release version specified please specify at least one"

--- a/scripts/release-framework.sh
+++ b/scripts/release-framework.sh
@@ -9,10 +9,10 @@ set -o nounset -e
 
 RELEASE_VERSION=${1}
 
-if [[ -z "${GPG_KEY}" ]]; then
-    echo "GPG_KEY not set unable to sign the release. Please export GPG_KEY" 1>&2
-    exit 1
-fi
+#if [[ -z "${GPG_KEY}" ]]; then
+#    echo "GPG_KEY not set unable to sign the release. Please export GPG_KEY" 1>&2
+#    exit 1
+#fi
 
 if [[ -z ${RELEASE_VERSION} ]]; then
   echo "no release version specified please specify at least one"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Don't check for the `GPG_KEY` variable in the module release scripts as they don't need it for the moment.

### Additional Context

_Why are you making this pull request?_
