### PR TITLE
Release cleanup

### DIFF
--- a/integrationtests/src/test/java/io/kroxylicious/proxy/multitenant/MultiTenantIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/multitenant/MultiTenantIT.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;

--- a/kroxylicious-multitenant/pom.xml
+++ b/kroxylicious-multitenant/pom.xml
@@ -22,7 +22,8 @@
     <packaging>jar</packaging>
 
     <name>Kroxylicious Multitenant</name>
-    <description>Kroxylicious Filters and other plugins required to implement Multitenancy over Apache Kafka</description>
+    <description>Kroxylicious Filters and other plugins required to implement Multitenancy over Apache Kafka
+    </description>
 
     <dependencies>
         <dependency>
@@ -113,10 +114,12 @@
                         </goals>
                         <phase>generate-test-sources</phase>
                         <configuration>
-                            <messageSpecDirectory>${project.build.directory}/message-specs/common/message</messageSpecDirectory>
+                            <messageSpecDirectory>${project.build.directory}/message-specs/common/message
+                            </messageSpecDirectory>
                             <messageSpecFilter>*{Request,Response}.json</messageSpecFilter>
                             <templateDirectory>${project.basedir}/src/test/templates</templateDirectory>
                             <templateNames>KafkaApiMessageConverter.ftl</templateNames>
+                            <!--suppress MavenModelInspection -->
                             <outputFilePattern>${templateName}.java</outputFilePattern>
                             <outputPackage>io.kroxylicious.proxy.filter.multitenant</outputPackage>
                             <outputDirectory>${project.build.directory}/generated-test-sources</outputDirectory>
@@ -146,9 +149,16 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <!-- Javadoc generation fails to resolve jackson databind.  KW doesn't understand why -->
-                    <!-- Turn off javadoc generation for this module to work-around -->
-                    <skip>true</skip>
+                    <!-- Javadoc generation fails to resolve jackson databind.  KW & SB don't understand why -->
+                    <!-- Databind is in test scope, and we are only generating javadocs for src/main -->
+                    <!-- so explicitly add the dependency, so we can build the javadoc -->
+                    <additionalDependencies>
+                        <additionalDependency>
+                            <groupId>com.fasterxml.jackson.core</groupId>
+                            <artifactId>jackson-databind</artifactId>
+                            <version>2.14.2</version>
+                        </additionalDependency>
+                    </additionalDependencies>
                 </configuration>
             </plugin>
         </plugins>

--- a/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilter.java
+++ b/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilter.java
@@ -19,12 +19,8 @@ import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.FindCoordinatorRequestData;
 import org.apache.kafka.common.message.FindCoordinatorResponseData;
 import org.apache.kafka.common.message.HeartbeatRequestData;
-import org.apache.kafka.common.message.HeartbeatResponseData;
 import org.apache.kafka.common.message.JoinGroupRequestData;
-import org.apache.kafka.common.message.JoinGroupResponseData;
 import org.apache.kafka.common.message.LeaveGroupRequestData;
-import org.apache.kafka.common.message.LeaveGroupResponseData;
-import org.apache.kafka.common.message.ListGroupsRequestData;
 import org.apache.kafka.common.message.ListGroupsResponseData;
 import org.apache.kafka.common.message.ListOffsetsRequestData;
 import org.apache.kafka.common.message.ListOffsetsResponseData;
@@ -41,7 +37,6 @@ import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
-import org.apache.kafka.common.message.SyncGroupResponseData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,13 +51,9 @@ import io.kroxylicious.proxy.filter.FetchResponseFilter;
 import io.kroxylicious.proxy.filter.FindCoordinatorRequestFilter;
 import io.kroxylicious.proxy.filter.FindCoordinatorResponseFilter;
 import io.kroxylicious.proxy.filter.HeartbeatRequestFilter;
-import io.kroxylicious.proxy.filter.HeartbeatResponseFilter;
 import io.kroxylicious.proxy.filter.JoinGroupRequestFilter;
-import io.kroxylicious.proxy.filter.JoinGroupResponseFilter;
 import io.kroxylicious.proxy.filter.KrpcFilterContext;
 import io.kroxylicious.proxy.filter.LeaveGroupRequestFilter;
-import io.kroxylicious.proxy.filter.LeaveGroupResponseFilter;
-import io.kroxylicious.proxy.filter.ListGroupsRequestFilter;
 import io.kroxylicious.proxy.filter.ListGroupsResponseFilter;
 import io.kroxylicious.proxy.filter.ListOffsetsRequestFilter;
 import io.kroxylicious.proxy.filter.ListOffsetsResponseFilter;
@@ -77,7 +68,6 @@ import io.kroxylicious.proxy.filter.OffsetForLeaderEpochResponseFilter;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
 import io.kroxylicious.proxy.filter.ProduceResponseFilter;
 import io.kroxylicious.proxy.filter.SyncGroupRequestFilter;
-import io.kroxylicious.proxy.filter.SyncGroupResponseFilter;
 
 /**
  * Simple multi-tenant filter.

--- a/release.sh
+++ b/release.sh
@@ -91,4 +91,4 @@ if [[ -n ${RELEASE_VERSION} ]]; then
 fi
 
 echo "Create pull request to merge the released version."
-gh pr create --base main --title "Kroxylicious Release %{RELEASE_DATE}" --body "${BODY}"
+gh pr create --base main --title "Kroxylicious Release ${RELEASE_DATE}" --body "${BODY}"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The release failed central validation as there was no Javadoc for the multi tenant module. This PR hacks around the underlying issue to enable javadoc for multitenant. It also cleans up a couple of other nits noticed during the release process.

### Additional Context

_Why are you making this pull request?_
