### PR TITLE
Enable Krpc Generator Mojo to add output directory to project compile or test source roots

### DIFF
--- a/kroxylicious-multitenant/pom.xml
+++ b/kroxylicious-multitenant/pom.xml
@@ -123,43 +123,10 @@
                             <outputFilePattern>${templateName}.java</outputFilePattern>
                             <outputPackage>io.kroxylicious.proxy.filter.multitenant</outputPackage>
                             <outputDirectory>${project.build.directory}/generated-test-sources</outputDirectory>
+                            <addToProjectSourceRoots>testCompile</addToProjectSourceRoots>
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>add-source</id>
-                        <phase>generate-test-sources</phase>
-                        <goals>
-                            <goal>add-test-source</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>${project.build.directory}/generated-test-sources</source>
-                            </sources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <!-- Javadoc generation fails to resolve jackson databind.  KW & SB don't understand why -->
-                    <!-- Databind is in test scope, and we are only generating javadocs for src/main -->
-                    <!-- so explicitly add the dependency, so we can build the javadoc -->
-                    <additionalDependencies>
-                        <additionalDependency>
-                            <groupId>com.fasterxml.jackson.core</groupId>
-                            <artifactId>jackson-databind</artifactId>
-                            <version>2.14.2</version>
-                        </additionalDependency>
-                    </additionalDependencies>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/maven/AbstractKrpcGeneratorMojo.java
+++ b/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/maven/AbstractKrpcGeneratorMojo.java
@@ -6,6 +6,7 @@
 package io.kroxylicious.krpccodegen.maven;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -46,6 +47,9 @@ public abstract class AbstractKrpcGeneratorMojo extends AbstractMojo {
     @Parameter(defaultValue = "${messageSpecName}.java")
     private String outputFilePattern;
 
+    @Parameter(defaultValue = "compile")
+    private String addToProjectSourceRoots;
+
     @Parameter(defaultValue = "${project.build.directory}${file.separator}generated-sources${file.separator}/krpc")
     private File outputDirectory;
 
@@ -77,7 +81,20 @@ public abstract class AbstractKrpcGeneratorMojo extends AbstractMojo {
                 throw new MojoExecutionException("Couldn't generate messages", e);
             }
 
-            project.addCompileSourceRoot(outputDirectory.getAbsolutePath());
+            String absolutePath = outputDirectory.getAbsolutePath();
+            Arrays.stream(addToProjectSourceRoots.split(",")).forEach(sourceRoot -> {
+                switch (sourceRoot) {
+                    case "compile" -> {
+                        project.addCompileSourceRoot(absolutePath);
+                    }
+                    case "testCompile" -> {
+                        project.addTestCompileSourceRoot(absolutePath);
+                    }
+                    default -> {
+                        throw new IllegalArgumentException("unexpected source root " + sourceRoot);
+                    }
+                }
+            });
         }
     }
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Enable the KRPC generator mojo to add it's output directory to any combination of test and compile source roots. Configure the kroxylicious-multitenant krpc generation plugin to add to test source root and remove build helper and javadoc customisation. It defaults to adding to compile source root only for backwards compatibility.

### Additional Context

We had some trouble while releasing. We need javadoc to release to central and it was skipped for multitenant. It was skipped because it was throwing an error during javadoc generation because the javadoc plugin was processing the generated test sources. On debugging we found that the KRPC mojo always adds the output dir to the compile source roots, which is how it ended up being processed for javadoc. To fix this we make the Krpc Generator Mojo responsible for adding the output dir to the correct source roots.

Closes #229 