### PR TITLE
Make the version command return the version of the kroxylicious project

### DIFF
--- a/kroxylicious/pom.xml
+++ b/kroxylicious/pom.xml
@@ -156,6 +156,16 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>src/main/templates</directory>
+                <filtering>true</filtering>
+                <targetPath>META-INF</targetPath>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/Kroxylicious.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/Kroxylicious.java
@@ -59,7 +59,9 @@ class Kroxylicious implements Callable<Integer> {
                 if (resource != null) {
                     Properties properties = new Properties();
                     properties.load(resource);
-                    return new String[]{ properties.getProperty("kroxylicious.version", "unknown") };
+                    String version = properties.getProperty("kroxylicious.version", "unknown");
+                    String apiVersion = properties.getProperty("kroxylicious.api.version", "unknown");
+                    return new String[]{ "kroxylicious: " + version, "kroxylicous apis: " + apiVersion };
                 }
             }
             return new String[]{ "unknown" };

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/Kroxylicious.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/Kroxylicious.java
@@ -8,6 +8,7 @@ package io.kroxylicious.proxy;
 import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.util.Properties;
 import java.util.concurrent.Callable;
 
 import io.kroxylicious.proxy.config.ConfigParser;
@@ -20,7 +21,7 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.ParameterException;
 import picocli.CommandLine.Spec;
 
-@Command(name = "kroxilicious", mixinStandardHelpOptions = true, version = "kroxilicious 1.0", description = "A customizeable wire protocol proxy for Apache Kafka")
+@Command(name = "kroxilicious", mixinStandardHelpOptions = true, versionProvider = Kroxylicious.VersionProvider.class, description = "A customizeable wire protocol proxy for Apache Kafka")
 class Kroxylicious implements Callable<Integer> {
 
     @Spec
@@ -49,5 +50,19 @@ class Kroxylicious implements Callable<Integer> {
     public static void main(String... args) {
         int exitCode = new CommandLine(new Kroxylicious()).execute(args);
         System.exit(exitCode);
+    }
+
+    static class VersionProvider implements CommandLine.IVersionProvider {
+        @Override
+        public String[] getVersion() throws Exception {
+            try (InputStream resource = this.getClass().getClassLoader().getResourceAsStream("META-INF/metadata.properties")) {
+                if (resource != null) {
+                    Properties properties = new Properties();
+                    properties.load(resource);
+                    return new String[]{ properties.getProperty("kroxylicious.version", "unknown") };
+                }
+            }
+            return new String[]{ "unknown" };
+        }
     }
 }

--- a/kroxylicious/src/main/templates/metadata.properties
+++ b/kroxylicious/src/main/templates/metadata.properties
@@ -1,0 +1,7 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+kroxylicious.version=${project.version}

--- a/kroxylicious/src/main/templates/metadata.properties
+++ b/kroxylicious/src/main/templates/metadata.properties
@@ -5,3 +5,4 @@
 #
 
 kroxylicious.version=${project.version}
+kroxylicious.api.version=${kroxyliciousApi.version}


### PR DESCRIPTION

### Type of change

- Bugfix

### Description

Using maven we copy src/main/templates/* into META-INF filtering the property placeholders. Then in Kroxylicious we install a custom IVersionProvider to look it up from the jar.

```
java -jar kroxylicious/target/kroxylicious-0.2.0-SNAPSHOT.jar -V
0.2.0-SNAPSHOT
```

### Additional Context

The version is currently a hardcoded 1.0 which is misleading
