### PR TITLE
Create .lift.toml

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -1,0 +1,2 @@
+build = "mvn"
+jdkVersion = "19"


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Bugfix

### Description

Overriding the default to force the use of JDK 19 so that integrationtests module is processed correctly. https://help.sonatype.com/lift/configuring-lift#ConfiguringLift-specifying+build+systemSpecifyingBuildSystem

### Additional Context

_Why are you making this pull request?_
