### PR TITLE
bump to the latest version of plexus-build-api

### DIFF
--- a/krpc-code-gen/pom.xml
+++ b/krpc-code-gen/pom.xml
@@ -65,9 +65,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.sonatype.plexus</groupId>
+            <!-- according to https://github.com/codehaus-plexus/plexus-build-api this replaces org.sonatype.plexus:plexus-build-api -->
+            <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-build-api</artifactId>
-            <version>0.0.7</version>
+            <version>1.0.0</version>
         </dependency>
 
         <dependency>

--- a/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/maven/AbstractKrpcGeneratorMojo.java
+++ b/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/maven/AbstractKrpcGeneratorMojo.java
@@ -17,7 +17,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-import org.sonatype.plexus.build.incremental.BuildContext;
+import org.codehaus.plexus.build.BuildContext;
 
 import io.kroxylicious.krpccodegen.main.KrpcGenerator;
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
### Description

Bump to the latest version of `plexus-build-api` as that avoids a high [severity CVE](https://lift.sonatype.com/results/github.com/kroxylicious/kroxylicious/01GWJTKP8W1N5VF9GBCSPQKFT7?tab=dependencies&selectedComponent=pkg%3Amaven%2Forg.sonatype.plexus%2Fplexus-build-api%400.0.7) 

### Additional Context

_Why are you making this pull request?_
