### PR TITLE
Wait for services to start in performance action

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -73,6 +73,24 @@ jobs:
 
       - name: 'Run kroxy'
         run: java -jar ${{ env.KROXY_JAR_FILE }} --config kroxylicious/example-proxy-config.yml &
+      
+      - name: 'await zookeeper'
+        uses: iFaxity/wait-on-action@v1
+        with:
+            resource: tcp:localhost:2181
+            timeout: 30000
+
+      - name: 'await kafka'
+        uses: iFaxity/wait-on-action@v1
+        with:
+            resource: tcp:localhost:9092
+            timeout: 30000
+      
+      - name: 'await kroxylicious'
+        uses: iFaxity/wait-on-action@v1
+        with:
+            resource: tcp:localhost:9192
+            timeout: 30000
 
       - name: 'Run warm-up'
         run: cd kafka_2.13; bin/kafka-producer-perf-test.sh --topic perf-test --throughput -1 --num-records 1000000 --record-size 1024 --producer-props acks=all bootstrap.servers=localhost:9192
@@ -144,6 +162,24 @@ jobs:
 
       - name: 'Run kroxy'
         run: java -jar ${{ env.KROXY_JAR_FILE }} --config kroxylicious/example-proxy-config.yml &
+      
+      - name: 'await zookeeper'
+        uses: iFaxity/wait-on-action@v1
+        with:
+            resource: tcp:localhost:2181
+            timeout: 30000
+
+      - name: 'await kafka'
+        uses: iFaxity/wait-on-action@v1
+        with:
+            resource: tcp:localhost:9092
+            timeout: 30000
+      
+      - name: 'await kroxylicious'
+        uses: iFaxity/wait-on-action@v1
+        with:
+            resource: tcp:localhost:9192
+            timeout: 30000
 
       - name: 'Run warm-up'
         run: cd kafka_2.13; bin/kafka-producer-perf-test.sh --topic perf-test --throughput -1 --num-records 1000000 --record-size 1024 --producer-props acks=all bootstrap.servers=localhost:9192


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Waits for zookeeper, kafka and kroxylicious to listen on their respective ports before kicking off the tests and fail if they don't come up within 30 seconds.

### Additional Context

We saw a failure where kroxylicious was never started due to trying to reference a non-existent JAR. Because this was backgrounded it didn't cause the action to fail and the kafka producer performance script will retry forever, so the action eventually timed out after 6 hours. We want to fail faster to conserve action time and expose the issue.

Note: the action is a little dilapidated and warns that node 12 is deprecated. I couldn't find another good option for waiting on a port, I tried https://github.com/MaximeGoyette/wait-for-it-action which has rotted and no longer works with the latest ubuntu docker image. We could potentially commit and run the [wait-for-it script](https://github.com/vishnubob/wait-for-it/blob/master/wait-for-it.sh)