### PR TITLE
Fix metrics that were always scraped as zero

### DIFF
--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -27,7 +27,6 @@ import javax.net.ssl.KeyManagerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.micrometer.core.instrument.Metrics;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -58,11 +57,8 @@ import io.kroxylicious.proxy.internal.KafkaProxyInitializer;
 import io.kroxylicious.proxy.internal.MeterRegistries;
 import io.kroxylicious.proxy.internal.admin.AdminHttpInitializer;
 import io.kroxylicious.proxy.internal.filter.UpstreamBrokerAddressCachingNetFilter;
+import io.kroxylicious.proxy.internal.util.Metrics;
 import io.kroxylicious.proxy.service.HostPort;
-
-import static io.kroxylicious.proxy.internal.util.Metrics.KROXYLICIOUS_INBOUND_DOWNSTREAM_DECODED_MESSAGES;
-import static io.kroxylicious.proxy.internal.util.Metrics.KROXYLICIOUS_INBOUND_DOWNSTREAM_MESSAGES;
-import static io.kroxylicious.proxy.internal.util.Metrics.KROXYLICIOUS_REQUEST_SIZE_BYTES;
 
 public final class KafkaProxy implements AutoCloseable {
 
@@ -192,9 +188,8 @@ public final class KafkaProxy implements AutoCloseable {
 
         // Pre-register counters/summaries to avoid creating them on first request and thus skewing the request latency
         // TODO add a virtual host tag to metrics
-        Metrics.counter(KROXYLICIOUS_INBOUND_DOWNSTREAM_MESSAGES);
-        Metrics.counter(KROXYLICIOUS_INBOUND_DOWNSTREAM_DECODED_MESSAGES);
-        Metrics.summary(KROXYLICIOUS_REQUEST_SIZE_BYTES);
+        Metrics.inboundDownstreamMessagesCounter();
+        Metrics.inboundDownstreamDecodedMessagesCounter();
         return this;
     }
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoder.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoder.java
@@ -64,7 +64,7 @@ public class KafkaRequestDecoder extends KafkaMessageDecoder {
         short headerVersion = apiKey.requestHeaderVersion(apiVersion);
         if (decodeRequest) {
             Metrics.inboundDownstreamDecodedMessagesCounter().increment();
-            Metrics.requestSizeBytesUpstreamSummary(apiKey, apiVersion).record(length);
+            Metrics.payloadSizeBytesUpstreamSummary(apiKey, apiVersion).record(length);
             if (log().isTraceEnabled()) { // avoid boxing
                 log().trace("{}: headerVersion {}", ctx, headerVersion);
             }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseDecoder.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseDecoder.java
@@ -70,7 +70,7 @@ public class KafkaResponseDecoder extends KafkaMessageDecoder {
             ApiMessage body = BodyDecoder.decodeResponse(apiKey, apiVersion, accessor);
             log().trace("{}: Body: {}", ctx, body);
             KrpcFilter recipient = correlation.recipient();
-            Metrics.requestSizeBytesDownstreamSummary(apiKey, apiVersion).record(length);
+            Metrics.payloadSizeBytesDownstreamSummary(apiKey, apiVersion).record(length);
             if (recipient == null) {
                 frame = new DecodedResponseFrame<>(apiVersion, correlationId, header, body);
             }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/util/Metrics.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/util/Metrics.java
@@ -25,7 +25,7 @@ public class Metrics {
 
     private static final String KROXYLICIOUS_INBOUND_DOWNSTREAM_DECODED_MESSAGES = "kroxylicious_inbound_downstream_decoded_messages";
 
-    private static final String KROXYLICIOUS_REQUEST_SIZE_BYTES = "kroxylicious_request_size_bytes";
+    private static final String KROXYLICIOUS_PAYLOAD_SIZE_BYTES = "kroxylicious_payload_size_bytes";
 
     private static final String FLOWING_TAG = "flowing";
 
@@ -41,20 +41,20 @@ public class Metrics {
         return counter(KROXYLICIOUS_INBOUND_DOWNSTREAM_DECODED_MESSAGES, List.of(FLOWING_DOWNSTREAM));
     }
 
-    public static DistributionSummary requestSizeBytesUpstreamSummary(ApiKeys apiKey, short apiVersion) {
-        return requestSizeBytesSummary(apiKey, apiVersion, FLOWING_UPSTREAM);
+    public static DistributionSummary payloadSizeBytesUpstreamSummary(ApiKeys apiKey, short apiVersion) {
+        return payloadSizeBytesSummary(apiKey, apiVersion, FLOWING_UPSTREAM);
     }
 
-    public static DistributionSummary requestSizeBytesDownstreamSummary(ApiKeys apiKey, short apiVersion) {
-        return requestSizeBytesSummary(apiKey, apiVersion, FLOWING_DOWNSTREAM);
+    public static DistributionSummary payloadSizeBytesDownstreamSummary(ApiKeys apiKey, short apiVersion) {
+        return payloadSizeBytesSummary(apiKey, apiVersion, FLOWING_DOWNSTREAM);
     }
 
-    private static DistributionSummary requestSizeBytesSummary(ApiKeys apiKey, short apiVersion, Tag flowing) {
+    private static DistributionSummary payloadSizeBytesSummary(ApiKeys apiKey, short apiVersion, Tag flowing) {
         List<Tag> tags = List.of(
                 Tag.of("ApiKey", apiKey.name()),
                 Tag.of("ApiVersion", String.valueOf(apiVersion)),
                 flowing);
-        return summary(KROXYLICIOUS_REQUEST_SIZE_BYTES, tags);
+        return summary(KROXYLICIOUS_PAYLOAD_SIZE_BYTES, tags);
     }
 
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/util/Metrics.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/util/Metrics.java
@@ -6,22 +6,55 @@
 
 package io.kroxylicious.proxy.internal.util;
 
+import java.util.List;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Tag;
+
+import static io.micrometer.core.instrument.Metrics.counter;
+import static io.micrometer.core.instrument.Metrics.summary;
 
 public class Metrics {
 
     // creating a constant for all Metrics in the one place so we can easily see what metrics there are
 
-    public static final String KROXYLICIOUS_INBOUND_DOWNSTREAM_MESSAGES = "kroxylicious_inbound_downstream_messages";
+    private static final String KROXYLICIOUS_INBOUND_DOWNSTREAM_MESSAGES = "kroxylicious_inbound_downstream_messages";
 
-    public static final String KROXYLICIOUS_INBOUND_DOWNSTREAM_DECODED_MESSAGES = "kroxylicious_inbound_downstream_decoded_messages";
+    private static final String KROXYLICIOUS_INBOUND_DOWNSTREAM_DECODED_MESSAGES = "kroxylicious_inbound_downstream_decoded_messages";
 
-    public static final String KROXYLICIOUS_REQUEST_SIZE_BYTES = "kroxylicious_request_size_bytes";
+    private static final String KROXYLICIOUS_REQUEST_SIZE_BYTES = "kroxylicious_request_size_bytes";
 
-    public static final String FLOWING_TAG = "flowing";
+    private static final String FLOWING_TAG = "flowing";
 
-    public static final Tag FLOWING_UPSTREAM = Tag.of(FLOWING_TAG, "upstream");
+    private static final Tag FLOWING_UPSTREAM = Tag.of(FLOWING_TAG, "upstream");
 
-    public static final Tag FLOWING_DOWNSTREAM = Tag.of(FLOWING_TAG, "downstream");
+    private static final Tag FLOWING_DOWNSTREAM = Tag.of(FLOWING_TAG, "downstream");
+
+    public static Counter inboundDownstreamMessagesCounter() {
+        return counter(KROXYLICIOUS_INBOUND_DOWNSTREAM_MESSAGES, List.of(FLOWING_DOWNSTREAM));
+    }
+
+    public static Counter inboundDownstreamDecodedMessagesCounter() {
+        return counter(KROXYLICIOUS_INBOUND_DOWNSTREAM_DECODED_MESSAGES, List.of(FLOWING_DOWNSTREAM));
+    }
+
+    public static DistributionSummary requestSizeBytesUpstreamSummary(ApiKeys apiKey, short apiVersion) {
+        return requestSizeBytesSummary(apiKey, apiVersion, FLOWING_UPSTREAM);
+    }
+
+    public static DistributionSummary requestSizeBytesDownstreamSummary(ApiKeys apiKey, short apiVersion) {
+        return requestSizeBytesSummary(apiKey, apiVersion, FLOWING_DOWNSTREAM);
+    }
+
+    private static DistributionSummary requestSizeBytesSummary(ApiKeys apiKey, short apiVersion, Tag flowing) {
+        List<Tag> tags = List.of(
+                Tag.of("ApiKey", apiKey.name()),
+                Tag.of("ApiVersion", String.valueOf(apiVersion)),
+                flowing);
+        return summary(KROXYLICIOUS_REQUEST_SIZE_BYTES, tags);
+    }
 
 }

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/MeterRegistriesTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/MeterRegistriesTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+
+class MeterRegistriesTest {
+
+    @Test
+    public void testPreventingRegistrationOfMetersWithSameNameButDifferentTags() {
+        CompositeMeterRegistry registry = new CompositeMeterRegistry();
+        MeterRegistries.preventDifferentTagNameRegistration(registry);
+        registry.counter("abc", List.of(Tag.of("a", "b")));
+        registry.counter("abc", List.of(Tag.of("a", "c")));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            registry.counter("abc", List.of(Tag.of("c", "d")));
+        });
+    }
+
+}


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The message count and size metrics were always zero. This was because when we pre-registered the metrics we used a different set of tags. Data recorded later with the real tags was effectively invisible. This is a limitation of micrometer combined
with the prometheus java client and is quite silent.

To fix I've pulled more work into `io.kroxylicious.proxy.internal.util.Metrics` so that the pre-register and real usages both use the same code with the same tags. We also configure a meter filter that will explode early if we attempt to register a Meter with a different set of tags to existing filters, this is to make the failure visible.

I also removed pre-registration of the summary, this is because the summary is broken down by apiKey and apiVersion, we would have to pre-register the ~250 combinations to pre-register all possibilities.

### Additional Context

Closes #266