### PR TITLE
Adding summary-always to the PR

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -113,6 +113,7 @@ jobs:
           auto-push: true
           alert-threshold: '150%'
           comment-on-alert: true
+          summary-always: true
           fail-on-alert: true
           alert-comment-cc-users: '@kroxylicious/developers'
 
@@ -202,5 +203,6 @@ jobs:
           auto-push: true
           alert-threshold: '150%'
           comment-on-alert: false
+          summary-always: true
           fail-on-alert: true
           alert-comment-cc-users: '@kroxylicious/developers'


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adding `summary-always` option to be able to upload a summary to the PR every time is called.

