### PR TITLE
Avoid potential for infinite blocking in IT

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -4,6 +4,7 @@
     <JavaCodeStyleSettings>
       <option name="SPACE_AFTER_CLOSING_ANGLE_BRACKET_IN_TYPE_ARGUMENT" value="true" />
       <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
       <option name="IMPORT_LAYOUT_TABLE">
         <value>
           <package name="java" withSubpackages="true" static="false" />

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -10,15 +10,16 @@
         <module name="kroxylicious-multitenant" />
         <module name="kroxylicious.main" />
         <module name="integrationtests.main" />
+        <module name="kroxylicious-test-tools" />
         <module name="kroxylicious-api" />
+        <module name="kroxylicious" />
+        <module name="integrationtests" />
+        <module name="integrationtests.test" />
         <module name="kroxylicious-krpc-plugin.main" />
         <module name="kroxylicious.test" />
-        <module name="kroxylicious" />
         <module name="kroxylicious-filter-api" />
         <module name="kroxylicious-krpc-plugin" />
-        <module name="integrationtests" />
         <module name="kroxylicious-krpc-plugin.test" />
-        <module name="integrationtests.test" />
       </profile>
     </annotationProcessing>
   </component>
@@ -35,6 +36,7 @@
       <module name="kroxylicious-krpc-plugin.test" options="-parameters" />
       <module name="kroxylicious-multitenant" options="-parameters" />
       <module name="kroxylicious-parent" options="-parameters" />
+      <module name="kroxylicious-test-tools" options="-parameters" />
       <module name="kroxylicious.main" options="-parameters" />
       <module name="kroxylicious.test" options="-parameters" />
     </option>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -5,12 +5,17 @@
     <file url="file://$PROJECT_DIR$/api/kroxylicious-api/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/api/kroxylicious-filter-api/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/api/kroxylicious-filter-api/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/api/kroxylicious-filter-api/target/generated-sources/krpc" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/integrationtests/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/integrationtests/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious-multitenant/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious-multitenant/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/kroxylicious-test-tools/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/kroxylicious-test-tools/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/kroxylicious-test-tools/target/generated-sources/krpc" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/kroxylicious/src/main/templates" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious/target/generated-sources/krpc" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/krpc-code-gen/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/krpc-code-gen/src/main/resources" charset="UTF-8" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -11,5 +11,5 @@
   <component name="PDMPlugin">
     <option name="skipTestSources" value="false" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="temurin-17" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_19" default="true" project-jdk-name="temurin-19" project-jdk-type="JavaSDK" />
 </project>

--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@ $ mvn clean install
 
 The running of the tests can be controlled with the following Maven properties:
 
-| property           | description            |
-|--------------------|------------------------|
-| `-DskipUTs=true`   | skip unit tests        |
-| `-DskipITs=true`   | skip integration tests |
-| `-DskipTests=true` | skip all tests         |
+| property           | description                                                                               |
+|--------------------|-------------------------------------------------------------------------------------------|
+| `-DskipUTs=true`   | skip unit tests                                                                           |
+| `-DskipITs=true`   | skip integration tests                                                                    |
+| `-DskipTests=true` | skip all tests                                                                            |
+| `-Pdebug`          | enables logging so you can see what the Kafka clients, Proxy and in VM brokers are up to. |
 
 The kafka environment used by the integrations tests can be _defaulted_ with these two environment variables.
 

--- a/kroxylicious/pom.xml
+++ b/kroxylicious/pom.xml
@@ -332,10 +332,31 @@
         </profile>
         <profile>
             <id>debug</id>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-bom</artifactId>
+                        <version>2.20.0</version>
+                        <scope>import</scope>
+                        <type>pom</type>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
             <dependencies>
                 <dependency>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-simple</artifactId>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-core</artifactId>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j2-impl</artifactId>
                     <scope>runtime</scope>
                 </dependency>
             </dependencies>

--- a/kroxylicious/pom.xml
+++ b/kroxylicious/pom.xml
@@ -23,6 +23,7 @@
 
     <properties>
         <libs.dir>libs</libs.dir>
+        <log4j.version>2.20.0</log4j.version>
     </properties>
 
     <name>Kroxylicious Proxy</name>
@@ -337,7 +338,7 @@
                     <dependency>
                         <groupId>org.apache.logging.log4j</groupId>
                         <artifactId>log4j-bom</artifactId>
-                        <version>2.20.0</version>
+                        <version>${log4j.version}</version>
                         <scope>import</scope>
                         <type>pom</type>
                     </dependency>


### PR DESCRIPTION
### Type of change


- Bugfix

### Description
Apply a timeout to `Future.get` calls in the MultiTenantIT and wrap the Kafka clients in a wrapper which intercepts the call to close and calls it with a much more appropriate timeout.

### Additional Context
The multiTenantIT can block for what amounts to forever. I found this the hard way debugging @racheljpg's transactions IT. What makes things rather insidious is that even timing out the producer future doesn't let the test complete as by the Kafka Clients implement close as `close(Duration.ofMillis(Long.MAX_VALUE))` which means the try-with-resources statements we use for managing clients block indefinitely (and magically as its done implicitly)

If there is consensus that this is the right approach then we should wrap clients in other tests using the same fix.
