### PR TITLE
Fix #280: Use SLF4J 2.x compatible log4j-slf4j-impl

### DIFF
--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -55,7 +55,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kroxylicious-multitenant/pom.xml
+++ b/kroxylicious-multitenant/pom.xml
@@ -54,7 +54,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kroxylicious/pom.xml
+++ b/kroxylicious/pom.xml
@@ -130,7 +130,7 @@
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Use SLF4J 2.x compatible log4j-slf4j-impl.

### Additional Context

_Why are you making this pull request?_
