### PR TITLE
Remove duplicated kroxy.extension.version setting in parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,6 @@
         <mockito.version>5.3.1</mockito.version>
         <slf4j.version>2.0.7</slf4j.version>
         <micrometer.version>1.10.6</micrometer.version>
-        <kroxy.extension.version>0.1</kroxy.extension.version>
         <zjsonpatch.version>0.4.14</zjsonpatch.version>
         <sundr-builder-annotations.version>0.94.0</sundr-builder-annotations.version>
     </properties>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

We had  `kroxy.extension.version` defined twice, with the second one at 0.1, so #289 was ineffective.

### Additional Context

_Why are you making this pull request?_
