### PR TITLE
Enable forwarding response during request handling

### DIFF
--- a/api/kroxylicious-filter-api/src/main/java/io/kroxylicious/proxy/filter/KrpcFilterContext.java
+++ b/api/kroxylicious-filter-api/src/main/java/io/kroxylicious/proxy/filter/KrpcFilterContext.java
@@ -57,7 +57,13 @@ public interface KrpcFilterContext {
 
     /**
      * Send a response towards the client, invoking downstream filters.
+     * <p>If this is invoked while the message is flowing downstream towards the broker, then
+     * it will not be sent to the broker. So this method can be used to generate responses in
+     * the proxy.</p>
      * @param response The response to forward to the client.
+     * @throws AssertionError if response is logically inconsistent, for example responding with request data
+     * or responding with a produce response to a fetch request. It is up to specific implementations to
+     * determine what logically inconsistent means.
      */
     void forwardResponse(ApiMessage response);
 

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/CreateTopicRejectFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/CreateTopicRejectFilter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import org.apache.kafka.common.message.CreateTopicsRequestData;
+import org.apache.kafka.common.message.CreateTopicsResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.Errors;
+
+public class CreateTopicRejectFilter implements CreateTopicsRequestFilter {
+
+    public static final String ERROR_MESSAGE = "rejecting all topics";
+
+    @Override
+    public void onCreateTopicsRequest(RequestHeaderData header, CreateTopicsRequestData request, KrpcFilterContext context) {
+        CreateTopicsResponseData response = new CreateTopicsResponseData();
+        CreateTopicsResponseData.CreatableTopicResultCollection topics = new CreateTopicsResponseData.CreatableTopicResultCollection();
+        request.topics().forEach(creatableTopic -> {
+            CreateTopicsResponseData.CreatableTopicResult result = new CreateTopicsResponseData.CreatableTopicResult();
+            result.setErrorCode(Errors.INVALID_TOPIC_EXCEPTION.code()).setErrorMessage(ERROR_MESSAGE);
+            result.setName(creatableTopic.name());
+            topics.add(result);
+        });
+        response.setTopics(topics);
+        context.forwardResponse(response);
+    }
+}

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
@@ -10,7 +10,8 @@ import io.kroxylicious.proxy.service.BaseContributor;
 public class TestFilterContributor extends BaseContributor<KrpcFilter> implements FilterContributor {
 
     public static final BaseContributorBuilder<KrpcFilter> FILTERS = BaseContributor.<KrpcFilter> builder()
-            .add("FixedClientId", FixedClientIdFilter.FixedClientIdFilterConfig.class, FixedClientIdFilter::new);
+            .add("FixedClientId", FixedClientIdFilter.FixedClientIdFilterConfig.class, FixedClientIdFilter::new)
+            .add("CreateTopicRejectFilter", CreateTopicRejectFilter::new);
 
     public TestFilterContributor() {
         super(FILTERS);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This will short-circuit so that Kroxylicious does not send the message to the broker. Useful for cases where we may wish to not proxy the message at all and generate the response in the proxy.
