### PR TITLE
Add header to forwardRequest and forwardResponse of KrpcFilterContext

### DIFF
--- a/api/kroxylicious-filter-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvoker.java
+++ b/api/kroxylicious-filter-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvoker.java
@@ -72,7 +72,7 @@ public interface FilterInvoker {
      * <p>Handle deserialized request data. It is implicit that the underlying filter
      * wants to handle this data because it indicated that with {@link #shouldHandleRequest(ApiKeys, short)}
      * </p><p>
-     * Most Filters will want to call a method on {@link KrpcFilterContext} like {@link KrpcFilterContext#forwardRequest(ApiMessage)}
+     * Most Filters will want to call a method on {@link KrpcFilterContext} like {@link KrpcFilterContext#forwardRequest(RequestHeaderData, ApiMessage)}
      * so that the message continues to flow through the filter chain.
      * </p>
      * @param apiKey the key of the message
@@ -81,14 +81,14 @@ public interface FilterInvoker {
      * @param filterContext contains methods to continue the filter chain and other contextual data
      */
     default void onRequest(ApiKeys apiKey, short apiVersion, RequestHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
-        filterContext.forwardRequest(body);
+        filterContext.forwardRequest(header, body);
     }
 
     /**
      * <p>Handle deserialized response data. It is implicit that the underlying filter
      * wants to handle this data because it indicated that with {@link #shouldHandleResponse(ApiKeys, short)}
      * </p><p>
-     * Most Filters will want to call a method on {@link KrpcFilterContext} like {@link KrpcFilterContext#forwardRequest(ApiMessage)}
+     * Most Filters will want to call a method on {@link KrpcFilterContext} like {@link KrpcFilterContext#forwardResponse(ResponseHeaderData, ApiMessage)}
      * so that the message continues to flow through the filter chain.
      * </p>
      * @param apiKey the key of the message
@@ -98,7 +98,7 @@ public interface FilterInvoker {
      * @param filterContext contains methods to continue the filter chain and other contextual data
      */
     default void onResponse(ApiKeys apiKey, short apiVersion, ResponseHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
-        filterContext.forwardResponse(body);
+        filterContext.forwardResponse(header, body);
     }
 
 }

--- a/api/kroxylicious-filter-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvokers.java
+++ b/api/kroxylicious-filter-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvokers.java
@@ -134,7 +134,7 @@ public class FilterInvokers {
             invoker.onRequest(apiKey, apiVersion, header, body, filterContext);
         }
         else {
-            filterContext.forwardRequest(body);
+            filterContext.forwardRequest(header, body);
         }
     }
 
@@ -144,7 +144,7 @@ public class FilterInvokers {
             invoker.onResponse(apiKey, apiVersion, header, body, filterContext);
         }
         else {
-            filterContext.forwardResponse(body);
+            filterContext.forwardResponse(header, body);
         }
     }
 

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/FixedClientIdFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/FixedClientIdFilter.java
@@ -47,11 +47,11 @@ public class FixedClientIdFilter implements RequestFilter, ResponseFilter {
     @Override
     public void onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
         header.setClientId(clientId);
-        filterContext.forwardRequest(body);
+        filterContext.forwardRequest(header, body);
     }
 
     @Override
     public void onResponse(ApiKeys apiKey, ResponseHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
-        filterContext.forwardResponse(body);
+        filterContext.forwardResponse(header, body);
     }
 }

--- a/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilter.java
+++ b/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilter.java
@@ -105,75 +105,75 @@ public class MultiTenantTransformationFilter
     private static final Logger LOGGER = LoggerFactory.getLogger(MultiTenantTransformationFilter.class);
 
     @Override
-    public void onCreateTopicsRequest(RequestHeaderData data, CreateTopicsRequestData request, KrpcFilterContext context) {
+    public void onCreateTopicsRequest(RequestHeaderData header, CreateTopicsRequestData request, KrpcFilterContext context) {
         request.topics().forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, false));
-        context.forwardRequest(request);
+        context.forwardRequest(header, request);
     }
 
     @Override
-    public void onCreateTopicsResponse(ResponseHeaderData data, CreateTopicsResponseData response, KrpcFilterContext context) {
+    public void onCreateTopicsResponse(ResponseHeaderData header, CreateTopicsResponseData response, KrpcFilterContext context) {
         response.topics().forEach(topic -> removeTenantPrefix(context, topic::name, topic::setName, false));
-        context.forwardResponse(response);
+        context.forwardResponse(header, response);
     }
 
     @Override
-    public void onDeleteTopicsRequest(RequestHeaderData data, DeleteTopicsRequestData request, KrpcFilterContext context) {
+    public void onDeleteTopicsRequest(RequestHeaderData header, DeleteTopicsRequestData request, KrpcFilterContext context) {
         request.topics().forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, topic.topicId() != null));
-        context.forwardRequest(request);
+        context.forwardRequest(header, request);
     }
 
     @Override
-    public void onDeleteTopicsResponse(ResponseHeaderData data, DeleteTopicsResponseData response, KrpcFilterContext context) {
+    public void onDeleteTopicsResponse(ResponseHeaderData header, DeleteTopicsResponseData response, KrpcFilterContext context) {
         response.responses().forEach(topic -> removeTenantPrefix(context, topic::name, topic::setName, false));
-        context.forwardResponse(response);
+        context.forwardResponse(header, response);
     }
 
     @Override
-    public void onMetadataRequest(RequestHeaderData data, MetadataRequestData request, KrpcFilterContext context) {
+    public void onMetadataRequest(RequestHeaderData header, MetadataRequestData request, KrpcFilterContext context) {
         if (request.topics() != null) {
             // n.b. request.topics() == null used to query all the topics.
             request.topics().forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, false));
         }
-        context.forwardRequest(request);
+        context.forwardRequest(header, request);
 
     }
 
     @Override
-    public void onMetadataResponse(ResponseHeaderData data, MetadataResponseData response, KrpcFilterContext context) {
+    public void onMetadataResponse(ResponseHeaderData header, MetadataResponseData response, KrpcFilterContext context) {
         String tenantPrefix = getTenantPrefix(context);
         response.topics().removeIf(topic -> !topic.name().startsWith(tenantPrefix)); // TODO: allow kafka internal topics to be returned?
         response.topics().forEach(topic -> removeTenantPrefix(context, topic::name, topic::setName, false));
-        context.forwardResponse(response);
+        context.forwardResponse(header, response);
     }
 
     @Override
-    public void onProduceRequest(RequestHeaderData data, ProduceRequestData request, KrpcFilterContext context) {
+    public void onProduceRequest(RequestHeaderData header, ProduceRequestData request, KrpcFilterContext context) {
         request.topicData().forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, false));
-        context.forwardRequest(request);
+        context.forwardRequest(header, request);
 
     }
 
     @Override
-    public void onProduceResponse(ResponseHeaderData data, ProduceResponseData response, KrpcFilterContext context) {
+    public void onProduceResponse(ResponseHeaderData header, ProduceResponseData response, KrpcFilterContext context) {
         response.responses().forEach(topic -> removeTenantPrefix(context, topic::name, topic::setName, false));
-        context.forwardResponse(response);
+        context.forwardResponse(header, response);
 
     }
 
     @Override
-    public void onListOffsetsRequest(RequestHeaderData data, ListOffsetsRequestData request, KrpcFilterContext context) {
+    public void onListOffsetsRequest(RequestHeaderData header, ListOffsetsRequestData request, KrpcFilterContext context) {
         request.topics().forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, false));
-        context.forwardRequest(request);
+        context.forwardRequest(header, request);
     }
 
     @Override
-    public void onListOffsetsResponse(ResponseHeaderData data, ListOffsetsResponseData response, KrpcFilterContext context) {
+    public void onListOffsetsResponse(ResponseHeaderData header, ListOffsetsResponseData response, KrpcFilterContext context) {
         response.topics().forEach(topic -> removeTenantPrefix(context, topic::name, topic::setName, false));
-        context.forwardResponse(response);
+        context.forwardResponse(header, response);
     }
 
     @Override
-    public void onOffsetFetchRequest(RequestHeaderData data, OffsetFetchRequestData request, KrpcFilterContext context) {
+    public void onOffsetFetchRequest(RequestHeaderData header, OffsetFetchRequestData request, KrpcFilterContext context) {
         request.topics().forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, false));
         request.groups().forEach(requestGroup -> {
             applyTenantPrefix(context, requestGroup::groupId, requestGroup::setGroupId, false);
@@ -181,79 +181,79 @@ public class MultiTenantTransformationFilter
                     .ifPresent(topics -> topics.forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, false)));
         });
 
-        context.forwardRequest(request);
+        context.forwardRequest(header, request);
     }
 
     @Override
-    public void onOffsetFetchResponse(ResponseHeaderData data, OffsetFetchResponseData response, KrpcFilterContext context) {
+    public void onOffsetFetchResponse(ResponseHeaderData header, OffsetFetchResponseData response, KrpcFilterContext context) {
         response.topics().forEach(topic -> removeTenantPrefix(context, topic::name, topic::setName, false));
         response.groups().forEach(responseGroup -> {
             removeTenantPrefix(context, responseGroup::groupId, responseGroup::setGroupId, false);
             responseGroup.topics().forEach(topic -> removeTenantPrefix(context, topic::name, topic::setName, false));
         });
-        context.forwardResponse(response);
+        context.forwardResponse(header, response);
     }
 
     @Override
-    public void onOffsetForLeaderEpochRequest(RequestHeaderData data, OffsetForLeaderEpochRequestData request, KrpcFilterContext context) {
+    public void onOffsetForLeaderEpochRequest(RequestHeaderData header, OffsetForLeaderEpochRequestData request, KrpcFilterContext context) {
         request.topics().forEach(topic -> applyTenantPrefix(context, topic::topic, topic::setTopic, false));
-        context.forwardRequest(request);
+        context.forwardRequest(header, request);
     }
 
     @Override
-    public void onOffsetForLeaderEpochResponse(ResponseHeaderData data, OffsetForLeaderEpochResponseData response, KrpcFilterContext context) {
+    public void onOffsetForLeaderEpochResponse(ResponseHeaderData header, OffsetForLeaderEpochResponseData response, KrpcFilterContext context) {
         response.topics().forEach(topic -> removeTenantPrefix(context, topic::topic, topic::setTopic, false));
-        context.forwardResponse(response);
+        context.forwardResponse(header, response);
     }
 
     @Override
-    public void onOffsetCommitRequest(RequestHeaderData data, OffsetCommitRequestData request, KrpcFilterContext context) {
+    public void onOffsetCommitRequest(RequestHeaderData header, OffsetCommitRequestData request, KrpcFilterContext context) {
         applyTenantPrefix(context, request::groupId, request::setGroupId, false);
         request.topics().forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, false));
-        context.forwardRequest(request);
+        context.forwardRequest(header, request);
     }
 
     @Override
-    public void onOffsetCommitResponse(ResponseHeaderData data, OffsetCommitResponseData response, KrpcFilterContext context) {
+    public void onOffsetCommitResponse(ResponseHeaderData header, OffsetCommitResponseData response, KrpcFilterContext context) {
         response.topics().forEach(topic -> removeTenantPrefix(context, topic::name, topic::setName, false));
-        context.forwardResponse(response);
+        context.forwardResponse(header, response);
     }
 
     @Override
     public void onOffsetDeleteRequest(RequestHeaderData header, OffsetDeleteRequestData request, KrpcFilterContext context) {
         applyTenantPrefix(context, request::groupId, request::setGroupId, false);
         request.topics().forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, false));
-        context.forwardRequest(request);
+        context.forwardRequest(header, request);
     }
 
     @Override
     public void onOffsetDeleteResponse(ResponseHeaderData header, OffsetDeleteResponseData response, KrpcFilterContext context) {
         response.topics().forEach(topic -> removeTenantPrefix(context, topic::name, topic::setName, false));
-        context.forwardResponse(response);
+        context.forwardResponse(header, response);
     }
 
     @Override
-    public void onFetchRequest(RequestHeaderData data, FetchRequestData request, KrpcFilterContext context) {
+    public void onFetchRequest(RequestHeaderData header, FetchRequestData request, KrpcFilterContext context) {
         request.topics().forEach(topic -> applyTenantPrefix(context, topic::topic, topic::setTopic, topic.topicId() != null));
-        context.forwardRequest(request);
+        context.forwardRequest(header, request);
     }
 
     @Override
-    public void onFetchResponse(ResponseHeaderData data, FetchResponseData response, KrpcFilterContext context) {
+    public void onFetchResponse(ResponseHeaderData header, FetchResponseData response, KrpcFilterContext context) {
         response.responses().forEach(topic -> removeTenantPrefix(context, topic::topic, topic::setTopic, topic.topicId() != null));
-        context.forwardResponse(response);
+        context.forwardResponse(header, response);
     }
 
     @Override
     public void onFindCoordinatorRequest(RequestHeaderData header, FindCoordinatorRequestData request, KrpcFilterContext context) {
         request.setCoordinatorKeys(request.coordinatorKeys().stream().map(key -> applyTenantPrefix(context, key)).toList());
-        context.forwardRequest(request);
+        context.forwardRequest(header, request);
     }
 
     @Override
     public void onFindCoordinatorResponse(ResponseHeaderData header, FindCoordinatorResponseData response, KrpcFilterContext context) {
         response.coordinators().forEach(coordinator -> removeTenantPrefix(context, coordinator::key, coordinator::setKey, false));
-        context.forwardResponse(response);
+        context.forwardResponse(header, response);
     }
 
     @Override
@@ -262,47 +262,47 @@ public class MultiTenantTransformationFilter
         var filteredGroups = response.groups().stream().filter(listedGroup -> listedGroup.groupId().startsWith(tenantPrefix)).toList();
         filteredGroups.forEach(listedGroup -> removeTenantPrefix(context, listedGroup::groupId, listedGroup::setGroupId, false));
         response.setGroups(filteredGroups);
-        context.forwardResponse(response);
+        context.forwardResponse(header, response);
     }
 
     @Override
     public void onJoinGroupRequest(RequestHeaderData header, JoinGroupRequestData request, KrpcFilterContext context) {
         var tenantPrefix = getTenantPrefix(context);
         request.setGroupId(tenantPrefix + request.groupId());
-        context.forwardRequest(request);
+        context.forwardRequest(header, request);
     }
 
     @Override
     public void onSyncGroupRequest(RequestHeaderData header, SyncGroupRequestData request, KrpcFilterContext context) {
         var tenantPrefix = getTenantPrefix(context);
         request.setGroupId(tenantPrefix + request.groupId());
-        context.forwardRequest(request);
+        context.forwardRequest(header, request);
     }
 
     @Override
     public void onLeaveGroupRequest(RequestHeaderData header, LeaveGroupRequestData request, KrpcFilterContext context) {
         var tenantPrefix = getTenantPrefix(context);
         request.setGroupId(tenantPrefix + request.groupId());
-        context.forwardRequest(request);
+        context.forwardRequest(header, request);
     }
 
     @Override
     public void onHeartbeatRequest(RequestHeaderData header, HeartbeatRequestData request, KrpcFilterContext context) {
         var tenantPrefix = getTenantPrefix(context);
         request.setGroupId(tenantPrefix + request.groupId());
-        context.forwardRequest(request);
+        context.forwardRequest(header, request);
     }
 
     @Override
     public void onDescribeGroupsRequest(RequestHeaderData header, DescribeGroupsRequestData request, KrpcFilterContext context) {
         request.setGroups(request.groups().stream().map(group -> applyTenantPrefix(context, group)).toList());
-        context.forwardRequest(request);
+        context.forwardRequest(header, request);
     }
 
     @Override
     public void onDescribeGroupsResponse(ResponseHeaderData header, DescribeGroupsResponseData response, KrpcFilterContext context) {
         response.groups().forEach(group -> removeTenantPrefix(context, group::groupId, group::setGroupId, false));
-        context.forwardResponse(response);
+        context.forwardResponse(header, response);
     }
 
     private void applyTenantPrefix(KrpcFilterContext context, Supplier<String> getter, Consumer<String> setter, boolean ignoreEmpty) {

--- a/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterTest.java
+++ b/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterTest.java
@@ -44,6 +44,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static io.kroxylicious.proxy.filter.multitenant.KafkaApiMessageConverter.requestConverterFor;
 import static io.kroxylicious.proxy.filter.multitenant.KafkaApiMessageConverter.responseConverterFor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -147,7 +148,7 @@ class MultiTenantTransformationFilterTest {
         var marshalled = requestWriter.apply(request, header.requestApiVersion());
 
         invoker.onRequest(ApiKeys.forId(apiMessageType.apiKey()), header.requestApiVersion(), header, request, context);
-        verify(context).forwardRequest(apiMessageCaptor.capture());
+        verify(context).forwardRequest(any(), apiMessageCaptor.capture());
 
         var filtered = requestWriter.apply(apiMessageCaptor.getValue(), header.requestApiVersion());
         assertEquals(requestTestDef.expectedPatch(), JsonDiff.asJson(marshalled, filtered));
@@ -166,8 +167,9 @@ class MultiTenantTransformationFilterTest {
 
         var marshalled = responseWriter.apply(response, header.requestApiVersion());
 
-        invoker.onResponse(ApiKeys.forId(apiMessageType.apiKey()), header.requestApiVersion(), new ResponseHeaderData(), response, context);
-        verify(context).forwardResponse(apiMessageCaptor.capture());
+        ResponseHeaderData headerData = new ResponseHeaderData();
+        invoker.onResponse(ApiKeys.forId(apiMessageType.apiKey()), header.requestApiVersion(), headerData, response, context);
+        verify(context).forwardResponse(any(), apiMessageCaptor.capture());
 
         var filtered = responseWriter.apply(apiMessageCaptor.getValue(), header.requestApiVersion());
         assertEquals(responseTestDef.expectedPatch(), JsonDiff.asJson(marshalled, filtered));

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/example/authn/SaslAuthnObserver.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/example/authn/SaslAuthnObserver.java
@@ -35,7 +35,7 @@ public class SaslAuthnObserver
                                        SaslHandshakeRequestData request,
                                        KrpcFilterContext context) {
         this.mechanism = request.mechanism();
-        context.forwardRequest(request);
+        context.forwardRequest(header, request);
     }
 
     @Override
@@ -44,7 +44,7 @@ public class SaslAuthnObserver
         if (response.errorCode() != Errors.NONE.code()) {
             this.mechanism = null;
         }
-        context.forwardResponse(response);
+        context.forwardResponse(header, response);
     }
 
     @Override
@@ -63,7 +63,7 @@ public class SaslAuthnObserver
                 principalName = "baz";
                 break;
         }
-        context.forwardRequest(request);
+        context.forwardRequest(header, request);
     }
 
     @Override
@@ -79,7 +79,7 @@ public class SaslAuthnObserver
         // response.authBytes();
         // response.errorCode();
         // response.errorMessage();
-        context.forwardResponse(response);
+        context.forwardResponse(header, response);
     }
 
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/example/topicencryption/TopicEncryption.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/example/topicencryption/TopicEncryption.java
@@ -30,7 +30,7 @@ public class TopicEncryption implements ProduceRequestFilter, FetchResponseFilte
             return;
         }
         else {
-            context.forwardRequest(request);
+            context.forwardRequest(header, request);
         }
     }
 
@@ -43,7 +43,7 @@ public class TopicEncryption implements ProduceRequestFilter, FetchResponseFilte
             }
             // TODO the rest of it
         }
-        context.forwardResponse(response);
+        context.forwardResponse(header, response);
     }
 
     private String lookupTopic(Uuid topicId) {

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/example/topicname/TopicNameFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/example/topicname/TopicNameFilter.java
@@ -36,7 +36,7 @@ public class TopicNameFilter
         }
         // TODO how can we expose this state to other filters?
         // TODO filterContext.put("topicNames", topicNames);
-        context.forwardResponse(response);
+        context.forwardResponse(header, response);
     }
 
     // We don't implement DeleteTopicsRequestFilter because we don't know whether
@@ -46,7 +46,7 @@ public class TopicNameFilter
         for (var resp : response.responses()) {
             topicNames.remove(resp.topicId());
         }
-        context.forwardResponse(response);
+        context.forwardResponse(header, response);
     }
 
     @Override
@@ -54,6 +54,6 @@ public class TopicNameFilter
         for (var topic : response.topics()) {
             topicNames.put(topic.topicId(), topic.name());
         }
-        context.forwardResponse(response);
+        context.forwardResponse(header, response);
     }
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ApiVersionsFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ApiVersionsFilter.java
@@ -66,6 +66,6 @@ public class ApiVersionsFilter implements ApiVersionsResponseFilter {
     @Override
     public void onApiVersionsResponse(ResponseHeaderData header, ApiVersionsResponseData data, KrpcFilterContext context) {
         intersectApiVersions(context.channelDescriptor(), data);
-        context.forwardResponse(data);
+        context.forwardResponse(header, data);
     }
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilter.java
@@ -45,7 +45,7 @@ public class BrokerAddressFilter implements MetadataResponseFilter, FindCoordina
             apply(context, broker, MetadataResponseBroker::nodeId, MetadataResponseBroker::host, MetadataResponseBroker::port, MetadataResponseBroker::setHost,
                     MetadataResponseBroker::setPort);
         }
-        context.forwardResponse(data);
+        context.forwardResponse(header, data);
     }
 
     @Override
@@ -54,7 +54,7 @@ public class BrokerAddressFilter implements MetadataResponseFilter, FindCoordina
             apply(context, broker, DescribeClusterBroker::brokerId, DescribeClusterBroker::host, DescribeClusterBroker::port, DescribeClusterBroker::setHost,
                     DescribeClusterBroker::setPort);
         }
-        context.forwardResponse(data);
+        context.forwardResponse(header, data);
     }
 
     @Override
@@ -62,7 +62,7 @@ public class BrokerAddressFilter implements MetadataResponseFilter, FindCoordina
         for (Coordinator coordinator : data.coordinators()) {
             apply(context, coordinator, Coordinator::nodeId, Coordinator::host, Coordinator::port, Coordinator::setHost, Coordinator::setPort);
         }
-        context.forwardResponse(data);
+        context.forwardResponse(header, data);
     }
 
     private <T> void apply(KrpcFilterContext context, T broker, Function<T, Integer> nodeIdGetter, Function<T, String> hostGetter, ToIntFunction<T> portGetter,

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FetchResponseTransformationFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FetchResponseTransformationFilter.java
@@ -94,12 +94,12 @@ public class FetchResponseTransformationFilter implements FetchResponseFilter {
                         }
                         applyTransformation(context, fetchResponse);
                         LOGGER.debug("Forwarding original Fetch response");
-                        context.forwardResponse(fetchResponse);
+                        context.forwardResponse(header, fetchResponse);
                     });
         }
         else {
             applyTransformation(context, fetchResponse);
-            context.forwardResponse(fetchResponse);
+            context.forwardResponse(header, fetchResponse);
         }
     }
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ProduceRequestTransformationFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ProduceRequestTransformationFilter.java
@@ -72,7 +72,7 @@ public class ProduceRequestTransformationFilter implements ProduceRequestFilter 
     @Override
     public void onProduceRequest(RequestHeaderData header, ProduceRequestData data, KrpcFilterContext context) {
         applyTransformation(context, data);
-        context.forwardRequest(data);
+        context.forwardRequest(header, data);
     }
 
     private void applyTransformation(KrpcFilterContext ctx, ProduceRequestData req) {

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/UpstreamBrokerAddressCachingNetFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/UpstreamBrokerAddressCachingNetFilter.java
@@ -52,7 +52,7 @@ public class UpstreamBrokerAddressCachingNetFilter implements NetFilter {
                     LOGGER.info("Got upstream for broker {} : {}", b.nodeId(), replacement);
                 }
             });
-            filterContext.forwardResponse(response);
+            filterContext.forwardResponse(header, response);
         });
 
         var targetPort = ((InetSocketAddress) context.localAddress()).getPort();

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHandlerTest.java
@@ -35,7 +35,7 @@ public class FilterHandlerTest extends FilterHarness {
 
     @Test
     public void testForwardRequest() {
-        ApiVersionsRequestFilter filter = (header, request, context) -> context.forwardRequest(request);
+        ApiVersionsRequestFilter filter = (header, request, context) -> context.forwardRequest(header, request);
         buildChannel(filter);
         var frame = writeRequest(new ApiVersionsRequestData());
         var propagated = channel.readOutbound();
@@ -72,7 +72,7 @@ public class FilterHandlerTest extends FilterHarness {
 
     @Test
     public void testForwardResponse() {
-        ApiVersionsResponseFilter filter = (header, response, context) -> context.forwardResponse(response);
+        ApiVersionsResponseFilter filter = (header, response, context) -> context.forwardResponse(header, response);
         buildChannel(filter);
         var frame = writeResponse(new ApiVersionsResponseData());
         var propagated = channel.readInbound();

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/codec/RequestDecoderTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/codec/RequestDecoderTest.java
@@ -38,7 +38,7 @@ public class RequestDecoderTest extends AbstractCodecTest {
                         AbstractCodecTest::deserializeRequestHeaderUsingKafkaApis,
                         AbstractCodecTest::deserializeApiVersionsRequestUsingKafkaApis,
                         new KafkaRequestDecoder(
-                                DecodePredicate.forFilters((ApiVersionsRequestFilter) (header, request, context) -> context.forwardRequest(request))),
+                                DecodePredicate.forFilters((ApiVersionsRequestFilter) (header, request, context) -> context.forwardRequest(header, request))),
                         DecodedRequestFrame.class,
                         (RequestHeaderData header) -> header),
                 "Unexpected correlation id");
@@ -63,7 +63,7 @@ public class RequestDecoderTest extends AbstractCodecTest {
                                     @Override
                                     public void onApiVersionsRequest(RequestHeaderData header, ApiVersionsRequestData request,
                                                                      KrpcFilterContext context) {
-                                        context.forwardRequest(request);
+                                        context.forwardRequest(header, request);
                                     }
                                 })),
                         OpaqueRequestFrame.class),
@@ -83,7 +83,7 @@ public class RequestDecoderTest extends AbstractCodecTest {
 
         var messages = new ArrayList<>();
         new KafkaRequestDecoder(
-                DecodePredicate.forFilters((ApiVersionsRequestFilter) (header, request, context) -> context.forwardRequest(request)))
+                DecodePredicate.forFilters((ApiVersionsRequestFilter) (header, request, context) -> context.forwardRequest(header, request)))
                 .decode(null, byteBuf, messages);
 
         assertEquals(List.of(), messageClasses(messages));
@@ -101,7 +101,7 @@ public class RequestDecoderTest extends AbstractCodecTest {
 
         var messages = new ArrayList<>();
         new KafkaRequestDecoder(
-                DecodePredicate.forFilters((ApiVersionsRequestFilter) (header, request, context) -> context.forwardRequest(request)))
+                DecodePredicate.forFilters((ApiVersionsRequestFilter) (header, request, context) -> context.forwardRequest(header, request)))
                 .decode(null, byteBuf, messages);
 
         assertEquals(List.of(), messageClasses(messages));
@@ -143,7 +143,7 @@ public class RequestDecoderTest extends AbstractCodecTest {
 
         var messages = new ArrayList<>();
         new KafkaRequestDecoder(
-                DecodePredicate.forFilters((ApiVersionsRequestFilter) (head, request, context) -> context.forwardRequest(request)))
+                DecodePredicate.forFilters((ApiVersionsRequestFilter) (head, request, context) -> context.forwardRequest(header, request)))
                 .decode(null, byteBuf, messages);
 
         assertEquals(List.of(DecodedRequestFrame.class, DecodedRequestFrame.class), messageClasses(messages));


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Filters can currently mutate headers (added in #142) and that works but it is inconsistent with the forwardRequest/forwardResponse apis where we pass the ApiMessage. This will allow us to replace the header/body rather than mutate them in future if required.

Closes #98
