### PR TITLE
Record PR-comment triggered performance results against PR commit

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -102,7 +102,7 @@ jobs:
         run: ./benchmark_output_to_json.sh output.txt output.json
 
       - name: 'Store benchmark result'
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@v1.17.0
         with:
           name: kafka producer perf test Benchmark
           tool: 'customSmallerIsBetter'
@@ -116,6 +116,7 @@ jobs:
           summary-always: true
           fail-on-alert: true
           alert-comment-cc-users: '@kroxylicious/developers'
+          ref: refs/pull/${{ github.event.issue.number }}/head
 
   workflow:
     name: Benchmark manually launched


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Updates to latest version of github-action-benchmark and configures it with the ref being tested.

Why:
Until now the benchmark action was unaware that we were checking out a specific ref to test against. Now we can pass the ref to the plugin so it can look up the commit hash and message when updating the performance-results branch. This also makes the alert message on a failed perf run comment on the correct commit.

Closes #181