### PR TITLE
Refactor to faster FilterInvoker implementation

### DIFF
--- a/api/kroxylicious-filter-api/pom.xml
+++ b/api/kroxylicious-filter-api/pom.xml
@@ -115,6 +115,23 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>generate-per-message-filter-invokers</id>
+                        <goals>
+                            <goal>generate-single</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <messageSpecDirectory>${project.build.directory}/message-specs/common/message</messageSpecDirectory>
+                            <messageSpecFilter>*{Request,Response}.json</messageSpecFilter>
+                            <templateDirectory>${project.basedir}/src/main/templates</templateDirectory>
+                            <templateNames>Kproxy/FilterInvoker.ftl</templateNames>
+                            <!--suppress UnresolvedMavenProperty -->
+                            <outputFilePattern>${messageSpecName}FilterInvoker.java</outputFilePattern>
+                            <outputPackage>io.kroxylicious.proxy.filter</outputPackage>
+                            <outputDirectory>${project.build.directory}/generated-sources/krpc</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>generate-request-filters</id>
                         <goals>
                             <goal>generate-multi</goal>
@@ -125,6 +142,24 @@
                             <messageSpecFilter>*{Request,Response}.json</messageSpecFilter>
                             <templateDirectory>${project.basedir}/src/main/templates</templateDirectory>
                             <templateNames>Kproxy/SpecificFilterInvoker.ftl</templateNames>
+                            <!--suppress UnresolvedMavenProperty -->
+                            <outputFilePattern>${templateName}.java</outputFilePattern>
+                            <outputPackage>io.kroxylicious.proxy.filter</outputPackage>
+                            <outputDirectory>${project.build.directory}/generated-sources/krpc</outputDirectory>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>generate-array-filter-invoker</id>
+                        <goals>
+                            <goal>generate-multi</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <messageSpecDirectory>${project.build.directory}/message-specs/common/message</messageSpecDirectory>
+                            <messageSpecFilter>*{Request,Response}.json</messageSpecFilter>
+                            <templateDirectory>${project.basedir}/src/main/templates</templateDirectory>
+                            <templateNames>Kproxy/SpecificFilterArrayInvoker.ftl</templateNames>
                             <!--suppress UnresolvedMavenProperty -->
                             <outputFilePattern>${templateName}.java</outputFilePattern>
                             <outputPackage>io.kroxylicious.proxy.filter</outputPackage>

--- a/api/kroxylicious-filter-api/pom.xml
+++ b/api/kroxylicious-filter-api/pom.xml
@@ -166,6 +166,23 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>generate-request-map2-filters</id>
+                        <goals>
+                            <goal>generate-multi</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <messageSpecDirectory>${project.build.directory}/message-specs/common/message</messageSpecDirectory>
+                            <messageSpecFilter>*{Request,Response}.json</messageSpecFilter>
+                            <templateDirectory>${project.basedir}/src/main/templates</templateDirectory>
+                            <templateNames>Kproxy/SpecificFilterMapInvoker2.ftl</templateNames>
+                            <!--suppress UnresolvedMavenProperty -->
+                            <outputFilePattern>${templateName}.java</outputFilePattern>
+                            <outputPackage>io.kroxylicious.proxy.filter</outputPackage>
+                            <outputDirectory>${project.build.directory}/generated-sources/krpc</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>generate-request-array-filters</id>
                         <goals>
                             <goal>generate-multi</goal>

--- a/api/kroxylicious-filter-api/pom.xml
+++ b/api/kroxylicious-filter-api/pom.xml
@@ -200,6 +200,23 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>generate-array-filter-invoker2</id>
+                        <goals>
+                            <goal>generate-multi</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <messageSpecDirectory>${project.build.directory}/message-specs/common/message</messageSpecDirectory>
+                            <messageSpecFilter>*{Request,Response}.json</messageSpecFilter>
+                            <templateDirectory>${project.basedir}/src/main/templates</templateDirectory>
+                            <templateNames>Kproxy/SpecificFilterArrayInvoker2.ftl</templateNames>
+                            <!--suppress UnresolvedMavenProperty -->
+                            <outputFilePattern>${templateName}.java</outputFilePattern>
+                            <outputPackage>io.kroxylicious.proxy.filter</outputPackage>
+                            <outputDirectory>${project.build.directory}/generated-sources/krpc</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>generate-array-filter-invoker</id>
                         <goals>
                             <goal>generate-multi</goal>

--- a/api/kroxylicious-filter-api/pom.xml
+++ b/api/kroxylicious-filter-api/pom.xml
@@ -148,7 +148,40 @@
                             <outputDirectory>${project.build.directory}/generated-sources/krpc</outputDirectory>
                         </configuration>
                     </execution>
-
+                    <execution>
+                        <id>generate-request-map-filters</id>
+                        <goals>
+                            <goal>generate-multi</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <messageSpecDirectory>${project.build.directory}/message-specs/common/message</messageSpecDirectory>
+                            <messageSpecFilter>*{Request,Response}.json</messageSpecFilter>
+                            <templateDirectory>${project.basedir}/src/main/templates</templateDirectory>
+                            <templateNames>Kproxy/SpecificFilterMapInvoker.ftl</templateNames>
+                            <!--suppress UnresolvedMavenProperty -->
+                            <outputFilePattern>${templateName}.java</outputFilePattern>
+                            <outputPackage>io.kroxylicious.proxy.filter</outputPackage>
+                            <outputDirectory>${project.build.directory}/generated-sources/krpc</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-request-array-filters</id>
+                        <goals>
+                            <goal>generate-multi</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <messageSpecDirectory>${project.build.directory}/message-specs/common/message</messageSpecDirectory>
+                            <messageSpecFilter>*{Request,Response}.json</messageSpecFilter>
+                            <templateDirectory>${project.basedir}/src/main/templates</templateDirectory>
+                            <templateNames>Kproxy/SpecificFilterFieldInvoker.ftl</templateNames>
+                            <!--suppress UnresolvedMavenProperty -->
+                            <outputFilePattern>${templateName}.java</outputFilePattern>
+                            <outputPackage>io.kroxylicious.proxy.filter</outputPackage>
+                            <outputDirectory>${project.build.directory}/generated-sources/krpc</outputDirectory>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>generate-array-filter-invoker</id>
                         <goals>

--- a/api/kroxylicious-filter-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvoker.java
+++ b/api/kroxylicious-filter-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvoker.java
@@ -76,6 +76,7 @@ public interface FilterInvoker {
      * so that the message continues to flow through the filter chain.
      * </p>
      * @param apiKey the key of the message
+     * @param apiVersion the apiVersion of the message
      * @param header the header of the message
      * @param body the body of the message
      * @param filterContext contains methods to continue the filter chain and other contextual data

--- a/api/kroxylicious-filter-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvokers.java
+++ b/api/kroxylicious-filter-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvokers.java
@@ -17,6 +17,10 @@ import org.apache.kafka.common.protocol.ApiMessage;
  */
 public class FilterInvokers {
 
+    private FilterInvokers() {
+
+    }
+
     /**
      * Create a FilterInvoker for this filter. Supported cases are:
      * <ol>
@@ -54,8 +58,29 @@ public class FilterInvokers {
             return responseInvoker((ResponseFilter) filter);
         }
         else {
-            return new SpecificFilterInvoker(filter);
+            return instanceOfInvoker(filter);
         }
+    }
+
+    /**
+     * Create an invoker for this filter that uses instanceof when deciding
+     * if the filter should be consulted/handle messages.
+     * @param filter the filter
+     * @return an invoker for the filter
+     */
+    public static FilterInvoker instanceOfInvoker(KrpcFilter filter) {
+        return new SpecificFilterInvoker(filter);
+    }
+
+    /**
+     * Create an invoker for this filter that avoids instanceof when deciding
+     * if the filter should be consulted/handle messages. Instead, it stores
+     * an invoker for each targeted request-type and response-type in an array.
+     * @param filter the filter
+     * @return an invoker for the filter
+     */
+    public static FilterInvoker arrayInvoker(KrpcFilter filter) {
+        return new SpecificFilterArrayInvoker(filter);
     }
 
     private static IllegalArgumentException unsupportedFilterInstance(KrpcFilter filter, String message) {

--- a/api/kroxylicious-filter-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvokers.java
+++ b/api/kroxylicious-filter-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvokers.java
@@ -58,7 +58,7 @@ public class FilterInvokers {
             return responseInvoker((ResponseFilter) filter);
         }
         else {
-            return instanceOfInvoker(filter);
+            return arrayInvoker(filter);
         }
     }
 

--- a/api/kroxylicious-filter-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvokers.java
+++ b/api/kroxylicious-filter-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvokers.java
@@ -58,7 +58,7 @@ public class FilterInvokers {
             return responseInvoker((ResponseFilter) filter);
         }
         else {
-            return arrayInvoker(filter);
+            return arrayInvoker2(filter);
         }
     }
 

--- a/api/kroxylicious-filter-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvokers.java
+++ b/api/kroxylicious-filter-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvokers.java
@@ -85,6 +85,17 @@ public class FilterInvokers {
 
     /**
      * Create an invoker for this filter that avoids instanceof when deciding
+     * if the filter should be consulted/handle messages. Instead, it stores
+     * an invoker for each targeted request-type and response-type in an array.
+     * @param filter the filter
+     * @return an invoker for the filter
+     */
+    public static FilterInvoker arrayInvoker2(KrpcFilter filter) {
+        return new SpecificFilterArrayInvoker2(filter);
+    }
+
+    /**
+     * Create an invoker for this filter that avoids instanceof when deciding
      * if the filter should be consulted/handle messages. Instead, it has a field
      * for each specific filter type and populates them at construction time if the
      * filter matches those types.

--- a/api/kroxylicious-filter-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvokers.java
+++ b/api/kroxylicious-filter-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvokers.java
@@ -107,8 +107,35 @@ public class FilterInvokers {
         return new SpecificFilterMapInvoker(filter);
     }
 
+    /**
+     * Create an invoker for this filter that avoids instanceof when deciding
+     * if the filter should be consulted/handle messages. Instead, it has a map
+     * containing invokers for each specific filter type and populates them at
+     * construction time if the filter matches those types.
+     * @param filter the filter
+     * @return an invoker for the filter
+     */
+    public static FilterInvoker mapInvoker2(KrpcFilter filter) {
+        return new SpecificFilterMapInvoker2(filter);
+    }
+
     private static IllegalArgumentException unsupportedFilterInstance(KrpcFilter filter, String message) {
         return new IllegalArgumentException("Invoker could not be created for: " + filter.getClass().getName() + ". " + message);
+    }
+
+    public static FilterInvoker handleNothingInvoker() {
+        return new FilterInvoker() {
+
+            @Override
+            public void onRequest(ApiKeys apiKey, short apiVersion, RequestHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+                throw new IllegalStateException("I should never be invoked");
+            }
+
+            @Override
+            public void onResponse(ApiKeys apiKey, short apiVersion, ResponseHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+                throw new IllegalStateException("I should never be invoked");
+            }
+        };
     }
 
     private static FilterInvoker requestInvoker(RequestFilter filter) {

--- a/api/kroxylicious-filter-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvokers.java
+++ b/api/kroxylicious-filter-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvokers.java
@@ -83,6 +83,30 @@ public class FilterInvokers {
         return new SpecificFilterArrayInvoker(filter);
     }
 
+    /**
+     * Create an invoker for this filter that avoids instanceof when deciding
+     * if the filter should be consulted/handle messages. Instead, it has a field
+     * for each specific filter type and populates them at construction time if the
+     * filter matches those types.
+     * @param filter the filter
+     * @return an invoker for the filter
+     */
+    public static FilterInvoker fieldInvoker(KrpcFilter filter) {
+        return new SpecificFilterFieldInvoker(filter);
+    }
+
+    /**
+     * Create an invoker for this filter that avoids instanceof when deciding
+     * if the filter should be consulted/handle messages. Instead, it has a map
+     * containing invokers for each specific filter type and populates them at
+     * construction time if the filter matches those types.
+     * @param filter the filter
+     * @return an invoker for the filter
+     */
+    public static FilterInvoker mapInvoker(KrpcFilter filter) {
+        return new SpecificFilterMapInvoker(filter);
+    }
+
     private static IllegalArgumentException unsupportedFilterInstance(KrpcFilter filter, String message) {
         return new IllegalArgumentException("Invoker could not be created for: " + filter.getClass().getName() + ". " + message);
     }

--- a/api/kroxylicious-filter-api/src/main/templates/Kproxy/FilterInvoker.ftl
+++ b/api/kroxylicious-filter-api/src/main/templates/Kproxy/FilterInvoker.ftl
@@ -1,0 +1,64 @@
+<#--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<#assign
+  dataClass="${messageSpec.name}Data"
+  filterClass="${messageSpec.name}Filter"
+  filterInvokerClass="${messageSpec.name}FilterInvoker"
+  msgType=messageSpec.type?lower_case
+/>
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.kroxylicious.proxy.filter;
+
+import org.apache.kafka.common.message.${messageSpec.name}Data;
+
+<#if messageSpec.type?lower_case == 'response'>
+import org.apache.kafka.common.message.ResponseHeaderData;
+<#else>
+import org.apache.kafka.common.message.RequestHeaderData;
+</#if>
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+/**
+ * An invoker for ${filterClass}. The point is that this invoker knows the type of
+ * ${filterClass} to avoid using instanceof/cast, which has a performance issue in
+ * the current LTS java (17).
+ */
+class ${filterInvokerClass} implements FilterInvoker {
+
+    private final ${filterClass} filter;
+
+    ${filterInvokerClass}(${filterClass} filter) {
+        this.filter = filter;
+    }
+
+    @Override
+    public boolean shouldHandle<#if messageSpec.type?lower_case == 'response'>Response<#else>Request</#if>(ApiKeys apiKey, short apiVersion) {
+        return filter.shouldHandle${messageSpec.name}(apiVersion);
+    }
+
+    @Override
+    public void on<#if messageSpec.type?lower_case == 'response'>Response<#else>Request</#if>(ApiKeys apiKey, short apiVersion, <#if messageSpec.type?lower_case == 'response'>Response<#else>Request</#if>HeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+        filter.on${messageSpec.name}(header, (${messageSpec.name}Data) body, filterContext);
+    }
+}

--- a/api/kroxylicious-filter-api/src/main/templates/Kproxy/SpecificFilterArrayInvoker.ftl
+++ b/api/kroxylicious-filter-api/src/main/templates/Kproxy/SpecificFilterArrayInvoker.ftl
@@ -1,0 +1,172 @@
+<#--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${outputPackage};
+
+import java.util.Arrays;
+import java.util.OptionalInt;
+
+import org.apache.kafka.common.message.ApiMessageType;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+/**
+ * Invoker for KrpcFilters that implement any number of Specific Message interfaces (for
+ * example {@link io.kroxylicious.proxy.filter.AlterConfigsResponseFilter}.
+ */
+class SpecificFilterArrayInvoker implements FilterInvoker {
+
+    private final FilterInvoker[] requestInvokers;
+    private final FilterInvoker[] responseInvokers;
+
+    SpecificFilterArrayInvoker(KrpcFilter filter) {
+        OptionalInt maybeMaxId = Arrays.stream(ApiMessageType.values()).mapToInt(ApiMessageType::apiKey).max();
+        if (maybeMaxId.isEmpty()) {
+            throw new IllegalStateException("no maximum id found");
+        }
+        int arraySize = maybeMaxId.getAsInt() + 1;
+        this.requestInvokers = new FilterInvoker[arraySize];
+        this.responseInvokers = new FilterInvoker[arraySize];
+        <#list messageSpecs as messageSpec>
+        <#if messageSpec.type?lower_case == 'request'>
+        this.requestInvokers[${messageSpec.apiKey.get()}] = filter instanceof ${messageSpec.name}Filter ? new ${messageSpec.name}FilterInvoker((${messageSpec.name}Filter) filter) : null;
+        </#if>
+        </#list>
+        <#list messageSpecs as messageSpec>
+        <#if messageSpec.type?lower_case == 'response'>
+        this.responseInvokers[${messageSpec.apiKey.get()}] = filter instanceof ${messageSpec.name}Filter ? new ${messageSpec.name}FilterInvoker((${messageSpec.name}Filter) filter) : null;
+        </#if>
+        </#list>
+    }
+
+    /**
+     * Apply the filter to the given {@code header} and {@code body} using the given {@code filterContext}.
+     * @param apiKey The request api key.
+     * @param apiVersion The request api version.
+     * @param header The request header.
+     * @param body The request body.
+     * @param filterContext The filter context.
+     */
+    @Override
+    public void onRequest(ApiKeys apiKey,
+                           short apiVersion,
+                           RequestHeaderData header,
+                           ApiMessage body,
+                           KrpcFilterContext filterContext) {
+        FilterInvoker invoker = getInvoker(requestInvokers, apiKey);
+        if (invoker == null) {
+            filterContext.forwardRequest(header, body);
+        }
+        else {
+            invoker.onRequest(apiKey, apiVersion, header, body, filterContext);
+        }
+    }
+
+    /**
+     * Apply the filter to the given {@code header} and {@code body} using the given {@code filterContext}.
+     * @param apiKey The request api key.
+     * @param apiVersion The api version.
+     * @param header The request header.
+     * @param body The request body.
+     * @param filterContext The filter context.
+     */
+    @Override
+    public void onResponse(ApiKeys apiKey,
+                            short apiVersion,
+                            ResponseHeaderData header,
+                            ApiMessage body,
+                            KrpcFilterContext filterContext) {
+        FilterInvoker invoker = getInvoker(responseInvokers, apiKey);
+        if (invoker == null) {
+            filterContext.forwardResponse(header, body);
+        }
+        else {
+            invoker.onResponse(apiKey, apiVersion, header, body, filterContext);
+        }
+    }
+
+
+    /**
+     * <p>Determines whether a request with the given {@code apiKey} and {@code apiVersion} should be deserialized.
+     * Note that it is not guaranteed that this method will be called once per request,
+     * or that two consecutive calls refer to the same request.
+     * That is, the sequences of invocations like the following are allowed:</p>
+     * <ol>
+     *     <li>{@code shouldHandleRequest} on request A</li>
+     *     <li>{@code shouldHandleRequest} on request B</li>
+     *     <li>{@code shouldHandleRequest} on request A</li>
+     *     <li>{@code onRequest} on request A</li>
+     *     <li>{@code onRequest} on request B</li>
+     * </ol>
+     * @param apiKey The API key
+     * @param apiVersion The API version
+     * @return true if request should be deserialized
+     */
+    @Override
+    public boolean shouldHandleRequest(ApiKeys apiKey, short apiVersion) {
+        FilterInvoker invoker = getInvoker(requestInvokers, apiKey);
+        if (invoker == null) {
+            return false;
+        }
+        else {
+            return invoker.shouldHandleRequest(apiKey, apiVersion);
+        }
+    }
+
+    /**
+     * <p>Determines whether a response with the given {@code apiKey} and {@code apiVersion} should be deserialized.
+     * Note that it is not guaranteed that this method will be called once per response,
+     * or that two consecutive calls refer to the same response.
+     * That is, the sequences of invocations like the following are allowed:</p>
+     * <ol>
+     *     <li>{@code shouldHandleResponse} on response A</li>
+     *     <li>{@code shouldHandleResponse} on response B</li>
+     *     <li>{@code shouldHandleResponse} on response A</li>
+     *     <li>{@code apply} on response A</li>
+     *     <li>{@code apply} on response B</li>
+     * </ol>
+     * @param apiKey The API key
+     * @param apiVersion The API version
+     * @return true if response should be deserialized
+     */
+    @Override
+    public boolean shouldHandleResponse(ApiKeys apiKey, short apiVersion) {
+        FilterInvoker invoker = getInvoker(responseInvokers, apiKey);
+        if (invoker == null) {
+            return false;
+        }
+        else {
+            return invoker.shouldHandleResponse(apiKey, apiVersion);
+        }
+    }
+
+    private FilterInvoker getInvoker(FilterInvoker[] invokers, ApiKeys apiKey) {
+        if (apiKey.id >= invokers.length) {
+            return null;
+        }
+        return invokers[apiKey.id];
+    }
+
+}

--- a/api/kroxylicious-filter-api/src/main/templates/Kproxy/SpecificFilterArrayInvoker2.ftl
+++ b/api/kroxylicious-filter-api/src/main/templates/Kproxy/SpecificFilterArrayInvoker2.ftl
@@ -1,0 +1,168 @@
+<#--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${outputPackage};
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.OptionalInt;
+
+import org.apache.kafka.common.message.ApiMessageType;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+/**
+ * Invoker for KrpcFilters that implement any number of Specific Message interfaces (for
+ * example {@link io.kroxylicious.proxy.filter.AlterConfigsResponseFilter}.
+ */
+class SpecificFilterArrayInvoker2 implements FilterInvoker {
+
+    private static final FilterInvoker[] HANDLE_NOTHING = createHandleNothing();
+
+    private final FilterInvoker[] requestInvokers;
+    private final FilterInvoker[] responseInvokers;
+
+    SpecificFilterArrayInvoker2(KrpcFilter filter) {
+        Map<Integer, FilterInvoker> requestInvokers = new HashMap<>();
+        Map<Integer, FilterInvoker> responseInvokers = new HashMap<>();
+        <#list messageSpecs as messageSpec>
+        if (filter instanceof ${messageSpec.name}Filter) {
+            ${messageSpec.type?lower_case}Invokers.put(${messageSpec.apiKey.get()}, new ${messageSpec.name}FilterInvoker((${messageSpec.name}Filter) filter));
+        }
+        </#list>
+        this.requestInvokers = createFrom(requestInvokers);
+        this.responseInvokers = createFrom(responseInvokers);
+    }
+
+    /**
+     * Apply the filter to the given {@code header} and {@code body} using the given {@code filterContext}.
+     * @param apiKey The request api key.
+     * @param apiVersion The request api version.
+     * @param header The request header.
+     * @param body The request body.
+     * @param filterContext The filter context.
+     */
+    @Override
+    public void onRequest(ApiKeys apiKey,
+                           short apiVersion,
+                           RequestHeaderData header,
+                           ApiMessage body,
+                           KrpcFilterContext filterContext) {
+        FilterInvoker invoker = requestInvokers[apiKey.id];
+        invoker.onRequest(apiKey, apiVersion, header, body, filterContext);
+    }
+
+    /**
+     * Apply the filter to the given {@code header} and {@code body} using the given {@code filterContext}.
+     * @param apiKey The request api key.
+     * @param apiVersion The api version.
+     * @param header The request header.
+     * @param body The request body.
+     * @param filterContext The filter context.
+     */
+    @Override
+    public void onResponse(ApiKeys apiKey,
+                            short apiVersion,
+                            ResponseHeaderData header,
+                            ApiMessage body,
+                            KrpcFilterContext filterContext) {
+        FilterInvoker invoker = responseInvokers[apiKey.id];
+        invoker.onResponse(apiKey, apiVersion, header, body, filterContext);
+    }
+
+    /**
+     * <p>Determines whether a request with the given {@code apiKey} and {@code apiVersion} should be deserialized.
+     * Note that it is not guaranteed that this method will be called once per request,
+     * or that two consecutive calls refer to the same request.
+     * That is, the sequences of invocations like the following are allowed:</p>
+     * <ol>
+     *     <li>{@code shouldHandleRequest} on request A</li>
+     *     <li>{@code shouldHandleRequest} on request B</li>
+     *     <li>{@code shouldHandleRequest} on request A</li>
+     *     <li>{@code onRequest} on request A</li>
+     *     <li>{@code onRequest} on request B</li>
+     * </ol>
+     * @param apiKey The API key
+     * @param apiVersion The API version
+     * @return true if request should be deserialized
+     */
+    @Override
+    public boolean shouldHandleRequest(ApiKeys apiKey, short apiVersion) {
+        FilterInvoker invoker = requestInvokers[apiKey.id];
+        return invoker.shouldHandleRequest(apiKey, apiVersion);
+    }
+
+    /**
+     * <p>Determines whether a response with the given {@code apiKey} and {@code apiVersion} should be deserialized.
+     * Note that it is not guaranteed that this method will be called once per response,
+     * or that two consecutive calls refer to the same response.
+     * That is, the sequences of invocations like the following are allowed:</p>
+     * <ol>
+     *     <li>{@code shouldHandleResponse} on response A</li>
+     *     <li>{@code shouldHandleResponse} on response B</li>
+     *     <li>{@code shouldHandleResponse} on response A</li>
+     *     <li>{@code apply} on response A</li>
+     *     <li>{@code apply} on response B</li>
+     * </ol>
+     * @param apiKey The API key
+     * @param apiVersion The API version
+     * @return true if response should be deserialized
+     */
+    @Override
+    public boolean shouldHandleResponse(ApiKeys apiKey, short apiVersion) {
+        FilterInvoker invoker = responseInvokers[apiKey.id];
+        return invoker.shouldHandleResponse(apiKey, apiVersion);
+    }
+
+    private static FilterInvoker[] createHandleNothing() {
+        FilterInvoker[] filterInvokers = emptyInvokerArraySizedForMessageTypes();
+        Arrays.stream(ApiMessageType.values()).mapToInt(ApiMessageType::apiKey).forEach(value -> {
+            filterInvokers[value] = FilterInvokers.handleNothingInvoker();
+        });
+        return filterInvokers;
+    }
+
+    private static FilterInvoker[] createFrom(Map<Integer, FilterInvoker> filterInvokersByApiMessageId) {
+        if (filterInvokersByApiMessageId.isEmpty()) {
+            return HANDLE_NOTHING;
+        }
+        FilterInvoker[] filterInvokers = emptyInvokerArraySizedForMessageTypes();
+        Arrays.stream(ApiMessageType.values()).mapToInt(ApiMessageType::apiKey).forEach(value -> {
+            filterInvokers[value] = filterInvokersByApiMessageId.getOrDefault(value, FilterInvokers.handleNothingInvoker());
+        });
+        return filterInvokers;
+    }
+
+    private static FilterInvoker[] emptyInvokerArraySizedForMessageTypes() {
+        OptionalInt maybeMaxId = Arrays.stream(ApiMessageType.values()).mapToInt(ApiMessageType::apiKey).max();
+        if (maybeMaxId.isEmpty()) {
+            throw new IllegalStateException("no maximum id found");
+        }
+        int arraySize = maybeMaxId.getAsInt() + 1;
+        return new FilterInvoker[arraySize];
+    }
+
+}

--- a/api/kroxylicious-filter-api/src/main/templates/Kproxy/SpecificFilterFieldInvoker.ftl
+++ b/api/kroxylicious-filter-api/src/main/templates/Kproxy/SpecificFilterFieldInvoker.ftl
@@ -1,0 +1,168 @@
+<#--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${outputPackage};
+
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
+
+<#list messageSpecs as messageSpec>
+import org.apache.kafka.common.message.${messageSpec.name}Data;
+</#list>
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+/**
+ * Invoker for KrpcFilters that implement any number of Specific Message interfaces (for
+ * example {@link io.kroxylicious.proxy.filter.AlterConfigsResponseFilter}.
+ */
+class SpecificFilterFieldInvoker implements FilterInvoker {
+
+    <#list messageSpecs as messageSpec>
+    private ${messageSpec.name}Filter ${messageSpec.name}Filter;
+    </#list>
+    private final EnumSet<ApiKeys> requestKeys;
+    private final EnumSet<ApiKeys> responseKeys;
+
+    SpecificFilterFieldInvoker(KrpcFilter filter) {
+        Set<ApiKeys> requestKeys = new HashSet<>();
+        Set<ApiKeys> responseKeys = new HashSet<>();
+<#list messageSpecs as messageSpec>
+        if (filter instanceof ${messageSpec.name}Filter) {
+            ${messageSpec.name}Filter = (${messageSpec.name}Filter) filter;
+            ${messageSpec.type?lower_case}Keys.add(ApiKeys.${retrieveApiKey(messageSpec)});
+        }
+</#list>
+        this.requestKeys = requestKeys.isEmpty() ? EnumSet.noneOf(ApiKeys.class) : EnumSet.copyOf(requestKeys);
+        this.responseKeys = responseKeys.isEmpty() ? EnumSet.noneOf(ApiKeys.class) : EnumSet.copyOf(responseKeys);
+    }
+
+    /**
+     * Apply the filter to the given {@code header} and {@code body} using the given {@code filterContext}.
+     * @param apiKey The request api key.
+     * @param apiVersion The request api version.
+     * @param header The request header.
+     * @param body The request body.
+     * @param filterContext The filter context.
+     */
+    @Override
+    public void onRequest(ApiKeys apiKey,
+                           short apiVersion,
+                           RequestHeaderData header,
+                           ApiMessage body,
+                           KrpcFilterContext filterContext) {
+        switch (apiKey) {
+<#list messageSpecs as messageSpec>
+    <#if messageSpec.type?lower_case == 'request'>
+            case ${retrieveApiKey(messageSpec)} -> ${messageSpec.name}Filter.on${messageSpec.name}(header, (${messageSpec.name}Data) body, filterContext);
+    </#if>
+</#list>
+            default -> throw new IllegalStateException("Unsupported RPC " + apiKey);
+        }
+    }
+
+    /**
+     * Apply the filter to the given {@code header} and {@code body} using the given {@code filterContext}.
+     * @param apiKey The request api key.
+     * @param apiVersion The api version.
+     * @param header The request header.
+     * @param body The request body.
+     * @param filterContext The filter context.
+     */
+    @Override
+    public void onResponse(ApiKeys apiKey,
+                            short apiVersion,
+                            ResponseHeaderData header,
+                            ApiMessage body,
+                            KrpcFilterContext filterContext) {
+        switch (apiKey) {
+<#list messageSpecs as messageSpec>
+    <#if messageSpec.type?lower_case == 'response'>
+            case ${retrieveApiKey(messageSpec)} -> ${messageSpec.name}Filter.on${messageSpec.name}(header, (${messageSpec.name}Data) body, filterContext);
+    </#if>
+</#list>
+            default -> throw new IllegalStateException("Unsupported RPC " + apiKey);
+        }
+    }
+
+
+    /**
+     * <p>Determines whether a request with the given {@code apiKey} and {@code apiVersion} should be deserialized.
+     * Note that it is not guaranteed that this method will be called once per request,
+     * or that two consecutive calls refer to the same request.
+     * That is, the sequences of invocations like the following are allowed:</p>
+     * <ol>
+     *     <li>{@code shouldHandleRequest} on request A</li>
+     *     <li>{@code shouldHandleRequest} on request B</li>
+     *     <li>{@code shouldHandleRequest} on request A</li>
+     *     <li>{@code onRequest} on request A</li>
+     *     <li>{@code onRequest} on request B</li>
+     * </ol>
+     * @param apiKey The API key
+     * @param apiVersion The API version
+     * @return true if request should be deserialized
+     */
+    @Override
+    public boolean shouldHandleRequest(ApiKeys apiKey, short apiVersion) {
+        return switch (apiKey) {
+<#list messageSpecs as messageSpec>
+    <#if messageSpec.type?lower_case == 'request'>
+            case ${retrieveApiKey(messageSpec)} -> requestKeys.contains(apiKey) && ${messageSpec.name}Filter.shouldHandle${messageSpec.name}(apiVersion);
+    </#if>
+</#list>
+            default -> throw new IllegalStateException("Unsupported API key " + apiKey);
+        };
+    }
+
+    /**
+     * <p>Determines whether a response with the given {@code apiKey} and {@code apiVersion} should be deserialized.
+     * Note that it is not guaranteed that this method will be called once per response,
+     * or that two consecutive calls refer to the same response.
+     * That is, the sequences of invocations like the following are allowed:</p>
+     * <ol>
+     *     <li>{@code shouldHandleResponse} on response A</li>
+     *     <li>{@code shouldHandleResponse} on response B</li>
+     *     <li>{@code shouldHandleResponse} on response A</li>
+     *     <li>{@code apply} on response A</li>
+     *     <li>{@code apply} on response B</li>
+     * </ol>
+     * @param apiKey The API key
+     * @param apiVersion The API version
+     * @return true if response should be deserialized
+     */
+    @Override
+    public boolean shouldHandleResponse(ApiKeys apiKey, short apiVersion) {
+        return switch (apiKey) {
+<#list messageSpecs as messageSpec>
+    <#if messageSpec.type?lower_case == 'response'>
+            case ${retrieveApiKey(messageSpec)} -> responseKeys.contains(apiKey) && ${messageSpec.name}Filter.shouldHandle${messageSpec.name}(apiVersion);
+    </#if>
+</#list>
+            default -> throw new IllegalStateException("Unsupported API key " + apiKey);
+        };
+    }
+
+}

--- a/api/kroxylicious-filter-api/src/main/templates/Kproxy/SpecificFilterMapInvoker.ftl
+++ b/api/kroxylicious-filter-api/src/main/templates/Kproxy/SpecificFilterMapInvoker.ftl
@@ -1,0 +1,152 @@
+<#--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${outputPackage};
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+/**
+ * Invoker for KrpcFilters that implement any number of Specific Message interfaces (for
+ * example {@link io.kroxylicious.proxy.filter.AlterConfigsResponseFilter}.
+ */
+class SpecificFilterMapInvoker implements FilterInvoker {
+
+    private final Map<ApiKeys, FilterInvoker> requestInvokers;
+    private final Map<ApiKeys, FilterInvoker> responseInvokers;
+
+    SpecificFilterMapInvoker(KrpcFilter filter) {
+        this.requestInvokers = new HashMap<>();
+        this.responseInvokers = new HashMap<>();
+        <#list messageSpecs as messageSpec>
+        this.${messageSpec.type?lower_case}Invokers.put(ApiKeys.${retrieveApiKey(messageSpec)}, filter instanceof ${messageSpec.name}Filter ? new ${messageSpec.name}FilterInvoker((${messageSpec.name}Filter) filter) : null);
+        </#list>
+    }
+
+    /**
+     * Apply the filter to the given {@code header} and {@code body} using the given {@code filterContext}.
+     * @param apiKey The request api key.
+     * @param apiVersion The request api version.
+     * @param header The request header.
+     * @param body The request body.
+     * @param filterContext The filter context.
+     */
+    @Override
+    public void onRequest(ApiKeys apiKey,
+                           short apiVersion,
+                           RequestHeaderData header,
+                           ApiMessage body,
+                           KrpcFilterContext filterContext) {
+        FilterInvoker invoker = requestInvokers.get(apiKey);
+        if (invoker == null) {
+            filterContext.forwardRequest(header, body);
+        }
+        else {
+            invoker.onRequest(apiKey, apiVersion, header, body, filterContext);
+        }
+    }
+
+    /**
+     * Apply the filter to the given {@code header} and {@code body} using the given {@code filterContext}.
+     * @param apiKey The request api key.
+     * @param apiVersion The api version.
+     * @param header The request header.
+     * @param body The request body.
+     * @param filterContext The filter context.
+     */
+    @Override
+    public void onResponse(ApiKeys apiKey,
+                            short apiVersion,
+                            ResponseHeaderData header,
+                            ApiMessage body,
+                            KrpcFilterContext filterContext) {
+        FilterInvoker invoker = responseInvokers.get(apiKey);
+        if (invoker == null) {
+            filterContext.forwardResponse(header, body);
+        }
+        else {
+            invoker.onResponse(apiKey, apiVersion, header, body, filterContext);
+        }
+    }
+
+
+    /**
+     * <p>Determines whether a request with the given {@code apiKey} and {@code apiVersion} should be deserialized.
+     * Note that it is not guaranteed that this method will be called once per request,
+     * or that two consecutive calls refer to the same request.
+     * That is, the sequences of invocations like the following are allowed:</p>
+     * <ol>
+     *     <li>{@code shouldHandleRequest} on request A</li>
+     *     <li>{@code shouldHandleRequest} on request B</li>
+     *     <li>{@code shouldHandleRequest} on request A</li>
+     *     <li>{@code onRequest} on request A</li>
+     *     <li>{@code onRequest} on request B</li>
+     * </ol>
+     * @param apiKey The API key
+     * @param apiVersion The API version
+     * @return true if request should be deserialized
+     */
+    @Override
+    public boolean shouldHandleRequest(ApiKeys apiKey, short apiVersion) {
+        FilterInvoker invoker = requestInvokers.get(apiKey);
+        if (invoker == null) {
+            return false;
+        }
+        else {
+            return invoker.shouldHandleRequest(apiKey, apiVersion);
+        }
+    }
+
+    /**
+     * <p>Determines whether a response with the given {@code apiKey} and {@code apiVersion} should be deserialized.
+     * Note that it is not guaranteed that this method will be called once per response,
+     * or that two consecutive calls refer to the same response.
+     * That is, the sequences of invocations like the following are allowed:</p>
+     * <ol>
+     *     <li>{@code shouldHandleResponse} on response A</li>
+     *     <li>{@code shouldHandleResponse} on response B</li>
+     *     <li>{@code shouldHandleResponse} on response A</li>
+     *     <li>{@code apply} on response A</li>
+     *     <li>{@code apply} on response B</li>
+     * </ol>
+     * @param apiKey The API key
+     * @param apiVersion The API version
+     * @return true if response should be deserialized
+     */
+    @Override
+    public boolean shouldHandleResponse(ApiKeys apiKey, short apiVersion) {
+        FilterInvoker invoker = responseInvokers.get(apiKey);
+        if (invoker == null) {
+            return false;
+        }
+        else {
+            return invoker.shouldHandleResponse(apiKey, apiVersion);
+        }
+    }
+
+}

--- a/api/kroxylicious-filter-api/src/main/templates/Kproxy/SpecificFilterMapInvoker2.ftl
+++ b/api/kroxylicious-filter-api/src/main/templates/Kproxy/SpecificFilterMapInvoker2.ftl
@@ -1,0 +1,133 @@
+<#--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ${outputPackage};
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+/**
+ * Invoker for KrpcFilters that implement any number of Specific Message interfaces (for
+ * example {@link io.kroxylicious.proxy.filter.AlterConfigsResponseFilter}.
+ */
+class SpecificFilterMapInvoker2 implements FilterInvoker {
+
+    private final Map<ApiKeys, FilterInvoker> requestInvokers;
+    private final Map<ApiKeys, FilterInvoker> responseInvokers;
+
+    SpecificFilterMapInvoker2(KrpcFilter filter) {
+        this.requestInvokers = new HashMap<>();
+        this.responseInvokers = new HashMap<>();
+        <#list messageSpecs as messageSpec>
+        this.${messageSpec.type?lower_case}Invokers.put(ApiKeys.${retrieveApiKey(messageSpec)}, filter instanceof ${messageSpec.name}Filter ? new ${messageSpec.name}FilterInvoker((${messageSpec.name}Filter) filter) :
+                FilterInvokers.handleNothingInvoker());
+        </#list>
+    }
+
+    /**
+     * Apply the filter to the given {@code header} and {@code body} using the given {@code filterContext}.
+     * @param apiKey The request api key.
+     * @param apiVersion The request api version.
+     * @param header The request header.
+     * @param body The request body.
+     * @param filterContext The filter context.
+     */
+    @Override
+    public void onRequest(ApiKeys apiKey,
+                           short apiVersion,
+                           RequestHeaderData header,
+                           ApiMessage body,
+                           KrpcFilterContext filterContext) {
+        FilterInvoker invoker = requestInvokers.computeIfAbsent(apiKey, (apiKeys -> FilterInvokers.handleNothingInvoker()));
+        invoker.onRequest(apiKey, apiVersion, header, body, filterContext);
+    }
+
+    /**
+     * Apply the filter to the given {@code header} and {@code body} using the given {@code filterContext}.
+     * @param apiKey The request api key.
+     * @param apiVersion The api version.
+     * @param header The request header.
+     * @param body The request body.
+     * @param filterContext The filter context.
+     */
+    @Override
+    public void onResponse(ApiKeys apiKey,
+                            short apiVersion,
+                            ResponseHeaderData header,
+                            ApiMessage body,
+                            KrpcFilterContext filterContext) {
+        FilterInvoker invoker = responseInvokers.computeIfAbsent(apiKey, (apiKeys -> FilterInvokers.handleNothingInvoker()));
+        invoker.onResponse(apiKey, apiVersion, header, body, filterContext);
+    }
+
+
+    /**
+     * <p>Determines whether a request with the given {@code apiKey} and {@code apiVersion} should be deserialized.
+     * Note that it is not guaranteed that this method will be called once per request,
+     * or that two consecutive calls refer to the same request.
+     * That is, the sequences of invocations like the following are allowed:</p>
+     * <ol>
+     *     <li>{@code shouldHandleRequest} on request A</li>
+     *     <li>{@code shouldHandleRequest} on request B</li>
+     *     <li>{@code shouldHandleRequest} on request A</li>
+     *     <li>{@code onRequest} on request A</li>
+     *     <li>{@code onRequest} on request B</li>
+     * </ol>
+     * @param apiKey The API key
+     * @param apiVersion The API version
+     * @return true if request should be deserialized
+     */
+    @Override
+    public boolean shouldHandleRequest(ApiKeys apiKey, short apiVersion) {
+        FilterInvoker invoker = requestInvokers.computeIfAbsent(apiKey, (apiKeys -> FilterInvokers.handleNothingInvoker()));
+        return invoker.shouldHandleRequest(apiKey, apiVersion);
+    }
+
+    /**
+     * <p>Determines whether a response with the given {@code apiKey} and {@code apiVersion} should be deserialized.
+     * Note that it is not guaranteed that this method will be called once per response,
+     * or that two consecutive calls refer to the same response.
+     * That is, the sequences of invocations like the following are allowed:</p>
+     * <ol>
+     *     <li>{@code shouldHandleResponse} on response A</li>
+     *     <li>{@code shouldHandleResponse} on response B</li>
+     *     <li>{@code shouldHandleResponse} on response A</li>
+     *     <li>{@code apply} on response A</li>
+     *     <li>{@code apply} on response B</li>
+     * </ol>
+     * @param apiKey The API key
+     * @param apiVersion The API version
+     * @return true if response should be deserialized
+     */
+    @Override
+    public boolean shouldHandleResponse(ApiKeys apiKey, short apiVersion) {
+        FilterInvoker invoker = responseInvokers.computeIfAbsent(apiKey, (apiKeys -> FilterInvokers.handleNothingInvoker()));
+        return invoker.shouldHandleResponse(apiKey, apiVersion);
+    }
+
+}

--- a/etc/checkstyle-suppressions.xml
+++ b/etc/checkstyle-suppressions.xml
@@ -14,4 +14,6 @@
     <!-- Generated classes which we do not edit -->
     <suppress checks=".*"
               files="io[/\\]kroxylicious[/\\]proxy[/\\].*(Builder|Editable|Fluent|Nested|Visitor|Visitable).*\.java"/>
+    <suppress checks=".*"
+              files="io[/\\]kroxylicious[/\\]jmh_generated[/\\].*"/>
 </suppressions>

--- a/performance-tests/performance-tests.iml
+++ b/performance-tests/performance-tests.iml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="CheckStyle-IDEA-Module" serialisationVersion="2">
+    <option name="activeLocationsIds" />
+  </component>
+</module>

--- a/performance-tests/pom.xml
+++ b/performance-tests/pom.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>kroxylicious-parent</artifactId>
+        <groupId>io.kroxylicious</groupId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>io.kroxylicious</groupId>
+    <artifactId>performance-tests</artifactId>
+    <packaging>jar</packaging>
+
+    <name>performance-tests: microbenchmarks</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-filter-api</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-test-tools</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <jmh.version>1.36</jmh.version>
+        <uberjar.name>benchmarks</uberjar.name>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>${uberjar.name}</finalName>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <!--
+                                        Shading signed JARs will fail without this.
+                                        http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                                    -->
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>2.5</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>2.9.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>2.6</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.3</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>2.2.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.17</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+</project>

--- a/performance-tests/pom.xml
+++ b/performance-tests/pom.xml
@@ -111,7 +111,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.9.1</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>

--- a/performance-tests/src/main/java/io/kroxylicious/EightInterfaceFilter.java
+++ b/performance-tests/src/main/java/io/kroxylicious/EightInterfaceFilter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious;
+
+import org.apache.kafka.common.message.CreateTopicsRequestData;
+import org.apache.kafka.common.message.CreateTopicsResponseData;
+import org.apache.kafka.common.message.DeleteTopicsRequestData;
+import org.apache.kafka.common.message.DeleteTopicsResponseData;
+import org.apache.kafka.common.message.DescribeGroupsRequestData;
+import org.apache.kafka.common.message.DescribeGroupsResponseData;
+import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.message.ProduceResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+
+import io.kroxylicious.proxy.filter.CreateTopicsRequestFilter;
+import io.kroxylicious.proxy.filter.CreateTopicsResponseFilter;
+import io.kroxylicious.proxy.filter.DeleteTopicsRequestFilter;
+import io.kroxylicious.proxy.filter.DeleteTopicsResponseFilter;
+import io.kroxylicious.proxy.filter.DescribeGroupsRequestFilter;
+import io.kroxylicious.proxy.filter.DescribeGroupsResponseFilter;
+import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.ProduceRequestFilter;
+import io.kroxylicious.proxy.filter.ProduceResponseFilter;
+
+public class EightInterfaceFilter implements ProduceResponseFilter, ProduceRequestFilter, CreateTopicsRequestFilter, CreateTopicsResponseFilter,
+        DeleteTopicsRequestFilter, DeleteTopicsResponseFilter, DescribeGroupsRequestFilter, DescribeGroupsResponseFilter {
+
+    @Override
+    public void onProduceRequest(RequestHeaderData header, ProduceRequestData request, KrpcFilterContext context) {
+    }
+
+    @Override
+    public void onProduceResponse(ResponseHeaderData header, ProduceResponseData response, KrpcFilterContext context) {
+    }
+
+    @Override
+    public void onCreateTopicsRequest(RequestHeaderData header, CreateTopicsRequestData request, KrpcFilterContext context) {
+
+    }
+
+    @Override
+    public void onCreateTopicsResponse(ResponseHeaderData header, CreateTopicsResponseData response, KrpcFilterContext context) {
+
+    }
+
+    @Override
+    public void onDeleteTopicsRequest(RequestHeaderData header, DeleteTopicsRequestData request, KrpcFilterContext context) {
+
+    }
+
+    @Override
+    public void onDeleteTopicsResponse(ResponseHeaderData header, DeleteTopicsResponseData response, KrpcFilterContext context) {
+
+    }
+
+    @Override
+    public void onDescribeGroupsRequest(RequestHeaderData header, DescribeGroupsRequestData request, KrpcFilterContext context) {
+
+    }
+
+    @Override
+    public void onDescribeGroupsResponse(ResponseHeaderData header, DescribeGroupsResponseData response, KrpcFilterContext context) {
+
+    }
+}

--- a/performance-tests/src/main/java/io/kroxylicious/FourInterfaceFilter.java
+++ b/performance-tests/src/main/java/io/kroxylicious/FourInterfaceFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious;
+
+import org.apache.kafka.common.message.CreateTopicsRequestData;
+import org.apache.kafka.common.message.CreateTopicsResponseData;
+import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.message.ProduceResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+
+import io.kroxylicious.proxy.filter.CreateTopicsRequestFilter;
+import io.kroxylicious.proxy.filter.CreateTopicsResponseFilter;
+import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.ProduceRequestFilter;
+import io.kroxylicious.proxy.filter.ProduceResponseFilter;
+
+public class FourInterfaceFilter implements ProduceResponseFilter, ProduceRequestFilter, CreateTopicsRequestFilter, CreateTopicsResponseFilter {
+
+    @Override
+    public void onProduceRequest(RequestHeaderData header, ProduceRequestData request, KrpcFilterContext context) {
+    }
+
+    @Override
+    public void onProduceResponse(ResponseHeaderData header, ProduceResponseData response, KrpcFilterContext context) {
+    }
+
+    @Override
+    public void onCreateTopicsRequest(RequestHeaderData header, CreateTopicsRequestData request, KrpcFilterContext context) {
+
+    }
+
+    @Override
+    public void onCreateTopicsResponse(ResponseHeaderData header, CreateTopicsResponseData response, KrpcFilterContext context) {
+
+    }
+}

--- a/performance-tests/src/main/java/io/kroxylicious/InvokerBenchmark.java
+++ b/performance-tests/src/main/java/io/kroxylicious/InvokerBenchmark.java
@@ -14,7 +14,7 @@ import org.openjdk.jmh.infra.Blackhole;
 import io.kroxylicious.proxy.filter.FilterInvoker;
 import io.kroxylicious.proxy.filter.FilterInvokers;
 
-public class MyBenchmark {
+public class InvokerBenchmark {
 
     @org.openjdk.jmh.annotations.State(Scope.Benchmark)
     public static class BenchState {
@@ -38,6 +38,10 @@ public class MyBenchmark {
         volatile FilterInvoker arrayInvokerFilterHasTwoInterfaces = FilterInvokers.arrayInvoker(new TwoInterfaceFilter());
         volatile FilterInvoker arrayInvokerFilterHasFourInterfaces = FilterInvokers.arrayInvoker(new FourInterfaceFilter());
         volatile FilterInvoker arrayInvokerFilterHasEightInterfaces = FilterInvokers.arrayInvoker(new EightInterfaceFilter());
+        volatile FilterInvoker arrayInvokerFilter2HasOneInterface = FilterInvokers.arrayInvoker2(new OneInterfaceFilter());
+        volatile FilterInvoker arrayInvokerFilter2HasTwoInterfaces = FilterInvokers.arrayInvoker2(new TwoInterfaceFilter());
+        volatile FilterInvoker arrayInvokerFilter2HasFourInterfaces = FilterInvokers.arrayInvoker2(new FourInterfaceFilter());
+        volatile FilterInvoker arrayInvokerFilter2HasEightInterfaces = FilterInvokers.arrayInvoker2(new EightInterfaceFilter());
     }
 
     @Benchmark
@@ -78,6 +82,26 @@ public class MyBenchmark {
     @Benchmark
     public void testArrayInvokerFilterHasEightInterfaces(BenchState state, Blackhole blackhole) {
         invoke(blackhole, state.arrayInvokerFilterHasEightInterfaces);
+    }
+
+    @Benchmark
+    public void testArrayInvokerFilter2HasOneInterface(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.arrayInvokerFilter2HasOneInterface);
+    }
+
+    @Benchmark
+    public void testArrayInvokerFilter2HasTwoInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.arrayInvokerFilter2HasTwoInterfaces);
+    }
+
+    @Benchmark
+    public void testArrayInvokerFilter2HasFourInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.arrayInvokerFilter2HasFourInterfaces);
+    }
+
+    @Benchmark
+    public void testArrayInvokerFilter2HasEightInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.arrayInvokerFilter2HasEightInterfaces);
     }
 
     @Benchmark

--- a/performance-tests/src/main/java/io/kroxylicious/MyBenchmark.java
+++ b/performance-tests/src/main/java/io/kroxylicious/MyBenchmark.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.kroxylicious.proxy.filter.FilterInvoker;
+import io.kroxylicious.proxy.filter.FilterInvokers;
+
+public class MyBenchmark {
+
+    @org.openjdk.jmh.annotations.State(Scope.Benchmark)
+    public static class BenchState {
+        volatile FilterInvoker instanceOfInvokerFilterHasTwoInterfaces = FilterInvokers.instanceOfInvoker(new TwoInterfaceFilter());
+        volatile FilterInvoker arrayInvokerFilterHasTwoInterfaces = FilterInvokers.arrayInvoker(new TwoInterfaceFilter());
+        volatile FilterInvoker instanceOfInvokerFilterHasOneInterface = FilterInvokers.instanceOfInvoker(new OneInterfaceFilter());
+        volatile FilterInvoker arrayInvokerFilterHasOneInterface = FilterInvokers.arrayInvoker(new OneInterfaceFilter());
+    }
+
+    @Benchmark
+    public void testInstanceOfInvokerFilterHasTwoInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.instanceOfInvokerFilterHasTwoInterfaces);
+    }
+
+    @Benchmark
+    public void testArrayInvokerFilterHasTwoInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.arrayInvokerFilterHasTwoInterfaces);
+    }
+
+    @Benchmark
+    public void testInstanceOfInvokerFilterHasOneInterface(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.instanceOfInvokerFilterHasOneInterface);
+    }
+
+    @Benchmark
+    public void testArrayInvokerFilterHasOneInterface(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.arrayInvokerFilterHasOneInterface);
+    }
+
+    private static void invoke(Blackhole blackhole, FilterInvoker filter) {
+        blackhole.consume(filter.shouldHandleRequest(ApiKeys.PRODUCE, ApiKeys.PRODUCE.latestVersion()));
+        blackhole.consume(filter.shouldHandleRequest(ApiKeys.FETCH, ApiKeys.FETCH.latestVersion()));
+        blackhole.consume(filter.shouldHandleResponse(ApiKeys.PRODUCE, ApiKeys.PRODUCE.latestVersion()));
+        blackhole.consume(filter.shouldHandleResponse(ApiKeys.FETCH, ApiKeys.FETCH.latestVersion()));
+    }
+
+}

--- a/performance-tests/src/main/java/io/kroxylicious/MyBenchmark.java
+++ b/performance-tests/src/main/java/io/kroxylicious/MyBenchmark.java
@@ -19,7 +19,11 @@ public class MyBenchmark {
     @org.openjdk.jmh.annotations.State(Scope.Benchmark)
     public static class BenchState {
         volatile FilterInvoker instanceOfInvokerFilterHasTwoInterfaces = FilterInvokers.instanceOfInvoker(new TwoInterfaceFilter());
+        volatile FilterInvoker instanceOfInvokerFilterHasFourInterfaces = FilterInvokers.instanceOfInvoker(new FourInterfaceFilter());
+        volatile FilterInvoker instanceOfInvokerFilterHasEightInterfaces = FilterInvokers.instanceOfInvoker(new EightInterfaceFilter());
         volatile FilterInvoker arrayInvokerFilterHasTwoInterfaces = FilterInvokers.arrayInvoker(new TwoInterfaceFilter());
+        volatile FilterInvoker arrayInvokerFilterHasFourInterfaces = FilterInvokers.arrayInvoker(new FourInterfaceFilter());
+        volatile FilterInvoker arrayInvokerFilterHasEightInterfaces = FilterInvokers.arrayInvoker(new EightInterfaceFilter());
         volatile FilterInvoker instanceOfInvokerFilterHasOneInterface = FilterInvokers.instanceOfInvoker(new OneInterfaceFilter());
         volatile FilterInvoker arrayInvokerFilterHasOneInterface = FilterInvokers.arrayInvoker(new OneInterfaceFilter());
     }
@@ -32,6 +36,26 @@ public class MyBenchmark {
     @Benchmark
     public void testArrayInvokerFilterHasTwoInterfaces(BenchState state, Blackhole blackhole) {
         invoke(blackhole, state.arrayInvokerFilterHasTwoInterfaces);
+    }
+
+    @Benchmark
+    public void testInstanceOfInvokerFilterHasFourInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.instanceOfInvokerFilterHasFourInterfaces);
+    }
+
+    @Benchmark
+    public void testArrayInvokerFilterHasFourInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.arrayInvokerFilterHasFourInterfaces);
+    }
+
+    @Benchmark
+    public void testInstanceOfInvokerFilterHasEightInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.instanceOfInvokerFilterHasEightInterfaces);
+    }
+
+    @Benchmark
+    public void testArrayInvokerFilterHasEightInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.arrayInvokerFilterHasEightInterfaces);
     }
 
     @Benchmark

--- a/performance-tests/src/main/java/io/kroxylicious/MyBenchmark.java
+++ b/performance-tests/src/main/java/io/kroxylicious/MyBenchmark.java
@@ -26,6 +26,10 @@ public class MyBenchmark {
         volatile FilterInvoker mapInvokerFilterHasTwoInterfaces = FilterInvokers.mapInvoker(new TwoInterfaceFilter());
         volatile FilterInvoker mapInvokerFilterHasFourInterfaces = FilterInvokers.mapInvoker(new FourInterfaceFilter());
         volatile FilterInvoker mapInvokerFilterHasEightInterfaces = FilterInvokers.mapInvoker(new EightInterfaceFilter());
+        volatile FilterInvoker mapInvoker2FilterHasOneInterface = FilterInvokers.mapInvoker2(new OneInterfaceFilter());
+        volatile FilterInvoker mapInvoker2FilterHasTwoInterfaces = FilterInvokers.mapInvoker2(new TwoInterfaceFilter());
+        volatile FilterInvoker mapInvoker2FilterHasFourInterfaces = FilterInvokers.mapInvoker2(new FourInterfaceFilter());
+        volatile FilterInvoker mapInvoker2FilterHasEightInterfaces = FilterInvokers.mapInvoker2(new EightInterfaceFilter());
         volatile FilterInvoker fieldInvokerFilterHasOneInterface = FilterInvokers.fieldInvoker(new OneInterfaceFilter());
         volatile FilterInvoker fieldInvokerFilterHasTwoInterfaces = FilterInvokers.fieldInvoker(new TwoInterfaceFilter());
         volatile FilterInvoker fieldInvokerFilterHasFourInterfaces = FilterInvokers.fieldInvoker(new FourInterfaceFilter());
@@ -94,6 +98,26 @@ public class MyBenchmark {
     @Benchmark
     public void testMapInvokerFilterHasEightInterfaces(BenchState state, Blackhole blackhole) {
         invoke(blackhole, state.mapInvokerFilterHasEightInterfaces);
+    }
+
+    @Benchmark
+    public void testMapInvoker2FilterHasOneInterface(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.mapInvoker2FilterHasOneInterface);
+    }
+
+    @Benchmark
+    public void testMapInvoker2FilterHasTwoInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.mapInvoker2FilterHasTwoInterfaces);
+    }
+
+    @Benchmark
+    public void testMapInvoker2FilterHasFourInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.mapInvoker2FilterHasFourInterfaces);
+    }
+
+    @Benchmark
+    public void testMapInvoker2FilterHasEightInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.mapInvoker2FilterHasEightInterfaces);
     }
 
     @Benchmark

--- a/performance-tests/src/main/java/io/kroxylicious/MyBenchmark.java
+++ b/performance-tests/src/main/java/io/kroxylicious/MyBenchmark.java
@@ -18,44 +18,22 @@ public class MyBenchmark {
 
     @org.openjdk.jmh.annotations.State(Scope.Benchmark)
     public static class BenchState {
-        volatile FilterInvoker instanceOfInvokerFilterHasTwoInterfaces = FilterInvokers.instanceOfInvoker(new TwoInterfaceFilter());
-        volatile FilterInvoker mapInvokerFilterHasTwoInterfaces = FilterInvokers.mapInvoker(new TwoInterfaceFilter());
-        volatile FilterInvoker fieldInvokerFilterHasTwoInterfaces = FilterInvokers.fieldInvoker(new TwoInterfaceFilter());
-        volatile FilterInvoker arrayInvokerFilterHasTwoInterfaces = FilterInvokers.arrayInvoker(new TwoInterfaceFilter());
-        volatile FilterInvoker mapInvokerFilterHasOneInterface = FilterInvokers.mapInvoker(new OneInterfaceFilter());
-        volatile FilterInvoker fieldInvokerFilterHasOneInterface = FilterInvokers.fieldInvoker(new OneInterfaceFilter());
         volatile FilterInvoker instanceOfInvokerFilterHasOneInterface = FilterInvokers.instanceOfInvoker(new OneInterfaceFilter());
+        volatile FilterInvoker instanceOfInvokerFilterHasTwoInterfaces = FilterInvokers.instanceOfInvoker(new TwoInterfaceFilter());
+        volatile FilterInvoker instanceOfInvokerFilterHasFourInterfaces = FilterInvokers.instanceOfInvoker(new FourInterfaceFilter());
+        volatile FilterInvoker instanceOfInvokerFilterHasEightInterfaces = FilterInvokers.instanceOfInvoker(new EightInterfaceFilter());
+        volatile FilterInvoker mapInvokerFilterHasOneInterface = FilterInvokers.mapInvoker(new OneInterfaceFilter());
+        volatile FilterInvoker mapInvokerFilterHasTwoInterfaces = FilterInvokers.mapInvoker(new TwoInterfaceFilter());
+        volatile FilterInvoker mapInvokerFilterHasFourInterfaces = FilterInvokers.mapInvoker(new FourInterfaceFilter());
+        volatile FilterInvoker mapInvokerFilterHasEightInterfaces = FilterInvokers.mapInvoker(new EightInterfaceFilter());
+        volatile FilterInvoker fieldInvokerFilterHasOneInterface = FilterInvokers.fieldInvoker(new OneInterfaceFilter());
+        volatile FilterInvoker fieldInvokerFilterHasTwoInterfaces = FilterInvokers.fieldInvoker(new TwoInterfaceFilter());
+        volatile FilterInvoker fieldInvokerFilterHasFourInterfaces = FilterInvokers.fieldInvoker(new FourInterfaceFilter());
+        volatile FilterInvoker fieldInvokerFilterHasEightInterfaces = FilterInvokers.fieldInvoker(new EightInterfaceFilter());
         volatile FilterInvoker arrayInvokerFilterHasOneInterface = FilterInvokers.arrayInvoker(new OneInterfaceFilter());
-    }
-
-    @Benchmark
-    public void testInstanceOfInvokerFilterHasTwoInterfaces(BenchState state, Blackhole blackhole) {
-        invoke(blackhole, state.instanceOfInvokerFilterHasTwoInterfaces);
-    }
-
-    @Benchmark
-    public void testArrayInvokerFilterHasTwoInterfaces(BenchState state, Blackhole blackhole) {
-        invoke(blackhole, state.arrayInvokerFilterHasTwoInterfaces);
-    }
-
-    @Benchmark
-    public void testMapInvokerFilterHasTwoInterfaces(BenchState state, Blackhole blackhole) {
-        invoke(blackhole, state.mapInvokerFilterHasTwoInterfaces);
-    }
-
-    @Benchmark
-    public void testFieldInvokerFilterHasTwoInterfaces(BenchState state, Blackhole blackhole) {
-        invoke(blackhole, state.fieldInvokerFilterHasTwoInterfaces);
-    }
-
-    @Benchmark
-    public void testMapInvokerFilterHasOneInterface(BenchState state, Blackhole blackhole) {
-        invoke(blackhole, state.mapInvokerFilterHasOneInterface);
-    }
-
-    @Benchmark
-    public void testFieldInvokerFilterHasOneInterface(BenchState state, Blackhole blackhole) {
-        invoke(blackhole, state.fieldInvokerFilterHasOneInterface);
+        volatile FilterInvoker arrayInvokerFilterHasTwoInterfaces = FilterInvokers.arrayInvoker(new TwoInterfaceFilter());
+        volatile FilterInvoker arrayInvokerFilterHasFourInterfaces = FilterInvokers.arrayInvoker(new FourInterfaceFilter());
+        volatile FilterInvoker arrayInvokerFilterHasEightInterfaces = FilterInvokers.arrayInvoker(new EightInterfaceFilter());
     }
 
     @Benchmark
@@ -64,8 +42,78 @@ public class MyBenchmark {
     }
 
     @Benchmark
+    public void testInstanceOfInvokerFilterHasTwoInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.instanceOfInvokerFilterHasTwoInterfaces);
+    }
+
+    @Benchmark
+    public void testInstanceOfInvokerFilterHasFourInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.instanceOfInvokerFilterHasFourInterfaces);
+    }
+
+    @Benchmark
+    public void testInstanceOfInvokerFilterHasEightInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.instanceOfInvokerFilterHasEightInterfaces);
+    }
+
+    @Benchmark
     public void testArrayInvokerFilterHasOneInterface(BenchState state, Blackhole blackhole) {
         invoke(blackhole, state.arrayInvokerFilterHasOneInterface);
+    }
+
+    @Benchmark
+    public void testArrayInvokerFilterHasTwoInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.arrayInvokerFilterHasTwoInterfaces);
+    }
+
+    @Benchmark
+    public void testArrayInvokerFilterHasFourInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.arrayInvokerFilterHasFourInterfaces);
+    }
+
+    @Benchmark
+    public void testArrayInvokerFilterHasEightInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.arrayInvokerFilterHasEightInterfaces);
+    }
+
+    @Benchmark
+    public void testMapInvokerFilterHasOneInterface(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.mapInvokerFilterHasOneInterface);
+    }
+
+    @Benchmark
+    public void testMapInvokerFilterHasTwoInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.mapInvokerFilterHasTwoInterfaces);
+    }
+
+    @Benchmark
+    public void testMapInvokerFilterHasFourInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.mapInvokerFilterHasFourInterfaces);
+    }
+
+    @Benchmark
+    public void testMapInvokerFilterHasEightInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.mapInvokerFilterHasEightInterfaces);
+    }
+
+    @Benchmark
+    public void testFieldInvokerFilterHasOneInterface(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.fieldInvokerFilterHasOneInterface);
+    }
+
+    @Benchmark
+    public void testFieldInvokerFilterHasTwoInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.fieldInvokerFilterHasTwoInterfaces);
+    }
+
+    @Benchmark
+    public void testFieldInvokerFilterHasFourInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.fieldInvokerFilterHasFourInterfaces);
+    }
+
+    @Benchmark
+    public void testFieldInvokerFilterHasEightInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.fieldInvokerFilterHasEightInterfaces);
     }
 
     private static void invoke(Blackhole blackhole, FilterInvoker filter) {

--- a/performance-tests/src/main/java/io/kroxylicious/MyBenchmark.java
+++ b/performance-tests/src/main/java/io/kroxylicious/MyBenchmark.java
@@ -19,11 +19,11 @@ public class MyBenchmark {
     @org.openjdk.jmh.annotations.State(Scope.Benchmark)
     public static class BenchState {
         volatile FilterInvoker instanceOfInvokerFilterHasTwoInterfaces = FilterInvokers.instanceOfInvoker(new TwoInterfaceFilter());
-        volatile FilterInvoker instanceOfInvokerFilterHasFourInterfaces = FilterInvokers.instanceOfInvoker(new FourInterfaceFilter());
-        volatile FilterInvoker instanceOfInvokerFilterHasEightInterfaces = FilterInvokers.instanceOfInvoker(new EightInterfaceFilter());
+        volatile FilterInvoker mapInvokerFilterHasTwoInterfaces = FilterInvokers.mapInvoker(new TwoInterfaceFilter());
+        volatile FilterInvoker fieldInvokerFilterHasTwoInterfaces = FilterInvokers.fieldInvoker(new TwoInterfaceFilter());
         volatile FilterInvoker arrayInvokerFilterHasTwoInterfaces = FilterInvokers.arrayInvoker(new TwoInterfaceFilter());
-        volatile FilterInvoker arrayInvokerFilterHasFourInterfaces = FilterInvokers.arrayInvoker(new FourInterfaceFilter());
-        volatile FilterInvoker arrayInvokerFilterHasEightInterfaces = FilterInvokers.arrayInvoker(new EightInterfaceFilter());
+        volatile FilterInvoker mapInvokerFilterHasOneInterface = FilterInvokers.mapInvoker(new OneInterfaceFilter());
+        volatile FilterInvoker fieldInvokerFilterHasOneInterface = FilterInvokers.fieldInvoker(new OneInterfaceFilter());
         volatile FilterInvoker instanceOfInvokerFilterHasOneInterface = FilterInvokers.instanceOfInvoker(new OneInterfaceFilter());
         volatile FilterInvoker arrayInvokerFilterHasOneInterface = FilterInvokers.arrayInvoker(new OneInterfaceFilter());
     }
@@ -39,23 +39,23 @@ public class MyBenchmark {
     }
 
     @Benchmark
-    public void testInstanceOfInvokerFilterHasFourInterfaces(BenchState state, Blackhole blackhole) {
-        invoke(blackhole, state.instanceOfInvokerFilterHasFourInterfaces);
+    public void testMapInvokerFilterHasTwoInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.mapInvokerFilterHasTwoInterfaces);
     }
 
     @Benchmark
-    public void testArrayInvokerFilterHasFourInterfaces(BenchState state, Blackhole blackhole) {
-        invoke(blackhole, state.arrayInvokerFilterHasFourInterfaces);
+    public void testFieldInvokerFilterHasTwoInterfaces(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.fieldInvokerFilterHasTwoInterfaces);
     }
 
     @Benchmark
-    public void testInstanceOfInvokerFilterHasEightInterfaces(BenchState state, Blackhole blackhole) {
-        invoke(blackhole, state.instanceOfInvokerFilterHasEightInterfaces);
+    public void testMapInvokerFilterHasOneInterface(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.mapInvokerFilterHasOneInterface);
     }
 
     @Benchmark
-    public void testArrayInvokerFilterHasEightInterfaces(BenchState state, Blackhole blackhole) {
-        invoke(blackhole, state.arrayInvokerFilterHasEightInterfaces);
+    public void testFieldInvokerFilterHasOneInterface(BenchState state, Blackhole blackhole) {
+        invoke(blackhole, state.fieldInvokerFilterHasOneInterface);
     }
 
     @Benchmark

--- a/performance-tests/src/main/java/io/kroxylicious/OneInterfaceFilter.java
+++ b/performance-tests/src/main/java/io/kroxylicious/OneInterfaceFilter.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious;
+
+import org.apache.kafka.common.message.ProduceResponseData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+
+import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.ProduceResponseFilter;
+
+public class OneInterfaceFilter implements ProduceResponseFilter {
+
+    @Override
+    public void onProduceResponse(ResponseHeaderData header, ProduceResponseData response, KrpcFilterContext context) {
+    }
+}

--- a/performance-tests/src/main/java/io/kroxylicious/TwoInterfaceFilter.java
+++ b/performance-tests/src/main/java/io/kroxylicious/TwoInterfaceFilter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious;
+
+import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.message.ProduceResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+
+import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.ProduceRequestFilter;
+import io.kroxylicious.proxy.filter.ProduceResponseFilter;
+
+public class TwoInterfaceFilter implements ProduceResponseFilter, ProduceRequestFilter {
+
+    @Override
+    public void onProduceRequest(RequestHeaderData header, ProduceRequestData request, KrpcFilterContext context) {
+    }
+
+    @Override
+    public void onProduceResponse(ResponseHeaderData header, ProduceResponseData response, KrpcFilterContext context) {
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -224,6 +224,7 @@
         <module>kroxylicious</module>
         <module>kroxylicious-multitenant</module>
         <module>integrationtests</module>
+        <module>performance-tests</module>
     </modules>
 
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Kroxy is vulnerable to a JVM performance problem ([JDK-8180450](https://bugs.openjdk.org/browse/JDK-8180450)). A filter that implements two or more specific-message Filter interfaces its secondary_super_cache (in its Klass instance within the JVM) would frequently be changing between those interfaces, with cache line interference result in poor performance on some hardware.

Instead of switching on the ApiKey of the message and then using instanceof/cast to check if the filter wants to handle that ApiKey, we pre-instantiate a FilterInvoker for each interface implemented by the Filter. They are stored in an array where the array index is the id of the ApiKey using the fact that it is `the permanent and immutable id of an API - this can't change ever`. So when checking if the filter can handle a message we can lookup the invoker from the array and return false if there's nothing for that `ApiKey#id`.

Replaces #109 