### PR TITLE
Refactor main method to block on a composed CompletableFuture

### DIFF
--- a/integrationtests/src/test/java/io/kroxylicious/proxy/KroxyStandaloneIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/KroxyStandaloneIT.java
@@ -115,7 +115,7 @@ public class KroxyStandaloneIT {
         Files.writeString(configPath, config);
         String java = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
         String classpath = System.getProperty("java.class.path");
-        ProcessBuilder processBuilder = new ProcessBuilder(java, "-cp", classpath, Kroxylicious.class.getName(), "-c", configPath.toString());
+        var processBuilder = new ProcessBuilder(java, "-cp", classpath, Kroxylicious.class.getName(), "-c", configPath.toString()).inheritIO();
         try {
             Process start = processBuilder.start();
             return start::destroy;

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -121,7 +121,14 @@ public final class KafkaProxy implements AutoCloseable, VirtualClusterResolver {
     private CompletableFuture<Void> toCloseFuture(ChannelFuture channelFuture) {
         CompletableFuture<Void> future = new CompletableFuture<>();
         ChannelFuture closeFuture = channelFuture.syncUninterruptibly().channel().closeFuture();
-        closeFuture.addListener(f -> future.complete(null));
+        closeFuture.addListener(f -> {
+            if (f.cause() != null) {
+                future.completeExceptionally(f.cause());
+            }
+            else {
+                future.complete(null);
+            }
+        });
         return future;
     }
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

The queue/future mechanism felt a bit indirect when we can collect all the channel close futures during the `startup` method and compose them.

This was a follow up from fixing the blocking in #311 from a [discussion](https://github.com/kroxylicious/kroxylicious/pull/311#discussion_r1189249049)