### PR TITLE
Fix formatting error in overview.adoc

### DIFF
--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -100,5 +100,6 @@ If you do not control the Kafka cluster you can use a protocol filter to rewrite
 Single proxy instance::
 
 Proxy cluster::
+//-
 
 == More about filters


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

A missing list break after the "Deployment topologies" section meant that the following header did not correctly render. Added a list break comment (`//-`) after the last item in the list to fix this.

### Additional Context

_Why are you making this pull request?_
