### PR TITLE
Bump integration tests module from OpenJDK 19 to 20.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,7 +35,7 @@ jobs:
       - name: 'Set up Java'
         uses: actions/setup-java@v3
         with:
-          java-version: 19
+          java-version: 20
           distribution: 'zulu'
 
       - name: 'Cache Maven packages'

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -41,7 +41,7 @@ jobs:
       - name: 'Set up Java'
         uses: actions/setup-java@v3
         with:
-          java-version: 19
+          java-version: 20
           distribution: 'zulu'
 
       - name: 'Set Kafka Version'

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -20,8 +20,8 @@
     <description>Integration tests where Kroxylicious is tested end-to-end with a real Kafka cluster.</description>
 
     <properties>
-        <java.version>19</java.version>
-        <java.test.version>19</java.test.version>
+        <java.version>20</java.version>
+        <java.test.version>20</java.test.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION


### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Why: OpenJDK 19 was EOL'd in March 2023 and is [no longer being updated](https://endoflife.date/java).  OpenJDK 20 is the next short-term-support (STS) release. 

Why are we using STS releases?
`integrationtests` needs to be on STS releases as it uses `java.net.spi.InetAddressResolverProvider`. OpenJDK 21 is planned to be LTS, so we should be off the STS dependency soon.


### Additional Context

_Why are you making this pull request?_
