### PR TITLE
skip javadoc generation in the performance-tests module

### DIFF
--- a/performance-tests/pom.xml
+++ b/performance-tests/pom.xml
@@ -89,6 +89,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

The generated code was causing screeds of javadoc warnings.  I don't think we are interested in the javadoc for this module so turning off generation is path of least resistence.

### Additional Context

_Why are you making this pull request?_
