### PR TITLE
Remove ClusterEndpointConfigProvider from the Contributor instance methods

### DIFF
--- a/api/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/Contributor.java
+++ b/api/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/Contributor.java
@@ -27,9 +27,8 @@ public interface Contributor<T> {
      * Creates an instance of the service.
      *
      * @param shortName service short name
-     * @param endpointConfigProvider endpoint provider
-     * @param config service configuration which may be null if the service instance does not accept configuration.
+     * @param config    service configuration which may be null if the service instance does not accept configuration.
      * @return the service instance
      */
-    T getInstance(String shortName, ClusterEndpointConfigProvider endpointConfigProvider, BaseConfig config);
+    T getInstance(String shortName, BaseConfig config);
 }

--- a/api/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/HostPort.java
+++ b/api/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/HostPort.java
@@ -25,7 +25,7 @@ public final class HostPort {
 
     /**
      * Creates a host port.
-     * @param host the host - symbolic hostnames, FQDNs, IPv4, and IPv6 forms are supported
+     * @param host Symbolic hostnames, FQDNs, IPv4, and IPv6 forms are supported
      * @param port port number
      */
     public HostPort(String host, int port) {

--- a/api/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/HostPort.java
+++ b/api/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/HostPort.java
@@ -25,6 +25,8 @@ public final class HostPort {
 
     /**
      * Creates a host port.
+     * @param host the host - symbolic hostnames, FQDNs, IPv4, and IPv6 forms are supported
+     * @param port port number
      */
     public HostPort(String host, int port) {
         Objects.requireNonNull(host, "host cannot be null");

--- a/api/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
+++ b/api/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
@@ -11,7 +11,6 @@ import io.kroxylicious.proxy.config.BaseConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
 
 class BaseContributorTest {
     static class LongConfig extends BaseConfig {
@@ -38,7 +37,7 @@ class BaseContributorTest {
         builder.add("one", () -> 1L);
         BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
         };
-        Long instance = baseContributor.getInstance("one", mock(ClusterEndpointConfigProvider.class), new BaseConfig());
+        Long instance = baseContributor.getInstance("one", new BaseConfig());
         assertThat(instance).isEqualTo(1L);
     }
 
@@ -58,7 +57,7 @@ class BaseContributorTest {
         builder.add("fromBaseConfig", LongConfig.class, baseConfig -> baseConfig.value);
         BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
         };
-        Long instance = baseContributor.getInstance("fromBaseConfig", mock(ClusterEndpointConfigProvider.class), new LongConfig());
+        Long instance = baseContributor.getInstance("fromBaseConfig", new LongConfig());
         assertThat(instance).isEqualTo(2L);
     }
 
@@ -70,7 +69,7 @@ class BaseContributorTest {
         };
         AnotherConfig incompatibleConfig = new AnotherConfig();
         assertThatThrownBy(() -> {
-            baseContributor.getInstance("fromBaseConfig", mock(ClusterEndpointConfigProvider.class), incompatibleConfig);
+            baseContributor.getInstance("fromBaseConfig", incompatibleConfig);
         }).isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -8,7 +8,6 @@ package io.kroxylicious.proxy.bootstrap;
 import java.util.List;
 
 import io.kroxylicious.proxy.config.Configuration;
-import io.kroxylicious.proxy.config.VirtualCluster;
 import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.internal.filter.FilterContributorManager;
 
@@ -20,11 +19,9 @@ import io.kroxylicious.proxy.internal.filter.FilterContributorManager;
 public class FilterChainFactory {
 
     private final Configuration config;
-    private final VirtualCluster virtualCluster;
 
-    public FilterChainFactory(Configuration config, VirtualCluster virtualCluster) {
+    public FilterChainFactory(Configuration config) {
         this.config = config;
-        this.virtualCluster = virtualCluster;
     }
 
     /**
@@ -37,7 +34,7 @@ public class FilterChainFactory {
 
         return config.filters()
                 .stream()
-                .map(f -> filterContributorManager.getFilter(f.type(), virtualCluster.getClusterEndpointProvider(), f.config()))
+                .map(f -> filterContributorManager.getFilter(f.type(), f.config()))
                 .toList();
     }
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -167,7 +167,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
         }
 
         var frontendHandler = new KafkaProxyFrontendHandler(context -> {
-            var filterChainFactory = new FilterChainFactory(config, virtualCluster);
+            var filterChainFactory = new FilterChainFactory(config);
 
             var filters = new ArrayList<>(filterChainFactory.createFilters());
             // Add internal filters.

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/clusterendpointprovider/ClusterEndpointConfigProviderContributorManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/clusterendpointprovider/ClusterEndpointConfigProviderContributorManager.java
@@ -41,7 +41,7 @@ public class ClusterEndpointConfigProviderContributorManager {
 
     public ClusterEndpointConfigProvider getClusterEndpointConfigProvider(String shortName, BaseConfig baseConfig) {
         for (ClusterEndpointProviderContributor contributor : contributors) {
-            var assigner = contributor.getInstance(shortName, null, baseConfig);
+            var assigner = contributor.getInstance(shortName, baseConfig);
             if (assigner != null) {
                 return assigner;
             }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterContributorManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterContributorManager.java
@@ -11,7 +11,6 @@ import java.util.ServiceLoader;
 import io.kroxylicious.proxy.config.BaseConfig;
 import io.kroxylicious.proxy.filter.FilterContributor;
 import io.kroxylicious.proxy.filter.KrpcFilter;
-import io.kroxylicious.proxy.service.ClusterEndpointConfigProvider;
 
 public class FilterContributorManager {
 
@@ -40,11 +39,11 @@ public class FilterContributorManager {
         throw new IllegalArgumentException("No filter found for name '" + shortName + "'");
     }
 
-    public KrpcFilter getFilter(String shortName, ClusterEndpointConfigProvider proxyConfig, BaseConfig filterConfig) {
+    public KrpcFilter getFilter(String shortName, BaseConfig filterConfig) {
         Iterator<FilterContributor> it = contributors.iterator();
         while (it.hasNext()) {
             FilterContributor contributor = it.next();
-            KrpcFilter filter = contributor.getInstance(shortName, proxyConfig, filterConfig);
+            KrpcFilter filter = contributor.getInstance(shortName, filterConfig);
             if (filter != null) {
                 return filter;
             }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/MicrometerConfigurationHookContributorManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/MicrometerConfigurationHookContributorManager.java
@@ -36,7 +36,7 @@ public class MicrometerConfigurationHookContributorManager {
 
     public MicrometerConfigurationHook getHook(String shortName, BaseConfig filterConfig) {
         for (MicrometerConfigurationHookContributor contributor : contributors) {
-            MicrometerConfigurationHook hook = contributor.getInstance(shortName, null, filterConfig);
+            MicrometerConfigurationHook hook = contributor.getInstance(shortName, filterConfig);
             if (hook != null) {
                 return hook;
             }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

Why: The use case for `ClusterEndpointConfigProvider` being available to `Contributor` implementations was the `BrokerAddressFilter`.  Now BAF is an internal concern, that part of the API is redundant.


### Additional Context

_Why are you making this pull request?_
