### PR TITLE
Dockerise Kroxylicious and add scripts to build/push to quay.io and run the image against a strimzi cluster

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+**/target
+**/out
+**/.idea
+**/*.iml
+**/*.iws
+**/*.ipr
+docs
+etc
+sample-install
+!etc/eclipse-formatter-config.xml
+scripts
+Dockerfile
+.dockerignore
+.git
+.github
+README.md

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,12 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+ignored:
+  - DL4006
+  - SC3010
+  - DL3006
+  - DL3041

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,2 @@
+# Stop sonatype lift trying to follow sourced file
+disable=SC1091

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.15 AS builder
+
+USER root
+WORKDIR /opt/kroxylicious
+COPY . .
+RUN ./mvnw clean verify -Pdist -Dquick -pl :kroxylicious -am
+USER 185
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+
+ARG JAVA_VERSION=17
+ARG TARGETOS
+ARG TARGETARCH
+ARG KROXYLICIOUS_VERSION
+
+RUN microdnf update \
+    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
+    && microdnf reinstall -y tzdata \
+    && microdnf clean all
+
+ENV JAVA_HOME /usr/lib/jvm/jre-17
+
+#####
+# Add Tini
+#####
+ENV TINI_VERSION v0.19.0
+ENV TINI_SHA256_AMD64=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c
+ENV TINI_SHA256_ARM64=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81
+ENV TINI_SHA256_PPC64LE=3f658420974768e40810001a038c29d003728c5fe86da211cff5059e48cfdfde
+ENV TINI_SHA256_S390X=931b70a182af879ca249ae9de87ef68423121b38d235c78997fafc680ceab32d
+RUN set -ex; \
+    if [[ "${TARGETOS}/${TARGETARCH}" = "linux/ppc64le" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-ppc64le -o /usr/bin/tini; \
+        echo "${TINI_SHA256_PPC64LE} */usr/bin/tini" | sha256sum -c; \
+        chmod +x /usr/bin/tini; \
+    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/arm64" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 -o /usr/bin/tini; \
+        echo "${TINI_SHA256_ARM64} */usr/bin/tini" | sha256sum -c; \
+        chmod +x /usr/bin/tini; \
+    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/s390x" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x -o /usr/bin/tini; \
+        echo "${TINI_SHA256_S390X} */usr/bin/tini" | sha256sum -c; \
+        chmod +x /usr/bin/tini; \
+    else \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o /usr/bin/tini; \
+        echo "${TINI_SHA256_AMD64} */usr/bin/tini" | sha256sum -c; \
+        chmod +x /usr/bin/tini; \
+    fi
+COPY --from=builder /opt/kroxylicious/kroxylicious/target/libs /opt/kroxylicious/libs
+COPY --from=builder /opt/kroxylicious/kroxylicious/target/kroxylicious-${KROXYLICIOUS_VERSION}.jar /opt/kroxylicious/kroxylicious.jar
+ENTRYPOINT ["/usr/bin/tini", "--", "java", "-cp", "/opt/kroxylicious/kroxylicious.jar:/opt/kroxylicious/libs/*:/opt/kroxylicious/user-libs/*", "io.kroxylicious.proxy.Kroxylicious"]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,27 @@
 Kroxylicious is an exploration for building a Kafka protocol proxy,
 addressing use cases such as multi-tenancy, schema validation, or encryption.
 
+<!-- TOC -->
+* [Kroxylicious](#kroxylicious)
+  * [Quick Links](#quick-links)
+  * [Build](#build)
+    * [Formatting](#formatting)
+  * [Run](#run)
+    * [Run natively](#run-natively)
+      * [Debugging](#debugging)
+    * [Run on Minikube](#run-on-minikube)
+  * [Rendering documentation](#rendering-documentation)
+  * [Performance Testing](#performance-testing)
+    * [GitHub action for performance](#github-action-for-performance)
+  * [Architecture Monitoring](#architecture-monitoring)
+  * [IntelliJ setup](#intellij-setup)
+  * [License](#license)
+  * [Setting Up in Windows Using WSL](#setting-up-in-windows-using-wsl)
+    * [Installing WSL](#installing-wsl)
+    * [Ensure appropriate tooling available](#ensure-appropriate-tooling-available)
+  * [Releasing the project](#releasing-the-project)
+<!-- TOC -->
+
 ## Quick Links
 - [kroxylicious.io](https://www.kroxylicious.io)
 - [Documentation](https://www.kroxylicious.io/kroxylicious)
@@ -11,10 +32,10 @@ addressing use cases such as multi-tenancy, schema validation, or encryption.
 
 ## Build
 
-JDK version 19 or newer, and Apache Maven are required for building this project.
+JDK version 20 or newer, and Apache Maven are required for building this project.
 
 Kroxylicious targets language level 17, except for the `integrationtests` module
-which targets 19 to access some new language features.
+which targets 20 to access some new language features.
 
 Build the project like this:
 
@@ -75,6 +96,8 @@ No one likes to argue about code formatting in pull requests, as project we take
 
 ## Run
 
+### Run natively
+
 Build with the `dist` profile as shown above, then execute this:
 
 ```
@@ -89,12 +112,33 @@ Failed to load class org.slf4j.impl.StaticLoggerBinder
 
 Make sure to follow the [suggestions here](https://www.slf4j.org/codes.html#StaticLoggerBinder) to include one (and only one) of the suggested jars on the classpath.
 
-### Debugging
+#### Debugging
 Logging is turned off by default for better performance. In case you want to debug, logging should be turned on in the `example-proxy-config.yml` file:
 ```yaml
   logNetwork: true
   logFrames: true
 ```
+
+### Run on Minikube
+
+Kroxylicious can be containerised and run on Minikube against a [Strimzi](https://strimzi.io) managed Kafka cluster.
+
+**Prerequisites**
+* User must have a [quay.io](https://www.quay.io) account and create a public repository named `kroxylicious`
+* Minikube [installed](https://minikube.sigs.k8s.io/docs/start)
+* kubectl [installed](https://kubernetes.io/docs/tasks/tools)
+* OSX users must have `gsed` [installed](https://formulae.brew.sh/formula/gnu-sed)
+* Docker engine [installed](https://docs.docker.com/engine/install) ([podman](https://podman.io/docs/installation) may work too)
+
+Run `minikube delete && QUAY_ORG=$your_quay_username$ ./scripts/run-with-strimzi.sh`. This script:
+1. builds and pushes a kroxylicious image to quay.io
+2. starts minikube
+2. installs a 3-node Kafka cluster using Strimzi into minikube
+4. installs kroxylicious into minikube, configured to proxy the cluster
+
+If you want to only build and push an image to quay.io you can run `PUSH_IMAGE=y QUAY_ORG=$your_quay_username$ ./scripts/deploy-image.sh`
+
+To change the container engine to podman set `CONTAINER_ENGINE=podman`
 
 ## Rendering documentation
 

--- a/sample-install/01-config.yaml
+++ b/sample-install/01-config.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kroxylicious-config
+data:
+  config.yaml: |
+    adminHttp:
+      endpoints:
+        prometheus: {}
+    virtualClusters:
+      demo:
+        targetCluster:
+          bootstrap_servers: my-cluster-kafka-bootstrap:9092
+        clusterNetworkAddressConfigProvider:
+          type: PortPerBroker
+          config:
+            bootstrapAddress: localhost:9292
+            brokerAddressPattern: kroxylicious-service:$(portNumber)
+        logNetwork: false
+        logFrames: false
+    filters:
+    - type: ApiVersions

--- a/sample-install/02-deployment.yaml
+++ b/sample-install/02-deployment.yaml
@@ -1,0 +1,42 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kroxylicious-proxy
+  labels:
+    app: kroxylicious
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kroxylicious
+  template:
+    metadata:
+      labels:
+        app: kroxylicious
+    spec:
+      containers:
+      - name: kroxylicious
+        image: quay.io/kroxylicious/kroxylicious:0.3.0-SNAPSHOT
+        imagePullPolicy: Always
+        args: ["--config", "/opt/kroxylicious/config/config.yaml"]
+        ports:
+        - containerPort: 9193
+        - containerPort: 9292
+        - containerPort: 9293
+        - containerPort: 9294
+        - containerPort: 9295
+        volumeMounts:
+        - name: config-volume
+          mountPath: /opt/kroxylicious/config/config.yaml
+          subPath: config.yaml
+      volumes:
+      - name: config-volume
+        configMap:
+          name: kroxylicious-config

--- a/sample-install/03-service.yaml
+++ b/sample-install/03-service.yaml
@@ -1,0 +1,35 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kroxylicious-service
+spec:
+  selector:
+    app: kroxylicious
+  ports:
+  - name: port-9193
+    protocol: TCP
+    port: 9193
+    targetPort: 9193
+  - name: port-9292
+    protocol: TCP
+    port: 9292
+    targetPort: 9292
+  - name: port-9293
+    protocol: TCP
+    port: 9293
+    targetPort: 9293
+  - name: port-9294
+    protocol: TCP
+    port: 9294
+    targetPort: 9294
+  - name: port-9295
+    protocol: TCP
+    port: 9295
+    targetPort: 9295

--- a/sample-install/kafka-persistent.yaml
+++ b/sample-install/kafka-persistent.yaml
@@ -1,0 +1,47 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    version: 3.4.0
+    replicas: 3
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+    config:
+      offsets.topic.replication.factor: 2
+      transaction.state.log.replication.factor: 2
+      transaction.state.log.min.isr: 2
+      default.replication.factor: 2
+      min.insync.replicas: 2
+      inter.broker.protocol.version: "3.4"
+    storage:
+      type: jbod
+      volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+  zookeeper:
+    replicas: 1
+    storage:
+      type: persistent-claim
+      size: 100Gi
+      deleteClaim: false
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+OS=$(uname)
+
+if [[ -z $CONTAINER_ENGINE ]]; then
+  echo "Setting CONTAINER_ENGINE to default: docker"
+  CONTAINER_ENGINE=$(which docker)
+  export CONTAINER_ENGINE
+fi
+KUBECTL=$(which kubectl)
+export KUBECTL
+MINIKUBE=$(which minikube)
+export MINIKUBE
+
+if [ "$OS" = 'Darwin' ]; then
+  # for MacOS
+  SED=$(which gsed)
+else
+  # for Linux and Windows
+  SED=$(which sed)
+fi
+export SED

--- a/scripts/deploy-image.sh
+++ b/scripts/deploy-image.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+set -eo pipefail
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. "${SCRIPT_DIR}/common.sh"
+cd "${SCRIPT_DIR}/.."
+KROXYLICIOUS_VERSION=$(./mvnw org.apache.maven.plugins:maven-help-plugin:3.4.0:evaluate -Dexpression=project.version -q -DforceStdout)
+
+if [[ -z $QUAY_ORG ]]; then
+  echo "Please set QUAY_ORG, exiting"
+  exit 1
+fi
+
+IMAGE="quay.io/${QUAY_ORG}/kroxylicious:${KROXYLICIOUS_VERSION}"
+${CONTAINER_ENGINE} build -t "${IMAGE}" --build-arg "KROXYLICIOUS_VERSION=${KROXYLICIOUS_VERSION}" .
+if [[ -n $PUSH_IMAGE ]]; then
+  echo "Pushing image to quay.io"
+  ${CONTAINER_ENGINE} login quay.io
+  ${CONTAINER_ENGINE} push "${IMAGE}"
+else
+  echo "PUSH_IMAGE not set, not pushing to quay.io"
+fi

--- a/scripts/run-with-strimzi.sh
+++ b/scripts/run-with-strimzi.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+set -eo pipefail
+
+if [[ -z $QUAY_ORG ]]; then
+  echo "Please set QUAY_ORG, exiting"
+  exit 1
+fi
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. "${SCRIPT_DIR}/common.sh"
+cd "${SCRIPT_DIR}/.."
+
+if [[ "${QUAY_ORG}" != 'kroxylicious' ]]; then
+  echo "building and pushing image to quay.io"
+  PUSH_IMAGE=y "${SCRIPT_DIR}/deploy-image.sh"
+else
+  echo "QUAY_ORG is kroxylicious, not building/deploying image"
+fi
+set +e
+MINIKUBE_MEM=$(${MINIKUBE} config get memory)
+MINIKUBE_MEM_EXIT=$?
+set -e
+MINIKUBE_CONF='--memory=4096'
+if [ $MINIKUBE_MEM_EXIT -eq 0 ]; then
+  if [[ "$MINIKUBE_MEM" -lt 4096 ]]; then
+    echo "minikube memory is configured to below 4096 by user, overriding to 4096"
+  else
+    echo "minikube memory configured by user"
+    MINIKUBE_CONF=''
+  fi
+else
+  echo "no minikube memory configuration, defaulting to 4096M"
+fi
+INSTALL_DIR="sample-install"
+${MINIKUBE} start "${MINIKUBE_CONF}"
+${KUBECTL} create namespace kafka || true
+${KUBECTL} apply -f 'https://strimzi.io/install/latest?namespace=kafka' -n kafka
+${KUBECTL} apply -f "${INSTALL_DIR}/kafka-persistent.yaml" -n kafka
+${KUBECTL} wait kafka/my-cluster --for=condition=Ready --timeout=300s -n kafka 
+${SED} -i "s/quay\.io\/kroxylicious/quay\.io\/${QUAY_ORG}/g" "${INSTALL_DIR}"/*
+${KUBECTL} apply -f "${INSTALL_DIR}" -n kafka
+${KUBECTL} wait deployment/kroxylicious-proxy --for=condition=Available=True --timeout=300s -n kafka 
+
+echo "To produce to kroxylicious:"
+echo "kubectl -n kafka run kafka-producer -ti --image=quay.io/strimzi/kafka:0.35.0-kafka-3.4.0 --rm=true --restart=Never -- bin/kafka-console-producer.sh --bootstrap-server kroxylicious-service:9292 --topic my-topic"
+echo "To consume from kroxylicious:"
+echo "kubectl -n kafka run kafka-consumer -ti --image=quay.io/strimzi/kafka:0.35.0-kafka-3.4.0 --rm=true --restart=Never -- bin/kafka-console-consumer.sh --bootstrap-server kroxylicious-service:9292 --topic my-topic --from-beginning"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

We want Kroxylicious to be deployable in docker/kubernetes environments so we want to provide a public image. This PR introduces a `Dockerfile` to build kroxylicious from source. Because we build from source, most file changes will incur the cost of downloading all maven dependencies. We could avoid this by building natively before the docker build and copying in, but I think to get started it's okay. JIB is also an alternative we could move to.

The output image installs all kroxylicious dependency jars to `/opt/kroxylicious/libs` so users can extend this image and add filter jars to that directory.

#### Deploy Script

To develop conveniently with kubernetes and minikube it helps to have public images available somewhere like quay.io so that `minikube` can pull the image out-of-the-box. So I've scripted on the assumption developers will have a quay.io account and that they will set a `kroxylicious` repository to `public` under their account (the repository is automatically created on push).

`scripts/deploy-image.sh` builds and pushes the image to quay.io in a specific organisation (the image pushed will be `quay.io/${QUAY_ORG}/kroxylicious:${versionFromRootPom}`).

Environment variables:
`QUAY_ORG` - required, to set the quay.io organisation (using your username during development)
`PUSH_IMAGE` - optional, set to anything to push the image to quay. Default is to not push
`CONTAINER_ENGINE` - optional, configure container engine used to build image. Defaults to 'docker'

Examples:

- Build: `QUAY_ORG=robeyoun ./scripts/deploy-image.sh`
- Build and Push: `PUSH_IMAGE=y QUAY_ORG=robeyoun ./scripts/deploy-image.sh`

#### Run With Strimzi Script

`scripts/run-with-strimzi.sh` uses the `deploy-image.sh` script to build/deploy the image (only if the QUAY_ORG is not `kroxylicious`), then deploys kroxylicious and a 3-node strimzi cluster to `minikube`. The kubernetes resources are in the `install` directory.

Environment variables:
- `QUAY_ORG` - required, to set the quay.io organisation (using your username during development). This will build and pushes to quay.io if QUAY_ORG is not 'kroxylicious' on the assumption you are doing some development and want a custom image deployed into minikube.
- `CONTAINER_ENGINE` - optional, configure container engine used to build image. Defaults to 'docker'

Examples:
Build, push and deploy to clean minikube: `minikube delete && QUAY_ORG=robeyoun ./scripts/run-with-strimzi.sh`

Future work:
* JVM configuration (currently no mechanism to configure memory/JVM args etc)
* explore other mechanisms for users providing filters besides extending the container image