### PR TITLE
generate empty javadoc jar to keep Maven Central happy.

### DIFF
--- a/performance-tests/pom.xml
+++ b/performance-tests/pom.xml
@@ -89,12 +89,30 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- We don't actually care about javadoc here but we have to have it for maven central-->
+            <!-- so inspired by https://stackoverflow.com/a/59073656 we skip javadoc generation and attach an empty jar -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>javadoc</classifier>
+                            <classesDirectory>${project.basedir}/src/main/javadoc</classesDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Generate an minimal jar with the javadoc classififer.

### Additional Context

Maven central requires a javadoc jar for every jar published however there is little point in adding javadoc to the microbenchmarking code. We also don't want to generate javadoc for the module as its full of warnings which makes it harder to see other issues in the build.
