### PR TITLE
Add github action to build and deploy container images to quay.io

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,41 @@
+name: Docker Build
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Set Release version env variable
+        run: |
+          echo "RELEASE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
+      - name: Login to quay
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+      - name: Build
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            KROXYLICIOUS_VERSION=${{ env.RELEASE_VERSION }} 
+          tags: quay.io/kroxylicious/kroxylicious-developer:${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This runs in reaction to a pushed vX.Y.Z tag and builds the docker image, pushing it to `quay.io/kroxylicious/kroxylicious-development:${versionFromPomXml}` It builds amd64 and arm64 images for the tag. It can also be triggered via the github UI.

### Additional Context

Users will want a way to run kroxylicious on docker, we can offer a public image and users can build on top of it or mount in their custom filter jars.

This will also enable us to explore things like writing an operator in a separate repo to deploy/configure kroxylicious.