### PR TITLE
Don't throw threads around like confetti 

### DIFF
--- a/kroxylicious-multitenant/kroxylicious-multitenant.iml
+++ b/kroxylicious-multitenant/kroxylicious-multitenant.iml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="CheckStyle-IDEA-Module" serialisationVersion="2">
+    <option name="activeLocationsIds" />
+  </component>
+</module>

--- a/kroxylicious-schema-validation/kroxylicious-schema-validation.iml
+++ b/kroxylicious-schema-validation/kroxylicious-schema-validation.iml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="CheckStyle-IDEA-Module" serialisationVersion="2">
+    <option name="activeLocationsIds" />
+  </component>
+</module>

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/client/EventGroupConfig.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/client/EventGroupConfig.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test.client;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollServerSocketChannel;
+import io.netty.channel.epoll.EpollSocketChannel;
+import io.netty.channel.kqueue.KQueue;
+import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.channel.kqueue.KQueueServerSocketChannel;
+import io.netty.channel.kqueue.KQueueSocketChannel;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.ServerSocketChannel;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+
+public record EventGroupConfig(
+        Class<? extends SocketChannel> clientChannelClass,
+        Class<? extends ServerSocketChannel> serverChannelClass) {
+
+    public static EventGroupConfig create() {
+        final Class<? extends SocketChannel> clientChannelClass;
+        final Class<? extends ServerSocketChannel> serverChannelClass;
+
+        if (Epoll.isAvailable()) {
+            clientChannelClass = EpollSocketChannel.class;
+            serverChannelClass = EpollServerSocketChannel.class;
+        }
+        else if (KQueue.isAvailable()) {
+            clientChannelClass = KQueueSocketChannel.class;
+            serverChannelClass = KQueueServerSocketChannel.class;
+        }
+        else {
+            clientChannelClass = NioSocketChannel.class;
+            serverChannelClass = NioServerSocketChannel.class;
+        }
+        return new EventGroupConfig(clientChannelClass, serverChannelClass);
+    }
+
+    private static EventLoopGroup newGroup(int nThreads) {
+        if (Epoll.isAvailable()) {
+            return new EpollEventLoopGroup(nThreads);
+        }
+        else if (KQueue.isAvailable()) {
+            return new KQueueEventLoopGroup(nThreads);
+        }
+        else {
+            return new NioEventLoopGroup(nThreads);
+        }
+    }
+
+    public EventLoopGroup newWorkerGroup() {
+        return newGroup(1);
+    }
+    public EventLoopGroup newBossGroup() {
+        return newGroup(1);
+    }
+}

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/client/KafkaClient.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/client/KafkaClient.java
@@ -55,7 +55,7 @@ public final class KafkaClient implements AutoCloseable {
         this.port = port;
     }
 
-    private final EventLoopGroup group = new NioEventLoopGroup();
+    private final EventLoopGroup group = new NioEventLoopGroup(1);
 
     private static final AtomicInteger correlationId = new AtomicInteger(1);
 

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/client/KafkaClient.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/client/KafkaClient.java
@@ -17,9 +17,7 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.channel.socket.nio.NioSocketChannel;
 
 import io.kroxylicious.test.Request;
 import io.kroxylicious.test.Response;
@@ -45,6 +43,9 @@ public final class KafkaClient implements AutoCloseable {
     private final String host;
     private final int port;
 
+    private final EventGroupConfig eventGroupConfig;
+    private final EventLoopGroup bossGroup;
+
     /**
      * create empty kafkaClient
      * @param host host to connect to
@@ -53,9 +54,9 @@ public final class KafkaClient implements AutoCloseable {
     public KafkaClient(String host, int port) {
         this.host = host;
         this.port = port;
+        this.eventGroupConfig = EventGroupConfig.create();
+        bossGroup = eventGroupConfig.newBossGroup();
     }
-
-    private final EventLoopGroup group = new NioEventLoopGroup(1);
 
     private static final AtomicInteger correlationId = new AtomicInteger(1);
 
@@ -81,8 +82,8 @@ public final class KafkaClient implements AutoCloseable {
         CorrelationManager correlationManager = new CorrelationManager();
         KafkaClientHandler kafkaClientHandler = new KafkaClientHandler(decodedRequestFrame);
         Bootstrap b = new Bootstrap();
-        b.group(group)
-                .channel(NioSocketChannel.class)
+        b.group(bossGroup)
+                .channel(eventGroupConfig.clientChannelClass())
                 .option(ChannelOption.TCP_NODELAY, true)
                 .handler(new ChannelInitializer<SocketChannel>() {
                     @Override
@@ -114,6 +115,6 @@ public final class KafkaClient implements AutoCloseable {
 
     @Override
     public void close() {
-        group.shutdownGracefully();
+        bossGroup.shutdownGracefully();
     }
 }

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/server/MockServer.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/server/MockServer.java
@@ -15,12 +15,11 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
-import io.netty.channel.socket.nio.NioServerSocketChannel;
 
 import io.kroxylicious.test.Request;
 import io.kroxylicious.test.Response;
+import io.kroxylicious.test.client.EventGroupConfig;
 import io.kroxylicious.test.codec.DecodedRequestFrame;
 import io.kroxylicious.test.codec.KafkaRequestDecoder;
 import io.kroxylicious.test.codec.KafkaResponseEncoder;
@@ -88,12 +87,13 @@ public final class MockServer implements AutoCloseable {
      */
     public int start(int port, Response response) {
         // Configure the server.
-        bossGroup = new NioEventLoopGroup(1);
-        workerGroup = new NioEventLoopGroup();
+        final EventGroupConfig eventGroupConfig = EventGroupConfig.create();
+        bossGroup = eventGroupConfig.newBossGroup();
+        workerGroup = eventGroupConfig.newWorkerGroup();
         serverHandler = new MockHandler(response == null ? null : response.message());
         ServerBootstrap b = new ServerBootstrap();
         b.group(bossGroup, workerGroup)
-                .channel(NioServerSocketChannel.class)
+                .channel(eventGroupConfig.serverChannelClass())
                 .option(ChannelOption.SO_BACKLOG, 100)
                 .childHandler(new ChannelInitializer<SocketChannel>() {
                     @Override


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Reduce the number of threads created when using the mock server and Kafka Client and use platform native sockets where available.

### Additional Context

Creating a new KafkaClient instance creates a new NioEventLoopGroup using the no args constructor which by defaults to creating `2 * coreCount` threads. When run as part of `io.kroxylicious.mock.MockServerTest#testClientCanSendAndReceiveRPCToMock` ends up running 271 times for a single method resulting in churning through roughly 13,000 threads (which seems a little excessive).

The first commit replaces the no args ctor by supplying a thread count of 1. Which reduces the thread count to roughly 7k threads as the mock server is left alone. 

The second commit goes much further and reduces the thread count for the mock server as well and switches to using platform specific event loops where available. 

Fixes #385 