### PR TITLE
FilterContributor contribute List<KrpcFilter>

### DIFF
--- a/api/kroxylicious-filter-api/src/main/java/io/kroxylicious/proxy/filter/FilterContributor.java
+++ b/api/kroxylicious-filter-api/src/main/java/io/kroxylicious/proxy/filter/FilterContributor.java
@@ -5,11 +5,13 @@
  */
 package io.kroxylicious.proxy.filter;
 
+import java.util.List;
+
 import io.kroxylicious.proxy.service.Contributor;
 
 /**
  * FilterContributor is a pluggable source of Kroxylicious filter implementations.
  * @see Contributor
  */
-public interface FilterContributor extends Contributor<KrpcFilter> {
+public interface FilterContributor extends Contributor<List<KrpcFilter>> {
 }

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
@@ -20,6 +20,8 @@ import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.errors.InvalidTopicException;
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.serialization.Serdes;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -29,16 +31,21 @@ import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
 import io.kroxylicious.proxy.filter.CreateTopicRejectFilter;
 import io.kroxylicious.proxy.internal.filter.ByteBufferTransformation;
 import io.kroxylicious.proxy.service.HostPort;
+import io.kroxylicious.test.Request;
+import io.kroxylicious.test.Response;
+import io.kroxylicious.test.tester.MockServerKroxyliciousTester;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.withDefaultFilters;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
+import static io.kroxylicious.test.tester.KroxyliciousTesters.mockKafkaKroxyliciousTester;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.CLIENT_ID_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG;
+import static org.apache.kafka.common.protocol.ApiKeys.METADATA;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -120,6 +127,20 @@ public class KrpcFilterIT {
             consumer.close();
             assertEquals(1, records.count());
             assertEquals("Hello, world!", records.iterator().next().value());
+        }
+    }
+
+    @Test
+    public void supportsConfiguringMultipleFiltersWithSingleFilterDefinition() {
+        try (MockServerKroxyliciousTester tester = mockKafkaKroxyliciousTester((mockBootstrap) -> proxy(mockBootstrap)
+                .addToFilters(new FilterDefinitionBuilder("ApiVersions").build())
+                // FixedPrefixingClientId is implemented with two separate filters
+                .addToFilters(new FilterDefinitionBuilder("FixedPrefixingClientId")
+                        .withConfig("fixedClientId", "banana", "prefix", "123").build()));
+                var singleRequestClient = tester.singleRequestClient()) {
+            tester.setMockResponse(new Response(METADATA, METADATA.latestVersion(), new MetadataResponseData()));
+            singleRequestClient.getSync(new Request(METADATA, METADATA.latestVersion(), "client", new MetadataRequestData()));
+            assertEquals("123banana", tester.onlyRequest().clientIdHeader());
         }
     }
 

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/ClientIdPrefixingFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/ClientIdPrefixingFilter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+
+public class ClientIdPrefixingFilter implements RequestFilter, ResponseFilter {
+
+    private final String prefix;
+
+    public static class ClientIdPrefixingFilterConfig extends BaseConfig {
+
+        private final String clientId;
+
+        public ClientIdPrefixingFilterConfig(String clientId) {
+            this.clientId = clientId;
+        }
+
+        public String getClientId() {
+            return clientId;
+        }
+    }
+
+    ClientIdPrefixingFilter(ClientIdPrefixingFilterConfig config) {
+        this.prefix = config.getClientId();
+    }
+
+    @Override
+    public boolean shouldHandleRequest(ApiKeys apiKey, short apiVersion) {
+        return true;
+    }
+
+    @Override
+    public boolean shouldHandleResponse(ApiKeys apiKey, short apiVersion) {
+        return true;
+    }
+
+    @Override
+    public void onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+        header.setClientId(prefix + header.clientId());
+        filterContext.forwardRequest(header, body);
+    }
+
+    @Override
+    public void onResponse(ApiKeys apiKey, ResponseHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+        filterContext.forwardResponse(header, body);
+    }
+}

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/CombinedConfiguration.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/CombinedConfiguration.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+
+public class CombinedConfiguration extends BaseConfig {
+
+    private final String prefix;
+    private final String fixedClientId;
+
+    @JsonCreator
+    public CombinedConfiguration(@JsonProperty("prefix") String prefix, @JsonProperty("fixedClientId") String fixedClientId) {
+        this.prefix = prefix;
+        this.fixedClientId = fixedClientId;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public String getFixedClientId() {
+        return fixedClientId;
+    }
+}

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
@@ -5,13 +5,27 @@
  */
 package io.kroxylicious.proxy.filter;
 
+import java.util.List;
+import java.util.function.Function;
+
+import io.kroxylicious.proxy.filter.ClientIdPrefixingFilter.ClientIdPrefixingFilterConfig;
+import io.kroxylicious.proxy.filter.FixedClientIdFilter.FixedClientIdFilterConfig;
 import io.kroxylicious.proxy.service.BaseContributor;
 
-public class TestFilterContributor extends BaseContributor<KrpcFilter> implements FilterContributor {
+public class TestFilterContributor extends BaseContributor<List<KrpcFilter>> implements FilterContributor {
 
-    public static final BaseContributorBuilder<KrpcFilter> FILTERS = BaseContributor.<KrpcFilter> builder()
-            .add("FixedClientId", FixedClientIdFilter.FixedClientIdFilterConfig.class, FixedClientIdFilter::new)
-            .add("CreateTopicRejectFilter", CreateTopicRejectFilter::new);
+    public static final BaseContributorBuilder<List<KrpcFilter>> FILTERS = BaseContributor.<List<KrpcFilter>> builder()
+            .add("FixedClientId", FixedClientIdFilterConfig.class, config -> List.of(new FixedClientIdFilter(config)))
+            .add("FixedPrefixingClientId", CombinedConfiguration.class, fixedClientIdWithPrefix())
+            .add("CreateTopicRejectFilter", () -> List.of(new CreateTopicRejectFilter()));
+
+    private static Function<CombinedConfiguration, List<KrpcFilter>> fixedClientIdWithPrefix() {
+        return config -> {
+            FixedClientIdFilter fixedClientIdFilter = new FixedClientIdFilter(new FixedClientIdFilterConfig(config.getFixedClientId()));
+            ClientIdPrefixingFilter clientIdPrefixingFilter = new ClientIdPrefixingFilter(new ClientIdPrefixingFilterConfig(config.getPrefix()));
+            return List.of(fixedClientIdFilter, clientIdPrefixingFilter);
+        };
+    }
 
     public TestFilterContributor() {
         super(FILTERS);

--- a/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterContributor.java
+++ b/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterContributor.java
@@ -5,14 +5,16 @@
  */
 package io.kroxylicious.proxy.filter.multitenant;
 
+import java.util.List;
+
 import io.kroxylicious.proxy.filter.FilterContributor;
 import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.service.BaseContributor;
 
-public class MultiTenantFilterContributor extends BaseContributor<KrpcFilter> implements FilterContributor {
+public class MultiTenantFilterContributor extends BaseContributor<List<KrpcFilter>> implements FilterContributor {
 
-    public static final BaseContributorBuilder<KrpcFilter> FILTERS = BaseContributor.<KrpcFilter> builder()
-            .add("MultiTenant", MultiTenantTransformationFilter::new);
+    public static final BaseContributorBuilder<List<KrpcFilter>> FILTERS = BaseContributor.<List<KrpcFilter>> builder()
+            .add("MultiTenant", () -> List.of(new MultiTenantTransformationFilter()));
 
     public MultiTenantFilterContributor() {
         super(FILTERS);

--- a/kroxylicious-additional-filters/kroxylicious-schema-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceRequestValidationFilterContributor.java
+++ b/kroxylicious-additional-filters/kroxylicious-schema-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceRequestValidationFilterContributor.java
@@ -5,6 +5,8 @@
  */
 package io.kroxylicious.proxy.filter.schema;
 
+import java.util.List;
+
 import io.kroxylicious.proxy.filter.FilterContributor;
 import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.filter.schema.config.ValidationConfig;
@@ -14,12 +16,12 @@ import io.kroxylicious.proxy.service.BaseContributor;
 /**
  * Contributor for request validation filters
  */
-public class ProduceRequestValidationFilterContributor extends BaseContributor<KrpcFilter> implements FilterContributor {
+public class ProduceRequestValidationFilterContributor extends BaseContributor<List<KrpcFilter>> implements FilterContributor {
 
-    private static final BaseContributorBuilder<KrpcFilter> FILTERS = BaseContributor.<KrpcFilter> builder()
+    private static final BaseContributorBuilder<List<KrpcFilter>> FILTERS = BaseContributor.<List<KrpcFilter>> builder()
             .add("ProduceValidator", ValidationConfig.class, (config) -> {
                 ProduceRequestValidator validator = ProduceValidationFilterBuilder.build(config);
-                return new ProduceValidationFilter(config.isForwardPartialRequests(), validator);
+                return List.of(new ProduceValidationFilter(config.isForwardPartialRequests(), validator));
             });
 
     /**

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -34,7 +34,7 @@ public class FilterChainFactory {
 
         return config.filters()
                 .stream()
-                .map(f -> filterContributorManager.getFilter(f.type(), f.config()))
+                .flatMap(f -> filterContributorManager.getFilters(f.type(), f.config()).stream())
                 .toList();
     }
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BuiltinFilterContributor.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BuiltinFilterContributor.java
@@ -5,18 +5,20 @@
  */
 package io.kroxylicious.proxy.internal.filter;
 
+import java.util.List;
+
 import io.kroxylicious.proxy.filter.FilterContributor;
 import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.internal.filter.FetchResponseTransformationFilter.FetchResponseTransformationConfig;
 import io.kroxylicious.proxy.internal.filter.ProduceRequestTransformationFilter.ProduceRequestTransformationConfig;
 import io.kroxylicious.proxy.service.BaseContributor;
 
-public class BuiltinFilterContributor extends BaseContributor<KrpcFilter> implements FilterContributor {
+public class BuiltinFilterContributor extends BaseContributor<List<KrpcFilter>> implements FilterContributor {
 
-    public static final BaseContributorBuilder<KrpcFilter> FILTERS = BaseContributor.<KrpcFilter> builder()
-            .add("ApiVersions", ApiVersionsFilter::new)
-            .add("ProduceRequestTransformation", ProduceRequestTransformationConfig.class, ProduceRequestTransformationFilter::new)
-            .add("FetchResponseTransformation", FetchResponseTransformationConfig.class, FetchResponseTransformationFilter::new);
+    public static final BaseContributorBuilder<List<KrpcFilter>> FILTERS = BaseContributor.<List<KrpcFilter>> builder()
+            .add("ApiVersions", () -> List.of(new ApiVersionsFilter()))
+            .add("ProduceRequestTransformation", ProduceRequestTransformationConfig.class, config -> List.of(new ProduceRequestTransformationFilter(config)))
+            .add("FetchResponseTransformation", FetchResponseTransformationConfig.class, config -> List.of(new FetchResponseTransformationFilter(config)));
 
     public BuiltinFilterContributor() {
         super(FILTERS);

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterContributorManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterContributorManager.java
@@ -5,7 +5,7 @@
  */
 package io.kroxylicious.proxy.internal.filter;
 
-import java.util.Iterator;
+import java.util.List;
 import java.util.ServiceLoader;
 
 import io.kroxylicious.proxy.config.BaseConfig;
@@ -27,28 +27,24 @@ public class FilterContributorManager {
     }
 
     public Class<? extends BaseConfig> getConfigType(String shortName) {
-        Iterator<FilterContributor> it = contributors.iterator();
-        while (it.hasNext()) {
-            FilterContributor contributor = it.next();
+        for (FilterContributor contributor : contributors) {
             Class<? extends BaseConfig> configType = contributor.getConfigType(shortName);
             if (configType != null) {
                 return configType;
             }
         }
 
-        throw new IllegalArgumentException("No filter found for name '" + shortName + "'");
+        throw new IllegalArgumentException("No filters found for name '" + shortName + "'");
     }
 
-    public KrpcFilter getFilter(String shortName, BaseConfig filterConfig) {
-        Iterator<FilterContributor> it = contributors.iterator();
-        while (it.hasNext()) {
-            FilterContributor contributor = it.next();
-            KrpcFilter filter = contributor.getInstance(shortName, filterConfig);
-            if (filter != null) {
-                return filter;
+    public List<KrpcFilter> getFilters(String shortName, BaseConfig filterConfig) {
+        for (FilterContributor contributor : contributors) {
+            List<KrpcFilter> filters = contributor.getInstance(shortName, filterConfig);
+            if (filters != null) {
+                return filters;
             }
         }
 
-        throw new IllegalArgumentException("No filter found for name '" + shortName + "'");
+        throw new IllegalArgumentException("No filters found for name '" + shortName + "'");
     }
 }


### PR DESCRIPTION
Closes #348

### Type of change

- Enhancement / new feature

### Description

In some cases it may be preferable if we can contribute multiple filters for a single Filter definition in the config.

For example for multi-tenancy we need to use per-MessageType filters to intercept specific RPCs. But we also will want to map all clientIds in request headers, which makes more sense as a RequestFilter that intercepts all request. These types of filters cannot be mixed in a single implementing class currently, so the Users would have to add two filter definitions to their YAML.

It would be better if they could declare a single type and have the required filters installed into the chain in the right order. The configuration is simplified and better for evolution too. It allows us to decompose a single filter into multiple, or recombine them without the user configuration having to change.
### Additional Context

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [x] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
