### PR TITLE
Support forwarding new instances of headers and body

### DIFF
--- a/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
@@ -135,8 +135,7 @@ public class KrpcFilterIT {
     public void testFilterCanInstantiateNewKafkaMessages() {
         try (MockServerKroxyliciousTester tester = mockKafkaKroxyliciousTester((mockBootstrap) -> proxy(mockBootstrap)
                 .addToFilters(new FilterDefinitionBuilder("NewInstanceMetadataFilter").build()));
-                var singleRequestClient = tester.singleRequestClient()
-        ) {
+                var singleRequestClient = tester.singleRequestClient()) {
             tester.setMockResponse(new Response(METADATA, METADATA.latestVersion(), new MetadataResponseData()));
             Response response = singleRequestClient.getSync(new Request(METADATA, METADATA.latestVersion(), "client", new MetadataRequestData()));
             assertEquals(NewInstanceMetadataFilter.FIXED_THROTTLE_TIME, ((MetadataResponseData) response.message()).throttleTimeMs());

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/NewInstanceMetadataFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/NewInstanceMetadataFilter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+
+public class NewInstanceMetadataFilter implements MetadataRequestFilter, MetadataResponseFilter {
+
+    public static final int FIXED_THROTTLE_TIME = 999;
+    public static final String FIXED_CLIENT_ID = "newInstanceClientId";
+
+    @Override
+    public void onMetadataRequest(short apiVersion, RequestHeaderData header, MetadataRequestData request, KrpcFilterContext context) {
+        RequestHeaderData duplicate = header.duplicate();
+        duplicate.setClientId(FIXED_CLIENT_ID);
+        context.forwardRequest(duplicate, request.duplicate());
+    }
+
+    @Override
+    public void onMetadataResponse(short apiVersion, ResponseHeaderData header, MetadataResponseData response, KrpcFilterContext context) {
+        MetadataResponseData duplicate = response.duplicate();
+        duplicate.setThrottleTimeMs(FIXED_THROTTLE_TIME);
+        context.forwardResponse(header.duplicate(), duplicate);
+    }
+}

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
@@ -11,6 +11,7 @@ public class TestFilterContributor extends BaseContributor<KrpcFilter> implement
 
     public static final BaseContributorBuilder<KrpcFilter> FILTERS = BaseContributor.<KrpcFilter> builder()
             .add("FixedClientId", FixedClientIdFilter.FixedClientIdFilterConfig.class, FixedClientIdFilter::new)
+            .add("NewInstanceMetadataFilter", NewInstanceMetadataFilter::new)
             .add("CreateTopicRejectFilter", CreateTopicRejectFilter::new);
 
     public TestFilterContributor() {

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/DecodedFrame.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/DecodedFrame.java
@@ -74,7 +74,7 @@ public abstract class DecodedFrame<H extends ApiMessage>
         if (body == null) {
             throw new IllegalArgumentException("body was null");
         }
-        else if (body.apiKey() != body.apiKey()) {
+        else if (body.apiKey() != this.body.apiKey()) {
             throw new IllegalArgumentException("attempting to set a body with a different apiKey than the original");
         }
         else {

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/DecodedFrame.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/DecodedFrame.java
@@ -39,9 +39,8 @@ public abstract class DecodedFrame<H extends ApiMessage, B extends ApiMessage>
 
     protected final short apiVersion;
     protected final int correlationId;
-    protected final H header;
-    protected final B body;
-
+    protected H header;
+    protected B body;
     private final List<ByteBuf> buffers;
     private int headerAndBodyEncodedLength;
     private ObjectSerializationCache serializationCache;
@@ -68,6 +67,14 @@ public abstract class DecodedFrame<H extends ApiMessage, B extends ApiMessage>
 
     public B body() {
         return body;
+    }
+
+    public void setBody(ApiMessage body) {
+        this.body = (B) body;
+    }
+
+    public void setHeader(ApiMessage header) {
+        this.header = (H) header;
     }
 
     public ApiKeys apiKey() {

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/DecodedRequestFrame.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/DecodedRequestFrame.java
@@ -11,8 +11,8 @@ import org.apache.kafka.common.protocol.ApiMessage;
 /**
  * A decoded request frame.
  */
-public class DecodedRequestFrame<B extends ApiMessage>
-        extends DecodedFrame<RequestHeaderData, B>
+public class DecodedRequestFrame
+        extends DecodedFrame<RequestHeaderData>
         implements RequestFrame {
 
     private final boolean decodeResponse;
@@ -21,8 +21,8 @@ public class DecodedRequestFrame<B extends ApiMessage>
                                int correlationId,
                                boolean decodeResponse,
                                RequestHeaderData header,
-                               B body) {
-        super(apiVersion, correlationId, header, body);
+                               ApiMessage body) {
+        super(apiVersion, correlationId, header, RequestHeaderData.class, body);
         this.decodeResponse = decodeResponse;
     }
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/DecodedResponseFrame.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/DecodedResponseFrame.java
@@ -11,12 +11,12 @@ import org.apache.kafka.common.protocol.ApiMessage;
 /**
  * A decoded response frame.
  */
-public class DecodedResponseFrame<B extends ApiMessage>
-        extends DecodedFrame<ResponseHeaderData, B>
+public class DecodedResponseFrame
+        extends DecodedFrame<ResponseHeaderData>
         implements ResponseFrame {
 
-    public DecodedResponseFrame(short apiVersion, int correlationId, ResponseHeaderData header, B body) {
-        super(apiVersion, correlationId, header, body);
+    public DecodedResponseFrame(short apiVersion, int correlationId, ResponseHeaderData header, ApiMessage body) {
+        super(apiVersion, correlationId, header, ResponseHeaderData.class, body);
     }
 
     public short headerVersion() {

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/DefaultFilterContext.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/DefaultFilterContext.java
@@ -38,7 +38,7 @@ class DefaultFilterContext implements KrpcFilterContext {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultFilterContext.class);
 
-    private final DecodedFrame<?, ?> decodedFrame;
+    private final DecodedFrame<?> decodedFrame;
     private final ChannelHandlerContext channelContext;
     private final ChannelPromise promise;
     private final KrpcFilter filter;
@@ -47,7 +47,7 @@ class DefaultFilterContext implements KrpcFilterContext {
 
     DefaultFilterContext(KrpcFilter filter,
                          ChannelHandlerContext channelContext,
-                         DecodedFrame<?, ?> decodedFrame,
+                         DecodedFrame<?> decodedFrame,
                          ChannelPromise promise,
                          long timeoutMs,
                          String sniHostname) {
@@ -134,7 +134,7 @@ class DefaultFilterContext implements KrpcFilterContext {
                 || ((ProduceRequestData) message).acks() != 0;
         var filterPromise = new CompletableFuture<T>();
         var filterStage = new InternalCompletionStage<>(filterPromise);
-        var frame = new InternalRequestFrame<>(
+        var frame = new InternalRequestFrame(
                 apiVersion, -1, hasResponse,
                 filter, filterPromise, header, message);
 
@@ -224,7 +224,7 @@ class DefaultFilterContext implements KrpcFilterContext {
      * @param response the response body
      */
     private void forwardShortCircuitResponse(ResponseHeaderData header, ApiMessage response) {
-        DecodedResponseFrame<?> responseFrame = new DecodedResponseFrame<>(decodedFrame.apiVersion(), decodedFrame.correlationId(), header, response);
+        DecodedResponseFrame responseFrame = new DecodedResponseFrame(decodedFrame.apiVersion(), decodedFrame.correlationId(), header, response);
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("{}: Forwarding response: {}", channelDescriptor(), decodedFrame);
         }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -52,7 +52,7 @@ public class FilterHandler
 
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
-        if (msg instanceof DecodedRequestFrame<?> decodedFrame) {
+        if (msg instanceof DecodedRequestFrame decodedFrame) {
             var filterContext = new DefaultFilterContext(filter, ctx, decodedFrame, promise, timeoutMs, sniHostname);
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("{}: Dispatching downstream {} request to filter{}: {}",
@@ -74,8 +74,8 @@ public class FilterHandler
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-        if (msg instanceof DecodedResponseFrame<?> decodedFrame) {
-            if (decodedFrame instanceof InternalResponseFrame<?> frame) {
+        if (msg instanceof DecodedResponseFrame decodedFrame) {
+            if (decodedFrame instanceof InternalResponseFrame frame) {
                 if (frame.isRecipient(filter)) {
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug("{}: Completing {} response for request sent by this filter{}: {}",

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/InternalRequestFrame.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/InternalRequestFrame.java
@@ -14,7 +14,7 @@ import org.apache.kafka.common.protocol.ApiMessage;
 import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 
-public class InternalRequestFrame<B extends ApiMessage> extends DecodedRequestFrame<B> {
+public class InternalRequestFrame extends DecodedRequestFrame {
 
     private final CompletableFuture<?> promise;
     private final KrpcFilter recipient;
@@ -25,7 +25,7 @@ public class InternalRequestFrame<B extends ApiMessage> extends DecodedRequestFr
                                 KrpcFilter recipient,
                                 CompletableFuture<?> promise,
                                 RequestHeaderData header,
-                                B body) {
+                                ApiMessage body) {
         super(apiVersion, correlationId, decodeResponse, header, body);
         this.promise = promise;
         this.recipient = Objects.requireNonNull(recipient);

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/InternalResponseFrame.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/InternalResponseFrame.java
@@ -14,13 +14,13 @@ import org.apache.kafka.common.protocol.ApiMessage;
 import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 
-public class InternalResponseFrame<B extends ApiMessage> extends DecodedResponseFrame<B> {
+public class InternalResponseFrame extends DecodedResponseFrame {
 
     private final KrpcFilter recipient;
 
     private final CompletableFuture<?> future;
 
-    public InternalResponseFrame(KrpcFilter recipient, short apiVersion, int correlationId, ResponseHeaderData header, B body, CompletableFuture<?> future) {
+    public InternalResponseFrame(KrpcFilter recipient, short apiVersion, int correlationId, ResponseHeaderData header, ApiMessage body, CompletableFuture<?> future) {
         super(apiVersion, correlationId, header, body);
         this.recipient = Objects.requireNonNull(recipient);
         this.future = future;

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -189,9 +189,9 @@ public class KafkaProxyFrontendHandler
             else if ((state == State.START
                     || state == State.HA_PROXY)
                     && msg instanceof DecodedRequestFrame
-                    && ((DecodedRequestFrame<?>) msg).apiKey() == ApiKeys.API_VERSIONS) {
+                    && ((DecodedRequestFrame) msg).apiKey() == ApiKeys.API_VERSIONS) {
                 // This handler can respond to ApiVersions itself
-                writeApiVersionsResponse(ctx, (DecodedRequestFrame<ApiVersionsRequestData>) msg);
+                writeApiVersionsResponse(ctx, (DecodedRequestFrame) msg);
                 // Request to read the following request
                 ctx.channel().read();
                 state = State.API_VERSIONS;
@@ -316,19 +316,20 @@ public class KafkaProxyFrontendHandler
      * Sends an ApiVersions response from this handler to the client
      * (i.e. prior to having backend connection)
      */
-    private void writeApiVersionsResponse(ChannelHandlerContext ctx, DecodedRequestFrame<ApiVersionsRequestData> frame) {
+    private void writeApiVersionsResponse(ChannelHandlerContext ctx, DecodedRequestFrame frame) {
         // TODO check the format of the strings using a regex
         // Needed to reproduce the exact behaviour for how a broker handles this
         // see org.apache.kafka.common.requests.ApiVersionsRequest#isValid()
-        this.clientSoftwareName = frame.body().clientSoftwareName();
-        this.clientSoftwareVersion = frame.body().clientSoftwareVersion();
+        ApiVersionsRequestData request = (ApiVersionsRequestData) frame.body();
+        this.clientSoftwareName = request.clientSoftwareName();
+        this.clientSoftwareVersion = request.clientSoftwareVersion();
 
         short apiVersion = frame.apiVersion();
         int correlationId = frame.correlationId();
         ResponseHeaderData header = new ResponseHeaderData()
                 .setCorrelationId(correlationId);
         LOGGER.debug("{}: Writing ApiVersions response", ctx.channel());
-        ctx.writeAndFlush(new DecodedResponseFrame<>(
+        ctx.writeAndFlush(new DecodedResponseFrame(
                 apiVersion, correlationId, header, API_VERSIONS_RESPONSE));
     }
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoder.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoder.java
@@ -89,7 +89,7 @@ public class KafkaRequestDecoder extends KafkaMessageDecoder {
                 log().trace("{}: body {}", ctx, body);
             }
 
-            frame = new DecodedRequestFrame<ApiMessage>(apiVersion, correlationId, decodeResponse, header, body);
+            frame = new DecodedRequestFrame(apiVersion, correlationId, decodeResponse, header, body);
             if (log().isTraceEnabled()) {
                 log().trace("{}: frame {}", ctx, frame);
             }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestEncoder.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestEncoder.java
@@ -52,8 +52,8 @@ public class KafkaRequestEncoder extends KafkaMessageEncoder<RequestFrame> {
                 apiVersion,
                 downstreamCorrelationId,
                 hasResponse,
-                frame instanceof InternalRequestFrame ? ((InternalRequestFrame<?>) frame).recipient() : null,
-                frame instanceof InternalRequestFrame ? ((InternalRequestFrame<?>) frame).promise() : null, decodeResponse);
+                frame instanceof InternalRequestFrame ? ((InternalRequestFrame) frame).recipient() : null,
+                frame instanceof InternalRequestFrame ? ((InternalRequestFrame) frame).promise() : null, decodeResponse);
         out.writerIndex(LENGTH + API_KEY + API_VERSION);
         out.writeInt(upstreamCorrelationId);
         if (LOGGER.isDebugEnabled()) {
@@ -73,7 +73,7 @@ public class KafkaRequestEncoder extends KafkaMessageEncoder<RequestFrame> {
     private boolean hasResponse(RequestFrame frame, ByteBuf out, int ri, short apiKey, short apiVersion) {
         if (frame instanceof DecodedRequestFrame) {
             return apiKey != ApiKeys.PRODUCE.id
-                    || ((ProduceRequestData) ((DecodedRequestFrame<?>) frame).body()).acks() != 0;
+                    || ((ProduceRequestData) ((DecodedRequestFrame) frame).body()).acks() != 0;
         }
         else {
             return apiKey != ApiKeys.PRODUCE.id

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseDecoder.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseDecoder.java
@@ -72,10 +72,10 @@ public class KafkaResponseDecoder extends KafkaMessageDecoder {
             KrpcFilter recipient = correlation.recipient();
             Metrics.payloadSizeBytesDownstreamSummary(apiKey, apiVersion).record(length);
             if (recipient == null) {
-                frame = new DecodedResponseFrame<>(apiVersion, correlationId, header, body);
+                frame = new DecodedResponseFrame(apiVersion, correlationId, header, body);
             }
             else {
-                frame = new InternalResponseFrame<>(recipient, apiVersion, correlationId, header, body, correlation.promise());
+                frame = new InternalResponseFrame(recipient, apiVersion, correlationId, header, body, correlation.promise());
             }
         }
         else {

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHandlerTest.java
@@ -122,7 +122,7 @@ public class FilterHandlerTest extends FilterHarness {
         var frame = writeRequest(new ApiVersionsRequestData());
         var propagated = channel.readOutbound();
         assertTrue(propagated instanceof InternalRequestFrame);
-        assertEquals(body, ((InternalRequestFrame<?>) propagated).body(),
+        assertEquals(body, ((InternalRequestFrame) propagated).body(),
                 "Expect the body to be the Fetch request");
 
         InternalCompletionStage<ApiMessage> completionStage = fut[0];
@@ -167,7 +167,7 @@ public class FilterHandlerTest extends FilterHarness {
         var frame = writeRequest(new ApiVersionsRequestData());
         var propagated = channel.readOutbound();
         assertTrue(propagated instanceof InternalRequestFrame);
-        assertEquals(body, ((InternalRequestFrame<?>) propagated).body(),
+        assertEquals(body, ((InternalRequestFrame) propagated).body(),
                 "Expect the body to be the Fetch request");
 
         assertThrows(UnsupportedOperationException.class, () -> {
@@ -195,7 +195,7 @@ public class FilterHandlerTest extends FilterHarness {
         var frame = writeRequest(new ApiVersionsRequestData());
         var propagated = channel.readOutbound();
         assertTrue(propagated instanceof InternalRequestFrame);
-        assertEquals(body, ((InternalRequestFrame<?>) propagated).body(),
+        assertEquals(body, ((InternalRequestFrame) propagated).body(),
                 "Expect the body to be the Fetch request");
 
         CompletableFuture<ApiMessage> future = toCompletableFuture(fut[0]);
@@ -224,7 +224,7 @@ public class FilterHandlerTest extends FilterHarness {
         var frame = writeRequest(new ApiVersionsRequestData());
         var propagated = channel.readOutbound();
         assertTrue(propagated instanceof InternalRequestFrame);
-        assertEquals(body, ((InternalRequestFrame<?>) propagated).body(),
+        assertEquals(body, ((InternalRequestFrame) propagated).body(),
                 "Expect the body to be the Fetch request");
 
         CompletionStage<ApiMessage> p = fut[0];

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
@@ -55,9 +55,8 @@ public abstract class FilterHarness {
      * Write a client request to the pipeline.
      * @param data The request body.
      * @return The frame that was sent.
-     * @param <B> The type of the request.
      */
-    protected <B extends ApiMessage> DecodedRequestFrame<B> writeRequest(B data) {
+    protected DecodedRequestFrame writeRequest(ApiMessage data) {
         var apiKey = ApiKeys.forId(data.apiKey());
         var header = new RequestHeaderData();
         int correlationId = 42;
@@ -65,7 +64,7 @@ public abstract class FilterHarness {
         header.setRequestApiKey(apiKey.id);
         header.setRequestApiVersion(apiKey.latestVersion());
         header.setClientId(TEST_CLIENT);
-        var frame = new DecodedRequestFrame<>(apiKey.latestVersion(), correlationId, false, header, data);
+        var frame = new DecodedRequestFrame(apiKey.latestVersion(), correlationId, false, header, data);
         channel.writeOutbound(frame);
         return frame;
     }
@@ -74,14 +73,13 @@ public abstract class FilterHarness {
      * Write a normal client response, as if from the broker.
      * @param data The body of the response.
      * @return The frame that was written.
-     * @param <B> The type of the response body.
      */
-    protected <B extends ApiMessage> DecodedResponseFrame<B> writeResponse(B data) {
+    protected DecodedResponseFrame writeResponse(ApiMessage data) {
         var apiKey = ApiKeys.forId(data.apiKey());
         var header = new ResponseHeaderData();
         int correlationId = 42;
         header.setCorrelationId(correlationId);
-        var frame = new DecodedResponseFrame<>(apiKey.latestVersion(), correlationId, header, data);
+        var frame = new DecodedResponseFrame(apiKey.latestVersion(), correlationId, header, data);
         channel.writeInbound(frame);
         return frame;
     }
@@ -91,14 +89,13 @@ public abstract class FilterHarness {
      * @param data The body of the response.
      * @param future
      * @return The frame that was written.
-     * @param <B> The type of the response body.
      */
-    protected <B extends ApiMessage> DecodedResponseFrame<B> writeInternalResponse(B data, CompletableFuture<?> future) {
+    protected DecodedResponseFrame writeInternalResponse(ApiMessage data, CompletableFuture<?> future) {
         var apiKey = ApiKeys.forId(data.apiKey());
         var header = new ResponseHeaderData();
         int correlationId = 42;
         header.setCorrelationId(correlationId);
-        var frame = new InternalResponseFrame<>(filter, apiKey.latestVersion(), correlationId, header, data, future);
+        var frame = new InternalResponseFrame(filter, apiKey.latestVersion(), correlationId, header, data, future);
         channel.writeInbound(frame);
         return frame;
     }

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
@@ -213,11 +213,11 @@ public class KafkaAuthnHandlerTest {
             }
         }, new CompletableFuture<>(), true);
 
-        channel.writeInbound(new DecodedRequestFrame<>(apiVersion, corrId, true, header, body));
+        channel.writeInbound(new DecodedRequestFrame(apiVersion, corrId, true, header, body));
     }
 
     private <T extends ApiMessage> T readResponse(Class<T> cls) {
-        DecodedResponseFrame<?> authenticateResponseFrame = assertInstanceOf(DecodedResponseFrame.class, channel.readOutbound());
+        DecodedResponseFrame authenticateResponseFrame = assertInstanceOf(DecodedResponseFrame.class, channel.readOutbound());
         return assertInstanceOf(cls, authenticateResponseFrame.body());
     }
 

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -70,7 +70,7 @@ class KafkaProxyFrontendHandlerTest {
                 .setClientId("client-id")
                 .setCorrelationId(downstreamCorrelationId);
 
-        inboundChannel.writeInbound(new DecodedRequestFrame<>(apiVersion, corrId, true, header, body));
+        inboundChannel.writeInbound(new DecodedRequestFrame(apiVersion, corrId, true, header, body));
     }
 
     @BeforeEach

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/codec/AbstractCodecTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/codec/AbstractCodecTest.java
@@ -206,7 +206,7 @@ public abstract class AbstractCodecTest {
         assertEquals(akBuf.writerIndex(), akBuf.readerIndex(), "Expect to have read whole buf");
 
         assertEquals(List.of(frameClass), messageClasses(messages), "Expected a single decoded frame");
-        DecodedFrame<H, B> frame = (DecodedFrame<H, B>) messages.get(0);
+        DecodedFrame<H> frame = (DecodedFrame<H>) messages.get(0);
         assertEquals(akHeader, headerAdjuster.apply(frame.header()));
         assertEquals(akBody, frame.body());
         return frame.correlationId();

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/codec/RequestEncoderTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/codec/RequestEncoderTest.java
@@ -41,7 +41,7 @@ public class RequestEncoderTest extends AbstractCodecTest {
 
         CorrelationManager correlationManager = new CorrelationManager(exampleHeader.correlationId());
         var encoder = new KafkaRequestEncoder(correlationManager);
-        testEncode(expected, new DecodedRequestFrame<ApiVersionsRequestData>(apiVersion, exampleHeader.correlationId(), true, exampleHeader, exampleBody), encoder);
+        testEncode(expected, new DecodedRequestFrame(apiVersion, exampleHeader.correlationId(), true, exampleHeader, exampleBody), encoder);
         var corr = correlationManager.getBrokerCorrelation(exampleHeader.correlationId());
         assertEquals(ApiKeys.API_VERSIONS.id, corr.apiKey());
         assertEquals(exampleHeader.requestApiKey(), corr.apiKey());

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/codec/ResponseEncoderTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/codec/ResponseEncoderTest.java
@@ -23,6 +23,6 @@ public class ResponseEncoderTest extends AbstractCodecTest {
         ApiVersionsResponseData exampleBody = exampleApiVersionsResponse();
         short headerVersion = ApiKeys.API_VERSIONS.responseHeaderVersion(apiVersion);
         ByteBuffer expected = serializeUsingKafkaApis(headerVersion, exampleHeader, apiVersion, exampleBody);
-        testEncode(expected, new DecodedResponseFrame<>(apiVersion, exampleHeader.correlationId(), exampleHeader, exampleBody), new KafkaResponseEncoder());
+        testEncode(expected, new DecodedResponseFrame(apiVersion, exampleHeader.correlationId(), exampleHeader, exampleBody), new KafkaResponseEncoder());
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This enables Filter Authors to instantiate new instances of the relevant Kafka message rather than exclusively mutating the messages.

### Additional Context

Until now methods on KrpcFilterContext like `void forwardRequest(RequestHeaderData header, ApiMessage request)` have had the implicit expectation that you only forward the exact instances of the `header` and `request` delivered to your Filter by the framework. An exception would be thrown if you forwarded a different object from the one on the decoded frame.

This is a bit surprising, I as a Filter Author would like to be able to create a new instance of the message (of the same Api) and forward that, for example if I want to intercept a response from the broker and then return an error response to the client, it makes more sense to create that message from scratch than try to mutate the broker's response.

While implementing this I found that the generic body type on the DecodedFrame API was hindering more than helping. We almost never know the type of the frame body without some kind of unchecked cast and the type erasure made it hard to put a method on `DecodedFrame` like `setBody(B body)` as we are usually interacting with a `Decoded[Request|Response]Frame<?>`. So I removed the generic type, changed `body` to be an `ApiMessage` and updated usages to cast the `body` rather than the `frame`.

Closes #303 

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
