### PR TITLE
update run command in README to avoid problem with classpath arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ No one likes to argue about code formatting in pull requests, as project we take
 Build with the `dist` profile as shown above, then execute this:
 
 ```
-$ java -jar kroxylicious/target/kroxylicious-*-SNAPSHOT.jar -cp {path-to-your-class-path} --config {path-to-kroxylicious-config}
+$ java -cp {path-to-your-class-path} -jar kroxylicious/target/kroxylicious-*-SNAPSHOT.jar --config {path-to-kroxylicious-config}
 ```
 
 To prevent the [following error](https://www.slf4j.org/codes.html#StaticLoggerBinder):

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ No one likes to argue about code formatting in pull requests, as project we take
 Build with the `dist` profile as shown above, then execute this:
 
 ```
-$ java -cp {path-to-your-class-path} -jar kroxylicious/target/kroxylicious-*-SNAPSHOT.jar --config {path-to-kroxylicious-config}
+$ java -jar kroxylicious/target/kroxylicious-*-SNAPSHOT.jar --config {path-to-kroxylicious-config}
 ```
 
 To prevent the [following error](https://www.slf4j.org/codes.html#StaticLoggerBinder):

--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ Build with the `dist` profile as shown above, then execute this:
 $ java -jar kroxylicious/target/kroxylicious-*-SNAPSHOT.jar --config {path-to-kroxylicious-config}
 ```
 
+Or, to run with your own class path, run this instead:
+
+```
+$ java -cp {path-to-your-class-path}:kroxylicious/target/kroxylicious-*-SNAPSHOT.jar io.kroxylicious.proxy.Kroxylicious --config {path-to-kroxylicious-config}
+```
+
 To prevent the [following error](https://www.slf4j.org/codes.html#StaticLoggerBinder):
 
 ```


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Switching order of `-jar` and `-cp` arguments in the run command in the README.

### Additional Context

Specifying `-cp` after `-jar` in the run command causes it to be interpreted as an argument for Kroxylicious rather than for Java, which causes the command to fail. The [Java command docs](https://docs.oracle.com/en/java/javase/20/docs/specs/man/java.html#synopsis) instruct that all Java options should be placed *before* the `-jar` argument. Switching the order of these arguments fixes the issue.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
