### PR TITLE
Fix netty buffer leak on short-circuit response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.3.0
 
+* [#401](https://github.com/kroxylicious/kroxylicious/pull/401): Fix netty buffer leak when doing a short-circuit response
 * [#409](https://github.com/kroxylicious/kroxylicious/pull/409): Bump netty.version from 4.1.93.Final to 4.1.94.Final #409 
 * [#374](https://github.com/kroxylicious/kroxylicious/issues/374) Upstream TLS support
 * [#375](https://github.com/kroxylicious/kroxylicious/issues/375) Support key material in PEM format (X.509 certificates and PKCS-8 private keys) 

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -92,6 +92,7 @@
                         <TESTCONTAINERS_RYUK_DISABLED>true</TESTCONTAINERS_RYUK_DISABLED>
                     </environmentVariables>
                     <systemPropertyVariables>
+                        <io.netty.leakDetection.level>paranoid</io.netty.leakDetection.level>
                         <container.logs.dir>${project.build.directory}/container-logs/</container.logs.dir>
                     </systemPropertyVariables>
                     <runOrder>random</runOrder>

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
@@ -176,9 +176,6 @@ public class KrpcFilterIT {
 
             // check no topic created on the cluster
             Set<String> names = admin.listTopics().names().get(10, TimeUnit.SECONDS);
-            // remove once https://github.com/kroxylicious/kroxylicious-junit5-extension/issues/114 is fixed.
-            names = new HashSet<>(names);
-            names.removeIf(n -> n.startsWith("__org_kroxylicious_testing"));
             assertThat(names).isEmpty();
         }
     }

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/NettyLeakLogAppender.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/NettyLeakLogAppender.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginElement;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.junit.jupiter.api.Assertions;
+
+import io.netty.util.ResourceLeakDetector;
+
+@Plugin(name = "NettyLeakLogAppender", category = "Core", elementType = "appender", printObject = true)
+public class NettyLeakLogAppender extends AbstractAppender {
+    private List<String> leaks = new ArrayList<>();
+
+    public void verifyNoLeaks() {
+        if (!leaks.isEmpty()) {
+            Assertions.fail("Netty resource leak detected " + leaks);
+        }
+    }
+
+    protected NettyLeakLogAppender(String name, Filter filter, Layout<? extends Serializable> layout) {
+        super(name, filter, layout, true, Property.EMPTY_ARRAY);
+    }
+
+    @Override
+    public void append(LogEvent event) {
+        if (event.getLoggerName().equals(ResourceLeakDetector.class.getName()) && event.getLevel().equals(Level.ERROR) && event.getMessage().getFormattedMessage()
+                .contains("LEAK:")) {
+            leaks.add(event.getMessage().getFormattedMessage());
+        }
+    }
+
+    @PluginFactory
+    public static NettyLeakLogAppender createAppender(
+                                                      @PluginAttribute("name") String name,
+                                                      @PluginElement("Layout") Layout<? extends Serializable> layout,
+                                                      @PluginElement("Filter") final Filter filter,
+                                                      @PluginAttribute("otherAttribute") String otherAttribute) {
+        if (name == null) {
+            LOGGER.error("No name provided for TestAppender");
+            return null;
+        }
+        if (layout == null) {
+            layout = PatternLayout.createDefaultLayout();
+        }
+        return new NettyLeakLogAppender(name, filter, layout);
+    }
+
+    public void clear() {
+        leaks.clear();
+    }
+}

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/CreateTopicRejectFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/CreateTopicRejectFilter.java
@@ -19,6 +19,7 @@ public class CreateTopicRejectFilter implements CreateTopicsRequestFilter {
     public void onCreateTopicsRequest(short apiVersion, RequestHeaderData header, CreateTopicsRequestData request, KrpcFilterContext context) {
         CreateTopicsResponseData response = new CreateTopicsResponseData();
         CreateTopicsResponseData.CreatableTopicResultCollection topics = new CreateTopicsResponseData.CreatableTopicResultCollection();
+        allocateByteBufToTestKroxyliciousReleasesIt(context);
         request.topics().forEach(creatableTopic -> {
             CreateTopicsResponseData.CreatableTopicResult result = new CreateTopicsResponseData.CreatableTopicResult();
             result.setErrorCode(Errors.INVALID_TOPIC_EXCEPTION.code()).setErrorMessage(ERROR_MESSAGE);
@@ -27,5 +28,9 @@ public class CreateTopicRejectFilter implements CreateTopicsRequestFilter {
         });
         response.setTopics(topics);
         context.forwardResponse(response);
+    }
+
+    private static void allocateByteBufToTestKroxyliciousReleasesIt(KrpcFilterContext context) {
+        context.createByteBufferOutputStream(4000);
     }
 }

--- a/integrationtests/src/test/resources/log4j2-test.properties
+++ b/integrationtests/src/test/resources/log4j2-test.properties
@@ -11,10 +11,22 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c:%L - %m%n
 
+appender.NettyLeakLogAppender.type = NettyLeakLogAppender
+appender.NettyLeakLogAppender.name = NettyLeakLogAppender
+appender.NettyLeakLogAppender.layout.type = PatternLayout
+appender.NettyLeakLogAppender.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c:%L - %m%n
+
+logger.NettyResourceLeak.name = io.netty.util.ResourceLeakDetector
+logger.NettyResourceLeak.level = ERROR
+logger.NettyResourceLeak.additivity = true
+logger.NettyResourceLeak.appenderRefs = NettyLeakLogAppender
+logger.NettyResourceLeak.appenderRef.NettyLeakLogAppender.ref = NettyLeakLogAppender
+
 rootLogger.level = WARN
 rootLogger.appenderRefs = console
 rootLogger.appenderRef.console.ref = STDOUT
 rootLogger.additivity = false
+
 
 #logger.kproxy.name = io.kroxylicious.proxy
 #logger.kproxy.level = INFO
@@ -38,7 +50,6 @@ logger.broker.appenderRef.console.ref = STDOUT
 
 logger.net.name = org.apache.kafka.clients.NetworkClient
 logger.net.level = debug
-
 
 #
 #logger.scl.name = state.change.logger

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/DecodedFrame.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/DecodedFrame.java
@@ -135,4 +135,9 @@ public abstract class DecodedFrame<H extends ApiMessage, B extends ApiMessage>
     protected void deallocate() {
         buffers.forEach(ByteBuf::release);
     }
+
+    public void transferBuffersTo(DecodedFrame<?, ?> frame) {
+        frame.buffers.addAll(this.buffers);
+        this.buffers.clear();
+    }
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/DefaultFilterContext.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/DefaultFilterContext.java
@@ -223,6 +223,7 @@ class DefaultFilterContext implements KrpcFilterContext {
                     "Attempt to respond with ApiMessage of type " + ApiKeys.forId(response.apiKey()) + " but request is of type " + decodedFrame.apiKey());
         }
         DecodedResponseFrame<?> responseFrame = new DecodedResponseFrame<>(decodedFrame.apiVersion(), decodedFrame.correlationId(), header, response);
+        decodedFrame.transferBuffersTo(responseFrame);
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("{}: Forwarding response: {}", channelDescriptor(), decodedFrame);
         }


### PR DESCRIPTION


### Type of change
- Bugfix

### Description

Netty ByteBuf uses explicit reference counting to control when they are released back to a pool. The buffer has to be released by someone before it is garbage collected or we have a leak.

A leak was introduced when we added the ability to `forwardResponse` while handling a Request. If the filter allocates a buffer using KrpcFilterContext#createByteBufferOutputStream, then the buffer is added to the DecodedFrame associated with the context. Then it is assumed that this frame will be read or written to the netty channel, so that netty can call release on it, which releases the buffers on the frame. In the short-circuit response case we create a new frame and the buffers on the old frame are left to be garbage collected.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [x] Reference relevant issue(s) and close them after merging
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
