### PR TITLE
Ensure the formatter runs on both production and test sources.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -529,7 +529,7 @@
                         <artifactId>formatter-maven-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>format</id>
+                                <id>format-sources</id>
                                 <goals>
                                     <goal>format</goal>
                                 </goals>
@@ -537,6 +537,18 @@
                                 <configuration>
                                     <directories>
                                         <directory>${project.build.sourceDirectory}</directory>
+                                    </directories>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>format-test-sources</id>
+                                <goals>
+                                    <goal>format</goal>
+                                </goals>
+                                <phase>process-test-sources</phase>
+                                <configuration>
+                                    <directories>
+                                        <directory>${project.build.testSourceDirectory}</directory>
                                     </directories>
                                 </configuration>
                             </execution>
@@ -626,14 +638,35 @@
                         <artifactId>formatter-maven-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>validate-formatting</id>
+                                <id>validate-sources</id>
                                 <goals>
                                     <goal>validate</goal>
                                 </goals>
                                 <phase>process-sources</phase>
+                                <configuration>
+                                    <directories>
+                                        <directory>${project.build.sourceDirectory}</directory>
+                                    </directories>
+                                </configuration>
                             </execution>
                             <execution>
-                                <id>format</id>
+                                <id>validate-test-sources</id>
+                                <goals>
+                                    <goal>validate</goal>
+                                </goals>
+                                <phase>process-test-sources</phase>
+                                <configuration>
+                                    <directories>
+                                        <directory>${project.build.testSourceDirectory}</directory>
+                                    </directories>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>format-sources</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>format-test-sources</id>
                                 <phase>none</phase>
                             </execution>
                         </executions>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix


### Description

Change the formatter maven plugin to format the production and test sources in the appropriate phase.

### Additional Context

Previously the CI profile was validating all sources but the formatter was only being applied to production sources. It seems strange to format/validate test sources in the process-sources phase so this change binds the formatter to the appropriate phase.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [x] Update documentation
- [x] Reference relevant issue(s) and close them after merging
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
