### PR TITLE
Build a snapshot docker image on main push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,8 @@ name: Docker Build
 on:
   workflow_dispatch:
   push:
+    branches:
+      - 'main'
     tags:
       - 'v*.*.*'
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Builds and pushes a new tag of the kroxylicious docker image on push to main. The tag will be the project version from the root pom.

### Additional Context

So we have an up to date main image that we could deploy in the kubernetes examples without building/pushing to our personal quay account.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
