### PR TITLE
Enable batch mode in Dockerised maven build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-17:1.15 AS builder
 USER root
 WORKDIR /opt/kroxylicious
 COPY . .
-RUN ./mvnw clean verify -Pdist -Dquick -pl :kroxylicious -am
+RUN ./mvnw -B clean verify -Pdist -Dquick -pl :kroxylicious -am
 USER 185
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
 


### PR DESCRIPTION
Why: to stop the progress transfer noise.

### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Enable batch mode in Dockerised maven build in order to stop the verbose progress transfer during the build.


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
