### PR TITLE
Kroxylicious only BOM

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
+    <excludeFromCompile>
+      <directory url="file://$PROJECT_DIR$/api/kroxylicious-filter-api-bom/src/main/resources/archetype-resources" includeSubdirectories="true" />
+    </excludeFromCompile>
     <annotationProcessing>
       <profile default="true" name="Default" enabled="true" />
       <profile name="Maven default annotation processors profile" enabled="true">
@@ -15,12 +18,13 @@
         <module name="kroxylicious-unit-test" />
         <module name="kroxylicious" />
         <module name="integrationtests" />
+        <module name="kroxylicious-sample" />
         <module name="integrationtests.test" />
         <module name="kroxylicious-krpc-plugin.main" />
         <module name="kroxylicious-schema-validation" />
         <module name="kroxylicious.test" />
-        <module name="kroxylicious-filter-api" />
         <module name="kroxylicious-krpc-plugin" />
+        <module name="kroxylicious-filter-api" />
         <module name="performance-tests" />
         <module name="kroxylicious-krpc-plugin.test" />
       </profile>
@@ -40,6 +44,7 @@
       <module name="kroxylicious-krpc-plugin.test" options="-parameters" />
       <module name="kroxylicious-multitenant" options="-parameters" />
       <module name="kroxylicious-parent" options="-parameters" />
+      <module name="kroxylicious-sample" options="-parameters" />
       <module name="kroxylicious-schema-validation" options="-parameters" />
       <module name="kroxylicious-test-tools" options="-parameters" />
       <module name="kroxylicious-unit-test" options="-parameters" />

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -3,6 +3,8 @@
   <component name="Encoding">
     <file url="file://$PROJECT_DIR$/api/kroxylicious-api/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/api/kroxylicious-api/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/api/kroxylicious-filter-api-bom/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/api/kroxylicious-filter-api-bom/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/api/kroxylicious-filter-api/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/api/kroxylicious-filter-api/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/api/kroxylicious-filter-api/target/generated-sources/krpc" charset="UTF-8" />
@@ -14,6 +16,8 @@
     <file url="file://$PROJECT_DIR$/kroxylicious-additional-filters/kroxylicious-schema-validation/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious-additional-filters/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious-additional-filters/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/kroxylicious-sample/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/kroxylicious-sample/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious-test-tools/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious-test-tools/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious-test-tools/target/generated-sources/krpc" charset="UTF-8" />
@@ -30,5 +34,6 @@
     <file url="file://$PROJECT_DIR$/performance-tests/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/main/templates" charset="UTF-8" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,6 +5,8 @@
     <option name="originalFiles">
       <list>
         <option value="$PROJECT_DIR$/pom.xml" />
+        <option value="$PROJECT_DIR$/kroxylicious-filter-api-bom/pom.xml" />
+        <option value="$PROJECT_DIR$/api/kroxylicious-filter-api-bom/pom.xml" />
       </list>
     </option>
   </component>

--- a/api/kroxylicious-filter-api-bom/.gitignore
+++ b/api/kroxylicious-filter-api-bom/.gitignore
@@ -1,0 +1,38 @@
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/api/kroxylicious-filter-api-bom/pom.xml
+++ b/api/kroxylicious-filter-api-bom/pom.xml
@@ -8,11 +8,6 @@
     <name>Kroxylicious Filter API BOM</name>
 
     <packaging>pom</packaging>
-    <properties>
-        <kafka.version>3.5.0</kafka.version>
-        <micrometer.version>1.11.1</micrometer.version>
-        <slf4j.version>2.0.7</slf4j.version>
-    </properties>
 
     <dependencyManagement>
         <dependencies>
@@ -25,29 +20,6 @@
                 <groupId>io.kroxylicious</groupId>
                 <artifactId>kroxylicious-filter-api</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-
-            <!-- third party dependencies - runtime and compile -->
-            <dependency>
-                <groupId>org.apache.kafka</groupId>
-                <artifactId>kafka-clients</artifactId>
-                <version>${kafka.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-
-            <!-- third party dependency boms - import scope-->
-            <!-- We do this as the filter API depends on specific third party modules (usually just their API jars -->
-            <!-- however to avoid that leading to version conflicts we import the entire bom to provide a standard version-->
-            <dependency>
-                <groupId>io.micrometer</groupId>
-                <artifactId>micrometer-bom</artifactId>
-                <version>${micrometer.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/api/kroxylicious-filter-api-bom/pom.xml
+++ b/api/kroxylicious-filter-api-bom/pom.xml
@@ -1,26 +1,54 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>io.kroxylicious</groupId>
-  <artifactId>kroxylicious-filter-api-bom</artifactId>
-  <version>0.3.0-SNAPSHOT</version>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.kroxylicious</groupId>
+    <artifactId>kroxylicious-filter-api-bom</artifactId>
+    <version>0.3.0-SNAPSHOT</version>
 
-  <name>Kroxylicious Filter API BOM</name>
+    <name>Kroxylicious Filter API BOM</name>
 
-  <packaging>pom</packaging>
+    <packaging>pom</packaging>
+    <properties>
+        <kafka.version>3.5.0</kafka.version>
+        <micrometer.version>1.11.1</micrometer.version>
+        <slf4j.version>2.0.7</slf4j.version>
+    </properties>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>io.kroxylicious</groupId>
-        <artifactId>kroxylicious-api</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <groupId>io.kroxylicious</groupId>
-        <artifactId>kroxylicious-filter-api</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.kroxylicious</groupId>
+                <artifactId>kroxylicious-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.kroxylicious</groupId>
+                <artifactId>kroxylicious-filter-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!-- third party dependencies - runtime and compile -->
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <version>${kafka.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+
+            <!-- third party dependency boms - import scope-->
+            <!-- We do this as the filter API depends on specific third party modules (usually just their API jars -->
+            <!-- however to avoid that leading to version conflicts we import the entire bom to provide a standard version-->
+            <dependency>
+                <groupId>io.micrometer</groupId>
+                <artifactId>micrometer-bom</artifactId>
+                <version>${micrometer.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/api/kroxylicious-filter-api-bom/pom.xml
+++ b/api/kroxylicious-filter-api-bom/pom.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.kroxylicious</groupId>
+  <artifactId>kroxylicious-filter-api-bom</artifactId>
+  <version>0.3.0-SNAPSHOT</version>
+
+  <name>Kroxylicious Filter API BOM</name>
+
+  <packaging>pom</packaging>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.kroxylicious</groupId>
+        <artifactId>kroxylicious-api</artifactId>
+        <version>0.3.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>io.kroxylicious</groupId>
+        <artifactId>kroxylicious-filter-api</artifactId>
+        <version>0.3.0-SNAPSHOT</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/api/kroxylicious-filter-api/pom.xml
+++ b/api/kroxylicious-filter-api/pom.xml
@@ -44,6 +44,7 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -52,6 +53,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- third party dependencies - test -->

--- a/api/kroxylicious-filter-api/pom.xml
+++ b/api/kroxylicious-filter-api/pom.xml
@@ -34,13 +34,10 @@
         <dependency>
             <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-api</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- third party dependencies - runtime and compile -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-        </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>

--- a/kroxylicious-additional-filters/kroxylicious-multitenant/pom.xml
+++ b/kroxylicious-additional-filters/kroxylicious-multitenant/pom.xml
@@ -30,10 +30,17 @@
         <dependency>
             <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-filter-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- project dependencies - test -->

--- a/kroxylicious-additional-filters/kroxylicious-schema-validation/pom.xml
+++ b/kroxylicious-additional-filters/kroxylicious-schema-validation/pom.xml
@@ -30,16 +30,28 @@
         <dependency>
             <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-filter-api</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- third party dependencies - runtime and compile -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- third party dependencies - test -->

--- a/kroxylicious-bom/pom.xml
+++ b/kroxylicious-bom/pom.xml
@@ -17,6 +17,7 @@
     <properties>
         <kroxyliciousApi.version>0.3.0-SNAPSHOT</kroxyliciousApi.version>
         <kroxy.extension.version>0.4.0</kroxy.extension.version>
+        <jackson.version>2.15.2</jackson.version>
     </properties>
 
     <dependencyManagement>
@@ -74,6 +75,15 @@
                 <artifactId>testing-api</artifactId>
                 <version>${kroxy.extension.version}</version>
                 <scope>test</scope>
+            </dependency>
+
+            <!-- Third party -->
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/kroxylicious-bom/pom.xml
+++ b/kroxylicious-bom/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Kroxylicious Authors.
+  ~
+  ~ Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.kroxylicious</groupId>
+    <artifactId>kroxylicious-bom</artifactId>
+    <version>0.3.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <properties>
+        <kroxyliciousApi.version>0.3.0-SNAPSHOT</kroxyliciousApi.version>
+        <kroxy.extension.version>0.4.0</kroxy.extension.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Kroxylicious depends on its own filter API :D -->
+            <dependency>
+                <groupId>io.kroxylicious</groupId>
+                <artifactId>kroxylicious-filter-api-bom</artifactId>
+                <version>${kroxyliciousApi.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>io.kroxylicious</groupId>
+                <artifactId>kroxylicious</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.kroxylicious</groupId>
+                <artifactId>kroxylicious-multitenant</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.kroxylicious</groupId>
+                <artifactId>kroxylicious-schema-validation</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!-- project dependencies - test -->
+            <dependency>
+                <groupId>io.kroxylicious</groupId>
+                <artifactId>kroxylicious-test-tools</artifactId>
+                <version>${project.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>io.kroxylicious</groupId>
+                <artifactId>kroxylicious-unit-test</artifactId>
+                <version>${project.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>io.kroxylicious.testing</groupId>
+                <artifactId>testing-junit5-extension</artifactId>
+                <version>${kroxy.extension.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.kroxylicious.testing</groupId>
+                <artifactId>testing-api</artifactId>
+                <version>${kroxy.extension.version}</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/kroxylicious-bom/pom.xml
+++ b/kroxylicious-bom/pom.xml
@@ -14,10 +14,10 @@
     <artifactId>kroxylicious-bom</artifactId>
     <version>0.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
+
     <properties>
         <kroxyliciousApi.version>0.3.0-SNAPSHOT</kroxyliciousApi.version>
         <kroxy.extension.version>0.4.0</kroxy.extension.version>
-        <jackson.version>2.15.2</jackson.version>
     </properties>
 
     <dependencyManagement>
@@ -54,36 +54,24 @@
                 <groupId>io.kroxylicious</groupId>
                 <artifactId>kroxylicious-test-tools</artifactId>
                 <version>${project.version}</version>
-                <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>io.kroxylicious</groupId>
                 <artifactId>kroxylicious-unit-test</artifactId>
                 <version>${project.version}</version>
-                <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>io.kroxylicious.testing</groupId>
                 <artifactId>testing-junit5-extension</artifactId>
                 <version>${kroxy.extension.version}</version>
-                <scope>test</scope>
             </dependency>
+
             <dependency>
                 <groupId>io.kroxylicious.testing</groupId>
                 <artifactId>testing-api</artifactId>
                 <version>${kroxy.extension.version}</version>
-                <scope>test</scope>
-            </dependency>
-
-            <!-- Third party -->
-            <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>${jackson.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/kroxylicious-sample/pom.xml
+++ b/kroxylicious-sample/pom.xml
@@ -36,6 +36,17 @@
             <artifactId>kroxylicious-filter-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
 
         <!-- project dependencies - test -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
     <packaging>pom</packaging>
 
     <properties>
-        <kroxyliciousApi.version>0.3.0-SNAPSHOT</kroxyliciousApi.version>
         <java.version>17</java.version>
         <java.test.version>17</java.test.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
@@ -35,7 +34,6 @@
         <jackson.version>2.15.2</jackson.version>
         <junit.version>5.9.3</junit.version>
         <kafka.version>3.5.0</kafka.version>
-        <kroxy.extension.version>0.4.0</kroxy.extension.version>
         <log4j.version>2.20.0</log4j.version>
         <picocli.version>4.7.4</picocli.version>
         <netty.version>4.1.94.Final</netty.version>
@@ -111,52 +109,10 @@
             <!-- project dependencies - runtime and compile -->
             <dependency>
                 <groupId>io.kroxylicious</groupId>
-                <artifactId>kroxylicious-filter-api-bom</artifactId>
-                <version>${kroxyliciousApi.version}</version>
+                <artifactId>kroxylicious-bom</artifactId>
+                <version>0.3.0-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.kroxylicious</groupId>
-                <artifactId>kroxylicious</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.kroxylicious</groupId>
-                <artifactId>kroxylicious-multitenant</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.kroxylicious</groupId>
-                <artifactId>kroxylicious-schema-validation</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <!-- project dependencies - test -->
-            <dependency>
-                <groupId>io.kroxylicious</groupId>
-                <artifactId>kroxylicious-test-tools</artifactId>
-                <version>${project.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.kroxylicious</groupId>
-                <artifactId>kroxylicious-unit-test</artifactId>
-                <version>${project.version}</version>
-                <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>io.kroxylicious.testing</groupId>
-                <artifactId>testing-junit5-extension</artifactId>
-                <version>${kroxy.extension.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.kroxylicious.testing</groupId>
-                <artifactId>testing-api</artifactId>
-                <version>${kroxy.extension.version}</version>
-                <scope>test</scope>
             </dependency>
 
             <!-- third party dependencies - runtime and compile -->
@@ -275,6 +231,7 @@
         <module>krpc-code-gen</module>
         <module>kroxylicious-test-tools</module>
         <module>kroxylicious-unit-test</module>
+        <module>kroxylicious-bom</module>
         <module>kroxylicious</module>
         <module>integrationtests</module>
         <module>kroxylicious-additional-filters</module>

--- a/pom.xml
+++ b/pom.xml
@@ -111,18 +111,15 @@
             <!-- project dependencies - runtime and compile -->
             <dependency>
                 <groupId>io.kroxylicious</groupId>
+                <artifactId>kroxylicious-filter-api-bom</artifactId>
+                <version>${kroxyliciousApi.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.kroxylicious</groupId>
                 <artifactId>kroxylicious</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.kroxylicious</groupId>
-                <artifactId>kroxylicious-api</artifactId>
-                <version>${kroxyliciousApi.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.kroxylicious</groupId>
-                <artifactId>kroxylicious-filter-api</artifactId>
-                <version>${kroxyliciousApi.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.kroxylicious</groupId>
@@ -272,6 +269,7 @@
     </dependencyManagement>
 
     <modules>
+        <module>api/kroxylicious-filter-api-bom</module>
         <module>api/kroxylicious-api</module>
         <module>api/kroxylicious-filter-api</module>
         <module>krpc-code-gen</module>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,9 @@
         <skipITs>${skipTests}</skipITs>
         <skipUTs>${skipTests}</skipUTs>
 
+        <kafka.version>3.5.0</kafka.version>
+        <micrometer.version>1.11.1</micrometer.version>
+        <slf4j.version>2.0.7</slf4j.version>
         <freemarker.version>2.3.32</freemarker.version>
         <guava.version>32.0.1-jre</guava.version>
         <jackson.version>2.15.2</jackson.version>
@@ -123,6 +126,7 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>annotations</artifactId>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_


- Enhancement / new feature

### Description

Fix for https://github.com/kroxylicious/kroxylicious/issues/400 by introducing two separate Bill Of Material's POM's one for the filter API and one for Kroxylicious itself.

### Additional Context

This is a simplified version of #425. Having surveyed some large maven projects including third party dependencies in the bom is not common practice so I've backed away from that part of #425 and instead focused on defining versions for Kroxylicious components.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [x] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
