### PR TITLE
Use command rather than which

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
+    <excludeFromCompile>
+      <directory url="file://$PROJECT_DIR$/api/kroxylicious-filter-api-bom/src/main/resources/archetype-resources" includeSubdirectories="true" />
+    </excludeFromCompile>
     <annotationProcessing>
       <profile default="true" name="Default" enabled="true" />
       <profile name="Maven default annotation processors profile" enabled="true">
@@ -15,6 +18,7 @@
         <module name="kroxylicious-unit-test" />
         <module name="kroxylicious" />
         <module name="integrationtests" />
+        <module name="kroxylicious-sample" />
         <module name="integrationtests.test" />
         <module name="kroxylicious-krpc-plugin.main" />
         <module name="kroxylicious-schema-validation" />
@@ -25,6 +29,10 @@
         <module name="kroxylicious-krpc-plugin.test" />
       </profile>
     </annotationProcessing>
+    <bytecodeTargetLevel>
+      <module name="kroxylicious-bom" target="1.5" />
+      <module name="kroxylicious-filter-api-bom" target="1.5" />
+    </bytecodeTargetLevel>
   </component>
   <component name="JavacSettings">
     <option name="ADDITIONAL_OPTIONS_OVERRIDE">
@@ -40,6 +48,7 @@
       <module name="kroxylicious-krpc-plugin.test" options="-parameters" />
       <module name="kroxylicious-multitenant" options="-parameters" />
       <module name="kroxylicious-parent" options="-parameters" />
+      <module name="kroxylicious-sample" options="-parameters" />
       <module name="kroxylicious-schema-validation" options="-parameters" />
       <module name="kroxylicious-test-tools" options="-parameters" />
       <module name="kroxylicious-unit-test" options="-parameters" />

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -14,6 +14,8 @@
     <file url="file://$PROJECT_DIR$/kroxylicious-additional-filters/kroxylicious-schema-validation/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious-additional-filters/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious-additional-filters/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/kroxylicious-sample/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/kroxylicious-sample/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious-test-tools/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious-test-tools/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious-test-tools/target/generated-sources/krpc" charset="UTF-8" />

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -9,21 +9,21 @@ OS=$(uname)
 
 if [[ -z $CONTAINER_ENGINE ]]; then
   echo "Setting CONTAINER_ENGINE to default: docker"
-  CONTAINER_ENGINE=$(which docker)
+  CONTAINER_ENGINE=$(command -v docker)
   export CONTAINER_ENGINE
 fi
-KUBECTL=$(which kubectl)
+KUBECTL=$(command -v kubectl)
 export KUBECTL
-MINIKUBE=$(which minikube)
+MINIKUBE=$(command -v minikube)
 export MINIKUBE
-KUSTOMIZE=$(which kustomize)
+KUSTOMIZE=$(command -v kustomize)
 export KUSTOMIZE
 
 if [ "$OS" = 'Darwin' ]; then
   # for MacOS
-  SED=$(which gsed)
+  SED=$(command -v gsed)
 else
   # for Linux and Windows
-  SED=$(which sed)
+  SED=$(command -v sed)
 fi
 export SED

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright Kroxylicious Authors.
 #
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
-
+set -eu
 OS=$(uname)
 
 resolveCommand () {
@@ -12,7 +12,7 @@ resolveCommand () {
   local resolvedCommand
   resolvedCommand=$(command -v "${targetCommand}")
   if [[ -z ${resolvedCommand} ]]; then
-    >&2 echo -e "\033[0;31m Unable to resolve path to ${targetCommand}\n\033[0m"
+    >&2 echo -e "\033[0;31m Unable to resolve path to ${targetCommand}\033[0m"
     exit 127
   else
     echo "${resolvedCommand}"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -7,23 +7,36 @@
 
 OS=$(uname)
 
+resolveCommand () {
+  local targetCommand=${1}
+  local resolvedCommand
+  resolvedCommand=$(command -v ${targetCommand})
+  if [[ -z ${resolvedCommand} ]]; then
+    >&2 echo -e "\033[0;31m Unable to resolve path to ${targetCommand}\n\033[0m"
+    exit 127
+  else
+    echo "${resolvedCommand}"
+  fi
+}
+
 if [[ -z $CONTAINER_ENGINE ]]; then
   echo "Setting CONTAINER_ENGINE to default: docker"
-  CONTAINER_ENGINE=$(command -v docker)
+  CONTAINER_ENGINE=$(resolvedCommand docker)
   export CONTAINER_ENGINE
 fi
-KUBECTL=$(command -v kubectl)
+
+KUBECTL=$(resolveCommand kubectl)
 export KUBECTL
-MINIKUBE=$(command -v minikube)
+MINIKUBE=$(resolveCommand minikube)
 export MINIKUBE
-KUSTOMIZE=$(command -v kustomize)
+KUSTOMIZE=$(resolveCommand kustomize)
 export KUSTOMIZE
 
 if [ "$OS" = 'Darwin' ]; then
   # for MacOS
-  SED=$(command -v gsed)
+  SED=$(resolveCommand gsed)
 else
   # for Linux and Windows
-  SED=$(command -v sed)
+  SED=$(resolveCommand sed)
 fi
 export SED

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -4,7 +4,9 @@
 #
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
-set -eu
+
+set -Eu
+
 OS=$(uname)
 
 resolveCommand () {

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -10,7 +10,7 @@ OS=$(uname)
 resolveCommand () {
   local targetCommand=${1}
   local resolvedCommand
-  resolvedCommand=$(command -v ${targetCommand})
+  resolvedCommand=$(command -v "${targetCommand}")
   if [[ -z ${resolvedCommand} ]]; then
     >&2 echo -e "\033[0;31m Unable to resolve path to ${targetCommand}\n\033[0m"
     exit 127

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -21,7 +21,7 @@ resolveCommand () {
 
 if [[ -z $CONTAINER_ENGINE ]]; then
   echo "Setting CONTAINER_ENGINE to default: docker"
-  CONTAINER_ENGINE=$(resolvedCommand docker)
+  CONTAINER_ENGINE=$(resolveCommand docker)
   export CONTAINER_ENGINE
 fi
 

--- a/scripts/run-with-strimzi.sh
+++ b/scripts/run-with-strimzi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright Kroxylicious Authors.
 #


### PR DESCRIPTION
### Type of change


- Bugfix
- Enhancement / new feature

### Description

Extend @k-wall's change to use `command -v` so that it handles the failure to resolve the command.

### Additional Context

When testing https://github.com/kroxylicious/kroxylicious/pull/436 I discovered things silently fail if one of the commands is missing. So this change pulls out a function to test for the command and exit with an error if its missing.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
