### PR TITLE
Obtain upstream ApiVersions when proxy is not SASL offloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.3.0
 
+* [#443](https://github.com/kroxylicious/kroxylicious/pull/443): Obtain upstream ApiVersions when proxy is not SASL offloading
 * [#412](https://github.com/kroxylicious/kroxylicious/issues/412): Remove $(portNumber) pattern from brokerAddressPattern for SniRouting and PortPerBroker schemes
 * [#414](https://github.com/kroxylicious/kroxylicious/pull/414): Add kubernetes sample illustrating SNI based routing, downstream/upstream TLS and the use of certificates from cert-manager.
 * [#392](https://github.com/kroxylicious/kroxylicious/pull/392): Introduce CompositeFilters
@@ -31,3 +32,5 @@ In the kroxylicious config, the brokerAddressPattern parameter for the PortPerBr
 :$(portNumber) suffix.  In addition, for the SniRouting scheme the config now enforces that there is no port specifier
 present on the brokerAddressPattern parameter. Previously, it was accepted but would lead to a failure later.
 
+Kroxylicious configuration no longer requires a non empty `filters` list, users can leave it unset or configure in an empty
+list of filters and Kroxylicious will proxy to the cluster successfully.

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/ApiVersionsIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/ApiVersionsIT.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy;
+
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.test.Request;
+import io.kroxylicious.test.Response;
+import io.kroxylicious.test.client.KafkaClient;
+import io.kroxylicious.test.tester.KroxyliciousConfigUtils;
+import io.kroxylicious.test.tester.MockServerKroxyliciousTester;
+
+import static io.kroxylicious.test.tester.KroxyliciousTesters.mockKafkaKroxyliciousTester;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * For the kafka RPCs that Kroxylicious can intercept, Kroxylicious should only offer API versions
+ * that it can encode/decode using it's version of the kafka-clients lib. It should also only offer API versions
+ * that the Cluster can understand. So we use a Filter to intercept the ApiVersions response from the
+ * Cluster and intersect those versions with the versions supported by the proxy. We offer the highest
+ * minimum version for each api key supported by the Cluster and proxy. We offer the lowest maximum version
+ * for each api key supported by the Cluster and proxy.
+ * Any versions for ApiKeys unknown to the proxy are forwarded to the client untouched. (ie the broker supports
+ * a new ApiKey that this version of Kroxylicious is unaware of)
+ * TODO check if this is still sensible behaviour, potentially a RequestFilter would attempt to decode these and fail.
+ */
+public class ApiVersionsIT {
+
+    @Test
+    public void shouldOfferTheMinimumHighestSupportedVersionWhenBrokerIsAheadOfKroxylicious() {
+        try (var tester = mockKafkaKroxyliciousTester(KroxyliciousConfigUtils::proxy);
+                var client = tester.singleRequestClient()) {
+            givenMockRespondsWithApiVersionsForApiKey(tester, ApiKeys.METADATA, ApiKeys.METADATA.oldestVersion(), (short) (ApiKeys.METADATA.latestVersion() + 1));
+            Response response = whenGetApiVersionsFromKroxylicious(client);
+            assertKroxyliciousResponseOffersApiVersionsForApiKey(response, ApiKeys.METADATA, ApiKeys.METADATA.oldestVersion(), ApiKeys.METADATA.latestVersion());
+        }
+    }
+
+    @Test
+    public void shouldOfferTheMinimumHighestSupportedVersionWhenKroxyliciousIsAheadOfBroker() {
+        try (var tester = mockKafkaKroxyliciousTester(KroxyliciousConfigUtils::proxy);
+                var client = tester.singleRequestClient()) {
+            givenMockRespondsWithApiVersionsForApiKey(tester, ApiKeys.METADATA, ApiKeys.METADATA.oldestVersion(), (short) (ApiKeys.METADATA.latestVersion() - 1));
+            Response response = whenGetApiVersionsFromKroxylicious(client);
+            assertKroxyliciousResponseOffersApiVersionsForApiKey(response, ApiKeys.METADATA, ApiKeys.METADATA.oldestVersion(),
+                    (short) (ApiKeys.METADATA.latestVersion() - 1));
+        }
+    }
+
+    @Test
+    public void shouldOfferTheMaximumLowestSupportedVersionWhenBrokerIsAheadOfKroxylicious() {
+        try (var tester = mockKafkaKroxyliciousTester(KroxyliciousConfigUtils::proxy);
+                var client = tester.singleRequestClient()) {
+            short brokerOldestVersion = (short) (ApiKeys.METADATA.oldestVersion() + 1);
+            givenMockRespondsWithApiVersionsForApiKey(tester, ApiKeys.METADATA, brokerOldestVersion, ApiKeys.METADATA.latestVersion());
+            Response response = whenGetApiVersionsFromKroxylicious(client);
+            assertKroxyliciousResponseOffersApiVersionsForApiKey(response, ApiKeys.METADATA, brokerOldestVersion, ApiKeys.METADATA.latestVersion());
+        }
+    }
+
+    @Test
+    public void shouldOfferTheMaximumLowestSupportedVersionWhenKroxyliciousIsAheadOfBroker() {
+        try (var tester = mockKafkaKroxyliciousTester(KroxyliciousConfigUtils::proxy);
+                var client = tester.singleRequestClient()) {
+            short brokerOldestVersion = (short) (ApiKeys.METADATA.oldestVersion() - 1);
+            givenMockRespondsWithApiVersionsForApiKey(tester, ApiKeys.METADATA, brokerOldestVersion, ApiKeys.METADATA.latestVersion());
+            Response response = whenGetApiVersionsFromKroxylicious(client);
+            assertKroxyliciousResponseOffersApiVersionsForApiKey(response, ApiKeys.METADATA, ApiKeys.METADATA.oldestVersion(), ApiKeys.METADATA.latestVersion());
+        }
+    }
+
+    private static void givenMockRespondsWithApiVersionsForApiKey(MockServerKroxyliciousTester tester, ApiKeys keys, short minVersion, short maxVersion) {
+        ApiVersionsResponseData mockResponse = new ApiVersionsResponseData();
+        ApiVersionsResponseData.ApiVersion version = new ApiVersionsResponseData.ApiVersion();
+        version.setApiKey(keys.id).setMinVersion(minVersion).setMaxVersion(maxVersion);
+        mockResponse.apiKeys().add(version);
+        tester.setMockResponse(new Response(ApiKeys.API_VERSIONS, (short) 3, mockResponse));
+    }
+
+    private static Response whenGetApiVersionsFromKroxylicious(KafkaClient client) {
+        return client.getSync(new Request(ApiKeys.API_VERSIONS, (short) 3, "client", new ApiVersionsRequestData()));
+    }
+
+    private static void assertKroxyliciousResponseOffersApiVersionsForApiKey(Response response, ApiKeys apiKeys, short minVersion, short maxVersion) {
+        assertEquals(ApiKeys.API_VERSIONS, response.apiKeys());
+        assertEquals((short) 3, response.apiVersion());
+        ApiVersionsResponseData message = (ApiVersionsResponseData) response.message();
+        assertEquals(1, message.apiKeys().size());
+        ApiVersionsResponseData.ApiVersion singletonVersion = message.apiKeys().iterator().next();
+        assertEquals(apiKeys.id, singletonVersion.apiKey());
+        assertEquals(minVersion, singletonVersion.minVersion());
+        assertEquals(maxVersion, singletonVersion.maxVersion());
+    }
+
+}

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/ExpositionIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/ExpositionIT.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.io.TempDir;
 import io.kroxylicious.net.IntegrationTestInetAddressResolverProvider;
 import io.kroxylicious.proxy.config.ClusterNetworkAddressConfigProviderDefinitionBuilder;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
-import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.test.tester.KroxyliciousTester;
@@ -85,8 +84,7 @@ public class ExpositionIT {
                         .withClusterNetworkAddressConfigProvider(
                                 new ClusterNetworkAddressConfigProviderDefinitionBuilder("PortPerBroker").withConfig("bootstrapAddress", PROXY_ADDRESS)
                                         .build())
-                        .build())
-                .addToFilters(new FilterDefinitionBuilder("ApiVersions").build());
+                        .build());
 
         var demo = builder.getVirtualClusters().get("demo");
         demo = new VirtualClusterBuilder(demo)
@@ -118,8 +116,7 @@ public class ExpositionIT {
     public void exposesTwoClusterOverPlainWithSeparatePorts(KafkaCluster cluster) {
         List<String> clusterProxyAddresses = List.of("localhost:9192", "localhost:9294");
 
-        var builder = new ConfigurationBuilder()
-                .addToFilters(new FilterDefinitionBuilder("ApiVersions").build());
+        var builder = new ConfigurationBuilder();
 
         var base = new VirtualClusterBuilder()
                 .withNewTargetCluster()
@@ -155,8 +152,7 @@ public class ExpositionIT {
         var virtualClusterBootstrapPattern = "bootstrap" + virtualClusterCommonNamePattern;
         var virtualClusterBrokerAddressPattern = "broker-$(nodeId)" + virtualClusterCommonNamePattern;
 
-        var builder = new ConfigurationBuilder()
-                .addToFilters(new FilterDefinitionBuilder("ApiVersions").build());
+        var builder = new ConfigurationBuilder();
 
         var base = new VirtualClusterBuilder()
                 .withNewTargetCluster()
@@ -218,8 +214,7 @@ public class ExpositionIT {
                         .withClusterNetworkAddressConfigProvider(
                                 new ClusterNetworkAddressConfigProviderDefinitionBuilder("PortPerBroker").withConfig("bootstrapAddress", PROXY_ADDRESS)
                                         .build())
-                        .build())
-                .addToFilters(new FilterDefinitionBuilder("ApiVersions").build());
+                        .build());
 
         var brokerEndpoints = Map.of(0, "localhost:" + (PROXY_ADDRESS.port() + 1), 1, "localhost:" + (PROXY_ADDRESS.port() + 2));
 
@@ -246,8 +241,7 @@ public class ExpositionIT {
                         .withClusterNetworkAddressConfigProvider(
                                 new ClusterNetworkAddressConfigProviderDefinitionBuilder("PortPerBroker").withConfig("bootstrapAddress", PROXY_ADDRESS)
                                         .build())
-                        .build())
-                .addToFilters(new FilterDefinitionBuilder("ApiVersions").build());
+                        .build());
 
         try (var tester = kroxyliciousTester(builder)) {
 
@@ -279,8 +273,7 @@ public class ExpositionIT {
                         .withClusterNetworkAddressConfigProvider(
                                 new ClusterNetworkAddressConfigProviderDefinitionBuilder("PortPerBroker").withConfig("bootstrapAddress", PROXY_ADDRESS)
                                         .build())
-                        .build())
-                .addToFilters(new FilterDefinitionBuilder("ApiVersions").build());
+                        .build());
 
         try (var tester = kroxyliciousTester(builder)) {
 

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/KroxyStandaloneIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/KroxyStandaloneIT.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.io.TempDir;
 
 import io.kroxylicious.proxy.config.ConfigParser;
 import io.kroxylicious.proxy.config.Configuration;
-import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
@@ -53,8 +52,7 @@ public class KroxyStandaloneIT {
                 new NewTopic(TOPIC_1, 1, (short) 1),
                 new NewTopic(TOPIC_2, 1, (short) 1))).all().get();
 
-        ConfigurationBuilder builder = proxy(cluster);
-        try (var tester = kroxyliciousTester(builder, new SubprocessKroxyliciousFactory(tempDir));
+        try (var tester = kroxyliciousTester(proxy(cluster), new SubprocessKroxyliciousFactory(tempDir));
                 var producer = tester.producer(Map.of(
                         ProducerConfig.CLIENT_ID_CONFIG, "shouldModifyProduceMessage",
                         ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000));

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/KroxyStandaloneIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/KroxyStandaloneIT.java
@@ -26,12 +26,12 @@ import org.junit.jupiter.api.io.TempDir;
 
 import io.kroxylicious.proxy.config.ConfigParser;
 import io.kroxylicious.proxy.config.Configuration;
+import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
-import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.withDefaultFilters;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -53,7 +53,8 @@ public class KroxyStandaloneIT {
                 new NewTopic(TOPIC_1, 1, (short) 1),
                 new NewTopic(TOPIC_2, 1, (short) 1))).all().get();
 
-        try (var tester = kroxyliciousTester(withDefaultFilters(proxy(cluster)), new SubprocessKroxyliciousFactory(tempDir));
+        ConfigurationBuilder builder = proxy(cluster);
+        try (var tester = kroxyliciousTester(builder, new SubprocessKroxyliciousFactory(tempDir));
                 var producer = tester.producer(Map.of(
                         ProducerConfig.CLIENT_ID_CONFIG, "shouldModifyProduceMessage",
                         ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000));

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
 import io.kroxylicious.proxy.filter.CreateTopicRejectFilter;
 import io.kroxylicious.proxy.internal.filter.ByteBufferTransformation;
@@ -137,8 +136,7 @@ public class KrpcFilterIT {
 
         admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1))).all().get();
 
-        ConfigurationBuilder builder = proxy(cluster);
-        try (var tester = kroxyliciousTester(builder);
+        try (var tester = kroxyliciousTester(proxy(cluster));
                 var producer = tester.producer(Map.of(CLIENT_ID_CONFIG, "shouldPassThroughRecordUnchanged", DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000));
                 var consumer = tester.consumer()) {
             producer.send(new ProducerRecord<>(TOPIC_1, "my-key", "Hello, world!")).get();
@@ -152,8 +150,7 @@ public class KrpcFilterIT {
 
     @Test
     public void requestFiltersCanRespondWithoutProxying(KafkaCluster cluster, Admin admin) throws Exception {
-        ConfigurationBuilder builder = proxy(cluster);
-        var config = builder
+        var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("CreateTopicRejectFilter").build());
 
         try (var tester = kroxyliciousTester(config);
@@ -168,8 +165,7 @@ public class KrpcFilterIT {
 
     @Test
     public void requestFiltersCanRespondWithoutProxyingDoesntLeakBuffers(KafkaCluster cluster, Admin admin) throws Exception {
-        ConfigurationBuilder builder = proxy(cluster);
-        var config = builder
+        var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("CreateTopicRejectFilter").build());
 
         try (var tester = kroxyliciousTester(config);
@@ -217,8 +213,7 @@ public class KrpcFilterIT {
                 new NewTopic(TOPIC_1, 1, (short) 1),
                 new NewTopic(TOPIC_2, 1, (short) 1))).all().get();
 
-        ConfigurationBuilder builder = proxy(cluster);
-        var config = builder
+        var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("ProduceRequestTransformation").withConfig("transformation", TestEncoder.class.getName()).build());
 
         try (var tester = kroxyliciousTester(config);
@@ -251,8 +246,7 @@ public class KrpcFilterIT {
                 new NewTopic(TOPIC_1, 1, (short) 1),
                 new NewTopic(TOPIC_2, 1, (short) 1))).all().get();
 
-        ConfigurationBuilder builder = proxy(cluster);
-        var config = builder
+        var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("FetchResponseTransformation").withConfig("transformation", TestDecoder.class.getName()).build());
 
         try (var tester = kroxyliciousTester(config);

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/ProxyRpcTest.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/ProxyRpcTest.java
@@ -54,7 +54,6 @@ public class ProxyRpcTest {
     @BeforeAll
     public static void beforeAll() {
         mockTester = mockKafkaKroxyliciousTester((mockBootstrap) -> proxy(mockBootstrap)
-                .addToFilters(new FilterDefinitionBuilder("ApiVersions").build())
                 .addToFilters(new FilterDefinitionBuilder("FixedClientId").withConfig("clientId", "fixed").build()));
     }
 

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/TlsIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/TlsIT.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.io.TempDir;
 import io.kroxylicious.proxy.config.ClusterNetworkAddressConfigProviderDefinition;
 import io.kroxylicious.proxy.config.ClusterNetworkAddressConfigProviderDefinitionBuilder;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
-import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
@@ -95,8 +94,7 @@ public class TlsIT {
                         .endTls()
                         .endTargetCluster()
                         .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
-                        .build())
-                .addToFilters(new FilterDefinitionBuilder("ApiVersions").build());
+                        .build());
 
         try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
             // do some work to ensure connection is opened
@@ -134,8 +132,7 @@ public class TlsIT {
                         .endTls()
                         .endTargetCluster()
                         .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
-                        .build())
-                .addToFilters(new FilterDefinitionBuilder("ApiVersions").build());
+                        .build());
 
         try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
             // do some work to ensure connection is opened
@@ -156,8 +153,7 @@ public class TlsIT {
                         .endTls()
                         .endTargetCluster()
                         .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
-                        .build())
-                .addToFilters(new FilterDefinitionBuilder("ApiVersions").build());
+                        .build());
 
         try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
             // do some work to ensure connection is opened
@@ -191,8 +187,7 @@ public class TlsIT {
                         .endKeyStoreKey()
                         .endTls()
                         .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
-                        .build())
-                .addToFilters(new FilterDefinitionBuilder("ApiVersions").build());
+                        .build());
 
         try (var tester = kroxyliciousTester(builder);
                 var admin = tester.admin("demo",

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/multitenant/MultiTenantIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/multitenant/MultiTenantIT.java
@@ -608,7 +608,6 @@ public class MultiTenantIT {
                         .endKeyStoreKey()
                         .endTls()
                         .build())
-                .addToFilters(new FilterDefinitionBuilder("ApiVersions").build())
                 .addToFilters(new FilterDefinitionBuilder("MultiTenant").build());
     }
 

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSyntaxValidationIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSyntaxValidationIT.java
@@ -24,12 +24,12 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
-import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.withDefaultFilters;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
 import static java.util.UUID.randomUUID;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
@@ -52,7 +52,8 @@ public class JsonSyntaxValidationIT {
         assertEquals(1, cluster.getNumOfBrokers());
         admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1))).all().get();
 
-        var config = withDefaultFilters(proxy(cluster))
+        ConfigurationBuilder builder = proxy(cluster);
+        var config = builder
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator").withConfig("rules",
                         List.of(Map.of("topicNames", List.of(TOPIC_1), "valueRule",
                                 Map.of("allowsNulls", true, "syntacticallyCorrectJson", Map.of("validateObjectKeysUnique", true)))))
@@ -69,7 +70,8 @@ public class JsonSyntaxValidationIT {
         assertEquals(1, cluster.getNumOfBrokers());
         admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1))).all().get();
 
-        var config = withDefaultFilters(proxy(cluster))
+        ConfigurationBuilder builder = proxy(cluster);
+        var config = builder
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator").withConfig("rules",
                         List.of(Map.of("topicNames", List.of(TOPIC_1), "valueRule",
                                 Map.of("allowsNulls", true, "syntacticallyCorrectJson", Map.of("validateObjectKeysUnique", true)))))
@@ -93,7 +95,8 @@ public class JsonSyntaxValidationIT {
 
         admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1))).all().get();
 
-        var config = withDefaultFilters(proxy(cluster))
+        ConfigurationBuilder builder = proxy(cluster);
+        var config = builder
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator").withConfig("forwardPartialRequests", true, "rules",
                         List.of(Map.of("topicNames", List.of(TOPIC_1, TOPIC_2), "valueRule",
                                 Map.of("allowsNulls", true, "syntacticallyCorrectJson", Map.of("validateObjectKeysUnique", true)))))
@@ -119,7 +122,8 @@ public class JsonSyntaxValidationIT {
         admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1))).all().get();
 
         boolean forwardPartialRequests = false;
-        var config = withDefaultFilters(proxy(cluster))
+        ConfigurationBuilder builder = proxy(cluster);
+        var config = builder
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator").withConfig("forwardPartialRequests", forwardPartialRequests, "rules",
                         List.of(Map.of("topicNames", List.of(TOPIC_1, TOPIC_2), "valueRule",
                                 Map.of("allowsNulls", true, "syntacticallyCorrectJson", Map.of("validateObjectKeysUnique", true)))))
@@ -141,7 +145,8 @@ public class JsonSyntaxValidationIT {
 
         admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1))).all().get();
 
-        var config = withDefaultFilters(proxy(cluster))
+        ConfigurationBuilder builder = proxy(cluster);
+        var config = builder
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator")
                         .withConfig("forwardPartialRequests", true,
                                 "rules", List.of(Map.of("topicNames", List.of(TOPIC_1, TOPIC_2), "valueRule",
@@ -171,7 +176,8 @@ public class JsonSyntaxValidationIT {
 
         admin.createTopics(List.of(new NewTopic(TOPIC_1, 2, (short) 1))).all().get();
 
-        var config = withDefaultFilters(proxy(cluster))
+        ConfigurationBuilder builder = proxy(cluster);
+        var config = builder
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator")
                         .withConfig("forwardPartialRequests", true,
                                 "rules", List.of(Map.of("topicNames", List.of(TOPIC_1), "valueRule",
@@ -201,7 +207,8 @@ public class JsonSyntaxValidationIT {
 
         admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1))).all().get();
 
-        var config = withDefaultFilters(proxy(cluster))
+        ConfigurationBuilder builder = proxy(cluster);
+        var config = builder
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator").withConfig("forwardPartialRequests", true, "rules",
                         List.of(Map.of("topicNames", List.of(TOPIC_1), "valueRule",
                                 Map.of("allowsNulls", true, "syntacticallyCorrectJson", Map.of("validateObjectKeysUnique", true)))))
@@ -226,7 +233,8 @@ public class JsonSyntaxValidationIT {
 
         admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1))).all().get();
 
-        var config = withDefaultFilters(proxy(cluster))
+        ConfigurationBuilder builder = proxy(cluster);
+        var config = builder
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator").withConfig("rules",
                         List.of(Map.of("topicNames", List.of(TOPIC_1), "valueRule",
                                 Map.of("allowsNulls", true, "syntacticallyCorrectJson", Map.of("validateObjectKeysUnique", true)))))

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSyntaxValidationIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSyntaxValidationIT.java
@@ -24,7 +24,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
@@ -52,8 +51,7 @@ public class JsonSyntaxValidationIT {
         assertEquals(1, cluster.getNumOfBrokers());
         admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1))).all().get();
 
-        ConfigurationBuilder builder = proxy(cluster);
-        var config = builder
+        var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator").withConfig("rules",
                         List.of(Map.of("topicNames", List.of(TOPIC_1), "valueRule",
                                 Map.of("allowsNulls", true, "syntacticallyCorrectJson", Map.of("validateObjectKeysUnique", true)))))
@@ -70,8 +68,7 @@ public class JsonSyntaxValidationIT {
         assertEquals(1, cluster.getNumOfBrokers());
         admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1))).all().get();
 
-        ConfigurationBuilder builder = proxy(cluster);
-        var config = builder
+        var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator").withConfig("rules",
                         List.of(Map.of("topicNames", List.of(TOPIC_1), "valueRule",
                                 Map.of("allowsNulls", true, "syntacticallyCorrectJson", Map.of("validateObjectKeysUnique", true)))))
@@ -95,8 +92,7 @@ public class JsonSyntaxValidationIT {
 
         admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1))).all().get();
 
-        ConfigurationBuilder builder = proxy(cluster);
-        var config = builder
+        var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator").withConfig("forwardPartialRequests", true, "rules",
                         List.of(Map.of("topicNames", List.of(TOPIC_1, TOPIC_2), "valueRule",
                                 Map.of("allowsNulls", true, "syntacticallyCorrectJson", Map.of("validateObjectKeysUnique", true)))))
@@ -122,8 +118,7 @@ public class JsonSyntaxValidationIT {
         admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1))).all().get();
 
         boolean forwardPartialRequests = false;
-        ConfigurationBuilder builder = proxy(cluster);
-        var config = builder
+        var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator").withConfig("forwardPartialRequests", forwardPartialRequests, "rules",
                         List.of(Map.of("topicNames", List.of(TOPIC_1, TOPIC_2), "valueRule",
                                 Map.of("allowsNulls", true, "syntacticallyCorrectJson", Map.of("validateObjectKeysUnique", true)))))
@@ -145,8 +140,7 @@ public class JsonSyntaxValidationIT {
 
         admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1))).all().get();
 
-        ConfigurationBuilder builder = proxy(cluster);
-        var config = builder
+        var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator")
                         .withConfig("forwardPartialRequests", true,
                                 "rules", List.of(Map.of("topicNames", List.of(TOPIC_1, TOPIC_2), "valueRule",
@@ -176,8 +170,7 @@ public class JsonSyntaxValidationIT {
 
         admin.createTopics(List.of(new NewTopic(TOPIC_1, 2, (short) 1))).all().get();
 
-        ConfigurationBuilder builder = proxy(cluster);
-        var config = builder
+        var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator")
                         .withConfig("forwardPartialRequests", true,
                                 "rules", List.of(Map.of("topicNames", List.of(TOPIC_1), "valueRule",
@@ -207,8 +200,7 @@ public class JsonSyntaxValidationIT {
 
         admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1))).all().get();
 
-        ConfigurationBuilder builder = proxy(cluster);
-        var config = builder
+        var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator").withConfig("forwardPartialRequests", true, "rules",
                         List.of(Map.of("topicNames", List.of(TOPIC_1), "valueRule",
                                 Map.of("allowsNulls", true, "syntacticallyCorrectJson", Map.of("validateObjectKeysUnique", true)))))
@@ -233,8 +225,7 @@ public class JsonSyntaxValidationIT {
 
         admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1))).all().get();
 
-        ConfigurationBuilder builder = proxy(cluster);
-        var config = builder
+        var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator").withConfig("rules",
                         List.of(Map.of("topicNames", List.of(TOPIC_1), "valueRule",
                                 Map.of("allowsNulls", true, "syntacticallyCorrectJson", Map.of("validateObjectKeysUnique", true)))))

--- a/kroxylicious-sample/sample-proxy-config.yml
+++ b/kroxylicious-sample/sample-proxy-config.yml
@@ -19,7 +19,6 @@ virtualClusters:
     logNetwork: false
     logFrames: false
 filters:
-  - type: ApiVersions
   - type: SampleProduceRequest
     config:
       findValue: foo

--- a/kroxylicious-sample/src/test/java/io/kroxylicious/sample/SampleFilterIntegrationTest.java
+++ b/kroxylicious-sample/src/test/java/io/kroxylicious/sample/SampleFilterIntegrationTest.java
@@ -34,7 +34,6 @@ import io.kroxylicious.testing.kafka.common.BrokerCluster;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
-import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.withDefaultFilters;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -135,7 +134,8 @@ public class SampleFilterIntegrationTest {
          * @param filters the filters to be used in the test
          */
         FilterIntegrationTest(TestFilter... filters) {
-            ConfigurationBuilder builder = withDefaultFilters(proxy(cluster));
+            ConfigurationBuilder builder1 = proxy(cluster);
+            ConfigurationBuilder builder = builder1;
             for (TestFilter filter : filters) {
                 builder.addToFilters(new FilterDefinitionBuilder(filter.name()).withConfig(filter.config()).build());
             }

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/KroxyliciousConfigUtils.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/KroxyliciousConfigUtils.java
@@ -9,7 +9,6 @@ package io.kroxylicious.test.tester;
 import io.kroxylicious.proxy.config.ClusterNetworkAddressConfigProviderDefinitionBuilder;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
-import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
@@ -50,15 +49,6 @@ public class KroxyliciousConfigUtils {
      */
     public static ConfigurationBuilder proxy(KafkaCluster cluster) {
         return proxy(cluster.getBootstrapServers());
-    }
-
-    /**
-     * Augments a KroxyliciousConfigBuilder with standard filters required to proxy a Kafka broker
-     * @param builder builder to add filters to
-     * @return builder
-     */
-    public static ConfigurationBuilder withDefaultFilters(ConfigurationBuilder builder) {
-        return builder.addToFilters(new FilterDefinitionBuilder("ApiVersions").build());
     }
 
     /**

--- a/kroxylicious-test-tools/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
+++ b/kroxylicious-test-tools/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
@@ -47,7 +47,6 @@ import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.DEFAULT_VIRTUAL_CLUSTER;
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
-import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.withDefaultFilters;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.mockKafkaKroxyliciousTester;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -63,10 +62,13 @@ public class KroxyliciousTestersTest {
 
     @Test
     public void testAdminMethods(KafkaCluster cluster) {
-        try (var tester = kroxyliciousTester(withDefaultFilters(proxy(cluster)))) {
-            assertNotNull(tester.admin().describeCluster().clusterId().get(10, TimeUnit.SECONDS));
-            assertNotNull(tester.admin(Map.of()).describeCluster().clusterId().get(10, TimeUnit.SECONDS));
-            assertNotNull(tester.admin(DEFAULT_VIRTUAL_CLUSTER, Map.of()).describeCluster().clusterId().get(10, TimeUnit.SECONDS));
+        try {
+            ConfigurationBuilder builder = proxy(cluster);
+            try (var tester = kroxyliciousTester(builder)) {
+                assertNotNull(tester.admin().describeCluster().clusterId().get(10, TimeUnit.SECONDS));
+                assertNotNull(tester.admin(Map.of()).describeCluster().clusterId().get(10, TimeUnit.SECONDS));
+                assertNotNull(tester.admin(DEFAULT_VIRTUAL_CLUSTER, Map.of()).describeCluster().clusterId().get(10, TimeUnit.SECONDS));
+            }
         }
         catch (Exception e) {
             fail("unexpected exception", e);
@@ -80,14 +82,17 @@ public class KroxyliciousTestersTest {
     public void testConsumerMethods(KafkaCluster cluster) throws Exception {
         KafkaProducer<String, String> producer = new KafkaProducer<>(cluster.getKafkaClientConfiguration(), new StringSerializer(), new StringSerializer());
         producer.send(new ProducerRecord<>(TOPIC, "key", "value")).get(10, TimeUnit.SECONDS);
-        try (var tester = kroxyliciousTester(withDefaultFilters(proxy(cluster)))) {
-            assertOneRecordConsumedFrom(tester.consumer());
-            assertOneRecordConsumedFrom(tester.consumer(randomGroupIdAndEarliestReset()));
-            assertOneRecordConsumedFrom(tester.consumer(Serdes.String(), Serdes.String(), randomGroupIdAndEarliestReset()));
+        try {
+            ConfigurationBuilder builder = proxy(cluster);
+            try (var tester = kroxyliciousTester(builder)) {
+                assertOneRecordConsumedFrom(tester.consumer());
+                assertOneRecordConsumedFrom(tester.consumer(randomGroupIdAndEarliestReset()));
+                assertOneRecordConsumedFrom(tester.consumer(Serdes.String(), Serdes.String(), randomGroupIdAndEarliestReset()));
 
-            assertOneRecordConsumedFrom(tester.consumer(DEFAULT_VIRTUAL_CLUSTER));
-            assertOneRecordConsumedFrom(tester.consumer(DEFAULT_VIRTUAL_CLUSTER, randomGroupIdAndEarliestReset()));
-            assertOneRecordConsumedFrom(tester.consumer(DEFAULT_VIRTUAL_CLUSTER, Serdes.String(), Serdes.String(), randomGroupIdAndEarliestReset()));
+                assertOneRecordConsumedFrom(tester.consumer(DEFAULT_VIRTUAL_CLUSTER));
+                assertOneRecordConsumedFrom(tester.consumer(DEFAULT_VIRTUAL_CLUSTER, randomGroupIdAndEarliestReset()));
+                assertOneRecordConsumedFrom(tester.consumer(DEFAULT_VIRTUAL_CLUSTER, Serdes.String(), Serdes.String(), randomGroupIdAndEarliestReset()));
+            }
         }
         catch (Exception e) {
             fail("unexpected exception", e);
@@ -96,20 +101,23 @@ public class KroxyliciousTestersTest {
 
     @Test
     public void testProducerMethods(KafkaCluster cluster) {
-        try (var tester = kroxyliciousTester(withDefaultFilters(proxy(cluster)))) {
-            send(tester.producer());
-            send(tester.producer(Map.of()));
-            send(tester.producer(Serdes.String(), Serdes.String(), Map.of()));
-            send(tester.producer(DEFAULT_VIRTUAL_CLUSTER));
-            send(tester.producer(DEFAULT_VIRTUAL_CLUSTER, Map.of()));
-            send(tester.producer(DEFAULT_VIRTUAL_CLUSTER, Serdes.String(), Serdes.String(), Map.of()));
+        try {
+            ConfigurationBuilder builder = proxy(cluster);
+            try (var tester = kroxyliciousTester(builder)) {
+                send(tester.producer());
+                send(tester.producer(Map.of()));
+                send(tester.producer(Serdes.String(), Serdes.String(), Map.of()));
+                send(tester.producer(DEFAULT_VIRTUAL_CLUSTER));
+                send(tester.producer(DEFAULT_VIRTUAL_CLUSTER, Map.of()));
+                send(tester.producer(DEFAULT_VIRTUAL_CLUSTER, Serdes.String(), Serdes.String(), Map.of()));
 
-            HashMap<String, Object> config = new HashMap<>(cluster.getKafkaClientConfiguration());
-            config.putAll(randomGroupIdAndEarliestReset());
-            KafkaConsumer<String, String> consumer = new KafkaConsumer<>(config, new StringDeserializer(), new StringDeserializer());
-            consumer.subscribe(List.of(TOPIC));
-            int recordCount = consumer.poll(Duration.ofSeconds(10)).count();
-            assertEquals(6, recordCount);
+                HashMap<String, Object> config = new HashMap<>(cluster.getKafkaClientConfiguration());
+                config.putAll(randomGroupIdAndEarliestReset());
+                KafkaConsumer<String, String> consumer = new KafkaConsumer<>(config, new StringDeserializer(), new StringDeserializer());
+                consumer.subscribe(List.of(TOPIC));
+                int recordCount = consumer.poll(Duration.ofSeconds(10)).count();
+                assertEquals(6, recordCount);
+            }
         }
         catch (Exception e) {
             fail("unexpected exception", e);
@@ -118,9 +126,12 @@ public class KroxyliciousTestersTest {
 
     @Test
     public void testSingleRequestClient(KafkaCluster cluster) {
-        try (var tester = kroxyliciousTester(withDefaultFilters(proxy(cluster)))) {
-            assertCanSendSingleRequestAndGetResponse(tester.singleRequestClient());
-            assertCanSendSingleRequestAndGetResponse(tester.singleRequestClient(DEFAULT_VIRTUAL_CLUSTER));
+        try {
+            ConfigurationBuilder builder = proxy(cluster);
+            try (var tester = kroxyliciousTester(builder)) {
+                assertCanSendSingleRequestAndGetResponse(tester.singleRequestClient());
+                assertCanSendSingleRequestAndGetResponse(tester.singleRequestClient(DEFAULT_VIRTUAL_CLUSTER));
+            }
         }
         catch (Exception e) {
             fail("unexpected exception", e);
@@ -129,7 +140,7 @@ public class KroxyliciousTestersTest {
 
     @Test
     public void testMockTester() {
-        try (var tester = mockKafkaKroxyliciousTester(clusterBootstrapServers -> withDefaultFilters(proxy(clusterBootstrapServers)))) {
+        try (var tester = mockKafkaKroxyliciousTester(clusterBootstrapServers -> proxy(clusterBootstrapServers))) {
             assertCanSendSingleRequestAndReceiveMockMessage(tester, tester.singleRequestClient());
             assertCanSendSingleRequestAndReceiveMockMessage(tester, tester.singleRequestClient(DEFAULT_VIRTUAL_CLUSTER));
         }
@@ -140,16 +151,19 @@ public class KroxyliciousTestersTest {
 
     @Test
     public void testIllegalToAskForNonExistantVirtualCluster(KafkaCluster cluster) {
-        try (var tester = kroxyliciousTester(withDefaultFilters(proxy(cluster)))) {
-            assertThrows(IllegalArgumentException.class, () -> tester.singleRequestClient("NON_EXIST"));
-            assertThrows(IllegalArgumentException.class, () -> tester.consumer("NON_EXIST"));
-            assertThrows(IllegalArgumentException.class, () -> tester.consumer("NON_EXIST", Map.of()));
-            assertThrows(IllegalArgumentException.class, () -> tester.consumer("NON_EXIST", Serdes.String(), Serdes.String(), Map.of()));
-            assertThrows(IllegalArgumentException.class, () -> tester.producer("NON_EXIST"));
-            assertThrows(IllegalArgumentException.class, () -> tester.producer("NON_EXIST", Map.of()));
-            assertThrows(IllegalArgumentException.class, () -> tester.producer("NON_EXIST", Serdes.String(), Serdes.String(), Map.of()));
-            assertThrows(IllegalArgumentException.class, () -> tester.admin("NON_EXIST"));
-            assertThrows(IllegalArgumentException.class, () -> tester.admin("NON_EXIST", Map.of()));
+        try {
+            ConfigurationBuilder builder = proxy(cluster);
+            try (var tester = kroxyliciousTester(builder)) {
+                assertThrows(IllegalArgumentException.class, () -> tester.singleRequestClient("NON_EXIST"));
+                assertThrows(IllegalArgumentException.class, () -> tester.consumer("NON_EXIST"));
+                assertThrows(IllegalArgumentException.class, () -> tester.consumer("NON_EXIST", Map.of()));
+                assertThrows(IllegalArgumentException.class, () -> tester.consumer("NON_EXIST", Serdes.String(), Serdes.String(), Map.of()));
+                assertThrows(IllegalArgumentException.class, () -> tester.producer("NON_EXIST"));
+                assertThrows(IllegalArgumentException.class, () -> tester.producer("NON_EXIST", Map.of()));
+                assertThrows(IllegalArgumentException.class, () -> tester.producer("NON_EXIST", Serdes.String(), Serdes.String(), Map.of()));
+                assertThrows(IllegalArgumentException.class, () -> tester.admin("NON_EXIST"));
+                assertThrows(IllegalArgumentException.class, () -> tester.admin("NON_EXIST", Map.of()));
+            }
         }
         catch (Exception e) {
             fail("unexpected exception", e);
@@ -162,16 +176,18 @@ public class KroxyliciousTestersTest {
         ConfigurationBuilder builder = new ConfigurationBuilder();
         ConfigurationBuilder proxy = addVirtualCluster(clusterBootstrapServers, addVirtualCluster(clusterBootstrapServers, builder, "foo",
                 "localhost:9192"), "bar", "localhost:9296");
-        try (var tester = kroxyliciousTester(withDefaultFilters(proxy))) {
-            assertThrows(AmbiguousVirtualClusterException.class, tester::singleRequestClient);
-            assertThrows(AmbiguousVirtualClusterException.class, tester::consumer);
-            assertThrows(AmbiguousVirtualClusterException.class, () -> tester.consumer(Map.of()));
-            assertThrows(AmbiguousVirtualClusterException.class, () -> tester.consumer(Serdes.String(), Serdes.String(), Map.of()));
-            assertThrows(AmbiguousVirtualClusterException.class, tester::producer);
-            assertThrows(AmbiguousVirtualClusterException.class, () -> tester.producer(Map.of()));
-            assertThrows(AmbiguousVirtualClusterException.class, () -> tester.producer(Serdes.String(), Serdes.String(), Map.of()));
-            assertThrows(AmbiguousVirtualClusterException.class, tester::admin);
-            assertThrows(AmbiguousVirtualClusterException.class, () -> tester.admin(Map.of()));
+        try {
+            try (var tester = kroxyliciousTester(proxy)) {
+                assertThrows(AmbiguousVirtualClusterException.class, tester::singleRequestClient);
+                assertThrows(AmbiguousVirtualClusterException.class, tester::consumer);
+                assertThrows(AmbiguousVirtualClusterException.class, () -> tester.consumer(Map.of()));
+                assertThrows(AmbiguousVirtualClusterException.class, () -> tester.consumer(Serdes.String(), Serdes.String(), Map.of()));
+                assertThrows(AmbiguousVirtualClusterException.class, tester::producer);
+                assertThrows(AmbiguousVirtualClusterException.class, () -> tester.producer(Map.of()));
+                assertThrows(AmbiguousVirtualClusterException.class, () -> tester.producer(Serdes.String(), Serdes.String(), Map.of()));
+                assertThrows(AmbiguousVirtualClusterException.class, tester::admin);
+                assertThrows(AmbiguousVirtualClusterException.class, () -> tester.admin(Map.of()));
+            }
         }
         catch (Exception e) {
             fail("unexpected exception", e);

--- a/kroxylicious-test-tools/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
+++ b/kroxylicious-test-tools/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
@@ -62,12 +62,10 @@ public class KroxyliciousTestersTest {
 
     @Test
     public void testAdminMethods(KafkaCluster cluster) {
-        try {
-            try (var tester = kroxyliciousTester(proxy(cluster))) {
-                assertNotNull(tester.admin().describeCluster().clusterId().get(10, TimeUnit.SECONDS));
-                assertNotNull(tester.admin(Map.of()).describeCluster().clusterId().get(10, TimeUnit.SECONDS));
-                assertNotNull(tester.admin(DEFAULT_VIRTUAL_CLUSTER, Map.of()).describeCluster().clusterId().get(10, TimeUnit.SECONDS));
-            }
+        try (var tester = kroxyliciousTester(proxy(cluster))) {
+            assertNotNull(tester.admin().describeCluster().clusterId().get(10, TimeUnit.SECONDS));
+            assertNotNull(tester.admin(Map.of()).describeCluster().clusterId().get(10, TimeUnit.SECONDS));
+            assertNotNull(tester.admin(DEFAULT_VIRTUAL_CLUSTER, Map.of()).describeCluster().clusterId().get(10, TimeUnit.SECONDS));
         }
         catch (Exception e) {
             fail("unexpected exception", e);
@@ -81,16 +79,14 @@ public class KroxyliciousTestersTest {
     public void testConsumerMethods(KafkaCluster cluster) throws Exception {
         KafkaProducer<String, String> producer = new KafkaProducer<>(cluster.getKafkaClientConfiguration(), new StringSerializer(), new StringSerializer());
         producer.send(new ProducerRecord<>(TOPIC, "key", "value")).get(10, TimeUnit.SECONDS);
-        try {
-            try (var tester = kroxyliciousTester(proxy(cluster))) {
-                assertOneRecordConsumedFrom(tester.consumer());
-                assertOneRecordConsumedFrom(tester.consumer(randomGroupIdAndEarliestReset()));
-                assertOneRecordConsumedFrom(tester.consumer(Serdes.String(), Serdes.String(), randomGroupIdAndEarliestReset()));
+        try (var tester = kroxyliciousTester(proxy(cluster))) {
+            assertOneRecordConsumedFrom(tester.consumer());
+            assertOneRecordConsumedFrom(tester.consumer(randomGroupIdAndEarliestReset()));
+            assertOneRecordConsumedFrom(tester.consumer(Serdes.String(), Serdes.String(), randomGroupIdAndEarliestReset()));
 
-                assertOneRecordConsumedFrom(tester.consumer(DEFAULT_VIRTUAL_CLUSTER));
-                assertOneRecordConsumedFrom(tester.consumer(DEFAULT_VIRTUAL_CLUSTER, randomGroupIdAndEarliestReset()));
-                assertOneRecordConsumedFrom(tester.consumer(DEFAULT_VIRTUAL_CLUSTER, Serdes.String(), Serdes.String(), randomGroupIdAndEarliestReset()));
-            }
+            assertOneRecordConsumedFrom(tester.consumer(DEFAULT_VIRTUAL_CLUSTER));
+            assertOneRecordConsumedFrom(tester.consumer(DEFAULT_VIRTUAL_CLUSTER, randomGroupIdAndEarliestReset()));
+            assertOneRecordConsumedFrom(tester.consumer(DEFAULT_VIRTUAL_CLUSTER, Serdes.String(), Serdes.String(), randomGroupIdAndEarliestReset()));
         }
         catch (Exception e) {
             fail("unexpected exception", e);
@@ -99,22 +95,20 @@ public class KroxyliciousTestersTest {
 
     @Test
     public void testProducerMethods(KafkaCluster cluster) {
-        try {
-            try (var tester = kroxyliciousTester(proxy(cluster))) {
-                send(tester.producer());
-                send(tester.producer(Map.of()));
-                send(tester.producer(Serdes.String(), Serdes.String(), Map.of()));
-                send(tester.producer(DEFAULT_VIRTUAL_CLUSTER));
-                send(tester.producer(DEFAULT_VIRTUAL_CLUSTER, Map.of()));
-                send(tester.producer(DEFAULT_VIRTUAL_CLUSTER, Serdes.String(), Serdes.String(), Map.of()));
+        try (var tester = kroxyliciousTester(proxy(cluster))) {
+            send(tester.producer());
+            send(tester.producer(Map.of()));
+            send(tester.producer(Serdes.String(), Serdes.String(), Map.of()));
+            send(tester.producer(DEFAULT_VIRTUAL_CLUSTER));
+            send(tester.producer(DEFAULT_VIRTUAL_CLUSTER, Map.of()));
+            send(tester.producer(DEFAULT_VIRTUAL_CLUSTER, Serdes.String(), Serdes.String(), Map.of()));
 
-                HashMap<String, Object> config = new HashMap<>(cluster.getKafkaClientConfiguration());
-                config.putAll(randomGroupIdAndEarliestReset());
-                KafkaConsumer<String, String> consumer = new KafkaConsumer<>(config, new StringDeserializer(), new StringDeserializer());
-                consumer.subscribe(List.of(TOPIC));
-                int recordCount = consumer.poll(Duration.ofSeconds(10)).count();
-                assertEquals(6, recordCount);
-            }
+            HashMap<String, Object> config = new HashMap<>(cluster.getKafkaClientConfiguration());
+            config.putAll(randomGroupIdAndEarliestReset());
+            KafkaConsumer<String, String> consumer = new KafkaConsumer<>(config, new StringDeserializer(), new StringDeserializer());
+            consumer.subscribe(List.of(TOPIC));
+            int recordCount = consumer.poll(Duration.ofSeconds(10)).count();
+            assertEquals(6, recordCount);
         }
         catch (Exception e) {
             fail("unexpected exception", e);
@@ -123,11 +117,9 @@ public class KroxyliciousTestersTest {
 
     @Test
     public void testSingleRequestClient(KafkaCluster cluster) {
-        try {
-            try (var tester = kroxyliciousTester(proxy(cluster))) {
-                assertCanSendSingleRequestAndGetResponse(tester.singleRequestClient());
-                assertCanSendSingleRequestAndGetResponse(tester.singleRequestClient(DEFAULT_VIRTUAL_CLUSTER));
-            }
+        try (var tester = kroxyliciousTester(proxy(cluster))) {
+            assertCanSendSingleRequestAndGetResponse(tester.singleRequestClient());
+            assertCanSendSingleRequestAndGetResponse(tester.singleRequestClient(DEFAULT_VIRTUAL_CLUSTER));
         }
         catch (Exception e) {
             fail("unexpected exception", e);
@@ -147,19 +139,16 @@ public class KroxyliciousTestersTest {
 
     @Test
     public void testIllegalToAskForNonExistantVirtualCluster(KafkaCluster cluster) {
-        try {
-            ConfigurationBuilder builder = proxy(cluster);
-            try (var tester = kroxyliciousTester(builder)) {
-                assertThrows(IllegalArgumentException.class, () -> tester.singleRequestClient("NON_EXIST"));
-                assertThrows(IllegalArgumentException.class, () -> tester.consumer("NON_EXIST"));
-                assertThrows(IllegalArgumentException.class, () -> tester.consumer("NON_EXIST", Map.of()));
-                assertThrows(IllegalArgumentException.class, () -> tester.consumer("NON_EXIST", Serdes.String(), Serdes.String(), Map.of()));
-                assertThrows(IllegalArgumentException.class, () -> tester.producer("NON_EXIST"));
-                assertThrows(IllegalArgumentException.class, () -> tester.producer("NON_EXIST", Map.of()));
-                assertThrows(IllegalArgumentException.class, () -> tester.producer("NON_EXIST", Serdes.String(), Serdes.String(), Map.of()));
-                assertThrows(IllegalArgumentException.class, () -> tester.admin("NON_EXIST"));
-                assertThrows(IllegalArgumentException.class, () -> tester.admin("NON_EXIST", Map.of()));
-            }
+        try (var tester = kroxyliciousTester(proxy(cluster))) {
+            assertThrows(IllegalArgumentException.class, () -> tester.singleRequestClient("NON_EXIST"));
+            assertThrows(IllegalArgumentException.class, () -> tester.consumer("NON_EXIST"));
+            assertThrows(IllegalArgumentException.class, () -> tester.consumer("NON_EXIST", Map.of()));
+            assertThrows(IllegalArgumentException.class, () -> tester.consumer("NON_EXIST", Serdes.String(), Serdes.String(), Map.of()));
+            assertThrows(IllegalArgumentException.class, () -> tester.producer("NON_EXIST"));
+            assertThrows(IllegalArgumentException.class, () -> tester.producer("NON_EXIST", Map.of()));
+            assertThrows(IllegalArgumentException.class, () -> tester.producer("NON_EXIST", Serdes.String(), Serdes.String(), Map.of()));
+            assertThrows(IllegalArgumentException.class, () -> tester.admin("NON_EXIST"));
+            assertThrows(IllegalArgumentException.class, () -> tester.admin("NON_EXIST", Map.of()));
         }
         catch (Exception e) {
             fail("unexpected exception", e);
@@ -172,18 +161,16 @@ public class KroxyliciousTestersTest {
         ConfigurationBuilder builder = new ConfigurationBuilder();
         ConfigurationBuilder proxy = addVirtualCluster(clusterBootstrapServers, addVirtualCluster(clusterBootstrapServers, builder, "foo",
                 "localhost:9192"), "bar", "localhost:9296");
-        try {
-            try (var tester = kroxyliciousTester(proxy)) {
-                assertThrows(AmbiguousVirtualClusterException.class, tester::singleRequestClient);
-                assertThrows(AmbiguousVirtualClusterException.class, tester::consumer);
-                assertThrows(AmbiguousVirtualClusterException.class, () -> tester.consumer(Map.of()));
-                assertThrows(AmbiguousVirtualClusterException.class, () -> tester.consumer(Serdes.String(), Serdes.String(), Map.of()));
-                assertThrows(AmbiguousVirtualClusterException.class, tester::producer);
-                assertThrows(AmbiguousVirtualClusterException.class, () -> tester.producer(Map.of()));
-                assertThrows(AmbiguousVirtualClusterException.class, () -> tester.producer(Serdes.String(), Serdes.String(), Map.of()));
-                assertThrows(AmbiguousVirtualClusterException.class, tester::admin);
-                assertThrows(AmbiguousVirtualClusterException.class, () -> tester.admin(Map.of()));
-            }
+        try (var tester = kroxyliciousTester(proxy)) {
+            assertThrows(AmbiguousVirtualClusterException.class, tester::singleRequestClient);
+            assertThrows(AmbiguousVirtualClusterException.class, tester::consumer);
+            assertThrows(AmbiguousVirtualClusterException.class, () -> tester.consumer(Map.of()));
+            assertThrows(AmbiguousVirtualClusterException.class, () -> tester.consumer(Serdes.String(), Serdes.String(), Map.of()));
+            assertThrows(AmbiguousVirtualClusterException.class, tester::producer);
+            assertThrows(AmbiguousVirtualClusterException.class, () -> tester.producer(Map.of()));
+            assertThrows(AmbiguousVirtualClusterException.class, () -> tester.producer(Serdes.String(), Serdes.String(), Map.of()));
+            assertThrows(AmbiguousVirtualClusterException.class, tester::admin);
+            assertThrows(AmbiguousVirtualClusterException.class, () -> tester.admin(Map.of()));
         }
         catch (Exception e) {
             fail("unexpected exception", e);

--- a/kroxylicious-test-tools/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
+++ b/kroxylicious-test-tools/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
@@ -63,8 +63,7 @@ public class KroxyliciousTestersTest {
     @Test
     public void testAdminMethods(KafkaCluster cluster) {
         try {
-            ConfigurationBuilder builder = proxy(cluster);
-            try (var tester = kroxyliciousTester(builder)) {
+            try (var tester = kroxyliciousTester(proxy(cluster))) {
                 assertNotNull(tester.admin().describeCluster().clusterId().get(10, TimeUnit.SECONDS));
                 assertNotNull(tester.admin(Map.of()).describeCluster().clusterId().get(10, TimeUnit.SECONDS));
                 assertNotNull(tester.admin(DEFAULT_VIRTUAL_CLUSTER, Map.of()).describeCluster().clusterId().get(10, TimeUnit.SECONDS));
@@ -83,8 +82,7 @@ public class KroxyliciousTestersTest {
         KafkaProducer<String, String> producer = new KafkaProducer<>(cluster.getKafkaClientConfiguration(), new StringSerializer(), new StringSerializer());
         producer.send(new ProducerRecord<>(TOPIC, "key", "value")).get(10, TimeUnit.SECONDS);
         try {
-            ConfigurationBuilder builder = proxy(cluster);
-            try (var tester = kroxyliciousTester(builder)) {
+            try (var tester = kroxyliciousTester(proxy(cluster))) {
                 assertOneRecordConsumedFrom(tester.consumer());
                 assertOneRecordConsumedFrom(tester.consumer(randomGroupIdAndEarliestReset()));
                 assertOneRecordConsumedFrom(tester.consumer(Serdes.String(), Serdes.String(), randomGroupIdAndEarliestReset()));
@@ -102,8 +100,7 @@ public class KroxyliciousTestersTest {
     @Test
     public void testProducerMethods(KafkaCluster cluster) {
         try {
-            ConfigurationBuilder builder = proxy(cluster);
-            try (var tester = kroxyliciousTester(builder)) {
+            try (var tester = kroxyliciousTester(proxy(cluster))) {
                 send(tester.producer());
                 send(tester.producer(Map.of()));
                 send(tester.producer(Serdes.String(), Serdes.String(), Map.of()));
@@ -127,8 +124,7 @@ public class KroxyliciousTestersTest {
     @Test
     public void testSingleRequestClient(KafkaCluster cluster) {
         try {
-            ConfigurationBuilder builder = proxy(cluster);
-            try (var tester = kroxyliciousTester(builder)) {
+            try (var tester = kroxyliciousTester(proxy(cluster))) {
                 assertCanSendSingleRequestAndGetResponse(tester.singleRequestClient());
                 assertCanSendSingleRequestAndGetResponse(tester.singleRequestClient(DEFAULT_VIRTUAL_CLUSTER));
             }
@@ -140,7 +136,7 @@ public class KroxyliciousTestersTest {
 
     @Test
     public void testMockTester() {
-        try (var tester = mockKafkaKroxyliciousTester(clusterBootstrapServers -> proxy(clusterBootstrapServers))) {
+        try (var tester = mockKafkaKroxyliciousTester(KroxyliciousConfigUtils::proxy)) {
             assertCanSendSingleRequestAndReceiveMockMessage(tester, tester.singleRequestClient());
             assertCanSendSingleRequestAndReceiveMockMessage(tester, tester.singleRequestClient(DEFAULT_VIRTUAL_CLUSTER));
         }

--- a/kroxylicious/example-proxy-config.yml
+++ b/kroxylicious/example-proxy-config.yml
@@ -19,7 +19,6 @@ virtualClusters:
     logNetwork: false
     logFrames: false
 filters:
-- type: ApiVersions
 #- type: ProduceRequestTransformation
 #  config:
 #    transformation: io.kroxylicious.proxy.internal.filter.ProduceRequestTransformationFilter$UpperCasing

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -8,6 +8,7 @@ package io.kroxylicious.proxy.bootstrap;
 import java.util.List;
 
 import io.kroxylicious.proxy.config.Configuration;
+import io.kroxylicious.proxy.config.FilterDefinition;
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
 import io.kroxylicious.proxy.internal.filter.FilterContributorManager;
 
@@ -32,7 +33,11 @@ public class FilterChainFactory {
     public List<FilterAndInvoker> createFilters() {
         FilterContributorManager filterContributorManager = FilterContributorManager.getInstance();
 
-        return config.filters()
+        List<FilterDefinition> filters = config.filters();
+        if (filters == null || filters.isEmpty()) {
+            return List.of();
+        }
+        return filters
                 .stream()
                 .map(f -> filterContributorManager.getFilter(f.type(), f.config()))
                 .flatMap(filter -> FilterAndInvoker.build(filter).stream())

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/SaslDecodePredicate.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/SaslDecodePredicate.java
@@ -58,7 +58,11 @@ class SaslDecodePredicate implements DecodePredicate {
     }
 
     private boolean isAuthenticationOffloaded(ApiKeys apiKey) {
-        return handleSasl && (apiKey == ApiKeys.SASL_HANDSHAKE || apiKey == ApiKeys.SASL_AUTHENTICATE);
+        return isAuthenticationOffloadEnabled() && (apiKey == ApiKeys.SASL_HANDSHAKE || apiKey == ApiKeys.SASL_AUTHENTICATE);
+    }
+
+    public boolean isAuthenticationOffloadEnabled() {
+        return handleSasl;
     }
 
     @Override

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BuiltinFilterContributor.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BuiltinFilterContributor.java
@@ -14,7 +14,6 @@ import io.kroxylicious.proxy.service.BaseContributor;
 public class BuiltinFilterContributor extends BaseContributor<KrpcFilter> implements FilterContributor {
 
     public static final BaseContributorBuilder<KrpcFilter> FILTERS = BaseContributor.<KrpcFilter> builder()
-            .add("ApiVersions", ApiVersionsFilter::new)
             .add("ProduceRequestTransformation", ProduceRequestTransformationConfig.class, ProduceRequestTransformationFilter::new)
             .add("FetchResponseTransformation", FetchResponseTransformationConfig.class, FetchResponseTransformationFilter::new);
 

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.bootstrap;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.config.Configuration;
+import io.kroxylicious.proxy.filter.FilterAndInvoker;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FilterChainFactoryTest {
+
+    @Test
+    public void testNullFiltersInConfigResultsInEmptyList() {
+        FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, null, null, true));
+        List<FilterAndInvoker> filters = filterChainFactory.createFilters();
+        assertNotNull(filters, "Filters list should not be null");
+        assertTrue(filters.isEmpty(), "Filters list should be empty");
+    }
+
+    @Test
+    public void testEmptyFiltersInConfigResultsInEmptyList() {
+        FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, List.of(), null, true));
+        List<FilterAndInvoker> filters = filterChainFactory.createFilters();
+        assertNotNull(filters, "Filters list should not be null");
+        assertTrue(filters.isEmpty(), "Filters list should be empty");
+    }
+
+}

--- a/kubernetes-examples/portperbroker_plain/base/kroxylicious-config.yaml
+++ b/kubernetes-examples/portperbroker_plain/base/kroxylicious-config.yaml
@@ -25,5 +25,3 @@ data:
             brokerAddressPattern: kroxylicious-service
         logNetwork: false
         logFrames: false
-    filters:
-    - type: ApiVersions

--- a/kubernetes-examples/snirouting_tls/base/kroxylicious-config.yaml
+++ b/kubernetes-examples/snirouting_tls/base/kroxylicious-config.yaml
@@ -35,5 +35,3 @@ data:
             storeFile: /opt/kroxylicious/server/key-material/keystore.p12
             storePassword:
               filePath: /opt/kroxylicious/server/keystore-password/storePassword
-    filters:
-    - type: ApiVersions


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

If Kroxylicious is not handling SASL offload (currently it never handles SASL offload) then we initiate NetFilter#selectServer if we receive an `ApiVersions` request and buffer the message. After the connect is successful we send the buffered message to the backend. We also install the ApiVersionsFilter if we are not handling SASL offload so that we are intersecting the Kroxylicious supported versions with the upstream versions without further configuration.

ApiVersionsFilter becomes an internal concern, it is no longer available via the BuiltinFilterContributor and is installed into the filter chain automatically by kroxylicious where appropriate.

Also, as a consequence, many tests no longer install any custom filters. This used to throw exceptions but it is now allowed. There could be cases where users want to use Kroxylicious as a proxy with no interception. 

Closes #441
Closes #337

### Additional Context

Why:
Currently Kroxylicious responds with a hardcoded ApiVersions response. This is intentional, to support the proxy handling SASL authentication before we make a connection to the upstream broker, protecting the broker from unauthorized requests and enabling NetFilter to use the authorized id as a criteria for backend server selection. The response is hardcoded to the ApiVersions values for a kafka 3.2 broker.

This means that if we are proxying a broker older than v3.2, Kroxy will be declaring it supports api versions that it doesn't know about, causing errors when you try to use a newer client that supports those newer API versions. Conversely if the backing broker is newer and supports new api versions, the client would be told that the broker only supports v3.2 APIs and the client can't take advantage of new APIs.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
