### PR TITLE
Add syntax highlighting to the index page

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -3,6 +3,7 @@
 :toc:
 :icons: font
 :url-quickref: https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/
+:source-highlighter: pygments
 
 include::overview.adoc[leveloffset=1]
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Add syntax highlighting to the index page using pygments.

### Additional Context

I enabled syntax highlight for https://kroxylicious.io/kroxylicious/custom-filters.html but this doesn't apply to the index page.