### PR TITLE
Kubernetes script fixes

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -21,11 +21,13 @@ resolveCommand () {
   fi
 }
 
+set +u
 if [[ -z $CONTAINER_ENGINE ]]; then
   echo "Setting CONTAINER_ENGINE to default: docker"
   CONTAINER_ENGINE=$(resolveCommand docker)
   export CONTAINER_ENGINE
 fi
+set -u
 
 KUBECTL=$(resolveCommand kubectl)
 export KUBECTL

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -21,13 +21,8 @@ resolveCommand () {
   fi
 }
 
-set +u
-if [[ -z $CONTAINER_ENGINE ]]; then
-  echo "Setting CONTAINER_ENGINE to default: docker"
-  CONTAINER_ENGINE=$(resolveCommand docker)
-  export CONTAINER_ENGINE
-fi
-set -u
+CONTAINER_ENGINE=$(resolveCommand ${CONTAINER_ENGINE:-docker})
+export CONTAINER_ENGINE
 
 KUBECTL=$(resolveCommand kubectl)
 export KUBECTL

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -21,7 +21,7 @@ resolveCommand () {
   fi
 }
 
-CONTAINER_ENGINE=$(resolveCommand ${CONTAINER_ENGINE:-docker})
+CONTAINER_ENGINE=$(resolveCommand "${CONTAINER_ENGINE:-docker}")
 export CONTAINER_ENGINE
 
 KUBECTL=$(resolveCommand kubectl)

--- a/scripts/run-with-strimzi.sh
+++ b/scripts/run-with-strimzi.sh
@@ -5,7 +5,7 @@
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
-set -eo pipefail
+set -euo pipefail
 DEFAULT_QUAY_ORG='kroxylicious'
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
@@ -28,10 +28,12 @@ function cleanTmpDir {
 }
 trap cleanTmpDir EXIT
 
+set +u
 if [[ -z "${QUAY_ORG}" ]]; then
   echo "Please set QUAY_ORG, exiting"
   exit 1
 fi
+set -u
 
 if [[ "${QUAY_ORG}" != "${DEFAULT_QUAY_ORG}" ]]; then
   echo "building and pushing image to quay.io"

--- a/scripts/run-with-strimzi.sh
+++ b/scripts/run-with-strimzi.sh
@@ -6,7 +6,7 @@
 #
 
 set -eo pipefail
-DEFAULT_QUAY_ORG='kroxylicious-developer'
+DEFAULT_QUAY_ORG='kroxylicious'
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . "${SCRIPT_DIR}/common.sh"

--- a/scripts/run-with-strimzi.sh
+++ b/scripts/run-with-strimzi.sh
@@ -28,12 +28,10 @@ function cleanTmpDir {
 }
 trap cleanTmpDir EXIT
 
-set +u
-if [[ -z "${QUAY_ORG}" ]]; then
+if [[ -z "${QUAY_ORG:-}" ]]; then
   echo "Please set QUAY_ORG, exiting"
   exit 1
 fi
-set -u
 
 if [[ "${QUAY_ORG}" != "${DEFAULT_QUAY_ORG}" ]]; then
   echo "building and pushing image to quay.io"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fix a couple of problems in the kubernetes scripts

### Additional Context

I had some problems using the script.

```
QUAY_ORG=robeyoun ./scripts/run-with-strimzi.sh kubernetes-examples/portperbroker_plain
/home/roby/development/redhat-managed-kafka/upstream/kroxylicious/scripts/common.sh: line 24: CONTAINER_ENGINE: unbound variable
```

```
CONTAINER_ENGINE=docker ./scripts/run-with-strimzi.sh kubernetes-examples/portperbroker_plain
./scripts/run-with-strimzi.sh: line 31: QUAY_ORG: unbound variable
```

and then later, once it had deployed everything to the cluster I saw it had deployed `quay.io/kroxylicious/kroxylicious-developer:0.3.0-SNAPSHOT` instead of the one pushed up to my quay account.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
