### PR TITLE
Fix #463 - deregister micrometer hooks, meters and the registry on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.3.0
 
+* [#463](https://github.com/kroxylicious/kroxylicious/issues/463): deregister micrometer hooks, meters and the registry on shutdown
 * [#443](https://github.com/kroxylicious/kroxylicious/pull/443): Obtain upstream ApiVersions when proxy is not SASL offloading
 * [#412](https://github.com/kroxylicious/kroxylicious/issues/412): Remove $(portNumber) pattern from brokerAddressPattern for SniRouting and PortPerBroker schemes
 * [#414](https://github.com/kroxylicious/kroxylicious/pull/414): Add kubernetes sample illustrating SNI based routing, downstream/upstream TLS and the use of certificates from cert-manager.

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/MetricsIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/MetricsIT.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.regex.Pattern;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -31,11 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(KafkaClusterExtension.class)
 public class MetricsIT {
-
-    @BeforeEach
-    public void beforeEach() {
-        Metrics.globalRegistry.clear();
-    }
 
     @Test
     public void shouldOfferPrometheusMetricsScrapeEndpoint(KafkaCluster cluster) {

--- a/integrationtests/src/test/resources/log4j2-test.properties
+++ b/integrationtests/src/test/resources/log4j2-test.properties
@@ -43,13 +43,13 @@ rootLogger.additivity = false
 #logger.netty.additivity = false
 #logger.netty.appenderRef.console.ref = STDOUT
 #
-logger.broker.name = kafka
-logger.broker.level = DEBUG
-logger.broker.additivity = false
-logger.broker.appenderRef.console.ref = STDOUT
-
-logger.net.name = org.apache.kafka.clients.NetworkClient
-logger.net.level = debug
+#logger.broker.name = kafka
+#logger.broker.level = DEBUG
+#logger.broker.additivity = false
+#logger.broker.appenderRef.console.ref = STDOUT
+#
+#logger.net.name = org.apache.kafka.clients.NetworkClient
+#logger.net.level = debug
 
 #
 #logger.scl.name = state.change.logger

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/MeterRegistries.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/MeterRegistries.java
@@ -85,8 +85,9 @@ public class MeterRegistries implements AutoCloseable {
     @Override
     public void close() {
         hooks.forEach(MicrometerConfigurationHook::close);
+        // remove the meters we contributed to the global registry.
         var copy = List.copyOf(prometheusMeterRegistry.getMeters());
-        copy.forEach(prometheusMeterRegistry::remove);
+        copy.forEach(Metrics.globalRegistry::remove);
         Metrics.removeRegistry(prometheusMeterRegistry);
     }
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/MicrometerConfigurationHook.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/MicrometerConfigurationHook.java
@@ -7,7 +7,19 @@ package io.kroxylicious.proxy.micrometer;
 
 import io.micrometer.core.instrument.MeterRegistry;
 
-public interface MicrometerConfigurationHook {
+public interface MicrometerConfigurationHook extends AutoCloseable {
+    /**
+     * Configures this hook into the given registry.
+     *
+     * @param targetRegistry meter registry.
+     */
     void configure(MeterRegistry targetRegistry);
+
+    /**
+     * Releases resources that may have been registered by this hook.  Implementations
+     * of this method must not throw unchecked exceptions.
+     */
+    default void close() {
+    }
 
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/StandardBindersHook.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/StandardBindersHook.java
@@ -68,35 +68,25 @@ public class StandardBindersHook implements MicrometerConfigurationHook {
             try {
                 closeable.close();
             }
-            catch (Exception ignore) {
+            catch (Exception e) {
+                log.warn("Ignoring exception whilst closing standard binder {}", closeable.getClass(), e);
             }
         });
     }
 
-    private MeterBinder getBinder(String binderName) {
-        switch (binderName) {
-            case "UptimeMetrics":
-                return new UptimeMetrics();
-            case "ProcessorMetrics":
-                return new ProcessorMetrics();
-            case "FileDescriptorMetrics":
-                return new FileDescriptorMetrics();
-            case "ClassLoaderMetrics":
-                return new ClassLoaderMetrics();
-            case "JvmCompilationMetrics":
-                return new JvmCompilationMetrics();
-            case "JvmGcMetrics":
-                return new JvmGcMetrics();
-            case "JvmHeapPressureMetrics":
-                return new JvmHeapPressureMetrics();
-            case "JvmInfoMetrics":
-                return new JvmInfoMetrics();
-            case "JvmMemoryMetrics":
-                return new JvmMemoryMetrics();
-            case "JvmThreadMetrics":
-                return new JvmThreadMetrics();
-            default:
-                throw new IllegalArgumentException("no binder available for " + binderName);
-        }
+    /* testing */ protected MeterBinder getBinder(String binderName) {
+        return switch (binderName) {
+            case "UptimeMetrics" -> new UptimeMetrics();
+            case "ProcessorMetrics" -> new ProcessorMetrics();
+            case "FileDescriptorMetrics" -> new FileDescriptorMetrics();
+            case "ClassLoaderMetrics" -> new ClassLoaderMetrics();
+            case "JvmCompilationMetrics" -> new JvmCompilationMetrics();
+            case "JvmGcMetrics" -> new JvmGcMetrics();
+            case "JvmHeapPressureMetrics" -> new JvmHeapPressureMetrics();
+            case "JvmInfoMetrics" -> new JvmInfoMetrics();
+            case "JvmMemoryMetrics" -> new JvmMemoryMetrics();
+            case "JvmThreadMetrics" -> new JvmThreadMetrics();
+            default -> throw new IllegalArgumentException("no binder available for " + binderName);
+        };
     }
 }

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/micrometer/StandardBindersHookTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/micrometer/StandardBindersHookTest.java
@@ -25,29 +25,33 @@ class StandardBindersHookTest {
 
     @Test
     public void testNullBinderNames() {
-        StandardBindersHook hook = new StandardBindersHook(new StandardBindersHook.StandardBindersHookConfig(null));
-        MeterRegistry registry = whenRegistryConfiguredWith(hook);
-        thenNoMetersRegistered(registry);
+        try (StandardBindersHook hook = new StandardBindersHook(new StandardBindersHook.StandardBindersHookConfig(null))) {
+            MeterRegistry registry = whenRegistryConfiguredWith(hook);
+            thenNoMetersRegistered(registry);
+        }
     }
 
     @Test
     public void testEmptyBinderNames() {
-        StandardBindersHook hook = new StandardBindersHook(new StandardBindersHook.StandardBindersHookConfig(List.of()));
-        MeterRegistry registry = whenRegistryConfiguredWith(hook);
-        thenNoMetersRegistered(registry);
+        try (StandardBindersHook hook = new StandardBindersHook(new StandardBindersHook.StandardBindersHookConfig(List.of()))) {
+            MeterRegistry registry = whenRegistryConfiguredWith(hook);
+            thenNoMetersRegistered(registry);
+        }
     }
 
     @Test
     public void testKnownBinder() {
-        StandardBindersHook hook = new StandardBindersHook(new StandardBindersHook.StandardBindersHookConfig(List.of("UptimeMetrics")));
-        MeterRegistry registry = whenRegistryConfiguredWith(hook);
-        thenUptimeMeterRegistered(registry);
+        try (StandardBindersHook hook = new StandardBindersHook(new StandardBindersHook.StandardBindersHookConfig(List.of("UptimeMetrics")))) {
+            MeterRegistry registry = whenRegistryConfiguredWith(hook);
+            thenUptimeMeterRegistered(registry);
+        }
     }
 
     @Test
     public void testUnknownBinder() {
-        StandardBindersHook hook = new StandardBindersHook(new StandardBindersHook.StandardBindersHookConfig(List.of("SadClown")));
-        assertThatThrownBy(() -> whenRegistryConfiguredWith(hook)).isInstanceOf(IllegalArgumentException.class);
+        try (StandardBindersHook hook = new StandardBindersHook(new StandardBindersHook.StandardBindersHookConfig(List.of("SadClown")))) {
+            assertThatThrownBy(() -> whenRegistryConfiguredWith(hook)).isInstanceOf(IllegalArgumentException.class);
+        }
     }
 
     private static void thenUptimeMeterRegistered(MeterRegistry registry) {


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Bugfix

### Description

Trying to prevent the stack trace originating from the JMX notifications during integration test runs.
The issue is not causing test failures, but the noise is polluting the logs.

### Additional Context

Build hygiene.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [x] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [x] Reference relevant issue(s) and close them after merging
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
