### PR TITLE
Ensure Metric Registry is clean before/after each MetricIT test

### DIFF
--- a/integrationtests/src/test/java/io/kroxylicious/proxy/MetricsIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/MetricsIT.java
@@ -12,6 +12,9 @@ import java.util.Map;
 import java.util.Random;
 import java.util.regex.Pattern;
 
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -30,6 +33,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(KafkaClusterExtension.class)
 public class MetricsIT {
+
+    @BeforeEach
+    public void beforeEach() {
+        Assertions.assertThat(Metrics.globalRegistry.getMeters()).isEmpty();
+    }
+
+    @AfterEach
+    public void afterEach() throws Exception {
+        Assertions.assertThat(Metrics.globalRegistry.getMeters()).isEmpty();
+    }
 
     @Test
     public void shouldOfferPrometheusMetricsScrapeEndpoint(KafkaCluster cluster) {


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

I had intended this change to be part of #465.
Ensure Metric Registry is clean before/after each MetricIT test.
Why: we want to know if kroxylicious is leaving behind metrics unintentionally.

_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
