### PR TITLE
Enable async forwarding

### DIFF
--- a/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
 import io.kroxylicious.proxy.filter.CreateTopicRejectFilter;
@@ -270,6 +272,29 @@ public class KrpcFilterIT {
             assertEquals(List.of(PLAINTEXT, PLAINTEXT),
                     List.of(records1.iterator().next().value(),
                             records2.iterator().next().value()));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "RequestForwardDelaying", "ResponseForwardDelaying" })
+    public void supportsRequestResponseForwardAsynchronicity(String delayType, KafkaCluster cluster) throws Exception {
+
+        var config = proxy(cluster).addToFilters(new FilterDefinitionBuilder(delayType).build());
+
+        try (var tester = kroxyliciousTester(config);
+                var admin = tester.admin();
+                var producer = tester.producer(Map.of(CLIENT_ID_CONFIG, "supportsRequestResponseForwardAsynchronicity", DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000));
+                var consumer = tester.consumer()) {
+
+            admin.createTopics(List.of(
+                    new NewTopic(TOPIC_1, 1, (short) 1))).all().get(10, TimeUnit.SECONDS);
+
+            producer.send(new ProducerRecord<>(TOPIC_1, "my-key", "Hello, world!")).get(10, TimeUnit.SECONDS);
+            consumer.subscribe(Set.of(TOPIC_1));
+            var records = consumer.poll(Duration.ofSeconds(10));
+            consumer.close();
+            assertEquals(1, records.count());
+            assertEquals("Hello, world!", records.iterator().next().value());
         }
     }
 

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RequestForwardDelayingFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RequestForwardDelayingFilter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+public class RequestForwardDelayingFilter implements RequestFilter {
+    @Override
+    public void onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+
+        try (var executor = Executors.newScheduledThreadPool(1)) {
+            var delay = (long) (Math.random() * 200);
+            executor.schedule(() -> {
+                filterContext.forwardRequest(header, body);
+            }, delay, TimeUnit.MILLISECONDS);
+        }
+    }
+}

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/ResponseForwardDelayingFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/ResponseForwardDelayingFilter.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+public class ResponseForwardDelayingFilter implements ResponseFilter {
+
+    @Override
+    public void onResponse(ApiKeys apiKey, ResponseHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+        try (var executor = Executors.newScheduledThreadPool(1)) {
+            var delay = (long) (Math.random() * 200);
+            executor.schedule(() -> {
+                filterContext.forwardResponse(header, body);
+            }, delay, TimeUnit.MILLISECONDS);
+        }
+
+    }
+}

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
@@ -14,6 +14,8 @@ public class TestFilterContributor extends BaseContributor<KrpcFilter> implement
             .add("FixedClientId", FixedClientIdFilter.FixedClientIdFilterConfig.class, FixedClientIdFilter::new)
             .add("RequestResponseMarking", RequestResponseMarkingFilter.RequestResponseMarkingFilterConfig.class, RequestResponseMarkingFilter::new)
             .add("OutOfBandSend", OutOfBandSendFilter.OutOfBandSendFilterConfig.class, OutOfBandSendFilter::new)
+            .add("RequestForwardDelaying", RequestForwardDelayingFilter::new)
+            .add("ResponseForwardDelaying", ResponseForwardDelayingFilter::new)
             .add("CompositePrefixingFixedClientId", CompositePrefixingFixedClientIdFilterConfig.class, CompositePrefixingFixedClientIdFilter::new)
             .add("CreateTopicRejectFilter", CreateTopicRejectFilter::new);
 

--- a/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilter.java
+++ b/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilter.java
@@ -178,14 +178,12 @@ public class MultiTenantTransformationFilter
         applyTenantPrefix(context, request::transactionalId, request::setTransactionalId, true);
         request.topicData().forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, false));
         context.forwardRequest(header, request);
-
     }
 
     @Override
     public void onProduceResponse(short apiVersion, ResponseHeaderData header, ProduceResponseData response, KrpcFilterContext context) {
         response.responses().forEach(topic -> removeTenantPrefix(context, topic::name, topic::setName, false));
         context.forwardResponse(header, response);
-
     }
 
     @Override

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/KrpcFilterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/KrpcFilterContext.java
@@ -64,11 +64,12 @@ public interface KrpcFilterContext {
      * <p>If this is invoked while the message is flowing downstream towards the broker, then
      * it will not be sent to the broker. So this method can be used to generate responses in
      * the proxy.</p>
-     * @param header The header to forward to the client.
+     *
+     * @param header   The header to forward to the client.
      * @param response The response to forward to the client.
      * @throws AssertionError if response is logically inconsistent, for example responding with request data
-     * or responding with a produce response to a fetch request. It is up to specific implementations to
-     * determine what logically inconsistent means.
+     *                        or responding with a produce response to a fetch request. It is up to specific implementations to
+     *                        determine what logically inconsistent means.
      */
     void forwardResponse(ResponseHeaderData header, ApiMessage response);
 
@@ -90,5 +91,8 @@ public interface KrpcFilterContext {
      */
     void closeConnection();
 
+    void discard();
+
     // TODO an API to allow a filter to add/remove another filter from the pipeline
+
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilter.java
@@ -101,9 +101,9 @@ public class BrokerAddressFilter implements MetadataResponseFilter, FindCoordina
 
     private void doReconcileThenForwardResponse(ResponseHeaderData header, ApiMessage data, KrpcFilterContext context, Map<Integer, HostPort> nodeMap) {
         // https://github.com/kroxylicious/kroxylicious/issues/351
-        // Using synchronous approach for now
-        reconciler.reconcile(virtualCluster, nodeMap).toCompletableFuture().join();
-        context.forwardResponse(header, data);
-        LOGGER.debug("Endpoint reconciliation complete for  virtual cluster {}", virtualCluster);
+        reconciler.reconcile(virtualCluster, nodeMap).toCompletableFuture().thenAccept(unused -> {
+            context.forwardResponse(header, data);
+            LOGGER.debug("Endpoint reconciliation complete for  virtual cluster {}", virtualCluster);
+        });
     }
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FetchResponseTransformationFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FetchResponseTransformationFilter.java
@@ -96,6 +96,7 @@ public class FetchResponseTransformationFilter implements FetchResponseFilter {
                         LOGGER.debug("Forwarding original Fetch response");
                         context.forwardResponse(header, fetchResponse);
                     });
+            context.discard();
         }
         else {
             applyTransformation(context, fetchResponse);

--- a/performance-tests/src/main/java/io/kroxylicious/benchmarks/InvokerDispatchBenchmark.java
+++ b/performance-tests/src/main/java/io/kroxylicious/benchmarks/InvokerDispatchBenchmark.java
@@ -191,7 +191,10 @@ public class InvokerDispatchBenchmark {
 
         @Override
         public void closeConnection() {
+        }
 
+        @Override
+        public void discard() {
         }
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Implicitly allow `forwardRequest` and `forwardResponse` to be called asynchronously from a thread other than the netty event loop. If a Filter calls one of these methods then it is implied that kroxylicious can continue handling the next message flowing in that direction. So if I am intercepting a request and hand-off some work to another thread, then call `forwardRequest` later, further requests would not be handled by that filter until `forwardRequest` is called.

Adds `discard` to FilterContext to support some odd usages where we do not want to forward.

Note that this controls the flow of events through each Filter instance but does not prevent the Channel from reading more data from the client or proxied broker.

Why:
Currently if we try to do work in threads other than the netty IO thread then the event loop is free to continue piping messages around and the result is we can end up sending messages to the client in an unexpected order. The client expects responses in the order it sent them.

With this change the FilterHandler is responsible for queueing up read and write jobs so that the next read/write is not called until the previous read/write has completed. The read/write are marked complete after the DefaultFilterContext has finished interacting with the channel context and CompletableFutures are used to drive the next lot of work.

Note that there is some ambiguity around sendRequest, if the user is free to send numerous out of band requests and then forward a message on (or optionally not forward), how do we know when the Filter has finished doing work and we are ready to work on the next message?

To solve the case where we only want to send a new out of band request and forward nothing, we add a discard() method to the context to say we are done with the initial message.

What remains unsolved is supporting asynchronous work in the CompletionStage of the sendRequest, we should also support async work there but currently we don't have a good way to detect if the response has finished being handled. Maybe we also need to supply a KrpcFilterContext to that CompletionStage.

Resolves #351
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
