### PR TITLE
Enable async forwarding - option 2

### DIFF
--- a/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
 import io.kroxylicious.proxy.filter.CreateTopicRejectFilter;
@@ -270,6 +272,29 @@ public class KrpcFilterIT {
             assertEquals(List.of(PLAINTEXT, PLAINTEXT),
                     List.of(records1.iterator().next().value(),
                             records2.iterator().next().value()));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "RequestForwardDelaying", "ResponseForwardDelaying" })
+    public void supportsRequestResponseForwardAsynchronicity(String delayType, KafkaCluster cluster) throws Exception {
+
+        var config = proxy(cluster).addToFilters(new FilterDefinitionBuilder(delayType).build());
+
+        try (var tester = kroxyliciousTester(config);
+                var admin = tester.admin();
+                var producer = tester.producer(Map.of(CLIENT_ID_CONFIG, "supportsRequestResponseForwardAsynchronicity", DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000));
+                var consumer = tester.consumer()) {
+
+            admin.createTopics(List.of(
+                    new NewTopic(TOPIC_1, 1, (short) 1))).all().get(10, TimeUnit.SECONDS);
+
+            producer.send(new ProducerRecord<>(TOPIC_1, "my-key", "Hello, world!")).get(10, TimeUnit.SECONDS);
+            consumer.subscribe(Set.of(TOPIC_1));
+            var records = consumer.poll(Duration.ofSeconds(10));
+            consumer.close();
+            assertEquals(1, records.count());
+            assertEquals("Hello, world!", records.iterator().next().value());
         }
     }
 

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/CreateTopicRejectFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/CreateTopicRejectFilter.java
@@ -30,7 +30,7 @@ public class CreateTopicRejectFilter implements CreateTopicsRequestFilter {
         context.forwardResponse(response);
     }
 
-    private static void allocateByteBufToTestKroxyliciousReleasesIt(KrpcFilterContext context) {
+    private static void allocateByteBufToTestKroxyliciousReleasesIt(BaseKrpcFilterContext context) {
         context.createByteBufferOutputStream(4000);
     }
 }

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RequestForwardDelayingFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RequestForwardDelayingFilter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+public class RequestForwardDelayingFilter implements RequestFilter {
+    @Override
+    public void onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+
+        try (var executor = Executors.newScheduledThreadPool(1)) {
+            var delay = (long) (Math.random() * 200);
+            executor.schedule(() -> {
+                filterContext.forwardRequest(header, body);
+            }, delay, TimeUnit.MILLISECONDS);
+        }
+    }
+}

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RequestForwardDelayingFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RequestForwardDelayingFilter.java
@@ -16,11 +16,11 @@ import org.apache.kafka.common.protocol.ApiMessage;
 public class RequestForwardDelayingFilter implements RequestFilter {
     @Override
     public void onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
-
+        RequestForwardingContext requestForwardingContext = filterContext.deferredForwardRequest();
         try (var executor = Executors.newScheduledThreadPool(1)) {
             var delay = (long) (Math.random() * 200);
             executor.schedule(() -> {
-                filterContext.forwardRequest(header, body);
+                requestForwardingContext.forwardRequest(header, body);
             }, delay, TimeUnit.MILLISECONDS);
         }
     }

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/ResponseForwardDelayingFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/ResponseForwardDelayingFilter.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+public class ResponseForwardDelayingFilter implements ResponseFilter {
+
+    @Override
+    public void onResponse(ApiKeys apiKey, ResponseHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+        try (var executor = Executors.newScheduledThreadPool(1)) {
+            var delay = (long) (Math.random() * 200);
+            executor.schedule(() -> {
+                filterContext.forwardResponse(header, body);
+            }, delay, TimeUnit.MILLISECONDS);
+        }
+
+    }
+}

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/ResponseForwardDelayingFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/ResponseForwardDelayingFilter.java
@@ -17,10 +17,11 @@ public class ResponseForwardDelayingFilter implements ResponseFilter {
 
     @Override
     public void onResponse(ApiKeys apiKey, ResponseHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+        ResponseForwardingContext forwardingContext = filterContext.deferredForwardResponse();
         try (var executor = Executors.newScheduledThreadPool(1)) {
             var delay = (long) (Math.random() * 200);
             executor.schedule(() -> {
-                filterContext.forwardResponse(header, body);
+                forwardingContext.forwardResponse(header, body);
             }, delay, TimeUnit.MILLISECONDS);
         }
 

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
@@ -14,6 +14,8 @@ public class TestFilterContributor extends BaseContributor<KrpcFilter> implement
             .add("FixedClientId", FixedClientIdFilter.FixedClientIdFilterConfig.class, FixedClientIdFilter::new)
             .add("RequestResponseMarking", RequestResponseMarkingFilter.RequestResponseMarkingFilterConfig.class, RequestResponseMarkingFilter::new)
             .add("OutOfBandSend", OutOfBandSendFilter.OutOfBandSendFilterConfig.class, OutOfBandSendFilter::new)
+            .add("RequestForwardDelaying", RequestForwardDelayingFilter::new)
+            .add("ResponseForwardDelaying", ResponseForwardDelayingFilter::new)
             .add("CompositePrefixingFixedClientId", CompositePrefixingFixedClientIdFilterConfig.class, CompositePrefixingFixedClientIdFilter::new)
             .add("CreateTopicRejectFilter", CreateTopicRejectFilter::new);
 

--- a/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilter.java
+++ b/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilter.java
@@ -56,6 +56,7 @@ import org.slf4j.LoggerFactory;
 import io.kroxylicious.proxy.filter.AddOffsetsToTxnRequestFilter;
 import io.kroxylicious.proxy.filter.AddPartitionsToTxnRequestFilter;
 import io.kroxylicious.proxy.filter.AddPartitionsToTxnResponseFilter;
+import io.kroxylicious.proxy.filter.BaseKrpcFilterContext;
 import io.kroxylicious.proxy.filter.CreateTopicsRequestFilter;
 import io.kroxylicious.proxy.filter.CreateTopicsResponseFilter;
 import io.kroxylicious.proxy.filter.DeleteTopicsRequestFilter;
@@ -418,7 +419,7 @@ public class MultiTenantTransformationFilter
         context.forwardRequest(header, request);
     }
 
-    private void applyTenantPrefix(KrpcFilterContext context, Supplier<String> getter, Consumer<String> setter, boolean ignoreEmpty) {
+    private void applyTenantPrefix(BaseKrpcFilterContext context, Supplier<String> getter, Consumer<String> setter, boolean ignoreEmpty) {
         String clientSideName = getter.get();
         if (ignoreEmpty && (clientSideName == null || clientSideName.isEmpty())) {
             return;
@@ -426,12 +427,12 @@ public class MultiTenantTransformationFilter
         setter.accept(applyTenantPrefix(context, clientSideName));
     }
 
-    private String applyTenantPrefix(KrpcFilterContext context, String clientSideName) {
+    private String applyTenantPrefix(BaseKrpcFilterContext context, String clientSideName) {
         var tenantPrefix = getTenantPrefix(context);
         return tenantPrefix + clientSideName;
     }
 
-    private void removeTenantPrefix(KrpcFilterContext context, Supplier<String> getter, Consumer<String> setter, boolean ignoreEmpty) {
+    private void removeTenantPrefix(BaseKrpcFilterContext context, Supplier<String> getter, Consumer<String> setter, boolean ignoreEmpty) {
         var brokerSideName = getter.get();
         if (ignoreEmpty && (brokerSideName == null || brokerSideName.isEmpty())) {
             return;
@@ -440,12 +441,12 @@ public class MultiTenantTransformationFilter
         setter.accept(removeTenantPrefix(context, brokerSideName));
     }
 
-    private String removeTenantPrefix(KrpcFilterContext context, String brokerSideName) {
+    private String removeTenantPrefix(BaseKrpcFilterContext context, String brokerSideName) {
         var tenantPrefix = getTenantPrefix(context);
         return brokerSideName.substring(tenantPrefix.length());
     }
 
-    private static String getTenantPrefix(KrpcFilterContext context) {
+    private static String getTenantPrefix(BaseKrpcFilterContext context) {
         // TODO naive - POC implementation uses the first component of a FQDN as the multi-tenant prefix.
         var sniHostname = context.sniHostname();
         if (sniHostname == null) {

--- a/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilter.java
+++ b/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilter.java
@@ -178,14 +178,12 @@ public class MultiTenantTransformationFilter
         applyTenantPrefix(context, request::transactionalId, request::setTransactionalId, true);
         request.topicData().forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, false));
         context.forwardRequest(header, request);
-
     }
 
     @Override
     public void onProduceResponse(short apiVersion, ResponseHeaderData header, ProduceResponseData response, KrpcFilterContext context) {
         response.responses().forEach(topic -> removeTenantPrefix(context, topic::name, topic::setName, false));
         context.forwardResponse(header, response);
-
     }
 
     @Override

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/BaseKrpcFilterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/BaseKrpcFilterContext.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.utils.ByteBufferOutputStream;
+
+public interface BaseKrpcFilterContext {
+    /**
+     * A description of this channel.
+     * @return A description of this channel (typically used for logging).
+     */
+    String channelDescriptor();
+
+    /**
+     * Create a ByteBufferOutputStream of the given capacity.
+     * The backing buffer will be deallocated when the request processing is completed
+     * @param initialCapacity The initial capacity of the buffer.
+     * @return The allocated ByteBufferOutputStream
+     */
+    ByteBufferOutputStream createByteBufferOutputStream(int initialCapacity);
+
+    /**
+     * The SNI hostname provided by the client, if any.
+     * @return the SNI hostname provided by the client.  Will be null if the client is
+     * using a non-TLS connection or the TLS client hello didn't provide one.
+     */
+    String sniHostname();
+
+    /**
+     * Allows a filter to decide to close the connection. The client will be disconnected.  The client is free
+     * to retry the connection.  The client will receive no indication why the connection was closed.
+     */
+    void closeConnection();
+
+    void discard();
+
+    /**
+     * Send a message from a filter towards the broker, invoking upstream filters
+     * and being informed of the response via TODO.
+     * The response will pass through upstream filters, invoking them, prior to the handler being invoked.
+     * Response propagation will stop once the handler has completed,
+     * i.e. the downstream filters will not receive the response.
+     *
+     * @param apiVersion The version of the request to use
+     * @param request The request to send.
+     * @param <T> The type of the response
+     * @return CompletionStage providing the response.
+     */
+    <T extends ApiMessage> CompletionStage<T> sendRequest(short apiVersion, ApiMessage request);
+
+    /**
+     * Send a message from a filter towards the broker, invoking upstream filters
+     * and being informed of the response via TODO.
+     * The response will pass through upstream filters, invoking them, prior to the handler being invoked.
+     * Response propagation will stop once the handler has completed,
+     * i.e. the downstream filters will not receive the response.
+     *
+     * @param apiVersion The version of the request to use
+     * @param request The request to send.
+     * @param <T> The type of the response
+     * @return CompletionStage providing the response.
+     */
+    <T extends ApiMessage> CompletionStage<ReplacementResponseContext<T>> replaceRequest(short apiVersion, ApiMessage request);
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/KrpcFilterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/KrpcFilterContext.java
@@ -5,94 +5,13 @@
  */
 package io.kroxylicious.proxy.filter;
 
-import java.util.concurrent.CompletionStage;
-
-import org.apache.kafka.common.message.RequestHeaderData;
-import org.apache.kafka.common.message.ResponseHeaderData;
-import org.apache.kafka.common.protocol.ApiMessage;
-import org.apache.kafka.common.utils.ByteBufferOutputStream;
-
 /**
  * A context to allow filters to interact with other filters and the pipeline.
  */
-public interface KrpcFilterContext {
-    /**
-     * A description of this channel.
-     * @return A description of this channel (typically used for logging).
-     */
-    String channelDescriptor();
+public interface KrpcFilterContext extends BaseKrpcFilterContext, RequestForwardingContext, ResponseForwardingContext {
 
-    /**
-     * Create a ByteBufferOutputStream of the given capacity.
-     * The backing buffer will be deallocated when the request processing is completed
-     * @param initialCapacity The initial capacity of the buffer.
-     * @return The allocated ByteBufferOutputStream
-     */
-    ByteBufferOutputStream createByteBufferOutputStream(int initialCapacity);
+    RequestForwardingContext deferredForwardRequest();
 
-    /**
-     * The SNI hostname provided by the client, if any.
-     * @return the SNI hostname provided by the client.  Will be null if the client is
-     * using a non-TLS connection or the TLS client hello didn't provide one.
-     */
-    String sniHostname();
-
-    /**
-     * Send a request towards the broker, invoking upstream filters.
-     *
-     * @param header The header to forward to the broker.
-     * @param request The request to forward to the broker.
-     */
-    void forwardRequest(RequestHeaderData header, ApiMessage request);
-
-    /**
-     * Send a message from a filter towards the broker, invoking upstream filters
-     * and being informed of the response via TODO.
-     * The response will pass through upstream filters, invoking them, prior to the handler being invoked.
-     * Response propagation will stop once the handler has completed,
-     * i.e. the downstream filters will not receive the response.
-     *
-     * @param apiVersion The version of the request to use
-     * @param request The request to send.
-     * @param <T> The type of the response
-     * @return CompletionStage providing the response.
-     */
-    <T extends ApiMessage> CompletionStage<T> sendRequest(short apiVersion, ApiMessage request);
-
-    /**
-     * Send a response towards the client, invoking downstream filters.
-     * <p>If this is invoked while the message is flowing downstream towards the broker, then
-     * it will not be sent to the broker. So this method can be used to generate responses in
-     * the proxy.</p>
-     *
-     * @param header   The header to forward to the client.
-     * @param response The response to forward to the client.
-     * @throws AssertionError if response is logically inconsistent, for example responding with request data
-     *                        or responding with a produce response to a fetch request. It is up to specific implementations to
-     *                        determine what logically inconsistent means.
-     */
-    void forwardResponse(ResponseHeaderData header, ApiMessage response);
-
-    /**
-     * Send a response towards the client, invoking downstream filters.
-     * <p>If this is invoked while the message is flowing downstream towards the broker, then
-     * it will not be sent to the broker. So this method can be used to generate responses in
-     * the proxy. In this case response headers will be created with a correlationId matching the request</p>
-     * @param response The response to forward to the client.
-     * @throws AssertionError if response is logically inconsistent, for example responding with request data
-     * or responding with a produce response to a fetch request. It is up to specific implementations to
-     * determine what logically inconsistent means.
-     */
-    void forwardResponse(ApiMessage response);
-
-    /**
-     * Allows a filter to decide to close the connection. The client will be disconnected.  The client is free
-     * to retry the connection.  The client will receive no indication why the connection was closed.
-     */
-    void closeConnection();
-
-    void discard();
-
-    // TODO an API to allow a filter to add/remove another filter from the pipeline
+    ResponseForwardingContext deferredForwardResponse();
 
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/KrpcFilterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/KrpcFilterContext.java
@@ -64,11 +64,12 @@ public interface KrpcFilterContext {
      * <p>If this is invoked while the message is flowing downstream towards the broker, then
      * it will not be sent to the broker. So this method can be used to generate responses in
      * the proxy.</p>
-     * @param header The header to forward to the client.
+     *
+     * @param header   The header to forward to the client.
      * @param response The response to forward to the client.
      * @throws AssertionError if response is logically inconsistent, for example responding with request data
-     * or responding with a produce response to a fetch request. It is up to specific implementations to
-     * determine what logically inconsistent means.
+     *                        or responding with a produce response to a fetch request. It is up to specific implementations to
+     *                        determine what logically inconsistent means.
      */
     void forwardResponse(ResponseHeaderData header, ApiMessage response);
 
@@ -90,5 +91,8 @@ public interface KrpcFilterContext {
      */
     void closeConnection();
 
+    void discard();
+
     // TODO an API to allow a filter to add/remove another filter from the pipeline
+
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/ReplacementResponseContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/ReplacementResponseContext.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import org.apache.kafka.common.protocol.ApiMessage;
+
+public interface ReplacementResponseContext<T extends ApiMessage> {
+
+    ResponseForwardingContext context();
+
+    T apiMessage();
+
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestForwardingContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestForwardingContext.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+public interface RequestForwardingContext extends BaseKrpcFilterContext {
+    /**
+     * Send a request towards the broker, invoking upstream filters.
+     *
+     * @param header The header to forward to the broker.
+     * @param request The request to forward to the broker.
+     */
+    void forwardRequest(RequestHeaderData header, ApiMessage request);
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/ResponseForwardingContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/ResponseForwardingContext.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+public interface ResponseForwardingContext extends BaseKrpcFilterContext {
+    /**
+     * Send a response towards the client, invoking downstream filters.
+     * <p>If this is invoked while the message is flowing downstream towards the broker, then
+     * it will not be sent to the broker. So this method can be used to generate responses in
+     * the proxy.</p>
+     *
+     * @param header   The header to forward to the client.
+     * @param response The response to forward to the client.
+     * @throws AssertionError if response is logically inconsistent, for example responding with request data
+     *                        or responding with a produce response to a fetch request. It is up to specific implementations to
+     *                        determine what logically inconsistent means.
+     */
+    void forwardResponse(ResponseHeaderData header, ApiMessage response);
+
+    /**
+     * Send a response towards the client, invoking downstream filters.
+     * <p>If this is invoked while the message is flowing downstream towards the broker, then
+     * it will not be sent to the broker. So this method can be used to generate responses in
+     * the proxy. In this case response headers will be created with a correlationId matching the request</p>
+     * @param response The response to forward to the client.
+     * @throws AssertionError if response is logically inconsistent, for example responding with request data
+     * or responding with a produce response to a fetch request. It is up to specific implementations to
+     * determine what logically inconsistent means.
+     */
+    void forwardResponse(ApiMessage response);
+}

--- a/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleFetchResponseFilter.java
+++ b/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleFetchResponseFilter.java
@@ -12,6 +12,7 @@ import org.apache.kafka.common.message.ResponseHeaderData;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
 
+import io.kroxylicious.proxy.filter.BaseKrpcFilterContext;
 import io.kroxylicious.proxy.filter.FetchResponseFilter;
 import io.kroxylicious.proxy.filter.KrpcFilterContext;
 import io.kroxylicious.sample.config.SampleFilterConfig;
@@ -64,7 +65,7 @@ public class SampleFetchResponseFilter implements FetchResponseFilter {
      * @param response the response to be transformed
      * @param context the context
      */
-    private void applyTransformation(FetchResponseData response, KrpcFilterContext context) {
+    private void applyTransformation(FetchResponseData response, BaseKrpcFilterContext context) {
         response.responses().forEach(responseData -> {
             for (FetchResponseData.PartitionData partitionData : responseData.partitions()) {
                 SampleFilterTransformer.transform(partitionData, context, this.config);

--- a/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleProduceRequestFilter.java
+++ b/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleProduceRequestFilter.java
@@ -13,6 +13,7 @@ import org.apache.kafka.common.message.RequestHeaderData;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
 
+import io.kroxylicious.proxy.filter.BaseKrpcFilterContext;
 import io.kroxylicious.proxy.filter.KrpcFilterContext;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
 import io.kroxylicious.sample.config.SampleFilterConfig;
@@ -65,7 +66,7 @@ public class SampleProduceRequestFilter implements ProduceRequestFilter {
      * @param request the request to be transformed
      * @param context the context
      */
-    private void applyTransformation(ProduceRequestData request, KrpcFilterContext context) {
+    private void applyTransformation(ProduceRequestData request, BaseKrpcFilterContext context) {
         request.topicData().forEach(topicData -> {
             for (PartitionProduceData partitionData : topicData.partitionData()) {
                 SampleFilterTransformer.transform(partitionData, context, this.config);

--- a/kroxylicious-sample/src/main/java/io/kroxylicious/sample/util/SampleFilterTransformer.java
+++ b/kroxylicious-sample/src/main/java/io/kroxylicious/sample/util/SampleFilterTransformer.java
@@ -20,7 +20,7 @@ import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.BaseKrpcFilterContext;
 import io.kroxylicious.sample.config.SampleFilterConfig;
 
 /**
@@ -35,7 +35,7 @@ public class SampleFilterTransformer {
      * @param context the context
      * @param config the transform configuration
      */
-    public static void transform(ProduceRequestData.PartitionProduceData partitionData, KrpcFilterContext context, SampleFilterConfig config) {
+    public static void transform(ProduceRequestData.PartitionProduceData partitionData, BaseKrpcFilterContext context, SampleFilterConfig config) {
         partitionData.setRecords(transformPartitionRecords((MemoryRecords) partitionData.records(), context, config.getFindValue(), config.getReplacementValue()));
     }
 
@@ -45,7 +45,7 @@ public class SampleFilterTransformer {
      * @param context the context
      * @param config the transform configuration
      */
-    public static void transform(FetchResponseData.PartitionData partitionData, KrpcFilterContext context, SampleFilterConfig config) {
+    public static void transform(FetchResponseData.PartitionData partitionData, BaseKrpcFilterContext context, SampleFilterConfig config) {
         partitionData.setRecords(transformPartitionRecords((MemoryRecords) partitionData.records(), context, config.getFindValue(), config.getReplacementValue()));
     }
 
@@ -57,7 +57,7 @@ public class SampleFilterTransformer {
      * @param replacementValue the replacement value
      * @return the transformed partition records
      */
-    private static MemoryRecords transformPartitionRecords(MemoryRecords records, KrpcFilterContext context, String findValue, String replacementValue) {
+    private static MemoryRecords transformPartitionRecords(MemoryRecords records, BaseKrpcFilterContext context, String findValue, String replacementValue) {
         ByteBufferOutputStream stream = context.createByteBufferOutputStream(records.sizeInBytes());
         MemoryRecordsBuilder newRecords = createMemoryRecordsBuilder(stream);
 

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/server/MockHandler.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/server/MockHandler.java
@@ -86,6 +86,8 @@ public class MockHandler extends ChannelInboundHandlerAdapter {
 
     /**
      * Set the response
+     *
+     * @param keys  apiKeys
      * @param response response
      */
     public void setMockResponseForApiKey(ApiKeys keys, ApiMessage response) {

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/DefaultFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/DefaultFilter.java
@@ -56,6 +56,10 @@ class DefaultFilter implements KrpcFilterContext {
         return state != State.INIITIAL;
     }
 
+    public boolean isDeferred() {
+        return state == State.DEFERRED_REQUEST || state == State.DEFERRED_RESPONSE;
+    }
+
     private enum State {
         INIITIAL,
         DEFERRED_REQUEST,

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -75,7 +75,7 @@ public class FilterHandler
             }
             invoker.onRequest(decodedFrame.apiKey(), decodedFrame.apiVersion(), decodedFrame.header(), decodedFrame.body(), filterContext);
             if (!filterContext.isClosedOrDeferred()) {
-                LOGGER.warn("{}: {} context for filter {} was not completed or deferred!",
+                LOGGER.warn("{}: {} write context for filter {} was not completed or deferred!",
                         ctx.channel(), decodedFrame.apiKey(), filterDescriptor());
                 throw new IllegalStateException("FilterContext was not completed or deferred");
             }
@@ -123,6 +123,11 @@ public class FilterHandler
                             ctx.channel(), decodedFrame.apiKey(), filterDescriptor(), msg);
                 }
                 invoker.onResponse(decodedFrame.apiKey(), decodedFrame.apiVersion(), decodedFrame.header(), decodedFrame.body(), filterContext);
+                if (!filterContext.isClosedOrDeferred()) {
+                    LOGGER.warn("{}: {} read context for filter {} was not completed or deferred!",
+                            ctx.channel(), decodedFrame.apiKey(), filterDescriptor());
+                    throw new IllegalStateException("FilterContext was not completed or deferred");
+                }
                 return filterContext.onClose();
             }
         }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -270,7 +270,7 @@ public class KafkaProxyFrontendHandler
         if (logFrames) {
             pipeline.addFirst("frameLogger", new LoggingHandler("io.kroxylicious.proxy.internal.UpstreamFrameLogger"));
         }
-        addFiltersToPipeline(filters, pipeline);
+        addFiltersToPipeline(filters, pipeline, inboundChannel);
         pipeline.addFirst("responseDecoder", new KafkaResponseDecoder(correlationManager));
         pipeline.addFirst("requestEncoder", new KafkaRequestEncoder(correlationManager));
         if (logNetwork) {
@@ -301,10 +301,10 @@ public class KafkaProxyFrontendHandler
         return b.connect(remoteHost, remotePort);
     }
 
-    private void addFiltersToPipeline(List<FilterAndInvoker> filters, ChannelPipeline pipeline) {
+    private void addFiltersToPipeline(List<FilterAndInvoker> filters, ChannelPipeline pipeline, Channel inboundChannel) {
         for (var filter : filters) {
             // TODO configurable timeout
-            pipeline.addFirst(filter.toString(), new FilterHandler(filter, 20000, sniHostname));
+            pipeline.addFirst(filter.toString(), new FilterHandler(filter, 20000, sniHostname, inboundChannel));
         }
     }
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilter.java
@@ -101,9 +101,9 @@ public class BrokerAddressFilter implements MetadataResponseFilter, FindCoordina
 
     private void doReconcileThenForwardResponse(ResponseHeaderData header, ApiMessage data, KrpcFilterContext context, Map<Integer, HostPort> nodeMap) {
         // https://github.com/kroxylicious/kroxylicious/issues/351
-        // Using synchronous approach for now
-        reconciler.reconcile(virtualCluster, nodeMap).toCompletableFuture().join();
-        context.forwardResponse(header, data);
-        LOGGER.debug("Endpoint reconciliation complete for  virtual cluster {}", virtualCluster);
+        reconciler.reconcile(virtualCluster, nodeMap).toCompletableFuture().thenAccept(unused -> {
+            context.forwardResponse(header, data);
+            LOGGER.debug("Endpoint reconciliation complete for  virtual cluster {}", virtualCluster);
+        });
     }
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FetchResponseTransformationFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FetchResponseTransformationFilter.java
@@ -96,6 +96,7 @@ public class FetchResponseTransformationFilter implements FetchResponseFilter {
                         LOGGER.debug("Forwarding original Fetch response");
                         context.forwardResponse(header, fetchResponse);
                     });
+            context.discard();
         }
         else {
             applyTransformation(context, fetchResponse);

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ProduceRequestTransformationFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ProduceRequestTransformationFilter.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.record.TimestampType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.filter.BaseKrpcFilterContext;
 import io.kroxylicious.proxy.filter.KrpcFilterContext;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
 import io.kroxylicious.proxy.internal.util.MemoryRecordsHelper;
@@ -77,7 +78,7 @@ public class ProduceRequestTransformationFilter implements ProduceRequestFilter 
         context.forwardRequest(header, data);
     }
 
-    private void applyTransformation(KrpcFilterContext ctx, ProduceRequestData req) {
+    private void applyTransformation(BaseKrpcFilterContext ctx, ProduceRequestData req) {
         req.topicData().forEach(topicData -> {
             for (PartitionProduceData partitionData : topicData.partitionData()) {
                 MemoryRecords records = (MemoryRecords) partitionData.records();

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHandlerTest.java
@@ -72,6 +72,7 @@ public class FilterHandlerTest extends FilterHarness {
     public void testDropRequest() {
         ApiVersionsRequestFilter filter = (apiVersion, header, request, context) -> {
             /* don't call forwardRequest => drop the request */
+            context.discard();
         };
         buildChannel(filter);
         var frame = writeRequest(new ApiVersionsRequestData());
@@ -150,6 +151,7 @@ public class FilterHandlerTest extends FilterHarness {
             assertNull(fut[0],
                     "Expected to only be called once");
             fut[0] = (InternalCompletionStage<ApiMessage>) context.sendRequest((short) 3, body);
+            context.discard();
         };
 
         buildChannel(filter);
@@ -195,6 +197,7 @@ public class FilterHandlerTest extends FilterHarness {
             assertNull(fut[0],
                     "Expected to only be called once");
             fut[0] = context.sendRequest((short) 3, body);
+            context.discard();
         };
 
         buildChannel(filter);
@@ -212,7 +215,7 @@ public class FilterHandlerTest extends FilterHarness {
 
     /**
      * Test the special case within {@link FilterHandler} for
-     * {@link io.kroxylicious.proxy.filter.KrpcFilterContext#sendRequest(short, ApiMessage)}
+     * {@link KrpcFilterContext#sendRequest(short, ApiMessage)}
      * with acks=0 Produce requests.
      */
     @Test
@@ -223,6 +226,7 @@ public class FilterHandlerTest extends FilterHarness {
             assertNull(fut[0],
                     "Expected to only be called once");
             fut[0] = context.sendRequest((short) 3, body);
+            context.discard();
         };
 
         buildChannel(filter);
@@ -252,6 +256,7 @@ public class FilterHandlerTest extends FilterHarness {
             assertNull(fut[0],
                     "Expected to only be called once");
             fut[0] = context.sendRequest((short) 3, body);
+            context.discard();
         };
 
         buildChannel(filter, 50L);

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHandlerTest.java
@@ -138,6 +138,7 @@ public class FilterHandlerTest extends FilterHarness {
     public void testDropResponse() {
         ApiVersionsResponseFilter filter = (apiVersion, header, response, context) -> {
             /* don't call forwardRequest => drop the request */
+            context.discard();
         };
         buildChannel(filter);
         var frame = writeResponse(new ApiVersionsResponseData());

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
@@ -50,7 +50,8 @@ public abstract class FilterHarness {
      */
     protected void buildChannel(KrpcFilter filter, long timeoutMs) {
         this.filter = filter;
-        filterHandler = new FilterHandler(getOnlyElement(FilterAndInvoker.build(filter)), timeoutMs, null);
+        EmbeddedChannel inbound = new EmbeddedChannel();
+        filterHandler = new FilterHandler(getOnlyElement(FilterAndInvoker.build(filter)), timeoutMs, null, inbound);
         channel = new EmbeddedChannel(filterHandler);
     }
 

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
@@ -17,6 +17,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
 import io.kroxylicious.proxy.filter.KrpcFilter;
+import io.kroxylicious.proxy.filter.KrpcFilterContext;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 
@@ -45,7 +46,7 @@ public abstract class FilterHarness {
      * Build a {@link #channel} containing a single {@link FilterHandler} for the given
      * {@code filter}.
      * @param filter The filter in the pipeline.
-     * @param timeoutMs The timeout for {@link io.kroxylicious.proxy.filter.KrpcFilterContext#sendRequest(short, ApiMessage)}.
+     * @param timeoutMs The timeout for {@link KrpcFilterContext#sendRequest(short, ApiMessage)}.
      */
     protected void buildChannel(KrpcFilter filter, long timeoutMs) {
         this.filter = filter;

--- a/performance-tests/src/main/java/io/kroxylicious/benchmarks/InvokerDispatchBenchmark.java
+++ b/performance-tests/src/main/java/io/kroxylicious/benchmarks/InvokerDispatchBenchmark.java
@@ -38,6 +38,9 @@ import io.kroxylicious.proxy.filter.FilterInvoker;
 import io.kroxylicious.proxy.filter.FilterInvokers;
 import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.ReplacementResponseContext;
+import io.kroxylicious.proxy.filter.RequestForwardingContext;
+import io.kroxylicious.proxy.filter.ResponseForwardingContext;
 import io.kroxylicious.proxy.filter.SpecificFilterInvoker;
 
 // try hard to make shouldHandleXYZ to observe different receivers concrete types, saving unrolling to bias a specific call-site to a specific concrete type
@@ -103,7 +106,7 @@ public class InvokerDispatchBenchmark {
                     new FetchRequestData());
             apiMessages = messages.entrySet().toArray(new Map.Entry[0]); // Avoids iterator.next showing up in the benchmarks
             requestHeaders = new RequestHeaderData();
-            filterContext = new StubFilterContext();
+            filterContext = new StubFilter();
             keys = messages.keySet().toArray(new ApiKeys[0]);
         }
     }
@@ -153,7 +156,7 @@ public class InvokerDispatchBenchmark {
         }
     }
 
-    private static class StubFilterContext implements KrpcFilterContext {
+    private static class StubFilter implements KrpcFilterContext {
         @Override
         public String channelDescriptor() {
             return null;
@@ -180,6 +183,11 @@ public class InvokerDispatchBenchmark {
         }
 
         @Override
+        public <T extends ApiMessage> CompletionStage<ReplacementResponseContext<T>> replaceRequest(short apiVersion, ApiMessage request) {
+            return null;
+        }
+
+        @Override
         public void forwardResponse(ResponseHeaderData header, ApiMessage response) {
 
         }
@@ -195,6 +203,16 @@ public class InvokerDispatchBenchmark {
 
         @Override
         public void discard() {
+        }
+
+        @Override
+        public RequestForwardingContext deferredForwardRequest() {
+            return null;
+        }
+
+        @Override
+        public ResponseForwardingContext deferredForwardResponse() {
+            return null;
         }
     }
 }

--- a/performance-tests/src/main/java/io/kroxylicious/benchmarks/InvokerDispatchBenchmark.java
+++ b/performance-tests/src/main/java/io/kroxylicious/benchmarks/InvokerDispatchBenchmark.java
@@ -191,7 +191,10 @@ public class InvokerDispatchBenchmark {
 
         @Override
         public void closeConnection() {
+        }
 
+        @Override
+        public void discard() {
         }
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Currently if we try to do work in threads other than the netty IO thread then the
event loop is free to continue piping messages around and the result is we can end
up sending messages to the client in an unexpected order. The client expects responses
in the order it sent them.
    
With this change the FilterHandler is responsible for queueing up read and write jobs
so that the next read/write is not called until the previous read/write has completed.
The read/write are marked complete after the DefaultFilterContext has finished interacting
with the channel context and CompletableFutures are used to drive the next lot of work.

In this implementation a user must explicitly decide while handling a request or response
to either take some immediate, terminal action (forwardRequest, forwardResponse,
closeConnection, discard) or defer the forwardRequest or defer the forwardResponse.
The FIlterHandler will check that the user has invoked one of these methods.

One problematic area was `sendRequest`, some usages in code wanted to forwardResponse
from the CompletionStage. But deferring blocks the filter from processing more requests. So
I've added a `replaceRequest` method that receives a ResponseForwardingContext in it's
completion stage. After `replaceRequest` has completed then the context future completes and
so the Filter is not blocked from doing more work. We can't do this from sendRequest as the
user should be enabled to send multiple out of band requests, plus forward on the initial request.

### Enabled Patterns

1. Do some asynchronous work while handling a request:
```java
    @Override
    public void onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
        RequestForwardingContext requestForwardingContext = filterContext.deferredForwardRequest();
        CompletableFuture.runAsync(() -> {
            requestForwardingContext.forwardRequest(header, body);
        });
    }
```

2. Do some asynchronous work while handling a response:
```java
    @Override
    public void onResponse(ApiKeys apiKey, ResponseHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
        ResponseForwardingContext responseForwardingContext = filterContext.deferredForwardResponse();
        CompletableFuture.runAsync(() -> {
            responseForwardingContext.forwardResponse(header, body);
        });
    }
```

3. Replace this request with another request (possible different API call) and forward a response to the client
```java
    @Override
    public void onMetadataRequest(short apiVersion, RequestHeaderData header, MetadataRequestData request, KrpcFilterContext context) {
        context.<MetadataResponseData> replaceRequest(ApiKeys.METADATA.latestVersion(), new MetadataRequestData())
                .thenAccept(responseContext -> {
                    responseContext.context().forwardResponse(responseContext.apiMessage());
                });
    }
```

4. Close connection after other terminal action
```java
    @Override
    public void onMetadataRequest(short apiVersion, RequestHeaderData header, MetadataRequestData request, KrpcFilterContext context) {
        ResponseForwardingContext responseForwardingContext = filterContext.deferredForwardResponse();
        CompletableFuture.runAsync(() -> {
            responseForwardingContext.forwardResponse(header, body); // completes context future driving enqueued work
            responseForwardingContext.close(); // close still succeeds
        });
    }
```

### Unsupported Patterns

1. immediate forward and delayed forward
```java
    @Override
    public void onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
        RequestForwardingContext requestForwardingContext = filterContext.deferredForwardRequest();
        CompletableFuture.runAsync(() -> {
            requestForwardingContext.forwardRequest(header, body);
        });
        filterContext.forwardRequest(header, body); // throws because we've already called deferredForwardRequest
    }
```

2. deferredResponse during request
```java
    @Override
    public void onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
        ResponseForwardingContext responseForwardingContext = filterContext.deferredForwardResponse(); // throws and terminates context
    }
```

3. deferredRequest during response
```java
        @Override
    public void onResponse(ApiKeys apiKey, ResponseHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
          RequestForwardingContext requestForwardingContext = filterContext.deferredForwardRequest(); // throws and terminates context
    }
```

4. doing nothing during response
```java
        @Override
    public void onResponse(ApiKeys apiKey, ResponseHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
         // do no work, throws exception in FilterHandler because Filter must terminate or defer
    }
```

5. multiple forwards
```java
    @Override
    public void onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
        filterContext.forwardRequest(header, body);
        filterContext.forwardRequest(header, body); // throws
    }
```
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
