### PR TITLE
Support configuring multiple responses in MockServer

### DIFF
--- a/integrationtests/src/test/java/io/kroxylicious/proxy/ApiVersionsIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/ApiVersionsIT.java
@@ -84,7 +84,7 @@ public class ApiVersionsIT {
             ApiVersionsResponseData.ApiVersion version = new ApiVersionsResponseData.ApiVersion();
             version.setApiKey((short) 9999).setMinVersion((short) 3).setMaxVersion((short) 4);
             mockResponse.apiKeys().add(version);
-            tester.setMockResponse(new Response(ApiKeys.API_VERSIONS, (short) 3, mockResponse));
+            tester.addMockResponseForApiKey(new Response(ApiKeys.API_VERSIONS, (short) 3, mockResponse));
             Response response = whenGetApiVersionsFromKroxylicious(client);
             assertEquals(ApiKeys.API_VERSIONS, response.apiKeys());
             assertEquals((short) 3, response.apiVersion());
@@ -102,7 +102,7 @@ public class ApiVersionsIT {
         ApiVersionsResponseData.ApiVersion version = new ApiVersionsResponseData.ApiVersion();
         version.setApiKey(keys.id).setMinVersion(minVersion).setMaxVersion(maxVersion);
         mockResponse.apiKeys().add(version);
-        tester.setMockResponse(new Response(ApiKeys.API_VERSIONS, (short) 3, mockResponse));
+        tester.addMockResponseForApiKey(new Response(ApiKeys.API_VERSIONS, (short) 3, mockResponse));
     }
 
     private static Response whenGetApiVersionsFromKroxylicious(KafkaClient client) {

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
@@ -199,9 +199,9 @@ public class KrpcFilterIT {
                 .addToFilters(new FilterDefinitionBuilder("CompositePrefixingFixedClientId")
                         .withConfig("clientId", "banana", "prefix", "123").build()));
                 var singleRequestClient = tester.singleRequestClient()) {
-            tester.setMockResponse(new Response(METADATA, METADATA.latestVersion(), new MetadataResponseData()));
+            tester.addMockResponseForApiKey(new Response(METADATA, METADATA.latestVersion(), new MetadataResponseData()));
             singleRequestClient.getSync(new Request(METADATA, METADATA.latestVersion(), "client", new MetadataRequestData()));
-            assertEquals("123banana", tester.onlyRequest().clientIdHeader());
+            assertEquals("123banana", tester.getOnlyRequest().clientIdHeader());
         }
     }
 

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/ProxyRpcTest.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/ProxyRpcTest.java
@@ -72,10 +72,10 @@ public class ProxyRpcTest {
     @MethodSource("scenarios")
     @ParameterizedTest
     public void testKroxyliciousCanDecodeManipulateAndProxyRPC(Scenario scenario) {
-        mockTester.setMockResponse(scenario.givenMockResponse());
+        mockTester.addMockResponseForApiKey(scenario.givenMockResponse());
         try (KafkaClient kafkaClient = mockTester.singleRequestClient()) {
             Response response = kafkaClient.getSync(scenario.whenSendRequest());
-            assertEquals(scenario.thenMockReceivesRequest(), mockTester.onlyRequest(), "unexpected request received at mock for scenario: " + scenario.name());
+            assertEquals(scenario.thenMockReceivesRequest(), mockTester.getOnlyRequest(), "unexpected request received at mock for scenario: " + scenario.name());
             assertEquals(scenario.thenResponseReceived(), response, "unexpected response received from kroxylicious for scenario: " + scenario.name());
         }
     }

--- a/kroxylicious-test-tools/pom.xml
+++ b/kroxylicious-test-tools/pom.xml
@@ -82,6 +82,10 @@
             <groupId>io.sundr</groupId>
             <artifactId>builder-annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+        </dependency>
 
         <!-- third party dependencies - test -->
         <dependency>

--- a/kroxylicious-test-tools/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
+++ b/kroxylicious-test-tools/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
@@ -193,7 +193,7 @@ public class KroxyliciousTestersTest {
         DescribeAclsResponseData data = new DescribeAclsResponseData();
         data.setErrorMessage("helllo");
         data.setErrorCode(Errors.UNKNOWN_SERVER_ERROR.code());
-        tester.setMockResponse(new Response(ApiKeys.DESCRIBE_ACLS, ApiKeys.DESCRIBE_ACLS.latestVersion(), data));
+        tester.addMockResponseForApiKey(new Response(ApiKeys.DESCRIBE_ACLS, ApiKeys.DESCRIBE_ACLS.latestVersion(), data));
         Response response = kafkaClient
                 .getSync(new Request(ApiKeys.DESCRIBE_ACLS, ApiKeys.DESCRIBE_ACLS.latestVersion(), "client", new DescribeAclsRequestData()));
         assertInstanceOf(DescribeAclsResponseData.class, response.message());

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <zjsonpatch.version>0.4.14</zjsonpatch.version>
         <sundr-builder-annotations.version>0.100.1</sundr-builder-annotations.version>
         <findbugs.annotations.version>3.0.1u2</findbugs.annotations.version>
+        <hamcrest.version>2.2</hamcrest.version>
     </properties>
 
     <name>Kroxylicious Parent</name>
@@ -228,6 +229,11 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
                 <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest</artifactId>
+                <version>${hamcrest.version}</version>
             </dependency>
 
             <!-- third party dependencies - test -->


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Why:
The OutOfBandRequestIT used an unsupported pattern to forward a response from within a sendRequest callback using a reference to the request context. By enabling the mocks server to have a separate response configured per api key we can use a supported pattern, storing the result of the send request in a member field to be augmented into a response later.

Resoves #460

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
