### PR TITLE
Only check that the failed topic creation topic has not been created

### DIFF
--- a/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
@@ -159,7 +159,7 @@ public class KrpcFilterIT {
 
             // check no topic created on the cluster
             Set<String> names = admin.listTopics().names().get(10, TimeUnit.SECONDS);
-            assertThat(names).isEmpty();
+            assertThat(names).doesNotContain(TOPIC_1);
         }
     }
 
@@ -181,7 +181,7 @@ public class KrpcFilterIT {
 
             // check no topic created on the cluster
             Set<String> names = admin.listTopics().names().get(10, TimeUnit.SECONDS);
-            assertThat(names).isEmpty();
+            assertThat(names).doesNotContain(TOPIC_1);
         }
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Why:
The kafka extension temporarily creates a topic as a consistency check. It deletes the topic but because the deletion is async the topic can be visible to our test unexpectedly. In this test we only really care that the topic we attempted to create has not been created.

Closes #459

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
