### PR TITLE
Do not expose unknown APIs to the client

### DIFF
--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ApiVersionsFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ApiVersionsFilter.java
@@ -5,6 +5,9 @@
  */
 package io.kroxylicious.proxy.internal.filter;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -23,13 +26,18 @@ public class ApiVersionsFilter implements ApiVersionsResponseFilter {
     private static final Logger LOGGER = LoggerFactory.getLogger(ApiVersionsFilter.class);
 
     private static void intersectApiVersions(String channel, ApiVersionsResponseData resp) {
+        Set<ApiVersionsResponseData.ApiVersion> unknownApis = new HashSet<>();
         for (var key : resp.apiKeys()) {
             short apiId = key.apiKey();
             if (ApiKeys.hasId(apiId)) {
                 ApiKeys apiKey = ApiKeys.forId(apiId);
                 intersectApiVersion(channel, key, apiKey);
             }
+            else {
+                unknownApis.add(key);
+            }
         }
+        resp.apiKeys().removeAll(unknownApis);
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

If we encounter unknown ApiKeys when intercepting the broker ApiVersionsResponse, we drop them so they are not exposed to clients.

Why:
If the broker is ahead of Kroxylicious and is offering a new RPC, but Kroxylicious does not know how to handle it we do not want to tell the client that we support that RPC. If the client sent that RPC to us we would fail to decode the request with an exception. So we remove unknown ApiKeys from the ApiVersionsResponse when intersecting with Kroxylicious's supported versions.

Resolves #444

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
