### PR TITLE
New base classes for integration test utility methods

### DIFF
--- a/integrationtests/src/test/java/io/kroxylicious/proxy/BaseIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/BaseIT.java
@@ -6,8 +6,6 @@
 
 package io.kroxylicious.proxy;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,8 +33,7 @@ public abstract class BaseIT {
 
     protected CreateTopicsResult createTopics(Admin admin, NewTopic... topics) {
         try {
-            List<NewTopic> topicsList = new ArrayList<>();
-            Collections.addAll(topicsList, topics);
+            List<NewTopic> topicsList = List.of(topics);
             var created = admin.createTopics(topicsList);
             assertThat(created.values()).hasSizeGreaterThanOrEqualTo(topicsList.size());
             created.all().get(10, TimeUnit.SECONDS);

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/BaseIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/BaseIT.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.DeleteTopicsResult;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.TopicCollection;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.kroxylicious.test.tester.KroxyliciousTester;
+import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(KafkaClusterExtension.class)
+public abstract class BaseIT {
+
+    protected static CreateTopicsResult createTopics(Admin admin, List<NewTopic> topics) {
+        try {
+            var created = admin.createTopics(topics);
+            assertEquals(topics.size(), created.values().size());
+            created.all().get(10, TimeUnit.SECONDS);
+            return created;
+        }
+        catch (ExecutionException e) {
+            throw new RuntimeException(e.getCause());
+        }
+        catch (InterruptedException | TimeoutException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected static DeleteTopicsResult deleteTopics(Admin admin, TopicCollection topics) {
+        try {
+            var deleted = admin.deleteTopics(topics);
+            deleted.all().get(10, TimeUnit.SECONDS);
+            return deleted;
+        }
+        catch (ExecutionException e) {
+            throw new RuntimeException(e.getCause());
+        }
+        catch (InterruptedException | TimeoutException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected static Map<String, Object> buildClientConfig(Map<String, Object>... configs) {
+        Map<String, Object> clientConfig = new HashMap<>();
+        for (var config : configs) {
+            clientConfig.putAll(config);
+        }
+        return clientConfig;
+    }
+
+    protected static Consumer<String, String> getConsumerWithConfig(KroxyliciousTester tester, Optional<String> virtualCluster, Map<String, Object>... configs) {
+        var consumerConfig = buildClientConfig(configs);
+        if (virtualCluster.isPresent()) {
+            return tester.consumer(virtualCluster.get(), consumerConfig);
+        }
+        return tester.consumer(consumerConfig);
+    }
+
+    protected static Producer<String, String> getProducerWithConfig(KroxyliciousTester tester, Optional<String> virtualCluster, Map<String, Object>... configs) {
+        var producerConfig = buildClientConfig(configs);
+        if (virtualCluster.isPresent()) {
+            return tester.producer(virtualCluster.get(), producerConfig);
+        }
+        return tester.producer(producerConfig);
+    }
+}

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/ExpositionIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/ExpositionIT.java
@@ -414,7 +414,7 @@ public class ExpositionIT extends BaseIT {
 
         try (var tester = kroxyliciousTester(builder)) {
 
-            assertThat(cluster.getNumOfBrokers()).isEqualTo(1);
+            assertThat(cluster.getNumOfBrokers()).isOne();
             try (var admin = tester.admin()) {
                 await().atMost(Duration.ofSeconds(5)).until(() -> admin.describeCluster().nodes().get(),
                         n -> n.size() == cluster.getNumOfBrokers());
@@ -453,7 +453,7 @@ public class ExpositionIT extends BaseIT {
 
                 var removedNodeId = 1;
                 cluster.removeBroker(removedNodeId);
-                assertThat(cluster.getNumOfBrokers()).isEqualTo(1);
+                assertThat(cluster.getNumOfBrokers()).isOne();
 
                 var updatedNodes = await().atMost(Duration.ofSeconds(5)).until(() -> admin.describeCluster().nodes().get(),
                         n -> n.size() == cluster.getNumOfBrokers());

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/ResilienceIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/ResilienceIT.java
@@ -7,14 +7,12 @@ package io.kroxylicious.proxy;
 
 import java.time.Duration;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -38,7 +36,6 @@ import static org.apache.kafka.clients.producer.ProducerConfig.RECONNECT_BACKOFF
 import static org.apache.kafka.clients.producer.ProducerConfig.RECONNECT_BACKOFF_MS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.RETRY_BACKOFF_MS_CONFIG;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests with the aim of demonstrating that system survives a Kroxylicious restart.
@@ -52,14 +49,14 @@ public class ResilienceIT extends BaseIT {
     @Test
     public void kafkaProducerShouldTolerateKroxyliciousRestarting(Admin admin) throws Exception {
         String randomTopic = UUID.randomUUID().toString();
-        createTopics(admin, List.of(new NewTopic(randomTopic, 1, (short) 1)));
+        createTopic(admin, randomTopic, 1);
         testProducerCanSurviveARestart(proxy(cluster), randomTopic);
     }
 
     @Test
     public void kafkaConsumerShouldTolerateKroxyliciousRestarting(Admin admin) throws Exception {
         String randomTopic = UUID.randomUUID().toString();
-        createTopics(admin, List.of(new NewTopic(randomTopic, 1, (short) 1)));
+        createTopic(admin, randomTopic, 1);
         testConsumerCanSurviveKroxyliciousRestart(proxy(cluster), randomTopic);
     }
 
@@ -81,8 +78,8 @@ public class ResilienceIT extends BaseIT {
             assertThat(records).hasSize(1);
             assertThat(records.iterator()).toIterable().map(ConsumerRecord::value).containsExactly("Hello, world!");
 
-            assertEquals(1, records.count());
-            assertEquals("Hello, world!", records.iterator().next().value());
+            assertThat(records.count()).isEqualTo(1);
+            assertThat(records.iterator().next().value()).isEqualTo("Hello, world!");
             producer.send(new ProducerRecord<>(topic, "my-key", "Hello, again!")).get(10, TimeUnit.SECONDS);
         }
 

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/ResilienceIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/ResilienceIT.java
@@ -78,7 +78,7 @@ public class ResilienceIT extends BaseIT {
             assertThat(records).hasSize(1);
             assertThat(records.iterator()).toIterable().map(ConsumerRecord::value).containsExactly("Hello, world!");
 
-            assertThat(records.count()).isEqualTo(1);
+            assertThat(records.count()).isOne();
             assertThat(records.iterator().next().value()).isEqualTo("Hello, world!");
             producer.send(new ProducerRecord<>(topic, "my-key", "Hello, again!")).get(10, TimeUnit.SECONDS);
         }

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/ResilienceIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/ResilienceIT.java
@@ -71,10 +71,9 @@ public class ResilienceIT extends BaseIT {
                 ConsumerConfig.GROUP_ID_CONFIG, "mygroup",
                 ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"));
 
-        Producer<String, String> producer;
         Consumer<String, String> consumer;
-        try (var tester = kroxyliciousTester(builder)) {
-            producer = tester.producer(producerConfig);
+        try (var tester = kroxyliciousTester(builder);
+                var producer = tester.producer(producerConfig)) {
             consumer = tester.consumer(consumerConfig);
             producer.send(new ProducerRecord<>(topic, "my-key", "Hello, world!")).get(10, TimeUnit.SECONDS);
             consumer.subscribe(Set.of(topic));

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/TlsIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/TlsIT.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.junit.jupiter.api.BeforeEach;
@@ -94,7 +93,7 @@ public class TlsIT extends BaseIT {
 
         try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
             // do some work to ensure connection is opened
-            createTopics(admin, List.of(new NewTopic(TOPIC, 1, (short) 1)));
+            createTopic(admin, TOPIC, 1);
         }
     }
 
@@ -132,7 +131,7 @@ public class TlsIT extends BaseIT {
 
         try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
             // do some work to ensure connection is opened
-            createTopics(admin, List.of(new NewTopic(TOPIC, 1, (short) 1)));
+            createTopic(admin, TOPIC, 1);
         }
     }
 
@@ -153,7 +152,7 @@ public class TlsIT extends BaseIT {
 
         try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
             // do some work to ensure connection is opened
-            createTopics(admin, List.of(new NewTopic(TOPIC, 1, (short) 1)));
+            createTopic(admin, TOPIC, 1);
         }
     }
 
@@ -191,7 +190,7 @@ public class TlsIT extends BaseIT {
                                 SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, clientTrustStore.toAbsolutePath().toString(),
                                 SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, downstreamCertificateGenerator.getPassword()))) {
             // do some work to ensure connection is opened
-            createTopics(admin, List.of(new NewTopic(TOPIC, 1, (short) 1)));
+            createTopic(admin, TOPIC, 1);
         }
     }
 

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/TlsIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/TlsIT.java
@@ -20,12 +20,8 @@ import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
@@ -53,7 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * TODO add integration tests covering kroylicious's ability to use JKS and PEM material. Needs https://github.com/kroxylicious/kroxylicious-junit5-extension/issues/120
  */
 @ExtendWith(KafkaClusterExtension.class)
-public class TlsIT {
+public class TlsIT extends BaseIT {
     private static final HostPort PROXY_ADDRESS = HostPort.parse("localhost:9192");
     private static final ClusterNetworkAddressConfigProviderDefinition CONFIG_PROVIDER_DEFINITION = new ClusterNetworkAddressConfigProviderDefinitionBuilder(
             "PortPerBroker").withConfig("bootstrapAddress", PROXY_ADDRESS)
@@ -98,7 +94,7 @@ public class TlsIT {
 
         try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
             // do some work to ensure connection is opened
-            createTopic(admin, TOPIC, 1);
+            createTopics(admin, List.of(new NewTopic(TOPIC, 1, (short) 1)));
         }
     }
 
@@ -136,7 +132,7 @@ public class TlsIT {
 
         try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
             // do some work to ensure connection is opened
-            createTopic(admin, TOPIC, 1);
+            createTopics(admin, List.of(new NewTopic(TOPIC, 1, (short) 1)));
         }
     }
 
@@ -157,7 +153,7 @@ public class TlsIT {
 
         try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
             // do some work to ensure connection is opened
-            createTopic(admin, TOPIC, 1);
+            createTopics(admin, List.of(new NewTopic(TOPIC, 1, (short) 1)));
         }
     }
 
@@ -195,19 +191,7 @@ public class TlsIT {
                                 SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, clientTrustStore.toAbsolutePath().toString(),
                                 SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, downstreamCertificateGenerator.getPassword()))) {
             // do some work to ensure connection is opened
-            createTopic(admin, TOPIC, 1);
-        }
-    }
-
-    private void createTopic(Admin admin, String topic, int numPartitions) {
-        try {
-            admin.createTopics(List.of(new NewTopic(topic, numPartitions, (short) 1))).all().get(10, TimeUnit.SECONDS);
-        }
-        catch (ExecutionException e) {
-            throw new RuntimeException(e.getCause());
-        }
-        catch (InterruptedException | TimeoutException e) {
-            throw new RuntimeException(e);
+            createTopics(admin, List.of(new NewTopic(TOPIC, 1, (short) 1)));
         }
     }
 

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/multitenant/BaseMultiTenantIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/multitenant/BaseMultiTenantIT.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.multitenant;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.assertj.core.api.Condition;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.kroxylicious.net.IntegrationTestInetAddressResolverProvider;
+import io.kroxylicious.proxy.BaseIT;
+import io.kroxylicious.proxy.config.ClusterNetworkAddressConfigProviderDefinitionBuilder;
+import io.kroxylicious.proxy.config.ConfigurationBuilder;
+import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
+import io.kroxylicious.proxy.config.VirtualClusterBuilder;
+import io.kroxylicious.proxy.service.HostPort;
+import io.kroxylicious.test.tester.KroxyliciousTester;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
+import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(KafkaClusterExtension.class)
+public abstract class BaseMultiTenantIT extends BaseIT {
+
+    public static final String TENANT_1_CLUSTER = "foo";
+    static final HostPort TENANT_1_PROXY_ADDRESS = HostPort
+            .parse(IntegrationTestInetAddressResolverProvider.generateFullyQualifiedDomainName(TENANT_1_CLUSTER, 9192));
+    public static final String TENANT_2_CLUSTER = "bar";
+    static final HostPort TENANT_2_PROXY_ADDRESS = HostPort
+            .parse(IntegrationTestInetAddressResolverProvider.generateFullyQualifiedDomainName(TENANT_2_CLUSTER, 9292));
+
+    static final long FUTURE_TIMEOUT_SECONDS = 5L;
+    Map<String, Object> clientConfig;
+
+    TestInfo testInfo;
+    KeytoolCertificateGenerator certificateGenerator;
+    @TempDir
+    Path certsDirectory;
+
+    void setup(TestInfo testInfo) throws Exception {
+        this.testInfo = testInfo;
+        // TODO: use a per-tenant server certificate.
+        this.certificateGenerator = new KeytoolCertificateGenerator();
+        this.certificateGenerator.generateSelfSignedCertificateEntry("test@redhat.com", IntegrationTestInetAddressResolverProvider.generateFullyQualifiedDomainName("*"),
+                "KI", "RedHat", null, null, "US");
+        Path clientTrustStore = certsDirectory.resolve("kafka.truststore.jks");
+        this.certificateGenerator.generateTrustStore(this.certificateGenerator.getCertFilePath(), "client", clientTrustStore.toAbsolutePath().toString());
+        this.clientConfig = Map.of(CommonClientConfigs.CLIENT_ID_CONFIG, testInfo.getDisplayName(),
+                CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name,
+                SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, clientTrustStore.toAbsolutePath().toString(),
+                SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, certificateGenerator.getPassword());
+    }
+
+    static ConfigurationBuilder getConfig(KafkaCluster cluster, KeytoolCertificateGenerator certificateGenerator) {
+        return new ConfigurationBuilder()
+                .addToVirtualClusters(TENANT_1_CLUSTER, new VirtualClusterBuilder()
+                        .withNewTargetCluster()
+                        .withBootstrapServers(cluster.getBootstrapServers())
+                        .endTargetCluster()
+                        .withClusterNetworkAddressConfigProvider(
+                                new ClusterNetworkAddressConfigProviderDefinitionBuilder("PortPerBroker").withConfig("bootstrapAddress", TENANT_1_PROXY_ADDRESS)
+                                        .build())
+                        .withNewTls()
+                        .withNewKeyStoreKey()
+                        .withStoreFile(certificateGenerator.getKeyStoreLocation())
+                        .withNewInlinePasswordStoreProvider(certificateGenerator.getPassword())
+                        .endKeyStoreKey()
+                        .endTls()
+                        .build())
+                .addToVirtualClusters(TENANT_2_CLUSTER, new VirtualClusterBuilder()
+                        .withNewTargetCluster()
+                        .withBootstrapServers(cluster.getBootstrapServers())
+                        .endTargetCluster()
+                        .withClusterNetworkAddressConfigProvider(
+                                new ClusterNetworkAddressConfigProviderDefinitionBuilder("PortPerBroker").withConfig("bootstrapAddress", TENANT_2_PROXY_ADDRESS)
+                                        .build())
+                        .withNewTls()
+                        .withNewKeyStoreKey()
+                        .withStoreFile(certificateGenerator.getKeyStoreLocation())
+                        .withNewInlinePasswordStoreProvider(certificateGenerator.getPassword())
+                        .endKeyStoreKey()
+                        .endTls()
+                        .build())
+                .addToFilters(new FilterDefinitionBuilder("MultiTenant").build());
+    }
+
+    static Consumer<String, String> getConsumerWithConfig(KroxyliciousTester tester, String virtualCluster, String groupId, Map<String, Object> baseConfig,
+                                                          Map<String, Object> additionalConfig) {
+        Map<String, Object> standardConfig = Map.of(ConsumerConfig.GROUP_ID_CONFIG, groupId,
+                ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, Boolean.FALSE.toString(),
+                ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, Boolean.FALSE.toString(),
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, OffsetResetStrategy.EARLIEST.toString());
+        return getConsumerWithConfig(tester, Optional.of(virtualCluster), baseConfig, standardConfig, additionalConfig);
+    }
+
+    static void consumeAndVerify(KroxyliciousTester tester, Map<String, Object> clientConfig, String virtualCluster, String topicName, String groupId,
+                                 Deque<Predicate<ConsumerRecord<String, String>>> expected, boolean offsetCommit) {
+        try (var consumer = getConsumerWithConfig(tester, virtualCluster, groupId, clientConfig, Map.of(
+                ConsumerConfig.MAX_POLL_RECORDS_CONFIG, String.format("%d", expected.size())))) {
+
+            var topicPartitions = List.of(new TopicPartition(topicName, 0));
+            consumer.assign(topicPartitions);
+
+            while (!expected.isEmpty()) {
+                ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(30));
+                assertThat(records.partitions()).hasSizeGreaterThanOrEqualTo(1);
+                records.forEach(r -> {
+                    assertFalse(expected.isEmpty(), String.format("received unexpected record %s", r));
+                    var predicate = expected.pop();
+                    assertThat(r).matches(predicate, predicate.toString());
+                });
+            }
+
+            if (offsetCommit) {
+                consumer.commitSync(Duration.ofSeconds(5));
+            }
+        }
+    }
+
+    static void produceAndVerify(KroxyliciousTester tester, Map<String, Object> clientConfig, String virtualCluster,
+                                 Stream<ProducerRecord<String, String>> records, Optional<String> transactionalId) {
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000);
+        transactionalId.ifPresent(tid -> config.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId.get()));
+        try (var producer = getProducerWithConfig(tester, Optional.of(virtualCluster), clientConfig, config)) {
+            transactionalId.ifPresent(u -> {
+                producer.initTransactions();
+                producer.beginTransaction();
+            });
+
+            records.forEach(rec -> {
+                RecordMetadata recordMetadata = null;
+                try {
+                    recordMetadata = producer.send(rec).get(FUTURE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                }
+                catch (Exception e) {
+                    fail("Caught: %s producing to %s", e.getMessage(), rec.topic());
+                }
+                assertNotNull(recordMetadata);
+                assertNotNull(rec.topic(), recordMetadata.topic());
+            });
+
+            transactionalId.ifPresent(u -> {
+                producer.commitTransaction();
+            });
+
+        }
+    }
+
+    @NotNull
+    static <T, V> Condition<T> matches(Function<T, V> extractor, V expectedValue) {
+        return new Condition<>(item -> Objects.equals(extractor.apply(item), expectedValue), "unexpected entry");
+    }
+
+    @NotNull
+    static <K, V> Predicate<ConsumerRecord<K, V>> matchesRecord(final String expectedTopic, final K expectedKey, final V expectedValue) {
+        return new Predicate<>() {
+            @Override
+            public boolean test(ConsumerRecord<K, V> item) {
+                return Objects.equals(item.topic(), expectedTopic) && Objects.equals(item.key(), expectedKey) && Objects.equals(
+                        item.value(), expectedValue);
+            }
+
+            @Override
+            public String toString() {
+                return String.format("expected: key %s value %s", expectedKey, expectedValue);
+            }
+        };
+    }
+}

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/multitenant/BaseMultiTenantIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/multitenant/BaseMultiTenantIT.java
@@ -140,7 +140,7 @@ public abstract class BaseMultiTenantIT extends BaseIT {
                 ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(30));
                 assertThat(records.partitions()).hasSizeGreaterThanOrEqualTo(1);
                 records.forEach(r -> {
-                    assertThat(expected.isEmpty()).withFailMessage("received unexpected record %s", r).isFalse();
+                    assertThat(expected).withFailMessage("received unexpected record %s", r).isNotEmpty();
                     var predicate = expected.pop();
                     assertThat(r).matches(predicate, predicate.toString());
                 });

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/multitenant/MultiTenantIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/multitenant/MultiTenantIT.java
@@ -5,32 +5,25 @@
  */
 package io.kroxylicious.proxy.multitenant;
 
-import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ConsumerGroupDescription;
 import org.apache.kafka.clients.admin.ConsumerGroupListing;
-import org.apache.kafka.clients.admin.CreateTopicsResult;
-import org.apache.kafka.clients.admin.DeleteTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.admin.TopicListing;
@@ -41,54 +34,36 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.ConsumerGroupState;
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicCollection;
 import org.apache.kafka.common.TopicCollection.TopicNameCollection;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.config.SslConfigs;
-import org.apache.kafka.common.security.auth.SecurityProtocol;
-import org.assertj.core.api.Condition;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.kroxylicious.net.IntegrationTestInetAddressResolverProvider;
-import io.kroxylicious.proxy.config.ClusterNetworkAddressConfigProviderDefinitionBuilder;
-import io.kroxylicious.proxy.config.ConfigurationBuilder;
-import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
-import io.kroxylicious.proxy.config.VirtualClusterBuilder;
-import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.test.tester.KroxyliciousTester;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
-import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 
 import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
 import static org.assertj.core.api.Assertions.allOf;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 @ExtendWith(KafkaClusterExtension.class)
-public class MultiTenantIT {
+public class MultiTenantIT extends BaseMultiTenantIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MultiTenantIT.class);
 
@@ -99,40 +74,20 @@ public class MultiTenantIT {
 
     private static final String TOPIC_3 = "and-another-test-topic";
     private static final NewTopic NEW_TOPIC_3 = new NewTopic(TOPIC_3, 1, (short) 1);
-
-    public static final String TENANT_1_CLUSTER = "foo";
-    private static final HostPort TENANT_1_PROXY_ADDRESS = HostPort
-            .parse(IntegrationTestInetAddressResolverProvider.generateFullyQualifiedDomainName(TENANT_1_CLUSTER, 9192));
-    public static final String TENANT_2_CLUSTER = "bar";
-    private static final HostPort TENANT_2_PROXY_ADDRESS = HostPort
-            .parse(IntegrationTestInetAddressResolverProvider.generateFullyQualifiedDomainName(TENANT_2_CLUSTER, 9292));
     private static final String MY_KEY = "my-key";
     private static final String MY_VALUE = "my-value";
-    private static final long FUTURE_TIMEOUT_SECONDS = 5L;
-
-    private TestInfo testInfo;
-    private KeytoolCertificateGenerator certificateGenerator;
-    private Path clientTrustStore;
-    @TempDir
-    private Path certsDirectory;
 
     @BeforeEach
     public void beforeEach(TestInfo testInfo) throws Exception {
-        this.testInfo = testInfo;
-        // TODO: use a per-tenant server certificate.
-        this.certificateGenerator = new KeytoolCertificateGenerator();
-        this.certificateGenerator.generateSelfSignedCertificateEntry("test@redhat.com", IntegrationTestInetAddressResolverProvider.generateFullyQualifiedDomainName("*"),
-                "KI", "RedHat", null, null, "US");
-        this.clientTrustStore = certsDirectory.resolve("kafka.truststore.jks");
-        this.certificateGenerator.generateTrustStore(this.certificateGenerator.getCertFilePath(), "client", clientTrustStore.toAbsolutePath().toString());
+        setup(testInfo);
     }
 
     @Test
     public void createAndDeleteTopic(KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster);
+        var config = getConfig(cluster, this.certificateGenerator);
 
         try (var tester = kroxyliciousTester(config);
-                var admin = tester.admin(TENANT_1_CLUSTER, commonConfig(Map.of()))) {
+                var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
             var created = createTopics(admin, List.of(NEW_TOPIC_1, NEW_TOPIC_2));
 
             var topicMap = await().atMost(Duration.ofSeconds(5)).until(() -> admin.listTopics().namesToListings().get(),
@@ -159,9 +114,9 @@ public class MultiTenantIT {
 
     @Test
     public void describeTopic(KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster);
+        var config = getConfig(cluster, this.certificateGenerator);
         try (var tester = kroxyliciousTester(config);
-                var admin = tester.admin(TENANT_1_CLUSTER, commonConfig(Map.of()))) {
+                var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
             var created = createTopics(admin, List.of(NEW_TOPIC_1));
 
             await().atMost(Duration.ofSeconds(5)).ignoreExceptions().untilAsserted(() -> {
@@ -173,149 +128,141 @@ public class MultiTenantIT {
         }
     }
 
-    private Map<String, Object> commonConfig(Map<String, Object> of) {
-        var config = new HashMap<>(of);
-        config.put(CommonClientConfigs.CLIENT_ID_CONFIG, testInfo.getDisplayName());
-        config.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name);
-        config.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, this.clientTrustStore.toAbsolutePath().toString());
-        config.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, certificateGenerator.getPassword());
-        return config;
-    }
-
     @Test
     public void produceOne(KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster);
-        try (var tester = kroxyliciousTester(config)) {
-            createTopics(tester, TENANT_1_CLUSTER, List.of(NEW_TOPIC_1));
-            produceAndVerify(tester, TENANT_1_CLUSTER, TOPIC_1, MY_KEY, MY_VALUE);
+        var config = getConfig(cluster, this.certificateGenerator);
+        try (var tester = kroxyliciousTester(config);
+                var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
+            createTopics(admin, List.of(NEW_TOPIC_1));
+            produceAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER, Stream.of(new ProducerRecord<>(TOPIC_1, MY_KEY, MY_VALUE)), Optional.empty());
         }
     }
 
     @Test
     public void consumeOne(KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster);
-        try (var tester = kroxyliciousTester(config)) {
+        var config = getConfig(cluster, this.certificateGenerator);
+        try (var tester = kroxyliciousTester(config);
+                var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
             var groupId = testInfo.getDisplayName();
-            createTopics(tester, TENANT_1_CLUSTER, List.of(NEW_TOPIC_1));
-            produceAndVerify(tester, TENANT_1_CLUSTER, TOPIC_1, MY_KEY, MY_VALUE);
-            consumeAndVerify(tester, TENANT_1_CLUSTER, TOPIC_1, groupId, MY_KEY, MY_VALUE, false);
+            createTopics(admin, List.of(NEW_TOPIC_1));
+            produceAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER, Stream.of(new ProducerRecord<>(TOPIC_1, MY_KEY, MY_VALUE)), Optional.empty());
+            consumeAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER, TOPIC_1, groupId, new LinkedList<>(List.of(matchesRecord(TOPIC_1, MY_KEY, MY_VALUE))), false);
         }
     }
 
     @Test
     public void consumeOneAndOffsetCommit(KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster);
-        try (var tester = kroxyliciousTester(config)) {
+        var config = getConfig(cluster, this.certificateGenerator);
+        try (var tester = kroxyliciousTester(config);
+                var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
             var groupId = testInfo.getDisplayName();
-            createTopics(tester, TENANT_1_CLUSTER, List.of(NEW_TOPIC_1));
-            produceAndVerify(tester, TENANT_1_CLUSTER,
+            createTopics(admin, List.of(NEW_TOPIC_1));
+            produceAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER,
                     Stream.of(new ProducerRecord<>(TOPIC_1, MY_KEY, "1"), new ProducerRecord<>(TOPIC_1, MY_KEY, "2"), inCaseOfFailure()), Optional.empty());
-            consumeAndVerify(tester, TENANT_1_CLUSTER, TOPIC_1, groupId, MY_KEY, "1", true);
-            consumeAndVerify(tester, TENANT_1_CLUSTER, TOPIC_1, groupId, MY_KEY, "2", true);
+            consumeAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER, TOPIC_1, groupId, new LinkedList<>(List.of(matchesRecord(TOPIC_1, MY_KEY, "1"))), true);
+            consumeAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER, TOPIC_1, groupId, new LinkedList<>(List.of(matchesRecord(TOPIC_1, MY_KEY, "2"))), true);
         }
     }
 
     @Test
     public void alterOffsetCommit(KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster);
+        var config = getConfig(cluster, this.certificateGenerator);
         try (var tester = kroxyliciousTester(config);
-                var admin = tester.admin(TENANT_1_CLUSTER, commonConfig(Map.of()))) {
+                var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
             var groupId = testInfo.getDisplayName();
-            createTopics(tester, TENANT_1_CLUSTER, List.of(NEW_TOPIC_1));
-            produceAndVerify(tester, TENANT_1_CLUSTER,
+            createTopics(admin, List.of(NEW_TOPIC_1));
+            produceAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER,
                     Stream.of(new ProducerRecord<>(TOPIC_1, MY_KEY, "1"), new ProducerRecord<>(TOPIC_1, MY_KEY, "2"), inCaseOfFailure()), Optional.empty());
-            consumeAndVerify(tester, TENANT_1_CLUSTER, TOPIC_1, groupId, MY_KEY, "1", true);
+            consumeAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER, TOPIC_1, groupId, new LinkedList<>(List.of(matchesRecord(TOPIC_1, MY_KEY, "1"))), true);
             var rememberedOffsets = admin.listConsumerGroupOffsets(groupId).partitionsToOffsetAndMetadata().get();
-            consumeAndVerify(tester, TENANT_1_CLUSTER, TOPIC_1, groupId, MY_KEY, "2", true);
+            consumeAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER, TOPIC_1, groupId, new LinkedList<>(List.of(matchesRecord(TOPIC_1, MY_KEY, "2"))), true);
 
             admin.alterConsumerGroupOffsets(groupId, rememberedOffsets).all().get();
-            consumeAndVerify(tester, TENANT_1_CLUSTER, TOPIC_1, groupId, MY_KEY, "2", true);
+            consumeAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER, TOPIC_1, groupId, new LinkedList<>(List.of(matchesRecord(TOPIC_1, MY_KEY, "2"))), true);
         }
     }
 
     @Test
     public void deleteConsumerGroupOffsets(KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster);
+        var config = getConfig(cluster, this.certificateGenerator);
         try (var tester = kroxyliciousTester(config);
-                var admin = tester.admin(TENANT_1_CLUSTER, commonConfig(Map.of()))) {
+                var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
             var groupId = testInfo.getDisplayName();
-            createTopics(tester, TENANT_1_CLUSTER, List.of(NEW_TOPIC_1));
-            produceAndVerify(tester, TENANT_1_CLUSTER, Stream.of(new ProducerRecord<>(TOPIC_1, MY_KEY, "1"), inCaseOfFailure()), Optional.empty());
-            consumeAndVerify(tester, TENANT_1_CLUSTER, TOPIC_1, groupId, MY_KEY, "1", true);
+            createTopics(admin, List.of(NEW_TOPIC_1));
+            produceAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER, Stream.of(new ProducerRecord<>(TOPIC_1, MY_KEY, "1"), inCaseOfFailure()), Optional.empty());
+            consumeAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER, TOPIC_1, groupId, new LinkedList<>(List.of(matchesRecord(TOPIC_1, MY_KEY, "1"))), true);
 
             admin.deleteConsumerGroupOffsets(groupId, Set.of(new TopicPartition(NEW_TOPIC_1.name(), 0))).all().get();
-            consumeAndVerify(tester, TENANT_1_CLUSTER, TOPIC_1, groupId, MY_KEY, "1", true);
+            consumeAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER, TOPIC_1, groupId, new LinkedList<>(List.of(matchesRecord(TOPIC_1, MY_KEY, "1"))), true);
         }
-    }
-
-    @NotNull
-    private static ProducerRecord<String, String> inCaseOfFailure() {
-        return new ProducerRecord<>(TOPIC_1, MY_KEY, "unexpected - should never be consumed");
     }
 
     @Test
     public void tenantTopicIsolation(KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster);
-        try (var tester = kroxyliciousTester(config)) {
-            createTopics(tester, TENANT_1_CLUSTER, List.of(NEW_TOPIC_1));
-            createTopics(tester, TENANT_2_CLUSTER, List.of(NEW_TOPIC_2, NEW_TOPIC_3));
+        var config = getConfig(cluster, this.certificateGenerator);
+        try (var tester = kroxyliciousTester(config);
+                var adminTenant1 = tester.admin(TENANT_1_CLUSTER, this.clientConfig);
+                var adminTenant2 = tester.admin(TENANT_2_CLUSTER, this.clientConfig)) {
+            createTopics(adminTenant1, List.of(NEW_TOPIC_1));
+            createTopics(adminTenant2, List.of(NEW_TOPIC_2, NEW_TOPIC_3));
 
-            verifyTenant(tester, TENANT_1_CLUSTER, TOPIC_1);
-            verifyTenant(tester, TENANT_2_CLUSTER, TOPIC_2, TOPIC_3);
+            verifyTenant(adminTenant1, TOPIC_1);
+            verifyTenant(adminTenant2, TOPIC_2, TOPIC_3);
         }
-    }
-
-    private enum ConsumerStyle {
-        ASSIGN,
-        SUBSCRIBE
     }
 
     @ParameterizedTest
     @EnumSource
     public void tenantConsumeWithGroup(ConsumerStyle consumerStyle, KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster);
-        try (var tester = kroxyliciousTester(config)) {
-            createTopics(tester, TENANT_1_CLUSTER, List.of(NEW_TOPIC_1));
-            runConsumerInOrderToCreateGroup(tester, TENANT_1_CLUSTER, "Tenant1Group", NEW_TOPIC_1, consumerStyle);
-            verifyConsumerGroupsWithList(tester, TENANT_1_CLUSTER, Set.of("Tenant1Group"));
+        var config = getConfig(cluster, this.certificateGenerator);
+        try (var tester = kroxyliciousTester(config);
+                var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
+            createTopics(admin, List.of(NEW_TOPIC_1));
+            runConsumerInOrderToCreateGroup(tester, TENANT_1_CLUSTER, "Tenant1Group", NEW_TOPIC_1, consumerStyle, this.clientConfig);
+            verifyConsumerGroupsWithList(admin, Set.of("Tenant1Group"));
         }
     }
 
     @ParameterizedTest
     @EnumSource
     public void tenantGroupIsolation(ConsumerStyle consumerStyle, KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster);
-        try (var tester = kroxyliciousTester(config)) {
-            createTopics(tester, TENANT_1_CLUSTER, List.of(NEW_TOPIC_1));
-            runConsumerInOrderToCreateGroup(tester, TENANT_1_CLUSTER, "Tenant1Group", NEW_TOPIC_1, consumerStyle);
+        var config = getConfig(cluster, this.certificateGenerator);
+        try (var tester = kroxyliciousTester(config);
+                var adminTenant1 = tester.admin(TENANT_1_CLUSTER, this.clientConfig);
+                var adminTenant2 = tester.admin(TENANT_2_CLUSTER, this.clientConfig)) {
+            createTopics(adminTenant1, List.of(NEW_TOPIC_1));
+            runConsumerInOrderToCreateGroup(tester, TENANT_1_CLUSTER, "Tenant1Group", NEW_TOPIC_1, consumerStyle, this.clientConfig);
 
-            createTopics(tester, TENANT_2_CLUSTER, List.of(NEW_TOPIC_1));
-            runConsumerInOrderToCreateGroup(tester, TENANT_2_CLUSTER, "Tenant2Group", NEW_TOPIC_1, consumerStyle);
-            verifyConsumerGroupsWithList(tester, TENANT_2_CLUSTER, Set.of("Tenant2Group"));
+            createTopics(adminTenant2, List.of(NEW_TOPIC_1));
+            runConsumerInOrderToCreateGroup(tester, TENANT_2_CLUSTER, "Tenant2Group", NEW_TOPIC_1, consumerStyle, this.clientConfig);
+            verifyConsumerGroupsWithList(adminTenant2, Set.of("Tenant2Group"));
         }
     }
 
     @Test
     public void describeGroup(KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster);
-        try (var tester = kroxyliciousTester(config)) {
-            createTopics(tester, TENANT_1_CLUSTER, List.of(NEW_TOPIC_1));
-            runConsumerInOrderToCreateGroup(tester, TENANT_1_CLUSTER, "Tenant1Group", NEW_TOPIC_1, ConsumerStyle.ASSIGN);
+        var config = getConfig(cluster, this.certificateGenerator);
+        try (var tester = kroxyliciousTester(config);
+                var adminTenant1 = tester.admin(TENANT_1_CLUSTER, this.clientConfig);
+                var adminTenant2 = tester.admin(TENANT_2_CLUSTER, this.clientConfig)) {
+            createTopics(adminTenant1, List.of(NEW_TOPIC_1));
+            runConsumerInOrderToCreateGroup(tester, TENANT_1_CLUSTER, "Tenant1Group", NEW_TOPIC_1, ConsumerStyle.ASSIGN, this.clientConfig);
 
-            createTopics(tester, TENANT_2_CLUSTER, List.of(NEW_TOPIC_1));
-            runConsumerInOrderToCreateGroup(tester, TENANT_2_CLUSTER, "Tenant2Group", NEW_TOPIC_1, ConsumerStyle.ASSIGN);
+            createTopics(adminTenant2, List.of(NEW_TOPIC_1));
+            runConsumerInOrderToCreateGroup(tester, TENANT_2_CLUSTER, "Tenant2Group", NEW_TOPIC_1, ConsumerStyle.ASSIGN, this.clientConfig);
 
-            verifyConsumerGroupsWithDescribe(tester, TENANT_1_CLUSTER, Set.of("Tenant1Group"), Set.of("Tenant2Group", "idontexist"));
-            verifyConsumerGroupsWithDescribe(tester, TENANT_2_CLUSTER, Set.of("Tenant2Group"), Set.of("Tenant1Group", "idontexist"));
+            verifyConsumerGroupsWithDescribe(adminTenant1, Set.of("Tenant1Group"), Set.of("Tenant2Group", "idontexist"));
+            verifyConsumerGroupsWithDescribe(adminTenant2, Set.of("Tenant2Group"), Set.of("Tenant1Group", "idontexist"));
         }
     }
 
     @Test
     public void produceInTransaction(KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster);
-        try (var tester = kroxyliciousTester(config)) {
-            createTopics(tester, TENANT_1_CLUSTER, List.of(NEW_TOPIC_1));
-            produceAndVerify(tester, TENANT_1_CLUSTER,
+        var config = getConfig(cluster, this.certificateGenerator);
+        try (var tester = kroxyliciousTester(config);
+                var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
+            createTopics(admin, List.of(NEW_TOPIC_1));
+            produceAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER,
                     Stream.of(new ProducerRecord<>(TOPIC_1, MY_KEY, "1")),
                     Optional.of("12345"));
         }
@@ -323,14 +270,15 @@ public class MultiTenantIT {
 
     @Test
     public void produceAndConsumeInTransaction(KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster);
-        try (var tester = kroxyliciousTester(config)) {
+        var config = getConfig(cluster, this.certificateGenerator);
+        try (var tester = kroxyliciousTester(config);
+                var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
             // put some records in an input topic
             var inputTopic = "input";
             var outputTopic = "output";
-            createTopics(tester, TENANT_1_CLUSTER, List.of(new NewTopic(inputTopic, 1, (short) 1),
+            createTopics(admin, List.of(new NewTopic(inputTopic, 1, (short) 1),
                     new NewTopic(outputTopic, 1, (short) 1)));
-            produceAndVerify(tester, TENANT_1_CLUSTER,
+            produceAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER,
                     Stream.of(new ProducerRecord<>(inputTopic, MY_KEY, "1"),
                             new ProducerRecord<>(inputTopic, MY_KEY, "2"),
                             new ProducerRecord<>(inputTopic, MY_KEY, "3")),
@@ -338,14 +286,10 @@ public class MultiTenantIT {
 
             // now consume and from input and produce to output, using a transaction.
             var groupId = testInfo.getDisplayName();
-            try (var consumer = tester.consumer(TENANT_1_CLUSTER, commonConfig(Map.of(
-                    ConsumerConfig.GROUP_ID_CONFIG, groupId,
-                    ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, Boolean.FALSE.toString(),
-                    ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, OffsetResetStrategy.EARLIEST.toString(),
-                    ConsumerConfig.ISOLATION_LEVEL_CONFIG, IsolationLevel.READ_UNCOMMITTED.toString().toLowerCase(Locale.ROOT))));
-                    var producer = tester.producer(TENANT_1_CLUSTER, commonConfig(Map.of(
-                            ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000,
-                            ProducerConfig.TRANSACTIONAL_ID_CONFIG, "12345")))) {
+            try (var consumer = getConsumerWithConfig(tester, TENANT_1_CLUSTER, groupId, this.clientConfig,
+                    Map.of(ConsumerConfig.ISOLATION_LEVEL_CONFIG, IsolationLevel.READ_UNCOMMITTED.toString().toLowerCase(Locale.ROOT)));
+                    var producer = getProducerWithConfig(tester, Optional.of(TENANT_1_CLUSTER), clientConfig,
+                            Map.of(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000, ProducerConfig.TRANSACTIONAL_ID_CONFIG, "12345"))) {
                 producer.initTransactions();
 
                 var topicPartitions = List.of(new TopicPartition(inputTopic, 0));
@@ -370,7 +314,7 @@ public class MultiTenantIT {
             }
 
             // now verify that output contains the expected values.
-            consumeAndVerify(tester, TENANT_1_CLUSTER, outputTopic, groupId, new LinkedList<>(
+            consumeAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER, outputTopic, groupId, new LinkedList<>(
                     List.of(matchesRecord(outputTopic, MY_KEY, "1"),
                             matchesRecord(outputTopic, MY_KEY, "2"),
                             matchesRecord(outputTopic, MY_KEY, "3"))),
@@ -381,12 +325,12 @@ public class MultiTenantIT {
 
     @Test
     public void describeTransaction(KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster);
+        var config = getConfig(cluster, this.certificateGenerator);
         try (var tester = kroxyliciousTester(config)) {
-            try (var admin = tester.admin(TENANT_1_CLUSTER, commonConfig(Map.of()))) {
-                createTopics(tester, TENANT_1_CLUSTER, List.of(NEW_TOPIC_1));
+            try (var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
+                createTopics(admin, List.of(NEW_TOPIC_1));
                 var transactionalId = "12345";
-                produceAndVerify(tester, TENANT_1_CLUSTER,
+                produceAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER,
                         Stream.of(new ProducerRecord<>(TOPIC_1, MY_KEY, "1")),
                         Optional.of(transactionalId));
 
@@ -400,37 +344,49 @@ public class MultiTenantIT {
 
     @Test
     public void tenantTransactionalIdIsolation(KafkaCluster cluster) throws Exception {
-        var config = getConfig(cluster);
-        try (var tester = kroxyliciousTester(config)) {
-            createTopics(tester, TENANT_1_CLUSTER, List.of(NEW_TOPIC_1));
+        var config = getConfig(cluster, this.certificateGenerator);
+        try (var tester = kroxyliciousTester(config);
+                var adminTenant1 = tester.admin(TENANT_1_CLUSTER, this.clientConfig);
+                var adminTenant2 = tester.admin(TENANT_2_CLUSTER, this.clientConfig)) {
+            createTopics(adminTenant1, List.of(NEW_TOPIC_1));
             var tenant1TransactionId = "12345";
-            produceAndVerify(tester, TENANT_1_CLUSTER,
+            produceAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER,
                     Stream.of(new ProducerRecord<>(TOPIC_1, MY_KEY, "1")),
                     Optional.of(tenant1TransactionId));
-            verifyTransactionsWithList(tester, TENANT_1_CLUSTER, Set.of(tenant1TransactionId));
+            verifyTransactionsWithList(adminTenant1, Set.of(tenant1TransactionId));
 
-            createTopics(tester, TENANT_2_CLUSTER, List.of(NEW_TOPIC_2));
+            createTopics(adminTenant2, List.of(NEW_TOPIC_2));
             var tenant2TransactionId = "54321";
-            produceAndVerify(tester, TENANT_2_CLUSTER,
+            produceAndVerify(tester, this.clientConfig, TENANT_2_CLUSTER,
                     Stream.of(new ProducerRecord<>(TOPIC_2, MY_KEY, "1")),
                     Optional.of(tenant2TransactionId));
-            verifyTransactionsWithList(tester, TENANT_2_CLUSTER, Set.of(tenant2TransactionId));
+            verifyTransactionsWithList(adminTenant2, Set.of(tenant2TransactionId));
         }
     }
 
-    private void verifyConsumerGroupsWithDescribe(KroxyliciousTester tester, String virtualCluster, Set<String> expectedPresent, Set<String> expectedAbsent)
-            throws Exception {
-        try (var admin = tester.admin(virtualCluster, commonConfig(Map.of()))) {
-            var describedGroups = admin.describeConsumerGroups(Stream.concat(expectedPresent.stream(), expectedAbsent.stream()).toList()).all().get();
-            assertThat(describedGroups).hasSize(expectedAbsent.size() + expectedPresent.size());
+    // ========================================================
+    // UTILS
+    // ========================================================
 
-            var actualPresent = retainKeySubset(describedGroups, expectedPresent);
-            var actualAbsent = retainKeySubset(describedGroups, expectedAbsent);
+    private enum ConsumerStyle {
+        ASSIGN
+    }
 
-            // The consumer group comes back as "dead" when it doesn't exist, so we have to check that it's not dead/it is dead if we don't expect to see it
-            assertThat(actualPresent).allSatisfy((s, consumerGroupDescription) -> assertThat(consumerGroupDescription.state()).isNotIn(ConsumerGroupState.DEAD));
-            assertThat(actualAbsent).allSatisfy((s, consumerGroupDescription) -> assertThat(consumerGroupDescription.state()).isIn(ConsumerGroupState.DEAD));
-        }
+    @NotNull
+    private static ProducerRecord<String, String> inCaseOfFailure() {
+        return new ProducerRecord<>(TOPIC_1, MY_KEY, "unexpected - should never be consumed");
+    }
+
+    private static void verifyConsumerGroupsWithDescribe(Admin admin, Set<String> expectedPresent, Set<String> expectedAbsent) throws Exception {
+        var describedGroups = admin.describeConsumerGroups(Stream.concat(expectedPresent.stream(), expectedAbsent.stream()).toList()).all().get();
+        assertThat(describedGroups).hasSize(expectedAbsent.size() + expectedPresent.size());
+
+        var actualPresent = retainKeySubset(describedGroups, expectedPresent);
+        var actualAbsent = retainKeySubset(describedGroups, expectedAbsent);
+
+        // The consumer group comes back as "dead" when it doesn't exist, so we have to check that it's not dead/it is dead if we don't expect to see it
+        assertThat(actualPresent).allSatisfy((s, consumerGroupDescription) -> assertThat(consumerGroupDescription.state()).isNotIn(ConsumerGroupState.DEAD));
+        assertThat(actualAbsent).allSatisfy((s, consumerGroupDescription) -> assertThat(consumerGroupDescription.state()).isIn(ConsumerGroupState.DEAD));
     }
 
     @NotNull
@@ -440,11 +396,9 @@ public class MultiTenantIT {
         return copy;
     }
 
-    private void runConsumerInOrderToCreateGroup(KroxyliciousTester tester, String virtualCluster, String groupId, NewTopic topic, ConsumerStyle consumerStyle) {
-        try (var consumer = tester.consumer(virtualCluster,
-                commonConfig(Map.of(ConsumerConfig.GROUP_ID_CONFIG, groupId, ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, Boolean.FALSE.toString(),
-                        ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, Boolean.FALSE.toString(), ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
-                        OffsetResetStrategy.EARLIEST.toString(), ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed")))) {
+    private static void runConsumerInOrderToCreateGroup(KroxyliciousTester tester, String virtualCluster, String groupId, NewTopic topic, ConsumerStyle consumerStyle,
+                                                        Map<String, Object> clientConfig) {
+        try (var consumer = getConsumerWithConfig(tester, virtualCluster, groupId, clientConfig, Map.of(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed"))) {
 
             if (consumerStyle == ConsumerStyle.ASSIGN) {
                 consumer.assign(List.of(new TopicPartition(topic.name(), 0)));
@@ -460,176 +414,29 @@ public class MultiTenantIT {
         }
     }
 
-    private void verifyConsumerGroupsWithList(KroxyliciousTester tester, String virtualCluster, Set<String> expectedGroupIds) throws Exception {
-        try (var admin = tester.admin(virtualCluster, commonConfig(Map.of()))) {
-            var groups = admin.listConsumerGroups().all().get().stream().map(ConsumerGroupListing::groupId).toList();
-            assertThat(groups).containsExactlyInAnyOrderElementsOf(expectedGroupIds);
-        }
+    private static void verifyConsumerGroupsWithList(Admin admin, Set<String> expectedGroupIds) throws Exception {
+        var groups = admin.listConsumerGroups().all().get().stream().map(ConsumerGroupListing::groupId).toList();
+        assertThat(groups).containsExactlyInAnyOrderElementsOf(expectedGroupIds);
     }
 
-    private void verifyTransactionsWithList(KroxyliciousTester tester, String virtualCluster, Set<String> expectedTransactionalIds) throws Exception {
-        try (var admin = tester.admin(virtualCluster, commonConfig(Map.of()))) {
-            var transactionalIds = admin.listTransactions().all().get().stream().map(TransactionListing::transactionalId).toList();
-            assertThat(transactionalIds).containsExactlyInAnyOrderElementsOf(expectedTransactionalIds);
-        }
+    private static void verifyTransactionsWithList(Admin admin, Set<String> expectedTransactionalIds) throws Exception {
+        var transactionalIds = admin.listTransactions().all().get().stream().map(TransactionListing::transactionalId).toList();
+        assertThat(transactionalIds).containsExactlyInAnyOrderElementsOf(expectedTransactionalIds);
     }
 
-    private void verifyTenant(KroxyliciousTester tester, String virtualCluster, String... expectedTopics) throws Exception {
-        try (var admin = tester.admin(virtualCluster, commonConfig(Map.of()))) {
+    private static void verifyTenant(Admin admin, String... expectedTopics) throws Exception {
+        var listTopicsResult = admin.listTopics();
 
-            var listTopicsResult = admin.listTopics();
+        var topicListMap = listTopicsResult.namesToListings().get();
+        assertEquals(expectedTopics.length, topicListMap.size());
+        Arrays.stream(expectedTopics)
+                .forEach(expectedTopic -> assertThat(topicListMap).hasEntrySatisfying(expectedTopic, allOf(matches(TopicListing::name, expectedTopic))));
 
-            var topicListMap = listTopicsResult.namesToListings().get();
-            assertEquals(expectedTopics.length, topicListMap.size());
-            Arrays.stream(expectedTopics)
-                    .forEach(expectedTopic -> assertThat(topicListMap).hasEntrySatisfying(expectedTopic, allOf(matches(TopicListing::name, expectedTopic))));
-
-            var describeTopicsResult = admin.describeTopics(TopicNameCollection.ofTopicNames(Arrays.stream(expectedTopics).toList()));
-            var topicDescribeMap = describeTopicsResult.allTopicNames().get();
-            assertEquals(expectedTopics.length, topicDescribeMap.size());
-            Arrays.stream(expectedTopics)
-                    .forEach(expectedTopic -> assertThat(topicDescribeMap).hasEntrySatisfying(expectedTopic, allOf(matches(TopicDescription::name, expectedTopic))));
-        }
-    }
-
-    private void consumeAndVerify(KroxyliciousTester tester, String virtualCluster, String topicName, String groupId, String expectedKey, String expectedValue,
-                                  boolean offsetCommit) {
-        consumeAndVerify(tester, virtualCluster, topicName, groupId, new LinkedList<>(List.of(matchesRecord(topicName, expectedKey, expectedValue))), offsetCommit);
-    }
-
-    private void consumeAndVerify(KroxyliciousTester tester, String virtualCluster, String topicName, String groupId,
-                                  Deque<Predicate<ConsumerRecord<String, String>>> expected, boolean offsetCommit) {
-        try (var consumer = tester.consumer(virtualCluster,
-                commonConfig(Map.of(ConsumerConfig.GROUP_ID_CONFIG, groupId, ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, Boolean.FALSE.toString(),
-                        ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, Boolean.FALSE.toString(), ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
-                        OffsetResetStrategy.EARLIEST.toString(), ConsumerConfig.MAX_POLL_RECORDS_CONFIG, String.format("%d", expected.size()))))) {
-
-            var topicPartitions = List.of(new TopicPartition(topicName, 0));
-            consumer.assign(topicPartitions);
-
-            while (!expected.isEmpty()) {
-                ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(30));
-                assertThat(records.partitions()).hasSizeGreaterThanOrEqualTo(1);
-                records.forEach(r -> {
-                    assertFalse(expected.isEmpty(), String.format("received unexpected record %s", r));
-                    var predicate = expected.pop();
-                    assertThat(r).matches(predicate, predicate.toString());
-                });
-            }
-
-            if (offsetCommit) {
-                consumer.commitSync(Duration.ofSeconds(5));
-            }
-        }
-    }
-
-    private void produceAndVerify(KroxyliciousTester tester, String virtualCluster, String topic, String key, String value) throws Exception {
-        produceAndVerify(tester, virtualCluster, Stream.of(new ProducerRecord<>(topic, key, value)), Optional.empty());
-    }
-
-    private void produceAndVerify(KroxyliciousTester tester, String virtualCluster, Stream<ProducerRecord<String, String>> records, Optional<String> transactionalId)
-            throws Exception {
-
-        Map<String, Object> config = new HashMap<>(Map.of(
-                ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000));
-        transactionalId.ifPresent(tid -> config.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId.get()));
-
-        try (var producer = tester.producer(virtualCluster, commonConfig(config))) {
-            transactionalId.ifPresent(u -> {
-                producer.initTransactions();
-                producer.beginTransaction();
-            });
-
-            records.forEach(rec -> {
-                RecordMetadata recordMetadata = null;
-                try {
-                    recordMetadata = producer.send(rec).get(FUTURE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-                }
-                catch (Exception e) {
-                    fail("Caught: %s producing to %s", e.getMessage(), rec.topic());
-                }
-                assertNotNull(recordMetadata);
-                assertNotNull(rec.topic(), recordMetadata.topic());
-            });
-
-            transactionalId.ifPresent(u -> {
-                producer.commitTransaction();
-            });
-
-        }
-    }
-
-    private void createTopics(KroxyliciousTester tester, String virtualCluster, List<NewTopic> topics) throws Exception {
-        try (var admin = tester.admin(virtualCluster, commonConfig(Map.of()))) {
-            createTopics(admin, topics);
-        }
-    }
-
-    private static CreateTopicsResult createTopics(Admin admin, List<NewTopic> topics) throws Exception {
-        var created = admin.createTopics(topics);
-        assertEquals(topics.size(), created.values().size());
-        created.all().get(FUTURE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        return created;
-    }
-
-    private DeleteTopicsResult deleteTopics(Admin admin, TopicCollection topics) throws Exception {
-        var deleted = admin.deleteTopics(topics);
-        deleted.all().get(FUTURE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-        return deleted;
-    }
-
-    private ConfigurationBuilder getConfig(KafkaCluster cluster) {
-        return new ConfigurationBuilder()
-                .addToVirtualClusters(TENANT_1_CLUSTER, new VirtualClusterBuilder()
-                        .withNewTargetCluster()
-                        .withBootstrapServers(cluster.getBootstrapServers())
-                        .endTargetCluster()
-                        .withClusterNetworkAddressConfigProvider(
-                                new ClusterNetworkAddressConfigProviderDefinitionBuilder("PortPerBroker").withConfig("bootstrapAddress", TENANT_1_PROXY_ADDRESS)
-                                        .build())
-                        .withNewTls()
-                        .withNewKeyStoreKey()
-                        .withStoreFile(certificateGenerator.getKeyStoreLocation())
-                        .withNewInlinePasswordStoreProvider(certificateGenerator.getPassword())
-                        .endKeyStoreKey()
-                        .endTls()
-                        .build())
-                .addToVirtualClusters(TENANT_2_CLUSTER, new VirtualClusterBuilder()
-                        .withNewTargetCluster()
-                        .withBootstrapServers(cluster.getBootstrapServers())
-                        .endTargetCluster()
-                        .withClusterNetworkAddressConfigProvider(
-                                new ClusterNetworkAddressConfigProviderDefinitionBuilder("PortPerBroker").withConfig("bootstrapAddress", TENANT_2_PROXY_ADDRESS)
-                                        .build())
-                        .withNewTls()
-                        .withNewKeyStoreKey()
-                        .withStoreFile(certificateGenerator.getKeyStoreLocation())
-                        .withNewInlinePasswordStoreProvider(certificateGenerator.getPassword())
-                        .endKeyStoreKey()
-                        .endTls()
-                        .build())
-                .addToFilters(new FilterDefinitionBuilder("MultiTenant").build());
-    }
-
-    @NotNull
-    private <T, V> Condition<T> matches(Function<T, V> extractor, V expectedValue) {
-        return new Condition<>(item -> Objects.equals(extractor.apply(item), expectedValue), "unexpected entry");
-    }
-
-    @NotNull
-    private static <K, V> Predicate<ConsumerRecord<K, V>> matchesRecord(final String expectedTopic, final K expectedKey, final V expectedValue) {
-        return new Predicate<>() {
-            @Override
-            public boolean test(ConsumerRecord<K, V> item) {
-                return Objects.equals(item.topic(), expectedTopic) && Objects.equals(item.key(), expectedKey) && Objects.equals(
-                        item.value(), expectedValue);
-            }
-
-            @Override
-            public String toString() {
-                return String.format("expected: key %s value %s", expectedKey, expectedValue);
-            }
-        };
+        var describeTopicsResult = admin.describeTopics(TopicNameCollection.ofTopicNames(Arrays.stream(expectedTopics).toList()));
+        var topicDescribeMap = describeTopicsResult.allTopicNames().get();
+        assertEquals(expectedTopics.length, topicDescribeMap.size());
+        Arrays.stream(expectedTopics)
+                .forEach(expectedTopic -> assertThat(topicDescribeMap).hasEntrySatisfying(expectedTopic, allOf(matches(TopicDescription::name, expectedTopic))));
     }
 
     private static class PartitionAssignmentAwaitingRebalanceListener<K, V> implements ConsumerRebalanceListener {

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/multitenant/MultiTenantIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/multitenant/MultiTenantIT.java
@@ -420,13 +420,13 @@ public class MultiTenantIT extends BaseMultiTenantIT {
         var listTopicsResult = admin.listTopics();
 
         var topicListMap = listTopicsResult.namesToListings().get();
-        assertThat(expectedTopics.length).isEqualTo(topicListMap.size());
+        assertThat(expectedTopics).hasSize(topicListMap.size());
         Arrays.stream(expectedTopics)
                 .forEach(expectedTopic -> assertThat(topicListMap).hasEntrySatisfying(expectedTopic, allOf(matches(TopicListing::name, expectedTopic))));
 
         var describeTopicsResult = admin.describeTopics(TopicNameCollection.ofTopicNames(Arrays.stream(expectedTopics).toList()));
         var topicDescribeMap = describeTopicsResult.allTopicNames().get();
-        assertThat(expectedTopics.length).isEqualTo(topicDescribeMap.size());
+        assertThat(expectedTopics).hasSize(topicDescribeMap.size());
         Arrays.stream(expectedTopics)
                 .forEach(expectedTopic -> assertThat(topicDescribeMap).hasEntrySatisfying(expectedTopic, allOf(matches(TopicDescription::name, expectedTopic))));
     }

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSyntaxValidationIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSyntaxValidationIT.java
@@ -23,7 +23,6 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.InvalidRecordException;
 import org.apache.kafka.common.KafkaException;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -40,8 +39,8 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET
 import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.LINGER_MS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.TRANSACTIONAL_ID_CONFIG;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(KafkaClusterExtension.class)
 public class JsonSyntaxValidationIT extends BaseIT {
@@ -53,8 +52,8 @@ public class JsonSyntaxValidationIT extends BaseIT {
 
     @Test
     public void testInvalidJsonProduceRejected(KafkaCluster cluster, Admin admin) throws Exception {
-        assertEquals(1, cluster.getNumOfBrokers());
-        createTopics(admin, List.of(new NewTopic(TOPIC_1, 1, (short) 1)));
+        assertThat(cluster.getNumOfBrokers()).isEqualTo(1);
+        createTopic(admin, TOPIC_1, 1);
 
         var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator").withConfig("rules",
@@ -70,8 +69,8 @@ public class JsonSyntaxValidationIT extends BaseIT {
 
     @Test
     public void testInvalidJsonProduceRejectedUsingTopicNames(KafkaCluster cluster, Admin admin) throws Exception {
-        assertEquals(1, cluster.getNumOfBrokers());
-        createTopics(admin, List.of(new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1)));
+        assertThat(cluster.getNumOfBrokers()).isEqualTo(1);
+        createTopics(admin, new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1));
 
         var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator").withConfig("rules",
@@ -86,15 +85,15 @@ public class JsonSyntaxValidationIT extends BaseIT {
             producer.send(new ProducerRecord<>(TOPIC_2, "my-key", SYNTACTICALLY_INCORRECT_JSON)).get();
             consumer.subscribe(Set.of(TOPIC_2));
             var records = consumer.poll(Duration.ofSeconds(10));
-            assertEquals(1, records.count());
-            assertEquals(SYNTACTICALLY_INCORRECT_JSON, records.iterator().next().value());
+            assertThat(records.count()).isEqualTo(1);
+            assertThat(records.iterator().next().value()).isEqualTo(SYNTACTICALLY_INCORRECT_JSON);
         }
     }
 
     @Test
     public void testPartiallyInvalidJsonTransactionalAllRejected(KafkaCluster cluster, Admin admin) throws Exception {
-        assertEquals(1, cluster.getNumOfBrokers());
-        createTopics(admin, List.of(new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1)));
+        assertThat(cluster.getNumOfBrokers()).isEqualTo(1);
+        createTopics(admin, new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1));
 
         var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator").withConfig("forwardPartialRequests", true, "rules",
@@ -117,8 +116,8 @@ public class JsonSyntaxValidationIT extends BaseIT {
 
     @Test
     public void testPartiallyInvalidJsonNotConfiguredToForwardAllRejected(KafkaCluster cluster, Admin admin) throws Exception {
-        assertEquals(1, cluster.getNumOfBrokers());
-        createTopics(admin, List.of(new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1)));
+        assertThat(cluster.getNumOfBrokers()).isEqualTo(1);
+        createTopics(admin, new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1));
 
         boolean forwardPartialRequests = false;
         var config = proxy(cluster)
@@ -139,8 +138,8 @@ public class JsonSyntaxValidationIT extends BaseIT {
 
     @Test
     public void testPartiallyInvalidJsonProduceRejected(KafkaCluster cluster, Admin admin) throws Exception {
-        assertEquals(1, cluster.getNumOfBrokers());
-        createTopics(admin, List.of(new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1)));
+        assertThat(cluster.getNumOfBrokers()).isEqualTo(1);
+        createTopics(admin, new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1));
 
         var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator")
@@ -157,19 +156,19 @@ public class JsonSyntaxValidationIT extends BaseIT {
             producer.flush();
             assertInvalidRecordExceptionThrown(invalid, "value was not syntactically correct JSON");
             RecordMetadata metadata = valid.get(10, TimeUnit.SECONDS);
-            assertTrue(metadata.hasOffset());
+            assertThat(metadata.hasOffset()).isTrue();
 
             consumer.subscribe(Set.of(TOPIC_2));
             var records = consumer.poll(Duration.ofSeconds(10));
-            assertEquals(1, records.count());
-            assertEquals(SYNTACTICALLY_CORRECT_JSON, records.iterator().next().value());
+            assertThat(records.count()).isEqualTo(1);
+            assertThat(records.iterator().next().value()).isEqualTo(SYNTACTICALLY_CORRECT_JSON);
         }
     }
 
     @Test
     public void testPartiallyInvalidAcrossPartitionsOfSameTopic(KafkaCluster cluster, Admin admin) throws Exception {
-        assertEquals(1, cluster.getNumOfBrokers());
-        createTopics(admin, List.of(new NewTopic(TOPIC_1, 2, (short) 1)));
+        assertThat(cluster.getNumOfBrokers()).isEqualTo(1);
+        createTopic(admin, TOPIC_1, 2);
 
         var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator")
@@ -186,19 +185,19 @@ public class JsonSyntaxValidationIT extends BaseIT {
             producer.flush();
             assertInvalidRecordExceptionThrown(invalid, "value was not syntactically correct JSON");
             RecordMetadata metadata = valid.get(10, TimeUnit.SECONDS);
-            assertTrue(metadata.hasOffset());
+            assertThat(metadata.hasOffset()).isTrue();
 
             consumer.subscribe(Set.of(TOPIC_1));
             var records = consumer.poll(Duration.ofSeconds(10));
-            assertEquals(1, records.count());
-            assertEquals(SYNTACTICALLY_CORRECT_JSON, records.iterator().next().value());
+            assertThat(records.count()).isEqualTo(1);
+            assertThat(records.iterator().next().value()).isEqualTo(SYNTACTICALLY_CORRECT_JSON);
         }
     }
 
     @Test
     public void testPartiallyInvalidWithinOnePartitionOfTopic(KafkaCluster cluster, Admin admin) throws Exception {
-        assertEquals(1, cluster.getNumOfBrokers());
-        createTopics(admin, List.of(new NewTopic(TOPIC_1, 1, (short) 1)));
+        assertThat(cluster.getNumOfBrokers()).isEqualTo(1);
+        createTopic(admin, TOPIC_1, 1);
 
         var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator").withConfig("forwardPartialRequests", true, "rules",
@@ -212,7 +211,7 @@ public class JsonSyntaxValidationIT extends BaseIT {
             Future<RecordMetadata> valid = producer.send(new ProducerRecord<>(TOPIC_1, "my-key", SYNTACTICALLY_CORRECT_JSON));
             producer.flush();
             assertInvalidRecordExceptionThrown(invalid, "value was not syntactically correct JSON");
-            Assertions.assertThatThrownBy(() -> {
+            assertThatThrownBy(() -> {
                 valid.get(10, TimeUnit.SECONDS);
             }).isInstanceOf(ExecutionException.class).hasCauseInstanceOf(KafkaException.class).cause()
                     .hasMessageContaining("Failed to append record because it was part of a batch which had one more more invalid records");
@@ -221,8 +220,8 @@ public class JsonSyntaxValidationIT extends BaseIT {
 
     @Test
     public void testValidJsonProduceAccepted(KafkaCluster cluster, Admin admin) throws Exception {
-        assertEquals(1, cluster.getNumOfBrokers());
-        createTopics(admin, List.of(new NewTopic(TOPIC_1, 1, (short) 1)));
+        assertThat(cluster.getNumOfBrokers()).isEqualTo(1);
+        createTopic(admin, TOPIC_1, 1);
 
         var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator").withConfig("rules",
@@ -236,16 +235,16 @@ public class JsonSyntaxValidationIT extends BaseIT {
         }
     }
 
-    private static Producer<String, String> getProducer(KroxyliciousTester tester, int linger, int batchSize) {
+    private Producer<String, String> getProducer(KroxyliciousTester tester, int linger, int batchSize) {
         return getProducerWithConfig(tester, Optional.empty(), Map.of(LINGER_MS_CONFIG, linger, ProducerConfig.BATCH_SIZE_CONFIG, batchSize));
     }
 
-    private static Consumer<String, String> getConsumer(KroxyliciousTester tester) {
+    private Consumer<String, String> getConsumer(KroxyliciousTester tester) {
         return getConsumerWithConfig(tester, Optional.empty(), Map.of(GROUP_ID_CONFIG, "my-group-id", AUTO_OFFSET_RESET_CONFIG, "earliest"));
     }
 
     private static void assertInvalidRecordExceptionThrown(Future<RecordMetadata> invalid, String message) {
-        Assertions.assertThatThrownBy(() -> {
+        assertThatThrownBy(() -> {
             invalid.get(10, TimeUnit.SECONDS);
         }).isInstanceOf(ExecutionException.class).hasCauseInstanceOf(InvalidRecordException.class).cause()
                 .hasMessageContaining(message);

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSyntaxValidationIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSyntaxValidationIT.java
@@ -52,7 +52,7 @@ public class JsonSyntaxValidationIT extends BaseIT {
 
     @Test
     public void testInvalidJsonProduceRejected(KafkaCluster cluster, Admin admin) throws Exception {
-        assertThat(cluster.getNumOfBrokers()).isEqualTo(1);
+        assertThat(cluster.getNumOfBrokers()).isOne();
         createTopic(admin, TOPIC_1, 1);
 
         var config = proxy(cluster)
@@ -69,7 +69,7 @@ public class JsonSyntaxValidationIT extends BaseIT {
 
     @Test
     public void testInvalidJsonProduceRejectedUsingTopicNames(KafkaCluster cluster, Admin admin) throws Exception {
-        assertThat(cluster.getNumOfBrokers()).isEqualTo(1);
+        assertThat(cluster.getNumOfBrokers()).isOne();
         createTopics(admin, new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1));
 
         var config = proxy(cluster)
@@ -85,14 +85,14 @@ public class JsonSyntaxValidationIT extends BaseIT {
             producer.send(new ProducerRecord<>(TOPIC_2, "my-key", SYNTACTICALLY_INCORRECT_JSON)).get();
             consumer.subscribe(Set.of(TOPIC_2));
             var records = consumer.poll(Duration.ofSeconds(10));
-            assertThat(records.count()).isEqualTo(1);
+            assertThat(records.count()).isOne();
             assertThat(records.iterator().next().value()).isEqualTo(SYNTACTICALLY_INCORRECT_JSON);
         }
     }
 
     @Test
     public void testPartiallyInvalidJsonTransactionalAllRejected(KafkaCluster cluster, Admin admin) throws Exception {
-        assertThat(cluster.getNumOfBrokers()).isEqualTo(1);
+        assertThat(cluster.getNumOfBrokers()).isOne();
         createTopics(admin, new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1));
 
         var config = proxy(cluster)
@@ -116,7 +116,7 @@ public class JsonSyntaxValidationIT extends BaseIT {
 
     @Test
     public void testPartiallyInvalidJsonNotConfiguredToForwardAllRejected(KafkaCluster cluster, Admin admin) throws Exception {
-        assertThat(cluster.getNumOfBrokers()).isEqualTo(1);
+        assertThat(cluster.getNumOfBrokers()).isOne();
         createTopics(admin, new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1));
 
         boolean forwardPartialRequests = false;
@@ -138,7 +138,7 @@ public class JsonSyntaxValidationIT extends BaseIT {
 
     @Test
     public void testPartiallyInvalidJsonProduceRejected(KafkaCluster cluster, Admin admin) throws Exception {
-        assertThat(cluster.getNumOfBrokers()).isEqualTo(1);
+        assertThat(cluster.getNumOfBrokers()).isOne();
         createTopics(admin, new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1));
 
         var config = proxy(cluster)
@@ -160,14 +160,14 @@ public class JsonSyntaxValidationIT extends BaseIT {
 
             consumer.subscribe(Set.of(TOPIC_2));
             var records = consumer.poll(Duration.ofSeconds(10));
-            assertThat(records.count()).isEqualTo(1);
+            assertThat(records.count()).isOne();
             assertThat(records.iterator().next().value()).isEqualTo(SYNTACTICALLY_CORRECT_JSON);
         }
     }
 
     @Test
     public void testPartiallyInvalidAcrossPartitionsOfSameTopic(KafkaCluster cluster, Admin admin) throws Exception {
-        assertThat(cluster.getNumOfBrokers()).isEqualTo(1);
+        assertThat(cluster.getNumOfBrokers()).isOne();
         createTopic(admin, TOPIC_1, 2);
 
         var config = proxy(cluster)
@@ -189,14 +189,14 @@ public class JsonSyntaxValidationIT extends BaseIT {
 
             consumer.subscribe(Set.of(TOPIC_1));
             var records = consumer.poll(Duration.ofSeconds(10));
-            assertThat(records.count()).isEqualTo(1);
+            assertThat(records.count()).isOne();
             assertThat(records.iterator().next().value()).isEqualTo(SYNTACTICALLY_CORRECT_JSON);
         }
     }
 
     @Test
     public void testPartiallyInvalidWithinOnePartitionOfTopic(KafkaCluster cluster, Admin admin) throws Exception {
-        assertThat(cluster.getNumOfBrokers()).isEqualTo(1);
+        assertThat(cluster.getNumOfBrokers()).isOne();
         createTopic(admin, TOPIC_1, 1);
 
         var config = proxy(cluster)
@@ -220,7 +220,7 @@ public class JsonSyntaxValidationIT extends BaseIT {
 
     @Test
     public void testValidJsonProduceAccepted(KafkaCluster cluster, Admin admin) throws Exception {
-        assertThat(cluster.getNumOfBrokers()).isEqualTo(1);
+        assertThat(cluster.getNumOfBrokers()).isOne();
         createTopic(admin, TOPIC_1, 1);
 
         var config = proxy(cluster)


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Moves common utility methods for various integration tests to a new base class `BaseIT`, moves Multi Tenant utility methods to new base class `BaseMultiTenantIT` (extends `BaseIT`).

### Additional Context

Addresses #450 - cleaning up common util methods across various integration tests so there's now a common way of accessing those methods.

Also contains prep work for #349 - moves util methods used by different kinds of Multi Tenant tests from `MultiTenantIT` to `BaseMultiTenantIT` so they can be reused once those tests are split up.

_NB: I seem to be getting a lot of intermittent test failures on this branch, but as far as I can tell most of these issues also exist in main._

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
