### PR TITLE
directly validate the GPG_KEY arg

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -20,6 +20,10 @@ while getopts ":a:f:b:r:k:" opt; do
     r) REPOSITORY="${OPTARG}"
     ;;
     k) GPG_KEY="${OPTARG}"
+      if [[ -z "${GPG_KEY}" ]]; then
+          echo "GPG_KEY not set unable to sign the release. Please specify -k <YOUR_GPG_KEY>" 1>&2
+          exit 1
+      fi
     ;;
 
     \?) echo "Invalid option -${OPTARG}" >&2
@@ -33,11 +37,6 @@ while getopts ":a:f:b:r:k:" opt; do
     ;;
   esac
 done
-
-if [[ -z "${GPG_KEY}" ]]; then
-    echo "GPG_KEY not set unable to sign the release. Please specify -k <YOUR_GPG_KEY>" 1>&2
-    exit 1
-fi
 
 if [[ -z ${RELEASE_API_VERSION} && -z ${RELEASE_VERSION} ]]; then
   echo "No versions specified aborting"

--- a/release.sh
+++ b/release.sh
@@ -52,10 +52,12 @@ git fetch -q "${REPOSITORY}"
 RELEASE_DATE=$(date -u '+%Y-%m-%d')
 git checkout -b "prepare-release-${RELEASE_DATE}" "${REPOSITORY}/${BRANCH_FROM}"
 
-#Disable the shell check as the colour codes only work with interpolation.
-# shellcheck disable=SC2059
-printf "Validating the build is ${GREEN}green${NC}"
-mvn -q clean verify
+if [[ -z "${SKIP_VALIDATION:-}" ]]; then
+  #Disable the shell check as the colour codes only work with interpolation.
+  # shellcheck disable=SC2059
+  printf "Validating the build is ${GREEN}green${NC}"
+  mvn -q clean verify
+fi
 
 if [[ -n ${RELEASE_API_VERSION} ]]; then
   echo "Versioning Public APIs as ${RELEASE_API_VERSION}"

--- a/release.sh
+++ b/release.sh
@@ -52,7 +52,7 @@ git fetch -q "${REPOSITORY}"
 RELEASE_DATE=$(date -u '+%Y-%m-%d')
 git checkout -b "prepare-release-${RELEASE_DATE}" "${REPOSITORY}/${BRANCH_FROM}"
 
-if [[ -z "${SKIP_VALIDATION:-}" ]]; then
+if [[ "${SKIP_VALIDATION:-false}" != true ]]; then
   #Disable the shell check as the colour codes only work with interpolation.
   # shellcheck disable=SC2059
   printf "Validating the build is ${GREEN}green${NC}"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Validate GPG_KEY is set during arg parsing.

### Additional Context

We already use getopt so actually validate it during arg parsing seems like a sensible change. 

note this PR also introduce an extra env var check to allow the testing of the script with out actually running the maven build every time as that is extremely slow in comparison to the rest of the script and is not yet stable enough.  

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
