### PR TITLE
MultiTenant - couple of fixes to make the filter operational with a sarama based client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.3.0
 
+* [#480](https://github.com/kroxylicious/kroxylicious/issues/480): Multi-tenant - add suport for the versions of OffsetFetch, FindCoordinator, and DeleteTopics used by Sarama client v1.38.1
 * [#472](https://github.com/kroxylicious/kroxylicious/issues/472): Respect logFrame/logNetwork options in virtualcluster config
 * [#470](https://github.com/kroxylicious/kroxylicious/issues/470): Ensure that the EagerMetadataLearner passes on a client's metadata request with fidelity (fix for kcat -C -E)
 * [#416](https://github.com/kroxylicious/kroxylicious/issues/416): Eagerly expose broker endpoints on startup to allow existing client to reconnect (without connecting to bootstrap).

--- a/kroxylicious-additional-filters/kroxylicious-multitenant/src/test/resources/io/kroxylicious/proxy/filter/multitenant/DeleteTopic.test.yaml
+++ b/kroxylicious-additional-filters/kroxylicious-multitenant/src/test/resources/io/kroxylicious/proxy/filter/multitenant/DeleteTopic.test.yaml
@@ -30,3 +30,26 @@
         path: "/responses/0/name"
         value: foo
   disabled: false
+- apiMessageType: DELETE_TOPICS
+  version: 1
+  request:
+    payload:
+      topicNames: [foo]
+      topics: []
+      timeoutMs: 0
+      validateOnly: false
+    diff:
+      - op: replace
+        path: "/topicNames/0"
+        value: tenant1-foo
+  response:
+    payload:
+      responses:
+        - name: tenant1-foo
+          errorCode: 0
+      throttleTimeMs: 0
+    diff:
+      - op: replace
+        path: "/responses/0/name"
+        value: foo
+  disabled: false

--- a/kroxylicious-additional-filters/kroxylicious-multitenant/src/test/resources/io/kroxylicious/proxy/filter/multitenant/FindCoordinator.test.yaml
+++ b/kroxylicious-additional-filters/kroxylicious-multitenant/src/test/resources/io/kroxylicious/proxy/filter/multitenant/FindCoordinator.test.yaml
@@ -32,3 +32,15 @@
         path: "/coordinators/0/key"
         value: mygroup
   disabled: false
+- apiMessageType: FIND_COORDINATOR
+  version: 1
+  request:
+    payload:
+      key: mygroup
+      keyType: 0
+      coordinatorKeys: []
+    diff:
+      - op: replace
+        path: /key
+        value: tenant1-mygroup
+  disabled: false

--- a/kroxylicious-additional-filters/kroxylicious-multitenant/src/test/resources/io/kroxylicious/proxy/filter/multitenant/OffsetFetch.test.yaml
+++ b/kroxylicious-additional-filters/kroxylicious-multitenant/src/test/resources/io/kroxylicious/proxy/filter/multitenant/OffsetFetch.test.yaml
@@ -57,3 +57,30 @@
         path: "/groups/0/groupId"
         value: tenant1-mygroup
   disabled: false
+- apiMessageType: OFFSET_FETCH
+  description: offset fetch group without topic
+  version: 2
+  request:
+    payload:
+      groupId: mygroup
+      topics: null
+      requireStable: false
+    diff:
+      - op: replace
+        path: "/groupId"
+        value: tenant1-mygroup
+  response:
+    payload:
+      topics:
+        - name: tenant1-foo
+          partitions:
+            - partitionIndex: 0
+              committedOffset: 0
+              metadata: null
+              errorCode: 0
+      errorCode: 0
+    diff:
+      - op: replace
+        path: "/topics/0/name"
+        value: foo
+  disabled: false


### PR DESCRIPTION
(I cherry-picked this PR out from #481 as it deserves to stand on its own).

### Type of change

_Select the type of your PR_

- Bugfix

### Description

Allows MultiTenant filter to be used with [kaf](https://github.com/birdayz/kaf) (sarama based tool) for simple publish/consume and topic/group management. It uses the Sarama client (v1.38.1) which uses some older Kafka RPCs.

* OffsetFetch v2
* FindCoordinator v1
* DeleteTopics v1

Why: I've been experimenting with `kaf` as a tool to use in demos.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [x] Reference relevant issue(s) and close them after merging
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
