### PR TITLE
Add onFilterRemoved to KrpcFilter to tear down resources

### DIFF
--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/KrpcFilter.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/KrpcFilter.java
@@ -11,4 +11,11 @@ package io.kroxylicious.proxy.filter;
  */
 public /* sealed */ interface KrpcFilter {
 
+    /**
+     * Called when the Filter is removed, for instance when the client connection is closed
+     */
+    default void onFilterRemoved() {
+
+    }
+
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -100,4 +100,9 @@ public class FilterHandler
         }
     }
 
+    @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+        filter.onFilterRemoved();
+        super.handlerRemoved(ctx);
+    }
 }


### PR DESCRIPTION
Resolves #350 

### Type of change

- Enhancement / new feature

### Description
Adds a method `onFilterRemoved` which is called when the underlying handler's `handlerRemoved` is called by netty. Note that this is called if the filter is removed from a pipeline as well as when the channel is closed.

Why:
A filter may have some resources it wishes to clean up when it the channel is closed. For example in topic-encryption we might want to deregister some file watchers.

This popped up in the context of TopicEncryption as I'm considering how to set up a service that watches for changes to some configuration files. We might want to tear down some of the file watchers when a channel is closed.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
