### PR TITLE
Magic modules

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,12 +31,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: 'true'
-
+          fetch-depth: 0
       - name: 'Set up Java'
         uses: actions/setup-java@v3
         with:
           java-version: 20
-          distribution: 'zulu'
+          distribution: 'temurin'
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
         with:

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -11,6 +11,7 @@
     <file url="file://$PROJECT_DIR$/kroxylicious-additional-filters/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious-api/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious-api/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/kroxylicious-api/target/generated-sources/krpc" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious-sample/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious-sample/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/kroxylicious-test-tools/src/main/java" charset="UTF-8" />

--- a/.lift.toml
+++ b/.lift.toml
@@ -1,5 +1,0 @@
-setup = "scripts/setupLift.sh"
-build = "mvn install -pl !:integrationtests --also-make-dependents -Dquick"
-jdkVersion = "17"
-
-# see .lift/ignoreFile for files being ignored

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-17:1.15 AS builder
 USER root
 WORKDIR /opt/kroxylicious
 COPY . .
-RUN ./mvnw -B clean verify -Pdist -Dquick -pl :kroxylicious -am
+RUN ./mvnw -B clean verify -Pdist -Dquick -pl :kroxylicious-bom,:kroxylicious -am
 USER 185
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
 

--- a/performance-tests/pom.xml
+++ b/performance-tests/pom.xml
@@ -23,6 +23,7 @@
     <properties>
         <jmh.version>1.36</jmh.version>
         <uberjar.name>benchmarks</uberjar.name>
+        <sonar.skip>true</sonar.skip>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -671,7 +671,6 @@
             <properties>
                 <sonar.organization>kroxylicious</sonar.organization>
                 <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-                <sonar.projectKey>kroxylicious_kroxylicious</sonar.projectKey>
             </properties>
             <build>
                 <plugins>
@@ -741,6 +740,15 @@
                         <groupId>org.sonarsource.scanner.maven</groupId>
                         <artifactId>sonar-maven-plugin</artifactId>
                         <version>3.9.1.2184</version>
+                        <executions>
+                            <execution>
+                                <id>sonar-scan</id>
+                                <goals>
+                                    <goal>sonar</goal>
+                                </goals>
+                                <phase>verify</phase>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/scripts/release-api.sh
+++ b/scripts/release-api.sh
@@ -21,7 +21,7 @@ if [[ -z ${RELEASE_API_VERSION} ]]; then
 fi
 
 echo "Setting API version to ${RELEASE_API_VERSION}"
-mvn -q versions:set -DnewVersion="${RELEASE_API_VERSION}" -DprocessAllModules=true -pl :kroxylicious-bom,{API_MODULES} -DgenerateBackupPoms=false
+mvn -q versions:set -DnewVersion="${RELEASE_API_VERSION}" -DprocessAllModules=true -pl :kroxylicious-bom,${API_MODULES} -DgenerateBackupPoms=false
 mvn -q clean install -Pquick -pl :kroxylicious-bom,${API_MODULES}  #quick sanity check to ensure the API modules still build
 mvn -q versions:set-property -Dproperty=kroxyliciousApi.version -DnewVersion="${RELEASE_API_VERSION}" -DgenerateBackupPoms=false
 

--- a/scripts/release-api.sh
+++ b/scripts/release-api.sh
@@ -21,8 +21,8 @@ if [[ -z ${RELEASE_API_VERSION} ]]; then
 fi
 
 echo "Setting API version to ${RELEASE_API_VERSION}"
-mvn -q versions:set -DnewVersion="${RELEASE_API_VERSION}" -DprocessAllModules=true -pl ${API_MODULES} -DgenerateBackupPoms=false
-mvn -q clean install -Pquick -pl ${API_MODULES}  #quick sanity check to ensure the API modules still build
+mvn -q versions:set -DnewVersion="${RELEASE_API_VERSION}" -DprocessAllModules=true -pl :kroxylicious-bom,{API_MODULES} -DgenerateBackupPoms=false
+mvn -q clean install -Pquick -pl :kroxylicious-bom,${API_MODULES}  #quick sanity check to ensure the API modules still build
 mvn -q versions:set-property -Dproperty=kroxyliciousApi.version -DnewVersion="${RELEASE_API_VERSION}" -DgenerateBackupPoms=false
 
 echo "Validating things still build"


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

The kroxylicious-bom is not being resolved as a dependency when building with `-pl` so this PR includes it by hand.

### Additional Context

I think this is caused by a variation of warning from the Bill of [materials docs](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies:~:text=Do%20not%20attempt%20to%20import%20a%20POM%20that%20is%20defined%20in%20a%20submodule%20of%20the%20current%20POM.%20Attempting%20to%20do%20that%20will%20result%20in%20the%20build%20failing%20since%20it%20won%27t%20be%20able%20to%20locate%20the%20POM.). As we list the bom as a module in `kroxylicious-parent` however that is not the root pom so things generally shake out. 

Fixes: #503 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
