### PR TITLE
Re-order responses to match the order they are received from client 

### DIFF
--- a/integrationtests/src/test/java/io/kroxylicious/proxy/ApiVersionsIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/ApiVersionsIT.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.test.Request;
 import io.kroxylicious.test.Response;
+import io.kroxylicious.test.ResponsePayload;
 import io.kroxylicious.test.client.KafkaClient;
 import io.kroxylicious.test.tester.KroxyliciousConfigUtils;
 import io.kroxylicious.test.tester.MockServerKroxyliciousTester;
@@ -87,11 +88,12 @@ public class ApiVersionsIT {
             ApiVersionsResponseData.ApiVersion version = new ApiVersionsResponseData.ApiVersion();
             version.setApiKey((short) 9999).setMinVersion((short) 3).setMaxVersion((short) 4);
             mockResponse.apiKeys().add(version);
-            tester.addMockResponseForApiKey(new Response(ApiKeys.API_VERSIONS, (short) 3, mockResponse));
+            tester.addMockResponseForApiKey(new ResponsePayload(ApiKeys.API_VERSIONS, (short) 3, mockResponse));
             Response response = whenGetApiVersionsFromKroxylicious(client);
-            assertEquals(ApiKeys.API_VERSIONS, response.apiKeys());
-            assertEquals((short) 3, response.apiVersion());
-            ApiVersionsResponseData message = (ApiVersionsResponseData) response.message();
+            ResponsePayload payload = response.payload();
+            assertEquals(ApiKeys.API_VERSIONS, payload.apiKeys());
+            assertEquals((short) 3, payload.apiVersion());
+            ApiVersionsResponseData message = (ApiVersionsResponseData) payload.message();
             assertTrue(message.apiKeys().isEmpty());
         }
     }
@@ -106,11 +108,12 @@ public class ApiVersionsIT {
                 version.setApiKey(knownValue.id).setMinVersion(knownValue.oldestVersion()).setMaxVersion(knownValue.latestVersion());
                 mockResponse.apiKeys().add(version);
             }
-            tester.addMockResponseForApiKey(new Response(ApiKeys.API_VERSIONS, (short) 3, mockResponse));
+            tester.addMockResponseForApiKey(new ResponsePayload(ApiKeys.API_VERSIONS, (short) 3, mockResponse));
             Response response = whenGetApiVersionsFromKroxylicious(client);
-            assertEquals(ApiKeys.API_VERSIONS, response.apiKeys());
-            assertEquals((short) 3, response.apiVersion());
-            ApiVersionsResponseData message = (ApiVersionsResponseData) response.message();
+            ResponsePayload payload = response.payload();
+            assertEquals(ApiKeys.API_VERSIONS, payload.apiKeys());
+            assertEquals((short) 3, payload.apiVersion());
+            ApiVersionsResponseData message = (ApiVersionsResponseData) payload.message();
             Map<ApiKeys, ApiVersionsResponseData.ApiVersion> responseVersions = message.apiKeys().stream()
                     .collect(Collectors.toMap(k -> ApiKeys.forId(k.apiKey()), k -> k));
             for (ApiKeys knownValue : ApiKeys.values()) {
@@ -126,7 +129,7 @@ public class ApiVersionsIT {
         ApiVersionsResponseData.ApiVersion version = new ApiVersionsResponseData.ApiVersion();
         version.setApiKey(keys.id).setMinVersion(minVersion).setMaxVersion(maxVersion);
         mockResponse.apiKeys().add(version);
-        tester.addMockResponseForApiKey(new Response(ApiKeys.API_VERSIONS, (short) 3, mockResponse));
+        tester.addMockResponseForApiKey(new ResponsePayload(ApiKeys.API_VERSIONS, (short) 3, mockResponse));
     }
 
     private static Response whenGetApiVersionsFromKroxylicious(KafkaClient client) {
@@ -134,9 +137,10 @@ public class ApiVersionsIT {
     }
 
     private static void assertKroxyliciousResponseOffersApiVersionsForApiKey(Response response, ApiKeys apiKeys, short minVersion, short maxVersion) {
-        assertEquals(ApiKeys.API_VERSIONS, response.apiKeys());
-        assertEquals((short) 3, response.apiVersion());
-        ApiVersionsResponseData message = (ApiVersionsResponseData) response.message();
+        ResponsePayload payload = response.payload();
+        assertEquals(ApiKeys.API_VERSIONS, payload.apiKeys());
+        assertEquals((short) 3, payload.apiVersion());
+        ApiVersionsResponseData message = (ApiVersionsResponseData) payload.message();
         assertEquals(1, message.apiKeys().size());
         ApiVersionsResponseData.ApiVersion singletonVersion = message.apiKeys().iterator().next();
         assertEquals(apiKeys.id, singletonVersion.apiKey());

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/OutOfBandRequestIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/OutOfBandRequestIT.java
@@ -23,6 +23,7 @@ import io.kroxylicious.proxy.config.FilterDefinition;
 import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
 import io.kroxylicious.test.Request;
 import io.kroxylicious.test.Response;
+import io.kroxylicious.test.ResponsePayload;
 import io.kroxylicious.test.client.KafkaClient;
 import io.kroxylicious.test.tester.KroxyliciousConfigUtils;
 import io.kroxylicious.test.tester.KroxyliciousTesters;
@@ -67,7 +68,7 @@ public class OutOfBandRequestIT {
         DescribeClusterResponseData message = new DescribeClusterResponseData();
         message.setErrorMessage("arbitrary");
         message.setErrorCode(Errors.UNSUPPORTED_VERSION.code());
-        tester.addMockResponseForApiKey(new Response(DESCRIBE_CLUSTER, DESCRIBE_CLUSTER.latestVersion(), message));
+        tester.addMockResponseForApiKey(new ResponsePayload(DESCRIBE_CLUSTER, DESCRIBE_CLUSTER.latestVersion(), message));
     }
 
     private static MockServerKroxyliciousTester createMockTesterWithFilters(FilterDefinition... definitions) {
@@ -97,7 +98,7 @@ public class OutOfBandRequestIT {
     private static DescribeClusterResponseData whenDescribeCluster(KafkaClient client) {
         Response response = client.getSync(
                 new Request(DESCRIBE_CLUSTER, DESCRIBE_CLUSTER.latestVersion(), "client", new DescribeClusterRequestData()));
-        return (DescribeClusterResponseData) response.message();
+        return (DescribeClusterResponseData) response.payload().message();
     }
 
     private static void givenMockReturnsArbitraryCreateTopicResponse(MockServerKroxyliciousTester tester) {
@@ -107,6 +108,6 @@ public class OutOfBandRequestIT {
         topic.setReplicationFactor((short) 3);
         topic.setNumPartitions(3);
         message.topics().add(topic);
-        tester.addMockResponseForApiKey(new Response(CREATE_TOPICS, CREATE_TOPICS.latestVersion(), message));
+        tester.addMockResponseForApiKey(new ResponsePayload(CREATE_TOPICS, CREATE_TOPICS.latestVersion(), message));
     }
 }

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/Response.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/Response.java
@@ -6,11 +6,6 @@
 
 package io.kroxylicious.test;
 
-import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ApiMessage;
-
-public record Response(ApiKeys apiKeys,
-                       short apiVersion,
-                       ApiMessage message) {
-
+public record Response(ResponsePayload payload,
+                       int sequenceNumber) {
 }

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/ResponsePayload.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/ResponsePayload.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+public record ResponsePayload(ApiKeys apiKeys,
+                              short apiVersion,
+                              ApiMessage message) {
+}

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/client/CorrelationManager.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/client/CorrelationManager.java
@@ -14,8 +14,6 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.kroxylicious.test.codec.DecodedResponseFrame;
-
 /**
  * Tracks api version for requests
  */
@@ -41,7 +39,7 @@ public class CorrelationManager {
      */
     public void putBrokerRequest(short apiKey,
                                  short apiVersion,
-                                 int correlationId, CompletableFuture<DecodedResponseFrame<?>> responseFuture) {
+                                 int correlationId, CompletableFuture<SequencedResponse> responseFuture) {
         Correlation existing = this.brokerRequests.put(correlationId, new Correlation(apiKey, apiVersion, responseFuture));
         if (existing != null) {
             LOGGER.error("Duplicate upstream correlation id {}", correlationId);
@@ -63,7 +61,7 @@ public class CorrelationManager {
      */
     public record Correlation(short apiKey,
                               short apiVersion,
-                              CompletableFuture<DecodedResponseFrame<?>> responseFuture) {
+                              CompletableFuture<SequencedResponse> responseFuture) {
 
         @Override
         public String toString() {

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/client/KafkaClient.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/client/KafkaClient.java
@@ -25,6 +25,7 @@ import io.netty.channel.socket.SocketChannel;
 
 import io.kroxylicious.test.Request;
 import io.kroxylicious.test.Response;
+import io.kroxylicious.test.ResponsePayload;
 import io.kroxylicious.test.codec.DecodedRequestFrame;
 import io.kroxylicious.test.codec.DecodedResponseFrame;
 import io.kroxylicious.test.codec.KafkaRequestEncoder;
@@ -164,8 +165,9 @@ public final class KafkaClient implements AutoCloseable {
         return c;
     }
 
-    private static Response toResponse(DecodedResponseFrame<?> decodedResponseFrame) {
-        return new Response(decodedResponseFrame.apiKey(), decodedResponseFrame.apiVersion(), decodedResponseFrame.body());
+    private static Response toResponse(SequencedResponse sequencedResponse) {
+        DecodedResponseFrame<?> frame = sequencedResponse.frame();
+        return new Response(new ResponsePayload(frame.apiKey(), frame.apiVersion(), frame.body()), sequencedResponse.sequenceNumber());
     }
 
 }

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/client/KafkaClientHandler.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/client/KafkaClientHandler.java
@@ -16,7 +16,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 
 import io.kroxylicious.test.codec.DecodedRequestFrame;
-import io.kroxylicious.test.codec.DecodedResponseFrame;
 
 /**
  * Simple kafka handle capable of sending one or more requests to a server side.
@@ -62,9 +61,9 @@ public class KafkaClientHandler extends ChannelInboundHandlerAdapter {
      * future will complete once the request is sent and yield a null value.
      *
      * @param decodedRequestFrame request frame to send
-     * @return future that will yield the response.
+     * @return future that will yield the response along with a sequenceNumber indicating the order it was received by the client.
      */
-    public CompletableFuture<DecodedResponseFrame<?>> sendRequest(DecodedRequestFrame<?> decodedRequestFrame) {
+    public CompletableFuture<SequencedResponse> sendRequest(DecodedRequestFrame<?> decodedRequestFrame) {
         queue.addLast(decodedRequestFrame);
         processPendingWrites();
         return decodedRequestFrame.getResponseFuture();

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/client/SequencedResponse.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/client/SequencedResponse.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test.client;
+
+import io.kroxylicious.test.codec.DecodedResponseFrame;
+
+public record SequencedResponse(DecodedResponseFrame<?> frame, int sequenceNumber) {
+}

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/codec/DecodedRequestFrame.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/codec/DecodedRequestFrame.java
@@ -11,6 +11,8 @@ import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.requests.ProduceRequest;
 
+import io.kroxylicious.test.client.SequencedResponse;
+
 /**
  * A decoded request frame.
  * @param <B> type of api message in decoded frame
@@ -19,7 +21,7 @@ public class DecodedRequestFrame<B extends ApiMessage>
         extends DecodedFrame<RequestHeaderData, B>
         implements Frame {
 
-    private final CompletableFuture<DecodedResponseFrame<?>> responseFuture = new CompletableFuture<>();
+    private final CompletableFuture<SequencedResponse> responseFuture = new CompletableFuture<>();
 
     /**
      * Create a decoded request frame
@@ -40,7 +42,7 @@ public class DecodedRequestFrame<B extends ApiMessage>
         return apiKey().messageType.requestHeaderVersion(apiVersion);
     }
 
-    public CompletableFuture<DecodedResponseFrame<?>> getResponseFuture() {
+    public CompletableFuture<SequencedResponse> getResponseFuture() {
         return responseFuture;
     }
 

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/codec/KafkaResponseDecoder.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/codec/KafkaResponseDecoder.java
@@ -16,12 +16,14 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 
 import io.kroxylicious.test.client.CorrelationManager;
+import io.kroxylicious.test.client.SequencedResponse;
 
 /**
  * KafkaResponseDecoder
  */
 public class KafkaResponseDecoder extends KafkaMessageDecoder {
 
+    int i = 0;
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaResponseDecoder.class);
 
     private final CorrelationManager correlationManager;
@@ -65,7 +67,7 @@ public class KafkaResponseDecoder extends KafkaMessageDecoder {
         ApiMessage body = BodyDecoder.decodeResponse(apiKey, apiVersion, accessor);
         log().trace("{}: Body: {}", ctx, body);
         frame = new DecodedResponseFrame<>(apiVersion, correlationId, header, body);
-        correlation.responseFuture().complete(frame);
+        correlation.responseFuture().complete(new SequencedResponse(frame, i++));
         return frame;
     }
 

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/server/Action.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/server/Action.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test.server;
+
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+import io.netty.channel.ChannelHandlerContext;
+
+import io.kroxylicious.test.codec.DecodedRequestFrame;
+import io.kroxylicious.test.codec.DecodedResponseFrame;
+
+interface Action {
+    void handle(ChannelHandlerContext ctx, DecodedRequestFrame<?> frame);
+
+    static Action drop() {
+        return (ctx, frame) -> {
+        };
+    }
+
+    static Action respond(ApiMessage message) {
+        return (ctx, frame) -> {
+            DecodedResponseFrame<?> responseFrame = new DecodedResponseFrame<>(frame.apiVersion(),
+                    frame.correlationId(), new ResponseHeaderData().setCorrelationId(frame.correlationId()), message);
+            ctx.write(responseFrame);
+        };
+    }
+}

--- a/kroxylicious-test-tools/src/test/java/io/kroxylicious/mock/MockServerTest.java
+++ b/kroxylicious-test-tools/src/test/java/io/kroxylicious/mock/MockServerTest.java
@@ -22,6 +22,7 @@ import io.kroxylicious.test.ApiMessageSampleGenerator.ApiAndVersion;
 import io.kroxylicious.test.DataClasses;
 import io.kroxylicious.test.Request;
 import io.kroxylicious.test.Response;
+import io.kroxylicious.test.ResponsePayload;
 import io.kroxylicious.test.client.KafkaClient;
 import io.kroxylicious.test.server.MockServer;
 
@@ -42,17 +43,17 @@ class MockServerTest {
     @ParameterizedTest
     @MethodSource("allSupportedApiVersions")
     void testClientCanSendAndReceiveRPCToMock(ApiAndVersion apiKey) throws Exception {
-        Response mockResponse = getResponse(apiKey);
+        ResponsePayload mockResponse = getResponse(apiKey);
         try (var mockServer = MockServer.startOnRandomPort(mockResponse);
                 var kafkaClient = new KafkaClient("127.0.0.1", mockServer.port())) {
             CompletableFuture<Response> future = kafkaClient.get(getRequest(apiKey));
             Response clientResponse = future.get(10, TimeUnit.SECONDS);
-            assertEquals(mockResponse, clientResponse);
+            assertEquals(mockResponse, clientResponse.payload());
         }
     }
 
-    private Response getResponse(ApiAndVersion apiAndVersion) {
-        return new Response(apiAndVersion.keys(), apiAndVersion.apiVersion(), responseSamples.get(apiAndVersion));
+    private ResponsePayload getResponse(ApiAndVersion apiAndVersion) {
+        return new ResponsePayload(apiAndVersion.keys(), apiAndVersion.apiVersion(), responseSamples.get(apiAndVersion));
     }
 
     private Request getRequest(ApiAndVersion apiAndVersion) {

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -159,8 +159,8 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
         // because it needs to know whether to decode requests
         KafkaRequestDecoder decoder = new KafkaRequestDecoder(dp);
         pipeline.addLast("requestDecoder", decoder);
-
         pipeline.addLast("responseEncoder", new KafkaResponseEncoder());
+        pipeline.addLast("responseOrderer", new ResponseOrderer());
         if (virtualCluster.isLogFrames()) {
             pipeline.addLast("frameLogger", new LoggingHandler("io.kroxylicious.proxy.internal.DownstreamFrameLogger", LogLevel.INFO));
         }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/ResponseOrderer.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/ResponseOrderer.java
@@ -19,6 +19,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 
 import io.kroxylicious.proxy.frame.Frame;
+import io.kroxylicious.proxy.frame.RequestFrame;
 
 /**
  * While processing a request from a Client, we want to enable custom Protocol
@@ -45,7 +46,12 @@ public class ResponseOrderer extends ChannelDuplexHandler {
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-        if (msg instanceof Frame frame) {
+        if (msg instanceof RequestFrame requestFrame) {
+            if (requestFrame.hasResponse()) {
+                inflightCorrelationIds.addLast(requestFrame.correlationId());
+            }
+        }
+        else if (msg instanceof Frame frame) {
             inflightCorrelationIds.addLast(frame.correlationId());
         }
         super.channelRead(ctx, msg);

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/ResponseOrderer.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/ResponseOrderer.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+
+import io.kroxylicious.proxy.frame.Frame;
+
+/**
+ * While processing a request from a Client, we want to enable custom Protocol
+ * Filters to decide to send a response toward the Client instead of forwarding
+ * the message on towards the upstream broker. In this case we may not be able
+ * to immediately send the response to the Client. There may be other requests
+ * in-flight that have already been forwarded to the upstream broker and the
+ * Kafka protocol requires responses to be sent to the Client in the same order
+ * they sent the requests.
+ * This class tries to ensure that we respond to requests in the correct order by
+ * remembering which correlationIds are in-flight and enqueuing any responses we
+ * get that are out of order. Then, when we do encounter the response for the
+ * oldest in-flight correlationId we can check if there are any enqueued
+ * responses that can now be forwarded towards the client.
+ */
+public class ResponseOrderer extends ChannelDuplexHandler {
+
+    Deque<Integer> inflightCorrelationIds = new ArrayDeque<>();
+    Map<Integer, QueuedResponse> queuedResponses = new HashMap<>();
+    private static final Logger logger = LoggerFactory.getLogger(ResponseOrderer.class);
+
+    record QueuedResponse(Object msg, ChannelPromise promise) {
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (msg instanceof Frame frame) {
+            inflightCorrelationIds.addLast(frame.correlationId());
+        }
+        super.channelRead(ctx, msg);
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        if (msg instanceof Frame responseFrame) {
+            Integer oldestCorrelationId = inflightCorrelationIds.peekFirst();
+            if (oldestCorrelationId == null) {
+                logger.warn("Handling a Frame {}, but we have no inflight correlation ids, continuing to write", msg);
+                super.write(ctx, msg, promise);
+            }
+            else if (oldestCorrelationId == responseFrame.correlationId()) {
+                inflightCorrelationIds.removeFirst();
+                super.write(ctx, msg, promise);
+                drainQueue(ctx);
+            }
+            else {
+                queuedResponses.put(responseFrame.correlationId(), new QueuedResponse(msg, promise));
+            }
+        }
+        else {
+            super.write(ctx, msg, promise);
+        }
+    }
+
+    private void drainQueue(ChannelHandlerContext ctx) throws Exception {
+        Integer oldestCorrelationId;
+        while ((oldestCorrelationId = inflightCorrelationIds.peekFirst()) != null && queuedResponses.containsKey(oldestCorrelationId)) {
+            Integer integer = inflightCorrelationIds.removeFirst();
+            QueuedResponse thing = queuedResponses.remove(integer);
+            super.write(ctx, thing.msg, thing.promise);
+        }
+    }
+
+    int inFlightRequestCount() {
+        return inflightCorrelationIds.size();
+    }
+
+    int queuedResponseCount() {
+        return queuedResponses.size();
+    }
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/ResponseOrdererTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/ResponseOrdererTest.java
@@ -13,6 +13,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 
 import io.kroxylicious.proxy.frame.ByteBufAccessor;
 import io.kroxylicious.proxy.frame.Frame;
+import io.kroxylicious.proxy.frame.RequestFrame;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,6 +41,35 @@ class ResponseOrdererTest {
 
     }
 
+    record TestRequestFrame(int correlationId, boolean hasResponse) implements RequestFrame {
+
+    @Override
+    public int estimateEncodedSize() {
+        return 0;
+    }
+
+    @Override
+    public void encode(ByteBufAccessor out) {
+
+    }
+
+    @Override
+    public int correlationId() {
+        return correlationId;
+    }
+
+    @Override
+    public boolean hasResponse() {
+        return hasResponse;
+    }
+
+    @Override
+    public boolean decodeResponse() {
+        return false;
+    }
+
+    }
+
     @BeforeEach
     public void beforeEach() {
         embeddedChannel = new EmbeddedChannel();
@@ -52,7 +82,8 @@ class ResponseOrdererTest {
         TestFrame request = new TestFrame(1);
         whenWriteInboundMessage(request);
         thenInboundContains(request);
-        thenOrdererStateEquals(1, 0);
+        thenInFlightRequestCountEquals(1);
+        thenQueuedResponseCountEquals(0);
     }
 
     @Test
@@ -60,7 +91,8 @@ class ResponseOrdererTest {
         Object request = new Object();
         whenWriteInboundMessage(request);
         thenInboundContains(request);
-        thenOrdererStateEquals(0, 0);
+        thenInFlightRequestCountEquals(0);
+        thenQueuedResponseCountEquals(0);
     }
 
     @Test
@@ -68,42 +100,88 @@ class ResponseOrdererTest {
         TestFrame request = new TestFrame(1);
         whenWriteInboundMessage(request);
         thenInboundContains(request);
-        thenOrdererStateEquals(1, 0);
+        thenInFlightRequestCountEquals(1);
+        thenQueuedResponseCountEquals(0);
         TestFrame response = new TestFrame(1);
         whenWriteOutboundMessage(response);
-        thenOrdererStateEquals(0, 0);
+        thenInFlightRequestCountEquals(0);
+        thenQueuedResponseCountEquals(0);
         thenOutboundContains(response);
     }
 
     @Test
-    void testMultipleInflightMessagesThatRespondInOrder() {
-        whenWriteInboundMessage(new TestFrame(1));
-        whenWriteInboundMessage(new TestFrame(2));
-        thenOrdererStateEquals(2, 0);
+    void testSingleRequestWithResponseExpected() {
+        TestRequestFrame request = new TestRequestFrame(1, true);
+        whenWriteInboundMessage(request);
+        thenInboundContains(request);
+        thenInFlightRequestCountEquals(1);
+        thenQueuedResponseCountEquals(0);
         TestFrame response = new TestFrame(1);
         whenWriteOutboundMessage(response);
-        thenOrdererStateEquals(1, 0);
+        thenInFlightRequestCountEquals(0);
+        thenQueuedResponseCountEquals(0);
         thenOutboundContains(response);
-        TestFrame response2 = new TestFrame(2);
-        whenWriteOutboundMessage(response2);
-        thenOrdererStateEquals(0, 0);
-        thenOutboundContains(response2);
+    }
+
+    /**
+     * Some specific requests do not have a corresponding response expected by the Kafka Client.
+     * In this case we do not want these requests to affect response re-ordering. So their
+     * correlation ids should not be added to the queue.
+     */
+    @Test
+    void testSingleRequestResponseNotDelayedByRequestWithNoResponse() {
+        TestRequestFrame noResponseRequest = new TestRequestFrame(1, false);
+        whenWriteInboundMessage(noResponseRequest);
+        thenInboundContains(noResponseRequest);
+
+        TestFrame requestForFrame2 = new TestFrame(2);
+        whenWriteInboundMessage(requestForFrame2);
+        thenInboundContains(requestForFrame2);
+        thenInFlightRequestCountEquals(1);
+        thenQueuedResponseCountEquals(0);
+
+        TestFrame responseForFrame2 = new TestFrame(2);
+        whenWriteOutboundMessage(responseForFrame2);
+        thenInFlightRequestCountEquals(0);
+        thenQueuedResponseCountEquals(0);
+        thenOutboundContains(responseForFrame2);
+    }
+
+    @Test
+    void testThatResponseOrderIsPreserved() {
+        whenWriteInboundMessage(new TestFrame(1));
+        whenWriteInboundMessage(new TestFrame(2));
+
+        TestFrame responseForFrame1 = new TestFrame(1);
+        whenWriteOutboundMessage(responseForFrame1);
+        thenInFlightRequestCountEquals(1);
+        thenQueuedResponseCountEquals(0);
+        thenOutboundContains(responseForFrame1);
+
+        TestFrame responseForFrame2 = new TestFrame(2);
+        whenWriteOutboundMessage(responseForFrame2);
+        thenInFlightRequestCountEquals(0);
+        thenQueuedResponseCountEquals(0);
+        thenOutboundContains(responseForFrame2);
     }
 
     @Test
     void testMultipleInflightMessagesThatRespondOutOfOrder() {
         whenWriteInboundMessage(new TestFrame(1));
         whenWriteInboundMessage(new TestFrame(2));
-        thenOrdererStateEquals(2, 0);
-        TestFrame response = new TestFrame(2);
-        whenWriteOutboundMessage(response);
-        thenOrdererStateEquals(2, 1);
+
+        TestFrame responseForFrame2 = new TestFrame(2);
+        whenWriteOutboundMessage(responseForFrame2);
+        thenInFlightRequestCountEquals(2);
+        thenQueuedResponseCountEquals(1);
         thenOutboundIsEmpty();
-        TestFrame response2 = new TestFrame(1);
-        whenWriteOutboundMessage(response2);
-        thenOrdererStateEquals(0, 0);
-        thenOutboundContains(response2);
-        thenOutboundContains(response);
+
+        TestFrame responseForFrame1 = new TestFrame(1);
+        whenWriteOutboundMessage(responseForFrame1);
+        thenInFlightRequestCountEquals(0);
+        thenQueuedResponseCountEquals(0);
+        thenOutboundContains(responseForFrame1);
+        thenOutboundContains(responseForFrame2);
     }
 
     @Test
@@ -112,31 +190,35 @@ class ResponseOrdererTest {
         whenWriteInboundMessage(new TestFrame(2));
         whenWriteInboundMessage(new TestFrame(3));
         whenWriteInboundMessage(new TestFrame(4));
-        thenOrdererStateEquals(4, 0);
-        TestFrame response = new TestFrame(2);
-        whenWriteOutboundMessage(response);
-        thenOrdererStateEquals(4, 1);
+
+        TestFrame responseForFrame2 = new TestFrame(2);
+        whenWriteOutboundMessage(responseForFrame2);
+        thenInFlightRequestCountEquals(4);
+        thenQueuedResponseCountEquals(1);
         thenOutboundIsEmpty();
 
-        TestFrame response2 = new TestFrame(4);
-        whenWriteOutboundMessage(response2);
-        thenOrdererStateEquals(4, 2);
+        TestFrame responseForFrame4 = new TestFrame(4);
+        whenWriteOutboundMessage(responseForFrame4);
+        thenInFlightRequestCountEquals(4);
+        thenQueuedResponseCountEquals(2);
         thenOutboundIsEmpty();
 
-        TestFrame response3 = new TestFrame(1);
-        whenWriteOutboundMessage(response3);
+        TestFrame responseForFrame1 = new TestFrame(1);
+        whenWriteOutboundMessage(responseForFrame1);
         // the response for correlationId 2 should be drained after the response for correlationId 1 is written
         // but the response for correlationId 4 cannot be sent until we have written the response for correlationId 3
-        thenOrdererStateEquals(2, 1);
-        thenOutboundContains(response3);
-        thenOutboundContains(response);
+        thenInFlightRequestCountEquals(2);
+        thenQueuedResponseCountEquals(1);
+        thenOutboundContains(responseForFrame1);
+        thenOutboundContains(responseForFrame2);
         thenOutboundIsEmpty();
 
-        TestFrame response4 = new TestFrame(3);
-        whenWriteOutboundMessage(response4);
-        thenOrdererStateEquals(0, 0);
-        thenOutboundContains(response4);
-        thenOutboundContains(response2);
+        TestFrame responseForFrame3 = new TestFrame(3);
+        whenWriteOutboundMessage(responseForFrame3);
+        thenInFlightRequestCountEquals(0);
+        thenQueuedResponseCountEquals(0);
+        thenOutboundContains(responseForFrame3);
+        thenOutboundContains(responseForFrame4);
         thenOutboundIsEmpty();
     }
 
@@ -145,23 +227,26 @@ class ResponseOrdererTest {
         whenWriteInboundMessage(new TestFrame(1));
         whenWriteInboundMessage(new TestFrame(2));
         whenWriteInboundMessage(new TestFrame(3));
-        thenOrdererStateEquals(3, 0);
-        TestFrame response = new TestFrame(2);
-        whenWriteOutboundMessage(response);
-        thenOrdererStateEquals(3, 1);
+
+        TestFrame responseForFrame2 = new TestFrame(2);
+        whenWriteOutboundMessage(responseForFrame2);
+        thenInFlightRequestCountEquals(3);
+        thenQueuedResponseCountEquals(1);
         thenOutboundIsEmpty();
 
-        TestFrame response2 = new TestFrame(3);
-        whenWriteOutboundMessage(response2);
-        thenOrdererStateEquals(3, 2);
+        TestFrame responseForFrame3 = new TestFrame(3);
+        whenWriteOutboundMessage(responseForFrame3);
+        thenInFlightRequestCountEquals(3);
+        thenQueuedResponseCountEquals(2);
         thenOutboundIsEmpty();
 
-        TestFrame response3 = new TestFrame(1);
-        whenWriteOutboundMessage(response3);
-        thenOrdererStateEquals(0, 0);
-        thenOutboundContains(response3);
-        thenOutboundContains(response);
-        thenOutboundContains(response2);
+        TestFrame responseForFrame1 = new TestFrame(1);
+        whenWriteOutboundMessage(responseForFrame1);
+        thenInFlightRequestCountEquals(0);
+        thenQueuedResponseCountEquals(0);
+        thenOutboundContains(responseForFrame1);
+        thenOutboundContains(responseForFrame2);
+        thenOutboundContains(responseForFrame3);
         thenOutboundIsEmpty();
     }
 
@@ -169,7 +254,8 @@ class ResponseOrdererTest {
     void testUnexpectedResponseWithNoMatchingRequest() {
         TestFrame response = new TestFrame(1);
         whenWriteOutboundMessage(response);
-        thenOrdererStateEquals(0, 0);
+        thenInFlightRequestCountEquals(0);
+        thenQueuedResponseCountEquals(0);
         thenOutboundContains(response);
     }
 
@@ -177,7 +263,8 @@ class ResponseOrdererTest {
     void testOutboundNonFrameAreForwarded() {
         Object response = new Object();
         whenWriteOutboundMessage(response);
-        thenOrdererStateEquals(0, 0);
+        thenInFlightRequestCountEquals(0);
+        thenQueuedResponseCountEquals(0);
         thenOutboundContains(response);
     }
 
@@ -185,9 +272,12 @@ class ResponseOrdererTest {
         embeddedChannel.writeOneOutbound(object);
     }
 
-    private void thenOrdererStateEquals(int expectedInFlightRequests, int expecteQueuedResponses) {
-        assertThat(orderer.inFlightRequestCount()).isEqualTo(expectedInFlightRequests);
+    private void thenQueuedResponseCountEquals(int expecteQueuedResponses) {
         assertThat(orderer.queuedResponseCount()).isEqualTo(expecteQueuedResponses);
+    }
+
+    private void thenInFlightRequestCountEquals(int expectedInFlightRequests) {
+        assertThat(orderer.inFlightRequestCount()).isEqualTo(expectedInFlightRequests);
     }
 
     private void thenInboundContains(Object object) {

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/ResponseOrdererTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/ResponseOrdererTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+import io.kroxylicious.proxy.frame.ByteBufAccessor;
+import io.kroxylicious.proxy.frame.Frame;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ResponseOrdererTest {
+
+    private EmbeddedChannel embeddedChannel;
+    private ResponseOrderer orderer;
+
+    record TestFrame(int correlationId) implements Frame {
+
+    @Override
+    public int estimateEncodedSize() {
+        return 0;
+    }
+
+    @Override
+    public void encode(ByteBufAccessor out) {
+        throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
+    public int correlationId() {
+        return correlationId;
+    }
+
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        embeddedChannel = new EmbeddedChannel();
+        orderer = new ResponseOrderer();
+        embeddedChannel.pipeline().addFirst(orderer);
+    }
+
+    @Test
+    void testInboundFrameForwarded() {
+        TestFrame request = new TestFrame(1);
+        whenWriteInboundMessage(request);
+        thenInboundContains(request);
+        thenOrdererStateEquals(1, 0);
+    }
+
+    @Test
+    void testInboundNonFrameForwarded() {
+        Object request = new Object();
+        whenWriteInboundMessage(request);
+        thenInboundContains(request);
+        thenOrdererStateEquals(0, 0);
+    }
+
+    @Test
+    void testSingleRequestResponse() {
+        TestFrame request = new TestFrame(1);
+        whenWriteInboundMessage(request);
+        thenInboundContains(request);
+        thenOrdererStateEquals(1, 0);
+        TestFrame response = new TestFrame(1);
+        whenWriteOutboundMessage(response);
+        thenOrdererStateEquals(0, 0);
+        thenOutboundContains(response);
+    }
+
+    @Test
+    void testMultipleInflightMessagesThatRespondInOrder() {
+        whenWriteInboundMessage(new TestFrame(1));
+        whenWriteInboundMessage(new TestFrame(2));
+        thenOrdererStateEquals(2, 0);
+        TestFrame response = new TestFrame(1);
+        whenWriteOutboundMessage(response);
+        thenOrdererStateEquals(1, 0);
+        thenOutboundContains(response);
+        TestFrame response2 = new TestFrame(2);
+        whenWriteOutboundMessage(response2);
+        thenOrdererStateEquals(0, 0);
+        thenOutboundContains(response2);
+    }
+
+    @Test
+    void testMultipleInflightMessagesThatRespondOutOfOrder() {
+        whenWriteInboundMessage(new TestFrame(1));
+        whenWriteInboundMessage(new TestFrame(2));
+        thenOrdererStateEquals(2, 0);
+        TestFrame response = new TestFrame(2);
+        whenWriteOutboundMessage(response);
+        thenOrdererStateEquals(2, 1);
+        thenOutboundIsEmpty();
+        TestFrame response2 = new TestFrame(1);
+        whenWriteOutboundMessage(response2);
+        thenOrdererStateEquals(0, 0);
+        thenOutboundContains(response2);
+        thenOutboundContains(response);
+    }
+
+    @Test
+    void testComplexScenarioWherePendingResponsesCanBePartiallyDrained() {
+        whenWriteInboundMessage(new TestFrame(1));
+        whenWriteInboundMessage(new TestFrame(2));
+        whenWriteInboundMessage(new TestFrame(3));
+        whenWriteInboundMessage(new TestFrame(4));
+        thenOrdererStateEquals(4, 0);
+        TestFrame response = new TestFrame(2);
+        whenWriteOutboundMessage(response);
+        thenOrdererStateEquals(4, 1);
+        thenOutboundIsEmpty();
+
+        TestFrame response2 = new TestFrame(4);
+        whenWriteOutboundMessage(response2);
+        thenOrdererStateEquals(4, 2);
+        thenOutboundIsEmpty();
+
+        TestFrame response3 = new TestFrame(1);
+        whenWriteOutboundMessage(response3);
+        // the response for correlationId 2 should be drained after the response for correlationId 1 is written
+        // but the response for correlationId 4 cannot be sent until we have written the response for correlationId 3
+        thenOrdererStateEquals(2, 1);
+        thenOutboundContains(response3);
+        thenOutboundContains(response);
+        thenOutboundIsEmpty();
+
+        TestFrame response4 = new TestFrame(3);
+        whenWriteOutboundMessage(response4);
+        thenOrdererStateEquals(0, 0);
+        thenOutboundContains(response4);
+        thenOutboundContains(response2);
+        thenOutboundIsEmpty();
+    }
+
+    @Test
+    void testMultiplePendingAreDrained() {
+        whenWriteInboundMessage(new TestFrame(1));
+        whenWriteInboundMessage(new TestFrame(2));
+        whenWriteInboundMessage(new TestFrame(3));
+        thenOrdererStateEquals(3, 0);
+        TestFrame response = new TestFrame(2);
+        whenWriteOutboundMessage(response);
+        thenOrdererStateEquals(3, 1);
+        thenOutboundIsEmpty();
+
+        TestFrame response2 = new TestFrame(3);
+        whenWriteOutboundMessage(response2);
+        thenOrdererStateEquals(3, 2);
+        thenOutboundIsEmpty();
+
+        TestFrame response3 = new TestFrame(1);
+        whenWriteOutboundMessage(response3);
+        thenOrdererStateEquals(0, 0);
+        thenOutboundContains(response3);
+        thenOutboundContains(response);
+        thenOutboundContains(response2);
+        thenOutboundIsEmpty();
+    }
+
+    @Test
+    void testUnexpectedResponseWithNoMatchingRequest() {
+        TestFrame response = new TestFrame(1);
+        whenWriteOutboundMessage(response);
+        thenOrdererStateEquals(0, 0);
+        thenOutboundContains(response);
+    }
+
+    @Test
+    void testOutboundNonFrameAreForwarded() {
+        Object response = new Object();
+        whenWriteOutboundMessage(response);
+        thenOrdererStateEquals(0, 0);
+        thenOutboundContains(response);
+    }
+
+    private void whenWriteOutboundMessage(Object object) {
+        embeddedChannel.writeOneOutbound(object);
+    }
+
+    private void thenOrdererStateEquals(int expectedInFlightRequests, int expecteQueuedResponses) {
+        assertThat(orderer.inFlightRequestCount()).isEqualTo(expectedInFlightRequests);
+        assertThat(orderer.queuedResponseCount()).isEqualTo(expecteQueuedResponses);
+    }
+
+    private void thenInboundContains(Object object) {
+        Object inbound = embeddedChannel.flushInbound().readInbound();
+        assertThat(inbound).isSameAs(object);
+    }
+
+    private void thenOutboundContains(Object object) {
+        Object o = embeddedChannel.flushOutbound().readOutbound();
+        assertThat(o).isSameAs(object);
+    }
+
+    private void thenOutboundIsEmpty() {
+        Object o = embeddedChannel.flushOutbound().readOutbound();
+        assertThat(o).isNull();
+    }
+
+    private void whenWriteInboundMessage(Object object) {
+        embeddedChannel.writeOneInbound(object);
+    }
+
+}


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Resolves #505 

Currently if we have proxied a message to the broker we could then move onto the next message and short-circuit respond. The client will receive the short-circuit response first, which breaks the contract that they expect responses back in the order they sent them.

The order of events looks like this:

1. client sends message A then message B to kroxylicious
2. kroxylicious forwards message A towards upstream broker
3. kroxylicious short-circuit response to message B, sending a response toward the client
4. the broker responds to message A, kroxylicious forwards it towards the client
5. the client receives B-response, then A-response. **wrong order**

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
