### PR TITLE
Introduce Nullable/NonNull annotations into the public API

### DIFF
--- a/kroxylicious-api/pom.xml
+++ b/kroxylicious-api/pom.xml
@@ -36,6 +36,11 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
         </dependency>

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterResultBuilder.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterResultBuilder.java
@@ -12,6 +12,8 @@ import io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage;
 import io.kroxylicious.proxy.filter.filterresultbuilder.CloseStage;
 import io.kroxylicious.proxy.filter.filterresultbuilder.TerminalStage;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 /**
  * Fluent builder for filter results.
  *
@@ -30,7 +32,7 @@ public interface FilterResultBuilder<H extends ApiMessage, FR extends FilterResu
      * @return next stage in the fluent builder API
      * @throws IllegalArgumentException header or message do not meet criteria described above.
      */
-    CloseOrTerminalStage<FR> forward(H header, ApiMessage message) throws IllegalArgumentException;
+    CloseOrTerminalStage<FR> forward(@NonNull H header, @NonNull ApiMessage message) throws IllegalArgumentException;
 
     /**
      * Signals the desire of the filter that the connection is closed.

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/KrpcFilterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/KrpcFilterContext.java
@@ -7,6 +7,8 @@ package io.kroxylicious.proxy.filter;
 
 import java.util.concurrent.CompletionStage;
 
+import javax.annotation.Nullable;
+
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
@@ -35,6 +37,7 @@ public interface KrpcFilterContext {
      * @return the SNI hostname provided by the client.  Will be null if the client is
      * using a non-TLS connection or the TLS client hello didn't provide one.
      */
+    @Nullable
     String sniHostname();
 
     /**

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestFilterResultBuilder.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestFilterResultBuilder.java
@@ -6,11 +6,15 @@
 
 package io.kroxylicious.proxy.filter;
 
+import javax.annotation.Nullable;
+
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
 
 import io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Builder for request filter results.
@@ -28,7 +32,7 @@ public interface RequestFilterResultBuilder extends FilterResultBuilder<RequestH
      * @return next stage in the fluent builder API
      * @throws IllegalArgumentException header or message do not meet criteria described above.
      */
-    CloseOrTerminalStage<RequestFilterResult> shortCircuitResponse(ResponseHeaderData header, ApiMessage message) throws IllegalArgumentException;
+    CloseOrTerminalStage<RequestFilterResult> shortCircuitResponse(@Nullable ResponseHeaderData header, @NonNull ApiMessage message) throws IllegalArgumentException;
 
     /**
      * A short-circuit response towards the client.
@@ -38,6 +42,6 @@ public interface RequestFilterResultBuilder extends FilterResultBuilder<RequestH
      * @return next stage in the fluent builder API
      * @throws IllegalArgumentException header or message do not meet criteria described above.
      */
-    CloseOrTerminalStage<RequestFilterResult> shortCircuitResponse(ApiMessage message) throws IllegalArgumentException;
+    CloseOrTerminalStage<RequestFilterResult> shortCircuitResponse(@NonNull ApiMessage message) throws IllegalArgumentException;
 
 }

--- a/kroxylicious/pom.xml
+++ b/kroxylicious/pom.xml
@@ -71,8 +71,8 @@
             <artifactId>jackson-datatype-jdk8</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>annotations</artifactId>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
         </dependency>
         <dependency>
             <groupId>info.picocli</groupId>

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterResultBuilderImpl.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterResultBuilderImpl.java
@@ -11,12 +11,12 @@ import java.util.concurrent.CompletionStage;
 
 import org.apache.kafka.common.protocol.ApiMessage;
 
-import io.micrometer.common.lang.NonNull;
-
 import io.kroxylicious.proxy.filter.FilterResult;
 import io.kroxylicious.proxy.filter.FilterResultBuilder;
 import io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage;
 import io.kroxylicious.proxy.filter.filterresultbuilder.TerminalStage;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public abstract class FilterResultBuilderImpl<H extends ApiMessage, FR extends FilterResult>
         implements FilterResultBuilder<H, FR>, CloseOrTerminalStage<FR> {

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/RequestFilterResultBuilderImpl.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/RequestFilterResultBuilderImpl.java
@@ -14,6 +14,9 @@ import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.filter.RequestFilterResultBuilder;
 import io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 public class RequestFilterResultBuilderImpl extends FilterResultBuilderImpl<RequestHeaderData, RequestFilterResult>
         implements RequestFilterResultBuilder {
 
@@ -34,7 +37,7 @@ public class RequestFilterResultBuilderImpl extends FilterResultBuilderImpl<Requ
     }
 
     @Override
-    public CloseOrTerminalStage<RequestFilterResult> shortCircuitResponse(ResponseHeaderData header, ApiMessage message) {
+    public CloseOrTerminalStage<RequestFilterResult> shortCircuitResponse(@Nullable ResponseHeaderData header, @NonNull ApiMessage message) {
         validateShortCircuitResponse(header, message);
         this.shortCircuitHeader = header;
         this.shortCircuitResponse = message;
@@ -42,7 +45,7 @@ public class RequestFilterResultBuilderImpl extends FilterResultBuilderImpl<Requ
     }
 
     @Override
-    public CloseOrTerminalStage<RequestFilterResult> shortCircuitResponse(ApiMessage message) {
+    public CloseOrTerminalStage<RequestFilterResult> shortCircuitResponse(@NonNull ApiMessage message) {
         validateShortCircuitResponse(null, message);
         this.shortCircuitResponse = message;
         return this;

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
 
         <freemarker.version>2.3.32</freemarker.version>
         <guava.version>32.1.1-jre</guava.version>
+        <hamcrest.version>2.2</hamcrest.version>
         <jackson.version>2.15.2</jackson.version>
         <junit.version>5.10.0</junit.version>
         <kafka.version>3.5.1</kafka.version>
@@ -45,12 +46,12 @@
         <netty.kqueue.classifier>osx-x86_64</netty.kqueue.classifier>
         <assertj-core.version>3.24.2</assertj-core.version>
         <mockito.version>5.4.0</mockito.version>
-        <slf4j.version>2.0.7</slf4j.version>
         <micrometer.version>1.11.2</micrometer.version>
-        <zjsonpatch.version>0.4.14</zjsonpatch.version>
+        <slf4j.version>2.0.7</slf4j.version>
         <sundr-builder-annotations.version>0.100.1</sundr-builder-annotations.version>
-        <findbugs.annotations.version>3.0.1u2</findbugs.annotations.version>
-        <hamcrest.version>2.2</hamcrest.version>
+        <spotbugs-annotations.version>4.7.3</spotbugs-annotations.version>
+        <zjsonpatch.version>0.4.14</zjsonpatch.version>
+
         <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
     </properties>
 
@@ -139,12 +140,14 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
             <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>annotations</artifactId>
-                <version>${findbugs.annotations.version}</version>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-annotations</artifactId>
+                <version>${spotbugs-annotations.version}</version>
                 <scope>provided</scope>
             </dependency>
+
             <dependency>
                 <groupId>info.picocli</groupId>
                 <artifactId>picocli</artifactId>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Why: improve the quality of the API by embracing self-documenting practices.  Hopefully, reduce the likelihood of coding errors by ourselves and users of the API.

### Additional Context

~~Being guided by https://stackoverflow.com/questions/4963300/which-notnull-java-annotation-should-i-use, `javax.annotations` seem like the best way to go, despite JSR305 is stalling.~~

In IntelliJ you see things like this:

<img width="1841" alt="Screenshot 2023-08-02 at 16 15 28" src="https://github.com/kroxylicious/kroxylicious/assets/18440250/6ad7bb65-adab-437e-83ce-c64f8a1734d0">

I need to config how SonarCloud is handling the annotations.  https://rules.sonarsource.com/java/RSPEC-2637/ makes me believe it will be okay.

The dependency is provided, so there should be no runtime overhead.

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
