### PR TITLE
Fix a couple of SonarCloud complaints  about the Async Filter API

### DIFF
--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterResultBuilder.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterResultBuilder.java
@@ -16,9 +16,9 @@ import io.kroxylicious.proxy.filter.filterresultbuilder.TerminalStage;
  * Fluent builder for filter results.
  *
  * @param <H>  kafka api message header class
- * @param <FR> filter result
+ * @param <R> filter result
  */
-public interface FilterResultBuilder<H extends ApiMessage, FR extends FilterResult> extends CloseStage<FR> {
+public interface FilterResultBuilder<H extends ApiMessage, R extends FilterResult> extends CloseStage<R> {
 
     /**
      * A forward of a request or response message to the next filter in the chain.
@@ -30,13 +30,13 @@ public interface FilterResultBuilder<H extends ApiMessage, FR extends FilterResu
      * @return next stage in the fluent builder API
      * @throws IllegalArgumentException header or message do not meet criteria described above.
      */
-    CloseOrTerminalStage<FR> forward(H header, ApiMessage message) throws IllegalArgumentException;
+    CloseOrTerminalStage<R> forward(H header, ApiMessage message) throws IllegalArgumentException;
 
     /**
      * Signals the desire of the filter that the connection is closed.
      *
      * @return last stage in the fluent API.
      */
-    TerminalStage<FR> drop();
+    TerminalStage<R> drop();
 
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/filterresultbuilder/CloseOrTerminalStage.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/filterresultbuilder/CloseOrTerminalStage.java
@@ -11,7 +11,7 @@ import io.kroxylicious.proxy.filter.FilterResult;
 /**
  * Interface supporting the {@link io.kroxylicious.proxy.filter.FilterResultBuilder} fluent API.
  *
- * @param <FR> filter result
+ * @param <R> filter result
  */
-public interface CloseOrTerminalStage<FR extends FilterResult> extends TerminalStage<FR>, CloseStage<FR> {
+public interface CloseOrTerminalStage<R extends FilterResult> extends TerminalStage<R>, CloseStage<R> {
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/filterresultbuilder/CloseStage.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/filterresultbuilder/CloseStage.java
@@ -11,13 +11,13 @@ import io.kroxylicious.proxy.filter.FilterResult;
 /**
  * Interface supporting the {@link io.kroxylicious.proxy.filter.FilterResultBuilder} fluent API.
  *
- * @param <FR> filter result
+ * @param <R> filter result
  */
-public interface CloseStage<FR extends FilterResult> {
+public interface CloseStage<R extends FilterResult> {
     /**
      * Signals the desire of the filter that the connection is closed.
      *
      * @return next stage in the fluent API.
      */
-    TerminalStage<FR> withCloseConnection();
+    TerminalStage<R> withCloseConnection();
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/filterresultbuilder/TerminalStage.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/filterresultbuilder/TerminalStage.java
@@ -13,19 +13,19 @@ import io.kroxylicious.proxy.filter.FilterResult;
 /**
  * Interface supporting the {@link io.kroxylicious.proxy.filter.FilterResultBuilder} fluent API.
  *
- * @param <FR> filter result
+ * @param <R> filter result
  */
-public interface TerminalStage<FR extends FilterResult> {
+public interface TerminalStage<R extends FilterResult> {
     /**
      * Constructs the filter result.
      *
      * @return filter result
      */
-    FR build();
+    R build();
 
     /**
      * Produces the filter result contained within a completed {@link CompletionStage}.
      * @return completion stage contain the filter result.
      */
-    CompletionStage<FR> completed();
+    CompletionStage<R> completed();
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterResultBuilderImpl.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterResultBuilderImpl.java
@@ -18,8 +18,8 @@ import io.kroxylicious.proxy.filter.FilterResultBuilder;
 import io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage;
 import io.kroxylicious.proxy.filter.filterresultbuilder.TerminalStage;
 
-public abstract class FilterResultBuilderImpl<H extends ApiMessage, FR extends FilterResult>
-        implements FilterResultBuilder<H, FR>, CloseOrTerminalStage<FR> {
+public abstract class FilterResultBuilderImpl<H extends ApiMessage, R extends FilterResult>
+        implements FilterResultBuilder<H, R>, CloseOrTerminalStage<R> {
     private ApiMessage message;
     private ApiMessage header;
     private boolean closeConnection;
@@ -29,7 +29,7 @@ public abstract class FilterResultBuilderImpl<H extends ApiMessage, FR extends F
     }
 
     @Override
-    public CloseOrTerminalStage<FR> forward(@NonNull H header, @NonNull ApiMessage message) {
+    public CloseOrTerminalStage<R> forward(@NonNull H header, @NonNull ApiMessage message) {
         validateForward(header, message);
         this.header = header;
         this.message = message;
@@ -55,7 +55,7 @@ public abstract class FilterResultBuilderImpl<H extends ApiMessage, FR extends F
     }
 
     @Override
-    public TerminalStage<FR> withCloseConnection() {
+    public TerminalStage<R> withCloseConnection() {
         this.closeConnection = true;
         return this;
     }
@@ -65,7 +65,7 @@ public abstract class FilterResultBuilderImpl<H extends ApiMessage, FR extends F
     }
 
     @Override
-    public TerminalStage<FR> drop() {
+    public TerminalStage<R> drop() {
         this.drop = true;
         return this;
     }
@@ -75,7 +75,7 @@ public abstract class FilterResultBuilderImpl<H extends ApiMessage, FR extends F
     }
 
     @Override
-    public CompletionStage<FR> completed() {
+    public CompletionStage<R> completed() {
         return CompletableFuture.completedStage(build());
     }
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/RequestFilterResultBuilderImpl.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/RequestFilterResultBuilderImpl.java
@@ -22,9 +22,6 @@ public class RequestFilterResultBuilderImpl extends FilterResultBuilderImpl<Requ
     private ResponseHeaderData shortCircuitHeader;
     private ApiMessage shortCircuitResponse;
 
-    public RequestFilterResultBuilderImpl() {
-    }
-
     @Override
     protected void validateForward(RequestHeaderData header, ApiMessage message) {
         super.validateForward(header, message);
@@ -35,7 +32,7 @@ public class RequestFilterResultBuilderImpl extends FilterResultBuilderImpl<Requ
 
     @Override
     public CloseOrTerminalStage<RequestFilterResult> shortCircuitResponse(ResponseHeaderData header, ApiMessage message) {
-        validateShortCircuitResponse(header, message);
+        validateShortCircuitResponse(message);
         this.shortCircuitHeader = header;
         this.shortCircuitResponse = message;
         return this;
@@ -43,12 +40,12 @@ public class RequestFilterResultBuilderImpl extends FilterResultBuilderImpl<Requ
 
     @Override
     public CloseOrTerminalStage<RequestFilterResult> shortCircuitResponse(ApiMessage message) {
-        validateShortCircuitResponse(null, message);
+        validateShortCircuitResponse(message);
         this.shortCircuitResponse = message;
         return this;
     }
 
-    private void validateShortCircuitResponse(ResponseHeaderData header, ApiMessage message) {
+    private void validateShortCircuitResponse(ApiMessage message) {
         if (message == null) {
             throw new IllegalArgumentException("message may not be null");
         }


### PR DESCRIPTION
### Type of change


- Refactoring

### Description

Fix a couple of SonarCloud complaints  about the Async Filter API.  No functional change.

* https://sonarcloud.io/organizations/kroxylicious/rules?open=java%3AS119&rule_key=java%3AS119
* https://sonarcloud.io/organizations/kroxylicious/rules?open=java%3AS1186&rule_key=java%3AS1186
* https://sonarcloud.io/organizations/kroxylicious/rules?open=java%3AS1172&rule_key=java%3AS1172

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
