### PR TITLE
Prevent short-circuit response to zero-acks Produce Request

### DIFF
--- a/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
@@ -54,6 +54,7 @@ import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester
 import static io.kroxylicious.test.tester.KroxyliciousTesters.mockKafkaKroxyliciousTester;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.ACKS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.CLIENT_ID_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG;
 import static org.apache.kafka.common.protocol.ApiKeys.LIST_GROUPS;
@@ -302,6 +303,52 @@ class KrpcFilterIT {
             assertArrayEquals(TOPIC_1_CIPHERTEXT, records1.iterator().next().value());
             assertEquals(1, records2.count());
             assertArrayEquals(TOPIC_2_CIPHERTEXT, records2.iterator().next().value());
+        }
+    }
+
+    // zero-ack produce requests require special handling because they have no response associated
+    // this checks that Kroxy can handle the basics of forwarding them.
+    @Test
+    public void shouldModifyZeroAckProduceMessage(KafkaCluster cluster, Admin admin) throws Exception {
+        admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1))).all().get();
+
+        var config = proxy(cluster)
+                .addToFilters(new FilterDefinitionBuilder("ProduceRequestTransformation").withConfig("transformation", TestEncoder.class.getName()).build());
+
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer(Map.of(CLIENT_ID_CONFIG, "shouldModifyProduceMessage", DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000, ACKS_CONFIG, "0"));
+                var consumer = tester
+                        .consumer(Serdes.String(), Serdes.ByteArray(), Map.of(GROUP_ID_CONFIG, "my-group-id", AUTO_OFFSET_RESET_CONFIG, "earliest"))) {
+            producer.send(new ProducerRecord<>(TOPIC_1, "my-key", PLAINTEXT)).get();
+            producer.flush();
+
+            ConsumerRecords<String, byte[]> records1;
+            consumer.subscribe(Set.of(TOPIC_1));
+            records1 = consumer.poll(Duration.ofSeconds(10));
+
+            assertEquals(1, records1.count());
+            assertArrayEquals(TOPIC_1_CIPHERTEXT, records1.iterator().next().value());
+        }
+    }
+
+    @Test
+    public void shouldForwardUnfilteredZeroAckProduceMessage(KafkaCluster cluster, Admin admin) throws Exception {
+        admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1))).all().get();
+
+        var config = proxy(cluster);
+
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer(Map.of(CLIENT_ID_CONFIG, "shouldModifyProduceMessage", DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000, ACKS_CONFIG, "0"));
+                var consumer = tester
+                        .consumer(Serdes.String(), Serdes.String(), Map.of(GROUP_ID_CONFIG, "my-group-id", AUTO_OFFSET_RESET_CONFIG, "earliest"))) {
+            producer.send(new ProducerRecord<>(TOPIC_1, "my-key", PLAINTEXT)).get();
+            producer.flush();
+
+            consumer.subscribe(Set.of(TOPIC_1));
+            var records1 = consumer.poll(Duration.ofSeconds(10));
+
+            assertEquals(1, records1.count());
+            assertEquals(PLAINTEXT, records1.iterator().next().value());
         }
     }
 

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/KrpcFilterIT.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.errors.InvalidTopicException;
@@ -326,8 +327,9 @@ class KrpcFilterIT {
             consumer.subscribe(Set.of(TOPIC_1));
             records1 = consumer.poll(Duration.ofSeconds(10));
 
-            assertEquals(1, records1.count());
-            assertArrayEquals(TOPIC_1_CIPHERTEXT, records1.iterator().next().value());
+            assertThat(records1).hasSize(1);
+            assertThat(records1.records(TOPIC_1)).map(ConsumerRecord::value)
+                    .containsExactly(TOPIC_1_CIPHERTEXT);
         }
     }
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/BareSaslRequest.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/BareSaslRequest.java
@@ -42,6 +42,12 @@ public class BareSaslRequest implements RequestFrame {
         return decodeResponse;
     }
 
+    @Override
+    public boolean hasResponse() {
+        // unsure about this, BareSaslRequests aren't constructed anywhere but tests
+        return true;
+    }
+
     public byte[] bytes() {
         return bytes;
     }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/BareSaslRequest.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/BareSaslRequest.java
@@ -42,12 +42,6 @@ public class BareSaslRequest implements RequestFrame {
         return decodeResponse;
     }
 
-    @Override
-    public boolean hasResponse() {
-        // unsure about this, BareSaslRequests aren't constructed anywhere but tests
-        return true;
-    }
-
     public byte[] bytes() {
         return bytes;
     }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/DecodedRequestFrame.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/DecodedRequestFrame.java
@@ -5,8 +5,11 @@
  */
 package io.kroxylicious.proxy.frame;
 
+import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
+
+import static org.apache.kafka.common.protocol.ApiKeys.PRODUCE;
 
 /**
  * A decoded request frame.
@@ -34,6 +37,15 @@ public class DecodedRequestFrame<B extends ApiMessage>
     @Override
     public boolean decodeResponse() {
         return decodeResponse;
+    }
+
+    @Override
+    public boolean hasResponse() {
+        return !isZeroAcksProduceRequest();
+    }
+
+    private boolean isZeroAcksProduceRequest() {
+        return apiKey() == PRODUCE && ((ProduceRequestData) body).acks() == 0;
     }
 
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/OpaqueRequestFrame.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/OpaqueRequestFrame.java
@@ -12,24 +12,33 @@ import io.netty.buffer.ByteBuf;
 public class OpaqueRequestFrame extends OpaqueFrame implements RequestFrame {
 
     private final boolean decodeResponse;
+    private boolean hasResponse;
 
     /**
      * @param buf The message buffer (excluding the frame size)
      * @param correlationId
      * @param decodeResponse
      * @param length
+     * @param hasResponse
      */
     public OpaqueRequestFrame(ByteBuf buf,
                               int correlationId,
                               boolean decodeResponse,
-                              int length) {
+                              int length,
+                              boolean hasResponse) {
         super(buf, correlationId, length);
         this.decodeResponse = decodeResponse;
+        this.hasResponse = hasResponse;
     }
 
     @Override
     public boolean decodeResponse() {
         return decodeResponse;
+    }
+
+    @Override
+    public boolean hasResponse() {
+        return hasResponse;
     }
 
     @Override

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/RequestFrame.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/RequestFrame.java
@@ -17,6 +17,8 @@ public interface RequestFrame extends Frame {
      * Whether the Kafka Client expects a response to this request
      * @return Whether the Kafka Client expects a response to this request
      */
-    boolean hasResponse();
+    default boolean hasResponse() {
+        return true;
+    }
 
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/RequestFrame.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/frame/RequestFrame.java
@@ -13,4 +13,10 @@ public interface RequestFrame extends Frame {
      */
     boolean decodeResponse();
 
+    /**
+     * Whether the Kafka Client expects a response to this request
+     * @return Whether the Kafka Client expects a response to this request
+     */
+    boolean hasResponse();
+
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestEncoder.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestEncoder.java
@@ -5,7 +5,6 @@
  */
 package io.kroxylicious.proxy.internal.codec;
 
-import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,7 +12,6 @@ import org.slf4j.LoggerFactory;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 
-import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.RequestFrame;
 import io.kroxylicious.proxy.internal.InternalRequestFrame;
 
@@ -45,7 +43,7 @@ public class KafkaRequestEncoder extends KafkaMessageEncoder<RequestFrame> {
         out.readerIndex(LENGTH);
         short apiKey = out.readShort();
         short apiVersion = out.readShort();
-        boolean hasResponse = hasResponse(frame, out, ri, apiKey, apiVersion);
+        boolean hasResponse = frame.hasResponse();
         boolean decodeResponse = frame.decodeResponse();
         int downstreamCorrelationId = frame.correlationId();
         int upstreamCorrelationId = correlationManager.putBrokerRequest(apiKey,
@@ -68,70 +66,6 @@ public class KafkaRequestEncoder extends KafkaMessageEncoder<RequestFrame> {
             log().warn("{}: Not honouring decode of acks=0 PRODUCE response, because there will be none. " +
                     "This is a bug in your filter.", ctx);
         }
-    }
-
-    private boolean hasResponse(RequestFrame frame, ByteBuf out, int ri, short apiKey, short apiVersion) {
-        if (frame instanceof DecodedRequestFrame) {
-            return apiKey != ApiKeys.PRODUCE.id
-                    || ((ProduceRequestData) ((DecodedRequestFrame<?>) frame).body()).acks() != 0;
-        }
-        else {
-            return apiKey != ApiKeys.PRODUCE.id
-                    || readAcks(out, ri, apiKey, apiVersion) != 0;
-        }
-    }
-
-    static short readAcks(ByteBuf in, int startOfMessage, short apiKey, short apiVersion) {
-        // Annoying case: we need to know whether to expect a response so that we know
-        // whether to add to the correlation (so that, in turn, we know how to rewrite the correlation
-        // id of the client response).
-        // Adding ack-less Produce requests to the correlation => OOME.
-        // This requires decoding at least the first one or two
-        // fields of all Produce requests.
-        // Because we want to avoid parsing the produce request using ProduceRequestData
-        // just for this we are stuck with hand coding deserialization code...
-        // final int keyVersionAndCorrIdSize = 8;
-        // final int startOfBodyOffset;
-        short headerVersion = ApiKeys.forId(apiKey).requestHeaderVersion(apiVersion);
-        incrementReaderIndex(in, 4);
-        if (headerVersion >= 1) {
-            int clientIdLength = in.readShort();
-            incrementReaderIndex(in, clientIdLength);
-        }
-        if (headerVersion >= 2) {
-            int numTaggedFields = ByteBufAccessorImpl.readUnsignedVarint(in);
-            for (int i = 0; i < numTaggedFields; i++) {
-                int tag = ByteBufAccessorImpl.readUnsignedVarint(in);
-                int size = ByteBufAccessorImpl.readUnsignedVarint(in);
-                incrementReaderIndex(in, size);
-            }
-        }
-
-        final short acks;
-        if (apiVersion < 3) {
-            acks = in.readShort();
-        }
-        else { // Transactional id comes before acks
-            int transactionIdLength;
-            if (apiVersion < 9) { // Last non-flexible version
-                transactionIdLength = in.readShort();
-            }
-            else if (apiVersion <= 9) { // First flexible version
-                transactionIdLength = ByteBufAccessorImpl.readUnsignedVarint(in);
-            }
-            else {
-                throw new AssertionError("Unsupported Produce apiVersion: " + apiVersion);
-            }
-            incrementReaderIndex(in, transactionIdLength);
-            acks = in.readShort();
-        }
-        // Reset index
-        in.readerIndex(startOfMessage);
-        return acks;
-    }
-
-    private static void incrementReaderIndex(ByteBuf byteBuf, int increment) {
-        byteBuf.readerIndex(byteBuf.readerIndex() + increment);
     }
 
 }

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/codec/ResponseDecoderTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/codec/ResponseDecoderTest.java
@@ -29,7 +29,7 @@ class ResponseDecoderTest extends AbstractCodecTest {
                 AbstractCodecTest::deserializeApiVersionsResponseUsingKafkaApis,
                 new KafkaResponseDecoder(mgr),
                 DecodedResponseFrame.class,
-                header -> header.setCorrelationId(12)),
+                header -> header.setCorrelationId(12), false),
                 "Unexpected correlation id");
     }
 
@@ -43,7 +43,7 @@ class ResponseDecoderTest extends AbstractCodecTest {
                 v -> AbstractCodecTest.exampleResponseHeader(),
                 AbstractCodecTest::exampleApiVersionsResponse,
                 new KafkaResponseDecoder(mgr),
-                OpaqueResponseFrame.class),
+                OpaqueResponseFrame.class, false),
                 "Unexpected correlation id");
     }
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

1. Moves the detection of zero-acks Produce Requests earlier in the chain to the `KafkaRequestDecoder`, so we know about it as soon as possible.
2. Drop short-circuit responses instead of forwarding if the Filter attempts to short-circuit respond to a zero-ack Produce Request.

### Additional Context

This PR was sparked by #507 because we need to know earlier whether a particular Request expects a Response according to the Kafka Protocol. In conversation about this with @SamBarker I mentioned that Filters could also break the new message re-ordering logic if they short-circuit responded in reaction to a zero-ack Produce Request, even if we avoid adding it's correlationId to the queue. We thought it would be worth preventing Filters from doing this.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
