### PR TITLE
Fix Kafka Client leaks in the SampleFilterIntegrationTest.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 ## 0.3.0
 
 
+* [#519](https://github.com/kroxylicious/kroxylicious/pull/519): Fix Kafka Client leaks in the SampleFilterIntegrationTest.
 * [#494](https://github.com/kroxylicious/kroxylicious/issues/494): [Breaking] Make the Filter API fully asynchronous (filter methods must return a CompletionStage)
 * [#498](https://github.com/kroxylicious/kroxylicious/issues/498): Include the cluster name from the configuration node in the config model.
 * [#488](https://github.com/kroxylicious/kroxylicious/pull/488): Kroxylicious Bill Of Materials 

--- a/kroxylicious-sample/src/test/java/io/kroxylicious/sample/SampleFilterIntegrationTest.java
+++ b/kroxylicious-sample/src/test/java/io/kroxylicious/sample/SampleFilterIntegrationTest.java
@@ -134,8 +134,7 @@ public class SampleFilterIntegrationTest {
          * @param filters the filters to be used in the test
          */
         FilterIntegrationTest(TestFilter... filters) {
-            ConfigurationBuilder builder1 = proxy(cluster);
-            ConfigurationBuilder builder = builder1;
+            ConfigurationBuilder builder = proxy(cluster);
             for (TestFilter filter : filters) {
                 builder.addToFilters(new FilterDefinitionBuilder(filter.name()).withConfig(filter.config()).build());
             }
@@ -212,6 +211,9 @@ public class SampleFilterIntegrationTest {
          */
         void close() {
             this.tester.close();
+            this.admin.close();
+            this.producer.close();
+            this.consumer.close();
         }
 
         /**


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fix Kafka Client leaks in the `SampleFilterIntegrationTest`.  Closing the test doesn't close the admin/consumer/producers
that it created.

### Additional Context


_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
