### PR TITLE
Fix #198: Address javadoc warnings from the codegen module

### DIFF
--- a/krpc-code-gen/pom.xml
+++ b/krpc-code-gen/pom.xml
@@ -92,6 +92,14 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <excludePackageNames>io.kroxylicious.krpccodegen.schema</excludePackageNames>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>

--- a/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/main/KrpcGenerator.java
+++ b/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/main/KrpcGenerator.java
@@ -48,7 +48,7 @@ import freemarker.template.Version;
 public class KrpcGenerator {
 
     /**
-     * Builder for the {@link KrpcGenerator}.
+     * Configures and instantiates the {@link KrpcGenerator}.
      */
     public static class Builder {
 

--- a/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/main/KrpcGenerator.java
+++ b/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/main/KrpcGenerator.java
@@ -42,8 +42,14 @@ import freemarker.template.TemplateException;
 import freemarker.template.TemplateExceptionHandler;
 import freemarker.template.Version;
 
+/**
+ * Code generator driven by Apache Kafka message specifications definitions.
+ */
 public class KrpcGenerator {
 
+    /**
+     * Builder for the {@link KrpcGenerator}.
+     */
     public static class Builder {
 
         private final GeneratorMode mode;
@@ -63,52 +69,105 @@ public class KrpcGenerator {
             this.mode = mode;
         }
 
+        /**
+         * configures logging.
+         * @param logger logger.
+         * @return this
+         */
         public Builder withLogger(Logger logger) {
             this.logger = logger;
             return this;
         }
 
+        /**
+         * configures the message specification directory.
+         *
+         * @param messageSpecDir message specification directory.
+         * @return this
+         */
         public Builder withMessageSpecDir(File messageSpecDir) {
             this.messageSpecDir = messageSpecDir;
             return this;
         }
 
+        /**
+         * configures the glob pattern used to match message specification files.
+         *
+         * @param messageSpecFilter the glob pattern
+         * @return this
+         */
         public Builder withMessageSpecFilter(String messageSpecFilter) {
             this.messageSpecFilter = messageSpecFilter;
             return this;
         }
 
+        /**
+         * configures the directory contain the Apache Free Maker template.
+         * @param templateDir template directory.
+         * @return this
+         */
         public Builder withTemplateDir(File templateDir) {
             this.templateDir = templateDir;
             return this;
         }
 
+        /**
+         * configures a list of template file names.
+         *
+         * @param templateNames list of template file names.
+         * @return this
+         */
         public Builder withTemplateNames(List<String> templateNames) {
             this.templateNames = templateNames;
             return this;
         }
 
+        /**
+         * configures the java package name to be used in the generated source.
+         *
+         * @param outputPackage output package name.
+         * @return this
+         */
         public Builder withOutputPackage(String outputPackage) {
             this.outputPackage = outputPackage;
             return this;
         }
 
+        /**
+         * configures the output directory to be used for the generated source files.
+         * @param outputDir output directory.
+         * @return this
+         */
         public Builder withOutputDir(File outputDir) {
             this.outputDir = outputDir;
             return this;
         }
 
+        /**
+         * configures the pattern used to form the output file name.
+         * This understands two pattern {@code ${messageSpecName}} and {@code ${templateName}}
+         * which if present will be replaced by the message specification name the template
+         * name respectively.
+         *
+         * @param outputFilePattern output filename pattern.
+         * @return this
+         */
         public Builder withOutputFilePattern(String outputFilePattern) {
             this.outputFilePattern = outputFilePattern;
             return this;
         }
 
+        /**
+         * Creates the generator.
+         *
+         * @return the generator.
+         */
         public KrpcGenerator build() {
             return new KrpcGenerator(logger, mode, messageSpecDir, messageSpecFilter, templateDir, templateNames, outputPackage, outputDir, outputFilePattern);
         }
     }
 
-    public enum GeneratorMode {
+    enum GeneratorMode {
         SINGLE,
         MULTI;
     }
@@ -137,9 +196,9 @@ public class KrpcGenerator {
     private final String outputFilePattern;
     private final Charset outputEncoding = StandardCharsets.UTF_8;
 
-    public KrpcGenerator(Logger logger, GeneratorMode mode, File messageSpecDir, String messageSpecFilter, File templateDir, List<String> templateNames,
-                         String outputPackage, File outputDir,
-                         String outputFilePattern) {
+    private KrpcGenerator(Logger logger, GeneratorMode mode, File messageSpecDir, String messageSpecFilter, File templateDir, List<String> templateNames,
+                          String outputPackage, File outputDir,
+                          String outputFilePattern) {
         this.logger = logger != null ? logger : System.getLogger(KrpcGenerator.class.getName());
         this.mode = mode;
         this.messageSpecDir = messageSpecDir != null ? messageSpecDir : new File(".");
@@ -155,14 +214,29 @@ public class KrpcGenerator {
         }
     }
 
+    /**
+     * Constructs a generator in single mode. The generator passes a list of all
+     * message specifications to the template which is used to produce a single
+     * output file.
+     * @return the builder
+     */
     public static Builder single() {
         return new Builder(GeneratorMode.SINGLE);
     }
 
+    /**
+     * Constructs a generator in multi-mode. The generator each message specification
+     * to the generator in turn, each of which produces a distinct output file.
+     * @return the builder
+     */
     public static Builder multi() {
         return new Builder(GeneratorMode.MULTI);
     }
 
+    /**
+     * Generates the sources.
+     * @throws Exception exception during source generation.
+     */
     public void generate() throws Exception {
         var cfg = buildFmConfiguration();
         Set<MessageSpec> messageSpecs = messageSpecs();

--- a/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/main/KrpcGenerator.java
+++ b/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/main/KrpcGenerator.java
@@ -196,6 +196,7 @@ public class KrpcGenerator {
     private final String outputFilePattern;
     private final Charset outputEncoding = StandardCharsets.UTF_8;
 
+    @SuppressWarnings("java:S107") // Methods should not have too many parameters - ignored as use-case with builder seems reasonable.
     private KrpcGenerator(Logger logger, GeneratorMode mode, File messageSpecDir, String messageSpecFilter, File templateDir, List<String> templateNames,
                           String outputPackage, File outputDir,
                           String outputFilePattern) {

--- a/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/maven/AbstractKrpcGeneratorMojo.java
+++ b/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/maven/AbstractKrpcGeneratorMojo.java
@@ -21,7 +21,11 @@ import org.codehaus.plexus.build.BuildContext;
 
 import io.kroxylicious.krpccodegen.main.KrpcGenerator;
 
-public abstract class AbstractKrpcGeneratorMojo extends AbstractMojo {
+/**
+ * Abstract Maven plugin capable of generating java source from Apache Kafka message
+ * specifications definitions.
+ */
+abstract class AbstractKrpcGeneratorMojo extends AbstractMojo {
 
     /**
      * Gives access to the Maven project information.
@@ -55,6 +59,10 @@ public abstract class AbstractKrpcGeneratorMojo extends AbstractMojo {
 
     @Component
     private BuildContext buildContext;
+
+    AbstractKrpcGeneratorMojo() {
+        super();
+    }
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -98,5 +106,5 @@ public abstract class AbstractKrpcGeneratorMojo extends AbstractMojo {
         }
     }
 
-    protected abstract KrpcGenerator.Builder builder();
+    abstract KrpcGenerator.Builder builder();
 }

--- a/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/maven/KrpcMultiGeneratorMojo.java
+++ b/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/maven/KrpcMultiGeneratorMojo.java
@@ -11,8 +11,20 @@ import org.apache.maven.plugins.annotations.Mojo;
 import io.kroxylicious.krpccodegen.main.KrpcGenerator;
 import io.kroxylicious.krpccodegen.main.KrpcGenerator.Builder;
 
+/**
+ * A Maven plugin capable of generating java source from Apache Kafka message
+ * specifications definitions.  The generator is invoked once per message specification.
+ * The Apache FreeMaker variable {@code messageSpec} is defined with the message specification
+ * being processed.
+ */
 @Mojo(name = "generate-multi", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
 public class KrpcMultiGeneratorMojo extends AbstractKrpcGeneratorMojo {
+
+    /**
+     * Constructs a multi-generator.
+     */
+    public KrpcMultiGeneratorMojo() {
+    }
 
     @Override
     protected Builder builder() {

--- a/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/maven/KrpcMultiGeneratorMojo.java
+++ b/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/maven/KrpcMultiGeneratorMojo.java
@@ -24,6 +24,7 @@ public class KrpcMultiGeneratorMojo extends AbstractKrpcGeneratorMojo {
      * Constructs a multi-generator.
      */
     public KrpcMultiGeneratorMojo() {
+        super();
     }
 
     @Override

--- a/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/maven/KrpcSingleGeneratorMojo.java
+++ b/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/maven/KrpcSingleGeneratorMojo.java
@@ -24,6 +24,7 @@ public class KrpcSingleGeneratorMojo extends AbstractKrpcGeneratorMojo {
      * Constructs a single-generator.
      */
     public KrpcSingleGeneratorMojo() {
+        super();
     }
 
     @Override

--- a/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/maven/KrpcSingleGeneratorMojo.java
+++ b/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/maven/KrpcSingleGeneratorMojo.java
@@ -11,8 +11,20 @@ import org.apache.maven.plugins.annotations.Mojo;
 import io.kroxylicious.krpccodegen.main.KrpcGenerator;
 import io.kroxylicious.krpccodegen.main.KrpcGenerator.Builder;
 
+/**
+ * A Maven plugin capable of generating java source from Apache Kafka message
+ * specifications definitions. This generator is invoked once per execution.
+ * The Apache FreeMaker variable {@code messageSpecs} will be defined with a list containing
+ * all message specifications.
+ */
 @Mojo(name = "generate-single", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
 public class KrpcSingleGeneratorMojo extends AbstractKrpcGeneratorMojo {
+
+    /**
+     * Constructs a single-generator.
+     */
+    public KrpcSingleGeneratorMojo() {
+    }
 
     @Override
     protected Builder builder() {

--- a/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/maven/MavenLogger.java
+++ b/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/maven/MavenLogger.java
@@ -10,12 +10,12 @@ import java.util.ResourceBundle;
 
 import org.apache.maven.plugin.logging.Log;
 
-public class MavenLogger implements System.Logger {
+class MavenLogger implements System.Logger {
 
     private final String name;
     private final Log mavenLog;
 
-    public MavenLogger(String name, Log mavenLog) {
+    MavenLogger(String name, Log mavenLog) {
         this.name = name;
         this.mavenLog = mavenLog;
     }

--- a/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/model/FieldSpecModel.java
+++ b/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/model/FieldSpecModel.java
@@ -12,11 +12,11 @@ import freemarker.template.TemplateHashModel;
 import freemarker.template.TemplateModel;
 import freemarker.template.TemplateModelException;
 
-public class FieldSpecModel implements TemplateHashModel, AdapterTemplateModel {
+class FieldSpecModel implements TemplateHashModel, AdapterTemplateModel {
     final FieldSpec spec;
     final KrpcSchemaObjectWrapper wrapper;
 
-    public FieldSpecModel(KrpcSchemaObjectWrapper wrapper, FieldSpec ms) {
+    FieldSpecModel(KrpcSchemaObjectWrapper wrapper, FieldSpec ms) {
         this.wrapper = wrapper;
         this.spec = ms;
     }

--- a/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/model/FieldTypeModel.java
+++ b/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/model/FieldTypeModel.java
@@ -13,11 +13,11 @@ import freemarker.template.TemplateModel;
 import freemarker.template.TemplateModelException;
 import freemarker.template.TemplateScalarModel;
 
-public class FieldTypeModel implements TemplateHashModel, TemplateScalarModel, AdapterTemplateModel {
+class FieldTypeModel implements TemplateHashModel, TemplateScalarModel, AdapterTemplateModel {
     final FieldType fieldType;
     final KrpcSchemaObjectWrapper wrapper;
 
-    public FieldTypeModel(KrpcSchemaObjectWrapper wrapper, FieldType fieldType) {
+    FieldTypeModel(KrpcSchemaObjectWrapper wrapper, FieldType fieldType) {
         this.wrapper = wrapper;
         this.fieldType = fieldType;
     }

--- a/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/model/KrpcSchemaObjectWrapper.java
+++ b/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/model/KrpcSchemaObjectWrapper.java
@@ -16,8 +16,16 @@ import freemarker.template.TemplateModel;
 import freemarker.template.TemplateModelException;
 import freemarker.template.Version;
 
+/**
+ * Wraps the java representation of the Kafka Model in a Apache FreeMaker
+ * template object.
+ */
 public class KrpcSchemaObjectWrapper extends DefaultObjectWrapper {
 
+    /**
+     * Creates a schema object wrapper for the specified version.
+     * @param version kafka model version.
+     */
     public KrpcSchemaObjectWrapper(Version version) {
         super(version);
     }

--- a/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/model/MessageSpecModel.java
+++ b/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/model/MessageSpecModel.java
@@ -12,11 +12,11 @@ import freemarker.template.TemplateHashModel;
 import freemarker.template.TemplateModel;
 import freemarker.template.TemplateModelException;
 
-public class MessageSpecModel implements TemplateHashModel, AdapterTemplateModel {
+class MessageSpecModel implements TemplateHashModel, AdapterTemplateModel {
     final MessageSpec spec;
     final KrpcSchemaObjectWrapper wrapper;
 
-    public MessageSpecModel(KrpcSchemaObjectWrapper wrapper, MessageSpec spec) {
+    MessageSpecModel(KrpcSchemaObjectWrapper wrapper, MessageSpec spec) {
         this.wrapper = wrapper;
         this.spec = spec;
     }

--- a/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/model/RetrieveApiKey.java
+++ b/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/model/RetrieveApiKey.java
@@ -10,12 +10,17 @@ import java.util.List;
 import org.apache.kafka.common.protocol.ApiKeys;
 
 import freemarker.template.TemplateMethodModelEx;
-import freemarker.template.TemplateModelException;
 
 /**
  * A custom FreeMarker function which obtains the API key (as an enum name) from a message spec, e.g. "CREATE_TOPICS".
  */
 public class RetrieveApiKey implements TemplateMethodModelEx {
+
+    /**
+     * Constructs a RetrieveApiKey.
+     */
+    public RetrieveApiKey() {
+    }
 
     private static String retrieveApiKey(MessageSpecModel messageSpecModel) {
         Short apiKey = messageSpecModel.spec.apiKey().orElseThrow();
@@ -23,7 +28,7 @@ public class RetrieveApiKey implements TemplateMethodModelEx {
     }
 
     @Override
-    public Object exec(List arguments) throws TemplateModelException {
+    public Object exec(List arguments) {
         return retrieveApiKey(((MessageSpecModel) arguments.get(0)));
     }
 }

--- a/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/model/RetrieveApiKey.java
+++ b/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/model/RetrieveApiKey.java
@@ -20,6 +20,7 @@ public class RetrieveApiKey implements TemplateMethodModelEx {
      * Constructs a RetrieveApiKey.
      */
     public RetrieveApiKey() {
+        super();
     }
 
     private static String retrieveApiKey(MessageSpecModel messageSpecModel) {

--- a/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/model/StructSpecModel.java
+++ b/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/model/StructSpecModel.java
@@ -12,11 +12,11 @@ import freemarker.template.TemplateHashModel;
 import freemarker.template.TemplateModel;
 import freemarker.template.TemplateModelException;
 
-public class StructSpecModel implements TemplateHashModel, AdapterTemplateModel {
+class StructSpecModel implements TemplateHashModel, AdapterTemplateModel {
     final StructSpec spec;
     final KrpcSchemaObjectWrapper wrapper;
 
-    public StructSpecModel(KrpcSchemaObjectWrapper wrapper, StructSpec ms) {
+    StructSpecModel(KrpcSchemaObjectWrapper wrapper, StructSpec ms) {
         this.wrapper = wrapper;
         this.spec = ms;
     }

--- a/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/model/VersionsModel.java
+++ b/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/model/VersionsModel.java
@@ -16,11 +16,11 @@ import freemarker.template.TemplateModelException;
 import freemarker.template.TemplateScalarModel;
 import freemarker.template.TemplateSequenceModel;
 
-public class VersionsModel implements TemplateHashModel, TemplateScalarModel, TemplateSequenceModel, AdapterTemplateModel {
+class VersionsModel implements TemplateHashModel, TemplateScalarModel, TemplateSequenceModel, AdapterTemplateModel {
     final Versions versions;
     final KrpcSchemaObjectWrapper wrapper;
 
-    public VersionsModel(KrpcSchemaObjectWrapper wrapper, Versions versions) {
+    VersionsModel(KrpcSchemaObjectWrapper wrapper, Versions versions) {
         this.wrapper = wrapper;
         this.versions = versions;
     }

--- a/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/schema/package-info.java
+++ b/krpc-code-gen/src/main/java/io/kroxylicious/krpccodegen/schema/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * This package contains copies of the classes from {@code org.apache.kafka.message} from
+ * Apache Kafka generator module.  Unfortunately, the Apache Kafka project does not publish
+ * an artefact containing these classes.
+ */
+package io.kroxylicious.krpccodegen.schema;


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

Contribute javadoc for the codegen module.  No functional change.

* backfill missing javadoc
* in some cases, reducing visibility of implementation seemed like the best course
* added package level note explaining why copies of classes from org.apache.kafka.message appear in io.kroxylicious.krpccodegen.schema. I purposefully didn't add javadoc to these classes. Instead, I excluded the package from javadoc'ing.

The module could have utility for filter author wishing to autogenerate filter code.  This is an additional reason to value the javadoc of this model.


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [x] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
