### PR TITLE
Fix #537: Ensure actions chained to the #sendRequest run on netty loop executor

### DIFF
--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/InternalCompletionStage.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/InternalCompletionStage.java
@@ -3,8 +3,9 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.kroxylicious.proxy.future;
+package io.kroxylicious.proxy.internal;
 
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
@@ -18,226 +19,238 @@ import java.util.function.Function;
  * to block the proxy thread loop using the CompletionStage we offer though the kroxylicious
  * filter api, or complete the underlying future unexpectedly.
  */
-public class InternalCompletionStage<T> implements CompletionStage<T> {
+class InternalCompletionStage<T> implements CompletionStage<T> {
 
     private final CompletionStage<T> completionStage;
+    private final Executor executor;
 
-    public InternalCompletionStage(CompletionStage<T> completionStage) {
+    InternalCompletionStage(CompletionStage<T> completionStage, Executor executor) {
+        Objects.requireNonNull(completionStage);
+        Objects.requireNonNull(executor);
         this.completionStage = completionStage;
+        this.executor = executor;
+    }
+
+    private <U> CompletionStage<U> wrap(CompletionStage<U> completionStage) {
+        return new InternalCompletionStage<>(completionStage, executor);
     }
 
     @Override
     public <U> CompletionStage<U> thenApply(Function<? super T, ? extends U> fn) {
-        return completionStage.thenApply(fn);
+        return wrap(completionStage.thenApply(fn));
     }
 
     @Override
     public <U> CompletionStage<U> thenApplyAsync(Function<? super T, ? extends U> fn) {
-        return completionStage.thenApplyAsync(fn);
+        return wrap(completionStage.thenApplyAsync(fn, executor));
     }
 
     @Override
     public <U> CompletionStage<U> thenApplyAsync(Function<? super T, ? extends U> fn, Executor executor) {
-        return completionStage.thenApplyAsync(fn, executor);
+        return wrap(completionStage.thenApplyAsync(fn, executor));
     }
 
     @Override
     public CompletionStage<Void> thenAccept(Consumer<? super T> action) {
-        return completionStage.thenAccept(action);
+        return wrap(completionStage.thenAccept(action));
     }
 
     @Override
     public CompletionStage<Void> thenAcceptAsync(Consumer<? super T> action) {
-        return completionStage.thenAcceptAsync(action);
+        return wrap(completionStage.thenAcceptAsync(action, executor));
     }
 
     @Override
     public CompletionStage<Void> thenAcceptAsync(Consumer<? super T> action, Executor executor) {
-        return completionStage.thenAcceptAsync(action, executor);
+        return wrap(completionStage.thenAcceptAsync(action, executor));
     }
 
     @Override
     public CompletionStage<Void> thenRun(Runnable action) {
-        return completionStage.thenRun(action);
+        return wrap(completionStage.thenRun(action));
     }
 
     @Override
     public CompletionStage<Void> thenRunAsync(Runnable action) {
-        return completionStage.thenRunAsync(action);
+        return wrap(completionStage.thenRunAsync(action, executor));
     }
 
     @Override
     public CompletionStage<Void> thenRunAsync(Runnable action, Executor executor) {
-        return completionStage.thenRunAsync(action, executor);
+        return wrap(completionStage.thenRunAsync(action, executor));
     }
 
     @Override
     public <U, V> CompletionStage<V> thenCombine(CompletionStage<? extends U> other, BiFunction<? super T, ? super U, ? extends V> fn) {
-        return completionStage.thenCombine(other, fn);
+        return wrap(completionStage.thenCombine(other, fn));
     }
 
     @Override
     public <U, V> CompletionStage<V> thenCombineAsync(CompletionStage<? extends U> other, BiFunction<? super T, ? super U, ? extends V> fn) {
-        return completionStage.thenCombineAsync(other, fn);
+        return wrap(completionStage.thenCombineAsync(other, fn, executor));
     }
 
     @Override
     public <U, V> CompletionStage<V> thenCombineAsync(CompletionStage<? extends U> other, BiFunction<? super T, ? super U, ? extends V> fn, Executor executor) {
-        return completionStage.thenCombineAsync(other, fn, executor);
+        return wrap(completionStage.thenCombineAsync(other, fn, executor));
     }
 
     @Override
     public <U> CompletionStage<Void> thenAcceptBoth(CompletionStage<? extends U> other, BiConsumer<? super T, ? super U> action) {
-        return completionStage.thenAcceptBoth(other, action);
+        return wrap(completionStage.thenAcceptBoth(other, action));
     }
 
     @Override
     public <U> CompletionStage<Void> thenAcceptBothAsync(CompletionStage<? extends U> other, BiConsumer<? super T, ? super U> action) {
-        return completionStage.thenAcceptBothAsync(other, action);
+        return wrap(completionStage.thenAcceptBothAsync(other, action, executor));
     }
 
     @Override
     public <U> CompletionStage<Void> thenAcceptBothAsync(CompletionStage<? extends U> other, BiConsumer<? super T, ? super U> action, Executor executor) {
-        return completionStage.thenAcceptBothAsync(other, action, executor);
+        return wrap(completionStage.thenAcceptBothAsync(other, action, executor));
     }
 
     @Override
     public CompletionStage<Void> runAfterBoth(CompletionStage<?> other, Runnable action) {
-        return completionStage.runAfterBoth(other, action);
+        return wrap(completionStage.runAfterBoth(other, action));
     }
 
     @Override
     public CompletionStage<Void> runAfterBothAsync(CompletionStage<?> other, Runnable action) {
-        return completionStage.runAfterBothAsync(other, action);
+        return wrap(completionStage.runAfterBothAsync(other, action, executor));
     }
 
     @Override
     public CompletionStage<Void> runAfterBothAsync(CompletionStage<?> other, Runnable action, Executor executor) {
-        return completionStage.runAfterBothAsync(other, action, executor);
+        return wrap(completionStage.runAfterBothAsync(other, action, executor));
     }
 
     @Override
     public <U> CompletionStage<U> applyToEither(CompletionStage<? extends T> other, Function<? super T, U> fn) {
-        return completionStage.applyToEither(other, fn);
+        return wrap(completionStage.applyToEither(other, fn));
     }
 
     @Override
     public <U> CompletionStage<U> applyToEitherAsync(CompletionStage<? extends T> other, Function<? super T, U> fn) {
-        return completionStage.applyToEitherAsync(other, fn);
+        return wrap(completionStage.applyToEitherAsync(other, fn, executor));
     }
 
     @Override
     public <U> CompletionStage<U> applyToEitherAsync(CompletionStage<? extends T> other, Function<? super T, U> fn, Executor executor) {
-        return completionStage.applyToEitherAsync(other, fn, executor);
+        return wrap(completionStage.applyToEitherAsync(other, fn, executor));
     }
 
     @Override
     public CompletionStage<Void> acceptEither(CompletionStage<? extends T> other, Consumer<? super T> action) {
-        return completionStage.acceptEither(other, action);
+        return wrap(completionStage.acceptEither(other, action));
     }
 
     @Override
     public CompletionStage<Void> acceptEitherAsync(CompletionStage<? extends T> other, Consumer<? super T> action) {
-        return completionStage.acceptEitherAsync(other, action);
+        return wrap(completionStage.acceptEitherAsync(other, action, executor));
     }
 
     @Override
     public CompletionStage<Void> acceptEitherAsync(CompletionStage<? extends T> other, Consumer<? super T> action, Executor executor) {
-        return completionStage.acceptEitherAsync(other, action, executor);
+        return wrap(completionStage.acceptEitherAsync(other, action, executor));
     }
 
     @Override
     public CompletionStage<Void> runAfterEither(CompletionStage<?> other, Runnable action) {
-        return completionStage.runAfterEither(other, action);
+        return wrap(completionStage.runAfterEither(other, action));
     }
 
     @Override
     public CompletionStage<Void> runAfterEitherAsync(CompletionStage<?> other, Runnable action) {
-        return completionStage.runAfterEitherAsync(other, action);
+        return wrap(completionStage.runAfterEitherAsync(other, action, executor));
     }
 
     @Override
     public CompletionStage<Void> runAfterEitherAsync(CompletionStage<?> other, Runnable action, Executor executor) {
-        return completionStage.runAfterEitherAsync(other, action, executor);
+        return wrap(completionStage.runAfterEitherAsync(other, action, executor));
     }
 
     @Override
     public <U> CompletionStage<U> thenCompose(Function<? super T, ? extends CompletionStage<U>> fn) {
-        return completionStage.thenCompose(fn);
+        return wrap(completionStage.thenCompose(fn));
     }
 
     @Override
     public <U> CompletionStage<U> thenComposeAsync(Function<? super T, ? extends CompletionStage<U>> fn) {
-        return completionStage.thenComposeAsync(fn);
+        return wrap(completionStage.thenComposeAsync(fn, executor));
     }
 
     @Override
     public <U> CompletionStage<U> thenComposeAsync(Function<? super T, ? extends CompletionStage<U>> fn, Executor executor) {
-        return completionStage.thenComposeAsync(fn, executor);
+        return wrap(completionStage.thenComposeAsync(fn, executor));
     }
 
     @Override
     public <U> CompletionStage<U> handle(BiFunction<? super T, Throwable, ? extends U> fn) {
-        return completionStage.handle(fn);
+        return wrap(completionStage.handle(fn));
     }
 
     @Override
     public <U> CompletionStage<U> handleAsync(BiFunction<? super T, Throwable, ? extends U> fn) {
-        return completionStage.handleAsync(fn);
+        return wrap(completionStage.handleAsync(fn, executor));
     }
 
     @Override
     public <U> CompletionStage<U> handleAsync(BiFunction<? super T, Throwable, ? extends U> fn, Executor executor) {
-        return completionStage.handleAsync(fn, executor);
+        return wrap(completionStage.handleAsync(fn, executor));
     }
 
     @Override
     public CompletionStage<T> whenComplete(BiConsumer<? super T, ? super Throwable> action) {
-        return completionStage.whenComplete(action);
+        return wrap(completionStage.whenComplete(action));
     }
 
     @Override
     public CompletionStage<T> whenCompleteAsync(BiConsumer<? super T, ? super Throwable> action) {
-        return completionStage.whenCompleteAsync(action);
+        return wrap(completionStage.whenCompleteAsync(action, executor));
     }
 
     @Override
     public CompletionStage<T> whenCompleteAsync(BiConsumer<? super T, ? super Throwable> action, Executor executor) {
-        return completionStage.whenCompleteAsync(action, executor);
+        return wrap(completionStage.whenCompleteAsync(action, executor));
     }
 
     @Override
     public CompletionStage<T> exceptionally(Function<Throwable, ? extends T> fn) {
-        return completionStage.exceptionally(fn);
+        return wrap(completionStage.exceptionally(fn));
     }
 
     @Override
     public CompletionStage<T> exceptionallyAsync(Function<Throwable, ? extends T> fn) {
-        return completionStage.exceptionallyAsync(fn);
+        return wrap(completionStage.exceptionallyAsync(fn, executor));
     }
 
     @Override
     public CompletionStage<T> exceptionallyAsync(Function<Throwable, ? extends T> fn, Executor executor) {
-        return completionStage.exceptionallyAsync(fn, executor);
+        return wrap(completionStage.exceptionallyAsync(fn, executor));
     }
 
     @Override
     public CompletionStage<T> exceptionallyCompose(Function<Throwable, ? extends CompletionStage<T>> fn) {
-        return completionStage.exceptionallyCompose(fn);
+        return wrap(completionStage.exceptionallyCompose(fn));
     }
 
     @Override
     public CompletionStage<T> exceptionallyComposeAsync(Function<Throwable, ? extends CompletionStage<T>> fn) {
-        return completionStage.exceptionallyComposeAsync(fn);
+        return wrap(completionStage.exceptionallyComposeAsync(fn, executor));
     }
 
     @Override
     public CompletionStage<T> exceptionallyComposeAsync(Function<Throwable, ? extends CompletionStage<T>> fn, Executor executor) {
-        return completionStage.exceptionallyComposeAsync(fn, executor);
+        return wrap(completionStage.exceptionallyComposeAsync(fn, executor));
     }
 
     @Override
     public CompletableFuture<T> toCompletableFuture() {
         throw new UnsupportedOperationException("CompletableFuture usage disallowed, we don't want to block the event loop or allow unexpected completion");
+    }
+
+    CompletableFuture<T> getUnderlyingCompletableFuture() {
+        return completionStage.toCompletableFuture();
     }
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/InternalCompletionStage.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/InternalCompletionStage.java
@@ -32,7 +32,8 @@ class InternalCompletionStage<T> implements CompletionStage<T> {
     }
 
     private <U> CompletionStage<U> wrap(CompletionStage<U> completionStage) {
-        return new InternalCompletionStage<>(completionStage, executor);
+        return completionStage instanceof InternalCompletionStage && ((InternalCompletionStage<U>) completionStage).getExecutor() == executor ? completionStage
+                : new InternalCompletionStage<>(completionStage, executor);
     }
 
     @Override
@@ -252,5 +253,9 @@ class InternalCompletionStage<T> implements CompletionStage<T> {
 
     CompletableFuture<T> getUnderlyingCompletableFuture() {
         return completionStage.toCompletableFuture();
+    }
+
+    Executor getExecutor() {
+        return executor;
     }
 }

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/InternalCompletionStageTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/InternalCompletionStageTest.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class InternalCompletionStageTest {
+    private final CompletableFuture<Void> underlying = new CompletableFuture<>();
+
+    private ExecutorService executor;
+    private TallyThread executorThread;
+    private InternalCompletionStage<Void> stage;
+
+    @BeforeEach
+    void beforeEach() throws Exception {
+        executor = Executors.newSingleThreadExecutor(TallyThread::new);
+        executorThread = ((TallyThread) executor.submit(Thread::currentThread).get());
+        stage = new InternalCompletionStage<>(underlying, executor);
+    }
+
+    @AfterEach
+    void afterEach() {
+        executor.shutdown();
+    }
+
+    static Stream<Arguments> noExecutorFormAsyncMethodsUsesConfiguredExecutor() {
+        var other = CompletableFuture.<Void> completedFuture(null);
+        return Stream.of(
+                Arguments.of("thenAcceptAsync", (Function<CompletionStage<Void>, CompletionStage<Void>>) (s) -> s.thenAcceptAsync(u -> tallyInvocations())),
+                Arguments.of("thenApplyAsync", (Function<CompletionStage<Void>, CompletionStage<Void>>) (s) -> s.thenApplyAsync(u -> tallyInvocations())),
+                Arguments.of("thenComposeAsync",
+                        (Function<CompletionStage<Void>, CompletionStage<Void>>) (s) -> s.thenComposeAsync(u -> CompletableFuture.completedStage(tallyInvocations()))),
+                Arguments.of("thenRunAsync", (Function<CompletionStage<Void>, CompletionStage<Void>>) (s) -> s.thenRunAsync(() -> tallyInvocations())),
+
+                Arguments.of("handleAsync", (Function<CompletionStage<Void>, CompletionStage<Void>>) (s) -> s.handleAsync((u, t) -> tallyInvocations())),
+                Arguments.of("whenCompleteAsync", (Function<CompletionStage<Void>, CompletionStage<Void>>) (s) -> s.whenCompleteAsync((u, t) -> tallyInvocations())),
+
+                Arguments.of("exceptionallyAsync", (Function<CompletionStage<Void>, CompletionStage<Void>>) (s) -> s.exceptionallyAsync((t) -> tallyInvocations())),
+                Arguments.of("exceptionallyComposeAsync",
+                        (Function<CompletionStage<Void>, CompletionStage<Void>>) (s) -> s
+                                .exceptionallyComposeAsync((t) -> CompletableFuture.completedStage(tallyInvocations()))),
+
+                Arguments.of("acceptEitherAsync", (Function<CompletionStage<Void>, CompletionStage<Void>>) (s) -> s.acceptEitherAsync(other, (u) -> tallyInvocations())),
+                Arguments.of("applyToEitherAsync",
+                        (Function<CompletionStage<Void>, CompletionStage<Void>>) (s) -> s.applyToEitherAsync(other, (u) -> tallyInvocations())),
+
+                Arguments.of("thenAcceptBothAsync",
+                        (Function<CompletionStage<Void>, CompletionStage<Void>>) (s) -> s.thenAcceptBothAsync(other, (u1, u2) -> tallyInvocations())),
+                Arguments.of("thenCombineAsync",
+                        (Function<CompletionStage<Void>, CompletionStage<Void>>) (s) -> s.thenCombineAsync(other, (u1, u2) -> tallyInvocations())),
+
+                Arguments.of("runAfterBothAsync",
+                        (Function<CompletionStage<Void>, CompletionStage<Void>>) (s) -> s.runAfterBothAsync(other, () -> CompletableFuture.completedStage(
+                                tallyInvocations()))),
+                Arguments.of("runAfterEitherAsync",
+                        (Function<CompletionStage<Void>, CompletionStage<Void>>) (s) -> s.runAfterEitherAsync(other, () -> CompletableFuture.completedStage(
+                                tallyInvocations()))));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource
+    void noExecutorFormAsyncMethodsUsesConfiguredExecutor(String name, Function<CompletionStage<Void>, CompletionStage<Void>> func) throws Exception {
+        var result = func.apply(stage);
+        completeUnderlyingFuture(name);
+
+        assertStageCompletion(result);
+        assertThat(executorThread.getTally()).isEqualTo(1);
+    }
+
+    static Stream<Arguments> executorFormAsyncMethodsUsesCallerExecutor() {
+        var other = CompletableFuture.<Void> completedFuture(null);
+        return Stream.of(
+                Arguments.of("thenAcceptAsync",
+                        (BiFunction<Executor, CompletionStage<Void>, CompletionStage<Void>>) (e, s) -> s.thenAcceptAsync(u -> tallyInvocations(), e)),
+                Arguments.of("thenApplyAsync",
+                        (BiFunction<Executor, CompletionStage<Void>, CompletionStage<Void>>) (e, s) -> s.thenApplyAsync(u -> tallyInvocations(), e)),
+                Arguments.of("thenComposeAsync",
+                        (BiFunction<Executor, CompletionStage<Void>, CompletionStage<Void>>) (e, s) -> s
+                                .thenComposeAsync(u -> CompletableFuture.completedStage(tallyInvocations()), e)),
+                Arguments.of("thenRunAsync", (BiFunction<Executor, CompletionStage<Void>, CompletionStage<Void>>) (e, s) -> s.thenRunAsync(() -> tallyInvocations(), e)),
+
+                Arguments.of("handleAsync",
+                        (BiFunction<Executor, CompletionStage<Void>, CompletionStage<Void>>) (e, s) -> s.handleAsync((u, t) -> tallyInvocations(), e)),
+                Arguments.of("whenCompleteAsync",
+                        (BiFunction<Executor, CompletionStage<Void>, CompletionStage<Void>>) (e, s) -> s.whenCompleteAsync((u, t) -> tallyInvocations(), e)),
+
+                Arguments.of("exceptionallyAsync",
+                        (BiFunction<Executor, CompletionStage<Void>, CompletionStage<Void>>) (e, s) -> s.exceptionallyAsync((t) -> tallyInvocations(), e)),
+                Arguments.of("exceptionallyComposeAsync",
+                        (BiFunction<Executor, CompletionStage<Void>, CompletionStage<Void>>) (e, s) -> s
+                                .exceptionallyComposeAsync((t) -> CompletableFuture.completedStage(tallyInvocations()), e)),
+
+                Arguments.of("acceptEitherAsync",
+                        (BiFunction<Executor, CompletionStage<Void>, CompletionStage<Void>>) (e, s) -> s.acceptEitherAsync(other, (u) -> tallyInvocations(), e)),
+                Arguments.of("applyToEitherAsync",
+                        (BiFunction<Executor, CompletionStage<Void>, CompletionStage<Void>>) (e, s) -> s.applyToEitherAsync(other, (u) -> tallyInvocations(), e)),
+
+                Arguments.of("thenAcceptBothAsync",
+                        (BiFunction<Executor, CompletionStage<Void>, CompletionStage<Void>>) (e, s) -> s.thenAcceptBothAsync(other, (u1, u2) -> tallyInvocations(), e)),
+                Arguments.of("thenCombineAsync",
+                        (BiFunction<Executor, CompletionStage<Void>, CompletionStage<Void>>) (e, s) -> s.thenCombineAsync(other, (u1, u2) -> tallyInvocations(), e)),
+
+                Arguments.of("runAfterBothAsync",
+                        (BiFunction<Executor, CompletionStage<Void>, CompletionStage<Void>>) (e, s) -> s.runAfterBothAsync(other, () -> CompletableFuture.completedStage(
+                                tallyInvocations()), e)),
+                Arguments.of("runAfterEitherAsync",
+                        (BiFunction<Executor, CompletionStage<Void>, CompletionStage<Void>>) (e, s) -> s.runAfterEitherAsync(other,
+                                () -> CompletableFuture.completedStage(
+                                        tallyInvocations()),
+                                e)));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource
+    void executorFormAsyncMethodsUsesCallerExecutor(String name, BiFunction<Executor, CompletionStage<Void>, CompletionStage<Void>> func) throws Exception {
+
+        var callerExecutor = Executors.newSingleThreadExecutor(TallyThread::new);
+        try {
+            var callerExecutorThread = ((TallyThread) callerExecutor.submit(Thread::currentThread).get());
+
+            var result = func.apply(callerExecutor, stage);
+            completeUnderlyingFuture(name);
+
+            assertStageCompletion(result);
+            // ensure the action ran on the caller's thread pool, rather than that of the ICS.
+            assertThat(executorThread.getTally()).isEqualTo(0);
+            assertThat(callerExecutorThread.getTally()).isEqualTo(1);
+        }
+        finally {
+            callerExecutor.shutdown();
+        }
+    }
+
+    static Stream<Arguments> chainingMethodsWrapReturnedValue() {
+        var other = CompletableFuture.<Void> completedFuture(null);
+        var completed = CompletableFuture.<Void> completedFuture(null);
+        return Stream.of(
+                Arguments.of("thenAccept", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.thenAccept(u -> {
+                })),
+                Arguments.of("thenAcceptAsync", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.thenAcceptAsync(u -> {
+                })),
+                Arguments.of("thenAcceptAsync(E)", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.thenAcceptAsync(u -> {
+                }, e)),
+
+                Arguments.of("thenApply", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.thenApply(u -> u)),
+                Arguments.of("thenApplyAsync", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.thenApplyAsync(u -> u)),
+                Arguments.of("thenApplyAsync(E)", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.thenApplyAsync(u -> u, e)),
+
+                Arguments.of("thenCombine", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.thenCombine(other, (u1, u2) -> u1)),
+                Arguments.of("thenCombineAsync",
+                        (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.thenCombineAsync(other, (u1, u2) -> u1)),
+                Arguments.of("thenCombineAsync(E)",
+                        (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.thenCombineAsync(other, (u1, u2) -> u1, e)),
+
+                Arguments.of("thenCompose", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.thenCompose(u -> completed)),
+                Arguments.of("thenComposeAsync", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.thenComposeAsync(u -> completed)),
+                Arguments.of("thenComposeAsync(E)", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.thenComposeAsync(u -> completed, e)),
+
+                Arguments.of("thenRun", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.thenRun(() -> {
+                })),
+                Arguments.of("thenRunAsync", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.thenRunAsync(() -> {
+                })),
+                Arguments.of("thenRunAsync(E)", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.thenRunAsync(() -> {
+                }, e)),
+
+                Arguments.of("handle", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.handle((u, t) -> u)),
+                Arguments.of("handleAsync", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.handleAsync((u, t) -> u)),
+                Arguments.of("handleAsync(E)", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.handleAsync((u, t) -> u, e)),
+
+                Arguments.of("whenComplete", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.whenComplete((u, t) -> {
+                })),
+                Arguments.of("whenCompleteAsync", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.whenCompleteAsync((u, t) -> {
+                })),
+                Arguments.of("whenCompleteAsync(E)", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.whenCompleteAsync((u, t) -> {
+                }, e)),
+
+                Arguments.of("exceptionally", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.exceptionally(t -> null)),
+                Arguments.of("exceptionallyAsync", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.exceptionallyAsync(t -> null)),
+                Arguments.of("exceptionallyAsync(E)", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.exceptionallyAsync(t -> null, e)),
+
+                Arguments.of("exceptionallyCompose",
+                        (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.exceptionallyCompose(t -> completed)),
+                Arguments.of("exceptionallyComposeAsync",
+                        (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.exceptionallyComposeAsync(t -> completed)),
+                Arguments.of("exceptionallyComposeAsync(E)",
+                        (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.exceptionallyComposeAsync(t -> completed, e)),
+
+                Arguments.of("acceptEither", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.acceptEither(other, u -> {
+                })),
+                Arguments.of("acceptEitherAsync", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.acceptEitherAsync(other, u -> {
+                })),
+                Arguments.of("acceptEitherAsync(E)", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.acceptEitherAsync(other, u -> {
+                }, e)),
+
+                Arguments.of("applyToEither", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.applyToEither(other, u -> u)),
+                Arguments.of("applyToEitherAsync", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.applyToEitherAsync(other, u -> u)),
+                Arguments.of("applyToEitherAsync(E)",
+                        (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.applyToEitherAsync(other, u -> u, e)),
+
+                Arguments.of("runAfterEither", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.runAfterEither(other, () -> {
+                })),
+                Arguments.of("runAfterEitherAsync", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.runAfterEitherAsync(other, () -> {
+                })),
+                Arguments.of("runAfterEitherAsync(E)", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.runAfterEitherAsync(other, () -> {
+                }, e)),
+
+                Arguments.of("theAcceptBoth", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.thenAcceptBoth(other, (u1, u2) -> {
+                })),
+                Arguments.of("thenAcceptBothAsync",
+                        (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.thenAcceptBothAsync(other, (u1, u2) -> {
+                        })),
+                Arguments.of("thenAcceptBothAsync(E)",
+                        (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.thenAcceptBothAsync(other, (u1, u2) -> {
+                        }, e)),
+
+                Arguments.of("runAfterBoth", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.runAfterBoth(other, () -> {
+                })),
+                Arguments.of("runAfterBothAsync", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.runAfterBothAsync(other, () -> {
+                })),
+                Arguments.of("runAfterBothAsync(E)", (BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>>) (s, e) -> s.runAfterBothAsync(other, () -> {
+                }, e)));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource
+    void chainingMethodsWrapReturnedValue(String name, BiFunction<CompletionStage<Void>, Executor, CompletionStage<Void>> func) throws Exception {
+        var result = func.apply(stage, executor);
+        completeUnderlyingFuture(name);
+
+        assertStageCompletion(result);
+        // Verify that the completion stage return is one of ours. The purpose of this is to make sure that thread safety
+        // guarantees made about our futures are upheld.
+        assertThat((Object) result).isInstanceOf(InternalCompletionStage.class);
+    }
+
+    @Test
+    void toCompletableFutureDisallowed() {
+        assertThatThrownBy(() -> stage.toCompletableFuture()).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    private void completeUnderlyingFuture(String name) {
+        if (name.startsWith("exceptionally")) {
+            underlying.completeExceptionally(new RuntimeException("exceptional completion"));
+        }
+        else {
+            underlying.complete(null);
+        }
+    }
+
+    private void assertStageCompletion(CompletionStage<Void> result) throws Exception {
+        var stageComplete = new CompletableFuture<Void>();
+        var unused = result.whenCompleteAsync((u, t) -> {
+            if (t != null) {
+                stageComplete.completeExceptionally(t);
+            }
+            else {
+                stageComplete.complete(null);
+            }
+        });
+        stageComplete.get();
+    }
+
+    private static Void tallyInvocations() {
+        assertThat(Thread.currentThread()).isInstanceOf(TallyThread.class);
+        ((TallyThread) Thread.currentThread()).incTally();
+        return null;
+    }
+
+    private static class TallyThread extends Thread {
+        private final AtomicInteger tally = new AtomicInteger();
+
+        TallyThread(@NotNull Runnable r) {
+            super(r);
+        }
+
+        public void incTally() {
+            tally.incrementAndGet();
+        }
+
+        public int getTally() {
+            return tally.get();
+        }
+    }
+
+}


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

As described by #537, I believe that actions chained to the sendRequest completion stage, should run on the Netty event loop.

* `thenApplyAsync(Function<? super T, ? extends U>)` should use *Netty's executor* rather than the ForkJoin executor provided by the JDK.
* `thenApplyAsync(Function<? super T, ? extends U>, Executor x)` should use the *executor provided by the caller.*  We should assume that the programmer knows what they are doing.  I think ignoring `Executor` fp would violate Least Surprise.

Why: Kroxylicious makes thread safety guarantees about chaining actions on `#sendRequest()`. This defect means we were not upholding that contract.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
