### PR TITLE
Update Build and Run sections of kroxylicious-sample/README.md

### DIFF
--- a/kroxylicious-sample/README.md
+++ b/kroxylicious-sample/README.md
@@ -11,13 +11,13 @@ Building the sample project is easy! You can build the **kroxylicious-sample** j
 To build all of Kroxylicious, including the sample:
 
 ```
-$ mvn clean install
+$ mvn clean verify
 ```
 
 To build the sample on its own:
 
 ```
-$ mvn clean install -pl kroxylicious-sample
+$ mvn clean verify -pl :kroxylicious-sample
 ```
 
 Build with the `dist` profile for creating executable JARs:
@@ -31,8 +31,12 @@ $ mvn clean verify -Pdist -Dquick
 Build with the `dist` profile as above, then run the following command:
 
 ```
-$ java -cp {path-to-your-class-path}:kroxylicious-sample/target/kroxylicious-sample-*-SNAPSHOT.jar:kroxylicious-app/target/kroxylicious-app-*-SNAPSHOT.jar io.kroxylicious.app.Kroxylicious --config kroxylicious-sample/sample-proxy-config.yml
+$ java -cp {path-to-your-class-path}:$(ls kroxylicious-sample/target/kroxylicious-sample-*-SNAPSHOT.jar):$(ls kroxylicious-app/target/kroxylicious-app-*-SNAPSHOT.jar) io.kroxylicious.app.Kroxylicious --config kroxylicious-sample/sample-proxy-config.yml
 ```
+
+**Note 1:** The `{path-to-your-class-path}:` is optional, but if you wanted to add any other JARs in (i.e. a specific SLF4J implementation) this is where you would put each JAR's file path (each one separated by a `:` character).
+
+**Note 2:** We wrap each Kroxylicious JAR path in `$(ls )` here so that the file names will be auto-completed without the rest of the `java` command potentially being interpreted as part of the file path. Alternately, you could leave these out and instead replace each wildcard character (`*`) with the specific Kroxylicious version you have built, i.e. for version `0.3.0-SNAPSHOT`, `$(ls kroxylicious-sample/target/kroxylicious-sample-*-SNAPSHOT.jar)` becomes `kroxylicious-sample/target/kroxylicious-sample-0.3.0-SNAPSHOT.jar`
 
 ### Configure
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Update Build section to use `verify` rather than `install`, update Run section with workaround command for bash globbing issue and add notes on class path and purpose of workaround.

### Additional Context

Addresses a few points in #536 (not all of them, next up I'm taking a look at the `dist` profile and the possibility of running with the [Maven Exec Plugin](https://www.mojohaus.org/exec-maven-plugin/)), making the kroxylicious-sample README actually able to be followed successfully.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
