### PR TITLE
Markdown shell/bash code block syntax highlighting

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -56,8 +56,8 @@ which targets 20 to access some new language features.
 
 Build the project like this:
 
-```
-$ mvn clean install
+```shell
+mvn clean install
 ```
 
 The running of the tests can be controlled with the following Maven properties:
@@ -81,26 +81,26 @@ the `container.logs.dir`  system property. When run through Maven this is defaul
 
 Pass the `-Dquick` option to skip all tests and non-essential plug-ins and create the output artifact as quickly as possible:
 
-```
-$ mvn clean verify -Dquick
+```shell
+mvn clean verify -Dquick
 ```
 
 Run the following command to format the source code and organize the imports as per the project's conventions:
 
-```
-$ mvn process-sources
+```shell
+mvn process-sources
 ```
 
 Build with the `dist` profile for creating an executable JAR:
 
-```
-$ mvn clean verify -Pdist -Dquick
+```shell
+mvn clean verify -Pdist -Dquick
 ```
 
 Run the following to add missing license headers e.g. when adding new source files:
 
-```
-$ mvn org.commonjava.maven.plugins:directory-maven-plugin:highest-basedir@resolve-rootdir license:format
+```shell
+mvn org.commonjava.maven.plugins:directory-maven-plugin:highest-basedir@resolve-rootdir license:format
 ```
 
 ### Formatting the Code
@@ -117,19 +117,19 @@ No one likes to argue about code formatting in pull requests, as project we take
 Build with the `dist` profile as shown above, then execute this:
 
 ```shell
-$ kroxylicious-app/target/kroxylicious-app-*-bin/kroxylicious-app-*/bin/kroxylicious-start.sh --config {path-to-kroxylicious-config}
+kroxylicious-app/target/kroxylicious-app-*-bin/kroxylicious-app-*/bin/kroxylicious-start.sh --config {path-to-kroxylicious-config}
 ```
 
 Or, to run with your own class path, run this instead:
 
 ```shell
-$ KROXYLICIOUS_CLASSPATH="{additional-classpath-entries}" kroxylicious-app/target/kroxylicious-app-*-bin/kroxylicious-app-*/bin/kroxylicious-start.sh --config {path-to-kroxylicious-config}
+KROXYLICIOUS_CLASSPATH="{additional-classpath-entries}" kroxylicious-app/target/kroxylicious-app-*-bin/kroxylicious-app-*/bin/kroxylicious-start.sh --config {path-to-kroxylicious-config}
 ```
 
 for example:
 
 ```shell
-$ KROXYLICIOUS_CLASSPATH="/path/to/any.jar:/path/to/libs/dir/*" kroxylicious-app/target/kroxylicious-app-*-bin/kroxylicious-app-*/bin/kroxylicious-start.sh --config kroxylicious-app/example-proxy-config.yml
+KROXYLICIOUS_CLASSPATH="/path/to/any.jar:/path/to/libs/dir/*" kroxylicious-app/target/kroxylicious-app-*-bin/kroxylicious-app-*/bin/kroxylicious-start.sh --config kroxylicious-app/example-proxy-config.yml
 ```
 
 ### Debugging
@@ -184,30 +184,30 @@ While Kroxylicious is a java application we've had reports of issues running the
 ### Ensure appropriate tooling available
 1. Open the WSL window.
 2. Update the packages using
-    ```bash
+    ```shell
     sudo apt update
     sudo apt upgrade
     ```
 3. 
     1. Check the Java version by typing
-      ```bash
+      ```shell
       java --version
       ```
       Expect output similar to: 
-      ```bash
+      ```shell
       > java --version
    openjdk 19.0.2 2023-01-17
    OpenJDK Runtime Environment Temurin-19.0.2+7 (build 19.0.2+7)
    OpenJDK 64-Bit Server VM Temurin-19.0.2+7 (build 19.0.2+7, mixed mode, sharing)
    ```
     2. Update if needed: sample update command like:
-    ```bash
+    ```shell
     sudo apt update
     sudo apt upgrade
     sudo apt install openjdk-18-jre-headless
     ```
 4. Ensure GIT is available
-   1. ```bash
+   1. ```shell
       git --version
       ```
       Expect a version string similar to `git version 2.37.1 (Apple Git-137.1)`
@@ -221,7 +221,7 @@ While Kroxylicious is a java application we've had reports of issues running the
 
 On Linux, it maybe necessary to configure the `DOCKER_HOST` environment variable to allow the tests to correctly use test containers.
 
-```bash
+```shell
 DOCKER_HOST=unix://$(podman info --format '{{.Host.RemoteSocket.Path}}')
 export DOCKER_HOST
 ```
@@ -285,7 +285,7 @@ has been applied ineffectively.
 The `docs` directory has some user documentation written in [AsciiDoc](https://docs.asciidoctor.org/asciidoc/latest/) format.
 You can render it to HTML using:
 
-```bash
+```shell
 mvn org.asciidoctor:asciidoctor-maven-plugin:process-asciidoc@convert-to-html
 ```
 

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -6,32 +6,32 @@ This document describes how to run some basic performance tests for the proxy.
 
 Download Apache Kafka:
 
-```
-$ wget https://downloads.apache.org/kafka/3.4.1/kafka_2.13-3.4.1.tgz
-$ tar xvf kafka_2.13-3.4.1.tgz
+```shell
+wget https://downloads.apache.org/kafka/3.4.1/kafka_2.13-3.4.1.tgz
+tar xvf kafka_2.13-3.4.1.tgz
 ```
 
 Start up ZooKeeper and Kafka:
 
-```
-$ cd kafka_2.13-3.4.1
-$ bin/zookeeper-server-start.sh config/zookeeper.properties
-$ bin/kafka-server-start.sh config/server.properties
+```shell
+cd kafka_2.13-3.4.1
+bin/zookeeper-server-start.sh config/zookeeper.properties
+bin/kafka-server-start.sh config/server.properties
 ```
 
 ## Execution
 
 Build and launch the proxy:
 
-```
-$ mvn clean verify -Pdist -Dquick
-$ kroxylicious-app/target/kroxylicious-app-*-bin/kroxylicious-app-*/bin/kroxylicious-start.sh --config kroxylicious-app/example-proxy-config.yml
+```shell
+mvn clean verify -Pdist -Dquick
+kroxylicious-app/target/kroxylicious-app-*-bin/kroxylicious-app-*/bin/kroxylicious-start.sh --config kroxylicious-app/example-proxy-config.yml
 ```
 
 Run Kafka's _kafka-producer-perf-test.sh_ script:
 
-```
-$ bin/kafka-producer-perf-test.sh \
+```shell
+bin/kafka-producer-perf-test.sh \
 --topic perf-test \
 --throughput -1 \
 --num-records 10000000 \

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ Any new package relationships need to be registered there.
 
 To verify whether the code base adheres to that target model, run the following:
 
-```bash
-$ mvn clean verify -Dquick -Parchitecture-check -pl kroxylicious
+```shell
+mvn clean verify -Dquick -Parchitecture-check -pl kroxylicious
 ```
 
 In case of any architecture violations, the actual architecture can be visualized using GraphViz like so:
 
-```bash
-$ dot -Tpng kroxylicious/target/generated-sources/annotations/deptective.dot > kroxylicious-arch.png
+```shell
+dot -Tpng kroxylicious/target/generated-sources/annotations/deptective.dot > kroxylicious-arch.png
 ```

--- a/kroxylicious-sample/README.md
+++ b/kroxylicious-sample/README.md
@@ -10,22 +10,22 @@ Building the sample project is easy! You can build the **kroxylicious-sample** j
 
 #### To build all of Kroxylicious, including the sample:
 
-```
-$ mvn verify
+```shell
+mvn verify
 ```
 
 #### To build the sample on its own:
 
-```
-$ mvn verify -pl :kroxylicious-sample --also-make
+```shell
+mvn verify -pl :kroxylicious-sample --also-make
 ```
 
 > *__Note:__ If you build just the `kroxylicious-sample` module, you will need to also build the `kroxylicious-app` module separately (with `dist` profile, as shown below) in order to run the sample.*
 
 #### Build with the `dist` profile for creating executable JARs:
 
-```
-$ mvn verify -Pdist -Dquick
+```shell
+mvn verify -Pdist -Dquick
 ```
 
 > *__Note:__ You can leave out `--also-make` from these commands if you have already built the whole Kroxylicious project.*
@@ -34,8 +34,8 @@ $ mvn verify -Pdist -Dquick
 
 Build both `kroxylicious-sample` and `kroxylicious-app` with the `dist` profile as above, then run the following command:
 
-```
-$ KROXYLICIOUS_CLASSPATH="kroxylicious-sample/target/*" kroxylicious-app/target/kroxylicious-app-*-bin/kroxylicious-app-*/bin/kroxylicious-start.sh --config kroxylicious-sample/sample-proxy-config.yml
+```shell
+KROXYLICIOUS_CLASSPATH="kroxylicious-sample/target/*" kroxylicious-app/target/kroxylicious-app-*-bin/kroxylicious-app-*/bin/kroxylicious-start.sh --config kroxylicious-sample/sample-proxy-config.yml
 ```
 
 ### Configure


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Use `shell` syntax highlighting on all shell (bash/zsh/etc) code blocks. Removed all leading `$ ` characters from lines in code blocks so they aren't included when people use the quick copy to clipboard buttons on the rendered code blocks.

### Additional Context

This is just so we're consistent with shell syntax highlighting across all the markdown files, because we had it in a few places but not others. Changed a few blocks with `bash` highlighting to `shell`, which doesn't change the functionality at all because [the former is just an alias for the latter](https://github.com/github-linguist/linguist/blob/master/lib/linguist/languages.yml#L6393) in Linguist, which is [what GitHub uses for syntax highlighting](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting). I figured using `shell` instead of `bash` reduced ambiguity about where you can run those commands.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] ~~Write tests~~
- [ ] ~~Make sure all tests pass~~
- [ ] ~~Review performance test results. Ensure that any degradations to performance numbers are understood and justified.~~
- [ ] ~~Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.~~
- [x] Update documentation
- [ ] ~~Reference relevant issue(s) and close them after merging~~
- [ ] ~~For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).~~
