### PR TITLE
do not drop headers in SampleFilterTransformer

### DIFF
--- a/kroxylicious-sample/src/main/java/io/kroxylicious/sample/util/SampleFilterTransformer.java
+++ b/kroxylicious-sample/src/main/java/io/kroxylicious/sample/util/SampleFilterTransformer.java
@@ -61,7 +61,8 @@ public class SampleFilterTransformer {
 
             for (RecordBatch batch : records.batches()) {
                 for (Record batchRecord : batch) {
-                    newRecords.append(batchRecord.timestamp(), batchRecord.key(), transformRecord(batchRecord.value(), findValue, replacementValue));
+                    newRecords.append(batchRecord.timestamp(), batchRecord.key(), transformRecord(batchRecord.value(), findValue, replacementValue),
+                            batchRecord.headers());
                 }
             }
             return newRecords.build();

--- a/kroxylicious-sample/src/test/java/io/kroxylicious/sample/SampleFetchResponseFilterTest.java
+++ b/kroxylicious-sample/src/test/java/io/kroxylicious/sample/SampleFetchResponseFilterTest.java
@@ -218,26 +218,9 @@ class SampleFetchResponseFilterTest {
 
     private static void checkRecordMetadataMatches(Record a, Record b) {
         // We don't compare record size, value, or value size as we expect the filter to change these
-        assertThat(a.offset()).isEqualTo(b.offset());
-        assertThat(a.sequence()).isEqualTo(b.sequence());
-        assertThat(a.timestamp()).isEqualTo(b.timestamp());
-        assertThat(a.keySize()).isEqualTo(b.keySize());
-        assertThat(a.hasKey()).isEqualTo(b.hasKey());
-        assertThat(a.key()).isSameAs(b.key());
-        assertThat(a.hasValue()).isEqualTo(b.hasValue());
-        assertThat(a.isCompressed()).isEqualTo(b.isCompressed());
-        checkRecordHeadersMatch(a.headers(), b.headers());
-    }
-
-    private static void checkRecordHeadersMatch(Header[] a, Header[] b) {
-        assertThat(a).hasSameSizeAs(b);
-        for (var i = 0; i < a.length; i++) {
-            var aHeader = a[i];
-            var bHeader = b[i];
-            assertThat(aHeader).isNotNull();
-            assertThat(bHeader).isNotNull();
-            assertThat(aHeader.key()).isEqualTo(bHeader.key());
-            assertThat(aHeader.value()).containsExactly(bHeader.value());
-        }
+        assertThat(a).usingRecursiveComparison()
+                .ignoringFields("sizeInBytes", "valueSize", "value")
+                .isEqualTo(b);
+        assertThat(a.headers()).usingRecursiveComparison().isEqualTo(b.headers());
     }
 }

--- a/kroxylicious-sample/src/test/java/io/kroxylicious/sample/SampleProduceRequestFilterTest.java
+++ b/kroxylicious-sample/src/test/java/io/kroxylicious/sample/SampleProduceRequestFilterTest.java
@@ -210,26 +210,9 @@ class SampleProduceRequestFilterTest {
 
     private static void checkRecordMetadataMatches(Record a, Record b) {
         // We don't compare record size, value, or value size as we expect the filter to change these
-        assertThat(a.offset()).isEqualTo(b.offset());
-        assertThat(a.sequence()).isEqualTo(b.sequence());
-        assertThat(a.timestamp()).isEqualTo(b.timestamp());
-        assertThat(a.keySize()).isEqualTo(b.keySize());
-        assertThat(a.hasKey()).isEqualTo(b.hasKey());
-        assertThat(a.key()).isSameAs(b.key());
-        assertThat(a.hasValue()).isEqualTo(b.hasValue());
-        assertThat(a.isCompressed()).isEqualTo(b.isCompressed());
-        checkRecordHeadersMatch(a.headers(), b.headers());
-    }
-
-    private static void checkRecordHeadersMatch(Header[] a, Header[] b) {
-        assertThat(a).hasSameSizeAs(b);
-        for (var i = 0; i < a.length; i++) {
-            var aHeader = a[i];
-            var bHeader = b[i];
-            assertThat(aHeader).isNotNull();
-            assertThat(bHeader).isNotNull();
-            assertThat(aHeader.key()).isEqualTo(bHeader.key());
-            assertThat(aHeader.value()).containsExactly(bHeader.value());
-        }
+        assertThat(a).usingRecursiveComparison()
+                .ignoringFields("sizeInBytes", "valueSize", "value")
+                .isEqualTo(b);
+        assertThat(a.headers()).usingRecursiveComparison().isEqualTo(b.headers());
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes #548 where SampleFilterTransformer was dropping the headers off each record.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
