### PR TITLE
Added note about Quay image to be public

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -157,6 +157,9 @@ This `run-with-strimzi.sh` script does the following:
 4. installs a 3-node Kafka cluster using Strimzi into minikube
 5. installs kroxylicious into minikube, configured to proxy the cluster
 
+> NOTE: If the kroxylicious pod doesn't come up but it's stuck on ImagePullBackOff with "unauthorized: access to the requested resource is not authorized" error, 
+it could mean you have to make the Quay image as public.
+
 If you want to only build and push an image to quay.io you can run `PUSH_IMAGE=y QUAY_ORG=$your_quay_username$ ./scripts/deploy-image.sh`
 
 To change the container engine to podman set `CONTAINER_ENGINE=podman`


### PR DESCRIPTION
While running the Kubernetes examples for the first time I have got the kroxylicious pod not coming up with following error:

```shell
Failed to pull image "quay.io/ppatierno/kroxylicious:0.3.0-SNAPSHOT": rpc error: code = Unknown desc = Error response from daemon: unauthorized: access to the requested resource is not authorized                                            
```

The reason was that after build and push image to your Quay organization, the pushed image is not public (at least it's not automatic for me) and I need to make it public from the Quay UI first in order to have kroxylicious working.
Trivial PR just a note in the DEV_GUIDE about the Quay image to be public.