### PR TITLE
Exclude JMH microbenchmarks from static analysis

### DIFF
--- a/.sonar-project.properties
+++ b/.sonar-project.properties
@@ -6,7 +6,9 @@
 
 # Path to sources
 #sonar.sources=.
-sonar.exclusions=performance-tests/src/main/java/io/kroxylicious/filters/**
+sonar.exclusions=performance-tests/**
+sonar.coverage.exclusions=performance-tests/**
+sonar.cpd.exclusions=performance-tests/**
 #sonar.inclusions=
 
 # Path to tests


### PR DESCRIPTION

### Type of change

- Enhancement / new feature

### Description

Why:
The JMH benchmark area is a playground with some intentionally heavy duplication we should exclude it from coverage reports etc.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
