### PR TITLE
Enable Filter Contributors to access netty event loop while constructing Filters

### DIFF
--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
@@ -7,10 +7,11 @@ package io.kroxylicious.proxy.filter;
 
 import io.kroxylicious.proxy.filter.CompositePrefixingFixedClientIdFilter.CompositePrefixingFixedClientIdFilterConfig;
 import io.kroxylicious.proxy.service.BaseContributor;
+import io.kroxylicious.proxy.service.ContributorContext;
 
-public class TestFilterContributor extends BaseContributor<KrpcFilter> implements FilterContributor {
+public class TestFilterContributor extends BaseContributor<KrpcFilter, ContributorContext> implements FilterContributor {
 
-    public static final BaseContributorBuilder<KrpcFilter> FILTERS = BaseContributor.<KrpcFilter> builder()
+    public static final BaseContributorBuilder<KrpcFilter, ContributorContext> FILTERS = BaseContributor.<KrpcFilter, ContributorContext> builder()
             .add("FixedClientId", FixedClientIdFilter.FixedClientIdFilterConfig.class, FixedClientIdFilter::new)
             .add("RequestResponseMarking", RequestResponseMarkingFilter.RequestResponseMarkingFilterConfig.class, RequestResponseMarkingFilter::new)
             .add("OutOfBandSend", OutOfBandSendFilter.OutOfBandSendFilterConfig.class, OutOfBandSendFilter::new)

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
@@ -7,11 +7,10 @@ package io.kroxylicious.proxy.filter;
 
 import io.kroxylicious.proxy.filter.CompositePrefixingFixedClientIdFilter.CompositePrefixingFixedClientIdFilterConfig;
 import io.kroxylicious.proxy.service.BaseContributor;
-import io.kroxylicious.proxy.service.ContributorContext;
 
-public class TestFilterContributor extends BaseContributor<KrpcFilter, ContributorContext> implements FilterContributor {
+public class TestFilterContributor extends BaseContributor<KrpcFilter, FilterContributorContext> implements FilterContributor {
 
-    public static final BaseContributorBuilder<KrpcFilter, ContributorContext> FILTERS = BaseContributor.<KrpcFilter, ContributorContext> builder()
+    public static final BaseContributorBuilder<KrpcFilter, FilterContributorContext> FILTERS = BaseContributor.<KrpcFilter, FilterContributorContext> builder()
             .add("FixedClientId", FixedClientIdFilter.FixedClientIdFilterConfig.class, FixedClientIdFilter::new)
             .add("RequestResponseMarking", RequestResponseMarkingFilter.RequestResponseMarkingFilterConfig.class, RequestResponseMarkingFilter::new)
             .add("OutOfBandSend", OutOfBandSendFilter.OutOfBandSendFilterConfig.class, OutOfBandSendFilter::new)

--- a/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterContributor.java
+++ b/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterContributor.java
@@ -6,13 +6,13 @@
 package io.kroxylicious.proxy.filter.multitenant;
 
 import io.kroxylicious.proxy.filter.FilterContributor;
+import io.kroxylicious.proxy.filter.FilterContributorContext;
 import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.service.BaseContributor;
-import io.kroxylicious.proxy.service.ContributorContext;
 
-public class MultiTenantFilterContributor extends BaseContributor<KrpcFilter, ContributorContext> implements FilterContributor {
+public class MultiTenantFilterContributor extends BaseContributor<KrpcFilter, FilterContributorContext> implements FilterContributor {
 
-    public static final BaseContributorBuilder<KrpcFilter, ContributorContext> FILTERS = BaseContributor.<KrpcFilter, ContributorContext> builder()
+    public static final BaseContributorBuilder<KrpcFilter, FilterContributorContext> FILTERS = BaseContributor.<KrpcFilter, FilterContributorContext> builder()
             .add("MultiTenant", MultiTenantTransformationFilter::new);
 
     public MultiTenantFilterContributor() {

--- a/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterContributor.java
+++ b/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterContributor.java
@@ -8,10 +8,11 @@ package io.kroxylicious.proxy.filter.multitenant;
 import io.kroxylicious.proxy.filter.FilterContributor;
 import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.service.BaseContributor;
+import io.kroxylicious.proxy.service.ContributorContext;
 
-public class MultiTenantFilterContributor extends BaseContributor<KrpcFilter> implements FilterContributor {
+public class MultiTenantFilterContributor extends BaseContributor<KrpcFilter, ContributorContext> implements FilterContributor {
 
-    public static final BaseContributorBuilder<KrpcFilter> FILTERS = BaseContributor.<KrpcFilter> builder()
+    public static final BaseContributorBuilder<KrpcFilter, ContributorContext> FILTERS = BaseContributor.<KrpcFilter, ContributorContext> builder()
             .add("MultiTenant", MultiTenantTransformationFilter::new);
 
     public MultiTenantFilterContributor() {

--- a/kroxylicious-additional-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterContributorTest.java
+++ b/kroxylicious-additional-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterContributorTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.multitenant;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.filter.FilterContributorContext;
+import io.kroxylicious.proxy.filter.KrpcFilter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MultiTenantFilterContributorTest {
+
+    private final MultiTenantFilterContributor contributor = new MultiTenantFilterContributor();
+
+    @Test
+    void testGetConfigType() {
+        Class<? extends BaseConfig> configType = contributor.getConfigType("MultiTenant");
+        assertEquals(BaseConfig.class, configType);
+    }
+
+    @Test
+    void testGetInstance() {
+        KrpcFilter multiTenant = contributor.getInstance("MultiTenant", new BaseConfig(), Mockito.mock(FilterContributorContext.class));
+        assertThat(multiTenant).isInstanceOf(MultiTenantTransformationFilter.class);
+    }
+}

--- a/kroxylicious-additional-filters/kroxylicious-schema-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceRequestValidationFilterContributor.java
+++ b/kroxylicious-additional-filters/kroxylicious-schema-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceRequestValidationFilterContributor.java
@@ -6,18 +6,18 @@
 package io.kroxylicious.proxy.filter.schema;
 
 import io.kroxylicious.proxy.filter.FilterContributor;
+import io.kroxylicious.proxy.filter.FilterContributorContext;
 import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.filter.schema.config.ValidationConfig;
 import io.kroxylicious.proxy.filter.schema.validation.request.ProduceRequestValidator;
 import io.kroxylicious.proxy.service.BaseContributor;
-import io.kroxylicious.proxy.service.ContributorContext;
 
 /**
  * Contributor for request validation filters
  */
-public class ProduceRequestValidationFilterContributor extends BaseContributor<KrpcFilter, ContributorContext> implements FilterContributor {
+public class ProduceRequestValidationFilterContributor extends BaseContributor<KrpcFilter, FilterContributorContext> implements FilterContributor {
 
-    private static final BaseContributorBuilder<KrpcFilter, ContributorContext> FILTERS = BaseContributor.<KrpcFilter, ContributorContext> builder()
+    private static final BaseContributorBuilder<KrpcFilter, FilterContributorContext> FILTERS = BaseContributor.<KrpcFilter, FilterContributorContext> builder()
             .add("ProduceValidator", ValidationConfig.class, (config) -> {
                 ProduceRequestValidator validator = ProduceValidationFilterBuilder.build(config);
                 return new ProduceValidationFilter(config.isForwardPartialRequests(), validator);

--- a/kroxylicious-additional-filters/kroxylicious-schema-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceRequestValidationFilterContributor.java
+++ b/kroxylicious-additional-filters/kroxylicious-schema-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceRequestValidationFilterContributor.java
@@ -10,13 +10,14 @@ import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.filter.schema.config.ValidationConfig;
 import io.kroxylicious.proxy.filter.schema.validation.request.ProduceRequestValidator;
 import io.kroxylicious.proxy.service.BaseContributor;
+import io.kroxylicious.proxy.service.ContributorContext;
 
 /**
  * Contributor for request validation filters
  */
-public class ProduceRequestValidationFilterContributor extends BaseContributor<KrpcFilter> implements FilterContributor {
+public class ProduceRequestValidationFilterContributor extends BaseContributor<KrpcFilter, ContributorContext> implements FilterContributor {
 
-    private static final BaseContributorBuilder<KrpcFilter> FILTERS = BaseContributor.<KrpcFilter> builder()
+    private static final BaseContributorBuilder<KrpcFilter, ContributorContext> FILTERS = BaseContributor.<KrpcFilter, ContributorContext> builder()
             .add("ProduceValidator", ValidationConfig.class, (config) -> {
                 ProduceRequestValidator validator = ProduceValidationFilterBuilder.build(config);
                 return new ProduceValidationFilter(config.isForwardPartialRequests(), validator);

--- a/kroxylicious-additional-filters/kroxylicious-schema-validation/src/test/java/io/kroxylicious/proxy/filter/schema/ProduceRequestValidationFilterContributorTest.java
+++ b/kroxylicious-additional-filters/kroxylicious-schema-validation/src/test/java/io/kroxylicious/proxy/filter/schema/ProduceRequestValidationFilterContributorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.schema;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.filter.FilterContributorContext;
+import io.kroxylicious.proxy.filter.KrpcFilter;
+import io.kroxylicious.proxy.filter.schema.config.BytebufValidation;
+import io.kroxylicious.proxy.filter.schema.config.RecordValidationRule;
+import io.kroxylicious.proxy.filter.schema.config.SyntacticallyCorrectJsonConfig;
+import io.kroxylicious.proxy.filter.schema.config.ValidationConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProduceRequestValidationFilterContributorTest {
+
+    private final ProduceRequestValidationFilterContributor contributor = new ProduceRequestValidationFilterContributor();
+
+    @Test
+    void testGetConfigType() {
+        Class<? extends BaseConfig> configType = contributor.getConfigType("ProduceValidator");
+        assertThat(configType).isEqualTo(ValidationConfig.class);
+    }
+
+    @Test
+    void testGetInstance() {
+        BytebufValidation validation = new BytebufValidation(new SyntacticallyCorrectJsonConfig(false), true, true);
+        ValidationConfig config = new ValidationConfig(true, List.of(), new RecordValidationRule(validation, validation));
+        KrpcFilter filter = contributor.getInstance("ProduceValidator", config, Mockito.mock(FilterContributorContext.class));
+        assertThat(filter).isInstanceOf(ProduceValidationFilter.class);
+    }
+
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/clusternetworkaddressconfigprovider/ClusterNetworkAddressConfigProviderContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/clusternetworkaddressconfigprovider/ClusterNetworkAddressConfigProviderContributor.java
@@ -7,10 +7,11 @@ package io.kroxylicious.proxy.clusternetworkaddressconfigprovider;
 
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
 import io.kroxylicious.proxy.service.Contributor;
+import io.kroxylicious.proxy.service.ContributorContext;
 
 /**
  * ClusterNetworkAddressConfigProviderContributor is a pluggable source of network address information.
  * @see Contributor
  */
-public interface ClusterNetworkAddressConfigProviderContributor extends Contributor<ClusterNetworkAddressConfigProvider> {
+public interface ClusterNetworkAddressConfigProviderContributor extends Contributor<ClusterNetworkAddressConfigProvider, ContributorContext> {
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContributor.java
@@ -6,11 +6,10 @@
 package io.kroxylicious.proxy.filter;
 
 import io.kroxylicious.proxy.service.Contributor;
-import io.kroxylicious.proxy.service.ContributorContext;
 
 /**
  * FilterContributor is a pluggable source of Kroxylicious filter implementations.
  * @see Contributor
  */
-public interface FilterContributor extends Contributor<KrpcFilter, ContributorContext> {
+public interface FilterContributor extends Contributor<KrpcFilter, FilterContributorContext> {
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContributor.java
@@ -6,10 +6,11 @@
 package io.kroxylicious.proxy.filter;
 
 import io.kroxylicious.proxy.service.Contributor;
+import io.kroxylicious.proxy.service.ContributorContext;
 
 /**
  * FilterContributor is a pluggable source of Kroxylicious filter implementations.
  * @see Contributor
  */
-public interface FilterContributor extends Contributor<KrpcFilter> {
+public interface FilterContributor extends Contributor<KrpcFilter, ContributorContext> {
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContributorContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContributorContext.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import io.kroxylicious.proxy.service.ContributorContext;
+
+public interface FilterContributorContext extends ContributorContext {
+
+    FilterExecutors executors();
+
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterExecutors.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterExecutors.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+public interface FilterExecutors {
+
+    ScheduledExecutorService filterExecutor();
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
@@ -7,6 +7,7 @@ package io.kroxylicious.proxy.service;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -17,47 +18,47 @@ import io.kroxylicious.proxy.config.BaseConfig;
  *
  * @param <T> the service type
  */
-public abstract class BaseContributor<T> implements Contributor<T> {
+public abstract class BaseContributor<T, S extends ContributorContext> implements Contributor<T, S> {
 
-    private final Map<String, InstanceBuilder<? extends BaseConfig, T>> shortNameToInstanceBuilder;
+    private final Map<String, InstanceBuilder<? extends BaseConfig, T, S>> shortNameToInstanceBuilder;
 
     /**
      * Constructs and configures the contributor using the supplied {@code builder}.
      * @param builder builder
      */
-    public BaseContributor(BaseContributorBuilder<T> builder) {
+    public BaseContributor(BaseContributorBuilder<T, S> builder) {
         shortNameToInstanceBuilder = builder.build();
     }
 
     @Override
     public Class<? extends BaseConfig> getConfigType(String shortName) {
-        InstanceBuilder<?, T> instanceBuilder = shortNameToInstanceBuilder.get(shortName);
+        InstanceBuilder<?, T, S> instanceBuilder = shortNameToInstanceBuilder.get(shortName);
         return instanceBuilder == null ? null : instanceBuilder.configClass;
     }
 
     @Override
-    public T getInstance(String shortName, BaseConfig config) {
-        InstanceBuilder<? extends BaseConfig, T> instanceBuilder = shortNameToInstanceBuilder.get(shortName);
-        return instanceBuilder == null ? null : instanceBuilder.construct(config);
+    public T getInstance(String shortName, BaseConfig config, S context) {
+        InstanceBuilder<? extends BaseConfig, T, S> instanceBuilder = shortNameToInstanceBuilder.get(shortName);
+        return instanceBuilder == null ? null : instanceBuilder.construct(context, config);
     }
 
-    private static class InstanceBuilder<T extends BaseConfig, L> {
+    private static class InstanceBuilder<T extends BaseConfig, L, S extends ContributorContext> {
 
         private final Class<T> configClass;
-        private final Function<T, L> instanceFunction;
+        private final BiFunction<S, T, L> instanceFunction;
 
-        InstanceBuilder(Class<T> configClass, Function<T, L> instanceFunction) {
+        InstanceBuilder(Class<T> configClass, BiFunction<S, T, L> instanceFunction) {
             this.configClass = configClass;
             this.instanceFunction = instanceFunction;
         }
 
-        L construct(BaseConfig config) {
+        L construct(S context, BaseConfig config) {
             if (config == null) {
                 // tests pass in a null config, which some instance functions can tolerate
-                return instanceFunction.apply(null);
+                return instanceFunction.apply(context, null);
             }
             else if (configClass.isAssignableFrom(config.getClass())) {
-                return instanceFunction.apply(configClass.cast(config));
+                return instanceFunction.apply(context, configClass.cast(config));
             }
             else {
                 throw new IllegalArgumentException("config has the wrong type, expected "
@@ -71,12 +72,12 @@ public abstract class BaseContributor<T> implements Contributor<T> {
      * @see BaseContributor#builder()
      * @param <L> the service type
      */
-    public static class BaseContributorBuilder<L> {
+    public static class BaseContributorBuilder<L, S extends ContributorContext> {
 
         private BaseContributorBuilder() {
         }
 
-        private final Map<String, InstanceBuilder<?, L>> shortNameToInstanceBuilder = new HashMap<>();
+        private final Map<String, InstanceBuilder<?, L, S>> shortNameToInstanceBuilder = new HashMap<>();
 
         /**
          * Registers a factory function for the construction of a service instance.
@@ -87,11 +88,11 @@ public abstract class BaseContributor<T> implements Contributor<T> {
          * @return this
          * @param <T> the configuration concrete type
          */
-        public <T extends BaseConfig> BaseContributorBuilder<L> add(String shortName, Class<T> configClass, Function<T, L> instanceFunction) {
+        public <T extends BaseConfig> BaseContributorBuilder<L, S> add(String shortName, Class<T> configClass, Function<T, L> instanceFunction) {
             if (shortNameToInstanceBuilder.containsKey(shortName)) {
                 throw new IllegalArgumentException(shortName + " already registered");
             }
-            shortNameToInstanceBuilder.put(shortName, new InstanceBuilder<>(configClass, instanceFunction));
+            shortNameToInstanceBuilder.put(shortName, new InstanceBuilder<>(configClass, (s, t) -> instanceFunction.apply(t)));
             return this;
         }
 
@@ -102,11 +103,11 @@ public abstract class BaseContributor<T> implements Contributor<T> {
          * @param instanceFunction function that constructs the service instance
          * @return this
          */
-        public BaseContributorBuilder<L> add(String shortName, Supplier<L> instanceFunction) {
+        public BaseContributorBuilder<L, S> add(String shortName, Supplier<L> instanceFunction) {
             return add(shortName, BaseConfig.class, (config) -> instanceFunction.get());
         }
 
-        Map<String, InstanceBuilder<?, L>> build() {
+        Map<String, InstanceBuilder<?, L, S>> build() {
             return Map.copyOf(shortNameToInstanceBuilder);
         }
     }
@@ -116,8 +117,9 @@ public abstract class BaseContributor<T> implements Contributor<T> {
      *
      * @return the builder
      * @param <L> the service type
+     * @param <S> the context type
      */
-    public static <L> BaseContributorBuilder<L> builder() {
+    public static <L, S extends ContributorContext> BaseContributorBuilder<L, S> builder() {
         return new BaseContributorBuilder<>();
     }
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
@@ -100,6 +100,23 @@ public abstract class BaseContributor<T, S extends ContributorContext> implement
          * Registers a factory function for the construction of a service instance.
          *
          * @param shortName service short name
+         * @param configClass concrete type of configuration required by the service
+         * @param instanceFunction function that constructs the service instance
+         * @return this
+         * @param <T> the configuration concrete type
+         */
+        public <T extends BaseConfig> BaseContributorBuilder<L, S> add(String shortName, Class<T> configClass, BiFunction<S, T, L> instanceFunction) {
+            if (shortNameToInstanceBuilder.containsKey(shortName)) {
+                throw new IllegalArgumentException(shortName + " already registered");
+            }
+            shortNameToInstanceBuilder.put(shortName, new InstanceBuilder<>(configClass, instanceFunction));
+            return this;
+        }
+
+        /**
+         * Registers a factory function for the construction of a service instance.
+         *
+         * @param shortName service short name
          * @param instanceFunction function that constructs the service instance
          * @return this
          */

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/Contributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/Contributor.java
@@ -13,7 +13,7 @@ import io.kroxylicious.proxy.config.BaseConfig;
  *
  * @param <T> the service type
  */
-public interface Contributor<T> {
+public interface Contributor<T, S extends ContributorContext> {
 
     /**
      * Gets the concrete type of the configuration required by this service instance.
@@ -30,5 +30,5 @@ public interface Contributor<T> {
      * @param config    service configuration which may be null if the service instance does not accept configuration.
      * @return the service instance
      */
-    T getInstance(String shortName, BaseConfig config);
+    T getInstance(String shortName, BaseConfig config, S context);
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/ContributorContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/ContributorContext.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.service;
+
+public interface ContributorContext {
+
+    static ContributorContext instance() {
+        return new ContributorContext() {
+        };
+    }
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/ContributorContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/ContributorContext.java
@@ -8,8 +8,10 @@ package io.kroxylicious.proxy.service;
 
 public interface ContributorContext {
 
+    ContributorContext CONTEXT = new ContributorContext() {
+    };
+
     static ContributorContext instance() {
-        return new ContributorContext() {
-        };
+        return CONTEXT;
     }
 }

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
@@ -23,9 +23,9 @@ class BaseContributorTest {
 
     @Test
     void testDefaultConfigClass() {
-        BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
+        BaseContributor.BaseContributorBuilder<Long, ContributorContext> builder = BaseContributor.builder();
         builder.add("one", () -> 1L);
-        BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
+        BaseContributor<Long, ContributorContext> baseContributor = new BaseContributor<>(builder) {
         };
         Class<? extends BaseConfig> one = baseContributor.getConfigType("one");
         assertThat(one).isEqualTo(BaseConfig.class);
@@ -33,19 +33,19 @@ class BaseContributorTest {
 
     @Test
     void testSupplier() {
-        BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
+        BaseContributor.BaseContributorBuilder<Long, ContributorContext> builder = BaseContributor.builder();
         builder.add("one", () -> 1L);
-        BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
+        BaseContributor<Long, ContributorContext> baseContributor = new BaseContributor<>(builder) {
         };
-        Long instance = baseContributor.getInstance("one", new BaseConfig());
+        Long instance = baseContributor.getInstance("one", new BaseConfig(), getContext());
         assertThat(instance).isEqualTo(1L);
     }
 
     @Test
     void testSpecifyingConfigType() {
-        BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
+        BaseContributor.BaseContributorBuilder<Long, ContributorContext> builder = BaseContributor.builder();
         builder.add("fromBaseConfig", LongConfig.class, baseConfig -> baseConfig.value);
-        BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
+        BaseContributor<Long, ContributorContext> baseContributor = new BaseContributor<>(builder) {
         };
         Class<? extends BaseConfig> configType = baseContributor.getConfigType("fromBaseConfig");
         assertThat(configType).isEqualTo(LongConfig.class);
@@ -53,24 +53,29 @@ class BaseContributorTest {
 
     @Test
     void testSpecifyingConfigTypeInstance() {
-        BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
+        BaseContributor.BaseContributorBuilder<Long, ContributorContext> builder = BaseContributor.builder();
         builder.add("fromBaseConfig", LongConfig.class, baseConfig -> baseConfig.value);
-        BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
+        BaseContributor<Long, ContributorContext> baseContributor = new BaseContributor<>(builder) {
         };
-        Long instance = baseContributor.getInstance("fromBaseConfig", new LongConfig());
+        Long instance = baseContributor.getInstance("fromBaseConfig", new LongConfig(), getContext());
         assertThat(instance).isEqualTo(2L);
     }
 
     @Test
     void testFailsIfConfigNotAssignableToSpecifiedType() {
-        BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
+        BaseContributor.BaseContributorBuilder<Long, ContributorContext> builder = BaseContributor.builder();
         builder.add("fromBaseConfig", LongConfig.class, baseConfig -> baseConfig.value);
-        BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
+        BaseContributor<Long, ContributorContext> baseContributor = new BaseContributor<>(builder) {
         };
         AnotherConfig incompatibleConfig = new AnotherConfig();
         assertThatThrownBy(() -> {
-            baseContributor.getInstance("fromBaseConfig", incompatibleConfig);
+            baseContributor.getInstance("fromBaseConfig", incompatibleConfig, getContext());
         }).isInstanceOf(IllegalArgumentException.class);
     }
 
+    private static ContributorContext getContext() {
+        return new ContributorContext() {
+
+        };
+    }
 }

--- a/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleContributor.java
+++ b/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleContributor.java
@@ -7,16 +7,16 @@
 package io.kroxylicious.sample;
 
 import io.kroxylicious.proxy.filter.FilterContributor;
+import io.kroxylicious.proxy.filter.FilterContributorContext;
 import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.service.BaseContributor;
-import io.kroxylicious.proxy.service.ContributorContext;
 import io.kroxylicious.sample.config.SampleFilterConfig;
 
-public class SampleContributor extends BaseContributor<KrpcFilter, ContributorContext> implements FilterContributor {
+public class SampleContributor extends BaseContributor<KrpcFilter, FilterContributorContext> implements FilterContributor {
 
     public static final String SAMPLE_FETCH = "SampleFetchResponse";
     public static final String SAMPLE_PRODUCE = "SampleProduceRequest";
-    public static final BaseContributorBuilder<KrpcFilter, ContributorContext> FILTERS = BaseContributor.<KrpcFilter, ContributorContext> builder()
+    public static final BaseContributorBuilder<KrpcFilter, FilterContributorContext> FILTERS = BaseContributor.<KrpcFilter, FilterContributorContext> builder()
             .add(SAMPLE_FETCH, SampleFilterConfig.class, SampleFetchResponseFilter::new)
             .add(SAMPLE_PRODUCE, SampleFilterConfig.class, SampleProduceRequestFilter::new);
 

--- a/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleContributor.java
+++ b/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleContributor.java
@@ -9,13 +9,14 @@ package io.kroxylicious.sample;
 import io.kroxylicious.proxy.filter.FilterContributor;
 import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.service.BaseContributor;
+import io.kroxylicious.proxy.service.ContributorContext;
 import io.kroxylicious.sample.config.SampleFilterConfig;
 
-public class SampleContributor extends BaseContributor<KrpcFilter> implements FilterContributor {
+public class SampleContributor extends BaseContributor<KrpcFilter, ContributorContext> implements FilterContributor {
 
     public static final String SAMPLE_FETCH = "SampleFetchResponse";
     public static final String SAMPLE_PRODUCE = "SampleProduceRequest";
-    public static final BaseContributorBuilder<KrpcFilter> FILTERS = BaseContributor.<KrpcFilter> builder()
+    public static final BaseContributorBuilder<KrpcFilter, ContributorContext> FILTERS = BaseContributor.<KrpcFilter, ContributorContext> builder()
             .add(SAMPLE_FETCH, SampleFilterConfig.class, SampleFetchResponseFilter::new)
             .add(SAMPLE_PRODUCE, SampleFilterConfig.class, SampleProduceRequestFilter::new);
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -10,6 +10,7 @@ import java.util.List;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.FilterDefinition;
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
+import io.kroxylicious.proxy.filter.FilterContributorContext;
 import io.kroxylicious.proxy.internal.filter.FilterContributorManager;
 
 /**
@@ -20,9 +21,11 @@ import io.kroxylicious.proxy.internal.filter.FilterContributorManager;
 public class FilterChainFactory {
 
     private final Configuration config;
+    private final FilterContributorContext context;
 
-    public FilterChainFactory(Configuration config) {
+    public FilterChainFactory(Configuration config, FilterContributorContext context) {
         this.config = config;
+        this.context = context;
     }
 
     /**
@@ -39,7 +42,7 @@ public class FilterChainFactory {
         }
         return filters
                 .stream()
-                .map(f -> filterContributorManager.getFilter(f.type(), f.config()))
+                .map(f -> filterContributorManager.getFilter(f.type(), f.config(), context))
                 .flatMap(filter -> FilterAndInvoker.build(filter).stream())
                 .toList();
     }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -34,6 +34,7 @@ import io.kroxylicious.proxy.internal.codec.KafkaResponseEncoder;
 import io.kroxylicious.proxy.internal.filter.ApiVersionsFilter;
 import io.kroxylicious.proxy.internal.filter.BrokerAddressFilter;
 import io.kroxylicious.proxy.internal.filter.EagerMetadataLearner;
+import io.kroxylicious.proxy.internal.filter.NettyFilterContributorContext;
 import io.kroxylicious.proxy.internal.net.Endpoint;
 import io.kroxylicious.proxy.internal.net.EndpointReconciler;
 import io.kroxylicious.proxy.internal.net.VirtualClusterBinding;
@@ -171,7 +172,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
         }
 
         var frontendHandler = new KafkaProxyFrontendHandler(context -> {
-            var filterChainFactory = new FilterChainFactory(config);
+            var filterChainFactory = new FilterChainFactory(config, new NettyFilterContributorContext(ch));
             List<FilterAndInvoker> apiVersionFilters = dp.isAuthenticationOffloadEnabled() ? List.of() : FilterAndInvoker.build(new ApiVersionsFilter());
             List<FilterAndInvoker> customProtocolFilters = filterChainFactory.createFilters();
             List<FilterAndInvoker> brokerAddressFilters = FilterAndInvoker.build(new BrokerAddressFilter(virtualCluster, endpointReconciler));

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/BuiltinClusterNetworkAddressConfigProviderContributor.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/BuiltinClusterNetworkAddressConfigProviderContributor.java
@@ -10,11 +10,13 @@ import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.PortPe
 import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.SniRoutingClusterNetworkAddressConfigProvider.SniRoutingClusterNetworkAddressConfigProviderConfig;
 import io.kroxylicious.proxy.service.BaseContributor;
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
+import io.kroxylicious.proxy.service.ContributorContext;
 
-public class BuiltinClusterNetworkAddressConfigProviderContributor extends BaseContributor<ClusterNetworkAddressConfigProvider>
+public class BuiltinClusterNetworkAddressConfigProviderContributor extends BaseContributor<ClusterNetworkAddressConfigProvider, ContributorContext>
         implements ClusterNetworkAddressConfigProviderContributor {
 
-    public static final BaseContributorBuilder<ClusterNetworkAddressConfigProvider> FILTERS = BaseContributor.<ClusterNetworkAddressConfigProvider> builder()
+    public static final BaseContributorBuilder<ClusterNetworkAddressConfigProvider, ContributorContext> FILTERS = BaseContributor
+            .<ClusterNetworkAddressConfigProvider, ContributorContext> builder()
             .add("PortPerBroker", PortPerBrokerClusterNetworkAddressConfigProviderConfig.class, PortPerBrokerClusterNetworkAddressConfigProvider::new)
             .add("SniRouting", SniRoutingClusterNetworkAddressConfigProviderConfig.class, SniRoutingClusterNetworkAddressConfigProvider::new);
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/ClusterNetworkAddressConfigProviderContributorManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/ClusterNetworkAddressConfigProviderContributorManager.java
@@ -11,6 +11,7 @@ import java.util.ServiceLoader;
 import io.kroxylicious.proxy.clusternetworkaddressconfigprovider.ClusterNetworkAddressConfigProviderContributor;
 import io.kroxylicious.proxy.config.BaseConfig;
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
+import io.kroxylicious.proxy.service.ContributorContext;
 
 public class ClusterNetworkAddressConfigProviderContributorManager {
 
@@ -41,7 +42,7 @@ public class ClusterNetworkAddressConfigProviderContributorManager {
 
     public ClusterNetworkAddressConfigProvider getClusterEndpointConfigProvider(String shortName, BaseConfig baseConfig) {
         for (ClusterNetworkAddressConfigProviderContributor contributor : contributors) {
-            var assigner = contributor.getInstance(shortName, baseConfig);
+            var assigner = contributor.getInstance(shortName, baseConfig, ContributorContext.instance());
             if (assigner != null) {
                 return assigner;
             }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BuiltinFilterContributor.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BuiltinFilterContributor.java
@@ -10,10 +10,11 @@ import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.internal.filter.FetchResponseTransformationFilter.FetchResponseTransformationConfig;
 import io.kroxylicious.proxy.internal.filter.ProduceRequestTransformationFilter.ProduceRequestTransformationConfig;
 import io.kroxylicious.proxy.service.BaseContributor;
+import io.kroxylicious.proxy.service.ContributorContext;
 
-public class BuiltinFilterContributor extends BaseContributor<KrpcFilter> implements FilterContributor {
+public class BuiltinFilterContributor extends BaseContributor<KrpcFilter, ContributorContext> implements FilterContributor {
 
-    public static final BaseContributorBuilder<KrpcFilter> FILTERS = BaseContributor.<KrpcFilter> builder()
+    public static final BaseContributorBuilder<KrpcFilter, ContributorContext> FILTERS = BaseContributor.<KrpcFilter, ContributorContext> builder()
             .add("ProduceRequestTransformation", ProduceRequestTransformationConfig.class, ProduceRequestTransformationFilter::new)
             .add("FetchResponseTransformation", FetchResponseTransformationConfig.class, FetchResponseTransformationFilter::new);
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BuiltinFilterContributor.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BuiltinFilterContributor.java
@@ -6,15 +6,15 @@
 package io.kroxylicious.proxy.internal.filter;
 
 import io.kroxylicious.proxy.filter.FilterContributor;
+import io.kroxylicious.proxy.filter.FilterContributorContext;
 import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.internal.filter.FetchResponseTransformationFilter.FetchResponseTransformationConfig;
 import io.kroxylicious.proxy.internal.filter.ProduceRequestTransformationFilter.ProduceRequestTransformationConfig;
 import io.kroxylicious.proxy.service.BaseContributor;
-import io.kroxylicious.proxy.service.ContributorContext;
 
-public class BuiltinFilterContributor extends BaseContributor<KrpcFilter, ContributorContext> implements FilterContributor {
+public class BuiltinFilterContributor extends BaseContributor<KrpcFilter, FilterContributorContext> implements FilterContributor {
 
-    public static final BaseContributorBuilder<KrpcFilter, ContributorContext> FILTERS = BaseContributor.<KrpcFilter, ContributorContext> builder()
+    public static final BaseContributorBuilder<KrpcFilter, FilterContributorContext> FILTERS = BaseContributor.<KrpcFilter, FilterContributorContext> builder()
             .add("ProduceRequestTransformation", ProduceRequestTransformationConfig.class, ProduceRequestTransformationFilter::new)
             .add("FetchResponseTransformation", FetchResponseTransformationConfig.class, FetchResponseTransformationFilter::new);
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterContributorManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterContributorManager.java
@@ -10,8 +10,8 @@ import java.util.ServiceLoader;
 
 import io.kroxylicious.proxy.config.BaseConfig;
 import io.kroxylicious.proxy.filter.FilterContributor;
+import io.kroxylicious.proxy.filter.FilterContributorContext;
 import io.kroxylicious.proxy.filter.KrpcFilter;
-import io.kroxylicious.proxy.service.ContributorContext;
 
 public class FilterContributorManager {
 
@@ -40,11 +40,11 @@ public class FilterContributorManager {
         throw new IllegalArgumentException("No filter found for name '" + shortName + "'");
     }
 
-    public KrpcFilter getFilter(String shortName, BaseConfig filterConfig) {
+    public KrpcFilter getFilter(String shortName, BaseConfig filterConfig, FilterContributorContext context) {
         Iterator<FilterContributor> it = contributors.iterator();
         while (it.hasNext()) {
             FilterContributor contributor = it.next();
-            KrpcFilter filter = contributor.getInstance(shortName, filterConfig, ContributorContext.instance());
+            KrpcFilter filter = contributor.getInstance(shortName, filterConfig, context);
             if (filter != null) {
                 return filter;
             }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterContributorManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterContributorManager.java
@@ -11,6 +11,7 @@ import java.util.ServiceLoader;
 import io.kroxylicious.proxy.config.BaseConfig;
 import io.kroxylicious.proxy.filter.FilterContributor;
 import io.kroxylicious.proxy.filter.KrpcFilter;
+import io.kroxylicious.proxy.service.ContributorContext;
 
 public class FilterContributorManager {
 
@@ -43,7 +44,7 @@ public class FilterContributorManager {
         Iterator<FilterContributor> it = contributors.iterator();
         while (it.hasNext()) {
             FilterContributor contributor = it.next();
-            KrpcFilter filter = contributor.getInstance(shortName, filterConfig);
+            KrpcFilter filter = contributor.getInstance(shortName, filterConfig, ContributorContext.instance());
             if (filter != null) {
                 return filter;
             }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/NettyFilterContributorContext.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/NettyFilterContributorContext.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import io.netty.channel.Channel;
+
+import io.kroxylicious.proxy.filter.FilterContributorContext;
+import io.kroxylicious.proxy.filter.FilterExecutors;
+
+public record NettyFilterContributorContext(Channel channel) implements FilterContributorContext {
+    @Override
+    public FilterExecutors executors() {
+        return new NettyFilterExecutors(channel);
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/NettyFilterExecutors.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/NettyFilterExecutors.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import io.netty.channel.Channel;
+
+import io.kroxylicious.proxy.filter.FilterExecutors;
+
+public record NettyFilterExecutors(Channel channel) implements FilterExecutors {
+    @Override
+    public ScheduledExecutorService filterExecutor() {
+        return channel.eventLoop();
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/DefaultMicrometerConfigurationHookContributor.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/DefaultMicrometerConfigurationHookContributor.java
@@ -6,10 +6,13 @@
 package io.kroxylicious.proxy.micrometer;
 
 import io.kroxylicious.proxy.service.BaseContributor;
+import io.kroxylicious.proxy.service.ContributorContext;
 
-public class DefaultMicrometerConfigurationHookContributor extends BaseContributor<MicrometerConfigurationHook> implements MicrometerConfigurationHookContributor {
+public class DefaultMicrometerConfigurationHookContributor extends BaseContributor<MicrometerConfigurationHook, ContributorContext>
+        implements MicrometerConfigurationHookContributor {
 
-    public static final BaseContributorBuilder<MicrometerConfigurationHook> BUILDER = BaseContributor.<MicrometerConfigurationHook> builder()
+    public static final BaseContributorBuilder<MicrometerConfigurationHook, ContributorContext> BUILDER = BaseContributor
+            .<MicrometerConfigurationHook, ContributorContext> builder()
             .add("CommonTags", CommonTagsHook.CommonTagsHookConfig.class, CommonTagsHook::new)
             .add("StandardBinders", StandardBindersHook.StandardBindersHookConfig.class, StandardBindersHook::new);
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/MicrometerConfigurationHookContributor.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/MicrometerConfigurationHookContributor.java
@@ -6,6 +6,7 @@
 package io.kroxylicious.proxy.micrometer;
 
 import io.kroxylicious.proxy.service.Contributor;
+import io.kroxylicious.proxy.service.ContributorContext;
 
-public interface MicrometerConfigurationHookContributor extends Contributor<MicrometerConfigurationHook> {
+public interface MicrometerConfigurationHookContributor extends Contributor<MicrometerConfigurationHook, ContributorContext> {
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/MicrometerConfigurationHookContributorManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/MicrometerConfigurationHookContributorManager.java
@@ -8,6 +8,7 @@ package io.kroxylicious.proxy.micrometer;
 import java.util.ServiceLoader;
 
 import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.service.ContributorContext;
 
 public class MicrometerConfigurationHookContributorManager {
 
@@ -36,7 +37,7 @@ public class MicrometerConfigurationHookContributorManager {
 
     public MicrometerConfigurationHook getHook(String shortName, BaseConfig filterConfig) {
         for (MicrometerConfigurationHookContributor contributor : contributors) {
-            MicrometerConfigurationHook hook = contributor.getInstance(shortName, filterConfig);
+            MicrometerConfigurationHook hook = contributor.getInstance(shortName, filterConfig, ContributorContext.instance());
             if (hook != null) {
                 return hook;
             }

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
@@ -9,9 +9,11 @@ package io.kroxylicious.proxy.bootstrap;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
+import io.kroxylicious.proxy.filter.FilterContributorContext;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -20,7 +22,8 @@ class FilterChainFactoryTest {
 
     @Test
     void testNullFiltersInConfigResultsInEmptyList() {
-        FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, null, null, true));
+        FilterContributorContext mockContext = Mockito.mock(FilterContributorContext.class);
+        FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, null, null, true), mockContext);
         List<FilterAndInvoker> filters = filterChainFactory.createFilters();
         assertNotNull(filters, "Filters list should not be null");
         assertTrue(filters.isEmpty(), "Filters list should be empty");
@@ -28,7 +31,8 @@ class FilterChainFactoryTest {
 
     @Test
     void testEmptyFiltersInConfigResultsInEmptyList() {
-        FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, List.of(), null, true));
+        FilterContributorContext mockContext = Mockito.mock(FilterContributorContext.class);
+        FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, List.of(), null, true), mockContext);
         List<FilterAndInvoker> filters = filterChainFactory.createFilters();
         assertNotNull(filters, "Filters list should not be null");
         assertTrue(filters.isEmpty(), "Filters list should be empty");

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
@@ -8,13 +8,19 @@ package io.kroxylicious.proxy.bootstrap;
 
 import java.util.List;
 
+import org.assertj.core.api.ListAssert;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import io.kroxylicious.proxy.config.Configuration;
+import io.kroxylicious.proxy.config.FilterDefinition;
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
 import io.kroxylicious.proxy.filter.FilterContributorContext;
+import io.kroxylicious.proxy.internal.filter.Config;
+import io.kroxylicious.proxy.internal.filter.TestFilterContributor;
+import io.kroxylicious.proxy.internal.filter.TestKrpcFilter;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -36,6 +42,39 @@ class FilterChainFactoryTest {
         List<FilterAndInvoker> filters = filterChainFactory.createFilters();
         assertNotNull(filters, "Filters list should not be null");
         assertTrue(filters.isEmpty(), "Filters list should be empty");
+    }
+
+    @Test
+    void testSingleFilterConstruction() {
+        FilterContributorContext mockContext = Mockito.mock(FilterContributorContext.class);
+        Config config = new Config();
+        FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, List.of(new FilterDefinition(TestFilterContributor.SHORT_NAME,
+                config)), null, true), mockContext);
+        List<FilterAndInvoker> filters = filterChainFactory.createFilters();
+        assertThat(filters).hasSize(1).first().extracting(FilterAndInvoker::filter).isInstanceOfSatisfying(TestKrpcFilter.class, testKrpcFilter -> {
+            assertThat(testKrpcFilter.context()).isSameAs(mockContext);
+            assertThat(testKrpcFilter.config()).isSameAs(config);
+        });
+    }
+
+    @Test
+    void testMultipleFilterConstruction() {
+        FilterContributorContext mockContext = Mockito.mock(FilterContributorContext.class);
+        Config configA = new Config();
+        FilterDefinition definitionA = new FilterDefinition(TestFilterContributor.SHORT_NAME, configA);
+        Config configB = new Config();
+        FilterDefinition definitionB = new FilterDefinition(TestFilterContributor.SHORT_NAME, configB);
+        FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, List.of(definitionA, definitionB), null, true), mockContext);
+        List<FilterAndInvoker> filters = filterChainFactory.createFilters();
+        ListAssert<FilterAndInvoker> filterAndInvokerListAssert = assertThat(filters).hasSize(2);
+        filterAndInvokerListAssert.element(0).extracting(FilterAndInvoker::filter).isInstanceOfSatisfying(TestKrpcFilter.class, testKrpcFilter -> {
+            assertThat(testKrpcFilter.context()).isSameAs(mockContext);
+            assertThat(testKrpcFilter.config()).isSameAs(configA);
+        });
+        filterAndInvokerListAssert.element(1).extracting(FilterAndInvoker::filter).isInstanceOfSatisfying(TestKrpcFilter.class, testKrpcFilter -> {
+            assertThat(testKrpcFilter.context()).isSameAs(mockContext);
+            assertThat(testKrpcFilter.config()).isSameAs(configB);
+        });
     }
 
 }

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/ClusterNetworkAddressConfigProviderContributorManagerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/ClusterNetworkAddressConfigProviderContributorManagerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
+import io.kroxylicious.proxy.service.ContributorContext;
+
+import static io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.TestClusterNetworkAddressConfigProviderContributor.SHORT_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ClusterNetworkAddressConfigProviderContributorManagerTest {
+
+    public static final ClusterNetworkAddressConfigProviderContributorManager INSTANCE = ClusterNetworkAddressConfigProviderContributorManager.getInstance();
+
+    @Test
+    void testGetConfigType() {
+        Class<? extends BaseConfig> clazz = INSTANCE.getConfigType(SHORT_NAME);
+        assertThat(clazz).isEqualTo(Config.class);
+    }
+
+    @Test
+    void testGetConfigTypeFailsWhenShortnameHasNoMatches() {
+        assertThatThrownBy(() -> INSTANCE.getConfigType("mismatch")).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("No endpoint provider found for name 'mismatch'");
+    }
+
+    @Test
+    void testGetClusterEndpointProvider() {
+        Config config = new Config();
+        ClusterNetworkAddressConfigProvider provider = INSTANCE.getClusterEndpointConfigProvider(SHORT_NAME, config);
+        assertThat(provider).isInstanceOf(TestClusterNetworkAddressConfigProvider.class);
+        TestClusterNetworkAddressConfigProvider testProvider = (TestClusterNetworkAddressConfigProvider) provider;
+        assertThat(testProvider.config()).isSameAs(config);
+        assertThat(testProvider.shortName()).isEqualTo(SHORT_NAME);
+        assertThat(testProvider.context()).isEqualTo(ContributorContext.instance());
+    }
+
+    @Test
+    void testGetClusterEndpointProviderFailsWhenShortnameHasNoMatches() {
+        Config config = new Config();
+        assertThatThrownBy(() -> INSTANCE.getClusterEndpointConfigProvider("mismatch", config))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("No endpoint provider found for name 'mismatch'");
+    }
+
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/Config.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/Config.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+
+public class Config extends BaseConfig {
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/TestClusterNetworkAddressConfigProvider.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/TestClusterNetworkAddressConfigProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
+
+import org.testcontainers.shaded.org.apache.commons.lang3.NotImplementedException;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
+import io.kroxylicious.proxy.service.ContributorContext;
+import io.kroxylicious.proxy.service.HostPort;
+
+public record TestClusterNetworkAddressConfigProvider(String shortName, BaseConfig config, ContributorContext context) implements ClusterNetworkAddressConfigProvider {
+    @Override
+    public HostPort getClusterBootstrapAddress() {
+        throw new NotImplementedException("not implemented!");
+    }
+
+    @Override
+    public HostPort getBrokerAddress(int nodeId) throws IllegalArgumentException {
+        throw new NotImplementedException("not implemented!");
+    }
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/TestClusterNetworkAddressConfigProviderContributor.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/TestClusterNetworkAddressConfigProviderContributor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
+
+import java.util.Objects;
+
+import io.kroxylicious.proxy.clusternetworkaddressconfigprovider.ClusterNetworkAddressConfigProviderContributor;
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
+import io.kroxylicious.proxy.service.ContributorContext;
+
+public class TestClusterNetworkAddressConfigProviderContributor implements ClusterNetworkAddressConfigProviderContributor {
+
+    public static final String SHORT_NAME = "test";
+
+    @Override
+    public Class<? extends BaseConfig> getConfigType(String shortName) {
+        if (!Objects.equals(shortName, SHORT_NAME)) {
+            return null;
+        }
+        return Config.class;
+    }
+
+    @Override
+    public ClusterNetworkAddressConfigProvider getInstance(String shortName, BaseConfig config, ContributorContext context) {
+        if (!Objects.equals(shortName, SHORT_NAME)) {
+            return null;
+        }
+        return new TestClusterNetworkAddressConfigProvider(shortName, config, context);
+    }
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/Config.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/Config.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+
+public class Config extends BaseConfig {
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/FilterContributorManagerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/FilterContributorManagerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.filter.FilterContributorContext;
+import io.kroxylicious.proxy.filter.KrpcFilter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FilterContributorManagerTest {
+
+    public static final FilterContributorManager INSTANCE = FilterContributorManager.getInstance();
+
+    @Test
+    void testGetConfigType() {
+        Class<? extends BaseConfig> configType = INSTANCE.getConfigType(TestFilterContributor.SHORT_NAME);
+        assertThat(configType).isEqualTo(Config.class);
+    }
+
+    @Test
+    void testGetConfigTypeFailsIfNoMatches() {
+        assertThatThrownBy(() -> INSTANCE.getConfigType("mismatch")).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("No filter found for name 'mismatch'");
+    }
+
+    @Test
+    void testGetFilter() {
+        FilterContributorContext mock = Mockito.mock(FilterContributorContext.class);
+        Config config = new Config();
+        KrpcFilter krpcFilter = INSTANCE.getFilter(TestFilterContributor.SHORT_NAME, config, mock);
+        assertThat(krpcFilter).isInstanceOf(TestKrpcFilter.class);
+        TestKrpcFilter testKrpcFilter = ((TestKrpcFilter) krpcFilter);
+        assertThat(testKrpcFilter.shortName()).isEqualTo(TestFilterContributor.SHORT_NAME);
+        assertThat(testKrpcFilter.config()).isSameAs(config);
+        assertThat(testKrpcFilter.context()).isSameAs(mock);
+    }
+
+    @Test
+    void testGetFilterFailsIfNoMatch() {
+        FilterContributorContext mock = Mockito.mock(FilterContributorContext.class);
+        Config config = new Config();
+        assertThatThrownBy(() -> INSTANCE.getFilter("mismatch", config, mock)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("No filter found for name 'mismatch'");
+    }
+
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/NettyFilterContributorContextTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/NettyFilterContributorContextTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import org.junit.jupiter.api.Test;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NettyFilterContributorContextTest {
+
+    @Test
+    void testExecutor() {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        NettyFilterContributorContext context = new NettyFilterContributorContext(channel);
+        assertThat(context.executors().filterExecutor()).isSameAs(channel.eventLoop());
+    }
+
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestFilterContributor.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestFilterContributor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import java.util.Objects;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.filter.FilterContributor;
+import io.kroxylicious.proxy.filter.FilterContributorContext;
+import io.kroxylicious.proxy.filter.KrpcFilter;
+
+public class TestFilterContributor implements FilterContributor {
+
+    public static final String SHORT_NAME = "test";
+
+    @Override
+    public Class<? extends BaseConfig> getConfigType(String shortName) {
+        if (!Objects.equals(shortName, SHORT_NAME)) {
+            return null;
+        }
+        else {
+            return Config.class;
+        }
+    }
+
+    @Override
+    public KrpcFilter getInstance(String shortName, BaseConfig config, FilterContributorContext context) {
+        if (!Objects.equals(shortName, SHORT_NAME)) {
+            return null;
+        }
+        else {
+            return new TestKrpcFilter(shortName, config, context);
+        }
+    }
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestKrpcFilter.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestKrpcFilter.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.filter.FilterContributorContext;
+import io.kroxylicious.proxy.filter.KrpcFilter;
+
+public record TestKrpcFilter(String shortName, BaseConfig config, FilterContributorContext context) implements KrpcFilter {
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestKrpcFilter.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestKrpcFilter.java
@@ -6,9 +6,21 @@
 
 package io.kroxylicious.proxy.internal.filter;
 
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
 import io.kroxylicious.proxy.config.BaseConfig;
 import io.kroxylicious.proxy.filter.FilterContributorContext;
-import io.kroxylicious.proxy.filter.KrpcFilter;
+import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.RequestFilter;
+import io.kroxylicious.proxy.filter.RequestFilterResult;
 
-public record TestKrpcFilter(String shortName, BaseConfig config, FilterContributorContext context) implements KrpcFilter {
+public record TestKrpcFilter(String shortName, BaseConfig config, FilterContributorContext context) implements RequestFilter {
+    @Override
+    public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage request, KrpcFilterContext context) {
+        return context.forwardRequest(header, request);
+    }
 }

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/micrometer/MicrometerConfigurationHookContributorManagerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/micrometer/MicrometerConfigurationHookContributorManagerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.micrometer;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.micrometer.TestMicrometerConfigurationHookContributor.Config;
+import io.kroxylicious.proxy.service.ContributorContext;
+
+import static io.kroxylicious.proxy.micrometer.TestMicrometerConfigurationHookContributor.SHORT_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MicrometerConfigurationHookContributorManagerTest {
+
+    public static final MicrometerConfigurationHookContributorManager INSTANCE = MicrometerConfigurationHookContributorManager.getInstance();
+
+    @Test
+    void testGetConfigType() {
+        Class<? extends BaseConfig> clazz = INSTANCE.getConfigType(SHORT_NAME);
+        assertThat(clazz).isEqualTo(Config.class);
+    }
+
+    @Test
+    void testGetConfigTypeWhenNoContributorMatchesShortName() {
+        assertThatThrownBy(() -> INSTANCE.getConfigType("mismatched"))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("No micrometer configuration hook found for name 'mismatched'");
+    }
+
+    @Test
+    void testGetHook() {
+        Config config = new Config();
+        MicrometerConfigurationHook hook = INSTANCE.getHook(SHORT_NAME, config);
+        assertThat(hook).isInstanceOf(TestHook.class);
+        TestHook hook1 = (TestHook) hook;
+        assertThat(hook1.shortName()).isEqualTo(SHORT_NAME);
+        assertThat(hook1.context()).isEqualTo(ContributorContext.instance());
+        assertThat(hook1.config()).isSameAs(config);
+    }
+
+    @Test
+    void testGetHookTypeWhenNoContributorMatchesShortName() {
+        Config config = new Config();
+        assertThatThrownBy(() -> INSTANCE.getHook("mismatched", config))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("No micrometer configuration hook found for name 'mismatched'");
+    }
+
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/micrometer/TestHook.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/micrometer/TestHook.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.micrometer;
+
+import org.testcontainers.shaded.org.apache.commons.lang3.NotImplementedException;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.service.ContributorContext;
+
+public record TestHook(String shortName, BaseConfig config, ContributorContext context) implements MicrometerConfigurationHook {
+    @Override
+    public void configure(MeterRegistry targetRegistry) {
+        throw new NotImplementedException("not implemented!");
+    }
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/micrometer/TestMicrometerConfigurationHookContributor.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/micrometer/TestMicrometerConfigurationHookContributor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.micrometer;
+
+import java.util.Objects;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.service.ContributorContext;
+
+public class TestMicrometerConfigurationHookContributor implements MicrometerConfigurationHookContributor {
+
+    public static class Config extends BaseConfig {
+
+    }
+
+    public static final String SHORT_NAME = "test";
+
+    @Override
+    public Class<? extends BaseConfig> getConfigType(String shortName) {
+        if (Objects.equals(shortName, SHORT_NAME)) {
+            return Config.class;
+        }
+        else {
+            return null;
+        }
+    }
+
+    @Override
+    public MicrometerConfigurationHook getInstance(String shortName, BaseConfig config, ContributorContext context) {
+        if (!Objects.equals(shortName, SHORT_NAME)) {
+            return null;
+        }
+        return new TestHook(shortName, config, context);
+    }
+}

--- a/kroxylicious/src/test/resources/META-INF/services/io.kroxylicious.proxy.clusternetworkaddressconfigprovider.ClusterNetworkAddressConfigProviderContributor
+++ b/kroxylicious/src/test/resources/META-INF/services/io.kroxylicious.proxy.clusternetworkaddressconfigprovider.ClusterNetworkAddressConfigProviderContributor
@@ -1,0 +1,1 @@
+io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.TestClusterNetworkAddressConfigProviderContributor

--- a/kroxylicious/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterContributor
+++ b/kroxylicious/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterContributor
@@ -1,0 +1,1 @@
+io.kroxylicious.proxy.internal.filter.TestFilterContributor

--- a/kroxylicious/src/test/resources/META-INF/services/io.kroxylicious.proxy.micrometer.MicrometerConfigurationHookContributor
+++ b/kroxylicious/src/test/resources/META-INF/services/io.kroxylicious.proxy.micrometer.MicrometerConfigurationHookContributor
@@ -1,0 +1,1 @@
+io.kroxylicious.proxy.micrometer.TestMicrometerConfigurationHookContributor


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This adds a concept of ContributorContext:
```
public interface Contributor<T, S extends ContributorContext> {
    Class<? extends BaseConfig> getConfigType(String shortName);

    T getInstance(String shortName, BaseConfig config, S context);
}
```
`ContributorContext` is meant to represent information about the context in which the Contributor is being invoked. So for a FilterContributor, the invocation will be relative to a virtual cluster and a netty channel. So we can use this context to make resources available to the contributor like the netty event loop or other executor services, potentially it could access virtual cluster scoped resources like shared HTTP clients, it could access the virtual cluster name. Then it can decide how to use those to construct the Filter.

The top level ContributorContext interface is currently empty, but maybe there will be some global resources we could offer through it, like a shared blocking pool or general purpose executor service. The FilterContributor is typed with a specialised FilterContributorContext that extends ContributorContext. This gives us type-safety in the `BaseContributor`.

A Filter could choose to have a constructor signature that accepts an ExecutorService, it would be up to the FilterContributor implementation to extract the right `ExecutorService` from the `FilterContributorContext` and inject it.

### example usage

given a filter implementation `ExampleFilter` with a custom configuration class `ExampleConfig` and a constructor like:
```
ExampleFilter(ScheduledExecutorService executorService, ExampleConfig config)
````
We can populate it with the event loop in a custom Contributor implementation like this":

```java
import io.kroxylicious.proxy.service.BaseContributor;

public class ExampleContributor extends BaseContributor<KrpcFilter, FilterContributorContext> implements FilterContributor {

    public static final BaseContributorBuilder<KrpcFilter, FilterContributorContext> FILTERS = BaseContributor.<KrpcFilter, FilterContributorContext> builder()
            .add("Example", ExampleConfig.class, (context, config) -> {
                return new ExampleFilter(context.executors().filterExecutor(), config);
            });

    public TestFilterContributor() {
        super(FILTERS);
    }
}
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
