### PR TITLE
Copy log4j2.yml into binary distribution and use it via system property

### DIFF
--- a/kroxylicious-app/src/assembly/binary-distribution.xml
+++ b/kroxylicious-app/src/assembly/binary-distribution.xml
@@ -31,6 +31,13 @@
         <include>example-proxy-config.yml</include>
       </includes>
     </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/src/main/resources/</directory>
+      <outputDirectory>/config/</outputDirectory>
+      <includes>
+        <include>log4j2.yml</include>
+      </includes>
+    </fileSet>
   </fileSets>
   <dependencySets>
     <dependencySet>

--- a/kroxylicious-app/src/assembly/binary-distribution.xml
+++ b/kroxylicious-app/src/assembly/binary-distribution.xml
@@ -32,6 +32,13 @@
       </includes>
     </fileSet>
     <fileSet>
+      <directory>${project.basedir}/..</directory>
+      <outputDirectory>/</outputDirectory>
+      <includes>
+        <include>LICENSE</include>
+      </includes>
+    </fileSet>
+    <fileSet>
       <directory>${project.basedir}/src/main/resources/</directory>
       <outputDirectory>/config/</outputDirectory>
       <includes>

--- a/kroxylicious-app/src/assembly/kroxylicious-start.sh
+++ b/kroxylicious-app/src/assembly/kroxylicious-start.sh
@@ -20,6 +20,7 @@ classpath() {
   echo "${class_path}"
 }
 
+export JAVA_OPTIONS="${JAVA_OPTIONS:-} -Dlog4j2.configurationFile=$(script_dir)/../config/log4j2.yml"
 export JAVA_CLASSPATH="$(classpath)"
 export JAVA_MAIN_CLASS=io.kroxylicious.app.Kroxylicious
 exec $(script_dir)/run-java.sh "$@"

--- a/kroxylicious-app/src/assembly/kroxylicious-start.sh
+++ b/kroxylicious-app/src/assembly/kroxylicious-start.sh
@@ -20,7 +20,10 @@ classpath() {
   echo "${class_path}"
 }
 
-export JAVA_OPTIONS="${JAVA_OPTIONS:-} -Dlog4j2.configurationFile=$(script_dir)/../config/log4j2.yml"
+if [ "${KROXYLICIOUS_LOGGING_OPTIONS+set}" != set ]; then
+  KROXYLICIOUS_LOGGING_OPTIONS="-Dlog4j2.configurationFile=$(script_dir)/../config/log4j2.yml"
+fi
+export JAVA_OPTIONS="${KROXYLICIOUS_LOGGING_OPTIONS} ${JAVA_OPTIONS:-}"
 export JAVA_CLASSPATH="$(classpath)"
 export JAVA_MAIN_CLASS=io.kroxylicious.app.Kroxylicious
 exec $(script_dir)/run-java.sh "$@"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds `config/log4j2.xml` to the binary distribution and set `-D-Dlog4j2.configurationFile=` to point at it instead of using the configuration on the classpath.

Adds `LICENSE` to the root of the binary distribution.

Note that the system prop is appended to JAVA_OPTIONS so users can still set it to configure the JVM

Resolves #555 

### Additional Context

Users will want a way to tweak log levels to their tastes.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
