### PR TITLE
Include .git when copying into the Docker build image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,5 @@ kubernetes-examples
 scripts
 Dockerfile
 .dockerignore
-.git
 .github
 README.md


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

We now use a maven plugin to extract information about the git commit we are building against, so we need the .git dir included when we run maven.

### Additional Context

The docker build action failed during `./mvnw -B clean verify -Pdist,withAdditionalFilters -Dquick -pl :kroxylicious-bom,:kroxylicious-app -am"` with:
```
Error: ERROR] Failed to execute goal io.github.git-commit-id:git-commit-id-maven-plugin:6.0.0:revision (get-the-git-infos) on project kroxylicious-app: .git directory is not found! Please specify a valid [dotGitDirectory] in your pom.xml -> [Help 1]
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
