### PR TITLE
Enable Filter Contributors to access netty event loop while constructing Filters - alternative

### DIFF
--- a/integrationtests/src/test/java/io/kroxylicious/proxy/FilterIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/FilterIT.java
@@ -249,6 +249,19 @@ class FilterIT {
 
     /**
      * This test verifies the use-case where a filter needs delay a request/response forward
+     * until a 3rd party asynchronous action completes.
+     * @param direction direction of the flow
+     */
+    @ParameterizedTest
+    @EnumSource(value = RequestResponseMarkingFilter.Direction.class)
+    void supportsForwardDeferredByAsynchronousActionOnEventLoop(RequestResponseMarkingFilter.Direction direction) {
+        doSupportsForwardDeferredByAsynchronousRequest(direction,
+                "supportsForwardDeferredByAsynchronousActionOnEventLoop",
+                ForwardingStyle.ASYNCHRONOUS_DELAYED_ON_EVENTlOOP);
+    }
+
+    /**
+     * This test verifies the use-case where a filter needs delay a request/response forward
      * until an asynchronous request to the broker completes.
      * @param direction direction of the flow
      */

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/ForwardContext.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/ForwardContext.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import org.apache.kafka.common.protocol.ApiMessage;
+
+public record ForwardContext(FilterContext filterContext, FilterConstructContext constructionContext, ApiMessage body) {}

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/ForwardingContext.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/ForwardingContext.java
@@ -8,4 +8,4 @@ package io.kroxylicious.proxy.filter;
 
 import org.apache.kafka.common.protocol.ApiMessage;
 
-public record ForwardContext(FilterContext filterContext, FilterConstructContext constructionContext, ApiMessage body) {}
+public record ForwardingContext(FilterContext filterContext, FilterConstructContext constructionContext, ApiMessage body) {}

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/ForwardingStyle.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/ForwardingStyle.java
@@ -11,7 +11,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import org.apache.kafka.common.message.ListGroupsRequestData;
 import org.apache.kafka.common.message.ListGroupsResponseData;
@@ -19,21 +19,21 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.protocol.Errors;
 
-public enum ForwardingStyle implements BiFunction<FilterContext, ApiMessage, CompletionStage<ApiMessage>> {
+public enum ForwardingStyle implements Function<ForwardContext, CompletionStage<ApiMessage>> {
     SYNCHRONOUS {
         @Override
-        public CompletionStage<ApiMessage> apply(FilterContext context, ApiMessage body) {
-            return CompletableFuture.completedStage(body);
+        public CompletionStage<ApiMessage> apply(ForwardContext context) {
+            return CompletableFuture.completedStage(context.body());
         }
     },
     ASYNCHRONOUS_DELAYED {
         @Override
-        public CompletionStage<ApiMessage> apply(FilterContext context, ApiMessage body) {
+        public CompletionStage<ApiMessage> apply(ForwardContext context) {
             CompletableFuture<ApiMessage> result = new CompletableFuture<>();
             ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
             try {
                 executor.schedule(() -> {
-                    result.complete(body);
+                    result.complete(context.body());
                 }, 200L, TimeUnit.MILLISECONDS);
             }
             finally {
@@ -42,10 +42,21 @@ public enum ForwardingStyle implements BiFunction<FilterContext, ApiMessage, Com
             return result;
         }
     },
+    ASYNCHRONOUS_DELAYED_ON_EVENTlOOP {
+        @Override
+        public CompletionStage<ApiMessage> apply(ForwardContext context) {
+            ScheduledExecutorService executor = context.constructionContext().executors().eventLoop();
+            CompletableFuture<ApiMessage> result = new CompletableFuture<>();
+            executor.schedule(() -> {
+                result.complete(context.body());
+            }, 200L, TimeUnit.MILLISECONDS);
+            return result;
+        }
+    },
     ASYNCHRONOUS_REQUEST_TO_BROKER {
         @Override
-        public CompletionStage<ApiMessage> apply(FilterContext context, ApiMessage body) {
-            return sendAsyncRequestAndCheckForResponseErrors(context).thenApply(unused -> body);
+        public CompletionStage<ApiMessage> apply(ForwardContext context) {
+            return sendAsyncRequestAndCheckForResponseErrors(context.filterContext()).thenApply(unused -> context.body());
         }
 
         private CompletionStage<ListGroupsResponseData> sendAsyncRequestAndCheckForResponseErrors(FilterContext filterContext) {

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/ForwardingStyle.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/ForwardingStyle.java
@@ -19,16 +19,16 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.protocol.Errors;
 
-public enum ForwardingStyle implements Function<ForwardContext, CompletionStage<ApiMessage>> {
+public enum ForwardingStyle implements Function<ForwardingContext, CompletionStage<ApiMessage>> {
     SYNCHRONOUS {
         @Override
-        public CompletionStage<ApiMessage> apply(ForwardContext context) {
+        public CompletionStage<ApiMessage> apply(ForwardingContext context) {
             return CompletableFuture.completedStage(context.body());
         }
     },
     ASYNCHRONOUS_DELAYED {
         @Override
-        public CompletionStage<ApiMessage> apply(ForwardContext context) {
+        public CompletionStage<ApiMessage> apply(ForwardingContext context) {
             CompletableFuture<ApiMessage> result = new CompletableFuture<>();
             ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
             try {
@@ -44,7 +44,7 @@ public enum ForwardingStyle implements Function<ForwardContext, CompletionStage<
     },
     ASYNCHRONOUS_DELAYED_ON_EVENTlOOP {
         @Override
-        public CompletionStage<ApiMessage> apply(ForwardContext context) {
+        public CompletionStage<ApiMessage> apply(ForwardingContext context) {
             ScheduledExecutorService executor = context.constructionContext().executors().eventLoop();
             CompletableFuture<ApiMessage> result = new CompletableFuture<>();
             executor.schedule(() -> {
@@ -55,7 +55,7 @@ public enum ForwardingStyle implements Function<ForwardContext, CompletionStage<
     },
     ASYNCHRONOUS_REQUEST_TO_BROKER {
         @Override
-        public CompletionStage<ApiMessage> apply(ForwardContext context) {
+        public CompletionStage<ApiMessage> apply(ForwardingContext context) {
             return sendAsyncRequestAndCheckForResponseErrors(context.filterContext()).thenApply(unused -> context.body());
         }
 

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RejectingCreateTopicFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RejectingCreateTopicFilter.java
@@ -27,8 +27,10 @@ public class RejectingCreateTopicFilter implements CreateTopicsRequestFilter {
     public static final String ERROR_MESSAGE = "rejecting all topics";
     private final ForwardingStyle forwardingStyle;
     private final boolean withCloseConnection;
+    private final FilterConstructContext constructionContext;
 
-    public RejectingCreateTopicFilter(RejectingCreateTopicFilterConfig config) {
+    public RejectingCreateTopicFilter(FilterConstructContext constructionContext, RejectingCreateTopicFilterConfig config) {
+        this.constructionContext = constructionContext;
         config = config == null ? new RejectingCreateTopicFilterConfig(false, ForwardingStyle.SYNCHRONOUS) : config;
         this.withCloseConnection = config.withCloseConnection;
         this.forwardingStyle = config.forwardingStyle;
@@ -37,7 +39,7 @@ public class RejectingCreateTopicFilter implements CreateTopicsRequestFilter {
     @Override
     public CompletionStage<RequestFilterResult> onCreateTopicsRequest(short apiVersion, RequestHeaderData header, CreateTopicsRequestData request,
                                                                       FilterContext context) {
-        return forwardingStyle.apply(context, request)
+        return forwardingStyle.apply(new ForwardContext(context, constructionContext, request))
                 .thenCompose((u) -> {
                     CreateTopicsResponseData response = new CreateTopicsResponseData();
                     CreateTopicsResponseData.CreatableTopicResultCollection topics = new CreateTopicsResponseData.CreatableTopicResultCollection();

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RejectingCreateTopicFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RejectingCreateTopicFilter.java
@@ -39,7 +39,7 @@ public class RejectingCreateTopicFilter implements CreateTopicsRequestFilter {
     @Override
     public CompletionStage<RequestFilterResult> onCreateTopicsRequest(short apiVersion, RequestHeaderData header, CreateTopicsRequestData request,
                                                                       FilterContext context) {
-        return forwardingStyle.apply(new ForwardContext(context, constructionContext, request))
+        return forwardingStyle.apply(new ForwardingContext(context, constructionContext, request))
                 .thenCompose((u) -> {
                     CreateTopicsResponseData response = new CreateTopicsResponseData();
                     CreateTopicsResponseData.CreatableTopicResultCollection topics = new CreateTopicsResponseData.CreatableTopicResultCollection();

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RequestResponseMarkingFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RequestResponseMarkingFilter.java
@@ -61,7 +61,7 @@ public class RequestResponseMarkingFilter implements RequestFilter, ResponseFilt
             return context.forwardRequest(header, body);
         }
 
-        return forwardingStyle.apply(new ForwardContext(context, constructionContext, body))
+        return forwardingStyle.apply(new ForwardingContext(context, constructionContext, body))
                 .thenApply(request -> applyTaggedField(request, Direction.REQUEST, name))
                 .thenCompose(taggedRequest -> context.forwardRequest(header, taggedRequest));
     }
@@ -72,7 +72,7 @@ public class RequestResponseMarkingFilter implements RequestFilter, ResponseFilt
             return context.forwardResponse(header, response);
         }
 
-        return forwardingStyle.apply(new ForwardContext(context, constructionContext, response))
+        return forwardingStyle.apply(new ForwardingContext(context, constructionContext, response))
                 .thenApply(request -> applyTaggedField(request, Direction.RESPONSE, name))
                 .thenCompose(taggedRequest -> context.forwardResponse(header, taggedRequest));
     }

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
@@ -7,11 +7,10 @@ package io.kroxylicious.proxy.filter;
 
 import io.kroxylicious.proxy.filter.CompositePrefixingFixedClientIdFilter.CompositePrefixingFixedClientIdFilterConfig;
 import io.kroxylicious.proxy.service.BaseContributor;
-import io.kroxylicious.proxy.service.Context;
 
-public class TestFilterContributor extends BaseContributor<Filter, Context> implements FilterContributor {
+public class TestFilterContributor extends BaseContributor<Filter, FilterConstructContext> implements FilterContributor {
 
-    public static final BaseContributorBuilder<Filter, Context> FILTERS = BaseContributor.<Filter, Context> builder()
+    public static final BaseContributorBuilder<Filter, FilterConstructContext> FILTERS = BaseContributor.<Filter, FilterConstructContext> builder()
             .add("FixedClientId", FixedClientIdFilter.FixedClientIdFilterConfig.class, FixedClientIdFilter::new)
             .add("ApiVersionsMarkingFilter", ApiVersionsMarkingFilter::new)
             .add("RequestResponseMarking", RequestResponseMarkingFilter.RequestResponseMarkingFilterConfig.class, RequestResponseMarkingFilter::new)

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
@@ -11,7 +11,7 @@ import io.kroxylicious.proxy.service.Context;
 
 public class TestFilterContributor extends BaseContributor<Filter, Context> implements FilterContributor {
 
-    public static final BaseContributorBuilder<Filter> FILTERS = BaseContributor.<Filter> builder()
+    public static final BaseContributorBuilder<Filter, Context> FILTERS = BaseContributor.<Filter, Context> builder()
             .add("FixedClientId", FixedClientIdFilter.FixedClientIdFilterConfig.class, FixedClientIdFilter::new)
             .add("ApiVersionsMarkingFilter", ApiVersionsMarkingFilter::new)
             .add("RequestResponseMarking", RequestResponseMarkingFilter.RequestResponseMarkingFilterConfig.class, RequestResponseMarkingFilter::new)

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
@@ -7,8 +7,9 @@ package io.kroxylicious.proxy.filter;
 
 import io.kroxylicious.proxy.filter.CompositePrefixingFixedClientIdFilter.CompositePrefixingFixedClientIdFilterConfig;
 import io.kroxylicious.proxy.service.BaseContributor;
+import io.kroxylicious.proxy.service.Context;
 
-public class TestFilterContributor extends BaseContributor<Filter> implements FilterContributor {
+public class TestFilterContributor extends BaseContributor<Filter, Context> implements FilterContributor {
 
     public static final BaseContributorBuilder<Filter> FILTERS = BaseContributor.<Filter> builder()
             .add("FixedClientId", FixedClientIdFilter.FixedClientIdFilterConfig.class, FixedClientIdFilter::new)

--- a/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterContributor.java
+++ b/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterContributor.java
@@ -12,7 +12,7 @@ import io.kroxylicious.proxy.service.Context;
 
 public class MultiTenantFilterContributor extends BaseContributor<Filter, Context> implements FilterContributor {
 
-    public static final BaseContributorBuilder<Filter> FILTERS = BaseContributor.<Filter> builder()
+    public static final BaseContributorBuilder<Filter, Context> FILTERS = BaseContributor.<Filter, Context> builder()
             .add("MultiTenant", MultiTenantTransformationFilter::new);
 
     public MultiTenantFilterContributor() {

--- a/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterContributor.java
+++ b/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterContributor.java
@@ -8,8 +8,9 @@ package io.kroxylicious.proxy.filter.multitenant;
 import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterContributor;
 import io.kroxylicious.proxy.service.BaseContributor;
+import io.kroxylicious.proxy.service.Context;
 
-public class MultiTenantFilterContributor extends BaseContributor<Filter> implements FilterContributor {
+public class MultiTenantFilterContributor extends BaseContributor<Filter, Context> implements FilterContributor {
 
     public static final BaseContributorBuilder<Filter> FILTERS = BaseContributor.<Filter> builder()
             .add("MultiTenant", MultiTenantTransformationFilter::new);

--- a/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterContributor.java
+++ b/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterContributor.java
@@ -6,13 +6,13 @@
 package io.kroxylicious.proxy.filter.multitenant;
 
 import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.filter.FilterConstructContext;
 import io.kroxylicious.proxy.filter.FilterContributor;
 import io.kroxylicious.proxy.service.BaseContributor;
-import io.kroxylicious.proxy.service.Context;
 
-public class MultiTenantFilterContributor extends BaseContributor<Filter, Context> implements FilterContributor {
+public class MultiTenantFilterContributor extends BaseContributor<Filter, FilterConstructContext> implements FilterContributor {
 
-    public static final BaseContributorBuilder<Filter, Context> FILTERS = BaseContributor.<Filter, Context> builder()
+    public static final BaseContributorBuilder<Filter, FilterConstructContext> FILTERS = BaseContributor.<Filter, FilterConstructContext> builder()
             .add("MultiTenant", MultiTenantTransformationFilter::new);
 
     public MultiTenantFilterContributor() {

--- a/kroxylicious-additional-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterContributorTest.java
+++ b/kroxylicious-additional-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterContributorTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import io.kroxylicious.proxy.config.BaseConfig;
-import io.kroxylicious.proxy.filter.FilterContext;
-import io.kroxylicious.proxy.filter.KrpcFilter;
+import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.filter.FilterConstructContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,7 +27,7 @@ class MultiTenantFilterContributorTest {
     @Test
     void testGetInstance() {
         MultiTenantFilterContributor contributor = new MultiTenantFilterContributor();
-        KrpcFilter filter = contributor.getInstance("MultiTenant", Mockito.mock(FilterContext.class));
+        Filter filter = contributor.getInstance("MultiTenant", Mockito.mock(FilterConstructContext.class));
         assertThat(filter).isNotNull().isInstanceOf(MultiTenantTransformationFilter.class);
     }
 

--- a/kroxylicious-additional-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterContributorTest.java
+++ b/kroxylicious-additional-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterContributorTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.multitenant;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.KrpcFilter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MultiTenantFilterContributorTest {
+
+    @Test
+    void testGetConfigType() {
+        MultiTenantFilterContributor contributor = new MultiTenantFilterContributor();
+        Class<? extends BaseConfig> configType = contributor.getConfigType("MultiTenant");
+        assertThat(configType).isEqualTo(BaseConfig.class);
+    }
+
+    @Test
+    void testGetInstance() {
+        MultiTenantFilterContributor contributor = new MultiTenantFilterContributor();
+        KrpcFilter filter = contributor.getInstance("MultiTenant", Mockito.mock(FilterContext.class));
+        assertThat(filter).isNotNull().isInstanceOf(MultiTenantTransformationFilter.class);
+    }
+
+}

--- a/kroxylicious-additional-filters/kroxylicious-schema-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceRequestValidationFilterContributor.java
+++ b/kroxylicious-additional-filters/kroxylicious-schema-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceRequestValidationFilterContributor.java
@@ -17,7 +17,7 @@ import io.kroxylicious.proxy.service.Context;
  */
 public class ProduceRequestValidationFilterContributor extends BaseContributor<Filter, Context> implements FilterContributor {
 
-    private static final BaseContributorBuilder<Filter> FILTERS = BaseContributor.<Filter> builder()
+    private static final BaseContributorBuilder<Filter, Context> FILTERS = BaseContributor.<Filter, Context> builder()
             .add("ProduceValidator", ValidationConfig.class, (config) -> {
                 ProduceRequestValidator validator = ProduceValidationFilterBuilder.build(config);
                 return new ProduceValidationFilter(config.isForwardPartialRequests(), validator);

--- a/kroxylicious-additional-filters/kroxylicious-schema-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceRequestValidationFilterContributor.java
+++ b/kroxylicious-additional-filters/kroxylicious-schema-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceRequestValidationFilterContributor.java
@@ -6,18 +6,18 @@
 package io.kroxylicious.proxy.filter.schema;
 
 import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.filter.FilterConstructContext;
 import io.kroxylicious.proxy.filter.FilterContributor;
 import io.kroxylicious.proxy.filter.schema.config.ValidationConfig;
 import io.kroxylicious.proxy.filter.schema.validation.request.ProduceRequestValidator;
 import io.kroxylicious.proxy.service.BaseContributor;
-import io.kroxylicious.proxy.service.Context;
 
 /**
  * Contributor for request validation filters
  */
-public class ProduceRequestValidationFilterContributor extends BaseContributor<Filter, Context> implements FilterContributor {
+public class ProduceRequestValidationFilterContributor extends BaseContributor<Filter, FilterConstructContext> implements FilterContributor {
 
-    private static final BaseContributorBuilder<Filter, Context> FILTERS = BaseContributor.<Filter, Context> builder()
+    private static final BaseContributorBuilder<Filter, FilterConstructContext> FILTERS = BaseContributor.<Filter, FilterConstructContext> builder()
             .add("ProduceValidator", ValidationConfig.class, (config) -> {
                 ProduceRequestValidator validator = ProduceValidationFilterBuilder.build(config);
                 return new ProduceValidationFilter(config.isForwardPartialRequests(), validator);

--- a/kroxylicious-additional-filters/kroxylicious-schema-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceRequestValidationFilterContributor.java
+++ b/kroxylicious-additional-filters/kroxylicious-schema-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceRequestValidationFilterContributor.java
@@ -10,11 +10,12 @@ import io.kroxylicious.proxy.filter.FilterContributor;
 import io.kroxylicious.proxy.filter.schema.config.ValidationConfig;
 import io.kroxylicious.proxy.filter.schema.validation.request.ProduceRequestValidator;
 import io.kroxylicious.proxy.service.BaseContributor;
+import io.kroxylicious.proxy.service.Context;
 
 /**
  * Contributor for request validation filters
  */
-public class ProduceRequestValidationFilterContributor extends BaseContributor<Filter> implements FilterContributor {
+public class ProduceRequestValidationFilterContributor extends BaseContributor<Filter, Context> implements FilterContributor {
 
     private static final BaseContributorBuilder<Filter> FILTERS = BaseContributor.<Filter> builder()
             .add("ProduceValidator", ValidationConfig.class, (config) -> {

--- a/kroxylicious-additional-filters/kroxylicious-schema-validation/src/test/java/io/kroxylicious/proxy/filter/schema/ProduceRequestValidationFilterContributorTest.java
+++ b/kroxylicious-additional-filters/kroxylicious-schema-validation/src/test/java/io/kroxylicious/proxy/filter/schema/ProduceRequestValidationFilterContributorTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.schema;
+
+import java.util.List;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.filter.FilterConstructContext;
+import io.kroxylicious.proxy.filter.schema.config.RecordValidationRule;
+import io.kroxylicious.proxy.filter.schema.config.ValidationConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProduceRequestValidationFilterContributorTest {
+
+    @Test
+    void testGetConfigType() {
+        ProduceRequestValidationFilterContributor contributor = new ProduceRequestValidationFilterContributor();
+        Class<? extends BaseConfig> configType = contributor.getConfigType("ProduceValidator");
+        assertThat(configType).isEqualTo(ValidationConfig.class);
+    }
+
+    @Test
+    void testGetInstance() {
+        ProduceRequestValidationFilterContributor contributor = new ProduceRequestValidationFilterContributor();
+        ValidationConfig config = new ValidationConfig(true, List.of(), new RecordValidationRule(null, null));
+        Filter filter = contributor.getInstance("ProduceValidator", FilterConstructContext.wrap(config, () -> Executors.newScheduledThreadPool(1)));
+        assertThat(filter).isNotNull().isInstanceOf(ProduceValidationFilter.class);
+    }
+
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/clusternetworkaddressconfigprovider/ClusterNetworkAddressConfigProviderContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/clusternetworkaddressconfigprovider/ClusterNetworkAddressConfigProviderContributor.java
@@ -6,11 +6,12 @@
 package io.kroxylicious.proxy.clusternetworkaddressconfigprovider;
 
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
+import io.kroxylicious.proxy.service.Context;
 import io.kroxylicious.proxy.service.Contributor;
 
 /**
  * ClusterNetworkAddressConfigProviderContributor is a pluggable source of network address information.
  * @see Contributor
  */
-public interface ClusterNetworkAddressConfigProviderContributor extends Contributor<ClusterNetworkAddressConfigProvider> {
+public interface ClusterNetworkAddressConfigProviderContributor extends Contributor<ClusterNetworkAddressConfigProvider, Context> {
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterConstructContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterConstructContext.java
@@ -6,8 +6,23 @@
 
 package io.kroxylicious.proxy.filter;
 
+import io.kroxylicious.proxy.config.BaseConfig;
 import io.kroxylicious.proxy.service.Context;
 
 public interface FilterConstructContext extends Context {
     FilterExecutors executors();
+
+    static FilterConstructContext wrap(BaseConfig config, FilterExecutors executors) {
+        return new FilterConstructContext() {
+            @Override
+            public FilterExecutors executors() {
+                return executors;
+            }
+
+            @Override
+            public BaseConfig getConfig() {
+                return config;
+            }
+        };
+    }
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterConstructContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterConstructContext.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import io.kroxylicious.proxy.service.Context;
+
+public interface FilterConstructContext extends Context {
+    FilterExecutors executors();
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContributor.java
@@ -5,11 +5,12 @@
  */
 package io.kroxylicious.proxy.filter;
 
+import io.kroxylicious.proxy.service.Context;
 import io.kroxylicious.proxy.service.Contributor;
 
 /**
  * FilterContributor is a pluggable source of Kroxylicious filter implementations.
  * @see Contributor
  */
-public interface FilterContributor extends Contributor<Filter> {
+public interface FilterContributor extends Contributor<Filter, Context> {
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContributor.java
@@ -5,12 +5,11 @@
  */
 package io.kroxylicious.proxy.filter;
 
-import io.kroxylicious.proxy.service.Context;
 import io.kroxylicious.proxy.service.Contributor;
 
 /**
  * FilterContributor is a pluggable source of Kroxylicious filter implementations.
  * @see Contributor
  */
-public interface FilterContributor extends Contributor<Filter, Context> {
+public interface FilterContributor extends Contributor<Filter, FilterConstructContext> {
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterExecutors.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterExecutors.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+public interface FilterExecutors {
+
+    ScheduledExecutorService eventLoop();
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
@@ -17,7 +17,7 @@ import io.kroxylicious.proxy.config.BaseConfig;
  *
  * @param <T> the service type
  */
-public abstract class BaseContributor<T> implements Contributor<T> {
+public abstract class BaseContributor<T, S extends Context> implements Contributor<T, S> {
 
     private final Map<String, InstanceBuilder<? extends BaseConfig, T>> shortNameToInstanceBuilder;
 

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
@@ -128,6 +128,17 @@ public abstract class BaseContributor<T, S extends Context> implements Contribut
             return add(shortName, BaseConfig.class, config -> instanceFunction.get());
         }
 
+        /**
+         * Registers a factory function for the construction of a service instance.
+         *
+         * @param shortName service short name
+         * @param instanceFunction function that constructs the service instance from a context
+         * @return this
+         */
+        public BaseContributorBuilder<L, D> add(String shortName, Function<D, L> instanceFunction) {
+            return add(shortName, BaseConfig.class, (context, config) -> instanceFunction.apply(context));
+        }
+
         Map<String, InstanceBuilder<L, D>> build() {
             return Map.copyOf(shortNameToInstanceBuilder);
         }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
@@ -25,7 +25,7 @@ public abstract class BaseContributor<T, S extends Context> implements Contribut
      * Constructs and configures the contributor using the supplied {@code builder}.
      * @param builder builder
      */
-    public BaseContributor(BaseContributorBuilder<T> builder) {
+    public BaseContributor(BaseContributorBuilder<T, S> builder) {
         shortNameToInstanceBuilder = builder.build();
     }
 
@@ -71,7 +71,7 @@ public abstract class BaseContributor<T, S extends Context> implements Contribut
      * @see BaseContributor#builder()
      * @param <L> the service type
      */
-    public static class BaseContributorBuilder<L> {
+    public static class BaseContributorBuilder<L, D extends Context> {
 
         private BaseContributorBuilder() {
         }
@@ -87,7 +87,7 @@ public abstract class BaseContributor<T, S extends Context> implements Contribut
          * @return this
          * @param <T> the configuration concrete type
          */
-        public <T extends BaseConfig> BaseContributorBuilder<L> add(String shortName, Class<T> configClass, Function<T, L> instanceFunction) {
+        public <T extends BaseConfig> BaseContributorBuilder<L, D> add(String shortName, Class<T> configClass, Function<T, L> instanceFunction) {
             if (shortNameToInstanceBuilder.containsKey(shortName)) {
                 throw new IllegalArgumentException(shortName + " already registered");
             }
@@ -102,7 +102,7 @@ public abstract class BaseContributor<T, S extends Context> implements Contribut
          * @param instanceFunction function that constructs the service instance
          * @return this
          */
-        public BaseContributorBuilder<L> add(String shortName, Supplier<L> instanceFunction) {
+        public BaseContributorBuilder<L, D> add(String shortName, Supplier<L> instanceFunction) {
             return add(shortName, BaseConfig.class, (config) -> instanceFunction.get());
         }
 
@@ -117,7 +117,7 @@ public abstract class BaseContributor<T, S extends Context> implements Contribut
      * @return the builder
      * @param <L> the service type
      */
-    public static <L> BaseContributorBuilder<L> builder() {
+    public static <L, D extends Context> BaseContributorBuilder<L, D> builder() {
         return new BaseContributorBuilder<>();
     }
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
@@ -36,9 +36,9 @@ public abstract class BaseContributor<T> implements Contributor<T> {
     }
 
     @Override
-    public T getInstance(String shortName, BaseConfig config) {
+    public T getInstance(String shortName, Context config) {
         InstanceBuilder<? extends BaseConfig, T> instanceBuilder = shortNameToInstanceBuilder.get(shortName);
-        return instanceBuilder == null ? null : instanceBuilder.construct(config);
+        return instanceBuilder == null ? null : instanceBuilder.construct(config.getConfig());
     }
 
     private static class InstanceBuilder<T extends BaseConfig, L> {

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
@@ -19,7 +19,7 @@ import io.kroxylicious.proxy.config.BaseConfig;
  */
 public abstract class BaseContributor<T, S extends Context> implements Contributor<T, S> {
 
-    private final Map<String, InstanceBuilder<? extends BaseConfig, T>> shortNameToInstanceBuilder;
+    private final Map<String, InstanceBuilder<? extends BaseConfig, T, S>> shortNameToInstanceBuilder;
 
     /**
      * Constructs and configures the contributor using the supplied {@code builder}.
@@ -31,17 +31,17 @@ public abstract class BaseContributor<T, S extends Context> implements Contribut
 
     @Override
     public Class<? extends BaseConfig> getConfigType(String shortName) {
-        InstanceBuilder<?, T> instanceBuilder = shortNameToInstanceBuilder.get(shortName);
+        InstanceBuilder<?, T, S> instanceBuilder = shortNameToInstanceBuilder.get(shortName);
         return instanceBuilder == null ? null : instanceBuilder.configClass;
     }
 
     @Override
     public T getInstance(String shortName, Context config) {
-        InstanceBuilder<? extends BaseConfig, T> instanceBuilder = shortNameToInstanceBuilder.get(shortName);
+        InstanceBuilder<? extends BaseConfig, T, S> instanceBuilder = shortNameToInstanceBuilder.get(shortName);
         return instanceBuilder == null ? null : instanceBuilder.construct(config.getConfig());
     }
 
-    private static class InstanceBuilder<T extends BaseConfig, L> {
+    private static class InstanceBuilder<T extends BaseConfig, L, D extends Context> {
 
         private final Class<T> configClass;
         private final Function<T, L> instanceFunction;
@@ -76,7 +76,7 @@ public abstract class BaseContributor<T, S extends Context> implements Contribut
         private BaseContributorBuilder() {
         }
 
-        private final Map<String, InstanceBuilder<?, L>> shortNameToInstanceBuilder = new HashMap<>();
+        private final Map<String, InstanceBuilder<?, L, D>> shortNameToInstanceBuilder = new HashMap<>();
 
         /**
          * Registers a factory function for the construction of a service instance.
@@ -106,7 +106,7 @@ public abstract class BaseContributor<T, S extends Context> implements Contribut
             return add(shortName, BaseConfig.class, (config) -> instanceFunction.get());
         }
 
-        Map<String, InstanceBuilder<?, L>> build() {
+        Map<String, InstanceBuilder<?, L, D>> build() {
             return Map.copyOf(shortNameToInstanceBuilder);
         }
     }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/Context.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/Context.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.service;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+
+/**
+ * Context in which a Contributor is getting an instance, this includes the user-supplied configuration.
+ */
+public interface Context {
+
+    /**
+     * service configuration which may be null if the service instance does not accept configuration.
+     * @return config
+     */
+    BaseConfig getConfig();
+
+    static Context wrap(BaseConfig config) {
+        return () -> config;
+    }
+
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/Contributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/Contributor.java
@@ -13,7 +13,7 @@ import io.kroxylicious.proxy.config.BaseConfig;
  *
  * @param <T> the service type
  */
-public interface Contributor<T> {
+public interface Contributor<T, S extends Context> {
 
     /**
      * Gets the concrete type of the configuration required by this service instance.
@@ -30,5 +30,5 @@ public interface Contributor<T> {
      * @param context   context containing service configuration which may be null if the service instance does not accept configuration.
      * @return the service instance, or null if this contributor does not offer this short name.
      */
-    T getInstance(String shortName, Context context);
+    T getInstance(String shortName, S context);
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/Contributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/Contributor.java
@@ -27,8 +27,8 @@ public interface Contributor<T> {
      * Creates an instance of the service.
      *
      * @param shortName service short name
-     * @param config    service configuration which may be null if the service instance does not accept configuration.
+     * @param context   context containing service configuration which may be null if the service instance does not accept configuration.
      * @return the service instance, or null if this contributor does not offer this short name.
      */
-    T getInstance(String shortName, BaseConfig config);
+    T getInstance(String shortName, Context context);
 }

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
@@ -45,6 +45,16 @@ class BaseContributorTest {
     }
 
     @Test
+    void testNullConfigIsAllowed() {
+        BaseContributor.BaseContributorBuilder<Long, Context> builder = BaseContributor.builder();
+        builder.add("one", () -> 1L);
+        BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
+        };
+        Long instance = baseContributor.getInstance("one", wrap(null));
+        assertThat(instance).isEqualTo(1L);
+    }
+
+    @Test
     void testContextAndConfigFunction() {
         BaseContributor.BaseContributorBuilder<Long, Context> builder = BaseContributor.builder();
         AtomicReference<Context> contextRef = new AtomicReference<>();

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.proxy.config.BaseConfig;
 
+import static io.kroxylicious.proxy.service.Context.wrap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -37,7 +38,7 @@ class BaseContributorTest {
         builder.add("one", () -> 1L);
         BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
         };
-        Long instance = baseContributor.getInstance("one", new BaseConfig());
+        Long instance = baseContributor.getInstance("one", wrap(new BaseConfig()));
         assertThat(instance).isEqualTo(1L);
     }
 
@@ -57,7 +58,7 @@ class BaseContributorTest {
         builder.add("fromBaseConfig", LongConfig.class, baseConfig -> baseConfig.value);
         BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
         };
-        Long instance = baseContributor.getInstance("fromBaseConfig", new LongConfig());
+        Long instance = baseContributor.getInstance("fromBaseConfig", wrap(new LongConfig()));
         assertThat(instance).isEqualTo(2L);
     }
 
@@ -69,7 +70,7 @@ class BaseContributorTest {
         };
         AnotherConfig incompatibleConfig = new AnotherConfig();
         assertThatThrownBy(() -> {
-            baseContributor.getInstance("fromBaseConfig", incompatibleConfig);
+            baseContributor.getInstance("fromBaseConfig", wrap(incompatibleConfig));
         }).isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
@@ -5,6 +5,8 @@
  */
 package io.kroxylicious.proxy.service;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.proxy.config.BaseConfig;
@@ -43,6 +45,22 @@ class BaseContributorTest {
     }
 
     @Test
+    void testContextAndConfigFunction() {
+        BaseContributor.BaseContributorBuilder<Long, Context> builder = BaseContributor.builder();
+        AtomicReference<Context> contextRef = new AtomicReference<>();
+        builder.add("one", (context -> {
+            contextRef.set(context);
+            return 1L;
+        }));
+        BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
+        };
+        Context context = wrap(new BaseConfig());
+        Long instance = baseContributor.getInstance("one", context);
+        assertThat(instance).isEqualTo(1L);
+        assertThat(contextRef).hasValue(context);
+    }
+
+    @Test
     void testSpecifyingConfigType() {
         BaseContributor.BaseContributorBuilder<Long, Context> builder = BaseContributor.builder();
         builder.add("fromBaseConfig", LongConfig.class, baseConfig -> baseConfig.value);
@@ -60,6 +78,22 @@ class BaseContributorTest {
         };
         Long instance = baseContributor.getInstance("fromBaseConfig", wrap(new LongConfig()));
         assertThat(instance).isEqualTo(2L);
+    }
+
+    @Test
+    void testSpecifyingConfigTypeInstanceAndContext() {
+        BaseContributor.BaseContributorBuilder<Long, Context> builder = BaseContributor.builder();
+        AtomicReference<Context> contextRef = new AtomicReference<>();
+        builder.add("fromBaseConfig", LongConfig.class, (context, baseConfig) -> {
+            contextRef.set(context);
+            return baseConfig.value;
+        });
+        BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
+        };
+        Context context = wrap(new LongConfig());
+        Long instance = baseContributor.getInstance("fromBaseConfig", context);
+        assertThat(instance).isEqualTo(2L);
+        assertThat(contextRef).hasValue(context);
     }
 
     @Test

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
@@ -24,7 +24,7 @@ class BaseContributorTest {
 
     @Test
     void testDefaultConfigClass() {
-        BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
+        BaseContributor.BaseContributorBuilder<Long, Context> builder = BaseContributor.builder();
         builder.add("one", () -> 1L);
         BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
         };
@@ -34,7 +34,7 @@ class BaseContributorTest {
 
     @Test
     void testSupplier() {
-        BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
+        BaseContributor.BaseContributorBuilder<Long, Context> builder = BaseContributor.builder();
         builder.add("one", () -> 1L);
         BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
         };
@@ -44,7 +44,7 @@ class BaseContributorTest {
 
     @Test
     void testSpecifyingConfigType() {
-        BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
+        BaseContributor.BaseContributorBuilder<Long, Context> builder = BaseContributor.builder();
         builder.add("fromBaseConfig", LongConfig.class, baseConfig -> baseConfig.value);
         BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
         };
@@ -54,7 +54,7 @@ class BaseContributorTest {
 
     @Test
     void testSpecifyingConfigTypeInstance() {
-        BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
+        BaseContributor.BaseContributorBuilder<Long, Context> builder = BaseContributor.builder();
         builder.add("fromBaseConfig", LongConfig.class, baseConfig -> baseConfig.value);
         BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
         };
@@ -64,7 +64,7 @@ class BaseContributorTest {
 
     @Test
     void testFailsIfConfigNotAssignableToSpecifiedType() {
-        BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
+        BaseContributor.BaseContributorBuilder<Long, Context> builder = BaseContributor.builder();
         builder.add("fromBaseConfig", LongConfig.class, baseConfig -> baseConfig.value);
         BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
         };

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
@@ -26,7 +26,7 @@ class BaseContributorTest {
     void testDefaultConfigClass() {
         BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
         builder.add("one", () -> 1L);
-        BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
+        BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
         };
         Class<? extends BaseConfig> one = baseContributor.getConfigType("one");
         assertThat(one).isEqualTo(BaseConfig.class);
@@ -36,7 +36,7 @@ class BaseContributorTest {
     void testSupplier() {
         BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
         builder.add("one", () -> 1L);
-        BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
+        BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
         };
         Long instance = baseContributor.getInstance("one", wrap(new BaseConfig()));
         assertThat(instance).isEqualTo(1L);
@@ -46,7 +46,7 @@ class BaseContributorTest {
     void testSpecifyingConfigType() {
         BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
         builder.add("fromBaseConfig", LongConfig.class, baseConfig -> baseConfig.value);
-        BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
+        BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
         };
         Class<? extends BaseConfig> configType = baseContributor.getConfigType("fromBaseConfig");
         assertThat(configType).isEqualTo(LongConfig.class);
@@ -56,7 +56,7 @@ class BaseContributorTest {
     void testSpecifyingConfigTypeInstance() {
         BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
         builder.add("fromBaseConfig", LongConfig.class, baseConfig -> baseConfig.value);
-        BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
+        BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
         };
         Long instance = baseContributor.getInstance("fromBaseConfig", wrap(new LongConfig()));
         assertThat(instance).isEqualTo(2L);
@@ -66,7 +66,7 @@ class BaseContributorTest {
     void testFailsIfConfigNotAssignableToSpecifiedType() {
         BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
         builder.add("fromBaseConfig", LongConfig.class, baseConfig -> baseConfig.value);
-        BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
+        BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
         };
         AnotherConfig incompatibleConfig = new AnotherConfig();
         assertThatThrownBy(() -> {

--- a/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleContributor.java
+++ b/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleContributor.java
@@ -9,9 +9,10 @@ package io.kroxylicious.sample;
 import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterContributor;
 import io.kroxylicious.proxy.service.BaseContributor;
+import io.kroxylicious.proxy.service.Context;
 import io.kroxylicious.sample.config.SampleFilterConfig;
 
-public class SampleContributor extends BaseContributor<Filter> implements FilterContributor {
+public class SampleContributor extends BaseContributor<Filter, Context> implements FilterContributor {
 
     public static final String SAMPLE_FETCH = "SampleFetchResponse";
     public static final String SAMPLE_PRODUCE = "SampleProduceRequest";

--- a/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleContributor.java
+++ b/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleContributor.java
@@ -16,7 +16,7 @@ public class SampleContributor extends BaseContributor<Filter, Context> implemen
 
     public static final String SAMPLE_FETCH = "SampleFetchResponse";
     public static final String SAMPLE_PRODUCE = "SampleProduceRequest";
-    public static final BaseContributorBuilder<Filter> FILTERS = BaseContributor.<Filter> builder()
+    public static final BaseContributorBuilder<Filter, Context> FILTERS = BaseContributor.<Filter, Context> builder()
             .add(SAMPLE_FETCH, SampleFilterConfig.class, SampleFetchResponseFilter::new)
             .add(SAMPLE_PRODUCE, SampleFilterConfig.class, SampleProduceRequestFilter::new);
 

--- a/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleContributor.java
+++ b/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleContributor.java
@@ -7,16 +7,16 @@
 package io.kroxylicious.sample;
 
 import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.filter.FilterConstructContext;
 import io.kroxylicious.proxy.filter.FilterContributor;
 import io.kroxylicious.proxy.service.BaseContributor;
-import io.kroxylicious.proxy.service.Context;
 import io.kroxylicious.sample.config.SampleFilterConfig;
 
-public class SampleContributor extends BaseContributor<Filter, Context> implements FilterContributor {
+public class SampleContributor extends BaseContributor<Filter, FilterConstructContext> implements FilterContributor {
 
     public static final String SAMPLE_FETCH = "SampleFetchResponse";
     public static final String SAMPLE_PRODUCE = "SampleProduceRequest";
-    public static final BaseContributorBuilder<Filter, Context> FILTERS = BaseContributor.<Filter, Context> builder()
+    public static final BaseContributorBuilder<Filter, FilterConstructContext> FILTERS = BaseContributor.<Filter, FilterConstructContext> builder()
             .add(SAMPLE_FETCH, SampleFilterConfig.class, SampleFetchResponseFilter::new)
             .add(SAMPLE_PRODUCE, SampleFilterConfig.class, SampleProduceRequestFilter::new);
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -11,6 +11,7 @@ import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.FilterDefinition;
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
 import io.kroxylicious.proxy.internal.filter.FilterContributorManager;
+import io.kroxylicious.proxy.internal.filter.NettyFilterContext;
 
 /**
  * Abstracts the creation of a chain of filter instances, hiding the configuration
@@ -30,7 +31,7 @@ public class FilterChainFactory {
      *
      * @return the new chain.
      */
-    public List<FilterAndInvoker> createFilters() {
+    public List<FilterAndInvoker> createFilters(NettyFilterContext context) {
         FilterContributorManager filterContributorManager = FilterContributorManager.getInstance();
 
         List<FilterDefinition> filters = config.filters();
@@ -39,7 +40,7 @@ public class FilterChainFactory {
         }
         return filters
                 .stream()
-                .map(f -> filterContributorManager.getFilter(f.type(), f.config()))
+                .map(f -> filterContributorManager.getFilter(f.type(), context, f.config()))
                 .flatMap(filter -> FilterAndInvoker.build(filter).stream())
                 .toList();
     }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -6,6 +6,7 @@
 package io.kroxylicious.proxy.bootstrap;
 
 import java.util.List;
+import java.util.Objects;
 
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.FilterDefinition;
@@ -23,6 +24,7 @@ public class FilterChainFactory {
     private final Configuration config;
 
     public FilterChainFactory(Configuration config) {
+        Objects.requireNonNull(config);
         this.config = config;
     }
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -34,6 +34,7 @@ import io.kroxylicious.proxy.internal.codec.KafkaResponseEncoder;
 import io.kroxylicious.proxy.internal.filter.ApiVersionsIntersectFilter;
 import io.kroxylicious.proxy.internal.filter.BrokerAddressFilter;
 import io.kroxylicious.proxy.internal.filter.EagerMetadataLearner;
+import io.kroxylicious.proxy.internal.filter.NettyFilterContext;
 import io.kroxylicious.proxy.internal.net.Endpoint;
 import io.kroxylicious.proxy.internal.net.EndpointReconciler;
 import io.kroxylicious.proxy.internal.net.VirtualClusterBinding;
@@ -175,7 +176,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
             var filterChainFactory = new FilterChainFactory(config);
             List<FilterAndInvoker> apiVersionFilters = dp.isAuthenticationOffloadEnabled() ? List.of()
                     : FilterAndInvoker.build(new ApiVersionsIntersectFilter(apiVersionService));
-            List<FilterAndInvoker> customProtocolFilters = filterChainFactory.createFilters();
+            List<FilterAndInvoker> customProtocolFilters = filterChainFactory.createFilters(new NettyFilterContext(ch.eventLoop()));
             List<FilterAndInvoker> brokerAddressFilters = FilterAndInvoker.build(new BrokerAddressFilter(virtualCluster, endpointReconciler));
             var filters = new ArrayList<>(apiVersionFilters);
             filters.addAll(customProtocolFilters);

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/BuiltinClusterNetworkAddressConfigProviderContributor.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/BuiltinClusterNetworkAddressConfigProviderContributor.java
@@ -10,8 +10,9 @@ import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.PortPe
 import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.SniRoutingClusterNetworkAddressConfigProvider.SniRoutingClusterNetworkAddressConfigProviderConfig;
 import io.kroxylicious.proxy.service.BaseContributor;
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
+import io.kroxylicious.proxy.service.Context;
 
-public class BuiltinClusterNetworkAddressConfigProviderContributor extends BaseContributor<ClusterNetworkAddressConfigProvider>
+public class BuiltinClusterNetworkAddressConfigProviderContributor extends BaseContributor<ClusterNetworkAddressConfigProvider, Context>
         implements ClusterNetworkAddressConfigProviderContributor {
 
     public static final BaseContributorBuilder<ClusterNetworkAddressConfigProvider> FILTERS = BaseContributor.<ClusterNetworkAddressConfigProvider> builder()

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/BuiltinClusterNetworkAddressConfigProviderContributor.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/BuiltinClusterNetworkAddressConfigProviderContributor.java
@@ -15,7 +15,8 @@ import io.kroxylicious.proxy.service.Context;
 public class BuiltinClusterNetworkAddressConfigProviderContributor extends BaseContributor<ClusterNetworkAddressConfigProvider, Context>
         implements ClusterNetworkAddressConfigProviderContributor {
 
-    public static final BaseContributorBuilder<ClusterNetworkAddressConfigProvider> FILTERS = BaseContributor.<ClusterNetworkAddressConfigProvider> builder()
+    public static final BaseContributorBuilder<ClusterNetworkAddressConfigProvider, Context> FILTERS = BaseContributor
+            .<ClusterNetworkAddressConfigProvider, Context> builder()
             .add("PortPerBroker", PortPerBrokerClusterNetworkAddressConfigProviderConfig.class, PortPerBrokerClusterNetworkAddressConfigProvider::new)
             .add("SniRouting", SniRoutingClusterNetworkAddressConfigProviderConfig.class, SniRoutingClusterNetworkAddressConfigProvider::new);
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/ClusterNetworkAddressConfigProviderContributorManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/ClusterNetworkAddressConfigProviderContributorManager.java
@@ -12,6 +12,8 @@ import io.kroxylicious.proxy.clusternetworkaddressconfigprovider.ClusterNetworkA
 import io.kroxylicious.proxy.config.BaseConfig;
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
 
+import static io.kroxylicious.proxy.service.Context.wrap;
+
 public class ClusterNetworkAddressConfigProviderContributorManager {
 
     private static final ClusterNetworkAddressConfigProviderContributorManager INSTANCE = new ClusterNetworkAddressConfigProviderContributorManager();
@@ -41,7 +43,7 @@ public class ClusterNetworkAddressConfigProviderContributorManager {
 
     public ClusterNetworkAddressConfigProvider getClusterEndpointConfigProvider(String shortName, BaseConfig baseConfig) {
         for (ClusterNetworkAddressConfigProviderContributor contributor : contributors) {
-            var assigner = contributor.getInstance(shortName, baseConfig);
+            var assigner = contributor.getInstance(shortName, wrap(baseConfig));
             if (assigner != null) {
                 return assigner;
             }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BuiltinFilterContributor.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BuiltinFilterContributor.java
@@ -14,7 +14,7 @@ import io.kroxylicious.proxy.service.Context;
 
 public class BuiltinFilterContributor extends BaseContributor<Filter, Context> implements FilterContributor {
 
-    public static final BaseContributorBuilder<Filter> FILTERS = BaseContributor.<Filter> builder()
+    public static final BaseContributorBuilder<Filter, Context> FILTERS = BaseContributor.<Filter, Context> builder()
             .add("ProduceRequestTransformation", ProduceRequestTransformationConfig.class, ProduceRequestTransformationFilter::new)
             .add("FetchResponseTransformation", FetchResponseTransformationConfig.class, FetchResponseTransformationFilter::new);
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BuiltinFilterContributor.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BuiltinFilterContributor.java
@@ -10,8 +10,9 @@ import io.kroxylicious.proxy.filter.FilterContributor;
 import io.kroxylicious.proxy.internal.filter.FetchResponseTransformationFilter.FetchResponseTransformationConfig;
 import io.kroxylicious.proxy.internal.filter.ProduceRequestTransformationFilter.ProduceRequestTransformationConfig;
 import io.kroxylicious.proxy.service.BaseContributor;
+import io.kroxylicious.proxy.service.Context;
 
-public class BuiltinFilterContributor extends BaseContributor<Filter> implements FilterContributor {
+public class BuiltinFilterContributor extends BaseContributor<Filter, Context> implements FilterContributor {
 
     public static final BaseContributorBuilder<Filter> FILTERS = BaseContributor.<Filter> builder()
             .add("ProduceRequestTransformation", ProduceRequestTransformationConfig.class, ProduceRequestTransformationFilter::new)

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BuiltinFilterContributor.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BuiltinFilterContributor.java
@@ -6,15 +6,15 @@
 package io.kroxylicious.proxy.internal.filter;
 
 import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.filter.FilterConstructContext;
 import io.kroxylicious.proxy.filter.FilterContributor;
 import io.kroxylicious.proxy.internal.filter.FetchResponseTransformationFilter.FetchResponseTransformationConfig;
 import io.kroxylicious.proxy.internal.filter.ProduceRequestTransformationFilter.ProduceRequestTransformationConfig;
 import io.kroxylicious.proxy.service.BaseContributor;
-import io.kroxylicious.proxy.service.Context;
 
-public class BuiltinFilterContributor extends BaseContributor<Filter, Context> implements FilterContributor {
+public class BuiltinFilterContributor extends BaseContributor<Filter, FilterConstructContext> implements FilterContributor {
 
-    public static final BaseContributorBuilder<Filter, Context> FILTERS = BaseContributor.<Filter, Context> builder()
+    public static final BaseContributorBuilder<Filter, FilterConstructContext> FILTERS = BaseContributor.<Filter, FilterConstructContext> builder()
             .add("ProduceRequestTransformation", ProduceRequestTransformationConfig.class, ProduceRequestTransformationFilter::new)
             .add("FetchResponseTransformation", FetchResponseTransformationConfig.class, FetchResponseTransformationFilter::new);
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterContributorManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterContributorManager.java
@@ -12,6 +12,8 @@ import io.kroxylicious.proxy.config.BaseConfig;
 import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterContributor;
 
+import static io.kroxylicious.proxy.service.Context.wrap;
+
 public class FilterContributorManager {
 
     private static final FilterContributorManager INSTANCE = new FilterContributorManager();
@@ -43,7 +45,7 @@ public class FilterContributorManager {
         Iterator<FilterContributor> it = contributors.iterator();
         while (it.hasNext()) {
             FilterContributor contributor = it.next();
-            Filter filter = contributor.getInstance(shortName, filterConfig);
+            Filter filter = contributor.getInstance(shortName, wrap(filterConfig));
             if (filter != null) {
                 return filter;
             }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterContributorManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterContributorManager.java
@@ -7,14 +7,11 @@ package io.kroxylicious.proxy.internal.filter;
 
 import java.util.Iterator;
 import java.util.ServiceLoader;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 
 import io.kroxylicious.proxy.config.BaseConfig;
 import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterConstructContext;
 import io.kroxylicious.proxy.filter.FilterContributor;
-import io.kroxylicious.proxy.filter.FilterExecutors;
 
 public class FilterContributorManager {
 
@@ -43,26 +40,12 @@ public class FilterContributorManager {
         throw new IllegalArgumentException("No filter found for name '" + shortName + "'");
     }
 
-    public Filter getFilter(String shortName, BaseConfig filterConfig) {
+    public Filter getFilter(String shortName, NettyFilterContext context, BaseConfig filterConfig) {
         Iterator<FilterContributor> it = contributors.iterator();
         while (it.hasNext()) {
             FilterContributor contributor = it.next();
-            Filter filter = contributor.getInstance(shortName, new FilterConstructContext() {
-                @Override
-                public FilterExecutors executors() {
-                    return new FilterExecutors() {
-                        @Override
-                        public ScheduledExecutorService eventLoop() {
-                            return Executors.newScheduledThreadPool(1);
-                        }
-                    };
-                }
-
-                @Override
-                public BaseConfig getConfig() {
-                    return filterConfig;
-                }
-            });
+            FilterConstructContext context1 = context.wrap(filterConfig);
+            Filter filter = contributor.getInstance(shortName, context1);
             if (filter != null) {
                 return filter;
             }
@@ -70,4 +53,5 @@ public class FilterContributorManager {
 
         throw new IllegalArgumentException("No filter found for name '" + shortName + "'");
     }
+
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/NettyFilterContext.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/NettyFilterContext.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.filter.FilterConstructContext;
+import io.kroxylicious.proxy.filter.FilterExecutors;
+
+public class NettyFilterContext {
+    private final ScheduledExecutorService eventLoop;
+
+    public NettyFilterContext(ScheduledExecutorService eventLoop) {
+        this.eventLoop = eventLoop;
+    }
+
+    FilterConstructContext wrap(BaseConfig config) {
+        return new NettyFilterConfigContext(config);
+    }
+
+    class NettyFilterConfigContext implements FilterConstructContext {
+        private final BaseConfig filterConfig;
+
+        NettyFilterConfigContext(BaseConfig filterConfig) {
+            this.filterConfig = filterConfig;
+        }
+
+        @Override
+        public FilterExecutors executors() {
+            return () -> eventLoop;
+        }
+
+        @Override
+        public BaseConfig getConfig() {
+            return filterConfig;
+        }
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/DefaultMicrometerConfigurationHookContributor.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/DefaultMicrometerConfigurationHookContributor.java
@@ -11,7 +11,7 @@ import io.kroxylicious.proxy.service.Context;
 public class DefaultMicrometerConfigurationHookContributor extends BaseContributor<MicrometerConfigurationHook, Context>
         implements MicrometerConfigurationHookContributor {
 
-    public static final BaseContributorBuilder<MicrometerConfigurationHook> BUILDER = BaseContributor.<MicrometerConfigurationHook> builder()
+    public static final BaseContributorBuilder<MicrometerConfigurationHook, Context> BUILDER = BaseContributor.<MicrometerConfigurationHook, Context> builder()
             .add("CommonTags", CommonTagsHook.CommonTagsHookConfig.class, CommonTagsHook::new)
             .add("StandardBinders", StandardBindersHook.StandardBindersHookConfig.class, StandardBindersHook::new);
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/DefaultMicrometerConfigurationHookContributor.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/DefaultMicrometerConfigurationHookContributor.java
@@ -6,8 +6,10 @@
 package io.kroxylicious.proxy.micrometer;
 
 import io.kroxylicious.proxy.service.BaseContributor;
+import io.kroxylicious.proxy.service.Context;
 
-public class DefaultMicrometerConfigurationHookContributor extends BaseContributor<MicrometerConfigurationHook> implements MicrometerConfigurationHookContributor {
+public class DefaultMicrometerConfigurationHookContributor extends BaseContributor<MicrometerConfigurationHook, Context>
+        implements MicrometerConfigurationHookContributor {
 
     public static final BaseContributorBuilder<MicrometerConfigurationHook> BUILDER = BaseContributor.<MicrometerConfigurationHook> builder()
             .add("CommonTags", CommonTagsHook.CommonTagsHookConfig.class, CommonTagsHook::new)

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/MicrometerConfigurationHookContributor.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/MicrometerConfigurationHookContributor.java
@@ -5,7 +5,8 @@
  */
 package io.kroxylicious.proxy.micrometer;
 
+import io.kroxylicious.proxy.service.Context;
 import io.kroxylicious.proxy.service.Contributor;
 
-public interface MicrometerConfigurationHookContributor extends Contributor<MicrometerConfigurationHook> {
+public interface MicrometerConfigurationHookContributor extends Contributor<MicrometerConfigurationHook, Context> {
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/MicrometerConfigurationHookContributorManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/MicrometerConfigurationHookContributorManager.java
@@ -9,6 +9,8 @@ import java.util.ServiceLoader;
 
 import io.kroxylicious.proxy.config.BaseConfig;
 
+import static io.kroxylicious.proxy.service.Context.wrap;
+
 public class MicrometerConfigurationHookContributorManager {
 
     private static final MicrometerConfigurationHookContributorManager INSTANCE = new MicrometerConfigurationHookContributorManager();
@@ -36,7 +38,7 @@ public class MicrometerConfigurationHookContributorManager {
 
     public MicrometerConfigurationHook getHook(String shortName, BaseConfig filterConfig) {
         for (MicrometerConfigurationHookContributor contributor : contributors) {
-            MicrometerConfigurationHook hook = contributor.getInstance(shortName, filterConfig);
+            MicrometerConfigurationHook hook = contributor.getInstance(shortName, wrap(filterConfig));
             if (hook != null) {
                 return hook;
             }

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
@@ -10,12 +10,19 @@ import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
+import org.assertj.core.api.ListAssert;
 import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.proxy.config.Configuration;
+import io.kroxylicious.proxy.config.FilterDefinition;
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
+import io.kroxylicious.proxy.internal.filter.ExampleConfig;
 import io.kroxylicious.proxy.internal.filter.NettyFilterContext;
+import io.kroxylicious.proxy.internal.filter.TestFilter;
+import io.kroxylicious.proxy.internal.filter.TestFilterContributor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -31,12 +38,58 @@ class FilterChainFactoryTest {
     }
 
     @Test
+    void testConfigurationNotNullable() {
+        assertThatThrownBy(() -> new FilterChainFactory(null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
     void testEmptyFiltersInConfigResultsInEmptyList() {
         ScheduledExecutorService eventLoop = Executors.newScheduledThreadPool(1);
         FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, List.of(), null, true));
         List<FilterAndInvoker> filters = filterChainFactory.createFilters(new NettyFilterContext(eventLoop));
         assertNotNull(filters, "Filters list should not be null");
         assertTrue(filters.isEmpty(), "Filters list should be empty");
+    }
+
+    @Test
+    void testCreateFilter() {
+        ScheduledExecutorService eventLoop = Executors.newScheduledThreadPool(1);
+        ExampleConfig config = new ExampleConfig();
+        FilterChainFactory filterChainFactory = new FilterChainFactory(
+                new Configuration(null, null, List.of(new FilterDefinition(TestFilterContributor.SHORT_NAME_A, config)), null, true));
+        NettyFilterContext context = new NettyFilterContext(eventLoop);
+        List<FilterAndInvoker> filters = filterChainFactory.createFilters(context);
+        assertThat(filters).isNotNull().hasSize(1).first().extracting(FilterAndInvoker::filter).isInstanceOfSatisfying(TestFilter.class, testFilter -> {
+            assertThat(testFilter.getShortName()).isEqualTo(TestFilterContributor.SHORT_NAME_A);
+            assertThat(testFilter.getContext().getConfig()).isSameAs(config);
+            assertThat(testFilter.getContext().executors().eventLoop()).isSameAs(eventLoop);
+            assertThat(testFilter.getExampleConfig()).isSameAs(config);
+        });
+    }
+
+    @Test
+    void testCreateFilters() {
+        ScheduledExecutorService eventLoop = Executors.newScheduledThreadPool(1);
+        ExampleConfig config = new ExampleConfig();
+        FilterDefinition definitionA = new FilterDefinition(TestFilterContributor.SHORT_NAME_A, config);
+        FilterDefinition definitionB = new FilterDefinition(TestFilterContributor.SHORT_NAME_B, config);
+        List<FilterDefinition> filterDefinitions = List.of(definitionA, definitionB);
+        FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, filterDefinitions, null, true));
+        NettyFilterContext context = new NettyFilterContext(eventLoop);
+        List<FilterAndInvoker> filters = filterChainFactory.createFilters(context);
+        ListAssert<FilterAndInvoker> listAssert = assertThat(filters).isNotNull().hasSize(2);
+        listAssert.element(0).extracting(FilterAndInvoker::filter).isInstanceOfSatisfying(TestFilter.class, testFilter -> {
+            assertThat(testFilter.getShortName()).isEqualTo(TestFilterContributor.SHORT_NAME_A);
+            assertThat(testFilter.getContext().getConfig()).isSameAs(config);
+            assertThat(testFilter.getContext().executors().eventLoop()).isSameAs(eventLoop);
+            assertThat(testFilter.getExampleConfig()).isSameAs(config);
+        });
+        listAssert.element(1).extracting(FilterAndInvoker::filter).isInstanceOfSatisfying(TestFilter.class, testFilter -> {
+            assertThat(testFilter.getShortName()).isEqualTo(TestFilterContributor.SHORT_NAME_B);
+            assertThat(testFilter.getContext().getConfig()).isSameAs(config);
+            assertThat(testFilter.getContext().executors().eventLoop()).isSameAs(eventLoop);
+            assertThat(testFilter.getExampleConfig()).isSameAs(config);
+        });
     }
 
 }

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
@@ -7,11 +7,14 @@
 package io.kroxylicious.proxy.bootstrap;
 
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
+import io.kroxylicious.proxy.internal.filter.NettyFilterContext;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -20,16 +23,18 @@ class FilterChainFactoryTest {
 
     @Test
     void testNullFiltersInConfigResultsInEmptyList() {
+        ScheduledExecutorService eventLoop = Executors.newScheduledThreadPool(1);
         FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, null, null, true));
-        List<FilterAndInvoker> filters = filterChainFactory.createFilters();
+        List<FilterAndInvoker> filters = filterChainFactory.createFilters(new NettyFilterContext(eventLoop));
         assertNotNull(filters, "Filters list should not be null");
         assertTrue(filters.isEmpty(), "Filters list should be empty");
     }
 
     @Test
     void testEmptyFiltersInConfigResultsInEmptyList() {
+        ScheduledExecutorService eventLoop = Executors.newScheduledThreadPool(1);
         FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, List.of(), null, true));
-        List<FilterAndInvoker> filters = filterChainFactory.createFilters();
+        List<FilterAndInvoker> filters = filterChainFactory.createFilters(new NettyFilterContext(eventLoop));
         assertNotNull(filters, "Filters list should not be null");
         assertTrue(filters.isEmpty(), "Filters list should be empty");
     }

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/ClusterNetworkAddressConfigProviderContributorManagerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/ClusterNetworkAddressConfigProviderContributorManagerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
+
+import static io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.TestClusterNetworkAddressConfigProviderContributor.SHORT_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ClusterNetworkAddressConfigProviderContributorManagerTest {
+
+    public static final ClusterNetworkAddressConfigProviderContributorManager INSTANCE = ClusterNetworkAddressConfigProviderContributorManager.getInstance();
+
+    @Test
+    void testGetConfigType() {
+        Class<? extends BaseConfig> clazz = INSTANCE.getConfigType(SHORT_NAME);
+        assertThat(clazz).isEqualTo(Config.class);
+    }
+
+    @Test
+    void testGetConfigTypeFailsWhenShortnameHasNoMatches() {
+        assertThatThrownBy(() -> INSTANCE.getConfigType("mismatch")).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("No endpoint provider found for name 'mismatch'");
+    }
+
+    @Test
+    void testGetClusterEndpointProvider() {
+        Config config = new Config();
+        ClusterNetworkAddressConfigProvider provider = INSTANCE.getClusterEndpointConfigProvider(SHORT_NAME, config);
+        assertThat(provider).isInstanceOf(TestClusterNetworkAddressConfigProvider.class);
+        TestClusterNetworkAddressConfigProvider testProvider = (TestClusterNetworkAddressConfigProvider) provider;
+        assertThat(testProvider.config()).isSameAs(config);
+        assertThat(testProvider.shortName()).isEqualTo(SHORT_NAME);
+        assertThat(testProvider.context().getConfig()).isEqualTo(config);
+    }
+
+    @Test
+    void testGetClusterEndpointProviderFailsWhenShortnameHasNoMatches() {
+        Config config = new Config();
+        assertThatThrownBy(() -> INSTANCE.getClusterEndpointConfigProvider("mismatch", config))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("No endpoint provider found for name 'mismatch'");
+    }
+
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/Config.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/Config.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+
+public class Config extends BaseConfig {
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/TestClusterNetworkAddressConfigProvider.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/TestClusterNetworkAddressConfigProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
+
+import org.testcontainers.shaded.org.apache.commons.lang3.NotImplementedException;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
+import io.kroxylicious.proxy.service.Context;
+import io.kroxylicious.proxy.service.HostPort;
+
+public record TestClusterNetworkAddressConfigProvider(String shortName, BaseConfig config, Context context) implements ClusterNetworkAddressConfigProvider {
+    @Override
+    public HostPort getClusterBootstrapAddress() {
+        throw new NotImplementedException("not implemented!");
+    }
+
+    @Override
+    public HostPort getBrokerAddress(int nodeId) throws IllegalArgumentException {
+        throw new NotImplementedException("not implemented!");
+    }
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/TestClusterNetworkAddressConfigProviderContributor.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/TestClusterNetworkAddressConfigProviderContributor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
+
+import java.util.Objects;
+
+import io.kroxylicious.proxy.clusternetworkaddressconfigprovider.ClusterNetworkAddressConfigProviderContributor;
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
+import io.kroxylicious.proxy.service.Context;
+
+public class TestClusterNetworkAddressConfigProviderContributor implements ClusterNetworkAddressConfigProviderContributor {
+
+    public static final String SHORT_NAME = "test";
+
+    @Override
+    public Class<? extends BaseConfig> getConfigType(String shortName) {
+        if (!Objects.equals(shortName, SHORT_NAME)) {
+            return null;
+        }
+        return Config.class;
+    }
+
+    @Override
+    public ClusterNetworkAddressConfigProvider getInstance(String shortName, Context context) {
+        if (!Objects.equals(shortName, SHORT_NAME)) {
+            return null;
+        }
+        return new TestClusterNetworkAddressConfigProvider(shortName, context.getConfig(), context);
+    }
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/ExampleConfig.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/ExampleConfig.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+
+public class ExampleConfig extends BaseConfig {
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestFilter.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestFilter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.RequestFilter;
+import io.kroxylicious.proxy.filter.RequestFilterResult;
+
+public class TestFilter implements RequestFilter {
+    private final String shortName;
+    private final FilterContext context;
+    private final ExampleConfig exampleConfig;
+
+    public TestFilter(String shortName, FilterContext context, ExampleConfig exampleConfig) {
+        this.shortName = shortName;
+        this.context = context;
+        this.exampleConfig = exampleConfig;
+    }
+
+    @Override
+    public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage request, KrpcFilterContext context) {
+        throw new IllegalStateException("not implemented!");
+    }
+
+    public String getShortName() {
+        return shortName;
+    }
+
+    public FilterContext getContext() {
+        return context;
+    }
+
+    public ExampleConfig getExampleConfig() {
+        return exampleConfig;
+    }
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestFilter.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestFilter.java
@@ -12,24 +12,24 @@ import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
 
+import io.kroxylicious.proxy.filter.FilterConstructContext;
 import io.kroxylicious.proxy.filter.FilterContext;
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
 import io.kroxylicious.proxy.filter.RequestFilter;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 
 public class TestFilter implements RequestFilter {
     private final String shortName;
-    private final FilterContext context;
+    private final FilterConstructContext context;
     private final ExampleConfig exampleConfig;
 
-    public TestFilter(String shortName, FilterContext context, ExampleConfig exampleConfig) {
+    public TestFilter(String shortName, FilterConstructContext context, ExampleConfig exampleConfig) {
         this.shortName = shortName;
         this.context = context;
         this.exampleConfig = exampleConfig;
     }
 
     @Override
-    public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage request, KrpcFilterContext context) {
+    public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage request, FilterContext context) {
         throw new IllegalStateException("not implemented!");
     }
 
@@ -37,7 +37,7 @@ public class TestFilter implements RequestFilter {
         return shortName;
     }
 
-    public FilterContext getContext() {
+    public FilterConstructContext getContext() {
         return context;
     }
 

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestFilterContributor.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestFilterContributor.java
@@ -6,15 +6,15 @@
 
 package io.kroxylicious.proxy.internal.filter;
 
-import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.filter.FilterConstructContext;
 import io.kroxylicious.proxy.filter.FilterContributor;
-import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.service.BaseContributor;
 
-public class TestFilterContributor extends BaseContributor<KrpcFilter, FilterContext> implements FilterContributor {
+public class TestFilterContributor extends BaseContributor<Filter, FilterConstructContext> implements FilterContributor {
     public static final String SHORT_NAME_A = "TEST1";
     public static final String SHORT_NAME_B = "TEST2";
-    public static final BaseContributorBuilder<KrpcFilter, FilterContext> FILTERS = BaseContributor.<KrpcFilter, FilterContext> builder()
+    public static final BaseContributorBuilder<Filter, FilterConstructContext> FILTERS = BaseContributor.<Filter, FilterConstructContext> builder()
             .add(SHORT_NAME_A, ExampleConfig.class, (context, exampleConfig) -> new TestFilter(SHORT_NAME_A, context, exampleConfig))
             .add(SHORT_NAME_B, ExampleConfig.class, (context, exampleConfig) -> new TestFilter(SHORT_NAME_B, context, exampleConfig));
 

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestFilterContributor.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestFilterContributor.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.FilterContributor;
+import io.kroxylicious.proxy.filter.KrpcFilter;
+import io.kroxylicious.proxy.service.BaseContributor;
+
+public class TestFilterContributor extends BaseContributor<KrpcFilter, FilterContext> implements FilterContributor {
+    public static final String SHORT_NAME_A = "TEST1";
+    public static final String SHORT_NAME_B = "TEST2";
+    public static final BaseContributorBuilder<KrpcFilter, FilterContext> FILTERS = BaseContributor.<KrpcFilter, FilterContext> builder()
+            .add(SHORT_NAME_A, ExampleConfig.class, (context, exampleConfig) -> new TestFilter(SHORT_NAME_A, context, exampleConfig))
+            .add(SHORT_NAME_B, ExampleConfig.class, (context, exampleConfig) -> new TestFilter(SHORT_NAME_B, context, exampleConfig));
+
+    public TestFilterContributor() {
+        super(FILTERS);
+    }
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/micrometer/MicrometerConfigurationHookContributorManagerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/micrometer/MicrometerConfigurationHookContributorManagerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.micrometer;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.micrometer.TestMicrometerConfigurationHookContributor.Config;
+
+import static io.kroxylicious.proxy.micrometer.TestMicrometerConfigurationHookContributor.SHORT_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MicrometerConfigurationHookContributorManagerTest {
+
+    public static final MicrometerConfigurationHookContributorManager INSTANCE = MicrometerConfigurationHookContributorManager.getInstance();
+
+    @Test
+    void testGetConfigType() {
+        Class<? extends BaseConfig> clazz = INSTANCE.getConfigType(SHORT_NAME);
+        assertThat(clazz).isEqualTo(Config.class);
+    }
+
+    @Test
+    void testGetConfigTypeWhenNoContributorMatchesShortName() {
+        assertThatThrownBy(() -> INSTANCE.getConfigType("mismatched"))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("No micrometer configuration hook found for name 'mismatched'");
+    }
+
+    @Test
+    void testGetHook() {
+        Config config = new Config();
+        MicrometerConfigurationHook hook = INSTANCE.getHook(SHORT_NAME, config);
+        assertThat(hook).isInstanceOf(TestHook.class);
+        TestHook hook1 = (TestHook) hook;
+        assertThat(hook1.shortName()).isEqualTo(SHORT_NAME);
+        assertThat(hook1.context().getConfig()).isSameAs(config);
+        assertThat(hook1.config()).isSameAs(config);
+    }
+
+    @Test
+    void testGetHookTypeWhenNoContributorMatchesShortName() {
+        Config config = new Config();
+        assertThatThrownBy(() -> INSTANCE.getHook("mismatched", config))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("No micrometer configuration hook found for name 'mismatched'");
+    }
+
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/micrometer/TestHook.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/micrometer/TestHook.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.micrometer;
+
+import org.testcontainers.shaded.org.apache.commons.lang3.NotImplementedException;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.service.Context;
+
+public record TestHook(String shortName, BaseConfig config, Context context) implements MicrometerConfigurationHook {
+    @Override
+    public void configure(MeterRegistry targetRegistry) {
+        throw new NotImplementedException("not implemented!");
+    }
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/micrometer/TestMicrometerConfigurationHookContributor.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/micrometer/TestMicrometerConfigurationHookContributor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.micrometer;
+
+import java.util.Objects;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.service.Context;
+
+public class TestMicrometerConfigurationHookContributor implements MicrometerConfigurationHookContributor {
+
+    public static class Config extends BaseConfig {
+
+    }
+
+    public static final String SHORT_NAME = "test";
+
+    @Override
+    public Class<? extends BaseConfig> getConfigType(String shortName) {
+        if (Objects.equals(shortName, SHORT_NAME)) {
+            return Config.class;
+        }
+        else {
+            return null;
+        }
+    }
+
+    @Override
+    public MicrometerConfigurationHook getInstance(String shortName, Context context) {
+        if (!Objects.equals(shortName, SHORT_NAME)) {
+            return null;
+        }
+        return new TestHook(shortName, context.getConfig(), context);
+    }
+}

--- a/kroxylicious/src/test/resources/META-INF/services/io.kroxylicious.proxy.clusternetworkaddressconfigprovider.ClusterNetworkAddressConfigProviderContributor
+++ b/kroxylicious/src/test/resources/META-INF/services/io.kroxylicious.proxy.clusternetworkaddressconfigprovider.ClusterNetworkAddressConfigProviderContributor
@@ -1,0 +1,1 @@
+io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.TestClusterNetworkAddressConfigProviderContributor

--- a/kroxylicious/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterContributor
+++ b/kroxylicious/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterContributor
@@ -1,0 +1,1 @@
+io.kroxylicious.proxy.internal.filter.TestFilterContributor

--- a/kroxylicious/src/test/resources/META-INF/services/io.kroxylicious.proxy.micrometer.MicrometerConfigurationHookContributor
+++ b/kroxylicious/src/test/resources/META-INF/services/io.kroxylicious.proxy.micrometer.MicrometerConfigurationHookContributor
@@ -1,0 +1,1 @@
+io.kroxylicious.proxy.micrometer.TestMicrometerConfigurationHookContributor


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

We want to begin making some resources available to Filter instances at contruction time. Some examples might be:
* executors like the event loop for the filter, or a shared blocking pool
* user-defined expensive components which may have their own threading model and pools
* virtual cluster name
* shared state that we want to be available across channels

This adds a concept of `Context` to `io.kroxylicious.proxy.service`:
```
public interface Context {
    BaseConfig getConfig();
}
```
and the Contributor interface changes to
```
public interface Contributor<T, S extends Context> {
    Class<? extends BaseConfig> getConfigType(String shortName);

    T getInstance(String shortName, S context);
}
```

`Context` is meant to represent information about the context in which the Contributor is being invoked to get an instance. So for a FilterContributor, the invocation will be relative to a virtual cluster and a netty channel. It also contains the configuration object parsed from the YAML configuration file.

We then add a `FilterContext` class used by `FilterContributor` that can offer the netty event loop, plus extend the `BaseContributor` to provide typesafe conveniences for registering filters. Users of BaseContributor will be able

### example usage

given a filter implementation `ExampleFilter` with a custom configuration class `ExampleConfig` and a constructor like:
```
ExampleFilter(ScheduledExecutorService executorService, ExampleConfig config)
````
We can populate it with the event loop in a custom Contributor implementation like this":

```java
import io.kroxylicious.proxy.service.BaseContributor;

public class ExampleContributor extends BaseContributor<KrpcFilter, FilterContext> implements FilterContributor {

    public static final BaseContributorBuilder<KrpcFilter, FilterContext> FILTERS = BaseContributor.<KrpcFilter, FilterContext> builder()
            .add("Example", ExampleConfig.class, (context, config) -> {
                return new ExampleFilter(context.executors().eventLoop(), config);
            });

    public TestFilterContributor() {
        super(FILTERS);
    }
}
```

Or it could accept FilterContext directly like:
```
ExampleFilter(FilterContext context, ExampleConfig config)
````

```java
import io.kroxylicious.proxy.service.BaseContributor;

public class ExampleContributor extends BaseContributor<KrpcFilter, FilterContext> implements FilterContributor {

    public static final BaseContributorBuilder<KrpcFilter, FilterContext> FILTERS = BaseContributor.<KrpcFilter, FilterContext> builder()
            .add("Example", ExampleConfig.class, ExampleFilter::new);

    public TestFilterContributor() {
        super(FILTERS);
    }
}
```

Or if there is no configuration for that filter it could accept:
```
ExampleFilter(FilterContext context)
````

```java
import io.kroxylicious.proxy.service.BaseContributor;

public class ExampleContributor extends BaseContributor<KrpcFilter, FilterContext> implements FilterContributor {

    public static final BaseContributorBuilder<KrpcFilter, FilterContext> FILTERS = BaseContributor.<KrpcFilter, FilterContext> builder()
            .add("Example", ExampleFilter::new);

    public TestFilterContributor() {
        super(FILTERS);
    }
}
```

or

```
ExampleFilter(ScheduledExecutorService service)
````

```java
import io.kroxylicious.proxy.service.BaseContributor;

public class ExampleContributor extends BaseContributor<KrpcFilter, FilterContext> implements FilterContributor {

    public static final BaseContributorBuilder<KrpcFilter, FilterContext> FILTERS = BaseContributor.<KrpcFilter, FilterContext> builder()
            .add("Example", context -> new ExampleFilter(context.executors().eventLoop()));

    public TestFilterContributor() {
        super(FILTERS);
    }
}
```
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
