### PR TITLE
Add ApiVersionsService to KrpcFilterContext

### DIFF
--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/ApiVersionsMarkingFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/ApiVersionsMarkingFilter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.types.RawTaggedField;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class ApiVersionsMarkingFilter implements RequestFilter {
+
+    public static final int INTERSECTED_API_VERSION_RANGE_TAG = 89;
+    public static final int UPSTREAM_API_VERSION_RANGE_TAG = 90;
+
+    @Override
+    public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage request, FilterContext context) {
+        return context.getApiVersionsService().getApiVersionRanges(apiKey).thenCompose(apiVersion -> {
+            ApiVersionsResponseData.ApiVersion intersected = apiVersion.intersected();
+            request.unknownTaggedFields().add(new RawTaggedField(INTERSECTED_API_VERSION_RANGE_TAG, (intersected.minVersion() + "-" + intersected.maxVersion()).getBytes(
+                    UTF_8)));
+            ApiVersionsResponseData.ApiVersion upstream = apiVersion.upstream();
+            request.unknownTaggedFields().add(new RawTaggedField(UPSTREAM_API_VERSION_RANGE_TAG, (upstream.minVersion() + "-" + upstream.maxVersion()).getBytes(
+                    UTF_8)));
+            return context.forwardRequest(header, request);
+        });
+    }
+}

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RequestResponseMarkingFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RequestResponseMarkingFilter.java
@@ -58,7 +58,6 @@ public class RequestResponseMarkingFilter implements RequestFilter, ResponseFilt
         if (!(direction.contains(Direction.REQUEST) && keysToMark.contains(apiKey))) {
             return context.forwardRequest(header, body);
         }
-
         return forwardingStyle.apply(context, body)
                 .thenApply(request -> applyTaggedField(request, Direction.REQUEST, name))
                 .thenCompose(taggedRequest -> context.forwardRequest(header, taggedRequest));

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
@@ -12,6 +12,7 @@ public class TestFilterContributor extends BaseContributor<Filter> implements Fi
 
     public static final BaseContributorBuilder<Filter> FILTERS = BaseContributor.<Filter> builder()
             .add("FixedClientId", FixedClientIdFilter.FixedClientIdFilterConfig.class, FixedClientIdFilter::new)
+            .add("ApiVersionsMarkingFilter", ApiVersionsMarkingFilter::new)
             .add("RequestResponseMarking", RequestResponseMarkingFilter.RequestResponseMarkingFilterConfig.class, RequestResponseMarkingFilter::new)
             .add("OutOfBandSend", OutOfBandSendFilter.OutOfBandSendFilterConfig.class, OutOfBandSendFilter::new)
             .add("CompositePrefixingFixedClientId", CompositePrefixingFixedClientIdFilterConfig.class, CompositePrefixingFixedClientIdFilter::new)

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/ApiVersionsService.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/ApiVersionsService.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy;
+
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersion;
+import org.apache.kafka.common.protocol.ApiKeys;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+public interface ApiVersionsService {
+
+    /**
+     * Information about version ranges for an ApiKey supported by the upstream and Kroxylicious
+     * @param upstream the version range supported by the upstream server, or null if this key is not supported by upstream
+     * @param intersected the version range supported by both Kroxylicious and the upstream server, or null if this ApiKey is not supported
+     */
+    record ApiVersionRanges(@Nullable ApiVersion upstream, @Nullable ApiVersion intersected) {
+    }
+
+    /**
+     * Get the supported version ranges for an ApiKey. Will contain the upstream supported
+     * version range, and the intersected version range supported by the proxy and upstream.
+     * Filters will likely want to work with the intersected range as both the proxy and the
+     * upstream can parse those versions.
+     * @param keys keys
+     * @return a CompletionStage that will be completed with the upstream ApiVersionRanges
+     */
+    CompletionStage<ApiVersionRanges> getApiVersionRanges(ApiKeys keys);
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/ApiVersionsService.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/ApiVersionsService.java
@@ -6,12 +6,13 @@
 
 package io.kroxylicious.proxy;
 
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersion;
 import org.apache.kafka.common.protocol.ApiKeys;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public interface ApiVersionsService {
 
@@ -20,7 +21,7 @@ public interface ApiVersionsService {
      * @param upstream the version range supported by the upstream server, or null if this key is not supported by upstream
      * @param intersected the version range supported by both Kroxylicious and the upstream server, or null if this ApiKey is not supported
      */
-    record ApiVersionRanges(@Nullable ApiVersion upstream, @Nullable ApiVersion intersected) {
+    record ApiVersionRanges(@NonNull ApiVersion upstream, @NonNull ApiVersion intersected) {
     }
 
     /**
@@ -29,7 +30,8 @@ public interface ApiVersionsService {
      * Filters will likely want to work with the intersected range as both the proxy and the
      * upstream can parse those versions.
      * @param keys keys
-     * @return a CompletionStage that will be completed with the upstream ApiVersionRanges
+     * @return a CompletionStage that will be completed with the upstream ApiVersionRanges,
+     * or an empty optional if the upstream doesn't support this key
      */
-    CompletionStage<ApiVersionRanges> getApiVersionRanges(ApiKeys keys);
+    CompletionStage<Optional<ApiVersionRanges>> getApiVersionRanges(ApiKeys keys);
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
@@ -14,6 +14,8 @@ import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 
+import io.kroxylicious.proxy.ApiVersionsService;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -124,4 +126,11 @@ public interface FilterContext {
      */
     String getVirtualClusterName();
     // TODO an API to allow a filter to add/remove another filter from the pipeline
+
+    /**
+     * Gets a Service responsible for exposing the API versions supported by the
+     * upstream broker and kroxylicious
+     * @return apiVersionsService
+     */
+    ApiVersionsService getApiVersionsService();
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -6,6 +6,7 @@
 package io.kroxylicious.proxy.internal;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
@@ -538,7 +539,7 @@ public class FilterHandler extends ChannelDuplexHandler {
         }
 
         @Override
-        public CompletionStage<ApiVersionRanges> getApiVersionRanges(ApiKeys keys) {
+        public CompletionStage<Optional<ApiVersionRanges>> getApiVersionRanges(ApiKeys keys) {
             return apiVersionService.getApiVersionRanges(keys, this);
         }
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -29,6 +29,7 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 
+import io.kroxylicious.proxy.ApiVersionsService;
 import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
 import io.kroxylicious.proxy.filter.FilterContext;
@@ -64,17 +65,20 @@ public class FilterHandler extends ChannelDuplexHandler {
     private final String sniHostname;
     private final VirtualCluster virtualCluster;
     private final Channel inboundChannel;
+    private final ApiVersionsServiceImpl apiVersionService;
     private CompletableFuture<Void> writeFuture = CompletableFuture.completedFuture(null);
     private CompletableFuture<Void> readFuture = CompletableFuture.completedFuture(null);
     private ChannelHandlerContext ctx;
 
-    public FilterHandler(FilterAndInvoker filterAndInvoker, long timeoutMs, String sniHostname, VirtualCluster virtualCluster, Channel inboundChannel) {
+    public FilterHandler(FilterAndInvoker filterAndInvoker, long timeoutMs, String sniHostname, VirtualCluster virtualCluster, Channel inboundChannel,
+                         ApiVersionsServiceImpl apiVersionService) {
         this.filter = Objects.requireNonNull(filterAndInvoker).filter();
         this.invoker = filterAndInvoker.invoker();
         this.timeoutMs = Assertions.requireStrictlyPositive(timeoutMs, "timeout");
         this.sniHostname = sniHostname;
         this.virtualCluster = virtualCluster;
         this.inboundChannel = inboundChannel;
+        this.apiVersionService = apiVersionService;
     }
 
     String filterDescriptor() {
@@ -161,7 +165,7 @@ public class FilterHandler extends ChannelDuplexHandler {
     }
 
     private CompletableFuture<Void> readDecodedResponse(DecodedResponseFrame<?> decodedFrame) {
-        var filterContext = new InternalFilterContext(decodedFrame);
+        var filterContext = new InternalFilterContext(decodedFrame, apiVersionService);
 
         final var future = dispatchDecodedResponseFrame(decodedFrame, filterContext);
         boolean defer = !future.isDone();
@@ -201,7 +205,7 @@ public class FilterHandler extends ChannelDuplexHandler {
     }
 
     private CompletableFuture<Void> writeDecodedRequest(DecodedRequestFrame<?> decodedFrame, ChannelPromise promise) {
-        var filterContext = new InternalFilterContext(decodedFrame);
+        var filterContext = new InternalFilterContext(decodedFrame, apiVersionService);
         final var future = dispatchDecodedRequest(decodedFrame, filterContext);
         boolean defer = !future.isDone();
         if (defer) {
@@ -427,12 +431,14 @@ public class FilterHandler extends ChannelDuplexHandler {
         });
     }
 
-    private class InternalFilterContext implements FilterContext {
+    private class InternalFilterContext implements FilterContext, ApiVersionsService {
 
         private final DecodedFrame<?, ?> decodedFrame;
+        private final ApiVersionsServiceImpl apiVersionService;
 
-        InternalFilterContext(DecodedFrame<?, ?> decodedFrame) {
+        InternalFilterContext(DecodedFrame<?, ?> decodedFrame, ApiVersionsServiceImpl apiVersionService) {
             this.decodedFrame = decodedFrame;
+            this.apiVersionService = apiVersionService;
         }
 
         @Override
@@ -455,6 +461,11 @@ public class FilterHandler extends ChannelDuplexHandler {
 
         public String getVirtualClusterName() {
             return virtualCluster.getClusterName();
+        }
+
+        @Override
+        public ApiVersionsService getApiVersionsService() {
+            return this;
         }
 
         @Override
@@ -525,5 +536,11 @@ public class FilterHandler extends ChannelDuplexHandler {
             }, timeoutMs, TimeUnit.MILLISECONDS);
             return filterStage;
         }
+
+        @Override
+        public CompletionStage<ApiVersionRanges> getApiVersionRanges(ApiKeys keys) {
+            return apiVersionService.getApiVersionRanges(keys, this);
+        }
+
     }
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -69,6 +69,7 @@ public class KafkaProxyFrontendHandler
 
     private final boolean logNetwork;
     private final boolean logFrames;
+    private final ApiVersionsServiceImpl apiVersionService;
     private final VirtualCluster virtualCluster;
 
     private ChannelHandlerContext outboundCtx;
@@ -133,12 +134,14 @@ public class KafkaProxyFrontendHandler
 
     KafkaProxyFrontendHandler(NetFilter filter,
                               SaslDecodePredicate dp,
-                              VirtualCluster virtualCluster) {
+                              VirtualCluster virtualCluster,
+                              ApiVersionsServiceImpl apiVersionService) {
         this.filter = filter;
         this.dp = dp;
         this.virtualCluster = virtualCluster;
         this.logNetwork = virtualCluster.isLogNetwork();
         this.logFrames = virtualCluster.isLogFrames();
+        this.apiVersionService = apiVersionService;
     }
 
     private IllegalStateException illegalState(String msg) {
@@ -336,7 +339,7 @@ public class KafkaProxyFrontendHandler
     private void addFiltersToPipeline(List<FilterAndInvoker> filters, ChannelPipeline pipeline, Channel inboundChannel) {
         for (var filter : filters) {
             // TODO configurable timeout
-            pipeline.addFirst(filter.toString(), new FilterHandler(filter, 20000, sniHostname, virtualCluster, inboundChannel));
+            pipeline.addFirst(filter.toString(), new FilterHandler(filter, 20000, sniHostname, virtualCluster, inboundChannel, apiVersionService));
         }
     }
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ApiVersionsIntersectFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ApiVersionsIntersectFilter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.filter;
+
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+
+import io.kroxylicious.proxy.filter.ApiVersionsResponseFilter;
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.ResponseFilterResult;
+import io.kroxylicious.proxy.internal.ApiVersionsServiceImpl;
+
+/**
+ * Changes an API_VERSIONS response so that a client sees the intersection of supported version ranges for each
+ * API key. This is an intrinsic part of correctly acting as a proxy.
+ */
+public class ApiVersionsIntersectFilter implements ApiVersionsResponseFilter {
+    private final ApiVersionsServiceImpl apiVersionsService;
+
+    public ApiVersionsIntersectFilter(ApiVersionsServiceImpl service) {
+        this.apiVersionsService = service;
+    }
+
+    @Override
+    public CompletionStage<ResponseFilterResult> onApiVersionsResponse(short apiVersion, ResponseHeaderData header, ApiVersionsResponseData data,
+                                                                       FilterContext context) {
+        apiVersionsService.mutateVersionsApplyingIntersection(context.channelDescriptor(), data);
+        return context.forwardResponse(header, data);
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ApiVersionsIntersectFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ApiVersionsIntersectFilter.java
@@ -29,7 +29,7 @@ public class ApiVersionsIntersectFilter implements ApiVersionsResponseFilter {
     @Override
     public CompletionStage<ResponseFilterResult> onApiVersionsResponse(short apiVersion, ResponseHeaderData header, ApiVersionsResponseData data,
                                                                        FilterContext context) {
-        apiVersionsService.mutateVersionsApplyingIntersection(context.channelDescriptor(), data);
+        apiVersionsService.updateVersions(context.channelDescriptor(), data);
         return context.forwardResponse(header, data);
     }
 }

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/ApiVersionsServiceImplTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/ApiVersionsServiceImplTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.kroxylicious.proxy.ApiVersionsService;
+import io.kroxylicious.proxy.filter.FilterContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyShort;
+
+class ApiVersionsServiceImplTest {
+
+    @Test
+    void testGetVersionRanges_UsesCachedResultFromIntersectionMutation() {
+        ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl();
+        ApiVersionsResponseData upstreamApiVersions = createApiVersionsWith(ApiKeys.METADATA.id, (short) (ApiKeys.METADATA.oldestVersion() + 1),
+                (short) (ApiKeys.METADATA.latestVersion() + 1));
+        apiVersionsService.mutateVersionsApplyingIntersection("channel", upstreamApiVersions);
+        ApiVersionsService.ApiVersionRanges range = apiVersionsService.getApiVersionRanges(ApiKeys.METADATA, Mockito.mock(FilterContext.class)).toCompletableFuture()
+                .getNow(null);
+        assertThat(range).isNotNull();
+        assertThat(range.upstream().minVersion()).isEqualTo((short) (ApiKeys.METADATA.oldestVersion() + 1));
+        assertThat(range.upstream().maxVersion()).isEqualTo((short) (ApiKeys.METADATA.latestVersion() + 1));
+        assertThat(range.intersected().minVersion()).isEqualTo((short) (ApiKeys.METADATA.oldestVersion() + 1));
+        assertThat(range.intersected().maxVersion()).isEqualTo(ApiKeys.METADATA.latestVersion());
+    }
+
+    @Test
+    void testGetVersionRanges_UsesFilterContextToObtainVersionsIfRequired() {
+        ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl();
+        ApiVersionsResponseData upstreamApiVersions = createApiVersionsWith(ApiKeys.METADATA.id, (short) (ApiKeys.METADATA.oldestVersion() - 1),
+                (short) (ApiKeys.METADATA.latestVersion() - 1));
+        FilterContext filterContext = Mockito.mock(FilterContext.class);
+        Mockito.when(filterContext.sendRequest(anyShort(), any())).thenReturn(CompletableFuture.completedFuture(upstreamApiVersions));
+        ApiVersionsService.ApiVersionRanges range = apiVersionsService.getApiVersionRanges(ApiKeys.METADATA, filterContext).toCompletableFuture()
+                .getNow(null);
+        assertThat(range).isNotNull();
+        assertThat(range.upstream().minVersion()).isEqualTo((short) (ApiKeys.METADATA.oldestVersion() - 1));
+        assertThat(range.upstream().maxVersion()).isEqualTo((short) (ApiKeys.METADATA.latestVersion() - 1));
+        assertThat(range.intersected().minVersion()).isEqualTo(ApiKeys.METADATA.oldestVersion());
+        assertThat(range.intersected().maxVersion()).isEqualTo((short) (ApiKeys.METADATA.latestVersion() - 1));
+    }
+
+    @Test
+    void testIntersection_UpstreamMatchesApiKeys() {
+        ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl();
+        ApiVersionsResponseData upstreamApiVersions = createApiVersionsWith(ApiKeys.METADATA.id, ApiKeys.METADATA.oldestVersion(),
+                ApiKeys.METADATA.latestVersion());
+        apiVersionsService.mutateVersionsApplyingIntersection("channel", upstreamApiVersions);
+        assertThatApiVersionsContainsExactly(upstreamApiVersions, ApiKeys.METADATA, ApiKeys.METADATA.oldestVersion(), ApiKeys.METADATA.latestVersion());
+    }
+
+    @Test
+    void testIntersection_UpstreamMinVersionLessThanApiKeys() {
+        ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl();
+        ApiVersionsResponseData upstreamApiVersions = createApiVersionsWith(ApiKeys.METADATA.id, (short) (ApiKeys.METADATA.oldestVersion() - 1),
+                ApiKeys.METADATA.latestVersion());
+        apiVersionsService.mutateVersionsApplyingIntersection("channel", upstreamApiVersions);
+        assertThatApiVersionsContainsExactly(upstreamApiVersions, ApiKeys.METADATA, ApiKeys.METADATA.oldestVersion(), ApiKeys.METADATA.latestVersion());
+    }
+
+    @Test
+    void testIntersection_UpstreamMinVersionGreaterThanApiKeys() {
+        ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl();
+        ApiVersionsResponseData upstreamApiVersions = createApiVersionsWith(ApiKeys.METADATA.id, (short) (ApiKeys.METADATA.oldestVersion() + 1),
+                ApiKeys.METADATA.latestVersion());
+        apiVersionsService.mutateVersionsApplyingIntersection("channel", upstreamApiVersions);
+        assertThatApiVersionsContainsExactly(upstreamApiVersions, ApiKeys.METADATA, (short) (ApiKeys.METADATA.oldestVersion() + 1), ApiKeys.METADATA.latestVersion());
+    }
+
+    @Test
+    void testIntersection_UpstreamMaxVersionLessThanApiKeys() {
+        ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl();
+        ApiVersionsResponseData upstreamApiVersions = createApiVersionsWith(ApiKeys.METADATA.id, ApiKeys.METADATA.oldestVersion(),
+                (short) (ApiKeys.METADATA.latestVersion() - 1));
+        apiVersionsService.mutateVersionsApplyingIntersection("channel", upstreamApiVersions);
+        assertThatApiVersionsContainsExactly(upstreamApiVersions, ApiKeys.METADATA, ApiKeys.METADATA.oldestVersion(), (short) (ApiKeys.METADATA.latestVersion() - 1));
+    }
+
+    @Test
+    void testIntersection_UpstreamMaxVersionGreaterThanApiKeys() {
+        ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl();
+        ApiVersionsResponseData upstreamApiVersions = createApiVersionsWith(ApiKeys.METADATA.id, ApiKeys.METADATA.oldestVersion(),
+                (short) (ApiKeys.METADATA.latestVersion() + 1));
+        apiVersionsService.mutateVersionsApplyingIntersection("channel", upstreamApiVersions);
+        assertThatApiVersionsContainsExactly(upstreamApiVersions, ApiKeys.METADATA, ApiKeys.METADATA.oldestVersion(), ApiKeys.METADATA.latestVersion());
+    }
+
+    @Test
+    void testIntersection_DiscardsUnknownUpstreamApiKeys() {
+        ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl();
+        ApiVersionsResponseData upstreamApiVersions = createApiVersionsWith((short) 678, ApiKeys.METADATA.oldestVersion(),
+                (short) (ApiKeys.METADATA.latestVersion() + 1));
+        apiVersionsService.mutateVersionsApplyingIntersection("channel", upstreamApiVersions);
+        assertThat(upstreamApiVersions.apiKeys()).isEmpty();
+    }
+
+    private static void assertThatApiVersionsContainsExactly(ApiVersionsResponseData upstreamApiVersions, ApiKeys apiKeys, short minVersion, short maxVersion) {
+        assertThat(upstreamApiVersions.apiKeys()).satisfies(apiVersions -> {
+            assertThat(apiVersions).hasSize(1).first().satisfies(apiVersion -> {
+                assertThat(apiVersion.apiKey()).isEqualTo(apiKeys.id);
+                assertThat(apiVersion.minVersion()).isEqualTo(minVersion);
+                assertThat(apiVersion.maxVersion()).isEqualTo(maxVersion);
+            });
+        });
+    }
+
+    private static ApiVersionsResponseData createApiVersionsWith(short api, short minVersion, short maxVersion) {
+        ApiVersionsResponseData upstreamApiVersions = new ApiVersionsResponseData();
+        upstreamApiVersions.apiKeys().add(new ApiVersionsResponseData.ApiVersion().setApiKey(api).setMinVersion(minVersion).setMaxVersion(
+                maxVersion));
+        return upstreamApiVersions;
+    }
+
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/ApiVersionsServiceImplTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/ApiVersionsServiceImplTest.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.proxy.internal;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.kafka.common.message.ApiVersionsResponseData;
@@ -27,9 +28,9 @@ class ApiVersionsServiceImplTest {
         ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl();
         ApiVersionsResponseData upstreamApiVersions = createApiVersionsWith(ApiKeys.METADATA.id, (short) (ApiKeys.METADATA.oldestVersion() + 1),
                 (short) (ApiKeys.METADATA.latestVersion() + 1));
-        apiVersionsService.mutateVersionsApplyingIntersection("channel", upstreamApiVersions);
+        apiVersionsService.updateVersions("channel", upstreamApiVersions);
         ApiVersionsService.ApiVersionRanges range = apiVersionsService.getApiVersionRanges(ApiKeys.METADATA, Mockito.mock(FilterContext.class)).toCompletableFuture()
-                .getNow(null);
+                .getNow(Optional.empty()).orElse(null);
         assertThat(range).isNotNull();
         assertThat(range.upstream().minVersion()).isEqualTo((short) (ApiKeys.METADATA.oldestVersion() + 1));
         assertThat(range.upstream().maxVersion()).isEqualTo((short) (ApiKeys.METADATA.latestVersion() + 1));
@@ -45,7 +46,7 @@ class ApiVersionsServiceImplTest {
         FilterContext filterContext = Mockito.mock(FilterContext.class);
         Mockito.when(filterContext.sendRequest(anyShort(), any())).thenReturn(CompletableFuture.completedFuture(upstreamApiVersions));
         ApiVersionsService.ApiVersionRanges range = apiVersionsService.getApiVersionRanges(ApiKeys.METADATA, filterContext).toCompletableFuture()
-                .getNow(null);
+                .getNow(Optional.empty()).orElse(null);
         assertThat(range).isNotNull();
         assertThat(range.upstream().minVersion()).isEqualTo((short) (ApiKeys.METADATA.oldestVersion() - 1));
         assertThat(range.upstream().maxVersion()).isEqualTo((short) (ApiKeys.METADATA.latestVersion() - 1));
@@ -58,7 +59,7 @@ class ApiVersionsServiceImplTest {
         ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl();
         ApiVersionsResponseData upstreamApiVersions = createApiVersionsWith(ApiKeys.METADATA.id, ApiKeys.METADATA.oldestVersion(),
                 ApiKeys.METADATA.latestVersion());
-        apiVersionsService.mutateVersionsApplyingIntersection("channel", upstreamApiVersions);
+        apiVersionsService.updateVersions("channel", upstreamApiVersions);
         assertThatApiVersionsContainsExactly(upstreamApiVersions, ApiKeys.METADATA, ApiKeys.METADATA.oldestVersion(), ApiKeys.METADATA.latestVersion());
     }
 
@@ -67,7 +68,7 @@ class ApiVersionsServiceImplTest {
         ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl();
         ApiVersionsResponseData upstreamApiVersions = createApiVersionsWith(ApiKeys.METADATA.id, (short) (ApiKeys.METADATA.oldestVersion() - 1),
                 ApiKeys.METADATA.latestVersion());
-        apiVersionsService.mutateVersionsApplyingIntersection("channel", upstreamApiVersions);
+        apiVersionsService.updateVersions("channel", upstreamApiVersions);
         assertThatApiVersionsContainsExactly(upstreamApiVersions, ApiKeys.METADATA, ApiKeys.METADATA.oldestVersion(), ApiKeys.METADATA.latestVersion());
     }
 
@@ -76,7 +77,7 @@ class ApiVersionsServiceImplTest {
         ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl();
         ApiVersionsResponseData upstreamApiVersions = createApiVersionsWith(ApiKeys.METADATA.id, (short) (ApiKeys.METADATA.oldestVersion() + 1),
                 ApiKeys.METADATA.latestVersion());
-        apiVersionsService.mutateVersionsApplyingIntersection("channel", upstreamApiVersions);
+        apiVersionsService.updateVersions("channel", upstreamApiVersions);
         assertThatApiVersionsContainsExactly(upstreamApiVersions, ApiKeys.METADATA, (short) (ApiKeys.METADATA.oldestVersion() + 1), ApiKeys.METADATA.latestVersion());
     }
 
@@ -85,7 +86,7 @@ class ApiVersionsServiceImplTest {
         ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl();
         ApiVersionsResponseData upstreamApiVersions = createApiVersionsWith(ApiKeys.METADATA.id, ApiKeys.METADATA.oldestVersion(),
                 (short) (ApiKeys.METADATA.latestVersion() - 1));
-        apiVersionsService.mutateVersionsApplyingIntersection("channel", upstreamApiVersions);
+        apiVersionsService.updateVersions("channel", upstreamApiVersions);
         assertThatApiVersionsContainsExactly(upstreamApiVersions, ApiKeys.METADATA, ApiKeys.METADATA.oldestVersion(), (short) (ApiKeys.METADATA.latestVersion() - 1));
     }
 
@@ -94,7 +95,7 @@ class ApiVersionsServiceImplTest {
         ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl();
         ApiVersionsResponseData upstreamApiVersions = createApiVersionsWith(ApiKeys.METADATA.id, ApiKeys.METADATA.oldestVersion(),
                 (short) (ApiKeys.METADATA.latestVersion() + 1));
-        apiVersionsService.mutateVersionsApplyingIntersection("channel", upstreamApiVersions);
+        apiVersionsService.updateVersions("channel", upstreamApiVersions);
         assertThatApiVersionsContainsExactly(upstreamApiVersions, ApiKeys.METADATA, ApiKeys.METADATA.oldestVersion(), ApiKeys.METADATA.latestVersion());
     }
 
@@ -103,7 +104,7 @@ class ApiVersionsServiceImplTest {
         ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl();
         ApiVersionsResponseData upstreamApiVersions = createApiVersionsWith((short) 678, ApiKeys.METADATA.oldestVersion(),
                 (short) (ApiKeys.METADATA.latestVersion() + 1));
-        apiVersionsService.mutateVersionsApplyingIntersection("channel", upstreamApiVersions);
+        apiVersionsService.updateVersions("channel", upstreamApiVersions);
         assertThat(upstreamApiVersions.apiKeys()).isEmpty();
     }
 

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
@@ -60,7 +60,7 @@ public abstract class FilterHarness {
         this.filter = filter;
         filterHandler = new FilterHandler(getOnlyElement(FilterAndInvoker.build(filter)), timeoutMs, null,
                 new VirtualCluster("TestVirtualCluster", mock(TargetCluster.class), mock(ClusterNetworkAddressConfigProvider.class), Optional.empty(), false, false),
-                new EmbeddedChannel());
+                new EmbeddedChannel(), new ApiVersionsServiceImpl());
         channel = new EmbeddedChannel(filterHandler);
     }
 

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -182,7 +182,7 @@ class KafkaProxyFrontendHandlerTest {
     }
 
     KafkaProxyFrontendHandler handler(NetFilter filter, SaslDecodePredicate dp, VirtualCluster virtualCluster) {
-        return new KafkaProxyFrontendHandler(filter, dp, virtualCluster) {
+        return new KafkaProxyFrontendHandler(filter, dp, virtualCluster, new ApiVersionsServiceImpl()) {
             @Override
             ChannelFuture initConnection(String remoteHost, int remotePort, Bootstrap b) {
                 // This is ugly... basically the EmbeddedChannel doesn't seem to handle the case

--- a/performance-tests/src/main/java/io/kroxylicious/benchmarks/InvokerDispatchBenchmark.java
+++ b/performance-tests/src/main/java/io/kroxylicious/benchmarks/InvokerDispatchBenchmark.java
@@ -33,6 +33,7 @@ import io.kroxylicious.filters.FourInterfaceFilter0;
 import io.kroxylicious.filters.FourInterfaceFilter1;
 import io.kroxylicious.filters.FourInterfaceFilter2;
 import io.kroxylicious.filters.FourInterfaceFilter3;
+import io.kroxylicious.proxy.ApiVersionsService;
 import io.kroxylicious.proxy.filter.ArrayFilterInvoker;
 import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterContext;
@@ -175,6 +176,11 @@ public class InvokerDispatchBenchmark {
 
         @Override
         public String getVirtualClusterName() {
+            return null;
+        }
+
+        @Override
+        public ApiVersionsService getApiVersionsService() {
             return null;
         }
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds interface `ApiVersionsService` to `kroxylicious-api`:

```
import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersion;
import org.apache.kafka.common.protocol.ApiKeys;

public interface ApiVersionsService {
    record ApiVersionRanges(ApiVersion upstream, ApiVersion intersected) {}

    CompletionStage<ApiVersionRanges> getApiVersionRanges(ApiKeys keys);
}
```
and adds `ApiVersionsService getApiVersionsService();` to `FilterContext`

This service:
1. uses the ApiVersionsFilter to record the upstream versions
2. is also capable of hijacking the connection if the user needs the upstream versions in cases where the ApiVersionsFilter has not yet intercepted them.

Why:
Filters can choose to hijack the connection to send their own extra requests to the upstream broker. To do this safely we need to know what versions of the RPC the upstream supports, so we don't send it unsupported requests.

Filters are free to implement ApiVersionsResponseFilter and intercept the response, or alternatively send an additional request to the upstream broker asking for the ApiVersions (some clients may not send an ApiVersionsRequest, therefore there is no response to intercept). We can implement this pattern for Filter Authors so it does not need to be implemented in each Filter that wants to know the upstream API versions.

The API provides the intersected versions supported by both upstream and this Kroxylicious instance and also the raw upstream versions in case they are of interest.

Closes #438

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
