### PR TITLE
Track clients spawned by tester and close them when the tester is closed

### DIFF
--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
@@ -178,7 +178,7 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
         }
     }
 
-    public static KafkaProxy spawnProxy(Configuration config) {
+    private static KafkaProxy spawnProxy(Configuration config) {
         KafkaProxy kafkaProxy = new KafkaProxy(config);
         try {
             kafkaProxy.startup();

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
@@ -16,6 +16,8 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.serialization.Serde;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.kroxylicious.proxy.KafkaProxy;
 import io.kroxylicious.proxy.config.Configuration;
@@ -27,6 +29,7 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     private final Configuration kroxyliciousConfig;
 
     private final Map<String, KroxyliciousClients> clients;
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultKroxyliciousTester.class);
 
     DefaultKroxyliciousTester(ConfigurationBuilder configurationBuilder) {
         this(configurationBuilder, DefaultKroxyliciousTester::spawnProxy);
@@ -169,7 +172,10 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
             }
             proxy.close();
             if (!exceptions.isEmpty()) {
-                // if we encountered any exceptions while closing, throw whichever one came first.
+                // if we encountered any exceptions while closing, log them all and then throw whichever one came first.
+                exceptions.forEach(e -> {
+                    LOGGER.error(e.getMessage(), e);
+                });
                 throw exceptions.get(0);
             }
         }

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
@@ -172,9 +172,7 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
             proxy.close();
             if (!exceptions.isEmpty()) {
                 // if we encountered any exceptions while closing, log them all and then throw whichever one came first.
-                exceptions.forEach(e -> {
-                    LOGGER.error(e.getMessage(), e);
-                });
+                exceptions.forEach(e -> LOGGER.error(e.getMessage(), e));
                 throw exceptions.get(0);
             }
         }

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
@@ -168,7 +168,7 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
                 }
             }
             proxy.close();
-            if (exceptions.size() > 0) {
+            if (!exceptions.isEmpty()) {
                 // if we encountered any exceptions while closing, throw whichever one came first.
                 throw exceptions.get(0);
             }

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
@@ -54,8 +54,7 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     }
 
     private KroxyliciousClients clients(String virtualCluster) {
-        clients.computeIfAbsent(virtualCluster, k -> new KroxyliciousClients(KroxyliciousConfigUtils.bootstrapServersFor(k, kroxyliciousConfig)));
-        return clients.get(virtualCluster);
+        return clients.computeIfAbsent(virtualCluster, k -> new KroxyliciousClients(KroxyliciousConfigUtils.bootstrapServersFor(k, kroxyliciousConfig)));
     }
 
     @Override

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
@@ -49,9 +49,7 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
         int numVirtualClusters = kroxyliciousConfig.virtualClusters().size();
         if (numVirtualClusters == 1) {
             String onlyCluster = kroxyliciousConfig.virtualClusters().keySet().stream().findFirst().orElseThrow();
-            KroxyliciousClients client = new KroxyliciousClients(KroxyliciousConfigUtils.bootstrapServersFor(onlyCluster, kroxyliciousConfig));
-            clients.put(onlyCluster, client);
-            return client;
+            return clients(onlyCluster);
         }
         else {
             throw new AmbiguousVirtualClusterException(
@@ -60,9 +58,14 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     }
 
     private KroxyliciousClients clients(String virtualCluster) {
-        KroxyliciousClients client = new KroxyliciousClients(KroxyliciousConfigUtils.bootstrapServersFor(virtualCluster, kroxyliciousConfig));
-        clients.put(virtualCluster, client);
-        return client;
+        if (clients.containsKey(virtualCluster)) {
+            return clients.get(virtualCluster);
+        }
+        else {
+            KroxyliciousClients client = new KroxyliciousClients(KroxyliciousConfigUtils.bootstrapServersFor(virtualCluster, kroxyliciousConfig));
+            clients.put(virtualCluster, client);
+            return client;
+        }
     }
 
     @Override

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/KroxyliciousClients.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/KroxyliciousClients.java
@@ -88,10 +88,36 @@ class KroxyliciousClients {
     }
 
     public void close() {
+        List<Exception> exceptions = new ArrayList<>();
         try {
-            admins.forEach(Admin::close);
-            producers.forEach(Producer::close);
-            consumers.forEach(Consumer::close);
+            for (Admin admin : admins) {
+                try {
+                    admin.close();
+                }
+                catch (Exception e) {
+                    exceptions.add(e);
+                }
+            }
+            for (Producer producer : producers) {
+                try {
+                    producer.close();
+                }
+                catch (Exception e) {
+                    exceptions.add(e);
+                }
+            }
+            for (Consumer consumer : consumers) {
+                try {
+                    consumer.close();
+                }
+                catch (Exception e) {
+                    exceptions.add(e);
+                }
+            }
+            if (exceptions.size() > 0) {
+                // if we encountered any exceptions while closing, throw whichever one came first.
+                throw exceptions.get(0);
+            }
         }
         catch (Exception e) {
             throw new RuntimeException(e);

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/KroxyliciousClients.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/KroxyliciousClients.java
@@ -43,7 +43,6 @@ class KroxyliciousClients {
 
     public Admin admin(Map<String, Object> additionalConfig) {
         Map<String, Object> config = createConfigMap(bootstrapServers, additionalConfig);
-        // Should we do something smart here to reuse admins with the same config???
         Admin admin = CloseableAdmin.create(config);
         admins.add(admin);
         return admin;
@@ -63,7 +62,6 @@ class KroxyliciousClients {
 
     public <U, V> Producer<U, V> producer(Serde<U> keySerde, Serde<V> valueSerde, Map<String, Object> additionalConfig) {
         Map<String, Object> config = createConfigMap(bootstrapServers, additionalConfig);
-        // Should we do something smart here to reuse producers with the same config???
         Producer<U, V> producer = CloseableProducer.wrap(new KafkaProducer<>(config, keySerde.serializer(), valueSerde.serializer()));
         producers.add(producer);
         return producer;
@@ -79,7 +77,6 @@ class KroxyliciousClients {
 
     public <U, V> Consumer<U, V> consumer(Serde<U> keySerde, Serde<V> valueSerde, Map<String, Object> additionalConfig) {
         Map<String, Object> config = createConfigMap(bootstrapServers, additionalConfig);
-        // Should we do something smart here to reuse consumers with the same config???
         Consumer<U, V> consumer = CloseableConsumer.wrap(new KafkaConsumer<>(config, keySerde.deserializer(), valueSerde.deserializer()));
         consumers.add(consumer);
         return consumer;

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/KroxyliciousClients.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/KroxyliciousClients.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.test.tester;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -90,31 +91,10 @@ class KroxyliciousClients {
     public void close() {
         List<Exception> exceptions = new ArrayList<>();
         try {
-            for (Admin admin : admins) {
-                try {
-                    admin.close();
-                }
-                catch (Exception e) {
-                    exceptions.add(e);
-                }
-            }
-            for (Producer producer : producers) {
-                try {
-                    producer.close();
-                }
-                catch (Exception e) {
-                    exceptions.add(e);
-                }
-            }
-            for (Consumer consumer : consumers) {
-                try {
-                    consumer.close();
-                }
-                catch (Exception e) {
-                    exceptions.add(e);
-                }
-            }
-            if (exceptions.size() > 0) {
+            exceptions.addAll(batchClose(admins));
+            exceptions.addAll(batchClose(producers));
+            exceptions.addAll(batchClose(consumers));
+            if (!exceptions.isEmpty()) {
                 // if we encountered any exceptions while closing, throw whichever one came first.
                 throw exceptions.get(0);
             }
@@ -122,6 +102,19 @@ class KroxyliciousClients {
         catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    Collection<Exception> batchClose(Collection<? extends AutoCloseable> closeables) {
+        List<Exception> exceptions = new ArrayList<>();
+        for (AutoCloseable closeable : closeables) {
+            try {
+                closeable.close();
+            }
+            catch (Exception e) {
+                exceptions.add(e);
+            }
+        }
+        return exceptions;
     }
 
     private Map<String, Object> createConfigMap(String bootstrapServers, Map<String, Object> additionalConfig) {

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/KroxyliciousTester.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/KroxyliciousTester.java
@@ -210,6 +210,11 @@ public interface KroxyliciousTester extends Closeable {
     KafkaClient simpleTestClient(String virtualCluster);
 
     /**
+     * Restarts the Kroxylicious server under test without closing any other resources.
+     */
+    void restartProxy();
+
+    /**
      * Close the Kroxylicious server under test and any other resources that need cleaning.
      */
     void close();

--- a/kroxylicious-test-tools/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
+++ b/kroxylicious-test-tools/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
@@ -49,6 +49,7 @@ import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.mockKafkaKroxyliciousTester;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -142,7 +143,7 @@ class KroxyliciousTestersTest {
             admin.describeCluster();
             send(producer);
             consumer.poll(Duration.ofSeconds(10));
-            assert false;
+            fail("No exception was thrown when invoking clients that should be closed");
         }
         catch (Exception e) {
             assertThat(e).isNotNull();

--- a/kroxylicious-test-tools/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
+++ b/kroxylicious-test-tools/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
@@ -151,6 +151,19 @@ class KroxyliciousTestersTest {
     }
 
     @Test
+    void testCanCloseTesterWithClosedClient(KafkaCluster cluster) {
+        try {
+            var tester = kroxyliciousTester(proxy(cluster));
+            var admin = tester.admin();
+            admin.close();
+            tester.close();
+        }
+        catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
     void testMockRequestMockTester() {
         try (var tester = mockKafkaKroxyliciousTester(KroxyliciousConfigUtils::proxy)) {
             assertCanSendRequestsAndReceiveMockResponses(tester, tester::simpleTestClient);

--- a/kroxylicious-test-tools/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
+++ b/kroxylicious-test-tools/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
@@ -137,6 +137,16 @@ class KroxyliciousTestersTest {
         consumer.subscribe(List.of(TOPIC));
         assertThat(consumer.poll(Duration.ofSeconds(10))).isNotNull();
         tester.close();
+        // we expect the following to throw an exception, but if it doesn't we fail.
+        try {
+            admin.describeCluster();
+            send(producer);
+            consumer.poll(Duration.ofSeconds(10));
+            assert false;
+        }
+        catch (Exception e) {
+            assertThat(e).isNotNull();
+        }
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

`KroxyliciousTester` now keeps a Map of all `KroxyliciousClients` it creates, and `KroxyliciousClients` now keeps Lists of all Admins, Producers, and Consumers it creates, and then when `close()` is called on `KroxyliciousTester`, it also calls `close()` on each `KroxyliciousClients` which then closes everything else that was spawned.

To solve the issue of `ResilienceIT` failing because of this change to `close()`, there is now a `restartProxy()` method in `KroxyliciousTester` that is used in place of closing the entire tester in these tests, which just calls `shutdown()` on the tester's existing `KafkaProxy`, then instantiates and starts up a new `KafkaProxy` for the tester.

### Additional Context

It's an easy assumption to make that closing the `KroxyliciousTester` would close everything spawned by that tester, but currently that is not the case. This PR aims to help with that, while still providing an avenue to restart just the tester's proxy if needed.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
