### PR TITLE
Remove Krpc prefix from KrpcFilter and KrpcFilterContext

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -181,7 +181,7 @@ as a suggestion if you used sdkman to install it).
 
 In the IDEA Maven dialogue click on `Generate Sources and Update Folders For All Projects`.
 
-Build the entire project by running `Build > Build Project` and then check that you can run `io.kroxylicious.proxy.KrpcFilterIT`
+Build the entire project by running `Build > Build Project` and then check that you can run `io.kroxylicious.proxy.FilterIT`
 
 If you encounter any further issues with generated sources, you can can try running `mvn clean install -DskipTests` again or running 
 `Generate Sources and Update Folders` for the specific module that is having problems.

--- a/docs/custom-filters.adoc
+++ b/docs/custom-filters.adoc
@@ -85,7 +85,7 @@ public class FetchRequestClientIdFilter implements FetchRequestFilter {
     public CompletionStage<RequestFilterResult> onFetchRequest(short apiVersion,
                                                                RequestHeaderData header,
                                                                FetchRequestData request,
-                                                               KrpcFilterContext context) {
+                                                               FilterContext context) {
         header.setClientId("fetch-client!");
         return context.forwardRequest(header, request);
     }
@@ -103,7 +103,7 @@ public class FetchRequestClientIdFilter implements FetchResponseFilter {
     public CompletionStage<ResponseFilterResult> onFetchResponse(short apiVersion,
                                                                  ResponseHeaderData header,
                                                                  FetchResponseData response,
-                                                                 KrpcFilterContext context) {
+                                                                 FilterContext context) {
         mutateResponse(response);
         return context.forwardResponse(header, response);
     }
@@ -122,7 +122,7 @@ public class FetchRequestClientIdFilter implements FetchRequestFilter, FetchResp
     public CompletionStage<RequestFilterResult> onFetchRequest(short apiVersion,
                                                                RequestHeaderData header,
                                                                FetchRequestData request,
-                                                               KrpcFilterContext context) {
+                                                               FilterContext context) {
         header.setClientId("fetch-client!");
         return context.forwardRequest(header, request);
     }
@@ -131,7 +131,7 @@ public class FetchRequestClientIdFilter implements FetchRequestFilter, FetchResp
     public CompletionStage<ResponseFilterResult> onFetchResponse(short apiVersion,
                                                                  ResponseHeaderData header,
                                                                  FetchResponseData response,
-                                                                 KrpcFilterContext context) {
+                                                                 FilterContext context) {
         mutateResponse(response);
         return context.forwardResponse(header, response);
     }
@@ -163,7 +163,7 @@ public class FixedClientIdFilter implements RequestFilter {
     public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey,
                                                           RequestHeaderData header,
                                                           ApiMessage body,
-                                                          KrpcFilterContext filterContext) {
+                                                          FilterContext filterContext) {
         header.setClientId("example!");
         return filterContext.forwardRequest(header, body);
     }
@@ -194,7 +194,7 @@ class ExampleCompositeFilter implements CompositeFilter {
         }
 
         @Override
-        public List<KrpcFilter> getFilters() {
+        public List<Filter> getFilters() {
             return List.of(
                 new OverrideAllClientIdHeadersFilter(configuration.clientId()),
                 new PrefixProduceRequestFilter(configuration.prefix())
@@ -245,7 +245,7 @@ If the `CompletionStage` completes exceptionally, the connection is closed.  Thi
 `CompletionStage` does not complete within a timeout (20000 milliseconds).
 
 ==== Creating a Filter Result
-The `KrpcFilterContext` is the factory for the `FilterResult` objects.
+The `FilterContext` is the factory for the `FilterResult` objects.
 
 There are two convenience methods{empty}footnote:[The `context.forward*()` methods behave exactly as the builder form
 `.forward(header, message).complete()`] that simply allow a filter to forward a result to the next filter.
@@ -318,7 +318,7 @@ public class SampleFetchResponseFilter implements FetchResponseFilter {
     public CompletionStage<ResponseFilterResult> onFetchResponse(short apiVersion,
                                                                  ResponseHeaderData header,
                                                                  FetchResponseData response,
-                                                                 KrpcFilterContext context) {
+                                                                 FilterContext context) {
         mutateResponse(response, context); //<1>
         return context.forwardResponse(header, response); //<2>
     }
@@ -370,7 +370,7 @@ For example:
 public class CreateTopicRejectFilter implements CreateTopicsRequestFilter {
 
     public CompletionStage<RequestFilterResult> onCreateTopicsRequest(short apiVersion, RequestHeaderData header, CreateTopicsRequestData request,
-                                                                      KrpcFilterContext context) {
+                                                                      FilterContext context) {
         CreateTopicsResponseData response = new CreateTopicsResponseData();
         CreateTopicsResponseData.CreatableTopicResultCollection topics = new CreateTopicsResponseData.CreatableTopicResultCollection(); // <1>
         request.topics().forEach(creatableTopic -> {
@@ -402,7 +402,7 @@ public class DisallowAlterConfigs implements AlterConfigsRequestFilter {
 
     @Override
     public CompletionStage<RequestFilterResult> onAlterConfigsRequest(short apiVersion, RequestHeaderData header, AlterConfigsRequestData request,
-                                                                      KrpcFilterContext context) {
+                                                                      FilterContext context) {
         var response = new AlterConfigsResponseData();
         response.setResponses(request.resources().stream()
                 .map(a -> new AlterConfigsResourceResponse()
@@ -444,7 +444,7 @@ public class FetchFilter implements FetchRequestFilter {
     public CompletionStage<RequestFilterResult> onFetchRequest(ApiKeys apiKey,
                                                                RequestHeaderData header,
                                                                FetchRequestData request,
-                                                               KrpcFilterContext context) {
+                                                               FilterContext context) {
         MetadataRequestData metadataRequest = new MetadataRequestData(); //<1>
         var topic = new MetadataRequestData.MetadataRequestTopic();
         topic.setTopicId(Uuid.randomUuid());
@@ -496,7 +496,7 @@ public class FetchFilter implements FetchRequestFilter {
     public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey,
                                                           RequestHeaderData header,
                                                           ApiMessage body,
-                                                          KrpcFilterContext filterContext) {
+                                                          FilterContext filterContext) {
         return context.forwardRequest(header, request);
     }
 }

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/FilterIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/FilterIT.java
@@ -83,7 +83,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 @ExtendWith(KafkaClusterExtension.class)
-class KrpcFilterIT {
+class FilterIT {
 
     private static final String TOPIC_1 = "my-test-topic";
     private static final String TOPIC_2 = "other-test-topic";

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/CompositePrefixingFixedClientIdFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/CompositePrefixingFixedClientIdFilter.java
@@ -28,14 +28,14 @@ public class CompositePrefixingFixedClientIdFilter implements CompositeFilter {
 
     private class PrefixingFilter implements RequestFilter {
         @Override
-        public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage request, KrpcFilterContext context) {
+        public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage request, FilterContext context) {
             header.setClientId(config.prefix + header.clientId());
             return context.forwardRequest(header, request);
         }
     }
 
     @Override
-    public List<KrpcFilter> getFilters() {
+    public List<Filter> getFilters() {
         FixedClientIdFilter clientIdFilter = new FixedClientIdFilter(new FixedClientIdFilter.FixedClientIdFilterConfig(config.clientId));
         return List.of(clientIdFilter, new PrefixingFilter());
     }

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/FixedClientIdFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/FixedClientIdFilter.java
@@ -37,13 +37,13 @@ public class FixedClientIdFilter implements RequestFilter, ResponseFilter {
     }
 
     @Override
-    public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage request, KrpcFilterContext context) {
+    public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage request, FilterContext context) {
         header.setClientId(clientId);
         return context.forwardRequest(header, request);
     }
 
     @Override
-    public CompletionStage<ResponseFilterResult> onResponse(ApiKeys apiKey, ResponseHeaderData header, ApiMessage response, KrpcFilterContext context) {
+    public CompletionStage<ResponseFilterResult> onResponse(ApiKeys apiKey, ResponseHeaderData header, ApiMessage response, FilterContext context) {
         return context.forwardResponse(header, response);
     }
 }

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/OutOfBandSendFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/OutOfBandSendFilter.java
@@ -57,7 +57,7 @@ public class OutOfBandSendFilter implements DescribeClusterRequestFilter, Descri
 
     @Override
     public CompletionStage<RequestFilterResult> onDescribeClusterRequest(short apiVersion, RequestHeaderData header, DescribeClusterRequestData request,
-                                                                         KrpcFilterContext context) {
+                                                                         FilterContext context) {
         ApiKeys apiKeyToSend = config.apiKeyToSend;
         ApiMessage message = createApiMessage(apiKeyToSend);
         context.sendRequest(apiKeyToSend.latestVersion(), message).thenAccept(apiMessage -> {
@@ -69,7 +69,7 @@ public class OutOfBandSendFilter implements DescribeClusterRequestFilter, Descri
 
     @Override
     public CompletionStage<ResponseFilterResult> onDescribeClusterResponse(short apiVersion, ResponseHeaderData header, DescribeClusterResponseData response,
-                                                                           KrpcFilterContext context) {
+                                                                           FilterContext context) {
         response.setErrorCode(Errors.UNKNOWN_SERVER_ERROR.code())
                 .setErrorMessage("filterNameTaggedFieldsFromOutOfBandResponse: " + values);
         return context.forwardResponse(header, response);

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RejectingCreateTopicFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RejectingCreateTopicFilter.java
@@ -36,7 +36,7 @@ public class RejectingCreateTopicFilter implements CreateTopicsRequestFilter {
 
     @Override
     public CompletionStage<RequestFilterResult> onCreateTopicsRequest(short apiVersion, RequestHeaderData header, CreateTopicsRequestData request,
-                                                                      KrpcFilterContext context) {
+                                                                      FilterContext context) {
         return forwardingStyle.apply(context, request)
                 .thenCompose((u) -> {
                     CreateTopicsResponseData response = new CreateTopicsResponseData();
@@ -58,7 +58,7 @@ public class RejectingCreateTopicFilter implements CreateTopicsRequestFilter {
                 });
     }
 
-    private static void allocateByteBufToTestKroxyliciousReleasesIt(KrpcFilterContext context) {
+    private static void allocateByteBufToTestKroxyliciousReleasesIt(FilterContext context) {
         context.createByteBufferOutputStream(4000);
     }
 

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RequestResponseMarkingFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RequestResponseMarkingFilter.java
@@ -54,7 +54,7 @@ public class RequestResponseMarkingFilter implements RequestFilter, ResponseFilt
     }
 
     @Override
-    public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage body, KrpcFilterContext context) {
+    public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage body, FilterContext context) {
         if (!(direction.contains(Direction.REQUEST) && keysToMark.contains(apiKey))) {
             return context.forwardRequest(header, body);
         }
@@ -65,7 +65,7 @@ public class RequestResponseMarkingFilter implements RequestFilter, ResponseFilt
     }
 
     @Override
-    public CompletionStage<ResponseFilterResult> onResponse(ApiKeys apiKey, ResponseHeaderData header, ApiMessage response, KrpcFilterContext context) {
+    public CompletionStage<ResponseFilterResult> onResponse(ApiKeys apiKey, ResponseHeaderData header, ApiMessage response, FilterContext context) {
         if (!(direction.contains(Direction.RESPONSE) && keysToMark.contains(apiKey))) {
             return context.forwardResponse(header, response);
         }

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
@@ -8,9 +8,9 @@ package io.kroxylicious.proxy.filter;
 import io.kroxylicious.proxy.filter.CompositePrefixingFixedClientIdFilter.CompositePrefixingFixedClientIdFilterConfig;
 import io.kroxylicious.proxy.service.BaseContributor;
 
-public class TestFilterContributor extends BaseContributor<KrpcFilter> implements FilterContributor {
+public class TestFilterContributor extends BaseContributor<Filter> implements FilterContributor {
 
-    public static final BaseContributorBuilder<KrpcFilter> FILTERS = BaseContributor.<KrpcFilter> builder()
+    public static final BaseContributorBuilder<Filter> FILTERS = BaseContributor.<Filter> builder()
             .add("FixedClientId", FixedClientIdFilter.FixedClientIdFilterConfig.class, FixedClientIdFilter::new)
             .add("RequestResponseMarking", RequestResponseMarkingFilter.RequestResponseMarkingFilterConfig.class, RequestResponseMarkingFilter::new)
             .add("OutOfBandSend", OutOfBandSendFilter.OutOfBandSendFilterConfig.class, OutOfBandSendFilter::new)

--- a/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterContributor.java
+++ b/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterContributor.java
@@ -5,13 +5,13 @@
  */
 package io.kroxylicious.proxy.filter.multitenant;
 
+import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterContributor;
-import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.service.BaseContributor;
 
-public class MultiTenantFilterContributor extends BaseContributor<KrpcFilter> implements FilterContributor {
+public class MultiTenantFilterContributor extends BaseContributor<Filter> implements FilterContributor {
 
-    public static final BaseContributorBuilder<KrpcFilter> FILTERS = BaseContributor.<KrpcFilter> builder()
+    public static final BaseContributorBuilder<Filter> FILTERS = BaseContributor.<Filter> builder()
             .add("MultiTenant", MultiTenantTransformationFilter::new);
 
     public MultiTenantFilterContributor() {

--- a/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilter.java
+++ b/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilter.java
@@ -68,12 +68,12 @@ import io.kroxylicious.proxy.filter.DescribeTransactionsResponseFilter;
 import io.kroxylicious.proxy.filter.EndTxnRequestFilter;
 import io.kroxylicious.proxy.filter.FetchRequestFilter;
 import io.kroxylicious.proxy.filter.FetchResponseFilter;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.FindCoordinatorRequestFilter;
 import io.kroxylicious.proxy.filter.FindCoordinatorResponseFilter;
 import io.kroxylicious.proxy.filter.HeartbeatRequestFilter;
 import io.kroxylicious.proxy.filter.InitProducerIdRequestFilter;
 import io.kroxylicious.proxy.filter.JoinGroupRequestFilter;
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
 import io.kroxylicious.proxy.filter.LeaveGroupRequestFilter;
 import io.kroxylicious.proxy.filter.ListGroupsResponseFilter;
 import io.kroxylicious.proxy.filter.ListOffsetsRequestFilter;
@@ -136,21 +136,21 @@ public class MultiTenantTransformationFilter
 
     @Override
     public CompletionStage<RequestFilterResult> onCreateTopicsRequest(short apiVersion, RequestHeaderData header, CreateTopicsRequestData request,
-                                                                      KrpcFilterContext context) {
+                                                                      FilterContext context) {
         request.topics().forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, false));
         return context.forwardRequest(header, request);
     }
 
     @Override
     public CompletionStage<ResponseFilterResult> onCreateTopicsResponse(short apiVersion, ResponseHeaderData header, CreateTopicsResponseData response,
-                                                                        KrpcFilterContext context) {
+                                                                        FilterContext context) {
         response.topics().forEach(topic -> removeTenantPrefix(context, topic::name, topic::setName, false));
         return context.forwardResponse(header, response);
     }
 
     @Override
     public CompletionStage<RequestFilterResult> onDeleteTopicsRequest(short apiVersion, RequestHeaderData header, DeleteTopicsRequestData request,
-                                                                      KrpcFilterContext context) {
+                                                                      FilterContext context) {
         // the topicName field was present up to and including version 5
         request.setTopicNames(request.topicNames().stream().map(topic -> applyTenantPrefix(context, topic)).toList());
         request.topics().forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, topic.topicId() != null));
@@ -159,13 +159,13 @@ public class MultiTenantTransformationFilter
 
     @Override
     public CompletionStage<ResponseFilterResult> onDeleteTopicsResponse(short apiVersion, ResponseHeaderData header, DeleteTopicsResponseData response,
-                                                                        KrpcFilterContext context) {
+                                                                        FilterContext context) {
         response.responses().forEach(topic -> removeTenantPrefix(context, topic::name, topic::setName, false));
         return context.forwardResponse(header, response);
     }
 
     @Override
-    public CompletionStage<RequestFilterResult> onMetadataRequest(short apiVersion, RequestHeaderData header, MetadataRequestData request, KrpcFilterContext context) {
+    public CompletionStage<RequestFilterResult> onMetadataRequest(short apiVersion, RequestHeaderData header, MetadataRequestData request, FilterContext context) {
         if (request.topics() != null) {
             // n.b. request.topics() == null used to query all the topics.
             request.topics().forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, false));
@@ -175,7 +175,7 @@ public class MultiTenantTransformationFilter
 
     @Override
     public CompletionStage<ResponseFilterResult> onMetadataResponse(short apiVersion, ResponseHeaderData header, MetadataResponseData response,
-                                                                    KrpcFilterContext context) {
+                                                                    FilterContext context) {
         String tenantPrefix = getTenantPrefix(context);
         response.topics().removeIf(topic -> !topic.name().startsWith(tenantPrefix)); // TODO: allow kafka internal topics to be returned?
         response.topics().forEach(topic -> removeTenantPrefix(context, topic::name, topic::setName, false));
@@ -183,7 +183,7 @@ public class MultiTenantTransformationFilter
     }
 
     @Override
-    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, KrpcFilterContext context) {
+    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, FilterContext context) {
         applyTenantPrefix(context, request::transactionalId, request::setTransactionalId, true);
         request.topicData().forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, false));
         return context.forwardRequest(header, request);
@@ -191,28 +191,28 @@ public class MultiTenantTransformationFilter
 
     @Override
     public CompletionStage<ResponseFilterResult> onProduceResponse(short apiVersion, ResponseHeaderData header, ProduceResponseData response,
-                                                                   KrpcFilterContext context) {
+                                                                   FilterContext context) {
         response.responses().forEach(topic -> removeTenantPrefix(context, topic::name, topic::setName, false));
         return context.forwardResponse(header, response);
     }
 
     @Override
     public CompletionStage<RequestFilterResult> onListOffsetsRequest(short apiVersion, RequestHeaderData header, ListOffsetsRequestData request,
-                                                                     KrpcFilterContext context) {
+                                                                     FilterContext context) {
         request.topics().forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, false));
         return context.forwardRequest(header, request);
     }
 
     @Override
     public CompletionStage<ResponseFilterResult> onListOffsetsResponse(short apiVersion, ResponseHeaderData header, ListOffsetsResponseData response,
-                                                                       KrpcFilterContext context) {
+                                                                       FilterContext context) {
         response.topics().forEach(topic -> removeTenantPrefix(context, topic::name, topic::setName, false));
         return context.forwardResponse(header, response);
     }
 
     @Override
     public CompletionStage<RequestFilterResult> onOffsetFetchRequest(short apiVersion, RequestHeaderData header, OffsetFetchRequestData request,
-                                                                     KrpcFilterContext context) {
+                                                                     FilterContext context) {
         // the groupId and top-level topic fields were present up to and including version 7
         Optional.ofNullable(request.groupId()).ifPresent(groupId -> applyTenantPrefix(context, request::groupId, request::setGroupId, true));
         Optional.ofNullable(request.topics()).ifPresent(topics -> topics.forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, false)));
@@ -227,7 +227,7 @@ public class MultiTenantTransformationFilter
 
     @Override
     public CompletionStage<ResponseFilterResult> onOffsetFetchResponse(short apiVersion, ResponseHeaderData header, OffsetFetchResponseData response,
-                                                                       KrpcFilterContext context) {
+                                                                       FilterContext context) {
         response.topics().forEach(topic -> removeTenantPrefix(context, topic::name, topic::setName, false));
         response.groups().forEach(responseGroup -> {
             removeTenantPrefix(context, responseGroup::groupId, responseGroup::setGroupId, false);
@@ -238,21 +238,21 @@ public class MultiTenantTransformationFilter
 
     @Override
     public CompletionStage<RequestFilterResult> onOffsetForLeaderEpochRequest(short apiVersion, RequestHeaderData header, OffsetForLeaderEpochRequestData request,
-                                                                              KrpcFilterContext context) {
+                                                                              FilterContext context) {
         request.topics().forEach(topic -> applyTenantPrefix(context, topic::topic, topic::setTopic, false));
         return context.forwardRequest(header, request);
     }
 
     @Override
     public CompletionStage<ResponseFilterResult> onOffsetForLeaderEpochResponse(short apiVersion, ResponseHeaderData header, OffsetForLeaderEpochResponseData response,
-                                                                                KrpcFilterContext context) {
+                                                                                FilterContext context) {
         response.topics().forEach(topic -> removeTenantPrefix(context, topic::topic, topic::setTopic, false));
         return context.forwardResponse(header, response);
     }
 
     @Override
     public CompletionStage<RequestFilterResult> onOffsetCommitRequest(short apiVersion, RequestHeaderData header, OffsetCommitRequestData request,
-                                                                      KrpcFilterContext context) {
+                                                                      FilterContext context) {
         applyTenantPrefix(context, request::groupId, request::setGroupId, false);
         request.topics().forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, false));
         return context.forwardRequest(header, request);
@@ -260,14 +260,14 @@ public class MultiTenantTransformationFilter
 
     @Override
     public CompletionStage<ResponseFilterResult> onOffsetCommitResponse(short apiVersion, ResponseHeaderData header, OffsetCommitResponseData response,
-                                                                        KrpcFilterContext context) {
+                                                                        FilterContext context) {
         response.topics().forEach(topic -> removeTenantPrefix(context, topic::name, topic::setName, false));
         return context.forwardResponse(header, response);
     }
 
     @Override
     public CompletionStage<RequestFilterResult> onOffsetDeleteRequest(short apiVersion, RequestHeaderData header, OffsetDeleteRequestData request,
-                                                                      KrpcFilterContext context) {
+                                                                      FilterContext context) {
         applyTenantPrefix(context, request::groupId, request::setGroupId, false);
         request.topics().forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, false));
         return context.forwardRequest(header, request);
@@ -275,26 +275,26 @@ public class MultiTenantTransformationFilter
 
     @Override
     public CompletionStage<ResponseFilterResult> onOffsetDeleteResponse(short apiVersion, ResponseHeaderData header, OffsetDeleteResponseData response,
-                                                                        KrpcFilterContext context) {
+                                                                        FilterContext context) {
         response.topics().forEach(topic -> removeTenantPrefix(context, topic::name, topic::setName, false));
         return context.forwardResponse(header, response);
     }
 
     @Override
-    public CompletionStage<RequestFilterResult> onFetchRequest(short apiVersion, RequestHeaderData header, FetchRequestData request, KrpcFilterContext context) {
+    public CompletionStage<RequestFilterResult> onFetchRequest(short apiVersion, RequestHeaderData header, FetchRequestData request, FilterContext context) {
         request.topics().forEach(topic -> applyTenantPrefix(context, topic::topic, topic::setTopic, topic.topicId() != null));
         return context.forwardRequest(header, request);
     }
 
     @Override
-    public CompletionStage<ResponseFilterResult> onFetchResponse(short apiVersion, ResponseHeaderData header, FetchResponseData response, KrpcFilterContext context) {
+    public CompletionStage<ResponseFilterResult> onFetchResponse(short apiVersion, ResponseHeaderData header, FetchResponseData response, FilterContext context) {
         response.responses().forEach(topic -> removeTenantPrefix(context, topic::topic, topic::setTopic, topic.topicId() != null));
         return context.forwardResponse(header, response);
     }
 
     @Override
     public CompletionStage<RequestFilterResult> onFindCoordinatorRequest(short apiVersion, RequestHeaderData header, FindCoordinatorRequestData request,
-                                                                         KrpcFilterContext context) {
+                                                                         FilterContext context) {
         // the key fields was present up to and including version 4
         Optional.ofNullable(request.key()).ifPresent(unused -> applyTenantPrefix(context, request::key, request::setKey, true));
         request.setCoordinatorKeys(request.coordinatorKeys().stream().map(key -> applyTenantPrefix(context, key)).toList());
@@ -303,14 +303,14 @@ public class MultiTenantTransformationFilter
 
     @Override
     public CompletionStage<ResponseFilterResult> onFindCoordinatorResponse(short apiVersion, ResponseHeaderData header, FindCoordinatorResponseData response,
-                                                                           KrpcFilterContext context) {
+                                                                           FilterContext context) {
         response.coordinators().forEach(coordinator -> removeTenantPrefix(context, coordinator::key, coordinator::setKey, false));
         return context.forwardResponse(header, response);
     }
 
     @Override
     public CompletionStage<ResponseFilterResult> onListGroupsResponse(short apiVersion, ResponseHeaderData header, ListGroupsResponseData response,
-                                                                      KrpcFilterContext context) {
+                                                                      FilterContext context) {
         var tenantPrefix = getTenantPrefix(context);
         var filteredGroups = response.groups().stream().filter(listedGroup -> listedGroup.groupId().startsWith(tenantPrefix)).toList();
         filteredGroups.forEach(listedGroup -> removeTenantPrefix(context, listedGroup::groupId, listedGroup::setGroupId, false));
@@ -320,7 +320,7 @@ public class MultiTenantTransformationFilter
 
     @Override
     public CompletionStage<RequestFilterResult> onJoinGroupRequest(short apiVersion, RequestHeaderData header, JoinGroupRequestData request,
-                                                                   KrpcFilterContext context) {
+                                                                   FilterContext context) {
         var tenantPrefix = getTenantPrefix(context);
         request.setGroupId(tenantPrefix + request.groupId());
         return context.forwardRequest(header, request);
@@ -328,7 +328,7 @@ public class MultiTenantTransformationFilter
 
     @Override
     public CompletionStage<RequestFilterResult> onSyncGroupRequest(short apiVersion, RequestHeaderData header, SyncGroupRequestData request,
-                                                                   KrpcFilterContext context) {
+                                                                   FilterContext context) {
         var tenantPrefix = getTenantPrefix(context);
         request.setGroupId(tenantPrefix + request.groupId());
         return context.forwardRequest(header, request);
@@ -336,7 +336,7 @@ public class MultiTenantTransformationFilter
 
     @Override
     public CompletionStage<RequestFilterResult> onLeaveGroupRequest(short apiVersion, RequestHeaderData header, LeaveGroupRequestData request,
-                                                                    KrpcFilterContext context) {
+                                                                    FilterContext context) {
         var tenantPrefix = getTenantPrefix(context);
         request.setGroupId(tenantPrefix + request.groupId());
         return context.forwardRequest(header, request);
@@ -344,7 +344,7 @@ public class MultiTenantTransformationFilter
 
     @Override
     public CompletionStage<RequestFilterResult> onHeartbeatRequest(short apiVersion, RequestHeaderData header, HeartbeatRequestData request,
-                                                                   KrpcFilterContext context) {
+                                                                   FilterContext context) {
         var tenantPrefix = getTenantPrefix(context);
         request.setGroupId(tenantPrefix + request.groupId());
         return context.forwardRequest(header, request);
@@ -352,28 +352,28 @@ public class MultiTenantTransformationFilter
 
     @Override
     public CompletionStage<RequestFilterResult> onDescribeGroupsRequest(short apiVersion, RequestHeaderData header, DescribeGroupsRequestData request,
-                                                                        KrpcFilterContext context) {
+                                                                        FilterContext context) {
         request.setGroups(request.groups().stream().map(group -> applyTenantPrefix(context, group)).toList());
         return context.forwardRequest(header, request);
     }
 
     @Override
     public CompletionStage<ResponseFilterResult> onDescribeGroupsResponse(short apiVersion, ResponseHeaderData header, DescribeGroupsResponseData response,
-                                                                          KrpcFilterContext context) {
+                                                                          FilterContext context) {
         response.groups().forEach(group -> removeTenantPrefix(context, group::groupId, group::setGroupId, false));
         return context.forwardResponse(header, response);
     }
 
     @Override
     public CompletionStage<RequestFilterResult> onInitProducerIdRequest(short apiVersion, RequestHeaderData header, InitProducerIdRequestData request,
-                                                                        KrpcFilterContext context) {
+                                                                        FilterContext context) {
         applyTenantPrefix(context, request::transactionalId, request::setTransactionalId, true);
         return context.forwardRequest(header, request);
     }
 
     @Override
     public CompletionStage<RequestFilterResult> onAddPartitionsToTxnRequest(short apiVersion, RequestHeaderData header, AddPartitionsToTxnRequestData request,
-                                                                            KrpcFilterContext context) {
+                                                                            FilterContext context) {
         request.v3AndBelowTopics().forEach(topic -> applyTenantPrefix(context, topic::name, topic::setName, false));
         applyTenantPrefix(context, request::v3AndBelowTransactionalId, request::setV3AndBelowTransactionalId, true);
 
@@ -388,7 +388,7 @@ public class MultiTenantTransformationFilter
 
     @Override
     public CompletionStage<ResponseFilterResult> onAddPartitionsToTxnResponse(short apiVersion, ResponseHeaderData header, AddPartitionsToTxnResponseData response,
-                                                                              KrpcFilterContext context) {
+                                                                              FilterContext context) {
         response.resultsByTopicV3AndBelow().forEach(results -> removeTenantPrefix(context, results::name, results::setName, false));
 
         response.resultsByTransaction().forEach(addPartitionsToTxnResult -> {
@@ -402,7 +402,7 @@ public class MultiTenantTransformationFilter
 
     @Override
     public CompletionStage<RequestFilterResult> onAddOffsetsToTxnRequest(short apiVersion, RequestHeaderData header, AddOffsetsToTxnRequestData request,
-                                                                         KrpcFilterContext context) {
+                                                                         FilterContext context) {
         var tenantPrefix = getTenantPrefix(context);
         request.setTransactionalId(tenantPrefix + request.transactionalId());
         request.setGroupId(tenantPrefix + request.groupId());
@@ -411,7 +411,7 @@ public class MultiTenantTransformationFilter
 
     @Override
     public CompletionStage<RequestFilterResult> onTxnOffsetCommitRequest(short apiVersion, RequestHeaderData header, TxnOffsetCommitRequestData request,
-                                                                         KrpcFilterContext context) {
+                                                                         FilterContext context) {
         var tenantPrefix = getTenantPrefix(context);
         request.setTransactionalId(tenantPrefix + request.transactionalId());
         request.setGroupId(tenantPrefix + request.groupId());
@@ -421,14 +421,14 @@ public class MultiTenantTransformationFilter
 
     @Override
     public CompletionStage<ResponseFilterResult> onTxnOffsetCommitResponse(short apiVersion, ResponseHeaderData header, TxnOffsetCommitResponseData response,
-                                                                           KrpcFilterContext context) {
+                                                                           FilterContext context) {
         response.topics().forEach(results -> removeTenantPrefix(context, results::name, results::setName, false));
         return context.forwardResponse(header, response);
     }
 
     @Override
     public CompletionStage<ResponseFilterResult> onListTransactionsResponse(short apiVersion, ResponseHeaderData header, ListTransactionsResponseData response,
-                                                                            KrpcFilterContext context) {
+                                                                            FilterContext context) {
         var tenantPrefix = getTenantPrefix(context);
         var filteredTransactions = response.transactionStates().stream().filter(listedTxn -> listedTxn.transactionalId().startsWith(tenantPrefix)).toList();
         filteredTransactions.forEach(listedTxn -> removeTenantPrefix(context, listedTxn::transactionalId, listedTxn::setTransactionalId, false));
@@ -438,14 +438,14 @@ public class MultiTenantTransformationFilter
 
     @Override
     public CompletionStage<RequestFilterResult> onDescribeTransactionsRequest(short apiVersion, RequestHeaderData header, DescribeTransactionsRequestData request,
-                                                                              KrpcFilterContext context) {
+                                                                              FilterContext context) {
         request.setTransactionalIds(request.transactionalIds().stream().map(group -> applyTenantPrefix(context, group)).toList());
         return context.forwardRequest(header, request);
     }
 
     @Override
     public CompletionStage<ResponseFilterResult> onDescribeTransactionsResponse(short apiVersion, ResponseHeaderData header, DescribeTransactionsResponseData response,
-                                                                                KrpcFilterContext context) {
+                                                                                FilterContext context) {
         response.transactionStates().forEach(ts -> {
             removeTenantPrefix(context, ts::transactionalId, ts::setTransactionalId, false);
             ts.topics().forEach(t -> removeTenantPrefix(context, t::topic, t::setTopic, false));
@@ -454,13 +454,13 @@ public class MultiTenantTransformationFilter
     }
 
     @Override
-    public CompletionStage<RequestFilterResult> onEndTxnRequest(short apiVersion, RequestHeaderData header, EndTxnRequestData request, KrpcFilterContext context) {
+    public CompletionStage<RequestFilterResult> onEndTxnRequest(short apiVersion, RequestHeaderData header, EndTxnRequestData request, FilterContext context) {
         var tenantPrefix = getTenantPrefix(context);
         request.setTransactionalId(tenantPrefix + request.transactionalId());
         return context.forwardRequest(header, request);
     }
 
-    private void applyTenantPrefix(KrpcFilterContext context, Supplier<String> getter, Consumer<String> setter, boolean ignoreEmpty) {
+    private void applyTenantPrefix(FilterContext context, Supplier<String> getter, Consumer<String> setter, boolean ignoreEmpty) {
         String clientSideName = getter.get();
         if (ignoreEmpty && (clientSideName == null || clientSideName.isEmpty())) {
             return;
@@ -468,12 +468,12 @@ public class MultiTenantTransformationFilter
         setter.accept(applyTenantPrefix(context, clientSideName));
     }
 
-    private String applyTenantPrefix(KrpcFilterContext context, String clientSideName) {
+    private String applyTenantPrefix(FilterContext context, String clientSideName) {
         var tenantPrefix = getTenantPrefix(context);
         return tenantPrefix + clientSideName;
     }
 
-    private void removeTenantPrefix(KrpcFilterContext context, Supplier<String> getter, Consumer<String> setter, boolean ignoreEmpty) {
+    private void removeTenantPrefix(FilterContext context, Supplier<String> getter, Consumer<String> setter, boolean ignoreEmpty) {
         var brokerSideName = getter.get();
         if (ignoreEmpty && (brokerSideName == null || brokerSideName.isEmpty())) {
             return;
@@ -482,12 +482,12 @@ public class MultiTenantTransformationFilter
         setter.accept(removeTenantPrefix(context, brokerSideName));
     }
 
-    private String removeTenantPrefix(KrpcFilterContext context, String brokerSideName) {
+    private String removeTenantPrefix(FilterContext context, String brokerSideName) {
         var tenantPrefix = getTenantPrefix(context);
         return brokerSideName.substring(tenantPrefix.length());
     }
 
-    private static String getTenantPrefix(KrpcFilterContext context) {
+    private static String getTenantPrefix(FilterContext context) {
         // TODO naive - POC implementation uses virtual cluster name as a tenant prefix
         var virtualClusterName = context.getVirtualClusterName();
         if (virtualClusterName == null) {

--- a/kroxylicious-additional-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterTest.java
+++ b/kroxylicious-additional-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterTest.java
@@ -32,8 +32,8 @@ import com.google.common.reflect.ClassPath;
 import com.google.common.reflect.ClassPath.ResourceInfo;
 
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.FilterInvoker;
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
 import io.kroxylicious.test.requestresponsetestdef.ApiMessageTestDef;
@@ -71,7 +71,7 @@ class MultiTenantTransformationFilterTest {
     private final FilterInvoker invoker = getOnlyElement(FilterAndInvoker.build(filter)).invoker();
 
     @Mock(strictness = LENIENT)
-    private KrpcFilterContext context;
+    private FilterContext context;
 
     @Captor
     private ArgumentCaptor<RequestHeaderData> requestHeaderDataCaptor;

--- a/kroxylicious-additional-filters/kroxylicious-schema-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceRequestValidationFilterContributor.java
+++ b/kroxylicious-additional-filters/kroxylicious-schema-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceRequestValidationFilterContributor.java
@@ -5,8 +5,8 @@
  */
 package io.kroxylicious.proxy.filter.schema;
 
+import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterContributor;
-import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.filter.schema.config.ValidationConfig;
 import io.kroxylicious.proxy.filter.schema.validation.request.ProduceRequestValidator;
 import io.kroxylicious.proxy.service.BaseContributor;
@@ -14,9 +14,9 @@ import io.kroxylicious.proxy.service.BaseContributor;
 /**
  * Contributor for request validation filters
  */
-public class ProduceRequestValidationFilterContributor extends BaseContributor<KrpcFilter> implements FilterContributor {
+public class ProduceRequestValidationFilterContributor extends BaseContributor<Filter> implements FilterContributor {
 
-    private static final BaseContributorBuilder<KrpcFilter> FILTERS = BaseContributor.<KrpcFilter> builder()
+    private static final BaseContributorBuilder<Filter> FILTERS = BaseContributor.<Filter> builder()
             .add("ProduceValidator", ValidationConfig.class, (config) -> {
                 ProduceRequestValidator validator = ProduceValidationFilterBuilder.build(config);
                 return new ProduceValidationFilter(config.isForwardPartialRequests(), validator);

--- a/kroxylicious-additional-filters/kroxylicious-schema-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceValidationFilter.java
+++ b/kroxylicious-additional-filters/kroxylicious-schema-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceValidationFilter.java
@@ -18,7 +18,7 @@ import org.apache.kafka.common.protocol.Errors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
 import io.kroxylicious.proxy.filter.ProduceResponseFilter;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
@@ -65,7 +65,7 @@ public class ProduceValidationFilter implements ProduceRequestFilter, ProduceRes
     }
 
     @Override
-    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, KrpcFilterContext context) {
+    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, FilterContext context) {
         ProduceRequestValidationResult result = validator.validateRequest(request);
         if (result.isAnyTopicPartitionInvalid()) {
             return handleInvalidTopicPartitions(header, request, context, result);
@@ -75,7 +75,7 @@ public class ProduceValidationFilter implements ProduceRequestFilter, ProduceRes
         }
     }
 
-    private CompletionStage<RequestFilterResult> handleInvalidTopicPartitions(RequestHeaderData header, ProduceRequestData request, KrpcFilterContext context,
+    private CompletionStage<RequestFilterResult> handleInvalidTopicPartitions(RequestHeaderData header, ProduceRequestData request, FilterContext context,
                                                                               ProduceRequestValidationResult result) {
         if (result.isAllTopicPartitionsInvalid()) {
             LOGGER.debug("all topic-partitions for request contained invalid data: {}", result);
@@ -150,7 +150,7 @@ public class ProduceValidationFilter implements ProduceRequestFilter, ProduceRes
 
     @Override
     public CompletionStage<ResponseFilterResult> onProduceResponse(short apiVersion, ResponseHeaderData header, ProduceResponseData response,
-                                                                   KrpcFilterContext context) {
+                                                                   FilterContext context) {
         ProduceRequestValidationResult produceRequestValidationResult = correlatedResults.remove(header.correlationId());
         if (produceRequestValidationResult != null) {
             LOGGER.debug("augmenting invalid topic-partition details into response: {}", produceRequestValidationResult);

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/CompositeFilter.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/CompositeFilter.java
@@ -25,12 +25,12 @@ import java.util.List;
  * user configuration.
  *</p>
  */
-public interface CompositeFilter extends KrpcFilter {
+public interface CompositeFilter extends Filter {
 
     /**
-     * Get composed KrpcFilters
+     * Get composed Filters
      * @return filters
      */
-    List<KrpcFilter> getFilters();
+    List<Filter> getFilters();
 
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/Filter.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/Filter.java
@@ -9,6 +9,6 @@ package io.kroxylicious.proxy.filter;
 /**
  * Marker interface all Filter interfaces extend from
  */
-public /* sealed */ interface KrpcFilter {
+public /* sealed */ interface Filter {
 
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterAndInvoker.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterAndInvoker.java
@@ -15,7 +15,7 @@ import static java.util.Objects.requireNonNull;
  * @param filter filter
  * @param invoker invoker
  */
-public record FilterAndInvoker(KrpcFilter filter, FilterInvoker invoker) {
+public record FilterAndInvoker(Filter filter, FilterInvoker invoker) {
     public FilterAndInvoker {
         requireNonNull(filter, "filter cannot be null");
         requireNonNull(invoker, "invoker cannot be null");
@@ -26,7 +26,7 @@ public record FilterAndInvoker(KrpcFilter filter, FilterInvoker invoker) {
      * @param filter filter
      * @return a filter and its respective invoker
      */
-    public static List<FilterAndInvoker> build(KrpcFilter filter) {
+    public static List<FilterAndInvoker> build(Filter filter) {
         return FilterInvokers.from(filter);
     }
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
@@ -19,7 +19,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 /**
  * A context to allow filters to interact with other filters and the pipeline.
  */
-public interface KrpcFilterContext {
+public interface FilterContext {
     /**
      * A description of this channel.
      * @return A description of this channel (typically used for logging).

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContributor.java
@@ -11,5 +11,5 @@ import io.kroxylicious.proxy.service.Contributor;
  * FilterContributor is a pluggable source of Kroxylicious filter implementations.
  * @see Contributor
  */
-public interface FilterContributor extends Contributor<KrpcFilter> {
+public interface FilterContributor extends Contributor<Filter> {
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvoker.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvoker.java
@@ -14,7 +14,7 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
 
 /**
- * The FilterInvoker connects Kroxylicious with the concrete implementation of a KrpcFilter.
+ * The FilterInvoker connects Kroxylicious with the concrete implementation of a Filter.
  * <p>When handling a message, we want to avoid the penalty of deserializing the bytes
  * into an ApiMessage. When Kroxylicious receives a message, all the Filters in the
  * filter chain will be consulted (via their invoker) to see if any want to handle that message.
@@ -27,7 +27,7 @@ import org.apache.kafka.common.protocol.ApiMessage;
  * <ol>
  *     <li>That each instance of the FilterInvoker is associated with a single channel</li>
  *     <li>That {@link #shouldHandleRequest(ApiKeys, short)} and
- *     {@link #onRequest(ApiKeys, short, RequestHeaderData, ApiMessage, KrpcFilterContext)} (or {@code on*Request} as appropriate)
+ *     {@link #onRequest(ApiKeys, short, RequestHeaderData, ApiMessage, FilterContext)} (or {@code on*Request} as appropriate)
  *     will always be invoked on the same thread.</li>
  *     <li>That filters are applied in the order they were configured.</li>
  * </ol>
@@ -45,7 +45,7 @@ public interface FilterInvoker {
     /**
      * Should this Invoker handle a request with a given api key and api version.
      * Returning true implies that this request will be deserialized and
-     * {@link #onRequest(ApiKeys, short, RequestHeaderData, ApiMessage, KrpcFilterContext)}
+     * {@link #onRequest(ApiKeys, short, RequestHeaderData, ApiMessage, FilterContext)}
      * is eligible to be called with the deserialized data (if the message flows to that filter).
      *
      * @param apiKey the key of the message
@@ -59,7 +59,7 @@ public interface FilterInvoker {
     /**
      * Should this Invoker handle a response with a given api key and api version.
      * Returning true implies that this response will be deserialized and
-     * {@link #onResponse(ApiKeys, short, ResponseHeaderData, ApiMessage, KrpcFilterContext)}
+     * {@link #onResponse(ApiKeys, short, ResponseHeaderData, ApiMessage, FilterContext)}
      * is eligible to be called with the deserialized data (if the message flows to that filter).
      *
      * @param apiKey the key of the message
@@ -78,9 +78,9 @@ public interface FilterInvoker {
      * encapsulates the request to be forwarded and, optionally, orders for actions such as closing the connection or
      * dropping the request.
      * </p><p>
-     * The {@link KrpcFilterContext} is the factory for {@link FilterResult} objects.  See
-     * {@link KrpcFilterContext#forwardRequest(RequestHeaderData, ApiMessage)} and
-     * {@link KrpcFilterContext#requestFilterResultBuilder()} for more details.
+     * The {@link FilterContext} is the factory for {@link FilterResult} objects.  See
+     * {@link FilterContext#forwardRequest(RequestHeaderData, ApiMessage)} and
+     * {@link FilterContext#requestFilterResultBuilder()} for more details.
      * </p>
      * @param apiKey        the key of the message
      * @param apiVersion    the apiVersion of the message
@@ -90,7 +90,7 @@ public interface FilterInvoker {
      * @return a {@link CompletionStage<RequestFilterResult>}, that when complete, will yield the request to forward.
      */
     default CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, short apiVersion, RequestHeaderData header, ApiMessage body,
-                                                           KrpcFilterContext filterContext) {
+                                                           FilterContext filterContext) {
         return filterContext.requestFilterResultBuilder().forward(header, body).completed();
     }
 
@@ -102,9 +102,9 @@ public interface FilterInvoker {
      * encapsulates the response to be forwarded and, optionally, orders for actions such as closing the connection or
      * dropping the response.
      * </p><p>
-     * The {@link KrpcFilterContext} is the factory for {@link FilterResult} objects.  See
-     * {@link KrpcFilterContext#forwardResponse(ResponseHeaderData, ApiMessage)} and
-     * {@link KrpcFilterContext#responseFilterResultBuilder()} for more details.
+     * The {@link FilterContext} is the factory for {@link FilterResult} objects.  See
+     * {@link FilterContext#forwardResponse(ResponseHeaderData, ApiMessage)} and
+     * {@link FilterContext#responseFilterResultBuilder()} for more details.
      * </p>
      *
      * @param apiKey        the key of the message
@@ -115,7 +115,7 @@ public interface FilterInvoker {
      * @return a {@link CompletionStage<ResponseFilterResult>}, that when complete, will yield the response to forward.
      */
     default CompletionStage<ResponseFilterResult> onResponse(ApiKeys apiKey, short apiVersion, ResponseHeaderData header, ApiMessage body,
-                                                             KrpcFilterContext filterContext) {
+                                                             FilterContext filterContext) {
         return filterContext.responseFilterResultBuilder().forward(header, body).completed();
     }
 

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/HandleNothingFilterInvoker.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/HandleNothingFilterInvoker.java
@@ -17,12 +17,12 @@ record HandleNothingFilterInvoker() implements FilterInvoker {
     static final FilterInvoker INSTANCE = new HandleNothingFilterInvoker();
 
     @Override
-    public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, short apiVersion, RequestHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+    public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, short apiVersion, RequestHeaderData header, ApiMessage body, FilterContext filterContext) {
         throw new IllegalStateException("I should never be invoked");
     }
 
     @Override
-    public CompletionStage<ResponseFilterResult> onResponse(ApiKeys apiKey, short apiVersion, ResponseHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+    public CompletionStage<ResponseFilterResult> onResponse(ApiKeys apiKey, short apiVersion, ResponseHeaderData header, ApiMessage body, FilterContext filterContext) {
         throw new IllegalStateException("I should never be invoked");
     }
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestFilter.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestFilter.java
@@ -13,17 +13,17 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
 
 /**
- * A KrpcFilter implementation intended to simplify cases where we want to handle all or
+ * A Filter implementation intended to simplify cases where we want to handle all or
  * most request types, for example to modify the request headers. If a Filter implements
  * RequestFilter, it cannot also implement {@link CompositeFilter} or any of the specific
  * message Filter interfaces like {@link ApiVersionsRequestFilter}. If a Filter implements
  * RequestFilter, it may also implement {@link ResponseFilter}.
  */
-public interface RequestFilter extends KrpcFilter {
+public interface RequestFilter extends Filter {
 
     /**
      * Does this filter implementation want to handle a request. If so, the
-     * {@link #onRequest(ApiKeys, RequestHeaderData, ApiMessage, KrpcFilterContext)} method
+     * {@link #onRequest(ApiKeys, RequestHeaderData, ApiMessage, FilterContext)} method
      * will be eligible to be called with the deserialized request data (if the
      * message reaches this filter in the filter chain).
      *
@@ -53,5 +53,5 @@ public interface RequestFilter extends KrpcFilter {
     CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey,
                                                    RequestHeaderData header,
                                                    ApiMessage request,
-                                                   KrpcFilterContext context);
+                                                   FilterContext context);
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestFilterInvoker.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestFilterInvoker.java
@@ -15,7 +15,7 @@ import org.apache.kafka.common.protocol.ApiMessage;
 record RequestFilterInvoker(RequestFilter filter) implements FilterInvoker {
 
     @Override
-    public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, short apiVersion, RequestHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+    public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, short apiVersion, RequestHeaderData header, ApiMessage body, FilterContext filterContext) {
         return filter.onRequest(apiKey, header, body, filterContext);
     }
 

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestResponseInvoker.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestResponseInvoker.java
@@ -16,12 +16,12 @@ import org.apache.kafka.common.protocol.ApiMessage;
 record RequestResponseInvoker(RequestFilter requestFilter, ResponseFilter responseFilter) implements FilterInvoker {
 
     @Override
-    public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, short apiVersion, RequestHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+    public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, short apiVersion, RequestHeaderData header, ApiMessage body, FilterContext filterContext) {
         return requestFilter.onRequest(apiKey, header, body, filterContext);
     }
 
     @Override
-    public CompletionStage<ResponseFilterResult> onResponse(ApiKeys apiKey, short apiVersion, ResponseHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+    public CompletionStage<ResponseFilterResult> onResponse(ApiKeys apiKey, short apiVersion, ResponseHeaderData header, ApiMessage body, FilterContext filterContext) {
         return responseFilter.onResponse(apiKey, header, body, filterContext);
     }
 

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/ResponseFilter.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/ResponseFilter.java
@@ -13,17 +13,17 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
 
 /**
- * A KrpcFilter implementation intended to simplify cases where we want to handle all or
+ * A Filter implementation intended to simplify cases where we want to handle all or
  * most response types, for example to modify the response headers. If a Filter implements
  * ResponseFilter, it cannot also implement {@link CompositeFilter} or any of the specific
  * message Filter interfaces like {@link ApiVersionsRequestFilter}. If a Filter implements
  * ResponseFilter, it may also implement {@link RequestFilter}.
  */
-public interface ResponseFilter extends KrpcFilter {
+public interface ResponseFilter extends Filter {
 
     /**
      * Does this filter implementation want to handle a response. If so, the
-     * {@link #onResponse(ApiKeys, ResponseHeaderData, ApiMessage, KrpcFilterContext)} method
+     * {@link #onResponse(ApiKeys, ResponseHeaderData, ApiMessage, FilterContext)} method
      * will be eligible to be called with the deserialized response data (if the
      * message reaches this filter in the filter chain).
      *
@@ -53,5 +53,5 @@ public interface ResponseFilter extends KrpcFilter {
     CompletionStage<ResponseFilterResult> onResponse(ApiKeys apiKey,
                                                      ResponseHeaderData header,
                                                      ApiMessage response,
-                                                     KrpcFilterContext context);
+                                                     FilterContext context);
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/ResponseFilterInvoker.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/ResponseFilterInvoker.java
@@ -15,7 +15,7 @@ import org.apache.kafka.common.protocol.ApiMessage;
 record ResponseFilterInvoker(ResponseFilter filter) implements FilterInvoker {
 
     @Override
-    public CompletionStage<ResponseFilterResult> onResponse(ApiKeys apiKey, short apiVersion, ResponseHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+    public CompletionStage<ResponseFilterResult> onResponse(ApiKeys apiKey, short apiVersion, ResponseHeaderData header, ApiMessage body, FilterContext filterContext) {
         return filter.onResponse(apiKey, header, body, filterContext);
     }
 

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/SafeInvoker.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/SafeInvoker.java
@@ -22,7 +22,7 @@ import org.apache.kafka.common.protocol.ApiMessage;
 record SafeInvoker(FilterInvoker invoker) implements FilterInvoker {
 
     @Override
-    public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, short apiVersion, RequestHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+    public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, short apiVersion, RequestHeaderData header, ApiMessage body, FilterContext filterContext) {
         if (invoker.shouldHandleRequest(apiKey, apiVersion)) {
             return invoker.onRequest(apiKey, apiVersion, header, body, filterContext);
         }
@@ -32,7 +32,7 @@ record SafeInvoker(FilterInvoker invoker) implements FilterInvoker {
     }
 
     @Override
-    public CompletionStage<ResponseFilterResult> onResponse(ApiKeys apiKey, short apiVersion, ResponseHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+    public CompletionStage<ResponseFilterResult> onResponse(ApiKeys apiKey, short apiVersion, ResponseHeaderData header, ApiMessage body, FilterContext filterContext) {
         if (invoker.shouldHandleResponse(apiKey, apiVersion)) {
             return invoker.onResponse(apiKey, apiVersion, header, body, filterContext);
         }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/package-info.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/package-info.java
@@ -27,16 +27,16 @@
  * <p><strong>IMPORTANT:</strong> The pausing of reads from the downstream is a relatively costly operation.  To maintain optimal performance
  * filter implementations should minimise the occasions on which an incomplete CompletionStage is returned.</p>
  * <h3 id='implementing.createFilterResults'>Creating Filter Result objects</h3>
- * <p>The {@link io.kroxylicious.proxy.filter.KrpcFilterContext} is the factory for the FilterResult objects.</p>
+ * <p>The {@link io.kroxylicious.proxy.filter.FilterContext} is the factory for the FilterResult objects.</p>
  * <p>There are two convenience methods that simply allow a filter to immediately forward a result:</p>
  * <ul>
- *     <li>{@link io.kroxylicious.proxy.filter.KrpcFilterContext#forwardRequest(org.apache.kafka.common.message.RequestHeaderData, org.apache.kafka.common.protocol.ApiMessage)}, and</li>
- *     <li>{@link io.kroxylicious.proxy.filter.KrpcFilterContext#forwardResponse(org.apache.kafka.common.message.ResponseHeaderData, org.apache.kafka.common.protocol.ApiMessage)}.</li>
+ *     <li>{@link io.kroxylicious.proxy.filter.FilterContext#forwardRequest(org.apache.kafka.common.message.RequestHeaderData, org.apache.kafka.common.protocol.ApiMessage)}, and</li>
+ *     <li>{@link io.kroxylicious.proxy.filter.FilterContext#forwardResponse(org.apache.kafka.common.message.ResponseHeaderData, org.apache.kafka.common.protocol.ApiMessage)}.</li>
  * </ul>
  * <p>To access richer features, use the filter result builders:</p>
  * <ul>
- *     <li>{@link io.kroxylicious.proxy.filter.KrpcFilterContext#requestFilterResultBuilder()} and</li>
- *     <li>{@link io.kroxylicious.proxy.filter.KrpcFilterContext#responseFilterResultBuilder()}.</li>
+ *     <li>{@link io.kroxylicious.proxy.filter.FilterContext#requestFilterResultBuilder()} and</li>
+ *     <li>{@link io.kroxylicious.proxy.filter.FilterContext#responseFilterResultBuilder()}.</li>
  * </ul>
  */
 package io.kroxylicious.proxy.filter;

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/package-info.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/package-info.java
@@ -6,7 +6,7 @@
 /**
  * <p>The API for writing protocol filters (aka interceptors).</p>
  *
- * <p>{@link io.kroxylicious.proxy.filter.KrpcFilter} is the base interface for filters,
+ * <p>{@link io.kroxylicious.proxy.filter.Filter} is the base interface for filters,
  * with a subinterface for each request and response API (e.g. {@link io.kroxylicious.proxy.filter.ProduceRequestFilter}).</p>
  *
  * <p>Filter plugins can multiply inherit several of the per-RPC interfaces if they need to intercept several kinds

--- a/kroxylicious-api/src/main/templates/Kproxy/Filter.ftl
+++ b/kroxylicious-api/src/main/templates/Kproxy/Filter.ftl
@@ -38,7 +38,7 @@ import org.apache.kafka.common.message.${headerClass};
 /**
  * A stateless filter for ${messageSpec.name}s.
  */
-public interface ${filterClass} extends KrpcFilter {
+public interface ${filterClass} extends Filter {
 
     /**
      * Determine if a ${msgType} message of type ${messageSpec.name} should be handled by
@@ -67,6 +67,6 @@ public interface ${filterClass} extends KrpcFilter {
      *         ${msgType} to be forwarded.
      * @see io.kroxylicious.proxy.filter Creating Filter Result objects
      */
-     CompletionStage<${filterResultClass}> on${messageSpec.name}(short apiVersion, ${headerClass} header, ${dataClass} ${msgType}, KrpcFilterContext context);
+     CompletionStage<${filterResultClass}> on${messageSpec.name}(short apiVersion, ${headerClass} header, ${dataClass} ${msgType}, FilterContext context);
 
 }

--- a/kroxylicious-api/src/main/templates/Kproxy/FilterInvoker.ftl
+++ b/kroxylicious-api/src/main/templates/Kproxy/FilterInvoker.ftl
@@ -62,7 +62,7 @@ class ${filterInvokerClass} implements FilterInvoker {
     }
 
     @Override
-    public CompletionStage<${filterResultClass}> on<#if messageSpec.type?lower_case == 'response'>Response<#else>Request</#if>(ApiKeys apiKey, short apiVersion, ${headerClass} header, ApiMessage body, KrpcFilterContext filterContext) {
+    public CompletionStage<${filterResultClass}> on<#if messageSpec.type?lower_case == 'response'>Response<#else>Request</#if>(ApiKeys apiKey, short apiVersion, ${headerClass} header, ApiMessage body, FilterContext filterContext) {
         return filter.on${messageSpec.name}(apiVersion, header, (${dataClass}) body, filterContext);
     }
 }

--- a/kroxylicious-api/src/main/templates/Kproxy/SpecificFilterArrayInvoker.ftl
+++ b/kroxylicious-api/src/main/templates/Kproxy/SpecificFilterArrayInvoker.ftl
@@ -37,7 +37,7 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
 
 /**
- * Invoker for KrpcFilters that implement any number of Specific Message interfaces (for
+ * Invoker for Filters that implement any number of Specific Message interfaces (for
  * example {@link io.kroxylicious.proxy.filter.AlterConfigsResponseFilter}.
  */
 class SpecificFilterArrayInvoker implements FilterInvoker {
@@ -47,7 +47,7 @@ class SpecificFilterArrayInvoker implements FilterInvoker {
     private final FilterInvoker[] requestInvokers;
     private final FilterInvoker[] responseInvokers;
 
-    SpecificFilterArrayInvoker(KrpcFilter filter) {
+    SpecificFilterArrayInvoker(Filter filter) {
         Map<Integer, FilterInvoker> requestInvokers = new HashMap<>();
         Map<Integer, FilterInvoker> responseInvokers = new HashMap<>();
         <#list messageSpecs as messageSpec>
@@ -73,7 +73,7 @@ class SpecificFilterArrayInvoker implements FilterInvoker {
                                                           short apiVersion,
                                                           RequestHeaderData header,
                                                           ApiMessage body,
-                                                          KrpcFilterContext filterContext) {
+                                                          FilterContext filterContext) {
         // We wrap the array lookup in a switch based on the API Key as it supports JIT optimisations around method dispatch.
         // See the InvokerDispatchBenchmark micro benchmark for a comparison
         return switch (apiKey) {
@@ -102,7 +102,7 @@ class SpecificFilterArrayInvoker implements FilterInvoker {
                                                             short apiVersion,
                                                             ResponseHeaderData header,
                                                             ApiMessage body,
-                                                            KrpcFilterContext filterContext) {
+                                                            FilterContext filterContext) {
         // We wrap the array lookup in a switch based on the API Key as it supports JIT optimisations around method dispatch.
         // See the InvokerDispatchBenchmark micro benchmark for a comparison
         return switch (apiKey) {
@@ -184,11 +184,11 @@ class SpecificFilterArrayInvoker implements FilterInvoker {
     }
 
     /**
-    * Check if a KrpcFilter implements any of the Specific Message Filter interfaces
+    * Check if a Filter implements any of the Specific Message Filter interfaces
     * @param filter the filter
     * @return true if the filter implements any Specific Message Filter interfaces
     */
-    public static boolean implementsAnySpecificFilterInterface(KrpcFilter filter) {
+    public static boolean implementsAnySpecificFilterInterface(Filter filter) {
         return <#list messageSpecs as messageSpec>filter instanceof ${messageSpec.name}Filter<#sep> ||
         </#sep></#list>;
     }

--- a/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleContributor.java
+++ b/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleContributor.java
@@ -6,16 +6,16 @@
 
 package io.kroxylicious.sample;
 
+import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterContributor;
-import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.service.BaseContributor;
 import io.kroxylicious.sample.config.SampleFilterConfig;
 
-public class SampleContributor extends BaseContributor<KrpcFilter> implements FilterContributor {
+public class SampleContributor extends BaseContributor<Filter> implements FilterContributor {
 
     public static final String SAMPLE_FETCH = "SampleFetchResponse";
     public static final String SAMPLE_PRODUCE = "SampleProduceRequest";
-    public static final BaseContributorBuilder<KrpcFilter> FILTERS = BaseContributor.<KrpcFilter> builder()
+    public static final BaseContributorBuilder<Filter> FILTERS = BaseContributor.<Filter> builder()
             .add(SAMPLE_FETCH, SampleFilterConfig.class, SampleFetchResponseFilter::new)
             .add(SAMPLE_PRODUCE, SampleFilterConfig.class, SampleProduceRequestFilter::new);
 

--- a/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleFetchResponseFilter.java
+++ b/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleFetchResponseFilter.java
@@ -15,7 +15,7 @@ import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
 
 import io.kroxylicious.proxy.filter.FetchResponseFilter;
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
 import io.kroxylicious.sample.config.SampleFilterConfig;
 import io.kroxylicious.sample.util.SampleFilterTransformer;
@@ -59,7 +59,7 @@ public class SampleFetchResponseFilter implements FetchResponseFilter {
      * @return CompletionStage that will yield a {@link ResponseFilterResult} containing the response to be forwarded.
      */
     @Override
-    public CompletionStage<ResponseFilterResult> onFetchResponse(short apiVersion, ResponseHeaderData header, FetchResponseData response, KrpcFilterContext context) {
+    public CompletionStage<ResponseFilterResult> onFetchResponse(short apiVersion, ResponseHeaderData header, FetchResponseData response, FilterContext context) {
         this.timer.record(() -> applyTransformation(response, context)); // We're timing this to report how long it takes through Micrometer
         return context.forwardResponse(header, response);
     }
@@ -69,7 +69,7 @@ public class SampleFetchResponseFilter implements FetchResponseFilter {
      * @param response the response to be transformed
      * @param context the context
      */
-    private void applyTransformation(FetchResponseData response, KrpcFilterContext context) {
+    private void applyTransformation(FetchResponseData response, FilterContext context) {
         response.responses().forEach(responseData -> {
             for (FetchResponseData.PartitionData partitionData : responseData.partitions()) {
                 SampleFilterTransformer.transform(partitionData, context, this.config);

--- a/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleProduceRequestFilter.java
+++ b/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleProduceRequestFilter.java
@@ -15,7 +15,7 @@ import org.apache.kafka.common.message.RequestHeaderData;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
 
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.sample.config.SampleFilterConfig;
@@ -60,7 +60,7 @@ public class SampleProduceRequestFilter implements ProduceRequestFilter {
      * @return CompletionStage that will yield a {@link RequestFilterResult} containing the request to be forwarded.
      */
     @Override
-    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, KrpcFilterContext context) {
+    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, FilterContext context) {
         this.timer.record(() -> applyTransformation(request, context)); // We're timing this to report how long it takes through Micrometer
 
         return context.forwardRequest(header, request);
@@ -71,7 +71,7 @@ public class SampleProduceRequestFilter implements ProduceRequestFilter {
      * @param request the request to be transformed
      * @param context the context
      */
-    private void applyTransformation(ProduceRequestData request, KrpcFilterContext context) {
+    private void applyTransformation(ProduceRequestData request, FilterContext context) {
         request.topicData().forEach(topicData -> {
             for (PartitionProduceData partitionData : topicData.partitionData()) {
                 SampleFilterTransformer.transform(partitionData, context, this.config);

--- a/kroxylicious-sample/src/main/java/io/kroxylicious/sample/util/SampleFilterTransformer.java
+++ b/kroxylicious-sample/src/main/java/io/kroxylicious/sample/util/SampleFilterTransformer.java
@@ -17,7 +17,7 @@ import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.sample.config.SampleFilterConfig;
 
 /**
@@ -32,7 +32,7 @@ public class SampleFilterTransformer {
      * @param context the context
      * @param config the transform configuration
      */
-    public static void transform(ProduceRequestData.PartitionProduceData partitionData, KrpcFilterContext context, SampleFilterConfig config) {
+    public static void transform(ProduceRequestData.PartitionProduceData partitionData, FilterContext context, SampleFilterConfig config) {
         partitionData.setRecords(transformPartitionRecords((AbstractRecords) partitionData.records(), context, config.getFindValue(), config.getReplacementValue()));
     }
 
@@ -42,7 +42,7 @@ public class SampleFilterTransformer {
      * @param context the context
      * @param config the transform configuration
      */
-    public static void transform(FetchResponseData.PartitionData partitionData, KrpcFilterContext context, SampleFilterConfig config) {
+    public static void transform(FetchResponseData.PartitionData partitionData, FilterContext context, SampleFilterConfig config) {
         partitionData.setRecords(transformPartitionRecords((AbstractRecords) partitionData.records(), context, config.getFindValue(), config.getReplacementValue()));
     }
 
@@ -54,7 +54,7 @@ public class SampleFilterTransformer {
      * @param replacementValue the replacement value
      * @return the transformed partition records
      */
-    private static AbstractRecords transformPartitionRecords(AbstractRecords records, KrpcFilterContext context, String findValue, String replacementValue) {
+    private static AbstractRecords transformPartitionRecords(AbstractRecords records, FilterContext context, String findValue, String replacementValue) {
         if (records.batchIterator().hasNext()) {
             ByteBufferOutputStream stream = context.createByteBufferOutputStream(records.sizeInBytes());
             MemoryRecordsBuilder newRecords = createMemoryRecordsBuilder(stream, records.firstBatch());

--- a/kroxylicious-sample/src/test/java/io/kroxylicious/sample/SampleFetchResponseFilterTest.java
+++ b/kroxylicious-sample/src/test/java/io/kroxylicious/sample/SampleFetchResponseFilterTest.java
@@ -34,7 +34,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
 
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
 import io.kroxylicious.sample.config.SampleFilterConfig;
 
@@ -51,7 +51,7 @@ class SampleFetchResponseFilterTest {
     private static final String CONFIG_FIND_VALUE = "from";
     private static final String CONFIG_REPLACE_VALUE = "to";
     @Mock
-    private KrpcFilterContext context;
+    private FilterContext context;
 
     @Mock(strictness = Mock.Strictness.LENIENT)
     private ResponseFilterResult responseFilterResult;

--- a/kroxylicious-sample/src/test/java/io/kroxylicious/sample/SampleProduceRequestFilterTest.java
+++ b/kroxylicious-sample/src/test/java/io/kroxylicious/sample/SampleProduceRequestFilterTest.java
@@ -34,7 +34,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
 
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.sample.config.SampleFilterConfig;
 
@@ -52,7 +52,7 @@ class SampleProduceRequestFilterTest {
     private static final String CONFIG_REPLACE_VALUE = "to";
 
     @Mock
-    private KrpcFilterContext context;
+    private FilterContext context;
 
     @Mock(strictness = Mock.Strictness.LENIENT)
     private RequestFilterResult requestFilterResult;

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -29,11 +29,11 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
 
+import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.FilterInvoker;
 import io.kroxylicious.proxy.filter.FilterResult;
-import io.kroxylicious.proxy.filter.KrpcFilter;
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.filter.RequestFilterResultBuilder;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
@@ -53,12 +53,12 @@ import io.kroxylicious.proxy.model.VirtualCluster;
 
 /**
  * A {@code ChannelInboundHandler} (for handling requests from downstream)
- * that applies a single {@link KrpcFilter}.
+ * that applies a single {@link Filter}.
  */
 public class FilterHandler extends ChannelDuplexHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FilterHandler.class);
-    private final KrpcFilter filter;
+    private final Filter filter;
     private final FilterInvoker invoker;
     private final long timeoutMs;
     private final String sniHostname;
@@ -427,7 +427,7 @@ public class FilterHandler extends ChannelDuplexHandler {
         });
     }
 
-    private class InternalFilterContext implements KrpcFilterContext {
+    private class InternalFilterContext implements FilterContext {
 
         private final DecodedFrame<?, ?> decodedFrame;
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/InternalRequestFrame.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/InternalRequestFrame.java
@@ -11,18 +11,18 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
 
-import io.kroxylicious.proxy.filter.KrpcFilter;
+import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 
 public class InternalRequestFrame<B extends ApiMessage> extends DecodedRequestFrame<B> {
 
     private final CompletableFuture<?> promise;
-    private final KrpcFilter recipient;
+    private final Filter recipient;
 
     public InternalRequestFrame(short apiVersion,
                                 int correlationId,
                                 boolean decodeResponse,
-                                KrpcFilter recipient,
+                                Filter recipient,
                                 CompletableFuture<?> promise,
                                 RequestHeaderData header,
                                 B body) {
@@ -31,7 +31,7 @@ public class InternalRequestFrame<B extends ApiMessage> extends DecodedRequestFr
         this.recipient = Objects.requireNonNull(recipient);
     }
 
-    public KrpcFilter recipient() {
+    public Filter recipient() {
         return recipient;
     }
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/InternalResponseFrame.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/InternalResponseFrame.java
@@ -11,26 +11,26 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
 
-import io.kroxylicious.proxy.filter.KrpcFilter;
+import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 
 public class InternalResponseFrame<B extends ApiMessage> extends DecodedResponseFrame<B> {
 
-    private final KrpcFilter recipient;
+    private final Filter recipient;
 
     private final CompletableFuture<?> future;
 
-    public InternalResponseFrame(KrpcFilter recipient, short apiVersion, int correlationId, ResponseHeaderData header, B body, CompletableFuture<?> future) {
+    public InternalResponseFrame(Filter recipient, short apiVersion, int correlationId, ResponseHeaderData header, B body, CompletableFuture<?> future) {
         super(apiVersion, correlationId, header, body);
         this.recipient = Objects.requireNonNull(recipient);
         this.future = future;
     }
 
-    public boolean isRecipient(KrpcFilter candidate) {
+    public boolean isRecipient(Filter candidate) {
         return recipient != null && recipient.equals(candidate);
     }
 
-    public KrpcFilter recipient() {
+    public Filter recipient() {
         return recipient;
     }
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/CorrelationManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/CorrelationManager.java
@@ -14,7 +14,7 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.kroxylicious.proxy.filter.KrpcFilter;
+import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 /**
@@ -54,7 +54,7 @@ public class CorrelationManager {
                                 short apiVersion,
                                 int downstreamCorrelationId,
                                 boolean hasResponse,
-                                KrpcFilter recipient,
+                                Filter recipient,
                                 CompletableFuture<?> promise,
                                 boolean decodeResponse) {
         // need to allocate an id and put in a map for quick lookup, along with the "tag"
@@ -90,14 +90,14 @@ public class CorrelationManager {
 
         private final int downstreamCorrelationId;
         private final boolean decodeResponse;
-        private final KrpcFilter recipient;
+        private final Filter recipient;
         private final CompletableFuture<?> promise;
 
         private Correlation(short apiKey,
                             short apiVersion,
                             int downstreamCorrelationId,
                             boolean decodeResponse,
-                            KrpcFilter recipient,
+                            Filter recipient,
                             CompletableFuture<?> promise) {
             this.apiKey = apiKey;
             this.apiVersion = apiVersion;
@@ -153,7 +153,7 @@ public class CorrelationManager {
             return decodeResponse;
         }
 
-        public KrpcFilter recipient() {
+        public Filter recipient() {
             return recipient;
         }
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseDecoder.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseDecoder.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 
-import io.kroxylicious.proxy.filter.KrpcFilter;
+import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 import io.kroxylicious.proxy.frame.Frame;
 import io.kroxylicious.proxy.frame.OpaqueFrame;
@@ -69,7 +69,7 @@ public class KafkaResponseDecoder extends KafkaMessageDecoder {
             log().trace("{}: Header: {}", ctx, header);
             ApiMessage body = BodyDecoder.decodeResponse(apiKey, apiVersion, accessor);
             log().trace("{}: Body: {}", ctx, body);
-            KrpcFilter recipient = correlation.recipient();
+            Filter recipient = correlation.recipient();
             Metrics.payloadSizeBytesDownstreamSummary(apiKey, apiVersion).record(length);
             if (recipient == null) {
                 frame = new DecodedResponseFrame<>(apiVersion, correlationId, header, body);

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ApiVersionsFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ApiVersionsFilter.java
@@ -16,7 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.kroxylicious.proxy.filter.ApiVersionsResponseFilter;
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
 
 /**
@@ -75,7 +75,7 @@ public class ApiVersionsFilter implements ApiVersionsResponseFilter {
 
     @Override
     public CompletionStage<ResponseFilterResult> onApiVersionsResponse(short apiVersion, ResponseHeaderData header, ApiVersionsResponseData data,
-                                                                       KrpcFilterContext context) {
+                                                                       FilterContext context) {
         intersectApiVersions(context.channelDescriptor(), data);
         return context.forwardResponse(header, data);
     }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BuiltinFilterContributor.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BuiltinFilterContributor.java
@@ -5,15 +5,15 @@
  */
 package io.kroxylicious.proxy.internal.filter;
 
+import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterContributor;
-import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.internal.filter.FetchResponseTransformationFilter.FetchResponseTransformationConfig;
 import io.kroxylicious.proxy.internal.filter.ProduceRequestTransformationFilter.ProduceRequestTransformationConfig;
 import io.kroxylicious.proxy.service.BaseContributor;
 
-public class BuiltinFilterContributor extends BaseContributor<KrpcFilter> implements FilterContributor {
+public class BuiltinFilterContributor extends BaseContributor<Filter> implements FilterContributor {
 
-    public static final BaseContributorBuilder<KrpcFilter> FILTERS = BaseContributor.<KrpcFilter> builder()
+    public static final BaseContributorBuilder<Filter> FILTERS = BaseContributor.<Filter> builder()
             .add("ProduceRequestTransformation", ProduceRequestTransformationConfig.class, ProduceRequestTransformationFilter::new)
             .add("FetchResponseTransformation", FetchResponseTransformationConfig.class, FetchResponseTransformationFilter::new);
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/EagerMetadataLearner.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/EagerMetadataLearner.java
@@ -17,7 +17,7 @@ import org.apache.kafka.common.protocol.ApiMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.RequestFilter;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 
@@ -45,7 +45,7 @@ public class EagerMetadataLearner implements RequestFilter {
     }
 
     @Override
-    public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage body, KrpcFilterContext context) {
+    public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage body, FilterContext context) {
         if (KAFKA_PRELUDE.contains(apiKey)) {
             return context.requestFilterResultBuilder().forward(header, body).completed();
         }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FetchResponseTransformationFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FetchResponseTransformationFilter.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import io.kroxylicious.proxy.config.BaseConfig;
 import io.kroxylicious.proxy.filter.FetchResponseFilter;
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
 import io.kroxylicious.proxy.internal.util.MemoryRecordsHelper;
 
@@ -75,7 +75,7 @@ public class FetchResponseTransformationFilter implements FetchResponseFilter {
 
     @Override
     public CompletionStage<ResponseFilterResult> onFetchResponse(short apiVersion, ResponseHeaderData header, FetchResponseData fetchResponse,
-                                                                 KrpcFilterContext context) {
+                                                                 FilterContext context) {
         List<MetadataRequestData.MetadataRequestTopic> requestTopics = fetchResponse.responses().stream()
                 .filter(t -> t.topic().isEmpty())
                 .map(fetchableTopicResponse -> {
@@ -112,7 +112,7 @@ public class FetchResponseTransformationFilter implements FetchResponseFilter {
         }
     }
 
-    private void applyTransformation(KrpcFilterContext context, FetchResponseData responseData) {
+    private void applyTransformation(FilterContext context, FetchResponseData responseData) {
         for (FetchableTopicResponse topicData : responseData.responses()) {
             for (PartitionData partitionData : topicData.partitions()) {
                 MemoryRecords records = (MemoryRecords) partitionData.records();

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterContributorManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterContributorManager.java
@@ -9,8 +9,8 @@ import java.util.Iterator;
 import java.util.ServiceLoader;
 
 import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterContributor;
-import io.kroxylicious.proxy.filter.KrpcFilter;
 
 public class FilterContributorManager {
 
@@ -39,11 +39,11 @@ public class FilterContributorManager {
         throw new IllegalArgumentException("No filter found for name '" + shortName + "'");
     }
 
-    public KrpcFilter getFilter(String shortName, BaseConfig filterConfig) {
+    public Filter getFilter(String shortName, BaseConfig filterConfig) {
         Iterator<FilterContributor> it = contributors.iterator();
         while (it.hasNext()) {
             FilterContributor contributor = it.next();
-            KrpcFilter filter = contributor.getInstance(shortName, filterConfig);
+            Filter filter = contributor.getInstance(shortName, filterConfig);
             if (filter != null) {
                 return filter;
             }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ProduceRequestTransformationFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ProduceRequestTransformationFilter.java
@@ -25,7 +25,7 @@ import org.apache.kafka.common.record.TimestampType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.kroxylicious.proxy.config.BaseConfig;
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.internal.util.MemoryRecordsHelper;
@@ -74,12 +74,12 @@ public class ProduceRequestTransformationFilter implements ProduceRequestFilter 
     }
 
     @Override
-    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData data, KrpcFilterContext context) {
+    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData data, FilterContext context) {
         applyTransformation(context, data);
         return context.forwardRequest(header, data);
     }
 
-    private void applyTransformation(KrpcFilterContext ctx, ProduceRequestData req) {
+    private void applyTransformation(FilterContext ctx, ProduceRequestData req) {
         req.topicData().forEach(topicData -> {
             for (PartitionProduceData partitionData : topicData.partitionData()) {
                 MemoryRecords records = (MemoryRecords) partitionData.records();

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHandlerTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import io.kroxylicious.proxy.filter.ApiVersionsRequestFilter;
 import io.kroxylicious.proxy.filter.ApiVersionsResponseFilter;
 import io.kroxylicious.proxy.filter.FetchRequestFilter;
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
@@ -513,7 +513,7 @@ public class FilterHandlerTest extends FilterHarness {
 
             @Override
             public CompletionStage<RequestFilterResult> onApiVersionsRequest(short apiVersion, RequestHeaderData header, ApiVersionsRequestData request,
-                                                                             KrpcFilterContext context) {
+                                                                             FilterContext context) {
                 fail("Should not be called");
                 return null;
             }
@@ -609,7 +609,7 @@ public class FilterHandlerTest extends FilterHarness {
 
             @Override
             public CompletionStage<ResponseFilterResult> onApiVersionsResponse(short apiVersion, ResponseHeaderData header, ApiVersionsResponseData response,
-                                                                               KrpcFilterContext context) {
+                                                                               FilterContext context) {
                 fail("Should not be called");
                 return null;
             }
@@ -704,7 +704,7 @@ public class FilterHandlerTest extends FilterHarness {
 
     /**
      * Test the special case within {@link FilterHandler} for
-     * {@link KrpcFilterContext#sendRequest(short, ApiMessage)}
+     * {@link FilterContext#sendRequest(short, ApiMessage)}
      * with acks=0 Produce requests.
      */
     @Test

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
@@ -18,8 +18,9 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 
 import io.kroxylicious.proxy.config.TargetCluster;
+import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
-import io.kroxylicious.proxy.filter.KrpcFilter;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 import io.kroxylicious.proxy.frame.OpaqueRequestFrame;
@@ -32,20 +33,20 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 /**
- * A test harness for {@link KrpcFilter} implementations.
+ * A test harness for {@link Filter} implementations.
  */
 public abstract class FilterHarness {
     public static final String TEST_CLIENT = "test-client";
     protected EmbeddedChannel channel;
     private FilterHandler filterHandler;
-    private KrpcFilter filter;
+    private Filter filter;
 
     /**
      * Build a {@link #channel} containing a single {@link FilterHandler} for the given
      * {@code filter}.
      * @param filter The filter in the pipeline.
      */
-    protected void buildChannel(KrpcFilter filter) {
+    protected void buildChannel(Filter filter) {
         buildChannel(filter, 1000L);
     }
 
@@ -53,9 +54,9 @@ public abstract class FilterHarness {
      * Build a {@link #channel} containing a single {@link FilterHandler} for the given
      * {@code filter}.
      * @param filter The filter in the pipeline.
-     * @param timeoutMs The timeout for {@link io.kroxylicious.proxy.filter.KrpcFilterContext#sendRequest(short, ApiMessage)}.
+     * @param timeoutMs The timeout for {@link FilterContext#sendRequest(short, ApiMessage)}.
      */
-    protected void buildChannel(KrpcFilter filter, long timeoutMs) {
+    protected void buildChannel(Filter filter, long timeoutMs) {
         this.filter = filter;
         filterHandler = new FilterHandler(getOnlyElement(FilterAndInvoker.build(filter)), timeoutMs, null,
                 new VirtualCluster("TestVirtualCluster", mock(TargetCluster.class), mock(ClusterNetworkAddressConfigProvider.class), Optional.empty(), false, false),
@@ -139,7 +140,7 @@ public abstract class FilterHarness {
      * @return The frame that was written.
      * @param <B> The type of the response body.
      */
-    protected <B extends ApiMessage> DecodedResponseFrame<B> writeInternalResponse(B data, CompletableFuture<?> future, KrpcFilter recipient) {
+    protected <B extends ApiMessage> DecodedResponseFrame<B> writeInternalResponse(B data, CompletableFuture<?> future, Filter recipient) {
         var apiKey = ApiKeys.forId(data.apiKey());
         var header = new ResponseHeaderData();
         int correlationId = 42;
@@ -157,7 +158,7 @@ public abstract class FilterHarness {
      * @return The frame that was written.
      * @param <B> The type of the response body.
      */
-    protected <B extends ApiMessage> DecodedRequestFrame<B> writeInternalRequest(B data, CompletableFuture<?> future, KrpcFilter recipient) {
+    protected <B extends ApiMessage> DecodedRequestFrame<B> writeInternalRequest(B data, CompletableFuture<?> future, Filter recipient) {
         var apiKey = ApiKeys.forId(data.apiKey());
         var header = new RequestHeaderData();
         int correlationId = 42;

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import io.netty.channel.embedded.EmbeddedChannel;
 
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ResponseFilter;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
 import io.kroxylicious.proxy.frame.BareSaslRequest;
@@ -210,7 +210,7 @@ public class KafkaAuthnHandlerTest {
             }
 
             @Override
-            public CompletionStage<ResponseFilterResult> onResponse(ApiKeys apiKey, ResponseHeaderData header, ApiMessage response, KrpcFilterContext context) {
+            public CompletionStage<ResponseFilterResult> onResponse(ApiKeys apiKey, ResponseHeaderData header, ApiMessage response, FilterContext context) {
 
                 return null;
             }

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/codec/RequestDecoderTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/codec/RequestDecoderTest.java
@@ -26,7 +26,7 @@ import io.netty.buffer.Unpooled;
 
 import io.kroxylicious.proxy.filter.ApiVersionsRequestFilter;
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.OpaqueRequestFrame;
@@ -109,7 +109,7 @@ public class RequestDecoderTest extends AbstractCodecTest {
                                     @Override
                                     public CompletionStage<RequestFilterResult> onApiVersionsRequest(short apiVersion, RequestHeaderData header,
                                                                                                      ApiVersionsRequestData request,
-                                                                                                     KrpcFilterContext context) {
+                                                                                                     FilterContext context) {
                                         return context.requestFilterResultBuilder().forward(header, request).completed();
                                     }
                                 }))),

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilterTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilterTest.java
@@ -32,8 +32,8 @@ import com.flipkart.zjsonpatch.JsonDiff;
 import com.google.common.reflect.ClassPath;
 
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.FilterInvoker;
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
 import io.kroxylicious.proxy.internal.net.EndpointReconciler;
 import io.kroxylicious.proxy.model.VirtualCluster;
 import io.kroxylicious.proxy.service.HostPort;
@@ -74,7 +74,7 @@ class BrokerAddressFilterTest {
     private EndpointReconciler endpointReconciler;
 
     @Mock
-    private KrpcFilterContext context;
+    private FilterContext context;
 
     private BrokerAddressFilter filter;
 

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/EagerMetadataLearnerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/EagerMetadataLearnerTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyShort;
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.when;
 class EagerMetadataLearnerTest {
 
     @Mock
-    KrpcFilterContext context;
+    FilterContext context;
     private EagerMetadataLearner learner;
 
     @BeforeEach

--- a/performance-tests/src/main/java/io/kroxylicious/benchmarks/InvokerDispatchBenchmark.java
+++ b/performance-tests/src/main/java/io/kroxylicious/benchmarks/InvokerDispatchBenchmark.java
@@ -34,10 +34,10 @@ import io.kroxylicious.filters.FourInterfaceFilter1;
 import io.kroxylicious.filters.FourInterfaceFilter2;
 import io.kroxylicious.filters.FourInterfaceFilter3;
 import io.kroxylicious.proxy.filter.ArrayFilterInvoker;
+import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.FilterInvoker;
 import io.kroxylicious.proxy.filter.FilterInvokers;
-import io.kroxylicious.proxy.filter.KrpcFilter;
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.filter.RequestFilterResultBuilder;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
@@ -56,24 +56,24 @@ public class InvokerDispatchBenchmark {
     public enum Invoker {
         array {
             @Override
-            FilterInvoker invokerWith(KrpcFilter filter) {
+            FilterInvoker invokerWith(Filter filter) {
                 return new ArrayFilterInvoker(filter);
             }
         },
         specific {
             @Override
-            FilterInvoker invokerWith(KrpcFilter filter) {
+            FilterInvoker invokerWith(Filter filter) {
                 return new SpecificFilterInvoker(filter);
             }
         },
         switching {
             @Override
-            FilterInvoker invokerWith(KrpcFilter filter) {
+            FilterInvoker invokerWith(Filter filter) {
                 return FilterInvokers.arrayInvoker(filter);
             }
         };
 
-        abstract FilterInvoker invokerWith(KrpcFilter filter);
+        abstract FilterInvoker invokerWith(Filter filter);
     }
 
     @State(Scope.Benchmark)
@@ -86,7 +86,7 @@ public class InvokerDispatchBenchmark {
         String invoker;
 
         private RequestHeaderData requestHeaders;
-        private KrpcFilterContext filterContext;
+        private FilterContext filterContext;
         private Map.Entry<ApiKeys, ApiMessage>[] apiMessages;
 
         @SuppressWarnings("unchecked")
@@ -145,7 +145,7 @@ public class InvokerDispatchBenchmark {
     }
 
     private static void invokeHandleRequest(FilterInvoker[] filters, Map.Entry<ApiKeys, ApiMessage>[] apiMessages, RequestHeaderData requestHeaders,
-                                            KrpcFilterContext filterContext) {
+                                            FilterContext filterContext) {
         for (Map.Entry<ApiKeys, ApiMessage> entry : apiMessages) {
             final ApiKeys apiKey = entry.getKey();
             final short apiVersion = apiKey.latestVersion();
@@ -157,7 +157,7 @@ public class InvokerDispatchBenchmark {
         }
     }
 
-    private static class StubFilterContext implements KrpcFilterContext {
+    private static class StubFilterContext implements FilterContext {
         @Override
         public String channelDescriptor() {
             return null;

--- a/performance-tests/src/main/java/io/kroxylicious/benchmarks/InvokerScalabilityBenchmark.java
+++ b/performance-tests/src/main/java/io/kroxylicious/benchmarks/InvokerScalabilityBenchmark.java
@@ -22,9 +22,9 @@ import org.openjdk.jmh.infra.Blackhole;
 import io.kroxylicious.filters.TwoInterfaceFilter0;
 import io.kroxylicious.filters.TwoInterfaceFilter1;
 import io.kroxylicious.proxy.filter.ArrayFilterInvoker;
+import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterInvoker;
 import io.kroxylicious.proxy.filter.FilterInvokers;
-import io.kroxylicious.proxy.filter.KrpcFilter;
 import io.kroxylicious.proxy.filter.SpecificFilterInvoker;
 
 // try hard to make shouldHandleXYZ to observe different receivers concrete types, saving unrolling to bias a specific call-site to a specific concrete type
@@ -36,24 +36,24 @@ public class InvokerScalabilityBenchmark {
     public enum Invoker {
         array {
             @Override
-            FilterInvoker invokerWith(KrpcFilter filter) {
+            FilterInvoker invokerWith(Filter filter) {
                 return new ArrayFilterInvoker(filter);
             }
         },
         specific {
             @Override
-            FilterInvoker invokerWith(KrpcFilter filter) {
+            FilterInvoker invokerWith(Filter filter) {
                 return new SpecificFilterInvoker(filter);
             }
         },
         switching {
             @Override
-            FilterInvoker invokerWith(KrpcFilter filter) {
+            FilterInvoker invokerWith(Filter filter) {
                 return FilterInvokers.arrayInvoker(filter);
             }
         };
 
-        abstract FilterInvoker invokerWith(KrpcFilter filter);
+        abstract FilterInvoker invokerWith(Filter filter);
     }
 
     @org.openjdk.jmh.annotations.State(Scope.Benchmark)

--- a/performance-tests/src/main/java/io/kroxylicious/filters/EightInterfaceFilter.java
+++ b/performance-tests/src/main/java/io/kroxylicious/filters/EightInterfaceFilter.java
@@ -25,7 +25,7 @@ import io.kroxylicious.proxy.filter.DeleteTopicsRequestFilter;
 import io.kroxylicious.proxy.filter.DeleteTopicsResponseFilter;
 import io.kroxylicious.proxy.filter.DescribeGroupsRequestFilter;
 import io.kroxylicious.proxy.filter.DescribeGroupsResponseFilter;
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
 import io.kroxylicious.proxy.filter.ProduceResponseFilter;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
@@ -35,54 +35,54 @@ public class EightInterfaceFilter implements ProduceResponseFilter, ProduceReque
         DeleteTopicsRequestFilter, DeleteTopicsResponseFilter, DescribeGroupsRequestFilter, DescribeGroupsResponseFilter {
 
     @Override
-    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, KrpcFilterContext context) {
+    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, FilterContext context) {
         return null;
     }
 
     @Override
     public CompletionStage<ResponseFilterResult> onProduceResponse(short apiVersion, ResponseHeaderData header, ProduceResponseData response,
-                                                                   KrpcFilterContext context) {
+                                                                   FilterContext context) {
         return null;
     }
 
     @Override
     public CompletionStage<RequestFilterResult> onCreateTopicsRequest(short apiVersion, RequestHeaderData header, CreateTopicsRequestData request,
-                                                                      KrpcFilterContext context) {
+                                                                      FilterContext context) {
 
         return null;
     }
 
     @Override
     public CompletionStage<ResponseFilterResult> onCreateTopicsResponse(short apiVersion, ResponseHeaderData header, CreateTopicsResponseData response,
-                                                                        KrpcFilterContext context) {
+                                                                        FilterContext context) {
 
         return null;
     }
 
     @Override
     public CompletionStage<RequestFilterResult> onDeleteTopicsRequest(short apiVersion, RequestHeaderData header, DeleteTopicsRequestData request,
-                                                                      KrpcFilterContext context) {
+                                                                      FilterContext context) {
 
         return null;
     }
 
     @Override
     public CompletionStage<ResponseFilterResult> onDeleteTopicsResponse(short apiVersion, ResponseHeaderData header, DeleteTopicsResponseData response,
-                                                                        KrpcFilterContext context) {
+                                                                        FilterContext context) {
 
         return null;
     }
 
     @Override
     public CompletionStage<RequestFilterResult> onDescribeGroupsRequest(short apiVersion, RequestHeaderData header, DescribeGroupsRequestData request,
-                                                                        KrpcFilterContext context) {
+                                                                        FilterContext context) {
 
         return null;
     }
 
     @Override
     public CompletionStage<ResponseFilterResult> onDescribeGroupsResponse(short apiVersion, ResponseHeaderData header, DescribeGroupsResponseData response,
-                                                                          KrpcFilterContext context) {
+                                                                          FilterContext context) {
 
         return null;
     }

--- a/performance-tests/src/main/java/io/kroxylicious/filters/FourInterfaceFilter.java
+++ b/performance-tests/src/main/java/io/kroxylicious/filters/FourInterfaceFilter.java
@@ -17,7 +17,7 @@ import org.apache.kafka.common.message.ResponseHeaderData;
 
 import io.kroxylicious.proxy.filter.CreateTopicsRequestFilter;
 import io.kroxylicious.proxy.filter.CreateTopicsResponseFilter;
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
 import io.kroxylicious.proxy.filter.ProduceResponseFilter;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
@@ -26,26 +26,26 @@ import io.kroxylicious.proxy.filter.ResponseFilterResult;
 public class FourInterfaceFilter implements ProduceResponseFilter, ProduceRequestFilter, CreateTopicsRequestFilter, CreateTopicsResponseFilter {
 
     @Override
-    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, KrpcFilterContext context) {
+    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, FilterContext context) {
         return null;
     }
 
     @Override
     public CompletionStage<ResponseFilterResult> onProduceResponse(short apiVersion, ResponseHeaderData header, ProduceResponseData response,
-                                                                   KrpcFilterContext context) {
+                                                                   FilterContext context) {
         return null;
     }
 
     @Override
     public CompletionStage<RequestFilterResult> onCreateTopicsRequest(short apiVersion, RequestHeaderData header, CreateTopicsRequestData request,
-                                                                      KrpcFilterContext context) {
+                                                                      FilterContext context) {
 
         return null;
     }
 
     @Override
     public CompletionStage<ResponseFilterResult> onCreateTopicsResponse(short apiVersion, ResponseHeaderData header, CreateTopicsResponseData response,
-                                                                        KrpcFilterContext context) {
+                                                                        FilterContext context) {
 
         return null;
     }

--- a/performance-tests/src/main/java/io/kroxylicious/filters/FourInterfaceFilter0.java
+++ b/performance-tests/src/main/java/io/kroxylicious/filters/FourInterfaceFilter0.java
@@ -18,7 +18,7 @@ import org.openjdk.jmh.infra.Blackhole;
 
 import io.kroxylicious.proxy.filter.ApiVersionsRequestFilter;
 import io.kroxylicious.proxy.filter.ApiVersionsResponseFilter;
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
 import io.kroxylicious.proxy.filter.ProduceResponseFilter;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
@@ -29,28 +29,28 @@ import static io.kroxylicious.benchmarks.InvokerDispatchBenchmark.CONSUME_TOKENS
 public class FourInterfaceFilter0 implements ProduceResponseFilter, ProduceRequestFilter, ApiVersionsRequestFilter, ApiVersionsResponseFilter {
 
     @Override
-    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, KrpcFilterContext context) {
+    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, FilterContext context) {
         Blackhole.consumeCPU(CONSUME_TOKENS);
         return null;
     }
 
     @Override
     public CompletionStage<ResponseFilterResult> onProduceResponse(short apiVersion, ResponseHeaderData header, ProduceResponseData response,
-                                                                   KrpcFilterContext context) {
+                                                                   FilterContext context) {
         Blackhole.consumeCPU(CONSUME_TOKENS);
         return null;
     }
 
     @Override
     public CompletionStage<RequestFilterResult> onApiVersionsRequest(short apiVersion, RequestHeaderData header, ApiVersionsRequestData request,
-                                                                     KrpcFilterContext context) {
+                                                                     FilterContext context) {
         Blackhole.consumeCPU(CONSUME_TOKENS);
         return null;
     }
 
     @Override
     public CompletionStage<ResponseFilterResult> onApiVersionsResponse(short apiVersion, ResponseHeaderData header, ApiVersionsResponseData response,
-                                                                       KrpcFilterContext context) {
+                                                                       FilterContext context) {
         Blackhole.consumeCPU(CONSUME_TOKENS);
         return null;
     }

--- a/performance-tests/src/main/java/io/kroxylicious/filters/FourInterfaceFilter1.java
+++ b/performance-tests/src/main/java/io/kroxylicious/filters/FourInterfaceFilter1.java
@@ -18,7 +18,7 @@ import org.openjdk.jmh.infra.Blackhole;
 
 import io.kroxylicious.proxy.filter.ApiVersionsRequestFilter;
 import io.kroxylicious.proxy.filter.ApiVersionsResponseFilter;
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
 import io.kroxylicious.proxy.filter.ProduceResponseFilter;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
@@ -28,28 +28,28 @@ import static io.kroxylicious.benchmarks.InvokerDispatchBenchmark.CONSUME_TOKENS
 
 public class FourInterfaceFilter1 implements ProduceResponseFilter, ProduceRequestFilter, ApiVersionsRequestFilter, ApiVersionsResponseFilter {
     @Override
-    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, KrpcFilterContext context) {
+    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, FilterContext context) {
         Blackhole.consumeCPU(CONSUME_TOKENS);
         return null;
     }
 
     @Override
     public CompletionStage<ResponseFilterResult> onProduceResponse(short apiVersion, ResponseHeaderData header, ProduceResponseData response,
-                                                                   KrpcFilterContext context) {
+                                                                   FilterContext context) {
         Blackhole.consumeCPU(CONSUME_TOKENS);
         return null;
     }
 
     @Override
     public CompletionStage<RequestFilterResult> onApiVersionsRequest(short apiVersion, RequestHeaderData header, ApiVersionsRequestData request,
-                                                                     KrpcFilterContext context) {
+                                                                     FilterContext context) {
         Blackhole.consumeCPU(CONSUME_TOKENS);
         return null;
     }
 
     @Override
     public CompletionStage<ResponseFilterResult> onApiVersionsResponse(short apiVersion, ResponseHeaderData header, ApiVersionsResponseData response,
-                                                                       KrpcFilterContext context) {
+                                                                       FilterContext context) {
         Blackhole.consumeCPU(CONSUME_TOKENS);
         return null;
     }

--- a/performance-tests/src/main/java/io/kroxylicious/filters/FourInterfaceFilter2.java
+++ b/performance-tests/src/main/java/io/kroxylicious/filters/FourInterfaceFilter2.java
@@ -18,7 +18,7 @@ import org.openjdk.jmh.infra.Blackhole;
 
 import io.kroxylicious.proxy.filter.FetchRequestFilter;
 import io.kroxylicious.proxy.filter.FetchResponseFilter;
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
 import io.kroxylicious.proxy.filter.ProduceResponseFilter;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
@@ -29,26 +29,26 @@ import static io.kroxylicious.benchmarks.InvokerDispatchBenchmark.CONSUME_TOKENS
 public class FourInterfaceFilter2 implements ProduceResponseFilter, ProduceRequestFilter, FetchRequestFilter, FetchResponseFilter {
 
     @Override
-    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, KrpcFilterContext context) {
+    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, FilterContext context) {
         Blackhole.consumeCPU(CONSUME_TOKENS);
         return null;
     }
 
     @Override
     public CompletionStage<ResponseFilterResult> onProduceResponse(short apiVersion, ResponseHeaderData header, ProduceResponseData response,
-                                                                   KrpcFilterContext context) {
+                                                                   FilterContext context) {
         Blackhole.consumeCPU(CONSUME_TOKENS);
         return null;
     }
 
     @Override
-    public CompletionStage<RequestFilterResult> onFetchRequest(short apiVersion, RequestHeaderData header, FetchRequestData request, KrpcFilterContext context) {
+    public CompletionStage<RequestFilterResult> onFetchRequest(short apiVersion, RequestHeaderData header, FetchRequestData request, FilterContext context) {
         Blackhole.consumeCPU(CONSUME_TOKENS);
         return null;
     }
 
     @Override
-    public CompletionStage<ResponseFilterResult> onFetchResponse(short apiVersion, ResponseHeaderData header, FetchResponseData response, KrpcFilterContext context) {
+    public CompletionStage<ResponseFilterResult> onFetchResponse(short apiVersion, ResponseHeaderData header, FetchResponseData response, FilterContext context) {
         Blackhole.consumeCPU(CONSUME_TOKENS);
         return null;
     }

--- a/performance-tests/src/main/java/io/kroxylicious/filters/FourInterfaceFilter3.java
+++ b/performance-tests/src/main/java/io/kroxylicious/filters/FourInterfaceFilter3.java
@@ -18,7 +18,7 @@ import org.openjdk.jmh.infra.Blackhole;
 
 import io.kroxylicious.proxy.filter.FetchRequestFilter;
 import io.kroxylicious.proxy.filter.FetchResponseFilter;
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
 import io.kroxylicious.proxy.filter.ProduceResponseFilter;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
@@ -29,26 +29,26 @@ import static io.kroxylicious.benchmarks.InvokerDispatchBenchmark.CONSUME_TOKENS
 public class FourInterfaceFilter3 implements ProduceResponseFilter, ProduceRequestFilter, FetchRequestFilter, FetchResponseFilter {
 
     @Override
-    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, KrpcFilterContext context) {
+    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, FilterContext context) {
         Blackhole.consumeCPU(CONSUME_TOKENS);
         return null;
     }
 
     @Override
     public CompletionStage<ResponseFilterResult> onProduceResponse(short apiVersion, ResponseHeaderData header, ProduceResponseData response,
-                                                                   KrpcFilterContext context) {
+                                                                   FilterContext context) {
         Blackhole.consumeCPU(CONSUME_TOKENS);
         return null;
     }
 
     @Override
-    public CompletionStage<RequestFilterResult> onFetchRequest(short apiVersion, RequestHeaderData header, FetchRequestData request, KrpcFilterContext context) {
+    public CompletionStage<RequestFilterResult> onFetchRequest(short apiVersion, RequestHeaderData header, FetchRequestData request, FilterContext context) {
         Blackhole.consumeCPU(CONSUME_TOKENS);
         return null;
     }
 
     @Override
-    public CompletionStage<ResponseFilterResult> onFetchResponse(short apiVersion, ResponseHeaderData header, FetchResponseData response, KrpcFilterContext context) {
+    public CompletionStage<ResponseFilterResult> onFetchResponse(short apiVersion, ResponseHeaderData header, FetchResponseData response, FilterContext context) {
         Blackhole.consumeCPU(CONSUME_TOKENS);
         return null;
     }

--- a/performance-tests/src/main/java/io/kroxylicious/filters/OneInterfaceFilter.java
+++ b/performance-tests/src/main/java/io/kroxylicious/filters/OneInterfaceFilter.java
@@ -11,7 +11,7 @@ import java.util.concurrent.CompletionStage;
 import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ProduceResponseFilter;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
 
@@ -19,7 +19,7 @@ public class OneInterfaceFilter implements ProduceResponseFilter {
 
     @Override
     public CompletionStage<ResponseFilterResult> onProduceResponse(short apiVersion, ResponseHeaderData header, ProduceResponseData response,
-                                                                   KrpcFilterContext context) {
+                                                                   FilterContext context) {
         return null;
     }
 }

--- a/performance-tests/src/main/java/io/kroxylicious/filters/TwoInterfaceFilter.java
+++ b/performance-tests/src/main/java/io/kroxylicious/filters/TwoInterfaceFilter.java
@@ -13,7 +13,7 @@ import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
 import io.kroxylicious.proxy.filter.ProduceResponseFilter;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
@@ -22,13 +22,13 @@ import io.kroxylicious.proxy.filter.ResponseFilterResult;
 public class TwoInterfaceFilter implements ProduceResponseFilter, ProduceRequestFilter {
 
     @Override
-    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, KrpcFilterContext context) {
+    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, FilterContext context) {
         return null;
     }
 
     @Override
     public CompletionStage<ResponseFilterResult> onProduceResponse(short apiVersion, ResponseHeaderData header, ProduceResponseData response,
-                                                                   KrpcFilterContext context) {
+                                                                   FilterContext context) {
         return null;
     }
 }

--- a/performance-tests/src/main/java/io/kroxylicious/filters/TwoInterfaceFilter0.java
+++ b/performance-tests/src/main/java/io/kroxylicious/filters/TwoInterfaceFilter0.java
@@ -13,7 +13,7 @@ import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
 import io.kroxylicious.proxy.filter.ProduceResponseFilter;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
@@ -22,13 +22,13 @@ import io.kroxylicious.proxy.filter.ResponseFilterResult;
 public class TwoInterfaceFilter0 implements ProduceResponseFilter, ProduceRequestFilter {
 
     @Override
-    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, KrpcFilterContext context) {
+    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, FilterContext context) {
         return null;
     }
 
     @Override
     public CompletionStage<ResponseFilterResult> onProduceResponse(short apiVersion, ResponseHeaderData header, ProduceResponseData response,
-                                                                   KrpcFilterContext context) {
+                                                                   FilterContext context) {
         return null;
     }
 }

--- a/performance-tests/src/main/java/io/kroxylicious/filters/TwoInterfaceFilter1.java
+++ b/performance-tests/src/main/java/io/kroxylicious/filters/TwoInterfaceFilter1.java
@@ -13,7 +13,7 @@ import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
 import io.kroxylicious.proxy.filter.ProduceResponseFilter;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
@@ -22,13 +22,13 @@ import io.kroxylicious.proxy.filter.ResponseFilterResult;
 public class TwoInterfaceFilter1 implements ProduceResponseFilter, ProduceRequestFilter {
 
     @Override
-    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, KrpcFilterContext context) {
+    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, FilterContext context) {
         return null;
     }
 
     @Override
     public CompletionStage<ResponseFilterResult> onProduceResponse(short apiVersion, ResponseHeaderData header, ProduceResponseData response,
-                                                                   KrpcFilterContext context) {
+                                                                   FilterContext context) {
         return null;
     }
 }

--- a/performance-tests/src/main/java/io/kroxylicious/proxy/filter/ArrayFilterInvoker.java
+++ b/performance-tests/src/main/java/io/kroxylicious/proxy/filter/ArrayFilterInvoker.java
@@ -18,7 +18,7 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
 
 /**
- * Invoker for KrpcFilters that implement any number of Specific Message interfaces (for
+ * Invoker for Filters that implement any number of Specific Message interfaces (for
  * example {@link AlterConfigsResponseFilter}.
  */
 public class ArrayFilterInvoker implements FilterInvoker {
@@ -28,7 +28,7 @@ public class ArrayFilterInvoker implements FilterInvoker {
     private final FilterInvoker[] requestInvokers;
     private final FilterInvoker[] responseInvokers;
 
-    public ArrayFilterInvoker(KrpcFilter filter) {
+    public ArrayFilterInvoker(Filter filter) {
         Map<Integer, FilterInvoker> requestInvokers = new HashMap<>();
         Map<Integer, FilterInvoker> responseInvokers = new HashMap<>();
         if (filter instanceof AddOffsetsToTxnRequestFilter) {
@@ -458,7 +458,7 @@ public class ArrayFilterInvoker implements FilterInvoker {
                                                           short apiVersion,
                                                           RequestHeaderData header,
                                                           ApiMessage body,
-                                                          KrpcFilterContext filterContext) {
+                                                          FilterContext filterContext) {
         FilterInvoker invoker = requestInvokers[apiKey.id];
         return invoker.onRequest(apiKey, apiVersion, header, body, filterContext);
     }
@@ -478,7 +478,7 @@ public class ArrayFilterInvoker implements FilterInvoker {
                                                             short apiVersion,
                                                             ResponseHeaderData header,
                                                             ApiMessage body,
-                                                            KrpcFilterContext filterContext) {
+                                                            FilterContext filterContext) {
         FilterInvoker invoker = responseInvokers[apiKey.id];
         return invoker.onResponse(apiKey, apiVersion, header, body, filterContext);
     }

--- a/performance-tests/src/main/java/io/kroxylicious/proxy/filter/SpecificFilterInvoker.java
+++ b/performance-tests/src/main/java/io/kroxylicious/proxy/filter/SpecificFilterInvoker.java
@@ -150,14 +150,14 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
 
 /**
- * Invoker for KrpcFilters that implement any number of Specific Message interfaces (for
+ * Invoker for Filters that implement any number of Specific Message interfaces (for
  * example {@link io.kroxylicious.proxy.filter.AlterConfigsResponseFilter}.
  */
 public class SpecificFilterInvoker implements FilterInvoker {
 
-    private final KrpcFilter filter;
+    private final Filter filter;
 
-    public SpecificFilterInvoker(KrpcFilter filter) {
+    public SpecificFilterInvoker(Filter filter) {
         this.filter = filter;
     }
 
@@ -176,7 +176,7 @@ public class SpecificFilterInvoker implements FilterInvoker {
                                                           short apiVersion,
                                                           RequestHeaderData header,
                                                           ApiMessage body,
-                                                          KrpcFilterContext filterContext) {
+                                                          FilterContext filterContext) {
         return switch (apiKey) {
             case ADD_OFFSETS_TO_TXN ->
                 ((AddOffsetsToTxnRequestFilter) filter).onAddOffsetsToTxnRequest(apiVersion, header, (AddOffsetsToTxnRequestData) body, filterContext);
@@ -300,7 +300,7 @@ public class SpecificFilterInvoker implements FilterInvoker {
                                                             short apiVersion,
                                                             ResponseHeaderData header,
                                                             ApiMessage body,
-                                                            KrpcFilterContext filterContext) {
+                                                            FilterContext filterContext) {
         return switch (apiKey) {
             case ADD_OFFSETS_TO_TXN ->
                 ((AddOffsetsToTxnResponseFilter) filter).onAddOffsetsToTxnResponse(apiVersion, header, (AddOffsetsToTxnResponseData) body, filterContext);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Rename KrpcFilter -> Filter and KrpcFilterContext -> FilterContext

The prefix will be mysterious for new Filter Authors, we should drop it while we are making other breaking changes like the async api.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
