### PR TITLE
Tolerate multiple messages being read from client during connection

### DIFF
--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.kafka.common.message.ApiVersionsRequestData;
@@ -84,10 +85,12 @@ public class KafkaProxyFrontendHandler
     private String sniHostname;
 
     private ChannelHandlerContext inboundCtx;
-    // The message buffered while we connect to the outbound cluster
-    // There can only be one such because auto read is disabled until outbound
+
+    // Messages buffered while we connect to the outbound cluster
+    // The size should be limited because auto read is disabled until outbound
     // channel activation
-    private Object bufferedMsg;
+    private List<Object> bufferedMsgs = new ArrayList<>();
+
     // Flag if we receive a channelReadComplete() prior to outbound connection activation
     // so we can perform the channelReadComplete()/outbound flush & auto_read
     // once the outbound channel is active
@@ -156,8 +159,10 @@ public class KafkaProxyFrontendHandler
         LOGGER.trace("{}: outboundChannelActive", inboundCtx.channel().id());
         outboundCtx = ctx;
         // connection is complete, so first forward the buffered message
-        forwardOutbound(ctx, bufferedMsg);
-        bufferedMsg = null; // don't pin in memory once we no longer need it
+        for (Object bufferedMsg : bufferedMsgs) {
+            forwardOutbound(ctx, bufferedMsg);
+        }
+        bufferedMsgs = null; // don't pin in memory once we no longer need it
         if (pendingReadComplete) {
             pendingReadComplete = false;
             channelReadComplete(ctx);
@@ -212,6 +217,9 @@ public class KafkaProxyFrontendHandler
                     && msg instanceof RequestFrame) {
                 bufferMsgAndSelectServer(msg);
             }
+            else if ((state == State.CONNECTING || state == State.CONNECTED) && msg instanceof RequestFrame) {
+                bufferedMsgs.add(msg);
+            }
             else {
                 throw illegalState("Unexpected channelRead() message of " + msg.getClass());
             }
@@ -219,15 +227,11 @@ public class KafkaProxyFrontendHandler
     }
 
     private void bufferMsgAndSelectServer(Object msg) {
-        if (bufferedMsg != null) {
-            // Single buffered message assertion failed
-            throw illegalState("Already have buffered msg");
-        }
         state = State.CONNECTING;
         // But for any other request we'll need a backend connection
         // (for which we need to ask the filter which cluster to connect to
         // and with what filters)
-        this.bufferedMsg = msg;
+        this.bufferedMsgs.add(msg);
         // TODO ensure that the filter makes exactly one upstream connection?
         // Or not for the topic routing case
 


### PR DESCRIPTION


### Type of change

- Bugfix

### Description

Enqueue further messages handled by KafkaProxyFrontendHandler while it is in the CONNECTING or CONNECTED state before it has received the OUTBOUND_ACTIVE signal from the outbound channel. Then write them all to the outbound when it becomes active and null out the queue.

Resolves #513

### Additional Context

It is possible for clients to send multiple messages to the broker immediately. In this case, even though we try to disable autoread of the inbound channel we can still read multiple messages from the socket and have to handle multiple messages while we are establishing the connection to upstream.

The Kafka Broker handles this case fine so we should too.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
