### PR TITLE
Support optional config objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.3.0
 
+* [#602](https://github.com/kroxylicious/kroxylicious/pull/602): Added `requiresConfig(String shortName)` to Contributor with a default implementation to say that custom config objects are required.
 * [#538](https://github.com/kroxylicious/kroxylicious/pull/538): Refactor FilterHandler and fix several bugs that would leave messages unflushed to client/broker.
 * [#531](https://github.com/kroxylicious/kroxylicious/pull/531): Simple Test Client now supports multi-RPC conversations with the server.
 * [#510](https://github.com/kroxylicious/kroxylicious/pull/510): Add multi-tenant kubernetes example

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
@@ -10,15 +10,25 @@ import io.kroxylicious.proxy.service.BaseContributor;
 
 public class TestFilterContributor extends BaseContributor<Filter> implements FilterContributor {
 
+    public static final String REJECTING_CREATE_TOPIC = "RejectingCreateTopic";
     public static final BaseContributorBuilder<Filter> FILTERS = BaseContributor.<Filter> builder()
             .add("FixedClientId", FixedClientIdFilter.FixedClientIdFilterConfig.class, FixedClientIdFilter::new)
             .add("ApiVersionsMarkingFilter", ApiVersionsMarkingFilter::new)
             .add("RequestResponseMarking", RequestResponseMarkingFilter.RequestResponseMarkingFilterConfig.class, RequestResponseMarkingFilter::new)
             .add("OutOfBandSend", OutOfBandSendFilter.OutOfBandSendFilterConfig.class, OutOfBandSendFilter::new)
             .add("CompositePrefixingFixedClientId", CompositePrefixingFixedClientIdFilterConfig.class, CompositePrefixingFixedClientIdFilter::new)
-            .add("RejectingCreateTopic", RejectingCreateTopicFilter.RejectingCreateTopicFilterConfig.class, RejectingCreateTopicFilter::new);
+            .add(REJECTING_CREATE_TOPIC, RejectingCreateTopicFilter.RejectingCreateTopicFilterConfig.class, RejectingCreateTopicFilter::new);
 
     public TestFilterContributor() {
         super(FILTERS);
+    }
+
+    @Override
+    public boolean requiresConfig(String shortName) {
+        if (shortName.equals(REJECTING_CREATE_TOPIC)) {
+            // The Rejecting Create Topic filter accepts nulls and defaults them thus the config is genuinely optional
+            return false;
+        }
+        return super.requiresConfig(shortName);
     }
 }

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
@@ -17,18 +17,9 @@ public class TestFilterContributor extends BaseContributor<Filter> implements Fi
             .add("RequestResponseMarking", RequestResponseMarkingFilter.RequestResponseMarkingFilterConfig.class, RequestResponseMarkingFilter::new)
             .add("OutOfBandSend", OutOfBandSendFilter.OutOfBandSendFilterConfig.class, OutOfBandSendFilter::new)
             .add("CompositePrefixingFixedClientId", CompositePrefixingFixedClientIdFilterConfig.class, CompositePrefixingFixedClientIdFilter::new)
-            .add(REJECTING_CREATE_TOPIC, RejectingCreateTopicFilter.RejectingCreateTopicFilterConfig.class, RejectingCreateTopicFilter::new);
+            .add(REJECTING_CREATE_TOPIC, RejectingCreateTopicFilter.RejectingCreateTopicFilterConfig.class, RejectingCreateTopicFilter::new, false);
 
     public TestFilterContributor() {
         super(FILTERS);
-    }
-
-    @Override
-    public boolean requiresConfig(String shortName) {
-        if (shortName.equals(REJECTING_CREATE_TOPIC)) {
-            // The Rejecting Create Topic filter accepts nulls and defaults them thus the config is genuinely optional
-            return false;
-        }
-        return super.requiresConfig(shortName);
     }
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContributor.java
@@ -12,4 +12,7 @@ import io.kroxylicious.proxy.service.Contributor;
  * @see Contributor
  */
 public interface FilterContributor extends Contributor<Filter> {
+    default Boolean requiresConfig(String shortName) {
+        return false;
+    }
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContributor.java
@@ -12,7 +12,4 @@ import io.kroxylicious.proxy.service.Contributor;
  * @see Contributor
  */
 public interface FilterContributor extends Contributor<Filter> {
-    default Boolean requiresConfig(String shortName) {
-        return false;
-    }
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
@@ -38,7 +38,14 @@ public abstract class BaseContributor<T> implements Contributor<T> {
     @Override
     public T getInstance(String shortName, BaseConfig config) {
         InstanceBuilder<? extends BaseConfig, T> instanceBuilder = shortNameToInstanceBuilder.get(shortName);
+        if (builderRequiresConfig(instanceBuilder) && config == null) {
+            throw new IllegalArgumentException(shortName + " requires config but it is null");
+        }
         return instanceBuilder == null ? null : instanceBuilder.construct(config);
+    }
+
+    private static <T> boolean builderRequiresConfig(InstanceBuilder<? extends BaseConfig, T> instanceBuilder) {
+        return instanceBuilder != null && instanceBuilder.requiresConfig();
     }
 
     private static class InstanceBuilder<T extends BaseConfig, L> {
@@ -63,6 +70,10 @@ public abstract class BaseContributor<T> implements Contributor<T> {
                 throw new IllegalArgumentException("config has the wrong type, expected "
                         + configClass.getName() + ", got " + config.getClass().getName());
             }
+        }
+
+        public boolean requiresConfig() {
+            return this.configClass != BaseConfig.class;
         }
     }
 

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
@@ -163,5 +163,5 @@ public abstract class BaseContributor<T> implements Contributor<T> {
         return new BaseContributorBuilder<>();
     }
 
-    private record ContributorDetails<C extends BaseConfig, T>(InstanceBuilder<C, T> instanceBuilder, boolean configRequired) { }
+    private record ContributorDetails<C extends BaseConfig, T>(InstanceBuilder<C, T> instanceBuilder, boolean configRequired) {}
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
@@ -38,14 +38,10 @@ public abstract class BaseContributor<T> implements Contributor<T> {
     @Override
     public T getInstance(String shortName, BaseConfig config) {
         InstanceBuilder<? extends BaseConfig, T> instanceBuilder = shortNameToInstanceBuilder.get(shortName);
-        if (builderRequiresConfig(instanceBuilder) && config == null) {
+        if (requiresConfig(shortName) && config == null) {
             throw new IllegalArgumentException(shortName + " requires config but it is null");
         }
         return instanceBuilder == null ? null : instanceBuilder.construct(config);
-    }
-
-    private static <T> boolean builderRequiresConfig(InstanceBuilder<? extends BaseConfig, T> instanceBuilder) {
-        return instanceBuilder != null && instanceBuilder.requiresConfig();
     }
 
     private static class InstanceBuilder<T extends BaseConfig, L> {
@@ -70,10 +66,6 @@ public abstract class BaseContributor<T> implements Contributor<T> {
                 throw new IllegalArgumentException("config has the wrong type, expected "
                         + configClass.getName() + ", got " + config.getClass().getName());
             }
-        }
-
-        public boolean requiresConfig() {
-            return this.configClass != BaseConfig.class;
         }
     }
 

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/Contributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/Contributor.java
@@ -5,8 +5,6 @@
  */
 package io.kroxylicious.proxy.service;
 
-import java.util.Objects;
-
 import io.kroxylicious.proxy.config.BaseConfig;
 
 /**
@@ -19,8 +17,8 @@ public interface Contributor<T> {
 
     /**
      * Gets the concrete type of the configuration required by this service instance.
-     * @param shortName service short name
      *
+     * @param shortName service short name
      * @return class of a concrete type, or null if this contributor does not offer this short name.
      */
     Class<? extends BaseConfig> getConfigType(String shortName);
@@ -31,13 +29,9 @@ public interface Contributor<T> {
      * To make custom config classes entirely optional implementors should override this method.
      *
      * @param shortName service short name
-     *
      * @return <code>true</code> if the configuration must be specified.
      */
-    default boolean requiresConfig(String shortName) {
-        final Class<? extends BaseConfig> configType = getConfigType(shortName);
-        return !Objects.isNull(configType) && !Objects.equals(configType, BaseConfig.class);
-    }
+    Boolean requiresConfig(String shortName);
 
     /**
      * Creates an instance of the service.

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/Contributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/Contributor.java
@@ -35,7 +35,8 @@ public interface Contributor<T> {
      * @return <code>true</code> if the configuration must be specified.
      */
     default boolean requiresConfig(String shortName) {
-        return !Objects.equals(getConfigType(shortName), BaseConfig.class);
+        final Class<? extends BaseConfig> configType = getConfigType(shortName);
+        return !Objects.isNull(configType) && !Objects.equals(configType, BaseConfig.class);
     }
 
     /**

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/Contributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/Contributor.java
@@ -5,6 +5,8 @@
  */
 package io.kroxylicious.proxy.service;
 
+import java.util.Objects;
+
 import io.kroxylicious.proxy.config.BaseConfig;
 
 /**
@@ -22,6 +24,19 @@ public interface Contributor<T> {
      * @return class of a concrete type, or null if this contributor does not offer this short name.
      */
     Class<? extends BaseConfig> getConfigType(String shortName);
+
+    /**
+     * Used to determine if a configuration object is required for this filter.
+     * By default, it is assumed that if a custom config type is specified it is required.
+     * To make custom config classes entirely optional implementors should override this method.
+     *
+     * @param shortName service short name
+     *
+     * @return <code>true</code> if the configuration must be specified.
+     */
+    default boolean requiresConfig(String shortName) {
+        return !Objects.equals(getConfigType(shortName), BaseConfig.class);
+    }
 
     /**
      * Creates an instance of the service.

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
@@ -34,13 +34,13 @@ class BaseContributorTest {
 
     @Test
     void shouldReturnNullConfigTypeForUnregisteredName() {
-        //Given
+        // Given
         BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
         builder.add("one", () -> 1L);
         BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
         };
 
-        //When
+        // When
         Class<? extends BaseConfig> actual = baseContributor.getConfigType("two");
 
         assertThat(actual).isNull();
@@ -48,13 +48,13 @@ class BaseContributorTest {
 
     @Test
     void shouldReturnNullToRequiresConfigForUnregisteredName() {
-        //Given
+        // Given
         BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
         builder.add("one", () -> 1L);
         BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
         };
 
-        //When
+        // When
         Boolean actual = baseContributor.requiresConfig("two");
 
         assertThat(actual).isNull();
@@ -62,13 +62,13 @@ class BaseContributorTest {
 
     @Test
     void shouldReturnTrueFroRequiredRegisteredConfig() {
-        //Given
+        // Given
         BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
         builder.add("one", LongConfig.class, longConfig -> 1L);
         BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
         };
 
-        //When
+        // When
         Boolean actual = baseContributor.requiresConfig("one");
 
         assertThat(actual).isTrue();
@@ -76,13 +76,13 @@ class BaseContributorTest {
 
     @Test
     void shouldReturnFalseFroOptionalRegisteredConfig() {
-        //Given
+        // Given
         BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
         builder.add("one", LongConfig.class, longConfig -> 1L, false);
         BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
         };
 
-        //When
+        // When
         Boolean actual = baseContributor.requiresConfig("one");
 
         assertThat(actual).isFalse();

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
@@ -33,6 +33,62 @@ class BaseContributorTest {
     }
 
     @Test
+    void shouldReturnNullConfigTypeForUnregisteredName() {
+        //Given
+        BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
+        builder.add("one", () -> 1L);
+        BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
+        };
+
+        //When
+        Class<? extends BaseConfig> actual = baseContributor.getConfigType("two");
+
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    void shouldReturnNullToRequiresConfigForUnregisteredName() {
+        //Given
+        BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
+        builder.add("one", () -> 1L);
+        BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
+        };
+
+        //When
+        Boolean actual = baseContributor.requiresConfig("two");
+
+        assertThat(actual).isNull();
+    }
+
+    @Test
+    void shouldReturnTrueFroRequiredRegisteredConfig() {
+        //Given
+        BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
+        builder.add("one", LongConfig.class, longConfig -> 1L);
+        BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
+        };
+
+        //When
+        Boolean actual = baseContributor.requiresConfig("one");
+
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseFroOptionalRegisteredConfig() {
+        //Given
+        BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
+        builder.add("one", LongConfig.class, longConfig -> 1L, false);
+        BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
+        };
+
+        //When
+        Boolean actual = baseContributor.requiresConfig("one");
+
+        assertThat(actual).isFalse();
+    }
+
+    @Test
     void testSupplier() {
         BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
         builder.add("one", () -> 1L);

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
@@ -84,7 +84,7 @@ class BaseContributorTest {
         final IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class,
                 () -> baseContributor.getInstance("requiresConfig", null));
 
-        //Then
+        // Then
         assertThat(illegalArgumentException).hasMessageContaining("requiresConfig requires config but it is null");
     }
 
@@ -99,7 +99,7 @@ class BaseContributorTest {
         // When
         final Long actualInstance = baseContributor.getInstance("noConfigRequired", null);
 
-        //Then
+        // Then
         assertThat(actualInstance).isNotNull();
     }
 
@@ -114,7 +114,7 @@ class BaseContributorTest {
         // When
         final Long actualInstance = baseContributor.getInstance("configRequired", new LongConfig());
 
-        //Then
+        // Then
         assertThat(actualInstance).isNotNull();
     }
 
@@ -129,7 +129,7 @@ class BaseContributorTest {
         // When
         final Long actualInstance = baseContributor.getInstance("configRequired", new LongConfig());
 
-        //Then
+        // Then
         assertThat(actualInstance).isNotNull();
     }
 

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
@@ -73,7 +73,7 @@ class BaseContributorTest {
     }
 
     @Test
-    void shouldFailsIfConfigIsNullAndRequired() {
+    void shouldFailIfConfigIsNullAndRequired() {
         // Given
         BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
         builder.add("requiresConfig", LongConfig.class, baseConfig -> 1L);
@@ -104,10 +104,29 @@ class BaseContributorTest {
     }
 
     @Test
+    void shouldConstructInstanceIfConfigTypeIsSpecifiedButNotRequiredAndConfigIsNull() {
+        // Given
+        BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
+        builder.add("configOptional", LongConfig.class, longConfig -> 1L);
+        BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
+            @Override
+            public boolean requiresConfig(String shortName) {
+                return false;
+            }
+        };
+
+        // When
+        final Long actualInstance = baseContributor.getInstance("configOptional", null);
+
+        // Then
+        assertThat(actualInstance).isNotNull();
+    }
+
+    @Test
     void shouldConstructInstanceIfConfigIsNotNullAndRequired() {
         // Given
         BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
-        builder.add("configRequired", LongConfig.class, (longConfig) -> longConfig.value);
+        builder.add("configRequired", LongConfig.class, longConfig -> longConfig.value);
         BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
         };
 
@@ -132,5 +151,4 @@ class BaseContributorTest {
         // Then
         assertThat(actualInstance).isNotNull();
     }
-
 }

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
@@ -76,7 +76,7 @@ class BaseContributorTest {
     void shouldFailIfConfigIsNullAndRequired() {
         // Given
         BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
-        builder.add("requiresConfig", LongConfig.class, baseConfig -> 1L);
+        builder.add("requiresConfig", LongConfig.class, baseConfig -> 1L, true);
         BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
         };
 
@@ -92,7 +92,7 @@ class BaseContributorTest {
     void shouldConstructInstanceIfConfigIsNullAndNotRequired() {
         // Given
         BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
-        builder.add("noConfigRequired", () -> 1L);
+        builder.add("noConfigRequired", LongConfig.class, longConfig -> 1L, false);
         BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
         };
 
@@ -107,12 +107,8 @@ class BaseContributorTest {
     void shouldConstructInstanceIfConfigTypeIsSpecifiedButNotRequiredAndConfigIsNull() {
         // Given
         BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
-        builder.add("configOptional", LongConfig.class, longConfig -> 1L);
+        builder.add("configOptional", LongConfig.class, longConfig -> 1L, false);
         BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
-            @Override
-            public boolean requiresConfig(String shortName) {
-                return false;
-            }
         };
 
         // When
@@ -141,12 +137,12 @@ class BaseContributorTest {
     void shouldConstructInstanceIfConfigIsNotNullAndNotRequired() {
         // Given
         BaseContributor.BaseContributorBuilder<Long> builder = BaseContributor.builder();
-        builder.add("configRequired", () -> 1L);
+        builder.add("configOptional", () -> 1L);
         BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
         };
 
         // When
-        final Long actualInstance = baseContributor.getInstance("configRequired", new LongConfig());
+        final Long actualInstance = baseContributor.getInstance("configOptional", new LongConfig());
 
         // Then
         assertThat(actualInstance).isNotNull();

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -41,7 +41,8 @@ public class FilterChainFactory {
         if (filters == null || filters.isEmpty()) {
             return List.of();
         }
-        final Set<String> filtersWithoutRequiredConfiguration = filters.stream().filter(f -> f.config() == null && filterContributorManager.requiresConfig(f.type())).map(FilterDefinition::type).collect(Collectors.toSet());
+        final Set<String> filtersWithoutRequiredConfiguration = filters.stream().filter(f -> f.config() == null && filterContributorManager.requiresConfig(f.type()))
+                .map(FilterDefinition::type).collect(Collectors.toSet());
         if (!filtersWithoutRequiredConfiguration.isEmpty()) {
             StringJoiner joiner = new StringJoiner(", ", "[", "]");
             for (String s : filtersWithoutRequiredConfiguration) {

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -34,6 +34,7 @@ import io.kroxylicious.proxy.internal.codec.KafkaResponseEncoder;
 import io.kroxylicious.proxy.internal.filter.ApiVersionsIntersectFilter;
 import io.kroxylicious.proxy.internal.filter.BrokerAddressFilter;
 import io.kroxylicious.proxy.internal.filter.EagerMetadataLearner;
+import io.kroxylicious.proxy.internal.filter.FilterContributorManager;
 import io.kroxylicious.proxy.internal.net.Endpoint;
 import io.kroxylicious.proxy.internal.net.EndpointReconciler;
 import io.kroxylicious.proxy.internal.net.VirtualClusterBinding;
@@ -172,7 +173,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
 
         ApiVersionsServiceImpl apiVersionService = new ApiVersionsServiceImpl();
         var frontendHandler = new KafkaProxyFrontendHandler(context -> {
-            var filterChainFactory = new FilterChainFactory(config);
+            var filterChainFactory = new FilterChainFactory(config, FilterContributorManager.getInstance());
             List<FilterAndInvoker> apiVersionFilters = dp.isAuthenticationOffloadEnabled() ? List.of()
                     : FilterAndInvoker.build(new ApiVersionsIntersectFilter(apiVersionService));
             List<FilterAndInvoker> customProtocolFilters = filterChainFactory.createFilters();

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterContributorManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterContributorManager.java
@@ -6,6 +6,7 @@
 package io.kroxylicious.proxy.internal.filter;
 
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.function.Supplier;
 
@@ -66,7 +67,10 @@ public class FilterContributorManager {
         Iterator<FilterContributor> it = contributors.get();
         while (it.hasNext()) {
             FilterContributor contributor = it.next();
-            return contributor.requiresConfig(shortName);
+            final Boolean requiresConfig = contributor.requiresConfig(shortName);
+            if (!Objects.isNull(requiresConfig)) {
+                return requiresConfig;
+            }
         }
         return false;
     }

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
@@ -90,7 +90,7 @@ class KafkaProxyTest {
                 """;
         try (var kafkaProxy = new KafkaProxy(new ConfigParser().parseConfiguration(config))) {
             var illegalStateException = assertThrows(IllegalStateException.class, kafkaProxy::startup);
-            assertThat(illegalStateException).hasStackTraceContaining("because \"config\" is null");
+            assertThat(illegalStateException).hasStackTraceContaining("Missing required config for");
         }
     }
 

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
@@ -8,6 +8,7 @@ package io.kroxylicious.proxy;
 
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -68,6 +69,28 @@ class KafkaProxyTest {
         try (var kafkaProxy = new KafkaProxy(new ConfigParser().parseConfiguration(config))) {
             var illegalStateException = assertThrows(IllegalStateException.class, kafkaProxy::startup);
             assertThat(illegalStateException).hasStackTraceContaining(expectedMessage);
+        }
+    }
+
+    @Test
+    void shouldThrowExceptionIFRequireFilterConfigIsMissing() throws Exception {
+        var config = """
+                    virtualClusters:
+                        demo1:
+                            targetCluster:
+                              bootstrap_servers: kafka.example:1234
+                            clusterNetworkAddressConfigProvider:
+                              type: PortPerBroker
+                              config:
+                                bootstrapAddress: localhost:9192
+                                brokerStartPort: 9193
+                                numberOfBrokerPorts: 2
+                    filters:
+                       - type: ProduceRequestTransformation
+                """;
+        try (var kafkaProxy = new KafkaProxy(new ConfigParser().parseConfiguration(config))) {
+            var illegalStateException = assertThrows(IllegalStateException.class, kafkaProxy::startup);
+            assertThat(illegalStateException).hasStackTraceContaining("because \"config\" is null");
         }
     }
 

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
@@ -52,15 +52,15 @@ class FilterChainFactoryTest {
 
     @Test
     void shouldConstructFilterWithoutConfig() {
-        //Given
+        // Given
         final FilterDefinition filterWithoutConfig = new FilterDefinition(TestFilterContributor.NO_CONFIG_REQUIRED_TYPE_NAME, null);
         FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, List.of(filterWithoutConfig), null, true),
                 testFilterContributorManager);
 
-        //When
+        // When
         final List<FilterAndInvoker> actualFilters = filterChainFactory.createFilters();
 
-        //Then
+        // Then
         assertThat(actualFilters).hasSize(1)
                 .allMatch(Objects::nonNull)
                 .allSatisfy(filterAndInvoker -> assertThat(filterAndInvoker.filter()).isInstanceOf(TestFilterContributor.NoConfigFilter.class));
@@ -68,16 +68,16 @@ class FilterChainFactoryTest {
 
     @Test
     void shouldConstructFilterWithConfig() {
-        //Given
+        // Given
         final FilterDefinition filterWithoutConfig = new FilterDefinition(TestFilterContributor.CONFIG_REQUIRED_TYPE_NAME,
                 new TestFilterContributor.ConfigRequiredFilter.Config("wibble"));
         FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, List.of(filterWithoutConfig), null, true),
                 testFilterContributorManager);
 
-        //When
+        // When
         final List<FilterAndInvoker> actualFilters = filterChainFactory.createFilters();
 
-        //Then
+        // Then
         assertThat(actualFilters).hasSize(1)
                 .allMatch(Objects::nonNull)
                 .allSatisfy(filterAndInvoker -> assertThat(filterAndInvoker.filter()).isInstanceOf(TestFilterContributor.ConfigRequiredFilter.class));
@@ -85,15 +85,15 @@ class FilterChainFactoryTest {
 
     @Test
     void shouldNotConstructFilterWithMissingConfig() {
-        //Given
+        // Given
         final FilterDefinition filterWithoutConfig = new FilterDefinition(TestFilterContributor.CONFIG_REQUIRED_TYPE_NAME, null);
         FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, List.of(filterWithoutConfig), null, true),
                 testFilterContributorManager);
 
-        //When
+        // When
         final IllegalStateException actualException = assertThrows(IllegalStateException.class, filterChainFactory::createFilters);
 
-        //Then
+        // Then
         assertThat(actualException).hasStackTraceContaining("Missing required config for [" + TestFilterContributor.CONFIG_REQUIRED_TYPE_NAME + "]");
     }
 

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
@@ -7,20 +7,36 @@
 package io.kroxylicious.proxy.bootstrap;
 
 import java.util.List;
+import java.util.Objects;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.proxy.config.Configuration;
+import io.kroxylicious.proxy.config.FilterDefinition;
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
+import io.kroxylicious.proxy.filter.FilterContributor;
+import io.kroxylicious.proxy.internal.filter.FilterContributorManager;
+import io.kroxylicious.proxy.internal.filter.TestFilterContributor;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FilterChainFactoryTest {
 
+    private FilterContributorManager testFilterContributorManager;
+
+    @BeforeEach
+    void setUp() {
+        final List<FilterContributor> testFilterContributors = List.of(new TestFilterContributor());
+        testFilterContributorManager = new FilterContributorManager(testFilterContributors::iterator);
+    }
+
     @Test
     void testNullFiltersInConfigResultsInEmptyList() {
-        FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, null, null, true));
+        FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, null, null, true), FilterContributorManager.getInstance());
         List<FilterAndInvoker> filters = filterChainFactory.createFilters();
         assertNotNull(filters, "Filters list should not be null");
         assertTrue(filters.isEmpty(), "Filters list should be empty");
@@ -28,10 +44,57 @@ class FilterChainFactoryTest {
 
     @Test
     void testEmptyFiltersInConfigResultsInEmptyList() {
-        FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, List.of(), null, true));
+        FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, List.of(), null, true), FilterContributorManager.getInstance());
         List<FilterAndInvoker> filters = filterChainFactory.createFilters();
         assertNotNull(filters, "Filters list should not be null");
         assertTrue(filters.isEmpty(), "Filters list should be empty");
+    }
+
+    @Test
+    void shouldConstructFilterWithoutConfig() {
+        //Given
+        final FilterDefinition filterWithoutConfig = new FilterDefinition(TestFilterContributor.NO_CONFIG_REQUIRED_TYPE_NAME, null);
+        FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, List.of(filterWithoutConfig), null, true),
+                testFilterContributorManager);
+
+        //When
+        final List<FilterAndInvoker> actualFilters = filterChainFactory.createFilters();
+
+        //Then
+        assertThat(actualFilters).hasSize(1)
+                .allMatch(Objects::nonNull)
+                .allSatisfy(filterAndInvoker -> assertThat(filterAndInvoker.filter()).isInstanceOf(TestFilterContributor.NoConfigFilter.class));
+    }
+
+    @Test
+    void shouldConstructFilterWithConfig() {
+        //Given
+        final FilterDefinition filterWithoutConfig = new FilterDefinition(TestFilterContributor.CONFIG_REQUIRED_TYPE_NAME,
+                new TestFilterContributor.ConfigRequiredFilter.Config("wibble"));
+        FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, List.of(filterWithoutConfig), null, true),
+                testFilterContributorManager);
+
+        //When
+        final List<FilterAndInvoker> actualFilters = filterChainFactory.createFilters();
+
+        //Then
+        assertThat(actualFilters).hasSize(1)
+                .allMatch(Objects::nonNull)
+                .allSatisfy(filterAndInvoker -> assertThat(filterAndInvoker.filter()).isInstanceOf(TestFilterContributor.ConfigRequiredFilter.class));
+    }
+
+    @Test
+    void shouldNotConstructFilterWithMissingConfig() {
+        //Given
+        final FilterDefinition filterWithoutConfig = new FilterDefinition(TestFilterContributor.CONFIG_REQUIRED_TYPE_NAME, null);
+        FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, List.of(filterWithoutConfig), null, true),
+                testFilterContributorManager);
+
+        //When
+        final IllegalStateException actualException = assertThrows(IllegalStateException.class, filterChainFactory::createFilters);
+
+        //Then
+        assertThat(actualException).hasStackTraceContaining("Missing required config for [" + TestFilterContributor.CONFIG_REQUIRED_TYPE_NAME + "]");
     }
 
 }

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/FilterContributorManagerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/FilterContributorManagerTest.java
@@ -27,23 +27,23 @@ class FilterContributorManagerTest {
 
     @Test
     void shouldReturnFalseIfConfigNotRequired() {
-        //Given
+        // Given
 
-        //When
+        // When
         final boolean actual = testFilterContributorManager.requiresConfig(TestFilterContributor.NO_CONFIG_REQUIRED_TYPE_NAME);
 
-        //Then
+        // Then
         assertThat(actual).isFalse();
     }
 
     @Test
     void shouldReturnTrueIfConfigRequired() {
-        //Given
+        // Given
 
-        //When
+        // When
         final boolean actual = testFilterContributorManager.requiresConfig(TestFilterContributor.CONFIG_REQUIRED_TYPE_NAME);
 
-        //Then
+        // Then
         assertThat(actual).isTrue();
     }
 

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/FilterContributorManagerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/FilterContributorManagerTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.filter.FilterContributor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FilterContributorManagerTest {
+
+    private FilterContributorManager testFilterContributorManager;
+
+    @BeforeEach
+    void setUp() {
+        final List<FilterContributor> testFilterContributors = List.of(new TestFilterContributor());
+        testFilterContributorManager = new FilterContributorManager(testFilterContributors::iterator);
+    }
+
+    @Test
+    void shouldReturnFalseIfConfigNotRequired() {
+        //Given
+
+        //When
+        final boolean actual = testFilterContributorManager.requiresConfig(TestFilterContributor.NO_CONFIG_REQUIRED_TYPE_NAME);
+
+        //Then
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    void shouldReturnTrueIfConfigRequired() {
+        //Given
+
+        //When
+        final boolean actual = testFilterContributorManager.requiresConfig(TestFilterContributor.CONFIG_REQUIRED_TYPE_NAME);
+
+        //Then
+        assertThat(actual).isTrue();
+    }
+
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestFilterContributor.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestFilterContributor.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.filter.FilterContributor;
+import io.kroxylicious.proxy.filter.KrpcFilter;
+import io.kroxylicious.proxy.filter.KrpcFilterContext;
+import io.kroxylicious.proxy.filter.RequestFilter;
+import io.kroxylicious.proxy.filter.RequestFilterResult;
+import io.kroxylicious.proxy.service.BaseContributor;
+
+public class TestFilterContributor extends BaseContributor<KrpcFilter> implements FilterContributor {
+
+    public static final String NO_CONFIG_REQUIRED_TYPE_NAME = "NoConfigRequired";
+    public static final String CONFIG_REQUIRED_TYPE_NAME = "ConfigRequired";
+    public static final BaseContributorBuilder<KrpcFilter> FILTERS = BaseContributor.<KrpcFilter> builder()
+            .add(NO_CONFIG_REQUIRED_TYPE_NAME, NoConfigFilter::new)
+            .add(CONFIG_REQUIRED_TYPE_NAME, ConfigRequiredFilter.Config.class, config -> new ConfigRequiredFilter(config.property));
+
+    public TestFilterContributor() {
+        super(FILTERS);
+    }
+
+    public static class NoConfigFilter implements RequestFilter {
+        @Override
+        public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    public static class ConfigRequiredFilter implements RequestFilter {
+
+        @SuppressWarnings("FieldCanBeLocal")
+        private final String property;
+
+        ConfigRequiredFilter(String property) {
+            this.property = property;
+        }
+
+        @Override
+        public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        public static final class Config extends BaseConfig {
+            private final String property;
+
+            public Config(String property) {
+                this.property = property;
+            }
+
+            public String property() {
+                return property;
+            }
+        }
+    }
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestFilterContributor.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestFilterContributor.java
@@ -14,18 +14,18 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
 
 import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.FilterContributor;
-import io.kroxylicious.proxy.filter.KrpcFilter;
-import io.kroxylicious.proxy.filter.KrpcFilterContext;
 import io.kroxylicious.proxy.filter.RequestFilter;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.service.BaseContributor;
 
-public class TestFilterContributor extends BaseContributor<KrpcFilter> implements FilterContributor {
+public class TestFilterContributor extends BaseContributor<Filter> implements FilterContributor {
 
     public static final String NO_CONFIG_REQUIRED_TYPE_NAME = "NoConfigRequired";
     public static final String CONFIG_REQUIRED_TYPE_NAME = "ConfigRequired";
-    public static final BaseContributorBuilder<KrpcFilter> FILTERS = BaseContributor.<KrpcFilter> builder()
+    public static final BaseContributorBuilder<Filter> FILTERS = BaseContributor.<Filter> builder()
             .add(NO_CONFIG_REQUIRED_TYPE_NAME, NoConfigFilter::new)
             .add(CONFIG_REQUIRED_TYPE_NAME, ConfigRequiredFilter.Config.class, config -> new ConfigRequiredFilter(config.property));
 
@@ -35,7 +35,7 @@ public class TestFilterContributor extends BaseContributor<KrpcFilter> implement
 
     public static class NoConfigFilter implements RequestFilter {
         @Override
-        public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+        public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage body, FilterContext filterContext) {
             return CompletableFuture.completedFuture(null);
         }
     }
@@ -50,7 +50,7 @@ public class TestFilterContributor extends BaseContributor<KrpcFilter> implement
         }
 
         @Override
-        public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+        public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage body, FilterContext filterContext) {
             return CompletableFuture.completedFuture(null);
         }
 


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

This PR allows Contributors to define if a filter actually requires configuration or not.

### Additional Context

In fixing https://github.com/kroxylicious/kroxylicious/issues/530 it made sense to add a check if configuration was required, however that requires us to introduce the notion of required config. The initial answer was to add a check for `configClass != BaseConfig`.

@robobario then posed the question 
> if they specify a specific subclass of BaseConfig as the configType, should we require it to be non-null?

To which the obvious answer is `no` filters should be able to support optional configuration see [RejectingCreateTopicFilter](https://github.com/kroxylicious/kroxylicious/blob/15c3d32a850ae92f82d063e81df4530e84c9cd6e/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RejectingCreateTopicFilter.java#L32C1-L32C1) as a good example. Thus we need a way for Filter **authors** to signal if configuration is required or not. The `Contributor` is the natural home for that as it is fully under the control of the filter author. Adding it to the `FilterDefinition` would  expose it to filter users which doesn't make sense. 

The one perhaps controversial aspect of this PR is it validates filter configuration during proxy startup and fails startup if there are **any** configuration errors. While that may not be our long term posture it is consistent with how we do port validation.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ x ] Write tests
- [ x ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
