### PR TITLE
Refactor Contributor

### DIFF
--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
@@ -34,8 +34,8 @@ public abstract class BaseContributor<T> implements Contributor<T> {
 
     @NonNull
     @Override
-    public Optional<InstanceFactory<T>> getInstanceFactory(String shortName) {
-        return Optional.ofNullable(shortNameToInstanceBuilder.get(shortName)).map(tInstanceBuilder -> new InstanceFactory<T>() {
+    public Optional<SpecificContributor<T>> getSpecificContributor(String shortName) {
+        return Optional.ofNullable(shortNameToInstanceBuilder.get(shortName)).map(tInstanceBuilder -> new SpecificContributor<T>() {
             @Override
             public Class<? extends BaseConfig> getConfigClass() {
                 return tInstanceBuilder.configClass;

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/Contributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/Contributor.java
@@ -17,12 +17,12 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public interface Contributor<T> {
 
     /**
-     * Gets an instanceFactory for this service short name.
+     * Gets an optional SpecificContributor for this service short name.
      * @param shortName service short name
      *
-     * @return instance factory, or empty if this contributor does not offer this short name.
+     * @return optional containing specific contributor, or empty if this contributor does not offer this short name.
      */
     @NonNull
-    Optional<InstanceFactory<T>> getInstanceFactory(String shortName);
+    Optional<SpecificContributor<T>> getSpecificContributor(String shortName);
 
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/Contributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/Contributor.java
@@ -5,30 +5,24 @@
  */
 package io.kroxylicious.proxy.service;
 
-import io.kroxylicious.proxy.config.BaseConfig;
+import java.util.Optional;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * Support loading an Instance of a service, optionally providing it with configuration obtained
- * from the Kroxylicious configuration file.
+ * Support loading an InstanceFactory of a service
  *
  * @param <T> the service type
  */
 public interface Contributor<T> {
 
     /**
-     * Gets the concrete type of the configuration required by this service instance.
+     * Gets an instanceFactory for this service short name.
      * @param shortName service short name
      *
-     * @return class of a concrete type, or null if this contributor does not offer this short name.
+     * @return instance factory, or empty if this contributor does not offer this short name.
      */
-    Class<? extends BaseConfig> getConfigType(String shortName);
+    @NonNull
+    Optional<InstanceFactory<T>> getInstanceFactory(String shortName);
 
-    /**
-     * Creates an instance of the service.
-     *
-     * @param shortName service short name
-     * @param config    service configuration which may be null if the service instance does not accept configuration.
-     * @return the service instance, or null if this contributor does not offer this short name.
-     */
-    T getInstance(String shortName, BaseConfig config);
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/InstanceFactory.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/InstanceFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.service;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+
+/**
+ * Factory for creating new instances of T and supplies details about the configuration
+ * class that should be populated by the Kroxylicious framework when creating an instance.
+ * @param <T> The type produced by the factory
+ */
+public interface InstanceFactory<T> {
+
+    /**
+     * Gets the concrete type of the configuration required by this service instance.
+     * @return type
+     */
+    Class<? extends BaseConfig> getConfigClass();
+
+    /**
+     * Creates an instance
+     * @param config service configuration which may be null if the service instance does not accept configuration
+     * @return instance
+     */
+    T getInstance(BaseConfig config);
+
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/SpecificContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/SpecificContributor.java
@@ -13,7 +13,7 @@ import io.kroxylicious.proxy.config.BaseConfig;
  * class that should be populated by the Kroxylicious framework when creating an instance.
  * @param <T> The type produced by the factory
  */
-public interface InstanceFactory<T> {
+public interface SpecificContributor<T> {
 
     /**
      * Gets the concrete type of the configuration required by this service instance.

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
@@ -5,6 +5,8 @@
  */
 package io.kroxylicious.proxy.service;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.proxy.config.BaseConfig;
@@ -27,8 +29,9 @@ class BaseContributorTest {
         builder.add("one", () -> 1L);
         BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
         };
-        Class<? extends BaseConfig> one = baseContributor.getConfigType("one");
-        assertThat(one).isEqualTo(BaseConfig.class);
+        Optional<InstanceFactory<Long>> factory = baseContributor.getInstanceFactory("one");
+        assertThat(factory).isPresent();
+        assertThat(factory.get().getConfigClass()).isEqualTo(BaseConfig.class);
     }
 
     @Test
@@ -37,7 +40,9 @@ class BaseContributorTest {
         builder.add("one", () -> 1L);
         BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
         };
-        Long instance = baseContributor.getInstance("one", new BaseConfig());
+        Optional<InstanceFactory<Long>> factory = baseContributor.getInstanceFactory("one");
+        assertThat(factory).isPresent();
+        Long instance = factory.get().getInstance(new BaseConfig());
         assertThat(instance).isEqualTo(1L);
     }
 
@@ -47,8 +52,9 @@ class BaseContributorTest {
         builder.add("fromBaseConfig", LongConfig.class, baseConfig -> baseConfig.value);
         BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
         };
-        Class<? extends BaseConfig> configType = baseContributor.getConfigType("fromBaseConfig");
-        assertThat(configType).isEqualTo(LongConfig.class);
+        Optional<InstanceFactory<Long>> factory = baseContributor.getInstanceFactory("fromBaseConfig");
+        assertThat(factory).isPresent();
+        assertThat(factory.get().getConfigClass()).isEqualTo(LongConfig.class);
     }
 
     @Test
@@ -57,8 +63,10 @@ class BaseContributorTest {
         builder.add("fromBaseConfig", LongConfig.class, baseConfig -> baseConfig.value);
         BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
         };
-        Long instance = baseContributor.getInstance("fromBaseConfig", new LongConfig());
-        assertThat(instance).isEqualTo(2L);
+
+        Optional<InstanceFactory<Long>> factory = baseContributor.getInstanceFactory("fromBaseConfig");
+        assertThat(factory).isPresent();
+        assertThat(factory.get().getInstance(new LongConfig())).isEqualTo(2L);
     }
 
     @Test
@@ -68,8 +76,11 @@ class BaseContributorTest {
         BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
         };
         AnotherConfig incompatibleConfig = new AnotherConfig();
+        Optional<InstanceFactory<Long>> factory = baseContributor.getInstanceFactory("fromBaseConfig");
+        assertThat(factory).isPresent();
+        InstanceFactory<Long> instanceFactory = factory.get();
         assertThatThrownBy(() -> {
-            baseContributor.getInstance("fromBaseConfig", incompatibleConfig);
+            instanceFactory.getInstance(incompatibleConfig);
         }).isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
@@ -29,7 +29,7 @@ class BaseContributorTest {
         builder.add("one", () -> 1L);
         BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
         };
-        Optional<InstanceFactory<Long>> factory = baseContributor.getInstanceFactory("one");
+        Optional<SpecificContributor<Long>> factory = baseContributor.getSpecificContributor("one");
         assertThat(factory).isPresent();
         assertThat(factory.get().getConfigClass()).isEqualTo(BaseConfig.class);
     }
@@ -40,7 +40,7 @@ class BaseContributorTest {
         builder.add("one", () -> 1L);
         BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
         };
-        Optional<InstanceFactory<Long>> factory = baseContributor.getInstanceFactory("one");
+        Optional<SpecificContributor<Long>> factory = baseContributor.getSpecificContributor("one");
         assertThat(factory).isPresent();
         Long instance = factory.get().getInstance(new BaseConfig());
         assertThat(instance).isEqualTo(1L);
@@ -52,7 +52,7 @@ class BaseContributorTest {
         builder.add("fromBaseConfig", LongConfig.class, baseConfig -> baseConfig.value);
         BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
         };
-        Optional<InstanceFactory<Long>> factory = baseContributor.getInstanceFactory("fromBaseConfig");
+        Optional<SpecificContributor<Long>> factory = baseContributor.getSpecificContributor("fromBaseConfig");
         assertThat(factory).isPresent();
         assertThat(factory.get().getConfigClass()).isEqualTo(LongConfig.class);
     }
@@ -64,7 +64,7 @@ class BaseContributorTest {
         BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
         };
 
-        Optional<InstanceFactory<Long>> factory = baseContributor.getInstanceFactory("fromBaseConfig");
+        Optional<SpecificContributor<Long>> factory = baseContributor.getSpecificContributor("fromBaseConfig");
         assertThat(factory).isPresent();
         assertThat(factory.get().getInstance(new LongConfig())).isEqualTo(2L);
     }
@@ -76,11 +76,11 @@ class BaseContributorTest {
         BaseContributor<Long> baseContributor = new BaseContributor<>(builder) {
         };
         AnotherConfig incompatibleConfig = new AnotherConfig();
-        Optional<InstanceFactory<Long>> factory = baseContributor.getInstanceFactory("fromBaseConfig");
+        Optional<SpecificContributor<Long>> factory = baseContributor.getSpecificContributor("fromBaseConfig");
         assertThat(factory).isPresent();
-        InstanceFactory<Long> instanceFactory = factory.get();
+        SpecificContributor<Long> specificContributor = factory.get();
         assertThatThrownBy(() -> {
-            instanceFactory.getInstance(incompatibleConfig);
+            specificContributor.getInstance(incompatibleConfig);
         }).isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -39,7 +39,7 @@ public class FilterChainFactory {
         }
         return filters
                 .stream()
-                .map(f -> filterContributorManager.getFilter(f.type(), f.config()))
+                .map(f -> filterContributorManager.getInstance(f.type(), f.config()))
                 .flatMap(filter -> FilterAndInvoker.build(filter).stream())
                 .toList();
     }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/config/ClusterNetworkAddressConfigProviderTypeIdResolver.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/config/ClusterNetworkAddressConfigProviderTypeIdResolver.java
@@ -5,8 +5,6 @@
  */
 package io.kroxylicious.proxy.config;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.DatabindContext;
 import com.fasterxml.jackson.databind.JavaType;
@@ -38,7 +36,7 @@ public class ClusterNetworkAddressConfigProviderTypeIdResolver extends TypeIdRes
     }
 
     @Override
-    public JavaType typeFromId(DatabindContext context, String id) throws IOException {
+    public JavaType typeFromId(DatabindContext context, String id) {
         Class<?> subType = ClusterNetworkAddressConfigProviderContributorManager.getInstance().getConfigType(id);
         return context.constructSpecializedType(superType, subType);
     }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
@@ -29,6 +29,6 @@ public record VirtualCluster(TargetCluster targetCluster,
 
     private ClusterNetworkAddressConfigProvider toClusterNetworkAddressConfigProviderModel() {
         return ClusterNetworkAddressConfigProviderContributorManager.getInstance()
-                .getClusterEndpointConfigProvider(clusterNetworkAddressConfigProvider().type(), clusterNetworkAddressConfigProvider().config());
+                .getInstance(clusterNetworkAddressConfigProvider().type(), clusterNetworkAddressConfigProvider().config());
     }
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/ContributorManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/ContributorManager.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import java.util.Optional;
+import java.util.ServiceLoader;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.service.Contributor;
+import io.kroxylicious.proxy.service.InstanceFactory;
+
+public class ContributorManager<Y, T extends Contributor<Y>> {
+
+    private final ServiceLoader<T> contributors;
+    private final String type;
+
+    public ContributorManager(Class<T> serviceClass, String type) {
+        this.contributors = ServiceLoader.load(serviceClass);
+        this.type = type;
+    }
+
+    public Class<? extends BaseConfig> getConfigType(String shortName) {
+        for (T contributor : contributors) {
+            Optional<InstanceFactory<Y>> configType = contributor.getInstanceFactory(shortName);
+            if (configType.isPresent()) {
+                return configType.get().getConfigClass();
+            }
+        }
+
+        throw new IllegalArgumentException("No " + type + " found for name '" + shortName + "'");
+    }
+
+    public Y getInstance(String shortName, BaseConfig config) {
+        for (T contributor : contributors) {
+            Optional<InstanceFactory<Y>> configType = contributor.getInstanceFactory(shortName);
+            if (configType.isPresent()) {
+                return configType.get().getInstance(config);
+            }
+        }
+
+        throw new IllegalArgumentException("No " + type + " found for name '" + shortName + "'");
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/ContributorManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/ContributorManager.java
@@ -11,7 +11,7 @@ import java.util.ServiceLoader;
 
 import io.kroxylicious.proxy.config.BaseConfig;
 import io.kroxylicious.proxy.service.Contributor;
-import io.kroxylicious.proxy.service.InstanceFactory;
+import io.kroxylicious.proxy.service.SpecificContributor;
 
 public class ContributorManager<Y, T extends Contributor<Y>> {
 
@@ -25,7 +25,7 @@ public class ContributorManager<Y, T extends Contributor<Y>> {
 
     public Class<? extends BaseConfig> getConfigType(String shortName) {
         for (T contributor : contributors) {
-            Optional<InstanceFactory<Y>> configType = contributor.getInstanceFactory(shortName);
+            Optional<SpecificContributor<Y>> configType = contributor.getSpecificContributor(shortName);
             if (configType.isPresent()) {
                 return configType.get().getConfigClass();
             }
@@ -36,7 +36,7 @@ public class ContributorManager<Y, T extends Contributor<Y>> {
 
     public Y getInstance(String shortName, BaseConfig config) {
         for (T contributor : contributors) {
-            Optional<InstanceFactory<Y>> configType = contributor.getInstanceFactory(shortName);
+            Optional<SpecificContributor<Y>> configType = contributor.getSpecificContributor(shortName);
             if (configType.isPresent()) {
                 return configType.get().getInstance(config);
             }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/MeterRegistries.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/MeterRegistries.java
@@ -41,7 +41,7 @@ public class MeterRegistries implements AutoCloseable {
         CompositeMeterRegistry globalRegistry = Metrics.globalRegistry;
         preventDifferentTagNameRegistration(globalRegistry);
         MicrometerConfigurationHookContributorManager manager = MicrometerConfigurationHookContributorManager.getInstance();
-        var hooks = micrometerConfig.stream().map(f -> manager.getHook(f.type(), f.config())).toList();
+        var hooks = micrometerConfig.stream().map(f -> manager.getInstance(f.type(), f.config())).toList();
         hooks.forEach(micrometerConfigurationHook -> micrometerConfigurationHook.configure(globalRegistry));
         return hooks;
     }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/ClusterNetworkAddressConfigProviderContributorManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/ClusterNetworkAddressConfigProviderContributorManager.java
@@ -5,47 +5,21 @@
  */
 package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
 
-import java.util.Optional;
-import java.util.ServiceLoader;
-
 import io.kroxylicious.proxy.clusternetworkaddressconfigprovider.ClusterNetworkAddressConfigProviderContributor;
-import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.internal.ContributorManager;
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
-import io.kroxylicious.proxy.service.InstanceFactory;
 
-public class ClusterNetworkAddressConfigProviderContributorManager {
+public class ClusterNetworkAddressConfigProviderContributorManager
+        extends ContributorManager<ClusterNetworkAddressConfigProvider, ClusterNetworkAddressConfigProviderContributor> {
 
     private static final ClusterNetworkAddressConfigProviderContributorManager INSTANCE = new ClusterNetworkAddressConfigProviderContributorManager();
 
-    private final ServiceLoader<ClusterNetworkAddressConfigProviderContributor> contributors;
-
     private ClusterNetworkAddressConfigProviderContributorManager() {
-        this.contributors = ServiceLoader.load(ClusterNetworkAddressConfigProviderContributor.class);
+        super(ClusterNetworkAddressConfigProviderContributor.class, "endpoint provider");
     }
 
     public static ClusterNetworkAddressConfigProviderContributorManager getInstance() {
         return INSTANCE;
     }
 
-    public Class<? extends BaseConfig> getConfigType(String shortName) {
-        for (ClusterNetworkAddressConfigProviderContributor contributor : contributors) {
-            Optional<InstanceFactory<ClusterNetworkAddressConfigProvider>> factory = contributor.getInstanceFactory(shortName);
-            if (factory.isPresent()) {
-                return factory.get().getConfigClass();
-            }
-        }
-
-        throw new IllegalArgumentException("No endpoint provider found for name '" + shortName + "'");
-    }
-
-    public ClusterNetworkAddressConfigProvider getClusterEndpointConfigProvider(String shortName, BaseConfig baseConfig) {
-        for (ClusterNetworkAddressConfigProviderContributor contributor : contributors) {
-            Optional<InstanceFactory<ClusterNetworkAddressConfigProvider>> factory = contributor.getInstanceFactory(shortName);
-            if (factory.isPresent()) {
-                return factory.get().getInstance(baseConfig);
-            }
-        }
-
-        throw new IllegalArgumentException("No endpoint provider found for name '" + shortName + "'");
-    }
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterContributorManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterContributorManager.java
@@ -5,47 +5,19 @@
  */
 package io.kroxylicious.proxy.internal.filter;
 
-import java.util.Optional;
-import java.util.ServiceLoader;
-
-import io.kroxylicious.proxy.config.BaseConfig;
 import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterContributor;
-import io.kroxylicious.proxy.service.InstanceFactory;
+import io.kroxylicious.proxy.internal.ContributorManager;
 
-public class FilterContributorManager {
+public class FilterContributorManager extends ContributorManager<Filter, FilterContributor> {
 
     private static final FilterContributorManager INSTANCE = new FilterContributorManager();
 
-    private final ServiceLoader<FilterContributor> contributors;
-
     private FilterContributorManager() {
-        this.contributors = ServiceLoader.load(FilterContributor.class);
+        super(FilterContributor.class, "filter");
     }
 
     public static FilterContributorManager getInstance() {
         return INSTANCE;
-    }
-
-    public Class<? extends BaseConfig> getConfigType(String shortName) {
-        for (FilterContributor contributor : contributors) {
-            Optional<InstanceFactory<Filter>> configType = contributor.getInstanceFactory(shortName);
-            if (configType.isPresent()) {
-                return configType.get().getConfigClass();
-            }
-        }
-
-        throw new IllegalArgumentException("No filter found for name '" + shortName + "'");
-    }
-
-    public Filter getFilter(String shortName, BaseConfig filterConfig) {
-        for (FilterContributor contributor : contributors) {
-            Optional<InstanceFactory<Filter>> configType = contributor.getInstanceFactory(shortName);
-            if (configType.isPresent()) {
-                return configType.get().getInstance(filterConfig);
-            }
-        }
-
-        throw new IllegalArgumentException("No filter found for name '" + shortName + "'");
     }
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterContributorManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FilterContributorManager.java
@@ -5,12 +5,13 @@
  */
 package io.kroxylicious.proxy.internal.filter;
 
-import java.util.Iterator;
+import java.util.Optional;
 import java.util.ServiceLoader;
 
 import io.kroxylicious.proxy.config.BaseConfig;
 import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterContributor;
+import io.kroxylicious.proxy.service.InstanceFactory;
 
 public class FilterContributorManager {
 
@@ -27,12 +28,10 @@ public class FilterContributorManager {
     }
 
     public Class<? extends BaseConfig> getConfigType(String shortName) {
-        Iterator<FilterContributor> it = contributors.iterator();
-        while (it.hasNext()) {
-            FilterContributor contributor = it.next();
-            Class<? extends BaseConfig> configType = contributor.getConfigType(shortName);
-            if (configType != null) {
-                return configType;
+        for (FilterContributor contributor : contributors) {
+            Optional<InstanceFactory<Filter>> configType = contributor.getInstanceFactory(shortName);
+            if (configType.isPresent()) {
+                return configType.get().getConfigClass();
             }
         }
 
@@ -40,12 +39,10 @@ public class FilterContributorManager {
     }
 
     public Filter getFilter(String shortName, BaseConfig filterConfig) {
-        Iterator<FilterContributor> it = contributors.iterator();
-        while (it.hasNext()) {
-            FilterContributor contributor = it.next();
-            Filter filter = contributor.getInstance(shortName, filterConfig);
-            if (filter != null) {
-                return filter;
+        for (FilterContributor contributor : contributors) {
+            Optional<InstanceFactory<Filter>> configType = contributor.getInstanceFactory(shortName);
+            if (configType.isPresent()) {
+                return configType.get().getInstance(filterConfig);
             }
         }
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/MicrometerConfigurationHookContributorManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/MicrometerConfigurationHookContributorManager.java
@@ -5,46 +5,19 @@
  */
 package io.kroxylicious.proxy.micrometer;
 
-import java.util.Optional;
-import java.util.ServiceLoader;
+import io.kroxylicious.proxy.internal.ContributorManager;
 
-import io.kroxylicious.proxy.config.BaseConfig;
-import io.kroxylicious.proxy.service.InstanceFactory;
-
-public class MicrometerConfigurationHookContributorManager {
+public class MicrometerConfigurationHookContributorManager
+        extends ContributorManager<MicrometerConfigurationHook, MicrometerConfigurationHookContributor> {
 
     private static final MicrometerConfigurationHookContributorManager INSTANCE = new MicrometerConfigurationHookContributorManager();
-
-    private final ServiceLoader<MicrometerConfigurationHookContributor> contributors;
 
     public static MicrometerConfigurationHookContributorManager getInstance() {
         return INSTANCE;
     }
 
     private MicrometerConfigurationHookContributorManager() {
-        this.contributors = ServiceLoader.load(MicrometerConfigurationHookContributor.class);
-    }
-
-    public Class<? extends BaseConfig> getConfigType(String shortName) {
-        for (MicrometerConfigurationHookContributor contributor : contributors) {
-            Optional<InstanceFactory<MicrometerConfigurationHook>> factory = contributor.getInstanceFactory(shortName);
-            if (factory.isPresent()) {
-                return factory.get().getConfigClass();
-            }
-        }
-
-        throw new IllegalArgumentException("No micrometer configuration hook found for name '" + shortName + "'");
-    }
-
-    public MicrometerConfigurationHook getHook(String shortName, BaseConfig filterConfig) {
-        for (MicrometerConfigurationHookContributor contributor : contributors) {
-            Optional<InstanceFactory<MicrometerConfigurationHook>> factory = contributor.getInstanceFactory(shortName);
-            if (factory.isPresent()) {
-                return factory.get().getInstance(filterConfig);
-            }
-        }
-
-        throw new IllegalArgumentException("No micrometer configuration hook found for name '" + shortName + "'");
+        super(MicrometerConfigurationHookContributor.class, "micrometer configuration hook");
     }
 
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/MicrometerConfigurationHookContributorManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/micrometer/MicrometerConfigurationHookContributorManager.java
@@ -5,9 +5,11 @@
  */
 package io.kroxylicious.proxy.micrometer;
 
+import java.util.Optional;
 import java.util.ServiceLoader;
 
 import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.service.InstanceFactory;
 
 public class MicrometerConfigurationHookContributorManager {
 
@@ -25,9 +27,9 @@ public class MicrometerConfigurationHookContributorManager {
 
     public Class<? extends BaseConfig> getConfigType(String shortName) {
         for (MicrometerConfigurationHookContributor contributor : contributors) {
-            Class<? extends BaseConfig> configType = contributor.getConfigType(shortName);
-            if (configType != null) {
-                return configType;
+            Optional<InstanceFactory<MicrometerConfigurationHook>> factory = contributor.getInstanceFactory(shortName);
+            if (factory.isPresent()) {
+                return factory.get().getConfigClass();
             }
         }
 
@@ -36,9 +38,9 @@ public class MicrometerConfigurationHookContributorManager {
 
     public MicrometerConfigurationHook getHook(String shortName, BaseConfig filterConfig) {
         for (MicrometerConfigurationHookContributor contributor : contributors) {
-            MicrometerConfigurationHook hook = contributor.getInstance(shortName, filterConfig);
-            if (hook != null) {
-                return hook;
+            Optional<InstanceFactory<MicrometerConfigurationHook>> factory = contributor.getInstanceFactory(shortName);
+            if (factory.isPresent()) {
+                return factory.get().getInstance(filterConfig);
             }
         }
 

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/ClusterNetworkAddressConfigProviderContributorManagerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/ClusterNetworkAddressConfigProviderContributorManagerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.PortPerBrokerClusterNetworkAddressConfigProvider.PortPerBrokerClusterNetworkAddressConfigProviderConfig;
+import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.SniRoutingClusterNetworkAddressConfigProvider.SniRoutingClusterNetworkAddressConfigProviderConfig;
+import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
+import io.kroxylicious.proxy.service.HostPort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ClusterNetworkAddressConfigProviderContributorManagerTest {
+    @Test
+    void testNonExistentConfigType() {
+        assertThatThrownBy(() -> getConfigType("nonexist")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testNonExistentGetInstance() {
+        BaseConfig config = new BaseConfig();
+        assertThatThrownBy(() -> getInstance("nonexist", config)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testGetConfigForPortPerBroker() {
+        assertThat(getConfigType("PortPerBroker")).isEqualTo(PortPerBrokerClusterNetworkAddressConfigProviderConfig.class);
+    }
+
+    @Test
+    void testGetConfigForSniRouting() {
+        assertThat(getConfigType("SniRouting")).isEqualTo(SniRoutingClusterNetworkAddressConfigProviderConfig.class);
+    }
+
+    @Test
+    void testGetInstanceForPortPerBroker() {
+        assertThat(getInstance("PortPerBroker",
+                new PortPerBrokerClusterNetworkAddressConfigProviderConfig(HostPort.parse("localhost:8080"), "brokerpattern.com", 9092, 3))).isInstanceOf(
+                        PortPerBrokerClusterNetworkAddressConfigProvider.class);
+    }
+
+    @Test
+    void testGetInstanceForSniRouting() {
+        assertThat(getInstance("SniRouting",
+                new SniRoutingClusterNetworkAddressConfigProviderConfig(HostPort.parse("localhost:8080"), "$(nodeId)-brokerpattern.com"))).isInstanceOf(
+                        SniRoutingClusterNetworkAddressConfigProvider.class);
+    }
+
+    private ClusterNetworkAddressConfigProvider getInstance(String shortName, BaseConfig config) {
+        return ClusterNetworkAddressConfigProviderContributorManager.getInstance().getInstance(shortName, config);
+    }
+
+    private static Class<? extends BaseConfig> getConfigType(String shortName) {
+        return ClusterNetworkAddressConfigProviderContributorManager.getInstance().getConfigType(shortName);
+    }
+
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/FilterContributorManagerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/FilterContributorManagerTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.internal.filter.ProduceRequestTransformationFilter.UpperCasing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FilterContributorManagerTest {
+
+    @Test
+    void testNonExistentConfigType() {
+        assertThatThrownBy(() -> getConfigType("nonexist")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testNonExistentGetInstance() {
+        BaseConfig config = new BaseConfig();
+        assertThatThrownBy(() -> getInstance("nonexist", config)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testProduceRequestTransformationConfigType() {
+        assertThat(getConfigType("ProduceRequestTransformation")).isEqualTo(ProduceRequestTransformationFilter.ProduceRequestTransformationConfig.class);
+    }
+
+    @Test
+    void testFetchResponseTransformationConfigType() {
+        assertThat(getConfigType("FetchResponseTransformation")).isEqualTo(FetchResponseTransformationFilter.FetchResponseTransformationConfig.class);
+    }
+
+    @Test
+    void testProduceRequestTransformationInstance() {
+        assertThat(getInstance("ProduceRequestTransformation", new ProduceRequestTransformationFilter.ProduceRequestTransformationConfig(
+                UpperCasing.class.getName()))).isInstanceOf(
+                        ProduceRequestTransformationFilter.class);
+    }
+
+    @Test
+    void testFetchResponseTransformationInstance() {
+        assertThat(getInstance("FetchResponseTransformation", new FetchResponseTransformationFilter.FetchResponseTransformationConfig(
+                UpperCasing.class.getName()))).isInstanceOf(
+                        FetchResponseTransformationFilter.class);
+    }
+
+    private Filter getInstance(String shortName, BaseConfig config) {
+        return FilterContributorManager.getInstance().getInstance(shortName, config);
+    }
+
+    private static Class<? extends BaseConfig> getConfigType(String shortName) {
+        return FilterContributorManager.getInstance().getConfigType(shortName);
+    }
+
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/micrometer/MicrometerConfigurationHookContributorManagerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/micrometer/MicrometerConfigurationHookContributorManagerTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.micrometer;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MicrometerConfigurationHookContributorManagerTest {
+
+    @Test
+    void testNonExistentConfigType() {
+        assertThatThrownBy(() -> getConfigType("nonexist")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testNonExistentGetInstance() {
+        BaseConfig config = new BaseConfig();
+        assertThatThrownBy(() -> getInstance("nonexist", config)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testCommonTagsConfigType() {
+        assertThat(getConfigType("CommonTags")).isEqualTo(CommonTagsHook.CommonTagsHookConfig.class);
+    }
+
+    @Test
+    void testCommonTagsInstance() {
+        assertThat(getInstance("CommonTags", new CommonTagsHook.CommonTagsHookConfig(Map.of()))).isInstanceOf(CommonTagsHook.class);
+    }
+
+    @Test
+    void testStandardBindersConfigType() {
+        assertThat(getConfigType("StandardBinders")).isEqualTo(StandardBindersHook.StandardBindersHookConfig.class);
+    }
+
+    @Test
+    void testStandardBindersInstance() {
+        assertThat(getInstance("StandardBinders", new StandardBindersHook.StandardBindersHookConfig(List.of()))).isInstanceOf(StandardBindersHook.class);
+    }
+
+    private MicrometerConfigurationHook getInstance(String shortName, BaseConfig config) {
+        return MicrometerConfigurationHookContributorManager.getInstance().getInstance(shortName, config);
+    }
+
+    private static Class<? extends BaseConfig> getConfigType(String shortName) {
+        return MicrometerConfigurationHookContributorManager.getInstance().getConfigType(shortName);
+    }
+
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description
Why:
The contributor interface has this awkward contract of returning null from it's component methods if the shortName is not supported. We can use an Optional to make it clear at a glance from the API that a contributor does not have to supply something. Also we contain this logic in one place, after we obtain an InstanceFactory for a shortName we don't have to keep passing the shortName in again. Also the InstanceFactory class will be easier to extend to indicate if the configuration is required or not (see #602).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
