### PR TITLE
move createTopics and deleteTopics from BaseIT to KroxyliciousTester

### DIFF
--- a/integrationtests/src/test/java/io/kroxylicious/proxy/BaseIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/BaseIT.java
@@ -7,63 +7,18 @@
 package io.kroxylicious.proxy;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
-import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.CreateTopicsResult;
-import org.apache.kafka.clients.admin.DeleteTopicsResult;
-import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.Producer;
-import org.apache.kafka.common.TopicCollection;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.kroxylicious.test.tester.KroxyliciousTester;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(KafkaClusterExtension.class)
 public abstract class BaseIT {
-
-    protected CreateTopicsResult createTopics(Admin admin, NewTopic... topics) {
-        try {
-            List<NewTopic> topicsList = List.of(topics);
-            var created = admin.createTopics(topicsList);
-            assertThat(created.values()).hasSizeGreaterThanOrEqualTo(topicsList.size());
-            created.all().get(10, TimeUnit.SECONDS);
-            return created;
-        }
-        catch (ExecutionException e) {
-            throw new RuntimeException(e.getCause());
-        }
-        catch (InterruptedException | TimeoutException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    protected CreateTopicsResult createTopic(Admin admin, String topic, int numPartitions) {
-        return createTopics(admin, new NewTopic(topic, numPartitions, (short) 1));
-    }
-
-    protected DeleteTopicsResult deleteTopics(Admin admin, TopicCollection topics) {
-        try {
-            var deleted = admin.deleteTopics(topics);
-            deleted.all().get(10, TimeUnit.SECONDS);
-            return deleted;
-        }
-        catch (ExecutionException e) {
-            throw new RuntimeException(e.getCause());
-        }
-        catch (InterruptedException | TimeoutException e) {
-            throw new RuntimeException(e);
-        }
-    }
 
     protected Map<String, Object> buildClientConfig(Map<String, Object>... configs) {
         Map<String, Object> clientConfig = new HashMap<>();

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/ExpositionIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/ExpositionIT.java
@@ -91,7 +91,7 @@ class ExpositionIT extends BaseIT {
         try (var tester = kroxyliciousTester(builder);
                 var admin = tester.admin("demo", clientSecurityProtocolConfig)) {
             // do some work to ensure connection is opened
-            createTopic(admin, TOPIC, 1);
+            tester.createTopic("demo", clientSecurityProtocolConfig, TOPIC, 1);
 
             var connectionsMetric = admin.metrics().entrySet().stream().filter(metricNameEntry -> "connections".equals(metricNameEntry.getKey().name()))
                     .findFirst();
@@ -126,10 +126,8 @@ class ExpositionIT extends BaseIT {
 
         try (var tester = kroxyliciousTester(builder)) {
             for (int i = 0; i < clusterProxyAddresses.size(); i++) {
-                try (var admin = tester.admin("cluster" + i)) {
-                    // do some work to ensure virtual cluster is operational
-                    createTopic(admin, TOPIC + i, 1);
-                }
+                // do some work to ensure virtual cluster is operational
+                tester.createTopic("cluster" + i, TOPIC + i, 1);
             }
         }
     }
@@ -175,13 +173,9 @@ class ExpositionIT extends BaseIT {
         try (var tester = kroxyliciousTester(builder)) {
             for (int i = 0; i < numberOfVirtualClusters; i++) {
                 var trust = keystoreTrustStoreList.get(i);
-                try (var admin = tester.admin("cluster" + i, Map.of(
-                        CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name,
-                        SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, trust.clientTrustStore(),
-                        SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, trust.password()))) {
-                    // do some work to ensure virtual cluster is operational
-                    createTopic(admin, TOPIC + i, 1);
-                }
+                // do some work to ensure virtual cluster is operational
+                tester.createTopic("cluster" + i, Map.of(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name,
+                        SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, trust.clientTrustStore(), SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, trust.password()), TOPIC + i, 1);
             }
         }
     }
@@ -474,7 +468,7 @@ class ExpositionIT extends BaseIT {
         // create topic and ensure that leaders are on different brokers.
         try (var admin = tester.admin();
                 var producer = tester.producer("demo", Map.of(ProducerConfig.CLIENT_ID_CONFIG, "myclient"))) {
-            createTopic(admin, topic, numberOfPartitions);
+            tester.createTopic(topic, numberOfPartitions);
             try {
                 await().atMost(Duration.ofSeconds(10))
                         .ignoreExceptions()
@@ -489,7 +483,7 @@ class ExpositionIT extends BaseIT {
                 }
             }
             finally {
-                deleteTopics(admin, TopicNameCollection.ofTopicNames(List.of(topic)));
+                tester.deleteTopics(TopicNameCollection.ofTopicNames(List.of(topic)));
             }
         }
     }

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/TlsIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/TlsIT.java
@@ -93,9 +93,9 @@ class TlsIT extends BaseIT {
                         .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
                         .build());
 
-        try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
+        try (var tester = kroxyliciousTester(builder)) {
             // do some work to ensure connection is opened
-            final CreateTopicsResult createTopicsResult = createTopic(admin, TOPIC, 1);
+            final CreateTopicsResult createTopicsResult = tester.createTopic("demo", TOPIC, 1);
             assertThat(createTopicsResult.all()).isDone();
         }
     }
@@ -132,9 +132,9 @@ class TlsIT extends BaseIT {
                         .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
                         .build());
 
-        try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
+        try (var tester = kroxyliciousTester(builder)) {
             // do some work to ensure connection is opened
-            final CreateTopicsResult createTopicsResult = createTopic(admin, TOPIC, 1);
+            final CreateTopicsResult createTopicsResult = tester.createTopic("demo", TOPIC, 1);
             assertThat(createTopicsResult.all()).isDone();
         }
     }
@@ -154,9 +154,9 @@ class TlsIT extends BaseIT {
                         .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
                         .build());
 
-        try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
+        try (var tester = kroxyliciousTester(builder)) {
             // do some work to ensure connection is opened
-            final CreateTopicsResult createTopicsResult = createTopic(admin, TOPIC, 1);
+            final CreateTopicsResult createTopicsResult = tester.createTopic("demo", TOPIC, 1);
             assertThat(createTopicsResult.all()).isDone();
         }
     }
@@ -189,13 +189,12 @@ class TlsIT extends BaseIT {
                         .withClusterNetworkAddressConfigProvider(CONFIG_PROVIDER_DEFINITION)
                         .build());
 
-        try (var tester = kroxyliciousTester(builder);
-                var admin = tester.admin("demo",
-                        Map.of(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name,
-                                SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, clientTrustStore.toAbsolutePath().toString(),
-                                SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, downstreamCertificateGenerator.getPassword()))) {
+        try (var tester = kroxyliciousTester(builder)) {
             // do some work to ensure connection is opened
-            final CreateTopicsResult createTopicsResult = createTopic(admin, TOPIC, 1);
+            final CreateTopicsResult createTopicsResult = tester.createTopic("demo",
+                    Map.of(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name, SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG,
+                            clientTrustStore.toAbsolutePath().toString(), SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, downstreamCertificateGenerator.getPassword()),
+                    TOPIC, 1);
             assertThat(createTopicsResult.all()).isDone();
         }
     }

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/multitenant/MultiTenantIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/multitenant/MultiTenantIT.java
@@ -80,7 +80,7 @@ class MultiTenantIT extends BaseMultiTenantIT {
 
         try (var tester = kroxyliciousTester(config);
                 var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
-            var created = createTopics(admin, NEW_TOPIC_1, NEW_TOPIC_2);
+            var created = tester.createTopics(TENANT_1_CLUSTER, this.clientConfig, NEW_TOPIC_1, NEW_TOPIC_2);
 
             var topicMap = await().atMost(Duration.ofSeconds(5)).until(() -> admin.listTopics().namesToListings().get(),
                     n -> n.size() == 2);
@@ -94,12 +94,12 @@ class MultiTenantIT extends BaseMultiTenantIT {
 
             // Delete by name
             var topics1 = TopicNameCollection.ofTopicNames(List.of(TOPIC_1));
-            var deleted = deleteTopics(admin, topics1);
+            var deleted = tester.deleteTopics(TENANT_1_CLUSTER, this.clientConfig, topics1);
             assertThat(deleted.topicNameValues().keySet()).containsAll(topics1.topicNames());
 
             // Delete by id
             var topics2 = TopicCollection.ofTopicIds(List.of(created.topicId(TOPIC_2).get()));
-            deleted = deleteTopics(admin, topics2);
+            deleted = tester.deleteTopics(TENANT_1_CLUSTER, this.clientConfig, topics2);
             assertThat(deleted.topicIdValues().keySet()).containsAll(topics2.topicIds());
         }
     }
@@ -109,7 +109,7 @@ class MultiTenantIT extends BaseMultiTenantIT {
         var config = getConfig(cluster, this.certificateGenerator);
         try (var tester = kroxyliciousTester(config);
                 var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
-            var created = createTopics(admin, NEW_TOPIC_1);
+            var created = tester.createTopics(TENANT_1_CLUSTER, this.clientConfig, NEW_TOPIC_1);
 
             await().atMost(Duration.ofSeconds(5)).ignoreExceptions().untilAsserted(() -> {
                 var describeTopicsResult = admin.describeTopics(TopicNameCollection.ofTopicNames(List.of(TOPIC_1)));
@@ -123,9 +123,8 @@ class MultiTenantIT extends BaseMultiTenantIT {
     @Test
     void produceOne(KafkaCluster cluster) throws Exception {
         var config = getConfig(cluster, this.certificateGenerator);
-        try (var tester = kroxyliciousTester(config);
-                var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
-            createTopics(admin, NEW_TOPIC_1);
+        try (var tester = kroxyliciousTester(config)) {
+            tester.createTopics(TENANT_1_CLUSTER, this.clientConfig, NEW_TOPIC_1);
             produceAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER, Stream.of(new ProducerRecord<>(TOPIC_1, MY_KEY, MY_VALUE)), Optional.empty());
         }
     }
@@ -133,10 +132,9 @@ class MultiTenantIT extends BaseMultiTenantIT {
     @Test
     void consumeOne(KafkaCluster cluster) throws Exception {
         var config = getConfig(cluster, this.certificateGenerator);
-        try (var tester = kroxyliciousTester(config);
-                var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
+        try (var tester = kroxyliciousTester(config)) {
             var groupId = testInfo.getDisplayName();
-            createTopics(admin, NEW_TOPIC_1);
+            tester.createTopics(TENANT_1_CLUSTER, this.clientConfig, NEW_TOPIC_1);
             produceAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER, Stream.of(new ProducerRecord<>(TOPIC_1, MY_KEY, MY_VALUE)), Optional.empty());
             consumeAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER, TOPIC_1, groupId, new LinkedList<>(List.of(matchesRecord(TOPIC_1, MY_KEY, MY_VALUE))), false);
         }
@@ -145,10 +143,9 @@ class MultiTenantIT extends BaseMultiTenantIT {
     @Test
     void consumeOneAndOffsetCommit(KafkaCluster cluster) throws Exception {
         var config = getConfig(cluster, this.certificateGenerator);
-        try (var tester = kroxyliciousTester(config);
-                var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
+        try (var tester = kroxyliciousTester(config)) {
             var groupId = testInfo.getDisplayName();
-            createTopics(admin, NEW_TOPIC_1);
+            tester.createTopics(TENANT_1_CLUSTER, this.clientConfig, NEW_TOPIC_1);
             produceAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER,
                     Stream.of(new ProducerRecord<>(TOPIC_1, MY_KEY, "1"), new ProducerRecord<>(TOPIC_1, MY_KEY, "2"), inCaseOfFailure()), Optional.empty());
             consumeAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER, TOPIC_1, groupId, new LinkedList<>(List.of(matchesRecord(TOPIC_1, MY_KEY, "1"))), true);
@@ -162,7 +159,7 @@ class MultiTenantIT extends BaseMultiTenantIT {
         try (var tester = kroxyliciousTester(config);
                 var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
             var groupId = testInfo.getDisplayName();
-            createTopics(admin, NEW_TOPIC_1);
+            tester.createTopics(TENANT_1_CLUSTER, this.clientConfig, NEW_TOPIC_1);
             produceAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER,
                     Stream.of(new ProducerRecord<>(TOPIC_1, MY_KEY, "1"), new ProducerRecord<>(TOPIC_1, MY_KEY, "2"), inCaseOfFailure()), Optional.empty());
             consumeAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER, TOPIC_1, groupId, new LinkedList<>(List.of(matchesRecord(TOPIC_1, MY_KEY, "1"))), true);
@@ -180,7 +177,7 @@ class MultiTenantIT extends BaseMultiTenantIT {
         try (var tester = kroxyliciousTester(config);
                 var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
             var groupId = testInfo.getDisplayName();
-            createTopics(admin, NEW_TOPIC_1);
+            tester.createTopics(TENANT_1_CLUSTER, this.clientConfig, NEW_TOPIC_1);
             produceAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER, Stream.of(new ProducerRecord<>(TOPIC_1, MY_KEY, "1"), inCaseOfFailure()), Optional.empty());
             consumeAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER, TOPIC_1, groupId, new LinkedList<>(List.of(matchesRecord(TOPIC_1, MY_KEY, "1"))), true);
 
@@ -195,8 +192,8 @@ class MultiTenantIT extends BaseMultiTenantIT {
         try (var tester = kroxyliciousTester(config);
                 var adminTenant1 = tester.admin(TENANT_1_CLUSTER, this.clientConfig);
                 var adminTenant2 = tester.admin(TENANT_2_CLUSTER, this.clientConfig)) {
-            createTopics(adminTenant1, NEW_TOPIC_1);
-            createTopics(adminTenant2, NEW_TOPIC_2, NEW_TOPIC_3);
+            tester.createTopics(TENANT_1_CLUSTER, this.clientConfig, NEW_TOPIC_1);
+            tester.createTopics(TENANT_2_CLUSTER, this.clientConfig, NEW_TOPIC_2, NEW_TOPIC_3);
 
             verifyTenant(adminTenant1, TOPIC_1);
             verifyTenant(adminTenant2, TOPIC_2, TOPIC_3);
@@ -209,7 +206,7 @@ class MultiTenantIT extends BaseMultiTenantIT {
         var config = getConfig(cluster, this.certificateGenerator);
         try (var tester = kroxyliciousTester(config);
                 var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
-            createTopics(admin, NEW_TOPIC_1);
+            tester.createTopics(TENANT_1_CLUSTER, this.clientConfig, NEW_TOPIC_1);
             runConsumerInOrderToCreateGroup(tester, TENANT_1_CLUSTER, "Tenant1Group", NEW_TOPIC_1, consumerStyle, this.clientConfig);
             verifyConsumerGroupsWithList(admin, Set.of("Tenant1Group"));
         }
@@ -220,12 +217,11 @@ class MultiTenantIT extends BaseMultiTenantIT {
     void tenantGroupIsolation(ConsumerStyle consumerStyle, KafkaCluster cluster) throws Exception {
         var config = getConfig(cluster, this.certificateGenerator);
         try (var tester = kroxyliciousTester(config);
-                var adminTenant1 = tester.admin(TENANT_1_CLUSTER, this.clientConfig);
                 var adminTenant2 = tester.admin(TENANT_2_CLUSTER, this.clientConfig)) {
-            createTopics(adminTenant1, NEW_TOPIC_1);
+            tester.createTopics(TENANT_1_CLUSTER, this.clientConfig, NEW_TOPIC_1);
             runConsumerInOrderToCreateGroup(tester, TENANT_1_CLUSTER, "Tenant1Group", NEW_TOPIC_1, consumerStyle, this.clientConfig);
 
-            createTopics(adminTenant2, NEW_TOPIC_1);
+            tester.createTopics(TENANT_2_CLUSTER, this.clientConfig, NEW_TOPIC_1);
             runConsumerInOrderToCreateGroup(tester, TENANT_2_CLUSTER, "Tenant2Group", NEW_TOPIC_1, consumerStyle, this.clientConfig);
             verifyConsumerGroupsWithList(adminTenant2, Set.of("Tenant2Group"));
         }
@@ -237,10 +233,10 @@ class MultiTenantIT extends BaseMultiTenantIT {
         try (var tester = kroxyliciousTester(config);
                 var adminTenant1 = tester.admin(TENANT_1_CLUSTER, this.clientConfig);
                 var adminTenant2 = tester.admin(TENANT_2_CLUSTER, this.clientConfig)) {
-            createTopics(adminTenant1, NEW_TOPIC_1);
+            tester.createTopics(TENANT_1_CLUSTER, this.clientConfig, NEW_TOPIC_1);
             runConsumerInOrderToCreateGroup(tester, TENANT_1_CLUSTER, "Tenant1Group", NEW_TOPIC_1, ConsumerStyle.ASSIGN, this.clientConfig);
 
-            createTopics(adminTenant2, NEW_TOPIC_1);
+            tester.createTopics(TENANT_2_CLUSTER, this.clientConfig, NEW_TOPIC_1);
             runConsumerInOrderToCreateGroup(tester, TENANT_2_CLUSTER, "Tenant2Group", NEW_TOPIC_1, ConsumerStyle.ASSIGN, this.clientConfig);
 
             verifyConsumerGroupsWithDescribe(adminTenant1, Set.of("Tenant1Group"), Set.of("Tenant2Group", "idontexist"));
@@ -251,9 +247,8 @@ class MultiTenantIT extends BaseMultiTenantIT {
     @Test
     void produceInTransaction(KafkaCluster cluster) throws Exception {
         var config = getConfig(cluster, this.certificateGenerator);
-        try (var tester = kroxyliciousTester(config);
-                var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
-            createTopics(admin, NEW_TOPIC_1);
+        try (var tester = kroxyliciousTester(config)) {
+            tester.createTopics(TENANT_1_CLUSTER, this.clientConfig, NEW_TOPIC_1);
             produceAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER,
                     Stream.of(new ProducerRecord<>(TOPIC_1, MY_KEY, "1")),
                     Optional.of("12345"));
@@ -263,12 +258,11 @@ class MultiTenantIT extends BaseMultiTenantIT {
     @Test
     void produceAndConsumeInTransaction(KafkaCluster cluster) throws Exception {
         var config = getConfig(cluster, this.certificateGenerator);
-        try (var tester = kroxyliciousTester(config);
-                var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
+        try (var tester = kroxyliciousTester(config)) {
             // put some records in an input topic
             var inputTopic = "input";
             var outputTopic = "output";
-            createTopics(admin, new NewTopic(inputTopic, 1, (short) 1),
+            tester.createTopics(TENANT_1_CLUSTER, this.clientConfig, new NewTopic(inputTopic, 1, (short) 1),
                     new NewTopic(outputTopic, 1, (short) 1));
             produceAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER,
                     Stream.of(new ProducerRecord<>(inputTopic, MY_KEY, "1"),
@@ -320,7 +314,7 @@ class MultiTenantIT extends BaseMultiTenantIT {
         var config = getConfig(cluster, this.certificateGenerator);
         try (var tester = kroxyliciousTester(config)) {
             try (var admin = tester.admin(TENANT_1_CLUSTER, this.clientConfig)) {
-                createTopics(admin, NEW_TOPIC_1);
+                tester.createTopics(TENANT_1_CLUSTER, this.clientConfig, NEW_TOPIC_1);
                 var transactionalId = "12345";
                 produceAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER,
                         Stream.of(new ProducerRecord<>(TOPIC_1, MY_KEY, "1")),
@@ -340,14 +334,14 @@ class MultiTenantIT extends BaseMultiTenantIT {
         try (var tester = kroxyliciousTester(config);
                 var adminTenant1 = tester.admin(TENANT_1_CLUSTER, this.clientConfig);
                 var adminTenant2 = tester.admin(TENANT_2_CLUSTER, this.clientConfig)) {
-            createTopics(adminTenant1, NEW_TOPIC_1);
+            tester.createTopics(TENANT_1_CLUSTER, this.clientConfig, NEW_TOPIC_1);
             var tenant1TransactionId = "12345";
             produceAndVerify(tester, this.clientConfig, TENANT_1_CLUSTER,
                     Stream.of(new ProducerRecord<>(TOPIC_1, MY_KEY, "1")),
                     Optional.of(tenant1TransactionId));
             verifyTransactionsWithList(adminTenant1, Set.of(tenant1TransactionId));
 
-            createTopics(adminTenant2, NEW_TOPIC_2);
+            tester.createTopics(TENANT_2_CLUSTER, this.clientConfig, NEW_TOPIC_2);
             var tenant2TransactionId = "54321";
             produceAndVerify(tester, this.clientConfig, TENANT_2_CLUSTER,
                     Stream.of(new ProducerRecord<>(TOPIC_2, MY_KEY, "1")),

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/KroxyliciousTester.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/KroxyliciousTester.java
@@ -214,42 +214,69 @@ public interface KroxyliciousTester extends Closeable {
     KafkaClient simpleTestClient(String virtualCluster);
 
     /**
-     *
+     * Creates the given topics on the specified virtual cluster, with an admin client using the specified configuration.
+     * @param topics the topics to be created
+     * @param additionalConfig additional admin config
+     * @param virtualCluster the virtual cluster we want the topics created on
+     * @return CreateTopicsResult
      */
     CreateTopicsResult createTopics(String virtualCluster, Map<String, Object> additionalConfig, NewTopic... topics);
 
     /**
-     *
+     * Creates the given topic on the specified virtual cluster, with an admin client using the specified configuration.
+     * @param topic the name of the topic to be created
+     * @param numPartitions the number of partitions for the topic
+     * @param additionalConfig additional admin config
+     * @param virtualCluster the virtual cluster we want the topics created on
+     * @return CreateTopicsResult
      */
     CreateTopicsResult createTopic(String virtualCluster, Map<String, Object> additionalConfig, String topic, int numPartitions);
 
     /**
-     *
+     * Creates the given topic on the specified virtual cluster.
+     * @param topic the name of the topic to be created
+     * @param numPartitions the number of partitions for the topic
+     * @param virtualCluster the virtual cluster we want the topics created on
+     * @return CreateTopicsResult
      */
     CreateTopicsResult createTopic(String virtualCluster, String topic, int numPartitions);
 
     /**
-     *
+     * Creates the given topics on the only virtual cluster.
+     * @param topics the topics to be created
+     * @return CreateTopicsResult
      */
     CreateTopicsResult createTopics(NewTopic... topics);
 
     /**
-     *
+     * Creates the given topic on the only virtual cluster.
+     * @param topic the name of the topic to be created
+     * @param numPartitions the number of partitions for the topic
+     * @return CreateTopicsResult
      */
     CreateTopicsResult createTopic(String topic, int numPartitions);
 
     /**
-     *
+     * Deletes the given topics on the specified virtual cluster, with an admin client using the specified configuration.
+     * @param topics the topics to be deleted
+     * @param additionalConfig additional admin config
+     * @param virtualCluster the virtual cluster we want the topics deleted from
+     * @return DeleteTopicsResult
      */
     DeleteTopicsResult deleteTopics(String virtualCluster, Map<String, Object> additionalConfig, TopicCollection topics);
 
     /**
-     *
+     * Deletes the given topics on the specified virtual cluster.
+     * @param topics the topics to be deleted
+     * @param virtualCluster the virtual cluster we want the topics deleted from
+     * @return DeleteTopicsResult
      */
     DeleteTopicsResult deleteTopics(String virtualCluster, TopicCollection topics);
 
     /**
-     *
+     * Deletes the given topics on the only virtual cluster.
+     * @param topics the topics to be deleted
+     * @return DeleteTopicsResult
      */
     DeleteTopicsResult deleteTopics(TopicCollection topics);
 

--- a/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/KroxyliciousTester.java
+++ b/kroxylicious-test-tools/src/main/java/io/kroxylicious/test/tester/KroxyliciousTester.java
@@ -10,8 +10,12 @@ import java.io.Closeable;
 import java.util.Map;
 
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.DeleteTopicsResult;
+import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.TopicCollection;
 import org.apache.kafka.common.serialization.Serde;
 
 import io.kroxylicious.test.client.KafkaClient;
@@ -208,6 +212,46 @@ public interface KroxyliciousTester extends Closeable {
      * @throws IllegalArgumentException if the named virtual cluster is not part of the kroxylicious server
      */
     KafkaClient simpleTestClient(String virtualCluster);
+
+    /**
+     *
+     */
+    CreateTopicsResult createTopics(String virtualCluster, Map<String, Object> additionalConfig, NewTopic... topics);
+
+    /**
+     *
+     */
+    CreateTopicsResult createTopic(String virtualCluster, Map<String, Object> additionalConfig, String topic, int numPartitions);
+
+    /**
+     *
+     */
+    CreateTopicsResult createTopic(String virtualCluster, String topic, int numPartitions);
+
+    /**
+     *
+     */
+    CreateTopicsResult createTopics(NewTopic... topics);
+
+    /**
+     *
+     */
+    CreateTopicsResult createTopic(String topic, int numPartitions);
+
+    /**
+     *
+     */
+    DeleteTopicsResult deleteTopics(String virtualCluster, Map<String, Object> additionalConfig, TopicCollection topics);
+
+    /**
+     *
+     */
+    DeleteTopicsResult deleteTopics(String virtualCluster, TopicCollection topics);
+
+    /**
+     *
+     */
+    DeleteTopicsResult deleteTopics(TopicCollection topics);
 
     /**
      * Restarts the Kroxylicious server under test without closing any other resources.


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Moves `createTopic`, `createTopics`, and `deleteTopics` to `KroxyliciousTester` from `BaseIT`. Rather than passing in an existing admin client to these methods, they now find or create the relevant `KroxyliciousClients` for the virtual cluster, then get an admin with that.

### Additional Context

This is part of trying to move relevant common test functionality to `KroxyliciousTester` and friends.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
