### PR TITLE
Support optional config objects 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 ## 1.0.0
 
 ## 0.3.0
-
+* [#612](https://github.com/kroxylicious/kroxylicious/pull/612): [Breaking] Allow filter authors to declare when their filter requires configuration. Note this includes a backwards incompatible change to the contract of the `Contributor`. `getInstance` will now throw exceptions rather than returning `null` to mean there was a problem or this contributor does not know about the requested type.
 * [#608](https://github.com/kroxylicious/kroxylicious/pull/608): Improve the contributor API to allow it to express more properties about the configuration. This release deprecates `Contributor.getConfigType` in favour of `Contributor.getConfigDefinition`. It also removes the proliferation of ContributorManager classes by providing a single type which can handle all Contributors.
 * [#538](https://github.com/kroxylicious/kroxylicious/pull/538): Refactor FilterHandler and fix several bugs that would leave messages unflushed to client/broker.
 * [#531](https://github.com/kroxylicious/kroxylicious/pull/531): Simple Test Client now supports multi-RPC conversations with the server.

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
@@ -13,10 +13,10 @@ public class TestFilterContributor extends BaseContributor<Filter, FilterConstru
     public static final BaseContributorBuilder<Filter, FilterConstructContext> FILTERS = BaseContributor.<Filter, FilterConstructContext> builder()
             .add("FixedClientId", FixedClientIdFilter.FixedClientIdFilterConfig.class, FixedClientIdFilter::new)
             .add("ApiVersionsMarkingFilter", ApiVersionsMarkingFilter::new)
-            .add("RequestResponseMarking", RequestResponseMarkingFilter.RequestResponseMarkingFilterConfig.class, RequestResponseMarkingFilter::new)
+            .add("RequestResponseMarking", RequestResponseMarkingFilter.RequestResponseMarkingFilterConfig.class, RequestResponseMarkingFilter::new, true)
             .add("OutOfBandSend", OutOfBandSendFilter.OutOfBandSendFilterConfig.class, OutOfBandSendFilter::new)
             .add("CompositePrefixingFixedClientId", CompositePrefixingFixedClientIdFilterConfig.class, CompositePrefixingFixedClientIdFilter::new)
-            .add("RejectingCreateTopic", RejectingCreateTopicFilter.RejectingCreateTopicFilterConfig.class, RejectingCreateTopicFilter::new);
+            .add("RejectingCreateTopic", RejectingCreateTopicFilter.RejectingCreateTopicFilterConfig.class, RejectingCreateTopicFilter::new, true);
 
     public TestFilterContributor() {
         super(FILTERS);

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
@@ -16,7 +16,7 @@ public class TestFilterContributor extends BaseContributor<Filter, FilterConstru
             .add("RequestResponseMarking", RequestResponseMarkingFilter.RequestResponseMarkingFilterConfig.class, RequestResponseMarkingFilter::new, true)
             .add("OutOfBandSend", OutOfBandSendFilter.OutOfBandSendFilterConfig.class, OutOfBandSendFilter::new)
             .add("CompositePrefixingFixedClientId", CompositePrefixingFixedClientIdFilterConfig.class, CompositePrefixingFixedClientIdFilter::new)
-            .add("RejectingCreateTopic", RejectingCreateTopicFilter.RejectingCreateTopicFilterConfig.class, RejectingCreateTopicFilter::new, true);
+            .add("RejectingCreateTopic", RejectingCreateTopicFilter.RejectingCreateTopicFilterConfig.class, RejectingCreateTopicFilter::new, false);
 
     public TestFilterContributor() {
         super(FILTERS);

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
@@ -207,6 +207,5 @@ public abstract class BaseContributor<T, S extends Context> implements Contribut
         return new BaseContributorBuilder<>();
     }
 
-    protected record ContributionDetails<T, D extends Context>(ConfigurationDefinition configurationDefinition, InstanceBuilder<T, D> instanceBuilder) {
-    }
+    protected record ContributionDetails<T, D extends Context>(ConfigurationDefinition configurationDefinition, InstanceBuilder<T, D> instanceBuilder) {}
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
@@ -83,14 +83,17 @@ public abstract class BaseContributor<T, S extends Context> implements Contribut
             final boolean hasConfiguration = context.getConfig() != null;
             if (!configurationRequired || hasConfiguration) {
                 InstanceBuilder<T, S> instanceBuilder = contributionDetails.instanceBuilder();
-                return instanceBuilder == null ? null : instanceBuilder.construct(context);
+                if (instanceBuilder == null) {
+                    throw new IllegalArgumentException("'" + typeName + "' is not a provided type");
+                }
+                return instanceBuilder.construct(context);
             }
             else {
                 throw new IllegalArgumentException("'" + typeName + "' requires configuration but none was supplied");
             }
         }
         else {
-            return null;
+            throw new IllegalArgumentException("'" + typeName + "' is not a provided type");
         }
     }
 

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
@@ -189,7 +189,7 @@ public abstract class BaseContributor<T, S extends Context> implements Contribut
          * @return this
          */
         public BaseContributorBuilder<L, D> add(String typeName, Function<D, L> instanceFunction) {
-            return add(typeName, BaseConfig.class, (context, config) -> instanceFunction.apply(context), true);
+            return add(typeName, BaseConfig.class, (context, config) -> instanceFunction.apply(context), false);
         }
 
         Map<String, ContributionDetails<L, D>> build() {

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/BaseContributor.java
@@ -7,6 +7,7 @@ package io.kroxylicious.proxy.service;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -20,14 +21,14 @@ import io.kroxylicious.proxy.config.BaseConfig;
  */
 public abstract class BaseContributor<T, S extends Context> implements Contributor<T, S> {
 
-    private final Map<String, ContributionDetails<T, S>> typeNameToInstanceBuilder;
+    private final Map<String, ContributionDetails<T, S>> typeNameToContributorDetails;
 
     /**
      * Constructs and configures the contributor using the supplied {@code builder}.
      * @param builder builder
      */
     protected BaseContributor(BaseContributorBuilder<T, S> builder) {
-        typeNameToInstanceBuilder = builder.build();
+        typeNameToContributorDetails = builder.build();
     }
 
     /**
@@ -37,7 +38,7 @@ public abstract class BaseContributor<T, S extends Context> implements Contribut
      */
     @Override
     public boolean contributes(String typeName) {
-        return typeNameToInstanceBuilder.containsKey(typeName);
+        return typeNameToContributorDetails.containsKey(typeName);
     }
 
     /**
@@ -48,8 +49,8 @@ public abstract class BaseContributor<T, S extends Context> implements Contribut
      */
     @Override
     public ConfigurationDefinition getConfigDefinition(String typeName) {
-        if (typeNameToInstanceBuilder.containsKey(typeName)) {
-            return typeNameToInstanceBuilder.get(typeName).configurationDefinition();
+        if (typeNameToContributorDetails.containsKey(typeName)) {
+            return typeNameToContributorDetails.get(typeName).configurationDefinition();
         }
         else {
             throw new IllegalArgumentException("No configuration definition registered for " + typeName);
@@ -66,8 +67,8 @@ public abstract class BaseContributor<T, S extends Context> implements Contribut
     @Override
     @Deprecated(forRemoval = true, since = "0.3.0")
     public Class<? extends BaseConfig> getConfigType(String typeName) {
-        if (typeNameToInstanceBuilder.containsKey(typeName)) {
-            return typeNameToInstanceBuilder.get(typeName).configurationDefinition().configurationType();
+        if (typeNameToContributorDetails.containsKey(typeName)) {
+            return typeNameToContributorDetails.get(typeName).configurationDefinition().configurationType();
         }
         else {
             return null;
@@ -76,9 +77,17 @@ public abstract class BaseContributor<T, S extends Context> implements Contribut
 
     @Override
     public T getInstance(String typeName, S context) {
-        if (typeNameToInstanceBuilder.containsKey(typeName)) {
-            InstanceBuilder<T, S> instanceBuilder = typeNameToInstanceBuilder.get(typeName).instanceBuilder();
-            return instanceBuilder == null ? null : instanceBuilder.construct(context);
+        if (typeNameToContributorDetails.containsKey(typeName)) {
+            final ContributionDetails<T, S> contributionDetails = typeNameToContributorDetails.get(typeName);
+            final boolean configurationRequired = contributionDetails.configurationDefinition().configurationRequired();
+            final boolean hasConfiguration = context.getConfig() != null;
+            if (!configurationRequired || hasConfiguration) {
+                InstanceBuilder<T, S> instanceBuilder = contributionDetails.instanceBuilder();
+                return instanceBuilder == null ? null : instanceBuilder.construct(context);
+            }
+            else {
+                throw new IllegalArgumentException("'" + typeName + "' requires configuration but none was supplied");
+            }
         }
         else {
             return null;
@@ -138,7 +147,7 @@ public abstract class BaseContributor<T, S extends Context> implements Contribut
          * @param <T> the configuration concrete type
          */
         public <T extends BaseConfig> BaseContributorBuilder<L, D> add(String typeName, Class<T> configClass, Function<T, L> instanceFunction) {
-            return add(typeName, configClass, (context, config) -> instanceFunction.apply(config));
+            return add(typeName, configClass, (context, config) -> instanceFunction.apply(config), !Objects.equals(BaseConfig.class, configClass));
         }
 
         /**
@@ -147,15 +156,17 @@ public abstract class BaseContributor<T, S extends Context> implements Contribut
          * @param typeName service short name
          * @param configClass concrete type of configuration required by the service
          * @param instanceFunction function that constructs the service instance
+         * @param configurationRequired {@code true} if the contribution requires configuration. {@code false} if the contribution uses configuration for optional properties or to override defaults.
          * @return this
          * @param <T> the configuration concrete type
          */
-        public <T extends BaseConfig> BaseContributorBuilder<L, D> add(String typeName, Class<T> configClass, BiFunction<D, T, L> instanceFunction) {
+        public <T extends BaseConfig> BaseContributorBuilder<L, D> add(String typeName, Class<T> configClass, BiFunction<D, T, L> instanceFunction,
+                                                                       boolean configurationRequired) {
             if (typeNameToInstanceBuilder.containsKey(typeName)) {
                 throw new IllegalArgumentException(typeName + " already registered");
             }
             typeNameToInstanceBuilder.put(typeName,
-                    new ContributionDetails<>(new ConfigurationDefinition(configClass), InstanceBuilder.builder(configClass, instanceFunction)));
+                    new ContributionDetails<>(new ConfigurationDefinition(configClass, configurationRequired), InstanceBuilder.builder(configClass, instanceFunction)));
             return this;
         }
 
@@ -178,7 +189,7 @@ public abstract class BaseContributor<T, S extends Context> implements Contribut
          * @return this
          */
         public BaseContributorBuilder<L, D> add(String typeName, Function<D, L> instanceFunction) {
-            return add(typeName, BaseConfig.class, (context, config) -> instanceFunction.apply(context));
+            return add(typeName, BaseConfig.class, (context, config) -> instanceFunction.apply(context), true);
         }
 
         Map<String, ContributionDetails<L, D>> build() {
@@ -196,5 +207,6 @@ public abstract class BaseContributor<T, S extends Context> implements Contribut
         return new BaseContributorBuilder<>();
     }
 
-    protected record ContributionDetails<T, D extends Context>(ConfigurationDefinition configurationDefinition, InstanceBuilder<T, D> instanceBuilder) {}
+    protected record ContributionDetails<T, D extends Context>(ConfigurationDefinition configurationDefinition, InstanceBuilder<T, D> instanceBuilder) {
+    }
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/ConfigurationDefinition.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/ConfigurationDefinition.java
@@ -10,8 +10,11 @@ import io.kroxylicious.proxy.config.BaseConfig;
 
 /**
  * Defines the details of how Contributions interact with configuration for {@link BaseContributor}'s purposes.
+ * <p>
+ * configurationRequired allows filter authors to tell Kroxylicious if the filter must be supplied with a config object.
+ * If the filter uses configuration to supply optional properties, or it can provide sensible default values for the configuration then it should be set to false.
  *
  * @param configurationType defines the expected class for configuration objects
- * @param configurationRequired {@code true} if the contribution requires configuration. {@code false} if the contribution uses configuration for optional properties or to override defaults.
+ * @param configurationRequired {@code true} if the contribution requires a non-null configuration object. {@code false} if the contribution can tolerate a null configuration object
  */
 public record ConfigurationDefinition(Class<? extends BaseConfig> configurationType, boolean configurationRequired) {}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/ConfigurationDefinition.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/service/ConfigurationDefinition.java
@@ -12,5 +12,6 @@ import io.kroxylicious.proxy.config.BaseConfig;
  * Defines the details of how Contributions interact with configuration for {@link BaseContributor}'s purposes.
  *
  * @param configurationType defines the expected class for configuration objects
+ * @param configurationRequired {@code true} if the contribution requires configuration. {@code false} if the contribution uses configuration for optional properties or to override defaults.
  */
-public record ConfigurationDefinition(Class<? extends BaseConfig> configurationType) {}
+public record ConfigurationDefinition(Class<? extends BaseConfig> configurationType, boolean configurationRequired) {}

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
@@ -7,12 +7,14 @@ package io.kroxylicious.proxy.service;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.proxy.config.BaseConfig;
 
 import static io.kroxylicious.proxy.service.Context.wrap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class BaseContributorTest {
@@ -297,5 +299,33 @@ class BaseContributorTest {
 
         // Then
         assertThat(actualInstance).isNotNull();
+    }
+
+    @Test
+    void shouldThrowExceptionIfNoTypeRegistered() {
+        // Given
+        BaseContributor<Long, Context> baseContributor = new BaseContributor<>(BaseContributor.builder()) {
+        };
+
+        // When
+        final ThrowableAssert.ThrowingCallable throwingCallable = () -> baseContributor.getInstance("unknown", BaseConfig::new);
+
+        // Then
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(throwingCallable).withMessage("'unknown' is not a provided type");
+    }
+
+    @Test
+    void shouldThrowExceptionIfRegisteredInstanceBuilderReturnsNull() {
+        // Given
+        BaseContributor.BaseContributorBuilder<Long, Context> builder = BaseContributor.builder();
+        builder.add("registered", () -> null);
+        BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
+        };
+
+        // When
+        final ThrowableAssert.ThrowingCallable throwingCallable = () -> baseContributor.getInstance("registered", BaseConfig::new);
+
+        // Then
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(throwingCallable).withMessage("'registered' is not a provided type");
     }
 }

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
@@ -25,6 +25,48 @@ class BaseContributorTest {
     }
 
     @Test
+    void shouldReturnTrueForConfigurationRequiredViaDefaulting() {
+        // Given
+        BaseContributor.BaseContributorBuilder<Long, Context> builder = BaseContributor.builder();
+        builder.add("one", LongConfig.class, longConfig -> 1L);
+        BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
+        };
+
+        // When
+        boolean actual = baseContributor.getConfigDefinition("one").configurationRequired();
+
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void shouldReturnTrueForExplicitlySpecifiedConfigurationRequired() {
+        // Given
+        BaseContributor.BaseContributorBuilder<Long, Context> builder = BaseContributor.builder();
+        builder.add("one", LongConfig.class, (longConfig, context) -> 1L, true);
+        BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
+        };
+
+        // When
+        boolean actual = baseContributor.getConfigDefinition("one").configurationRequired();
+
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseFroOptionalRegisteredConfig() {
+        // Given
+        BaseContributor.BaseContributorBuilder<Long, Context> builder = BaseContributor.builder();
+        builder.add("one", LongConfig.class, (longConfig, context) -> 1L, false);
+        BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
+        };
+
+        // When
+        boolean actual = baseContributor.getConfigDefinition("one").configurationRequired();
+
+        assertThat(actual).isFalse();
+    }
+
+    @Test
     void testDefaultConfigClass() {
         BaseContributor.BaseContributorBuilder<Long, Context> builder = BaseContributor.builder();
         builder.add("one", () -> 1L);
@@ -117,7 +159,7 @@ class BaseContributorTest {
         builder.add("fromBaseConfig", LongConfig.class, (context, baseConfig) -> {
             contextRef.set(context);
             return baseConfig.value;
-        });
+        }, true);
         BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
         };
         Context context = wrap(new LongConfig());
@@ -163,5 +205,80 @@ class BaseContributorTest {
         assertThatThrownBy(() -> baseContributor.getConfigDefinition("fromBaseConfig")).isInstanceOf(IllegalArgumentException.class);
 
         // Then
+    }
+
+    @Test
+    void shouldFailIfConfigIsNullAndRequired() {
+        // Given
+        BaseContributor.BaseContributorBuilder<Long, Context> builder = BaseContributor.builder();
+        builder.add("requiresConfig", LongConfig.class, (baseConfig, context) -> 1L, true);
+        BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
+        };
+
+        // When
+        assertThatThrownBy(() -> baseContributor.getInstance("requiresConfig", () -> null)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("'requiresConfig' requires configuration but none was supplied");
+
+        // Then
+    }
+
+    @Test
+    void shouldConstructInstanceIfConfigIsNullAndNotRequired() {
+        // Given
+        BaseContributor.BaseContributorBuilder<Long, Context> builder = BaseContributor.builder();
+        builder.add("noConfigRequired", LongConfig.class, (longConfig, context) -> 1L, false);
+        BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
+        };
+
+        // When
+        final Long actualInstance = baseContributor.getInstance("noConfigRequired", () -> null);
+
+        // Then
+        assertThat(actualInstance).isNotNull();
+    }
+
+    @Test
+    void shouldConstructInstanceIfConfigTypeIsSpecifiedButNotRequiredAndConfigIsNull() {
+        // Given
+        BaseContributor.BaseContributorBuilder<Long, Context> builder = BaseContributor.builder();
+        builder.add("configOptional", LongConfig.class, (longConfig, context) -> 1L, false);
+        BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
+        };
+
+        // When
+        final Long actualInstance = baseContributor.getInstance("configOptional", () -> null);
+
+        // Then
+        assertThat(actualInstance).isNotNull();
+    }
+
+    @Test
+    void shouldConstructInstanceIfConfigIsNotNullAndRequired() {
+        // Given
+        BaseContributor.BaseContributorBuilder<Long, Context> builder = BaseContributor.builder();
+        builder.add("configRequired", LongConfig.class, longConfig -> longConfig.value);
+        BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
+        };
+
+        // When
+        final Long actualInstance = baseContributor.getInstance("configRequired", LongConfig::new);
+
+        // Then
+        assertThat(actualInstance).isNotNull();
+    }
+
+    @Test
+    void shouldConstructInstanceIfConfigIsNotNullAndNotRequired() {
+        // Given
+        BaseContributor.BaseContributorBuilder<Long, Context> builder = BaseContributor.builder();
+        builder.add("configOptional", () -> 1L);
+        BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
+        };
+
+        // When
+        final Long actualInstance = baseContributor.getInstance("configOptional", () -> null);
+
+        // Then
+        assertThat(actualInstance).isNotNull();
     }
 }

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
@@ -123,6 +123,22 @@ class BaseContributorTest {
     }
 
     @Test
+    void testContextAndConfigFunctionWithNoConfig() {
+        BaseContributor.BaseContributorBuilder<Long, Context> builder = BaseContributor.builder();
+        AtomicReference<Context> contextRef = new AtomicReference<>();
+        builder.add("one", (context -> {
+            contextRef.set(context);
+            return 1L;
+        }));
+        BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
+        };
+        Context context = wrap(null);
+        Long instance = baseContributor.getInstance("one", context);
+        assertThat(instance).isEqualTo(1L);
+        assertThat(contextRef).hasValue(context);
+    }
+
+    @Test
     void testSpecifyingConfigType() {
         BaseContributor.BaseContributorBuilder<Long, Context> builder = BaseContributor.builder();
         builder.add("fromBaseConfig", LongConfig.class, baseConfig -> baseConfig.value);

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
@@ -318,7 +318,7 @@ class BaseContributorTest {
     void shouldThrowExceptionIfRegisteredInstanceBuilderReturnsNull() {
         // Given
         BaseContributor.BaseContributorBuilder<Long, Context> builder = BaseContributor.builder();
-        builder.add("registered", () -> null);
+        builder.add("registered", (context) -> null);
         BaseContributor<Long, Context> baseContributor = new BaseContributor<>(builder) {
         };
 
@@ -326,6 +326,7 @@ class BaseContributorTest {
         final ThrowableAssert.ThrowingCallable throwingCallable = () -> baseContributor.getInstance("registered", BaseConfig::new);
 
         // Then
-        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(throwingCallable).withMessage("'registered' is not a provided type");
+        assertThatExceptionOfType(NullPointerException.class).isThrownBy(throwingCallable)
+                .withMessage("Tried to instantiate 'registered' but the Contributor returned null");
     }
 }

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/service/BaseContributorTest.java
@@ -218,9 +218,10 @@ class BaseContributorTest {
         };
 
         // When
-        assertThatThrownBy(() -> baseContributor.getConfigDefinition("fromBaseConfig")).isInstanceOf(IllegalArgumentException.class);
+        var throwableAssert = assertThatThrownBy(() -> baseContributor.getConfigDefinition("fromBaseConfig"));
 
         // Then
+        throwableAssert.isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -232,10 +233,10 @@ class BaseContributorTest {
         };
 
         // When
-        assertThatThrownBy(() -> baseContributor.getInstance("requiresConfig", () -> null)).isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("'requiresConfig' requires configuration but none was supplied");
+        var throwableAssert = assertThatThrownBy(() -> baseContributor.getInstance("requiresConfig", () -> null));
 
         // Then
+        throwableAssert.isInstanceOf(IllegalArgumentException.class).hasMessage("'requiresConfig' requires configuration but none was supplied");
     }
 
     @Test

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -33,6 +33,7 @@ import io.netty.incubator.channel.uring.IOUringEventLoopGroup;
 import io.netty.incubator.channel.uring.IOUringServerSocketChannel;
 import io.netty.util.concurrent.Future;
 
+import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.MicrometerDefinition;
 import io.kroxylicious.proxy.config.admin.AdminHttpConfiguration;
@@ -105,6 +106,8 @@ public final class KafkaProxy implements AutoCloseable {
         var plainServerBootstrap = buildServerBootstrap(serverEventGroup, new KafkaProxyInitializer(config, false, endpointRegistry, endpointRegistry, false, Map.of()));
 
         bindingOperationProcessor.start(plainServerBootstrap, tlsServerBootstrap);
+
+        FilterChainFactory.validateFilterConfiguration(config.filters());
 
         // TODO: startup/shutdown should return a completionstage
         CompletableFuture.allOf(virtualClusters.stream().map(vc -> endpointRegistry.registerVirtualCluster(vc).toCompletableFuture()).toArray(CompletableFuture[]::new))

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import io.kroxylicious.proxy.config.Configuration;
@@ -41,9 +42,8 @@ public class FilterChainFactory {
             return Set.of();
         }
         return filterDefinitions.stream()
-                .filter(f -> f.config() == null)
+                .filter(Predicate.not(FilterDefinition::isDefinitionValid))
                 .map(FilterDefinition::type)
-                .filter(type -> ContributionManager.INSTANCE.getDefinition(FilterContributor.class, type).configurationRequired())
                 .collect(Collectors.toSet());
     }
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -37,7 +37,7 @@ public class FilterChainFactory {
      * @return the Set of filter names which fail validation.
      */
     public static Set<String> validateFilterConfiguration(Collection<FilterDefinition> filterDefinitions) {
-        if (Objects.isNull(filterDefinitions) || filterDefinitions.isEmpty()) {
+        if (filterDefinitions == null || filterDefinitions.isEmpty()) {
             return Set.of();
         }
         return filterDefinitions.stream()

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -5,6 +5,7 @@
  */
 package io.kroxylicious.proxy.bootstrap;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -30,20 +31,20 @@ public class FilterChainFactory {
         this.config = Objects.requireNonNull(config);
     }
 
-    public static boolean validateFilterConfiguration(List<FilterDefinition> filters) {
-        if (Objects.isNull(filters) || filters.isEmpty()) {
-            return true;
+    /**
+     * Validate that a collection of FilterDefinitions contains all the required configuration to configure the filter.
+     * @param filterDefinitions the candidates to validate.
+     * @return the Set of filter names which fail validation.
+     */
+    public static Set<String> validateFilterConfiguration(Collection<FilterDefinition> filterDefinitions) {
+        if (Objects.isNull(filterDefinitions) || filterDefinitions.isEmpty()) {
+            return Set.of();
         }
-        final Set<String> filtersWithoutRequiredConfiguration = filters.stream()
+        return filterDefinitions.stream()
                 .filter(f -> f.config() == null)
                 .map(FilterDefinition::type)
                 .filter(type -> ContributionManager.INSTANCE.getDefinition(FilterContributor.class, type).configurationRequired())
                 .collect(Collectors.toSet());
-        if (!filtersWithoutRequiredConfiguration.isEmpty()) {
-            throw new IllegalStateException(filtersWithoutRequiredConfiguration.stream()
-                    .collect(Collectors.joining(", ", "Missing required config for [", "]")));
-        }
-        return true;
     }
 
     /**

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -25,8 +25,7 @@ public class FilterChainFactory {
     private final Configuration config;
 
     public FilterChainFactory(Configuration config) {
-        Objects.requireNonNull(config);
-        this.config = config;
+        this.config = Objects.requireNonNull(config);
     }
 
     /**

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/config/FilterDefinition.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/config/FilterDefinition.java
@@ -8,14 +8,27 @@ package io.kroxylicious.proxy.config;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+
+import io.kroxylicious.proxy.filter.FilterContributor;
+import io.kroxylicious.proxy.service.ConfigurationDefinition;
+import io.kroxylicious.proxy.service.ContributionManager;
 
 public record FilterDefinition(@JsonProperty(required = true) String type,
                                @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "type") @JsonTypeIdResolver(FilterConfigTypeIdResolver.class) BaseConfig config) {
     @JsonCreator
     public FilterDefinition {
         Objects.requireNonNull(type);
+    }
+
+    @JsonIgnore
+    public boolean isDefinitionValid() {
+        // We could consider allowing Filter authors to supply a config validation function `config -> config.property != null` via the configurationDefinition
+        // We would then be able to apply that validation here.
+        final ConfigurationDefinition configurationDefinition = ContributionManager.INSTANCE.getDefinition(FilterContributor.class, type);
+        return config != null || !configurationDefinition.configurationRequired();
     }
 }

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import io.kroxylicious.proxy.config.ConfigParser;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class KafkaProxyTest {
@@ -37,8 +38,7 @@ class KafkaProxyTest {
                        - type: ProduceRequestTransformation
                 """;
         try (var kafkaProxy = new KafkaProxy(new ConfigParser().parseConfiguration(config))) {
-            var illegalStateException = assertThrows(IllegalStateException.class, kafkaProxy::startup);
-            assertThat(illegalStateException).hasStackTraceContaining("Missing required config for");
+            assertThatThrownBy(kafkaProxy::startup).isInstanceOf(IllegalStateException.class).hasMessage("Missing required config for [ProduceRequestTransformation]");
         }
     }
 

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
@@ -14,10 +14,12 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import io.kroxylicious.proxy.config.ConfigParser;
+import io.kroxylicious.proxy.config.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class KafkaProxyTest {
 
@@ -112,10 +114,12 @@ class KafkaProxyTest {
     @MethodSource
     void missingTls(String name, String config, String expectedMessage) throws Exception {
 
-        var illegalArgumentException = assertThrows(IllegalStateException.class, () -> {
-            try (var kafkaProxy = new KafkaProxy(new ConfigParser().parseConfiguration(config))) {
+        final Configuration parsedConfiguration = new ConfigParser().parseConfiguration(config);
+        var illegalStateException = assertThrows(IllegalStateException.class, () -> {
+            try (var ignored = new KafkaProxy(parsedConfiguration)) {
+                fail("The proxy started, but a failure was expected.");
             }
         });
-        assertThat(illegalArgumentException).hasStackTraceContaining(expectedMessage);
+        assertThat(illegalStateException).hasStackTraceContaining(expectedMessage);
     }
 }

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
@@ -88,57 +88,57 @@ class FilterChainFactoryTest {
 
     @Test
     void shouldThrowExceptionIfFilterRequiresConfigAndNoneIsSupplied() {
-        //Given
+        // Given
         final List<FilterDefinition> filters = List.of(new FilterDefinition(TestFilterContributor.TYPE_NAME_A, config),
                 new FilterDefinition(TestFilterContributor.TYPE_NAME_B, null));
 
-        //When
+        // When
         assertThatThrownBy(() -> FilterChainFactory.validateFilterConfiguration(filters))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining(TestFilterContributor.TYPE_NAME_B);
 
-        //Then
+        // Then
     }
 
     @Test
     void shouldThrowExceptionMentioningAllFiltersWithoutRequiredConfig() {
-        //Given
+        // Given
         final List<FilterDefinition> filters = List.of(new FilterDefinition(TestFilterContributor.TYPE_NAME_A, null),
                 new FilterDefinition(TestFilterContributor.TYPE_NAME_B, null));
 
-        //When
+        // When
         assertThatThrownBy(() -> FilterChainFactory.validateFilterConfiguration(filters))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining(TestFilterContributor.TYPE_NAME_A)
                 .hasMessageContaining(TestFilterContributor.TYPE_NAME_B);
 
-        //Then
+        // Then
     }
 
     @Test
     void shouldCompleteIfAllFiltersHaveConfiguration() {
-        //Given
+        // Given
         final List<FilterDefinition> filterDefinitions = List.of(new FilterDefinition(TestFilterContributor.TYPE_NAME_A, config),
                 new FilterDefinition(TestFilterContributor.TYPE_NAME_B, config));
 
-        //When
+        // When
         final boolean configurationValid = FilterChainFactory.validateFilterConfiguration(filterDefinitions);
 
-        //Then
+        // Then
         assertThat(configurationValid).isTrue();
     }
 
     @Test
     void shouldCompleteIfFiltersWithOptionalConfigurationAreMissingConfiguration() {
-        //Given
+        // Given
         final List<FilterDefinition> filterDefinitions = List.of(new FilterDefinition(TestFilterContributor.TYPE_NAME_A, config),
                 new FilterDefinition(TestFilterContributor.TYPE_NAME_B, config),
                 new FilterDefinition(TestFilterContributor.OPTIONAL_CONFIG_FILTER, null));
 
-        //When
+        // When
         final boolean configurationValid = FilterChainFactory.validateFilterConfiguration(filterDefinitions);
 
-        //Then
+        // Then
         assertThat(configurationValid).isTrue();
     }
 

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
@@ -86,6 +86,48 @@ class FilterChainFactoryTest {
         });
     }
 
+    @Test
+    void shouldThrowExceptionIfFilterRequiresConfigAndNoneIsSupplied() {
+        //Given
+        final List<FilterDefinition> filters = List.of(new FilterDefinition(TestFilterContributor.SHORT_NAME_A, config),
+                new FilterDefinition(TestFilterContributor.SHORT_NAME_B, null));
+
+        //When
+        assertThatThrownBy(() -> FilterChainFactory.validateFilterConfiguration(filters))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(TestFilterContributor.SHORT_NAME_B);
+
+        //Then
+    }
+
+    @Test
+    void shouldThrowExceptionMentioningAllFiltersWithoutRequiredConfig() {
+        //Given
+        final List<FilterDefinition> filters = List.of(new FilterDefinition(TestFilterContributor.SHORT_NAME_A, null),
+                new FilterDefinition(TestFilterContributor.SHORT_NAME_B, null));
+
+        //When
+        assertThatThrownBy(() -> FilterChainFactory.validateFilterConfiguration(filters))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining(TestFilterContributor.SHORT_NAME_A)
+                .hasMessageContaining(TestFilterContributor.SHORT_NAME_B);
+
+        //Then
+    }
+
+    @Test
+    void shouldCompleteIfAllFiltersHaveConfiguration() {
+        //Given
+        final List<FilterDefinition> filterDefinitions = List.of(new FilterDefinition(TestFilterContributor.SHORT_NAME_A, config),
+                new FilterDefinition(TestFilterContributor.SHORT_NAME_B, config));
+
+        //When
+        final boolean configurationValid = FilterChainFactory.validateFilterConfiguration(filterDefinitions);
+
+        //Then
+        assertThat(configurationValid).isTrue();
+    }
+
     private ListAssert<FilterAndInvoker> assertFiltersCreated(List<FilterDefinition> filterDefinitions) {
         FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, filterDefinitions, null, true));
         NettyFilterContext context = new NettyFilterContext(eventLoop);

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
@@ -59,9 +59,9 @@ class FilterChainFactoryTest {
 
     @Test
     void testCreateFilter() {
-        final ListAssert<FilterAndInvoker> listAssert = assertFiltersCreated(List.of(new FilterDefinition(TestFilterContributor.SHORT_NAME_A, config)));
+        final ListAssert<FilterAndInvoker> listAssert = assertFiltersCreated(List.of(new FilterDefinition(TestFilterContributor.TYPE_NAME_A, config)));
         listAssert.first().extracting(FilterAndInvoker::filter).isInstanceOfSatisfying(TestFilter.class, testFilter -> {
-            assertThat(testFilter.getShortName()).isEqualTo(TestFilterContributor.SHORT_NAME_A);
+            assertThat(testFilter.getShortName()).isEqualTo(TestFilterContributor.TYPE_NAME_A);
             assertThat(testFilter.getContext().getConfig()).isSameAs(config);
             assertThat(testFilter.getContext().executors().eventLoop()).isSameAs(eventLoop);
             assertThat(testFilter.getExampleConfig()).isSameAs(config);
@@ -70,16 +70,16 @@ class FilterChainFactoryTest {
 
     @Test
     void testCreateFilters() {
-        final ListAssert<FilterAndInvoker> listAssert = assertFiltersCreated(List.of(new FilterDefinition(TestFilterContributor.SHORT_NAME_A, config),
-                new FilterDefinition(TestFilterContributor.SHORT_NAME_B, config)));
+        final ListAssert<FilterAndInvoker> listAssert = assertFiltersCreated(List.of(new FilterDefinition(TestFilterContributor.TYPE_NAME_A, config),
+                new FilterDefinition(TestFilterContributor.TYPE_NAME_B, config)));
         listAssert.element(0).extracting(FilterAndInvoker::filter).isInstanceOfSatisfying(TestFilter.class, testFilter -> {
-            assertThat(testFilter.getShortName()).isEqualTo(TestFilterContributor.SHORT_NAME_A);
+            assertThat(testFilter.getShortName()).isEqualTo(TestFilterContributor.TYPE_NAME_A);
             assertThat(testFilter.getContext().getConfig()).isSameAs(config);
             assertThat(testFilter.getContext().executors().eventLoop()).isSameAs(eventLoop);
             assertThat(testFilter.getExampleConfig()).isSameAs(config);
         });
         listAssert.element(1).extracting(FilterAndInvoker::filter).isInstanceOfSatisfying(TestFilter.class, testFilter -> {
-            assertThat(testFilter.getShortName()).isEqualTo(TestFilterContributor.SHORT_NAME_B);
+            assertThat(testFilter.getShortName()).isEqualTo(TestFilterContributor.TYPE_NAME_B);
             assertThat(testFilter.getContext().getConfig()).isSameAs(config);
             assertThat(testFilter.getContext().executors().eventLoop()).isSameAs(eventLoop);
             assertThat(testFilter.getExampleConfig()).isSameAs(config);
@@ -89,13 +89,13 @@ class FilterChainFactoryTest {
     @Test
     void shouldThrowExceptionIfFilterRequiresConfigAndNoneIsSupplied() {
         //Given
-        final List<FilterDefinition> filters = List.of(new FilterDefinition(TestFilterContributor.SHORT_NAME_A, config),
-                new FilterDefinition(TestFilterContributor.SHORT_NAME_B, null));
+        final List<FilterDefinition> filters = List.of(new FilterDefinition(TestFilterContributor.TYPE_NAME_A, config),
+                new FilterDefinition(TestFilterContributor.TYPE_NAME_B, null));
 
         //When
         assertThatThrownBy(() -> FilterChainFactory.validateFilterConfiguration(filters))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining(TestFilterContributor.SHORT_NAME_B);
+                .hasMessageContaining(TestFilterContributor.TYPE_NAME_B);
 
         //Then
     }
@@ -103,14 +103,14 @@ class FilterChainFactoryTest {
     @Test
     void shouldThrowExceptionMentioningAllFiltersWithoutRequiredConfig() {
         //Given
-        final List<FilterDefinition> filters = List.of(new FilterDefinition(TestFilterContributor.SHORT_NAME_A, null),
-                new FilterDefinition(TestFilterContributor.SHORT_NAME_B, null));
+        final List<FilterDefinition> filters = List.of(new FilterDefinition(TestFilterContributor.TYPE_NAME_A, null),
+                new FilterDefinition(TestFilterContributor.TYPE_NAME_B, null));
 
         //When
         assertThatThrownBy(() -> FilterChainFactory.validateFilterConfiguration(filters))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining(TestFilterContributor.SHORT_NAME_A)
-                .hasMessageContaining(TestFilterContributor.SHORT_NAME_B);
+                .hasMessageContaining(TestFilterContributor.TYPE_NAME_A)
+                .hasMessageContaining(TestFilterContributor.TYPE_NAME_B);
 
         //Then
     }
@@ -118,8 +118,22 @@ class FilterChainFactoryTest {
     @Test
     void shouldCompleteIfAllFiltersHaveConfiguration() {
         //Given
-        final List<FilterDefinition> filterDefinitions = List.of(new FilterDefinition(TestFilterContributor.SHORT_NAME_A, config),
-                new FilterDefinition(TestFilterContributor.SHORT_NAME_B, config));
+        final List<FilterDefinition> filterDefinitions = List.of(new FilterDefinition(TestFilterContributor.TYPE_NAME_A, config),
+                new FilterDefinition(TestFilterContributor.TYPE_NAME_B, config));
+
+        //When
+        final boolean configurationValid = FilterChainFactory.validateFilterConfiguration(filterDefinitions);
+
+        //Then
+        assertThat(configurationValid).isTrue();
+    }
+
+    @Test
+    void shouldCompleteIfFiltersWithOptionalConfigurationAreMissingConfiguration() {
+        //Given
+        final List<FilterDefinition> filterDefinitions = List.of(new FilterDefinition(TestFilterContributor.TYPE_NAME_A, config),
+                new FilterDefinition(TestFilterContributor.TYPE_NAME_B, config),
+                new FilterDefinition(TestFilterContributor.OPTIONAL_CONFIG_FILTER, null));
 
         //When
         final boolean configurationValid = FilterChainFactory.validateFilterConfiguration(filterDefinitions);

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/config/FilterDefinitionTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/config/FilterDefinitionTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.internal.filter.ExampleConfig;
+
+import static io.kroxylicious.proxy.internal.filter.TestFilterContributor.OPTIONAL_CONFIG_FILTER;
+import static io.kroxylicious.proxy.internal.filter.TestFilterContributor.REQUIRED_CONFIG_FILTER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FilterDefinitionTest {
+
+    @Test
+    void shouldFailValidationIfRequireConfigMissing() {
+        // Given
+        final FilterDefinition requiredConfig = new FilterDefinition(REQUIRED_CONFIG_FILTER, null);
+
+        // When
+        final boolean actual = requiredConfig.isDefinitionValid();
+
+        // Then
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    void shouldPassValidationIfRequireConfigSupplied() {
+        // Given
+        final FilterDefinition requiredConfig = new FilterDefinition(REQUIRED_CONFIG_FILTER, new ExampleConfig());
+
+        // When
+        final boolean actual = requiredConfig.isDefinitionValid();
+
+        // Then
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void shouldPassValidationIfOptionalConfigSupplied() {
+        // Given
+        final FilterDefinition requiredConfig = new FilterDefinition(OPTIONAL_CONFIG_FILTER, new ExampleConfig());
+
+        // When
+        final boolean actual = requiredConfig.isDefinitionValid();
+
+        // Then
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void shouldPassValidationIfOptionalConfigIsMissing() {
+        // Given
+        final FilterDefinition requiredConfig = new FilterDefinition(OPTIONAL_CONFIG_FILTER, null);
+
+        // When
+        final boolean actual = requiredConfig.isDefinitionValid();
+
+        // Then
+        assertThat(actual).isTrue();
+    }
+}

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/TestClusterNetworkAddressConfigProviderContributor.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/TestClusterNetworkAddressConfigProviderContributor.java
@@ -34,7 +34,7 @@ public class TestClusterNetworkAddressConfigProviderContributor implements Clust
     @Override
     public ConfigurationDefinition getConfigDefinition(String shortName) {
         if (Objects.equals(shortName, SHORT_NAME)) {
-            return new ConfigurationDefinition(Config.class);
+            return new ConfigurationDefinition(Config.class, true);
         }
         return null;
     }

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestFilterContributor.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestFilterContributor.java
@@ -15,9 +15,11 @@ public class TestFilterContributor extends BaseContributor<Filter, FilterConstru
     public static final String TYPE_NAME_A = "TEST1";
     public static final String TYPE_NAME_B = "TEST2";
     public static final String OPTIONAL_CONFIG_FILTER = "TEST3";
+    public static final String REQUIRED_CONFIG_FILTER = "TEST4";
     public static final BaseContributorBuilder<Filter, FilterConstructContext> FILTERS = BaseContributor.<Filter, FilterConstructContext> builder()
             .add(TYPE_NAME_A, ExampleConfig.class, (context, exampleConfig) -> new TestFilter(TYPE_NAME_A, context, exampleConfig), true)
             .add(TYPE_NAME_B, ExampleConfig.class, (context, exampleConfig) -> new TestFilter(TYPE_NAME_B, context, exampleConfig), true)
+            .add(REQUIRED_CONFIG_FILTER, ExampleConfig.class, (context, exampleConfig) -> new TestFilter(REQUIRED_CONFIG_FILTER, context, exampleConfig), true)
             .add(OPTIONAL_CONFIG_FILTER, ExampleConfig.class, (context, exampleConfig) -> new TestFilter(OPTIONAL_CONFIG_FILTER, context, exampleConfig), false);
 
     public TestFilterContributor() {

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestFilterContributor.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestFilterContributor.java
@@ -12,11 +12,13 @@ import io.kroxylicious.proxy.filter.FilterContributor;
 import io.kroxylicious.proxy.service.BaseContributor;
 
 public class TestFilterContributor extends BaseContributor<Filter, FilterConstructContext> implements FilterContributor {
-    public static final String SHORT_NAME_A = "TEST1";
-    public static final String SHORT_NAME_B = "TEST2";
+    public static final String TYPE_NAME_A = "TEST1";
+    public static final String TYPE_NAME_B = "TEST2";
+    public static final String OPTIONAL_CONFIG_FILTER = "TEST3";
     public static final BaseContributorBuilder<Filter, FilterConstructContext> FILTERS = BaseContributor.<Filter, FilterConstructContext> builder()
-            .add(SHORT_NAME_A, ExampleConfig.class, (context, exampleConfig) -> new TestFilter(SHORT_NAME_A, context, exampleConfig), true)
-            .add(SHORT_NAME_B, ExampleConfig.class, (context, exampleConfig) -> new TestFilter(SHORT_NAME_B, context, exampleConfig), true);
+            .add(TYPE_NAME_A, ExampleConfig.class, (context, exampleConfig) -> new TestFilter(TYPE_NAME_A, context, exampleConfig), true)
+            .add(TYPE_NAME_B, ExampleConfig.class, (context, exampleConfig) -> new TestFilter(TYPE_NAME_B, context, exampleConfig), true)
+            .add(OPTIONAL_CONFIG_FILTER, ExampleConfig.class, (context, exampleConfig) -> new TestFilter(OPTIONAL_CONFIG_FILTER, context, exampleConfig), false);
 
     public TestFilterContributor() {
         super(FILTERS);

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestFilterContributor.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestFilterContributor.java
@@ -15,8 +15,8 @@ public class TestFilterContributor extends BaseContributor<Filter, FilterConstru
     public static final String SHORT_NAME_A = "TEST1";
     public static final String SHORT_NAME_B = "TEST2";
     public static final BaseContributorBuilder<Filter, FilterConstructContext> FILTERS = BaseContributor.<Filter, FilterConstructContext> builder()
-            .add(SHORT_NAME_A, ExampleConfig.class, (context, exampleConfig) -> new TestFilter(SHORT_NAME_A, context, exampleConfig))
-            .add(SHORT_NAME_B, ExampleConfig.class, (context, exampleConfig) -> new TestFilter(SHORT_NAME_B, context, exampleConfig));
+            .add(SHORT_NAME_A, ExampleConfig.class, (context, exampleConfig) -> new TestFilter(SHORT_NAME_A, context, exampleConfig), true)
+            .add(SHORT_NAME_B, ExampleConfig.class, (context, exampleConfig) -> new TestFilter(SHORT_NAME_B, context, exampleConfig), true);
 
     public TestFilterContributor() {
         super(FILTERS);

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/micrometer/TestMicrometerConfigurationHookContributor.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/micrometer/TestMicrometerConfigurationHookContributor.java
@@ -38,7 +38,7 @@ public class TestMicrometerConfigurationHookContributor implements MicrometerCon
     @Override
     public ConfigurationDefinition getConfigDefinition(String shortName) {
         if (Objects.equals(shortName, SHORT_NAME)) {
-            return new ConfigurationDefinition(Config.class);
+            return new ConfigurationDefinition(Config.class, true);
         }
         else {
             return null;

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/service/ContributionManagerTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/service/ContributionManagerTest.java
@@ -131,7 +131,7 @@ class ContributionManagerTest {
 
         @Override
         public ConfigurationDefinition getConfigDefinition(String shortName) {
-            return new ConfigurationDefinition(LongConfig.class);
+            return new ConfigurationDefinition(LongConfig.class, true);
         }
 
         @Override
@@ -168,7 +168,7 @@ class ContributionManagerTest {
 
         @Override
         public ConfigurationDefinition getConfigDefinition(String shortName) {
-            return new ConfigurationDefinition(configurationType);
+            return new ConfigurationDefinition(configurationType, true);
         }
 
         @Override


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

Allows Contributors to define if a filter actually requires configuration or not.

Additional Context
In fixing https://github.com/kroxylicious/kroxylicious/issues/530 it made sense to add a check if configuration was required, however that requires us to introduce the notion of required config. The initial answer was to add a check for configClass != BaseConfig.

@robobario then posed the question

> if they specify a specific subclass of BaseConfig as the configType, should we require it to be non-null?

To which the obvious answer is **no** filters should be able to support optional configuration see [RejectingCreateTopicFilter](https://github.com/kroxylicious/kroxylicious/blob/15c3d32a850ae92f82d063e81df4530e84c9cd6e/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RejectingCreateTopicFilter.java#L32C1-L32C1) as a good example. Thus we need a way for Filter authors to signal if configuration is required or not. The Contributor is the natural home for that as it is fully under the control of the filter author. Adding it to the FilterDefinition would expose it to filter users which doesn't make sense.

The one perhaps controversial aspect of this PR is it validates filter configuration during proxy startup and fails startup if there are any configuration errors. While that may not be our long term posture it is consistent with how we do port validation.

Replaces https://github.com/kroxylicious/kroxylicious/pull/602 as the rebase after merging https://github.com/kroxylicious/kroxylicious/pull/608 was just too hairy. 


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
