### PR TITLE
Safe invoker check future

### DIFF
--- a/kroxylicious-api/pom.xml
+++ b/kroxylicious-api/pom.xml
@@ -54,6 +54,12 @@
         </dependency>
 
         <!-- third party dependencies - test -->
+        <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-slf4j-impl -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/filter/SafeInvokerTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/filter/SafeInvokerTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.apache.kafka.common.protocol.ApiKeys.API_VERSIONS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyShort;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SafeInvokerTest {
+
+    private final FilterInvoker invoker = Mockito.mock(FilterInvoker.class);
+    private final SafeInvoker safeInvoker = new SafeInvoker(invoker);
+
+    @Test
+    void testShouldHandleRequestDelegated() {
+        // given
+        when(invoker.shouldHandleRequest(API_VERSIONS, (short) 1)).thenReturn(true);
+
+        // when
+        boolean shouldHandleRequest = safeInvoker.shouldHandleRequest(API_VERSIONS, (short) 1);
+
+        // then
+        assertThat(shouldHandleRequest).isTrue();
+        verify(invoker).shouldHandleRequest(API_VERSIONS, (short) 1);
+    }
+
+    @Test
+    void testShouldHandleResponseDelegated() {
+        // given
+        when(invoker.shouldHandleResponse(API_VERSIONS, (short) 1)).thenReturn(true);
+
+        // when
+        boolean shouldHandleResponse = safeInvoker.shouldHandleResponse(API_VERSIONS, (short) 1);
+
+        // then
+        assertThat(shouldHandleResponse).isTrue();
+        verify(invoker).shouldHandleResponse(API_VERSIONS, (short) 1);
+    }
+
+    @Test
+    void testIfDelegateNotInterestedInRequestSafeInvokerForwards() {
+        // given
+        when(invoker.shouldHandleRequest(API_VERSIONS, (short) 1)).thenReturn(false);
+        ApiVersionsRequestData message = new ApiVersionsRequestData();
+        RequestHeaderData header = new RequestHeaderData();
+        FilterContext filterContext = Mockito.mock(FilterContext.class);
+        CompletableFuture<RequestFilterResult> forwardStage = new CompletableFuture<>();
+        when(filterContext.forwardRequest(header, message)).thenReturn(forwardStage);
+
+        // when
+        CompletionStage<RequestFilterResult> stage = safeInvoker.onRequest(API_VERSIONS, (short) 1, header, message,
+                filterContext);
+
+        // then
+        assertThat(stage).isSameAs(forwardStage);
+    }
+
+    @Test
+    void testIfDelegateInterestedInRequestSafeInvokerDelegates() {
+        // given
+        when(invoker.shouldHandleRequest(API_VERSIONS, (short) 1)).thenReturn(true);
+        ApiVersionsRequestData message = new ApiVersionsRequestData();
+        RequestHeaderData header = new RequestHeaderData();
+        FilterContext filterContext = Mockito.mock(FilterContext.class);
+        CompletableFuture<RequestFilterResult> delegateStage = new CompletableFuture<>();
+        when(invoker.onRequest(any(), anyShort(), any(), any(), any())).thenReturn(delegateStage);
+
+        // when
+        CompletionStage<RequestFilterResult> stage = safeInvoker.onRequest(API_VERSIONS, (short) 1, header, message,
+                filterContext);
+
+        // then
+        assertThat(stage).isSameAs(delegateStage);
+        verify(invoker).onRequest(API_VERSIONS, (short) 1, header, message, filterContext);
+    }
+
+    @Test
+    void testIfDelegateInterestedInResponseSafeInvokerDelegates() {
+        // given
+        when(invoker.shouldHandleResponse(API_VERSIONS, (short) 1)).thenReturn(true);
+        ApiVersionsResponseData message = new ApiVersionsResponseData();
+        ResponseHeaderData header = new ResponseHeaderData();
+        FilterContext filterContext = Mockito.mock(FilterContext.class);
+        CompletableFuture<ResponseFilterResult> delegateStage = new CompletableFuture<>();
+        when(invoker.onResponse(any(), anyShort(), any(), any(), any())).thenReturn(delegateStage);
+
+        // when
+        CompletionStage<ResponseFilterResult> stage = safeInvoker.onResponse(API_VERSIONS, (short) 1, header, message,
+                filterContext);
+
+        // then
+        assertThat(stage).isSameAs(delegateStage);
+        verify(invoker).onResponse(API_VERSIONS, (short) 1, header, message, filterContext);
+    }
+
+    @Test
+    void testIfDelegateNotInterestedInResponseSafeInvokerForwards() {
+        // given
+        when(invoker.shouldHandleResponse(API_VERSIONS, (short) 1)).thenReturn(false);
+        ApiVersionsResponseData message = new ApiVersionsResponseData();
+        ResponseHeaderData header = new ResponseHeaderData();
+        FilterContext filterContext = Mockito.mock(FilterContext.class);
+        CompletableFuture<ResponseFilterResult> forwardStage = new CompletableFuture<>();
+        when(filterContext.forwardResponse(header, message)).thenReturn(forwardStage);
+
+        // when
+        CompletionStage<ResponseFilterResult> stage = safeInvoker.onResponse(API_VERSIONS, (short) 1, header, message,
+                filterContext);
+
+        // then
+        assertThat(stage).isSameAs(forwardStage);
+    }
+
+    @Test
+    void testIfDelegateReturnsNullOnRequestThenFailedFutureReturned() {
+        // given
+        when(invoker.shouldHandleRequest(API_VERSIONS, (short) 1)).thenReturn(true);
+        when(invoker.onRequest(any(), anyShort(), any(), any(), any())).thenReturn(null);
+
+        // when
+        CompletionStage<RequestFilterResult> stage = safeInvoker.onRequest(API_VERSIONS, (short) 1, new RequestHeaderData(), new ApiVersionsRequestData(),
+                Mockito.mock(FilterContext.class));
+
+        // then
+        assertThat(stage).isCompletedExceptionally().failsWithin(Duration.ZERO).withThrowableOfType(ExecutionException.class)
+                .withCauseInstanceOf(IllegalStateException.class).havingCause()
+                .withMessageContaining("invoker onRequest returned null for apiKey API_VERSIONS");
+    }
+
+    @Test
+    void testIfDelegateReturnsNullOnResponseThenFailedFutureReturned() {
+        // given
+        when(invoker.shouldHandleResponse(API_VERSIONS, (short) 1)).thenReturn(true);
+        when(invoker.onResponse(any(), anyShort(), any(), any(), any())).thenReturn(null);
+
+        // when
+        CompletionStage<ResponseFilterResult> stage = safeInvoker.onResponse(API_VERSIONS, (short) 1, new ResponseHeaderData(), new ApiVersionsResponseData(),
+                Mockito.mock(FilterContext.class));
+
+        // then
+        assertThat(stage).isCompletedExceptionally().failsWithin(Duration.ZERO).withThrowableOfType(ExecutionException.class)
+                .withCauseInstanceOf(IllegalStateException.class).havingCause()
+                .withMessageContaining("invoker onResponse returned null for apiKey API_VERSIONS");
+    }
+
+}

--- a/kroxylicious-api/src/test/resources/log4j2-test.properties
+++ b/kroxylicious-api/src/test/resources/log4j2-test.properties
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+name = Config
+
+appender.null.type = Null
+appender.null.name = NullAppender
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} <%t> %-5p %c:%L - %m%n
+
+rootLogger.level = TRACE
+rootLogger.appenderRefs = null,console
+rootLogger.appenderRef.console.ref = STDOUT
+rootLogger.appenderRef.console.level = WARN
+rootLogger.additivity = false

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -187,14 +187,6 @@ public class FilterHandler extends ChannelDuplexHandler {
         }
         var stage = invoker.onResponse(decodedFrame.apiKey(), decodedFrame.apiVersion(),
                 decodedFrame.header(), decodedFrame.body(), filterContext);
-        if (stage == null) {
-            if (LOGGER.isWarnEnabled()) {
-                LOGGER.warn("{}: Filter{} for {} response unexpectedly returned null. This is a coding error in the filter. Closing connection.",
-                        channelDescriptor(), filterDescriptor(), decodedFrame.apiKey());
-            }
-            closeConnection();
-            return CompletableFuture.completedFuture(null);
-        }
         return stage instanceof InternalCompletionStage ? ((InternalCompletionStage<ResponseFilterResult>) stage).getUnderlyingCompletableFuture()
                 : stage.toCompletableFuture();
     }
@@ -228,14 +220,6 @@ public class FilterHandler extends ChannelDuplexHandler {
 
         var stage = invoker.onRequest(decodedFrame.apiKey(), decodedFrame.apiVersion(), decodedFrame.header(),
                 decodedFrame.body(), filterContext);
-        if (stage == null) {
-            if (LOGGER.isWarnEnabled()) {
-                LOGGER.warn("{}: Filter{} for {} request unexpectedly returned null. This is a coding error in the filter. Closing connection.",
-                        channelDescriptor(), filterDescriptor(), decodedFrame.apiKey());
-            }
-            closeConnection();
-            return CompletableFuture.completedFuture(null);
-        }
         return stage instanceof InternalCompletionStage ? ((InternalCompletionStage<RequestFilterResult>) stage).getUnderlyingCompletableFuture()
                 : stage.toCompletableFuture();
     }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

SafeInvoker detects if the delegate Filter has returned null and instead returns a failed CompletionStage. This will drive similar logic and result in a closed connection.

Resolves #558

Since the filters are pluggable we cannot guarantee that they will always return a non-null CompletionStage. Moving this logic into the SafeInvoker means client code can rely on a non-null CompletionStage

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
