### PR TITLE
Remove integrationtests topic helper methods entirely (re: #609)

### DIFF
--- a/integrationtests/src/test/java/io/kroxylicious/proxy/BaseIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/BaseIT.java
@@ -7,63 +7,18 @@
 package io.kroxylicious.proxy;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
-import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.CreateTopicsResult;
-import org.apache.kafka.clients.admin.DeleteTopicsResult;
-import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.Producer;
-import org.apache.kafka.common.TopicCollection;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.kroxylicious.test.tester.KroxyliciousTester;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(KafkaClusterExtension.class)
 public abstract class BaseIT {
-
-    protected CreateTopicsResult createTopics(Admin admin, NewTopic... topics) {
-        try {
-            List<NewTopic> topicsList = List.of(topics);
-            var created = admin.createTopics(topicsList);
-            assertThat(created.values()).hasSizeGreaterThanOrEqualTo(topicsList.size());
-            created.all().get(10, TimeUnit.SECONDS);
-            return created;
-        }
-        catch (ExecutionException e) {
-            throw new RuntimeException(e.getCause());
-        }
-        catch (InterruptedException | TimeoutException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    protected CreateTopicsResult createTopic(Admin admin, String topic, int numPartitions) {
-        return createTopics(admin, new NewTopic(topic, numPartitions, (short) 1));
-    }
-
-    protected DeleteTopicsResult deleteTopics(Admin admin, TopicCollection topics) {
-        try {
-            var deleted = admin.deleteTopics(topics);
-            deleted.all().get(10, TimeUnit.SECONDS);
-            return deleted;
-        }
-        catch (ExecutionException e) {
-            throw new RuntimeException(e.getCause());
-        }
-        catch (InterruptedException | TimeoutException e) {
-            throw new RuntimeException(e);
-        }
-    }
 
     protected Map<String, Object> buildClientConfig(Map<String, Object>... configs) {
         Map<String, Object> clientConfig = new HashMap<>();

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/ResilienceIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/ResilienceIT.java
@@ -7,12 +7,14 @@ package io.kroxylicious.proxy;
 
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -49,14 +51,14 @@ class ResilienceIT extends BaseIT {
     @Test
     void kafkaProducerShouldTolerateKroxyliciousRestarting(Admin admin) throws Exception {
         String randomTopic = UUID.randomUUID().toString();
-        createTopic(admin, randomTopic, 1);
+        admin.createTopics(List.of(new NewTopic(randomTopic, 1, (short) 1))).all().get(10, TimeUnit.SECONDS);
         testProducerCanSurviveARestart(proxy(cluster), randomTopic);
     }
 
     @Test
     void kafkaConsumerShouldTolerateKroxyliciousRestarting(Admin admin) throws Exception {
         String randomTopic = UUID.randomUUID().toString();
-        createTopic(admin, randomTopic, 1);
+        admin.createTopics(List.of(new NewTopic(randomTopic, 1, (short) 1))).all().get(10, TimeUnit.SECONDS);
         testConsumerCanSurviveKroxyliciousRestart(proxy(cluster), randomTopic);
     }
 

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/TlsIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/TlsIT.java
@@ -20,9 +20,11 @@ import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.junit.jupiter.api.BeforeEach;
@@ -72,7 +74,7 @@ class TlsIT extends BaseIT {
     }
 
     @Test
-    void upstreamUsesSelfSignedTls_TrustStore(@Tls KafkaCluster cluster) {
+    void upstreamUsesSelfSignedTls_TrustStore(@Tls KafkaCluster cluster) throws Exception {
         var bootstrapServers = cluster.getBootstrapServers();
         var brokerTruststore = (String) cluster.getKafkaClientConfiguration().get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);
         var brokerTruststorePassword = (String) cluster.getKafkaClientConfiguration().get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
@@ -95,7 +97,8 @@ class TlsIT extends BaseIT {
 
         try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
             // do some work to ensure connection is opened
-            final CreateTopicsResult createTopicsResult = createTopic(admin, TOPIC, 1);
+            final CreateTopicsResult createTopicsResult = admin.createTopics(List.of(new NewTopic(TOPIC, 1, (short) 1)));
+            createTopicsResult.all().get(10, TimeUnit.SECONDS);
             assertThat(createTopicsResult.all()).isDone();
         }
     }
@@ -134,13 +137,14 @@ class TlsIT extends BaseIT {
 
         try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
             // do some work to ensure connection is opened
-            final CreateTopicsResult createTopicsResult = createTopic(admin, TOPIC, 1);
+            final CreateTopicsResult createTopicsResult = admin.createTopics(List.of(new NewTopic(TOPIC, 1, (short) 1)));
+            createTopicsResult.all().get(10, TimeUnit.SECONDS);
             assertThat(createTopicsResult.all()).isDone();
         }
     }
 
     @Test
-    void upstreamUsesTlsInsecure(@Tls KafkaCluster cluster) {
+    void upstreamUsesTlsInsecure(@Tls KafkaCluster cluster) throws Exception {
         var bootstrapServers = cluster.getBootstrapServers();
 
         var builder = new ConfigurationBuilder()
@@ -156,13 +160,14 @@ class TlsIT extends BaseIT {
 
         try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
             // do some work to ensure connection is opened
-            final CreateTopicsResult createTopicsResult = createTopic(admin, TOPIC, 1);
+            final CreateTopicsResult createTopicsResult = admin.createTopics(List.of(new NewTopic(TOPIC, 1, (short) 1)));
+            createTopicsResult.all().get(10, TimeUnit.SECONDS);
             assertThat(createTopicsResult.all()).isDone();
         }
     }
 
     @Test
-    void downstreamAndUpstreamTls(@Tls KafkaCluster cluster) {
+    void downstreamAndUpstreamTls(@Tls KafkaCluster cluster) throws Exception {
         var bootstrapServers = cluster.getBootstrapServers();
         var brokerTruststore = (String) cluster.getKafkaClientConfiguration().get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG);
         var brokerTruststorePassword = (String) cluster.getKafkaClientConfiguration().get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG);
@@ -195,7 +200,8 @@ class TlsIT extends BaseIT {
                                 SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, clientTrustStore.toAbsolutePath().toString(),
                                 SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, downstreamCertificateGenerator.getPassword()))) {
             // do some work to ensure connection is opened
-            final CreateTopicsResult createTopicsResult = createTopic(admin, TOPIC, 1);
+            final CreateTopicsResult createTopicsResult = admin.createTopics(List.of(new NewTopic(TOPIC, 1, (short) 1)));
+            createTopicsResult.all().get(10, TimeUnit.SECONDS);
             assertThat(createTopicsResult.all()).isDone();
         }
     }

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSyntaxValidationIT.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSyntaxValidationIT.java
@@ -53,7 +53,7 @@ class JsonSyntaxValidationIT extends BaseIT {
     @Test
     void testInvalidJsonProduceRejected(KafkaCluster cluster, Admin admin) throws Exception {
         assertThat(cluster.getNumOfBrokers()).isOne();
-        createTopic(admin, TOPIC_1, 1);
+        admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1))).all().get(10, TimeUnit.SECONDS);
 
         var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator").withConfig("rules",
@@ -70,7 +70,7 @@ class JsonSyntaxValidationIT extends BaseIT {
     @Test
     void testInvalidJsonProduceRejectedUsingTopicNames(KafkaCluster cluster, Admin admin) throws Exception {
         assertThat(cluster.getNumOfBrokers()).isOne();
-        createTopics(admin, new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1));
+        admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1))).all().get(10, TimeUnit.SECONDS);
 
         var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator").withConfig("rules",
@@ -93,7 +93,7 @@ class JsonSyntaxValidationIT extends BaseIT {
     @Test
     void testPartiallyInvalidJsonTransactionalAllRejected(KafkaCluster cluster, Admin admin) throws Exception {
         assertThat(cluster.getNumOfBrokers()).isOne();
-        createTopics(admin, new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1));
+        admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1))).all().get(10, TimeUnit.SECONDS);
 
         var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator").withConfig("forwardPartialRequests", true, "rules",
@@ -117,7 +117,7 @@ class JsonSyntaxValidationIT extends BaseIT {
     @Test
     void testPartiallyInvalidJsonNotConfiguredToForwardAllRejected(KafkaCluster cluster, Admin admin) throws Exception {
         assertThat(cluster.getNumOfBrokers()).isOne();
-        createTopics(admin, new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1));
+        admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1))).all().get(10, TimeUnit.SECONDS);
 
         boolean forwardPartialRequests = false;
         var config = proxy(cluster)
@@ -139,7 +139,7 @@ class JsonSyntaxValidationIT extends BaseIT {
     @Test
     void testPartiallyInvalidJsonProduceRejected(KafkaCluster cluster, Admin admin) throws Exception {
         assertThat(cluster.getNumOfBrokers()).isOne();
-        createTopics(admin, new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1));
+        admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1))).all().get(10, TimeUnit.SECONDS);
 
         var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator")
@@ -168,7 +168,7 @@ class JsonSyntaxValidationIT extends BaseIT {
     @Test
     void testPartiallyInvalidAcrossPartitionsOfSameTopic(KafkaCluster cluster, Admin admin) throws Exception {
         assertThat(cluster.getNumOfBrokers()).isOne();
-        createTopic(admin, TOPIC_1, 2);
+        admin.createTopics(List.of(new NewTopic(TOPIC_1, 2, (short) 1))).all().get(10, TimeUnit.SECONDS);
 
         var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator")
@@ -197,7 +197,7 @@ class JsonSyntaxValidationIT extends BaseIT {
     @Test
     void testPartiallyInvalidWithinOnePartitionOfTopic(KafkaCluster cluster, Admin admin) throws Exception {
         assertThat(cluster.getNumOfBrokers()).isOne();
-        createTopic(admin, TOPIC_1, 1);
+        admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1))).all().get(10, TimeUnit.SECONDS);
 
         var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator").withConfig("forwardPartialRequests", true, "rules",
@@ -221,7 +221,7 @@ class JsonSyntaxValidationIT extends BaseIT {
     @Test
     void testValidJsonProduceAccepted(KafkaCluster cluster, Admin admin) throws Exception {
         assertThat(cluster.getNumOfBrokers()).isOne();
-        createTopic(admin, TOPIC_1, 1);
+        admin.createTopics(List.of(new NewTopic(TOPIC_1, 1, (short) 1))).all().get(10, TimeUnit.SECONDS);
 
         var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder("ProduceValidator").withConfig("rules",


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

As opposed to draft PR #609, this removes the `createTopics`, `createTopic`, and `deleteTopics` methods entirely.

### Additional Context

Based on discussion on #609, I thought I'd offer up an alternative. Rather than offloading these methods to the `KroxyliciousTester` or some related API, this puts the onus on test authors to use the Kafka `Admin` interface for topic creation and deletion.

As I understand it, the reasoning behind this approach as opposed to moving these methods to the tester is that these methods do not offer a great deal over what the Kafka `Admin` API does already, and so removing them entirely avoids adding potentially unnecessary bulk to the public Kroxylicious API. Note that for other topic management tasks (i.e. describe, or anything else that is not create/delete) we are currently using the `Admin` methods, and we don't have a wrapper in either the `KroxyliciousTester` or `BaseIT` for those. This approach also means we are creating fewer `Admin` instances in the tester overall than in #609 (which creates a new `Admin` every time a create/delete topic method is invoked and closes it once it's done).

The argument against this approach (and in favour of moving them to the tester) is that a common wrapper for creating/deleting topic(s) makes it easier for developers to write tests, as it simplifies the process somewhat. This potentially makes it easier for custom filter authors to focus on the business logic of their filters rather than the Kafka API.

Mostly just putting this out there to see if people have any strong feelings either way.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
