### PR TITLE
Log at all levels to null-appender in tests

### DIFF
--- a/kroxylicious-additional-filters/kroxylicious-multitenant/src/test/resources/log4j2-test.properties
+++ b/kroxylicious-additional-filters/kroxylicious-multitenant/src/test/resources/log4j2-test.properties
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+name = Config
+
+appender.null.type = Null
+appender.null.name = NullAppender
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} <%t> %-5p %c:%L - %m%n
+
+rootLogger.level = TRACE
+rootLogger.appenderRefs = null,console
+rootLogger.appenderRef.console.ref = STDOUT
+rootLogger.appenderRef.console.level = WARN
+rootLogger.additivity = false

--- a/kroxylicious-additional-filters/kroxylicious-schema-validation/src/test/resources/log4j2-test.properties
+++ b/kroxylicious-additional-filters/kroxylicious-schema-validation/src/test/resources/log4j2-test.properties
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+name = Config
+
+appender.null.type = Null
+appender.null.name = NullAppender
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} <%t> %-5p %c:%L - %m%n
+
+rootLogger.level = TRACE
+rootLogger.appenderRefs = null,console
+rootLogger.appenderRef.console.ref = STDOUT
+rootLogger.appenderRef.console.level = WARN
+rootLogger.additivity = false

--- a/kroxylicious-app/src/test/resources/log4j2-test.properties
+++ b/kroxylicious-app/src/test/resources/log4j2-test.properties
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+name = Config
+
+appender.null.type = Null
+appender.null.name = NullAppender
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} <%t> %-5p %c:%L - %m%n
+
+rootLogger.level = TRACE
+rootLogger.appenderRefs = null,console
+rootLogger.appenderRef.console.ref = STDOUT
+rootLogger.appenderRef.console.level = WARN
+rootLogger.additivity = false

--- a/kroxylicious-sample/pom.xml
+++ b/kroxylicious-sample/pom.xml
@@ -47,6 +47,11 @@
 
         <!-- third party dependencies - test -->
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/kroxylicious-sample/src/test/resources/log4j2-test.properties
+++ b/kroxylicious-sample/src/test/resources/log4j2-test.properties
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+name = Config
+
+appender.null.type = Null
+appender.null.name = NullAppender
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} <%t> %-5p %c:%L - %m%n
+
+rootLogger.level = TRACE
+rootLogger.appenderRefs = null,console
+rootLogger.appenderRef.console.ref = STDOUT
+rootLogger.appenderRef.console.level = WARN
+rootLogger.additivity = false

--- a/kroxylicious-test-tools/pom.xml
+++ b/kroxylicious-test-tools/pom.xml
@@ -89,6 +89,11 @@
 
         <!-- third party dependencies - test -->
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.flipkart.zjsonpatch</groupId>
             <artifactId>zjsonpatch</artifactId>
             <scope>test</scope>

--- a/kroxylicious-test-tools/src/test/resources/log4j2-test.properties
+++ b/kroxylicious-test-tools/src/test/resources/log4j2-test.properties
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+name = Config
+
+appender.null.type = Null
+appender.null.name = NullAppender
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} <%t> %-5p %c:%L - %m%n
+
+rootLogger.level = TRACE
+rootLogger.appenderRefs = null,console
+rootLogger.appenderRef.console.ref = STDOUT
+rootLogger.appenderRef.console.level = WARN
+rootLogger.additivity = false

--- a/kroxylicious/src/test/resources/log4j2-test.properties
+++ b/kroxylicious/src/test/resources/log4j2-test.properties
@@ -6,14 +6,18 @@
 
 name = Config
 
+appender.null.type = Null
+appender.null.name = NullAppender
+
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c:%L - %m%n
 
-rootLogger.level = WARN
-rootLogger.appenderRefs = console
+rootLogger.level = TRACE
+rootLogger.appenderRefs = null,console
 rootLogger.appenderRef.console.ref = STDOUT
+rootLogger.appenderRef.console.level = WARN
 rootLogger.additivity = false
 
 #logger.kproxy.name = io.kroxylicious.proxy


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Log at TRACE to a null appender and route everything at WARN or above to console appender during the tests for all modules using slf4j logging.

Why:
We are sometimes using a pattern where we check if a log level is enabled for a logger before we construct the logs. This avoids some un-necessary method calls when we aren't logging at that level. However this means we are pinged by sonar for not covering those lines (if the log level is less than WARN), and rightly, we want to at least know that our logging code isn't going to throw null pointer exceptions etc.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
