### PR TITLE
Revert "Bump io.netty:netty-bom from 4.1.97.Final to 4.1.98.Final"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.3.0
 
-* [#626](https://github.com/kroxylicious/kroxylicious/pull/626): Bump io.netty:netty-bom from 4.1.97.Final to 4.1.98.Final (#626)
 * [#537](https://github.com/kroxylicious/kroxylicious/issues/537): Computation stages chained to the CompletionStage return by #sendRequest using the default executor async methods now run on the Netty Event Loop.
 * [#612](https://github.com/kroxylicious/kroxylicious/pull/612): [Breaking] Allow filter authors to declare when their filter requires configuration. Note this includes a backwards incompatible change to the contract of the `Contributor`. `getInstance` will now throw exceptions rather than returning `null` to mean there was a problem or this contributor does not know about the requested type.
 * [#608](https://github.com/kroxylicious/kroxylicious/pull/608): Improve the contributor API to allow it to express more properties about the configuration. This release deprecates `Contributor.getConfigType` in favour of `Contributor.getConfigDefinition`. It also removes the proliferation of ContributorManager classes by providing a single type which can handle all Contributors.

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <kroxy.extension.version>0.5.0</kroxy.extension.version>
         <log4j.version>2.20.0</log4j.version>
         <picocli.version>4.7.5</picocli.version>
-        <netty.version>4.1.98.Final</netty.version>
+        <netty.version>4.1.97.Final</netty.version>
         <netty.io_uring.version>0.0.22.Final</netty.io_uring.version>
         <netty.epoll.classifier>linux-x86_64</netty.epoll.classifier>
         <netty.io_uring.classifier>linux-x86_64</netty.io_uring.classifier>


### PR DESCRIPTION
I am seeing JVM crashes on Mac OS X like the ones described in this issue:
https://github.com/netty/netty/issues/13632 

Reverts kroxylicious/kroxylicious#626

