### PR TITLE
Use Java 21 (LTS) for integration tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,7 +35,7 @@ jobs:
       - name: 'Set up Java'
         uses: actions/setup-java@v3
         with:
-          java-version: 20
+          java-version: 21
           distribution: 'temurin'
       - name: Cache SonarCloud packages
         uses: actions/cache@v3

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -44,10 +44,10 @@ jobs:
           git checkout -B ${{ fromJson(steps.get_pr_data.outputs.data).base.ref }} upstream/${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}
           git checkout ${{ github.event.workflow_run.head_branch }}
           git clean -ffdx && git reset --hard HEAD
-      - name: Set up JDK 20
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: 20
+          java-version: 21
           distribution: 'temurin'
       - name: 'Cache Maven packages'
         uses: actions/cache@v3

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -59,5 +59,5 @@
   <component name="PDMPlugin">
     <option name="skipTestSources" value="false" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_20" default="true" project-jdk-name="temurin-20" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="temurin-21" project-jdk-type="JavaSDK" />
 </project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.3.0
 
+* [#634](https://github.com/kroxylicious/kroxylicious/issues/634): Update integration tests JDK dependency to 21.
 * [#632](https://github.com/kroxylicious/kroxylicious/pull/632): Kroxylicious tester now supports creating & deleting topics on specific virtual clusters.
 * [#675](https://github.com/kroxylicious/kroxylicious/pull/675): Bump to Netty 4.1.100.Final to mitigate the Rapid Reset Attack (CVE-2023-44487)
 * [#665](https://github.com/kroxylicious/kroxylicious/pull/665): Bump org.apache.kafka:kafka-clients from 3.5.1 to 3.6.0

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -51,10 +51,10 @@ This document gives a detailed breakdown of the various build processes and opti
 
 ## Build
 
-JDK version 20 or newer, and Apache Maven are required for building this project.
+JDK version 21 or newer, and Apache Maven are required for building this project.
 
 Kroxylicious targets language level 17, except for the `integrationtests` module
-which targets 20 to access some new language features.
+which targets 21 to access some new language features.
 
 Build the project like this:
 
@@ -178,15 +178,15 @@ To change the container engine to podman set `CONTAINER_ENGINE=podman`
 
 ### Intellij
 
-The project requires JDK-20 to build and run the `integrationtests` module and the IDEA project is configured to build against an SDK
-named `temurin-20`. A suggested way to install this is with [skdman](https://sdkman.io/) using `sdk install java 20-tem`.
+The project requires JDK-21 to build and run the `integrationtests` module and the IDEA project is configured to build against an SDK
+named `temurin-21`. A suggested way to install this is with [skdman](https://sdkman.io/) using `sdk install java 21-tem`.
 
 Run `mvn clean install -DskipTests` to install the project into your local maven repository (in `~/.m2`). This is necessary because
 IDEA fails to synchronise the project if the kroxylicious maven plugin isn't available to maven.
 
 Open the root `pom.xml` as a project.
 
-Then navigate to `File > Project Structure > Project Settings` and update `SDK` to point at your install JDK 20 (it should be populated
+Then navigate to `File > Project Structure > Project Settings` and update `SDK` to point at your install JDK 21 (it should be populated
 as a suggestion if you used sdkman to install it).
 
 In the IDEA Maven dialogue click on `Generate Sources and Update Folders For All Projects`.

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -21,8 +21,8 @@
     <description>Integration tests where Kroxylicious is tested end-to-end with a real Kafka cluster.</description>
 
     <properties>
-        <java.version>20</java.version>
-        <java.test.version>20</java.test.version>
+        <java.version>21</java.version>
+        <java.test.version>21</java.test.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,9 @@
         <zjsonpatch.version>0.4.14</zjsonpatch.version>
         <moby-names-generator.version>20.10.1-r0</moby-names-generator.version>
         <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
+
+        <!-- Required for JDK 21 compatibility, remove dependency management for byte-buddy once assertj bumps to a newer bytebuddy -->
+        <byte-buddy.version>1.14.8</byte-buddy.version>
     </properties>
 
     <name>Kroxylicious Parent</name>
@@ -258,6 +261,12 @@
                 <version>${mockito.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${byte-buddy.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Use Java 21 (LTS) for integration tests, rather than JDK 20.   JDK 20 was always a temporary measure, until a LTS containing
`InetAddressResolverProvider` was available.

IntelliJ IDEA users:  Make sure you have at least 2023.2.3 to ensure your IDE knows about Java 21.

### Additional Context

Software currency.



### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [x] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
