### PR TITLE
Add check to validate our semver compliance

### DIFF
--- a/kroxylicious-api/pom.xml
+++ b/kroxylicious-api/pom.xml
@@ -174,6 +174,34 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+                <version>0.18.0</version>
+                <configuration>
+                    <oldVersion>
+                        <dependency>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>${project.artifactId}</artifactId>
+                            <version>0.2.0</version>
+                            <type>jar</type>
+                        </dependency>
+                    </oldVersion>
+                    <parameter>
+                        <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+                        <breakBuildBasedOnSemanticVersioningForMajorVersionZero>true</breakBuildBasedOnSemanticVersioningForMajorVersionZero>
+                        <!-- see documentation -->
+                    </parameter>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>cmp</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds a plug-in to fail the build on version changes which fail semver compatibility. I.e. if we made a breaking API change in a minor release.

as an example 
```
[INFO] --- japicmp-maven-plugin:0.18.0:cmp (default) @ kroxylicious-api ---
[INFO] Written file '/Users/sbarker/development/kroxy/kroxylicious/kroxylicious-api/target/japicmp/japicmp.diff'.
[INFO] Written file '/Users/sbarker/development/kroxy/kroxylicious/kroxylicious-api/target/japicmp/japicmp.xml'.
[INFO] Written file '/Users/sbarker/development/kroxy/kroxylicious/kroxylicious-api/target/japicmp/japicmp.html'.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  14.669 s
[INFO] Finished at: 2023-09-29T14:46:48+13:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal com.github.siom79.japicmp:japicmp-maven-plugin:0.18.0:cmp (default) on project kroxylicious-api: There is at least one incompatibility: io.kroxylicious.proxy.filter.FilterContext.sendRequest(short,org.apache.kafka.common.protocol.ApiMessage):CLASS_GENERIC_TEMPLATE_CHANGED,io.kroxylicious.proxy.service.BaseContributor.builder():CLASS_GENERIC_TEMPLATE_CHANGED,io.kroxylicious.proxy.service.BaseContributor.BaseContributor(io.kroxylicious.proxy.service.BaseContributor$BaseContributorBuilder):CONSTRUCTOR_LESS_ACCESSIBLE,io.kroxylicious.proxy.service.BaseContributor:CLASS_GENERIC_TEMPLATE_CHANGED,io.kroxylicious.proxy.service.BaseContributor$BaseContributorBuilder.add(java.lang.String,java.lang.Class,java.util.function.BiFunction,boolean):CLASS_GENERIC_TEMPLATE_CHANGED,io.kroxylicious.proxy.service.BaseContributor$BaseContributorBuilder:CLASS_GENERIC_TEMPLATE_CHANGED,io.kroxylicious.proxy.service.Contributor.contributes(java.lang.String):METHOD_ADDED_TO_INTERFACE,io.kroxylicious.proxy.service.Contributor.getConfigDefinition(java.lang.String):METHOD_ADDED_TO_INTERFACE,io.kroxylicious.proxy.service.Contributor.getInstance(java.lang.String,io.kroxylicious.proxy.config.BaseConfig):METHOD_REMOVED,io.kroxylicious.proxy.service.Contributor.getInstance(java.lang.String,io.kroxylicious.proxy.service.Context):METHOD_ADDED_TO_INTERFACE,io.kroxylicious.proxy.service.Contributor:CLASS_GENERIC_TEMPLATE_CHANGED -> [Help 1]
```

### Additional Context

To aid the discussion about API maturity annotations.



### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
