### PR TITLE
Config parsing

### DIFF
--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/ApiVersionsMarkingFilterFactory.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/ApiVersionsMarkingFilterFactory.java
@@ -6,16 +6,10 @@
 
 package io.kroxylicious.proxy.filter;
 
-public class ApiVersionsMarkingFilterFactory implements FilterFactory<ApiVersionsMarkingFilter, Void> {
+public class ApiVersionsMarkingFilterFactory extends FilterFactory<ApiVersionsMarkingFilter, Void> {
 
-    @Override
-    public Class<ApiVersionsMarkingFilter> filterType() {
-        return ApiVersionsMarkingFilter.class;
-    }
-
-    @Override
-    public Class<Void> configType() {
-        return Void.class;
+    public ApiVersionsMarkingFilterFactory() {
+        super(Void.class, ApiVersionsMarkingFilter.class);
     }
 
     @Override

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/CompositePrefixingFixedClientIdFilterFactory.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/CompositePrefixingFixedClientIdFilterFactory.java
@@ -9,16 +9,10 @@ package io.kroxylicious.proxy.filter;
 import io.kroxylicious.proxy.filter.CompositePrefixingFixedClientIdFilter.CompositePrefixingFixedClientIdFilterConfig;
 
 public class CompositePrefixingFixedClientIdFilterFactory
-        implements FilterFactory<CompositePrefixingFixedClientIdFilter, CompositePrefixingFixedClientIdFilterConfig> {
+        extends FilterFactory<CompositePrefixingFixedClientIdFilter, CompositePrefixingFixedClientIdFilterConfig> {
 
-    @Override
-    public Class<CompositePrefixingFixedClientIdFilter> filterType() {
-        return CompositePrefixingFixedClientIdFilter.class;
-    }
-
-    @Override
-    public Class<CompositePrefixingFixedClientIdFilterConfig> configType() {
-        return CompositePrefixingFixedClientIdFilterConfig.class;
+    public CompositePrefixingFixedClientIdFilterFactory() {
+        super(CompositePrefixingFixedClientIdFilterConfig.class, CompositePrefixingFixedClientIdFilter.class);
     }
 
     @Override

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/FixedClientIdFilterFactory.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/FixedClientIdFilterFactory.java
@@ -8,16 +8,10 @@ package io.kroxylicious.proxy.filter;
 
 import io.kroxylicious.proxy.filter.FixedClientIdFilter.FixedClientIdFilterConfig;
 
-public class FixedClientIdFilterFactory implements FilterFactory<FixedClientIdFilter, FixedClientIdFilterConfig> {
+public class FixedClientIdFilterFactory extends FilterFactory<FixedClientIdFilter, FixedClientIdFilterConfig> {
 
-    @Override
-    public Class<FixedClientIdFilter> filterType() {
-        return FixedClientIdFilter.class;
-    }
-
-    @Override
-    public Class<FixedClientIdFilterConfig> configType() {
-        return FixedClientIdFilterConfig.class;
+    public FixedClientIdFilterFactory() {
+        super(FixedClientIdFilterConfig.class, FixedClientIdFilter.class);
     }
 
     @Override

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/OutOfBandSendFilterFactory.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/OutOfBandSendFilterFactory.java
@@ -8,16 +8,10 @@ package io.kroxylicious.proxy.filter;
 
 import io.kroxylicious.proxy.filter.OutOfBandSendFilter.OutOfBandSendFilterConfig;
 
-public class OutOfBandSendFilterFactory implements FilterFactory<OutOfBandSendFilter, OutOfBandSendFilterConfig> {
+public class OutOfBandSendFilterFactory extends FilterFactory<OutOfBandSendFilter, OutOfBandSendFilterConfig> {
 
-    @Override
-    public Class<OutOfBandSendFilter> filterType() {
-        return OutOfBandSendFilter.class;
-    }
-
-    @Override
-    public Class<OutOfBandSendFilterConfig> configType() {
-        return OutOfBandSendFilterConfig.class;
+    public OutOfBandSendFilterFactory() {
+        super(OutOfBandSendFilterConfig.class, OutOfBandSendFilter.class);
     }
 
     @Override

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RejectingCreateTopicFilterFactory.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RejectingCreateTopicFilterFactory.java
@@ -8,16 +8,10 @@ package io.kroxylicious.proxy.filter;
 
 import io.kroxylicious.proxy.filter.RejectingCreateTopicFilter.RejectingCreateTopicFilterConfig;
 
-public class RejectingCreateTopicFilterFactory implements FilterFactory<RejectingCreateTopicFilter, RejectingCreateTopicFilterConfig> {
+public class RejectingCreateTopicFilterFactory extends FilterFactory<RejectingCreateTopicFilter, RejectingCreateTopicFilterConfig> {
 
-    @Override
-    public Class<RejectingCreateTopicFilter> filterType() {
-        return RejectingCreateTopicFilter.class;
-    }
-
-    @Override
-    public Class<RejectingCreateTopicFilterConfig> configType() {
-        return RejectingCreateTopicFilterConfig.class;
+    public RejectingCreateTopicFilterFactory() {
+        super(RejectingCreateTopicFilterConfig.class, RejectingCreateTopicFilter.class);
     }
 
     @Override

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RequestResponseMarkingFilterFactory.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/RequestResponseMarkingFilterFactory.java
@@ -8,22 +8,16 @@ package io.kroxylicious.proxy.filter;
 
 import io.kroxylicious.proxy.filter.RequestResponseMarkingFilter.RequestResponseMarkingFilterConfig;
 
-public class RequestResponseMarkingFilterFactory implements FilterFactory<RequestResponseMarkingFilter, RequestResponseMarkingFilterConfig> {
+public class RequestResponseMarkingFilterFactory extends FilterFactory<RequestResponseMarkingFilter, RequestResponseMarkingFilterConfig> {
+
+    public RequestResponseMarkingFilterFactory() {
+        super(RequestResponseMarkingFilterConfig.class, RequestResponseMarkingFilter.class);
+    }
 
     @Override
     public RequestResponseMarkingFilter createFilter(FilterCreationContext context,
                                                      RequestResponseMarkingFilterConfig configuration) {
         return new RequestResponseMarkingFilter(context, configuration);
-    }
-
-    @Override
-    public Class<RequestResponseMarkingFilter> filterType() {
-        return RequestResponseMarkingFilter.class;
-    }
-
-    @Override
-    public Class<RequestResponseMarkingFilterConfig> configType() {
-        return RequestResponseMarkingFilterConfig.class;
     }
 
 }

--- a/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterFactory.java
+++ b/kroxylicious-additional-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterFactory.java
@@ -9,16 +9,10 @@ package io.kroxylicious.proxy.filter.multitenant;
 import io.kroxylicious.proxy.filter.FilterCreationContext;
 import io.kroxylicious.proxy.filter.FilterFactory;
 
-public class MultiTenantTransformationFilterFactory implements FilterFactory<MultiTenantTransformationFilter, Void> {
+public class MultiTenantTransformationFilterFactory extends FilterFactory<MultiTenantTransformationFilter, Void> {
 
-    @Override
-    public Class<MultiTenantTransformationFilter> filterType() {
-        return MultiTenantTransformationFilter.class;
-    }
-
-    @Override
-    public Class<Void> configType() {
-        return Void.class;
+    public MultiTenantTransformationFilterFactory() {
+        super(Void.class, MultiTenantTransformationFilter.class);
     }
 
     @Override

--- a/kroxylicious-additional-filters/kroxylicious-schema-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceValidationFilterFactory.java
+++ b/kroxylicious-additional-filters/kroxylicious-schema-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceValidationFilterFactory.java
@@ -11,16 +11,10 @@ import io.kroxylicious.proxy.filter.FilterFactory;
 import io.kroxylicious.proxy.filter.schema.config.ValidationConfig;
 import io.kroxylicious.proxy.filter.schema.validation.request.ProduceRequestValidator;
 
-public class ProduceValidationFilterFactory implements FilterFactory<ProduceValidationFilter, ValidationConfig> {
+public class ProduceValidationFilterFactory extends FilterFactory<ProduceValidationFilter, ValidationConfig> {
 
-    @Override
-    public Class<ProduceValidationFilter> filterType() {
-        return ProduceValidationFilter.class;
-    }
-
-    @Override
-    public Class<ValidationConfig> configType() {
-        return ValidationConfig.class;
+    public ProduceValidationFilterFactory() {
+        super(ValidationConfig.class, ProduceValidationFilter.class);
     }
 
     @Override

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactory.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactory.java
@@ -31,6 +31,7 @@ public abstract class FilterFactory<F extends Filter, C> {
     }
 
     /**
+     * The type of filter.
      * @return The concrete class of {@code Filter} this factory {@linkplain #createFilter(FilterCreationContext, C) creates}.
      */
     public final Class<F> filterType() {

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactory.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactory.java
@@ -65,6 +65,9 @@ public abstract class FilterFactory<F extends Filter, C> {
         if (requiresConfiguration && config == null) {
             throw new InvalidFilterConfigurationException(filterType().getSimpleName() + " requires configuration, but config object is null");
         }
+        if (!requiresConfiguration && config != null) {
+            throw new InvalidFilterConfigurationException(filterType().getSimpleName() + " accepts no configuration, but config object is non-null");
+        }
     }
 
     /**

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactory.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactory.java
@@ -5,6 +5,8 @@
  */
 package io.kroxylicious.proxy.filter;
 
+import java.util.Objects;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -12,13 +14,28 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * @param <F> the {@code Filter} type.
  * @param <C> the type of configuration used to create the {@code Filter}. Use {@link Void} if the {@code Filter} is not configurable.
  */
-public interface FilterFactory<F extends Filter, C> {
+public abstract class FilterFactory<F extends Filter, C> {
+
+    private final Class<C> configType;
+    private final Class<F> filterType;
+
+    /**
+     * Constructor
+     * @param configType The concrete class of {@code Filter} this factory {@linkplain #createFilter(FilterCreationContext, C) creates}.
+     * @param filterType The type of configuration this factory requires.
+     * Use {@code Void.class} if the factory does not support configuration.
+     */
+    public FilterFactory(Class<C> configType, Class<F> filterType) {
+        this.configType = Objects.requireNonNull(configType);
+        this.filterType = Objects.requireNonNull(filterType);
+    }
 
     /**
      * @return The concrete class of {@code Filter} this factory {@linkplain #createFilter(FilterCreationContext, C) creates}.
      */
-    @NonNull
-    Class<F> filterType();
+    public final Class<F> filterType() {
+        return filterType;
+    }
 
     /**
      * The type of configuration used to create the {@code Filter}.
@@ -28,8 +45,9 @@ public interface FilterFactory<F extends Filter, C> {
      *
      * @return type of config expected by the Filter.
      */
-    @NonNull
-    Class<C> configType();
+    public final Class<C> configType() {
+        return configType;
+    }
 
     /**
      * Validates the configuration.
@@ -41,7 +59,7 @@ public interface FilterFactory<F extends Filter, C> {
      * @param config configuration
      * @throws InvalidFilterConfigurationException when the configuration is invalid
      */
-    default void validateConfiguration(C config) {
+    public void validateConfiguration(C config) {
         boolean requiresConfiguration = configType() != Void.class;
         if (requiresConfiguration && config == null) {
             throw new InvalidFilterConfigurationException(filterType().getSimpleName() + " requires configuration, but config object is null");
@@ -56,6 +74,6 @@ public interface FilterFactory<F extends Filter, C> {
      * @return the Filter instance.
      */
     @NonNull
-    F createFilter(FilterCreationContext context, C configuration);
+    public abstract F createFilter(FilterCreationContext context, C configuration);
 
 }

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/filter/FilterFactoryTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/filter/FilterFactoryTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletionStage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class FilterFactoryTest {
+
+    static class MyFilter implements ProduceRequestFilter {
+        @Override
+        public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, FilterContext context) {
+            return null;
+        }
+    }
+
+    private class MyFactory<C> extends FilterFactory<MyFilter, C> {
+        public MyFactory(Class<C> configType) {
+            super(configType, MyFilter.class);
+        }
+
+        @NonNull
+        @Override
+        public MyFilter createFilter(FilterCreationContext context, C configuration) {
+            return new MyFilter();
+        }
+    }
+
+    @Test
+    void filterType() {
+        assertEquals(MyFilter.class, new MyFactory<>(Void.class).filterType());
+    }
+
+    @Test
+    void configType() {
+        assertEquals(Void.class, new MyFactory<>(Void.class).configType());
+    }
+
+    @Test
+    void validateConfiguration() {
+        MyFactory factoryWithNoConfig = new MyFactory<>(Void.class);
+        factoryWithNoConfig.validateConfiguration(null);
+        assertThrows(InvalidFilterConfigurationException.class, () -> {
+            factoryWithNoConfig.validateConfiguration(new Object());
+        });
+        var factoryWithConfig = new MyFactory<>(String.class);
+        factoryWithConfig.validateConfiguration("");
+        assertThrows(InvalidFilterConfigurationException.class, () -> {
+            factoryWithConfig.validateConfiguration(null);
+        });
+    }
+
+}

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/filter/FilterFactoryTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/filter/FilterFactoryTest.java
@@ -6,13 +6,13 @@
 
 package io.kroxylicious.proxy.filter;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.concurrent.CompletionStage;
 
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CompletionStage;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -27,7 +27,7 @@ class FilterFactoryTest {
     }
 
     private class MyFactory<C> extends FilterFactory<MyFilter, C> {
-        public MyFactory(Class<C> configType) {
+        MyFactory(Class<C> configType) {
             super(configType, MyFilter.class);
         }
 

--- a/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleFetchResponseFilterFactory.java
+++ b/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleFetchResponseFilterFactory.java
@@ -10,20 +10,15 @@ import io.kroxylicious.proxy.filter.FilterCreationContext;
 import io.kroxylicious.proxy.filter.FilterFactory;
 import io.kroxylicious.sample.config.SampleFilterConfig;
 
-public class SampleFetchResponseFilterFactory implements FilterFactory<SampleFetchResponseFilter, SampleFilterConfig> {
+public class SampleFetchResponseFilterFactory extends FilterFactory<SampleFetchResponseFilter, SampleFilterConfig> {
+
+    public SampleFetchResponseFilterFactory() {
+        super(SampleFilterConfig.class, SampleFetchResponseFilter.class);
+    }
 
     @Override
     public SampleFetchResponseFilter createFilter(FilterCreationContext context, SampleFilterConfig configuration) {
         return new SampleFetchResponseFilter(configuration);
     }
 
-    @Override
-    public Class<SampleFetchResponseFilter> filterType() {
-        return SampleFetchResponseFilter.class;
-    }
-
-    @Override
-    public Class<SampleFilterConfig> configType() {
-        return SampleFilterConfig.class;
-    }
 }

--- a/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleProduceRequestFilterFactory.java
+++ b/kroxylicious-sample/src/main/java/io/kroxylicious/sample/SampleProduceRequestFilterFactory.java
@@ -10,16 +10,10 @@ import io.kroxylicious.proxy.filter.FilterCreationContext;
 import io.kroxylicious.proxy.filter.FilterFactory;
 import io.kroxylicious.sample.config.SampleFilterConfig;
 
-public class SampleProduceRequestFilterFactory implements FilterFactory<SampleProduceRequestFilter, SampleFilterConfig> {
+public class SampleProduceRequestFilterFactory extends FilterFactory<SampleProduceRequestFilter, SampleFilterConfig> {
 
-    @Override
-    public Class<SampleProduceRequestFilter> filterType() {
-        return SampleProduceRequestFilter.class;
-    }
-
-    @Override
-    public Class<SampleFilterConfig> configType() {
-        return SampleFilterConfig.class;
+    public SampleProduceRequestFilterFactory() {
+        super(SampleFilterConfig.class, SampleProduceRequestFilter.class);
     }
 
     @Override

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/config2/BoundFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/config2/BoundFilter.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config2;
+
+import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.filter.FilterCreationContext;
+import io.kroxylicious.proxy.filter.FilterFactory;
+
+/**
+ * A filter factory instance and a config object.
+ * @param filterFactory
+ * @param config
+ */
+record BoundFilter<C, F extends Filter>(FilterFactory<F, C> filterFactory, C config) {
+    public F createFilter(FilterCreationContext ctx) {
+        return filterFactory.createFilter(ctx, config());
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/config2/Parser.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/config2/Parser.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config2;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+
+import io.kroxylicious.proxy.config2.api.FilterPlugin;
+import io.kroxylicious.proxy.config2.api.MicrometerPlugin;
+import io.kroxylicious.proxy.config2.api.Plugin;
+import io.kroxylicious.proxy.config2.api.UnresolvedConfig;
+import io.kroxylicious.proxy.filter.FilterFactory;
+import io.kroxylicious.proxy.service.HostPort;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class Parser {
+    private final static ObjectMapper MAPPER = createObjectMapper();
+
+    public static ObjectMapper createObjectMapper() {
+        return new ObjectMapper(new YAMLFactory())
+                .registerModule(new ParameterNamesModule())
+                .registerModule(new Jdk8Module())
+                .registerModule(new SimpleModule().addSerializer(HostPort.class, new ToStringSerializer()))
+                .setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE)
+                .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+                .setVisibility(PropertyAccessor.CREATOR, JsonAutoDetect.Visibility.ANY)
+                .setConstructorDetector(ConstructorDetector.USE_PROPERTIES_BASED)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY, false)
+                .configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true)
+                .setSerializationInclusion(JsonInclude.Include.NON_DEFAULT);
+    }
+
+    private static UnresolvedConfig parseUnresolved(String stream) {
+        try {
+            return MAPPER.readValue(stream, UnresolvedConfig.class);
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static ResolvedConfig resolveConfig(UnresolvedConfig uc) {
+//        var loaders = serviceLoaders(uc.filters());
+//        // group plugins by service class
+//        // load service class
+//        // for each filter plugin create a filter factory
+//        var boundFilters = uc.filters().stream().map(fd -> {
+//            var serviceLoader = loaders.get(fd.serviceClass());
+//            for (FilterFactory filterFactory : serviceLoader) {
+//                // TODO verify shortnames are not ambiguous
+//                // TODO verify longnames are not ambiguous
+//                if (filterFactory.filterType().getName().equals(fd.type())) { // TODO support short names
+//                    // TODO validate types dynamically
+//                    var config = MAPPER.convertValue(fd.config(), filterFactory.configType());
+//                    filterFactory.validateConfiguration(config);
+//                    return new BoundFilter(filterFactory, config);
+//                }
+//            }
+//            throw new RuntimeException();
+//        }).toList();
+        List<BoundFilter<?,?>> boundFilters = resolvePlugins(uc.filters(),
+                FilterPlugin::type,
+                FilterPlugin::config,
+                FilterFactory::filterType,
+                FilterFactory::configType,
+                (filterFactory, config) -> (BoundFilter<?, ?>) new BoundFilter(filterFactory, config));
+
+        List<BoundMicrometer> boundMicrometers = resolvePlugins(Optional.ofNullable(uc.micrometerPlugins()).orElse(List.of()),
+                MicrometerPlugin::type,
+                MicrometerPlugin::config,
+                MicrometerPlugin.MicrometerFactory::micrometerType,
+                MicrometerPlugin.MicrometerFactory::configType,
+                BoundMicrometer::new);
+
+        return new ResolvedConfig(boundFilters, uc.useIoUring());
+    }
+
+    record BoundMicrometer(MicrometerPlugin.MicrometerFactory filterFactory, Object config) { }
+
+    private static <P extends Plugin<F>, F, B> List<B> resolvePlugins(
+            List<P> plugins,
+            Function<P, String> typeNameFn,
+            Function<P, JsonNode> confS,
+            Function<F, Class<?>> tyneFn,
+            Function<F, Class<?>> confFn,
+            BiFunction<F, Object, B> ctor) {
+        var servicesByServiceClass = serviceLoaders(plugins);
+        var bound = plugins.stream()
+                .map(fd -> resolvePlugin(fd, typeNameFn, confS, tyneFn, confFn, ctor, servicesByServiceClass))
+                .toList();
+        return bound;
+    }
+
+    private static <P extends Plugin<F>, F, B> B resolvePlugin(P plugin,
+                                                               Function<P, String> typeNameFn,
+                                                               Function<P, JsonNode> confS,
+                                                               Function<F, Class<?>> tyneFn,
+                                                               Function<F, Class<?>> confFn,
+                                                               BiFunction<F, Object, B> ctor,
+                                                               Map<Class<F>, ServiceLoader<F>> servicesByServiceClass) {
+        var serviceLoader = servicesByServiceClass.get(plugin.serviceClass());
+        for (F factory : serviceLoader) {
+            // TODO verify shortnames are not ambiguous
+            // TODO verify longnames are not ambiguous
+            if (tyneFn.apply(factory).getName().equals(typeNameFn.apply(plugin))) { // TODO support short names
+                // TODO validate types dynamically
+                var config = MAPPER.convertValue(confS.apply(plugin), confFn.apply(factory));
+                //filterFactory.validateConfiguration(config);
+                return ctor.apply(factory, config);
+            }
+        }
+        throw new RuntimeException();
+    }
+
+    private static <S, P extends Plugin<S>> Map<Class<S>, ServiceLoader<S>> serviceLoaders(List<P> filters) {
+        return filters.stream()
+                .map(Plugin::serviceClass)
+                .distinct()
+                .collect(Collectors.toMap(sc -> sc,
+                        ServiceLoader::load
+                ));
+    }
+
+    public static ResolvedConfig parse(String content) {
+        return resolveConfig(parseUnresolved(content));
+    }
+
+    // TODO support converting an unresolved tree back to YAML?
+
+    public static void main(String[] a) {
+        var resolvedConfig = Parser.parse("""
+                useIoUring: true
+                filters:
+                - type: io.kroxylicious.proxy.internal.filter.ProduceRequestTransformationFilter
+                  config:
+                    transformation: io.kroxylicious.proxy.internal.filter.ProduceRequestTransformationFilter$UpperCasing
+                """);
+
+        System.out.println(resolvedConfig);
+        // TODO build filter chain factory from the resolvedConfig.filters (change its constructor??)
+    }
+
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/config2/ResolvedConfig.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/config2/ResolvedConfig.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config2;
+
+import java.util.List;
+
+public record ResolvedConfig(List<BoundFilter<?, ?>> filters, boolean useIoUring) {
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/config2/api/FilterPlugin.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/config2/api/FilterPlugin.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config2.api;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.kroxylicious.proxy.filter.FilterFactory;
+
+public class FilterPlugin extends Plugin<FilterFactory<?, ?>> {
+    private final String type;
+    private final JsonNode config;
+
+    @JsonCreator
+    public FilterPlugin(@JsonProperty(required = true) String type,
+                        JsonNode config) {
+        super((Class) FilterFactory.class);
+        this.type = type;
+        this.config = config;
+    }
+
+    /**
+     * The type of the filter
+     * @return
+     */
+    public String type() {
+        return type;
+    }
+
+    /**
+     * The configuration for creating the filter
+     * @return
+     */
+    public JsonNode config() {
+        return config;
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/config2/api/MicrometerPlugin.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/config2/api/MicrometerPlugin.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config2.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class MicrometerPlugin extends Plugin<MicrometerPlugin.MicrometerFactory> {
+    public static class MicrometerFactory {
+        public Class<?> micrometerType() {
+            return null;
+        }
+
+        public Class<?> configType() {
+            return null;
+        }
+        // TODO replace this with Rob's stuff
+    }
+
+
+    private final String type;
+    private final JsonNode config;
+
+    public MicrometerPlugin(@JsonProperty(required = true) String type,
+                            JsonNode config) {
+        super(MicrometerFactory.class);
+        this.type = type;
+        this.config = config;
+    }
+
+    public String type() {
+        return type;
+    }
+
+    public JsonNode config() {
+        return config;
+    }
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/config2/api/Plugin.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/config2/api/Plugin.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config2.api;
+
+/**
+ * A base type for a plugin that can be loaded from a service loader
+ * @param <S> The service type
+ */
+public abstract class Plugin<S> {
+    private final Class<S> serviceClass;
+
+    public Plugin(Class<S> serviceClass) {
+        this.serviceClass = serviceClass;
+    }
+
+    public Class<S> serviceClass() {
+        return serviceClass;
+    }
+}
+

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/config2/api/UnresolvedConfig.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/config2/api/UnresolvedConfig.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config2.api;
+
+import java.util.List;
+
+public record UnresolvedConfig(List<FilterPlugin> filters,
+                               List<MicrometerPlugin> micrometerPlugins,
+                               boolean useIoUring) {
+}

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/config2/api/package-info.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/config2/api/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * API for the configuration file format.
+ */
+package io.kroxylicious.proxy.config2.api;

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FetchResponseTransformationFilterFactory.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/FetchResponseTransformationFilterFactory.java
@@ -10,20 +10,11 @@ import io.kroxylicious.proxy.filter.FilterCreationContext;
 import io.kroxylicious.proxy.filter.FilterFactory;
 import io.kroxylicious.proxy.internal.filter.FetchResponseTransformationFilter.FetchResponseTransformationConfig;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-
 public class FetchResponseTransformationFilterFactory
-        implements FilterFactory<FetchResponseTransformationFilter, FetchResponseTransformationConfig> {
+        extends FilterFactory<FetchResponseTransformationFilter, FetchResponseTransformationConfig> {
 
-    @NonNull
-    @Override
-    public Class<FetchResponseTransformationFilter> filterType() {
-        return FetchResponseTransformationFilter.class;
-    }
-
-    @Override
-    public Class<FetchResponseTransformationConfig> configType() {
-        return FetchResponseTransformationConfig.class;
+    public FetchResponseTransformationFilterFactory() {
+        super(FetchResponseTransformationConfig.class, FetchResponseTransformationFilter.class);
     }
 
     @Override

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ProduceRequestTransformationFilterFactory.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/ProduceRequestTransformationFilterFactory.java
@@ -10,20 +10,11 @@ import io.kroxylicious.proxy.filter.FilterCreationContext;
 import io.kroxylicious.proxy.filter.FilterFactory;
 import io.kroxylicious.proxy.internal.filter.ProduceRequestTransformationFilter.ProduceRequestTransformationConfig;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-
 public class ProduceRequestTransformationFilterFactory
-        implements FilterFactory<ProduceRequestTransformationFilter, ProduceRequestTransformationConfig> {
+        extends FilterFactory<ProduceRequestTransformationFilter, ProduceRequestTransformationConfig> {
 
-    @NonNull
-    @Override
-    public Class<ProduceRequestTransformationFilter> filterType() {
-        return ProduceRequestTransformationFilter.class;
-    }
-
-    @Override
-    public Class<ProduceRequestTransformationConfig> configType() {
-        return ProduceRequestTransformationConfig.class;
+    public ProduceRequestTransformationFilterFactory() {
+        super(ProduceRequestTransformationConfig.class, ProduceRequestTransformationFilter.class);
     }
 
     @Override

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/service/FilterFactoryManager.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/service/FilterFactoryManager.java
@@ -42,12 +42,12 @@ public class FilterFactoryManager {
         filterFactories = nameToFactory;
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     private static ServiceLoader<FilterFactory<?, ?>> serviceLoader() {
         return (ServiceLoader<FilterFactory<?, ?>>) (ServiceLoader) ServiceLoader.load(FilterFactory.class);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public Filter createInstance(String typeName, FilterCreationContext constructionContext, Object config) {
         return ((FilterFactory) getFactory(typeName)).createFilter(constructionContext, config);
     }
@@ -56,7 +56,7 @@ public class FilterFactoryManager {
         return getFactory(typeName).configType();
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public boolean validateConfig(String typeName, Object config) {
         try {
             FilterFactory factory = filterFactories.get(typeName);

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/OptionalConfigFactory.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/OptionalConfigFactory.java
@@ -6,25 +6,13 @@
 
 package io.kroxylicious.proxy.internal.filter;
 
-import org.jetbrains.annotations.NotNull;
-
 import io.kroxylicious.proxy.filter.FilterCreationContext;
 import io.kroxylicious.proxy.filter.FilterFactory;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
+public class OptionalConfigFactory extends FilterFactory<OptionalConfigFilter, ExampleConfig> {
 
-public class OptionalConfigFactory implements FilterFactory<OptionalConfigFilter, ExampleConfig> {
-
-    @NotNull
-    @Override
-    public Class<OptionalConfigFilter> filterType() {
-        return OptionalConfigFilter.class;
-    }
-
-    @NonNull
-    @Override
-    public Class<ExampleConfig> configType() {
-        return ExampleConfig.class;
+    public OptionalConfigFactory() {
+        super(ExampleConfig.class, OptionalConfigFilter.class);
     }
 
     @Override

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/RequiresConfigFactory.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/RequiresConfigFactory.java
@@ -6,25 +6,13 @@
 
 package io.kroxylicious.proxy.internal.filter;
 
-import org.jetbrains.annotations.NotNull;
-
 import io.kroxylicious.proxy.filter.FilterCreationContext;
 import io.kroxylicious.proxy.filter.FilterFactory;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
+public class RequiresConfigFactory extends FilterFactory<RequiresConfigFilter, ExampleConfig> {
 
-public class RequiresConfigFactory implements FilterFactory<RequiresConfigFilter, ExampleConfig> {
-
-    @NotNull
-    @Override
-    public Class<RequiresConfigFilter> filterType() {
-        return RequiresConfigFilter.class;
-    }
-
-    @NonNull
-    @Override
-    public Class<ExampleConfig> configType() {
-        return ExampleConfig.class;
+    public RequiresConfigFactory() {
+        super(ExampleConfig.class, RequiresConfigFilter.class);
     }
 
     @Override

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestFilterFactory.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/internal/filter/TestFilterFactory.java
@@ -6,25 +6,13 @@
 
 package io.kroxylicious.proxy.internal.filter;
 
-import org.jetbrains.annotations.NotNull;
-
 import io.kroxylicious.proxy.filter.FilterCreationContext;
 import io.kroxylicious.proxy.filter.FilterFactory;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
+public class TestFilterFactory extends FilterFactory<TestFilter, ExampleConfig> {
 
-public class TestFilterFactory implements FilterFactory<TestFilter, ExampleConfig> {
-
-    @NotNull
-    @Override
-    public Class<TestFilter> filterType() {
-        return TestFilter.class;
-    }
-
-    @NonNull
-    @Override
-    public Class<ExampleConfig> configType() {
-        return ExampleConfig.class;
+    public TestFilterFactory() {
+        super(ExampleConfig.class, TestFilter.class);
     }
 
     @Override


### PR DESCRIPTION
This is an experimental replacement for the existing config parsing. It is intended the remove the use of the singleton in the manager. The singleton was being accessed from the Jackson type resolvers, which looked like it would be a bit tricky to remove.  So this PR explores a different direction which avoids needing to resolve types during Jackson's deserialization... 

The idea is that we initially parse the config file without resolving any of the type references in it. The `api` package defines the classes for this unresolved config. We then resolve the plugins (e.g. filters, or micrometers), by finding the ServiceLoaders for different parts of the tree and matching the service implementations with the declared plugins. This produces the resolved config, where each plugin is bound to its configuration. Later during runtime the `Bound* ` can be used to create plugin instances.