### PR TITLE
Remove FilterChainFactory's dependence on Configuration

### DIFF
--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -51,7 +51,7 @@ public class FilterChainFactory {
     }
 
     /**
-     * Create a new chain of filter instances
+     * Creates and returns a new chain of filter instances.
      *
      * @return the new chain.
      */

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -7,15 +7,14 @@ package io.kroxylicious.proxy.bootstrap;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.FilterDefinition;
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
 import io.kroxylicious.proxy.filter.FilterCreationContext;
+import io.kroxylicious.proxy.filter.InvalidFilterConfigurationException;
 import io.kroxylicious.proxy.internal.filter.NettyFilterContext;
 import io.kroxylicious.proxy.service.FilterFactoryManager;
 
@@ -25,25 +24,30 @@ import io.kroxylicious.proxy.service.FilterFactoryManager;
  * New instances are created during initialization of a downstream channel.
  */
 public class FilterChainFactory {
-    private final Configuration config;
+    private final List<FilterDefinition> filterDefinitions;
 
-    public FilterChainFactory(Configuration config) {
-        this.config = Objects.requireNonNull(config);
+    public FilterChainFactory(List<FilterDefinition> filterDefinitions) {
+        validateFilterDefinitions(filterDefinitions);
+        this.filterDefinitions = Optional.ofNullable(filterDefinitions).orElse(List.of());
     }
 
     /**
      * Validate that a collection of FilterDefinitions contains all the required configuration to configure the filter.
      * @param filterDefinitions the candidates to validate.
-     * @return the Set of filter names which fail validation.
+     * @throws InvalidFilterConfigurationException If there are problems.
      */
-    public static Set<String> validateFilterConfiguration(Collection<FilterDefinition> filterDefinitions) {
+    public static void validateFilterDefinitions(Collection<FilterDefinition> filterDefinitions) {
         if (filterDefinitions == null || filterDefinitions.isEmpty()) {
-            return Set.of();
+            return;
         }
-        return filterDefinitions.stream()
+        var invalidFilters = filterDefinitions.stream()
                 .filter(Predicate.not(FilterDefinition::isDefinitionValid))
                 .map(FilterDefinition::type)
                 .collect(Collectors.toSet());
+        if (!invalidFilters.isEmpty()) {
+            throw new InvalidFilterConfigurationException(invalidFilters.stream()
+                    .collect(Collectors.joining(", ", "Invalid config for [", "]")));
+        }
     }
 
     /**
@@ -52,12 +56,7 @@ public class FilterChainFactory {
      * @return the new chain.
      */
     public List<FilterAndInvoker> createFilters(NettyFilterContext context) {
-        List<FilterDefinition> filters = config.filters();
-        if (filters == null || filters.isEmpty()) {
-            return List.of();
-        }
-        validateFilterConfiguration(filters);
-        return filters
+        return filterDefinitions
                 .stream()
                 .map(f -> {
                     FilterCreationContext wrap = context;

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import io.kroxylicious.proxy.config.ConfigParser;
 import io.kroxylicious.proxy.config.Configuration;
+import io.kroxylicious.proxy.filter.InvalidFilterConfigurationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -40,8 +41,8 @@ class KafkaProxyTest {
                        - type: ProduceRequestTransformationFilter
                 """;
         try (var kafkaProxy = new KafkaProxy(new ConfigParser().parseConfiguration(config))) {
-            assertThatThrownBy(kafkaProxy::startup).isInstanceOf(IllegalStateException.class)
-                    .hasMessage("Missing required config for [ProduceRequestTransformationFilter]");
+            assertThatThrownBy(kafkaProxy::startup).isInstanceOf(InvalidFilterConfigurationException.class)
+                    .hasMessage("Invalid config for [ProduceRequestTransformationFilter]");
         }
     }
 

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
@@ -7,7 +7,6 @@
 package io.kroxylicious.proxy.bootstrap;
 
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -15,9 +14,9 @@ import org.assertj.core.api.ListAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.FilterDefinition;
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
+import io.kroxylicious.proxy.filter.InvalidFilterConfigurationException;
 import io.kroxylicious.proxy.internal.filter.ExampleConfig;
 import io.kroxylicious.proxy.internal.filter.NettyFilterContext;
 import io.kroxylicious.proxy.internal.filter.OptionalConfigFilter;
@@ -25,8 +24,8 @@ import io.kroxylicious.proxy.internal.filter.TestFilter;
 import io.kroxylicious.proxy.internal.filter.TestFilterFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FilterChainFactoryTest {
@@ -43,15 +42,10 @@ class FilterChainFactoryTest {
     @Test
     void testNullFiltersInConfigResultsInEmptyList() {
         ScheduledExecutorService eventLoop = Executors.newScheduledThreadPool(1);
-        FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, null, null, true));
+        FilterChainFactory filterChainFactory = new FilterChainFactory(null);
         List<FilterAndInvoker> filters = filterChainFactory.createFilters(new NettyFilterContext(eventLoop));
         assertNotNull(filters, "Filters list should not be null");
         assertTrue(filters.isEmpty(), "Filters list should be empty");
-    }
-
-    @Test
-    void testConfigurationNotNullable() {
-        assertThatThrownBy(() -> new FilterChainFactory(null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
@@ -92,10 +86,10 @@ class FilterChainFactoryTest {
                 new FilterDefinition(TestFilter.class.getName(), null));
 
         // When
-        final Set<String> invalidFilters = FilterChainFactory.validateFilterConfiguration(filters);
+        var ex = assertThrows(InvalidFilterConfigurationException.class, () -> new FilterChainFactory(filters));
 
         // Then
-        assertThat(invalidFilters).containsOnly(TestFilter.class.getName());
+        assertThat(ex.getMessage()).contains(TestFilter.class.getName());
     }
 
     @Test
@@ -106,11 +100,10 @@ class FilterChainFactoryTest {
                 new FilterDefinition(OptionalConfigFilter.class.getName(), null));
 
         // When
-        final Set<String> invalidFilters = FilterChainFactory.validateFilterConfiguration(filters);
+        var ex = assertThrows(InvalidFilterConfigurationException.class, () -> new FilterChainFactory(filters));
 
         // Then
-        assertThat(invalidFilters).containsOnly(TestFilter.class.getName(),
-                TestFilter.class.getName());
+        assertThat(ex.getMessage()).contains(TestFilter.class.getName());
     }
 
     @Test
@@ -120,10 +113,10 @@ class FilterChainFactoryTest {
                 new FilterDefinition(TestFilter.class.getName(), config));
 
         // When
-        final Set<String> invalidFilters = FilterChainFactory.validateFilterConfiguration(filterDefinitions);
+        new FilterChainFactory(filterDefinitions);
 
         // Then
-        assertThat(invalidFilters).isEmpty();
+        // no exception thrown;
     }
 
     @Test
@@ -134,14 +127,14 @@ class FilterChainFactoryTest {
                 new FilterDefinition(OptionalConfigFilter.class.getName(), null));
 
         // When
-        final Set<String> invalidFilters = FilterChainFactory.validateFilterConfiguration(filterDefinitions);
+        new FilterChainFactory(filterDefinitions);
 
         // Then
-        assertThat(invalidFilters).isEmpty();
+        // no exception thrown
     }
 
     private ListAssert<FilterAndInvoker> assertFiltersCreated(List<FilterDefinition> filterDefinitions) {
-        FilterChainFactory filterChainFactory = new FilterChainFactory(new Configuration(null, null, filterDefinitions, null, true));
+        FilterChainFactory filterChainFactory = new FilterChainFactory(filterDefinitions);
         NettyFilterContext context = new NettyFilterContext(eventLoop);
         List<FilterAndInvoker> filters = filterChainFactory.createFilters(context);
         return assertThat(filters).isNotNull().hasSize(filterDefinitions.size());

--- a/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
+++ b/kroxylicious/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
@@ -113,10 +113,10 @@ class FilterChainFactoryTest {
                 new FilterDefinition(TestFilter.class.getName(), config));
 
         // When
-        new FilterChainFactory(filterDefinitions);
 
         // Then
         // no exception thrown;
+        assertThat(new FilterChainFactory(filterDefinitions)).isNotNull();
     }
 
     @Test
@@ -127,10 +127,9 @@ class FilterChainFactoryTest {
                 new FilterDefinition(OptionalConfigFilter.class.getName(), null));
 
         // When
-        new FilterChainFactory(filterDefinitions);
 
         // Then
-        // no exception thrown
+        assertThat(new FilterChainFactory(filterDefinitions)).isNotNull();
     }
 
     private ListAssert<FilterAndInvoker> assertFiltersCreated(List<FilterDefinition> filterDefinitions) {


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Removes `FilterChainFactory`'s dependency on `Configuration`. A FCF should depend only on a configured list of filters. It doesn't need to know where those originated from. In the future this might allow us to support multiple chains of filters. 

Furthermore the FCF can validate those filters on instantiation, and throw a new useful exception type. 

