### PR TITLE
[Maven] quick profile should skip javadoc generation too

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -801,6 +801,7 @@
             </activation>
             <properties>
                 <skipTests>true</skipTests>
+                <maven.javadoc.skip>true</maven.javadoc.skip>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
### Type of change


- Enhancement / new feature

### Description

Our maven `quick` profile ought to skip javadoc generation.

### Additional Context

I noticed that the docker image action was taking ages, javadoc generation (pointless) was taking significant time.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
