### PR TITLE
Make out-of-order imports fail the CI profile (better approach?)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,8 @@
         <skipITs>${skipTests}</skipITs>
         <skipUTs>${skipTests}</skipUTs>
 
+        <impsort-maven-plugin.goal>sort</impsort-maven-plugin.goal>
+
         <freemarker.version>2.3.32</freemarker.version>
         <guava.version>32.1.2-jre</guava.version>
         <hamcrest.version>2.2</hamcrest.version>
@@ -356,6 +358,14 @@
                         <!-- use langauge level 17, see https://github.com/javaparser/javaparser/issues/3833 -->
                         <compliance>17</compliance>
                     </configuration>
+                    <executions>
+                        <execution>
+                            <id>sort-imports</id>
+                            <goals>
+                                <goal>${impsort-maven-plugin.goal}</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -622,15 +632,6 @@
                     <plugin>
                         <groupId>net.revelc.code</groupId>
                         <artifactId>impsort-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>sort-imports</id>
-                                <goals>
-                                    <goal>sort</goal>
-                                </goals>
-                                <phase>process-sources</phase>
-                            </execution>
-                        </executions>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -710,6 +711,7 @@
             <properties>
                 <sonar.organization>kroxylicious</sonar.organization>
                 <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+                <impsort-maven-plugin.goal>check</impsort-maven-plugin.goal>
             </properties>
             <build>
                 <plugins>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Make out-of-order imports fail the CI profile. 

**I realised that there was a way to avoid the duplication, if you like this approach, I'll update kroxylicious-junit5-extension to work in the same way.**

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
