### PR TITLE
Dockerfile: mircodnf update needs a '-y' parameter too

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG TARGETOS
 ARG TARGETARCH
 ARG KROXYLICIOUS_VERSION
 
-RUN microdnf update \
+RUN microdnf -y update \
     && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
     && microdnf reinstall -y tzdata \
     && microdnf clean all


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

It seems the availability of a glib update has exposed a defect our Dockerfile. Our builds were hanging. `microdnf` update requires a `-y` for non-interactive use.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
