### PR TITLE
bump to Netty 4.1.100 for Rapid Reset Mitigation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <kroxy.extension.version>0.5.0</kroxy.extension.version>
         <log4j.version>2.20.0</log4j.version>
         <picocli.version>4.7.5</picocli.version>
-        <netty.version>4.1.99.Final</netty.version>
+        <netty.version>4.1.100.Final</netty.version>
         <netty.io_uring.version>0.0.23.Final</netty.io_uring.version>
         <netty.epoll.classifier>linux-x86_64</netty.epoll.classifier>
         <netty.io_uring.classifier>linux-x86_64</netty.io_uring.classifier>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

bump to Netty 4.1.100 for Rapid Reset Mitigation

### Additional Context

It seems simpler to bump and avoid issues with security scanners than to decide if the admin and metrics endpoints are actually un affected.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
