### PR TITLE
Fix #671: release fails to replace kroxylicious-api.version in BOM

### DIFF
--- a/kroxylicious-app/src/main/java/io/kroxylicious/app/Kroxylicious.java
+++ b/kroxylicious-app/src/main/java/io/kroxylicious/app/Kroxylicious.java
@@ -29,7 +29,7 @@ import picocli.CommandLine.Spec;
 /**
  * Kroxylicious application entrypoint
  */
-@Command(name = "kroxylicious", mixinStandardHelpOptions = true, versionProvider = Kroxylicious.VersionProvider.class, description = "A customizeable wire protocol proxy for Apache Kafka")
+@Command(name = "kroxylicious", mixinStandardHelpOptions = true, versionProvider = Kroxylicious.VersionProvider.class, description = "A customizable wire protocol proxy for Apache Kafka")
 public class Kroxylicious implements Callable<Integer> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger("io.kroxylicious.proxy.StartupShutdownLogger");

--- a/kroxylicious-app/src/main/templates/metadata.properties
+++ b/kroxylicious-app/src/main/templates/metadata.properties
@@ -5,6 +5,6 @@
 #
 
 kroxylicious.version=${project.version}
-kroxylicious.api.version=${kroxyliciousApi.version}
+kroxylicious.api.version=${kroxylicious-api.version}
 git.commit.id=${git.commit.id}
 git.commit.message.short=${git.commit.message.short}

--- a/kroxylicious/src/main/templates/metadata.properties
+++ b/kroxylicious/src/main/templates/metadata.properties
@@ -5,4 +5,4 @@
 #
 
 kroxylicious.version=${project.version}
-kroxylicious.api.version=${kroxyliciousApi.version}
+kroxylicious.api.version=${kroxylicious-api.version}

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <kroxyliciousApi.version>0.3.0-SNAPSHOT</kroxyliciousApi.version>
+        <kroxylicious-api.version>0.3.0-SNAPSHOT</kroxylicious-api.version>
         <java.version>17</java.version>
         <java.test.version>17</java.test.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>

--- a/scripts/release-api.sh
+++ b/scripts/release-api.sh
@@ -23,7 +23,7 @@ fi
 echo "Setting API version to ${RELEASE_API_VERSION}"
 mvn -q versions:set -DnewVersion="${RELEASE_API_VERSION}" -DprocessAllModules=true -pl :kroxylicious-bom,${API_MODULES} -DgenerateBackupPoms=false
 mvn -q clean install -Pquick -pl :kroxylicious-bom,${API_MODULES}  #quick sanity check to ensure the API modules still build
-mvn -q versions:set-property -Dproperty=kroxyliciousApi.version -DnewVersion="${RELEASE_API_VERSION}" -DgenerateBackupPoms=false
+mvn -q versions:set-property -Dproperty=kroxylicious-api.version -DnewVersion="${RELEASE_API_VERSION}" -DgenerateBackupPoms=false
 
 echo "Validating things still build"
 mvn -q clean install -Pquick


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

As reported by #671, the release script fails to relace  kroxylicious-api.version in the pom of the BOM.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
