### PR TITLE
kubernetes examples stopped working - kafka version incompatible with latest Strimzi

### DIFF
--- a/kubernetes-examples/multitenant/base/kafka-persistent.yaml
+++ b/kubernetes-examples/multitenant/base/kafka-persistent.yaml
@@ -11,7 +11,7 @@ metadata:
   name: my-cluster
 spec:
   kafka:
-    version: 3.4.0
+    version: 3.6.0
     replicas: 3
     listeners:
       - name: plain
@@ -24,7 +24,7 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 2
       min.insync.replicas: 2
-      inter.broker.protocol.version: "3.4"
+      inter.broker.protocol.version: "3.6"
     storage:
       type: jbod
       volumes:

--- a/kubernetes-examples/multitenant/postinstall.sh
+++ b/kubernetes-examples/multitenant/postinstall.sh
@@ -7,7 +7,7 @@
 
 set -eo pipefail
 
-STRIMZI_KAFKA=quay.io/strimzi/kafka:0.35.0-kafka-3.4.0
+STRIMZI_KAFKA=quay.io/strimzi/kafka:0.38.0-kafka-3.6.0
 BOOTSTRAP=my-cluster-kafka-bootstrap:9092
 
 GREEN='\033[0;32m'

--- a/kubernetes-examples/multitenant/script.txt
+++ b/kubernetes-examples/multitenant/script.txt
@@ -129,11 +129,11 @@ kaf consume billingapp --group billinggroup --commit
 # to query it using the Apache Kafka tooling.
 
 # first the topics
-kubectl -n kafka run listtopics -ti --image=quay.io/strimzi/kafka:0.35.0-kafka-3.4.0 --rm=true --restart=Never -- bin/kafka-topics.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 --list
+kubectl -n kafka run listtopics -ti --image=quay.io/strimzi/kafka:0.38.0-kafka-3.6.0 --rm=true --restart=Never -- bin/kafka-topics.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 --list
 # notice how the topics names are prefixed with the virtual cluster's name.
 
 # now, the groups
-kubectl -n kafka run listgroups -ti --image=quay.io/strimzi/kafka:0.35.0-kafka-3.4.0 --rm=true --restart=Never -- bin/kafka-consumer-groups.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 --list
+kubectl -n kafka run listgroups -ti --image=quay.io/strimzi/kafka:0.38.0-kafka-3.6.0 --rm=true --restart=Never -- bin/kafka-consumer-groups.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 --list
 # notice that the same prefixing has been done.
 
 # let's wrap up.

--- a/kubernetes-examples/portperbroker_plain/base/kafka-persistent.yaml
+++ b/kubernetes-examples/portperbroker_plain/base/kafka-persistent.yaml
@@ -11,7 +11,7 @@ metadata:
   name: my-cluster
 spec:
   kafka:
-    version: 3.4.0
+    version: 3.6.0
     replicas: 3
     listeners:
       - name: plain
@@ -28,7 +28,7 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 2
       min.insync.replicas: 2
-      inter.broker.protocol.version: "3.4"
+      inter.broker.protocol.version: "3.6"
     storage:
       type: jbod
       volumes:

--- a/kubernetes-examples/portperbroker_plain/postinstall.sh
+++ b/kubernetes-examples/portperbroker_plain/postinstall.sh
@@ -7,7 +7,7 @@
 
 set -eo pipefail
 
-STRIMZI_KAFKA=quay.io/strimzi/kafka:0.35.0-kafka-3.4.0
+STRIMZI_KAFKA=quay.io/strimzi/kafka:0.38.0-kafka-3.6.0
 KCAT=quay.io/kroxylicious/kcat:1.7.1
 TOPIC=my-topic
 BOOTSTRAP=kroxylicious-service:9292

--- a/kubernetes-examples/snirouting_tls/base/kafka-persistent.yaml
+++ b/kubernetes-examples/snirouting_tls/base/kafka-persistent.yaml
@@ -11,7 +11,7 @@ metadata:
   name: my-cluster
 spec:
   kafka:
-    version: 3.4.0
+    version: 3.6.0
     replicas: 3
     listeners:
       - name: tls
@@ -24,7 +24,7 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 2
       min.insync.replicas: 2
-      inter.broker.protocol.version: "3.4"
+      inter.broker.protocol.version: "3.6"
     storage:
       type: jbod
       volumes:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Running Kubernetes examples had stopped working with the strimzi 0.38 release because we install the latest strimzi and it doesn't support kafka 3.4.0 any more.

This is the quick fix to upgrade our desired kafka versions but as k8s becomes a bigger part of development we should move to a controlled strimzi version so we can have a more reproducible enviroment. That would mean a bit more scripting to pull down a distribution, modify the namespace and install it.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
