### PR TITLE
Bump sundr-builder-annotations from 0.101.0 to 0.101.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <mockito.version>5.6.0</mockito.version>
         <micrometer.version>1.11.5</micrometer.version>
         <slf4j.version>2.0.9</slf4j.version>
-        <sundr-builder-annotations.version>0.101.0</sundr-builder-annotations.version>
+        <sundr-builder-annotations.version>0.101.3</sundr-builder-annotations.version>
         <spotbugs-annotations.version>4.8.0</spotbugs-annotations.version>
         <zjsonpatch.version>0.4.14</zjsonpatch.version>
         <moby-names-generator.version>20.10.1-r0</moby-names-generator.version>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

We discovered a [regression](https://github.com/sundrio/sundrio/issues/442) in the 0.101.2 release (#698).  The project's now put out 0.101.3 in response. The issue has been fixed.

This is a build time test dependency, so no changelog entry is applicable.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
