### PR TITLE
Bind kroxylicious-sample's integration tests to the integration test phase

### DIFF
--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -93,25 +93,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <environmentVariables>
-                        <!-- https://github.com/containers/podman/issues/7927#issuecomment-731525556 - required for testcontainers/podman support -->
-                        <TESTCONTAINERS_RYUK_DISABLED>true</TESTCONTAINERS_RYUK_DISABLED>
-                    </environmentVariables>
-                    <systemPropertyVariables>
-                        <io.netty.leakDetection.level>paranoid</io.netty.leakDetection.level>
-                        <container.logs.dir>${project.build.directory}/container-logs/</container.logs.dir>
-                    </systemPropertyVariables>
-                    <runOrder>random</runOrder>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/kroxylicious-sample/pom.xml
+++ b/kroxylicious-sample/pom.xml
@@ -74,4 +74,12 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/kroxylicious-sample/src/test/java/io/kroxylicious/sample/SampleFilterIT.java
+++ b/kroxylicious-sample/src/test/java/io/kroxylicious/sample/SampleFilterIT.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @ExtendWith(KafkaClusterExtension.class)
-class SampleFilterIntegrationTest {
+class SampleFilterIT {
 
     // Configure filters here
     private static final String FIND_CONFIG_FIELD = "findValue";

--- a/pom.xml
+++ b/pom.xml
@@ -416,7 +416,30 @@
                     <version>3.2.2</version>
                     <configuration>
                         <skipTests>${skipITs}</skipTests>
+                        <environmentVariables>
+                            <!-- https://github.com/containers/podman/issues/7927#issuecomment-731525556 - required for testcontainers/podman support -->
+                            <TESTCONTAINERS_RYUK_DISABLED>true</TESTCONTAINERS_RYUK_DISABLED>
+                        </environmentVariables>
+                        <systemPropertyVariables>
+                            <io.netty.leakDetection.level>paranoid</io.netty.leakDetection.level>
+                            <container.logs.dir>${project.build.directory}/container-logs/</container.logs.dir>
+                        </systemPropertyVariables>
+                        <runOrder>random</runOrder>
                     </configuration>
+                    <executions>
+                        <execution>
+                            <id>integration-test</id>
+                            <goals>
+                                <goal>integration-test</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>verify</id>
+                            <goals>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Why: The ITs were running as part of the unit-test phase rather than the integration test phase which meant the `skipITs` property wasn't being respected properly.

Solution follows the model suggested: https://maven.apache.org/surefire/maven-failsafe-plugin/usage.html#usage-in-multi-module-projects


_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
