### PR TITLE
Exclude the upcoming systemtests module from coverage

### DIFF
--- a/.sonar-project.properties
+++ b/.sonar-project.properties
@@ -19,3 +19,6 @@ sonar.exclusions=performance-tests/src/main/java/io/kroxylicious/filters/**
 
 # Exclusions for copy-paste detection
 #sonar.cpd.exclusions=
+
+# Exclusions for coverage
+sonar.coverage.exclusions=kroxylicious-systemtests/src/**


### PR DESCRIPTION

### Type of change

_Select the type of your PR_


- Enhancement / new feature

### Description

Disable coverage checking for the systemtest suite.

### Additional Context

The PR for system tests is failing because of coverage concerns, however the sonar configuration comes from main so we need to exclude it there first or force merge the PR.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
