### PR TITLE
Fix out of data version reference in Kubernetes examples

### DIFF
--- a/kubernetes-examples/multitenant/base/kroxylicious-deployment.yaml
+++ b/kubernetes-examples/multitenant/base/kroxylicious-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: kroxylicious
-        image: quay.io/kroxylicious/kroxylicious-developer:0.3.0-SNAPSHOT
+        image: quay.io/kroxylicious/kroxylicious-developer:0.4.0-SNAPSHOT
         imagePullPolicy: Always
         args: ["--config", "/opt/kroxylicious/config/config.yaml"]
         ports:

--- a/kubernetes-examples/portperbroker_plain/base/kroxylicious-deployment.yaml
+++ b/kubernetes-examples/portperbroker_plain/base/kroxylicious-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: kroxylicious
-        image: quay.io/kroxylicious/kroxylicious-developer:0.3.0-SNAPSHOT
+        image: quay.io/kroxylicious/kroxylicious-developer:0.4.0-SNAPSHOT
         imagePullPolicy: Always
         args: ["--config", "/opt/kroxylicious/config/config.yaml"]
         ports:

--- a/kubernetes-examples/snirouting_tls/base/kroxylicious-deployment.yaml
+++ b/kubernetes-examples/snirouting_tls/base/kroxylicious-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: kroxylicious
-        image: quay.io/kroxylicious/kroxylicious-developer:0.3.0-SNAPSHOT
+        image: quay.io/kroxylicious/kroxylicious-developer:0.4.0-SNAPSHOT
         imagePullPolicy: Always
         args: ["--config", "/opt/kroxylicious/config/config.yaml"]
         ports:


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

The last release failed to update the image version references in the yamls.
If we chose to keep these examples, we need either a better way to inject the right version or something in the release process to update the version.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
