### PR TITLE
Revert "Bump io.sundr:builder-annotations from 0.101.3 to 0.103.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <mockito.version>5.7.0</mockito.version>
         <micrometer.version>1.12.0</micrometer.version>
         <slf4j.version>2.0.9</slf4j.version>
-        <sundr-builder-annotations.version>0.103.0</sundr-builder-annotations.version>
+        <sundr-builder-annotations.version>0.101.3</sundr-builder-annotations.version>
         <spotbugs-annotations.version>4.8.1</spotbugs-annotations.version>
         <zjsonpatch.version>0.4.14</zjsonpatch.version>
         <moby-names-generator.version>20.10.1-r0</moby-names-generator.version>


### PR DESCRIPTION
Reverts kroxylicious/kroxylicious#743.  To take a cautious approach, we need to make sure that the Strimzi, Fabric8 and Sundrio all use coincident version.  See discussion on https://github.com/fabric8io/kubernetes-client/issues/5617