### PR TITLE
Add note to pom warning that care should be taken to align versions when upgrading strimzi/fabric8/sundr

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@
         <mockito.version>5.7.0</mockito.version>
         <micrometer.version>1.12.0</micrometer.version>
         <slf4j.version>2.0.9</slf4j.version>
-        <sundr-builder-annotations.version>0.101.3</sundr-builder-annotations.version>
         <spotbugs-annotations.version>4.8.1</spotbugs-annotations.version>
         <zjsonpatch.version>0.4.14</zjsonpatch.version>
         <moby-names-generator.version>20.10.1-r0</moby-names-generator.version>
@@ -63,7 +62,11 @@
 
         <!-- Test dependencies -->
         <strimzi.version>0.37.0</strimzi.version>
+        <!-- keep Fabric8 version in lock step with the Fabric8 version used by Strimzi -->
         <fabric8.kubernetes.version>6.8.1</fabric8.kubernetes.version>
+        <!-- keep Sundr version in lock step with the Sundr version used by Strimzi and Fabric8 -->
+        <sundr-builder-annotations.version>0.101.3</sundr-builder-annotations.version>
+
         <enforcer.api.version>3.4.1</enforcer.api.version>
         <maven.core.version>3.9.5</maven.core.version>
         <awaitility.version>4.2.0</awaitility.version>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

Add note to pom warning that care should be taken to align versions when upgrading strimzi/fabric8/sundr.

I'm being cautious.  There are probably cases when we should overrule this stipulation (CVE remediation being one case)

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
