### PR TITLE
Hashicorp Vault KMS implementation and kubernetes-example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.4.0
 
+* [#741](https://github.com/kroxylicious/kroxylicious/issues/741): Encryption Filter: Implement a HashiCorp Vault KMS 
 * [#764](https://github.com/kroxylicious/kroxylicious/pull/764): Encryption Filter: Rotate to a new DEK when the old one is exhausted
 * [#696](https://github.com/kroxylicious/kroxylicious/pull/696): Initial work on an Envelope Encryption Filter
-* [#752](https://github.com/kroxylicious/kroxylicious/issues/752): Remove redudant reinstallation of time-zone data in Dockerfile used for Kroxylicious container image
+* [#752](https://github.com/kroxylicious/kroxylicious/issues/752): Remove redundant re-installation of time-zone data in Dockerfile used for Kroxylicious container image
 * [#727](https://github.com/kroxylicious/kroxylicious/pull/727): Tease out simple transform filters into their own module
 * [#628](https://github.com/kroxylicious/kroxylicious/pull/628): Kroxylicious system tests
 * [#738](https://github.com/kroxylicious/kroxylicious/pull/738): Update to Kroxylicious Junit Ext 0.7.0

--- a/kroxylicious-app/pom.xml
+++ b/kroxylicious-app/pom.xml
@@ -210,6 +210,14 @@
                     <groupId>io.kroxylicious</groupId>
                     <artifactId>kroxylicious-simple-transform</artifactId>
                 </dependency>
+                <dependency>
+                    <groupId>io.kroxylicious</groupId>
+                    <artifactId>kroxylicious-encryption</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>io.kroxylicious</groupId>
+                    <artifactId>kroxylicious-kms-provider-hashicorp-vault</artifactId>
+                </dependency>
             </dependencies>
         </profile>
     </profiles>

--- a/kroxylicious-bom/pom.xml
+++ b/kroxylicious-bom/pom.xml
@@ -125,6 +125,12 @@
 
             <dependency>
                 <groupId>io.kroxylicious</groupId>
+                <artifactId>kroxylicious-kms-provider-hashicorp-vault</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.kroxylicious</groupId>
                 <artifactId>kroxylicious-encryption</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EncryptionException.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EncryptionException.java
@@ -14,4 +14,5 @@ public class EncryptionException extends RuntimeException {
     public EncryptionException(String message) {
         super(message);
     }
+
 }

--- a/kroxylicious-kms-provider-hashicorp-vault/README.md
+++ b/kroxylicious-kms-provider-hashicorp-vault/README.md
@@ -1,0 +1,17 @@
+# Kroxylicious HashiCorp KMS Provider for Topic Encryption
+
+## What is it?
+
+An implementation of the KMS (Key Management System) interface backed by a remote instance of Hashicorp Vault (v1).
+
+It allows the Topic Encryption filter to be used with encryption keys stored with a HashiCorp Vault(TM)
+instance.  The instance may be a locally deployed instance, or could be a HashiCorp Vault instance provided by 
+HashiCorp Cloud Platform (HCP) .
+
+## How do I use it?
+
+These are interim instructions.  For the moment please refer to the [Topic Encryption Kubernetes Example](../kubernetes-examples/topicencryption/).
+Instructions to deploy the example are found in the [Developer Guide](../DEV_GUIDE.md).
+
+HashiCorp, HashiCorp Cloud Platform and HashiCorp Vault are registered trademarks of HashiCorp Inc.
+

--- a/kroxylicious-kms-provider-hashicorp-vault/pom.xml
+++ b/kroxylicious-kms-provider-hashicorp-vault/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.kroxylicious</groupId>
+        <artifactId>kroxylicious-parent</artifactId>
+        <version>0.4.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>kroxylicious-kms-provider-hashicorp-vault</artifactId>
+    <packaging>jar</packaging>
+    <name>Hashicorp Vault KMS</name>
+    <description>An KMS provider backed by a remote instance of Hashicorp Vault</description>
+    <properties>
+        <testcontainers-vault.version>1.19.3</testcontainers-vault.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-kms</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>vault</artifactId>
+            <version>${testcontainers-vault.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/kroxylicious-kms-provider-hashicorp-vault/pom.xml
+++ b/kroxylicious-kms-provider-hashicorp-vault/pom.xml
@@ -21,7 +21,7 @@
     <artifactId>kroxylicious-kms-provider-hashicorp-vault</artifactId>
     <packaging>jar</packaging>
     <name>Hashicorp Vault KMS</name>
-    <description>An KMS provider backed by a remote instance of Hashicorp Vault</description>
+    <description>A KMS provider backed by a remote instance of Hashicorp Vault</description>
     <properties>
         <testcontainers-vault.version>1.19.3</testcontainers-vault.version>
     </properties>

--- a/kroxylicious-kms-provider-hashicorp-vault/pom.xml
+++ b/kroxylicious-kms-provider-hashicorp-vault/pom.xml
@@ -35,7 +35,11 @@
             <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-api</artifactId>
         </dependency>
-
+        <!-- For ByteUtils used by the Serde etc -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>

--- a/kroxylicious-kms-provider-hashicorp-vault/pom.xml
+++ b/kroxylicious-kms-provider-hashicorp-vault/pom.xml
@@ -60,4 +60,12 @@
 
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/JsonBodyHandler.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/JsonBodyHandler.java
@@ -9,6 +9,7 @@ package io.kroxylicious.kms.provider.hashicorp.vault;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandler;
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -17,7 +18,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-class JsonBodyHandler<T> implements HttpResponse.BodyHandler<Supplier<T>> {
+/**
+ * A BodyHandler that deserializes JSON data using a Jackson ObjectMapper yielding an object of
+ * type {@code T}.
+ * @param <T> result type.
+ */
+class JsonBodyHandler<T> implements BodyHandler<Supplier<T>> {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     @NonNull
@@ -42,5 +48,4 @@ class JsonBodyHandler<T> implements HttpResponse.BodyHandler<Supplier<T>> {
                     }
                 });
     }
-
 }

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/JsonBodyHandler.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/JsonBodyHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kms.provider.hashicorp.vault;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.http.HttpResponse;
+import java.util.function.Supplier;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class JsonBodyHandler<T> implements HttpResponse.BodyHandler<Supplier<T>> {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static <T> Supplier<T> toSupplierOfType(InputStream inputStream) {
+        return () -> {
+            try (InputStream stream = inputStream) {
+                return OBJECT_MAPPER.readValue(stream, new TypeReference<T>() {
+                });
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        };
+    }
+
+    private static <T> HttpResponse.BodySubscriber<Supplier<T>> asJSON() {
+        return HttpResponse.BodySubscribers.mapping(
+                HttpResponse.BodySubscribers.ofInputStream(),
+                JsonBodyHandler::toSupplierOfType);
+    }
+
+    @Override
+    public HttpResponse.BodySubscriber<Supplier<T>> apply(HttpResponse.ResponseInfo responseInfo) {
+        return JsonBodyHandler.asJSON();
+    }
+
+}

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdek.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdek.java
@@ -14,6 +14,12 @@ record VaultEdek(String kekRef,
     VaultEdek {
         Objects.requireNonNull(kekRef);
         Objects.requireNonNull(edek);
+        if (kekRef.isEmpty()) {
+            throw new IllegalArgumentException("keyRef cannot be empty");
+        }
+        if (edek.length == 0) {
+            throw new IllegalArgumentException("edek cannot be empty");
+        }
     }
 
     /**

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdek.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdek.java
@@ -9,6 +9,16 @@ package io.kroxylicious.kms.provider.hashicorp.vault;
 import java.util.Arrays;
 import java.util.Objects;
 
+/**
+ * A HashiCorp Vault Encrypted Dek.
+ * <br/>
+ * Note: HashiCorp Vault restricts the formation of the key name. For the rules, see the
+ * <a href="https://github.com/hashicorp/vault/blob/cd8cc4ed967703b89aa0721bca4fe1c43b214b00/sdk/framework/path.go#L19">GenericNameRegexp</a>
+ * function in the Vault implementation.
+ *
+ * @param kekRef - kek reference. In this implementation it is the key's name.
+ * @param edek - edek bytes
+ */
 record VaultEdek(String kekRef,
                  byte[] edek) {
     VaultEdek {

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdek.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdek.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kms.provider.hashicorp.vault;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+record VaultEdek(String kekRef,
+                 byte[] edek) {
+    VaultEdek {
+        Objects.requireNonNull(kekRef);
+        Objects.requireNonNull(edek);
+    }
+
+    /**
+     * Overridden to provide deep equality on the {@code byte[]}.
+     * @param o   the reference object with which to compare.
+     * @return true iff this object is equal to the given object.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        VaultEdek that = (VaultEdek) o;
+        return Objects.equals(kekRef, that.kekRef) && Arrays.equals(edek, that.edek);
+    }
+
+    /**
+     * Overridden to provide a deep hashcode on the {@code byte[]}.
+     * @return the has code.
+     */
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(kekRef);
+        result = 31 * result + Arrays.hashCode(edek);
+        return result;
+    }
+
+    /**
+     * Overridden to provide a deep {@code toString()} on the {@code byte[]}.
+     * @return The string
+     */
+    @Override
+    public String toString() {
+        return "VaultEdek{" +
+                "keyRef=" + kekRef +
+                ", edek=" + Arrays.toString(edek) +
+                '}';
+    }
+}

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdekSerde.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdekSerde.java
@@ -13,6 +13,8 @@ import io.kroxylicious.kms.service.Serde;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+import static org.apache.kafka.common.utils.Utils.utf8Length;
+
 class VaultEdekSerde implements Serde<VaultEdek> {
 
     @Override
@@ -36,7 +38,9 @@ class VaultEdekSerde implements Serde<VaultEdek> {
 
     @Override
     public int sizeOf(VaultEdek edek) {
-        return edek.kekRef().getBytes(StandardCharsets.UTF_8).length + 1 + edek.edek().length;
+        return 1 // Single byte to store length of kek
+                + utf8Length(edek.kekRef()) // n bytes for the utf-8 encoded kek
+                + edek.edek().length; // n bytes for the edek
     }
 
     @Override

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdekSerde.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdekSerde.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kms.provider.hashicorp.vault;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import io.kroxylicious.kms.service.Serde;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+class VaultEdekSerde implements Serde<VaultEdek> {
+
+    @Override
+    public VaultEdek deserialize(@NonNull ByteBuffer buffer) {
+        // TODO use varints once approach is agreed.
+        short kekRefLength = Serde.getUnsignedByte(buffer);
+        if (kekRefLength < 1) {
+            throw new IllegalArgumentException("Unexpected key ref length (%d) read deserializing VaultEdek :".formatted(kekRefLength));
+        }
+        var buf = new byte[kekRefLength];
+        buffer.get(buf);
+        var keyRef = new String(buf, StandardCharsets.UTF_8);
+        int edekLength = buffer.limit() - buffer.position();
+        if (edekLength == 0) {
+            throw new IllegalArgumentException("Zero number of bytes remain in buffer when expecting an edek");
+        }
+        var edek = new byte[edekLength];
+        buffer.get(edek);
+        return new VaultEdek(keyRef, edek);
+    }
+
+    @Override
+    public int sizeOf(VaultEdek edek) {
+        return edek.kekRef().getBytes(StandardCharsets.UTF_8).length + 1 + edek.edek().length;
+    }
+
+    @Override
+    public void serialize(VaultEdek edek, @NonNull ByteBuffer buffer) {
+        var keyRefBuf = edek.kekRef().getBytes(StandardCharsets.UTF_8);
+        if (keyRefBuf.length == 0 || keyRefBuf.length > 255) {
+            throw new IllegalArgumentException("Kek ref '%s' is of an unexpected length (%d)".formatted(edek.kekRef(), keyRefBuf.length));
+        }
+        Serde.putUnsignedByte(buffer, keyRefBuf.length);
+        buffer.put(keyRefBuf);
+        buffer.put(edek.edek());
+    }
+}

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdekSerde.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdekSerde.java
@@ -27,7 +27,7 @@ class VaultEdekSerde implements Serde<VaultEdek> {
         var keyRef = new String(buf, StandardCharsets.UTF_8);
         int edekLength = buffer.limit() - buffer.position();
         if (edekLength == 0) {
-            throw new IllegalArgumentException("Zero number of bytes remain in buffer when expecting an edek");
+           throw new IllegalArgumentException("unable to deserialize edek as there are zero bytes remaining in the buffer");
         }
         var edek = new byte[edekLength];
         buffer.get(edek);

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdekSerde.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdekSerde.java
@@ -27,7 +27,7 @@ class VaultEdekSerde implements Serde<VaultEdek> {
         var keyRef = new String(buf, StandardCharsets.UTF_8);
         int edekLength = buffer.limit() - buffer.position();
         if (edekLength == 0) {
-           throw new IllegalArgumentException("unable to deserialize edek as there are zero bytes remaining in the buffer");
+            throw new IllegalArgumentException("unable to deserialize edek as there are zero bytes remaining in the buffer");
         }
         var edek = new byte[edekLength];
         buffer.get(edek);

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKms.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKms.java
@@ -39,8 +39,6 @@ import static java.net.URLEncoder.encode;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
- * {@inheritDoc}
- * <br/>
  * An implementation of the KMS interface backed by a remote instance of HashiCorp Vault (v1).
  * <br/>
  * <h2>TODO</h2>

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKms.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKms.java
@@ -35,7 +35,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 /**
  * {@inheritDoc}
  * <br/>
- * An implementation of the KMS interface backed by a remote instance of Hashicorp Vault (v1).
+ * An implementation of the KMS interface backed by a remote instance of HashiCorp Vault (v1).
  * <br/>
  * <h2>TODO</h2>
  * <ul>

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKms.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKms.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kms.provider.hashicorp.vault;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.kroxylicious.kms.service.DekPair;
+import io.kroxylicious.kms.service.Kms;
+import io.kroxylicious.kms.service.KmsException;
+import io.kroxylicious.kms.service.Serde;
+import io.kroxylicious.kms.service.UnknownKeyException;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * {@inheritDoc}
+ * <br/>
+ * An implementation of the KMS interface backed by a remote instance of Hashicorp Vault (v1).
+ * <br/>
+ * <h2>TODO</h2>
+ * <ul>
+ *    <li>don't assume /transit endpoint</li>
+ *    <li>HTTPs</li>
+ *    <li>Client trust store</li>
+ *    <li>Securely pass vault token</li>
+ * </ul>
+ */
+public class VaultKms implements Kms<String, VaultEdek> {
+
+    private static final String AES_KEY_ALGO = "AES";
+
+    private final HttpClient vaultClient = HttpClient.newBuilder()
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .connectTimeout(Duration.ofSeconds(20))
+            .build();
+    private final URI vaultUrl;
+    private final String vaultToken;
+
+    VaultKms(URI vaultUrl, String vaultToken) {
+        this.vaultUrl = vaultUrl;
+        this.vaultToken = vaultToken;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <br/>
+     * @see <a href="https://developer.hashicorp.com/vault/api-docs/secret/transit#generate-data-key">https://developer.hashicorp.com/vault/api-docs/secret/transit#generate-data-key</a>
+     */
+    @NonNull
+    @Override
+    public CompletionStage<DekPair<VaultEdek>> generateDekPair(@NonNull String kekRef) {
+
+        var request = createVaultRequest()
+                .uri(vaultUrl.resolve("v1/transit/datakey/plaintext/%s".formatted(kekRef)))
+                .POST(HttpRequest.BodyPublishers.noBody())
+                .build();
+
+        return vaultClient.sendAsync(request, statusHandler(kekRef, new JsonBodyHandler<Map<String, Map<String, String>>>()))
+                .thenApply(HttpResponse::body)
+                .thenApply(Supplier::get)
+                .thenApply(x -> x.get("data"))
+                .thenApply(data -> {
+
+                    var plaintext = data.get("plaintext");
+                    var ciphertext = data.get("ciphertext");
+                    var secretKey = new SecretKeySpec(Base64.getDecoder().decode(plaintext), AES_KEY_ALGO);
+
+                    return new DekPair<>(new VaultEdek(kekRef, ciphertext.getBytes(StandardCharsets.UTF_8)), secretKey);
+
+                });
+
+    }
+
+    /**
+     * {@inheritDoc}
+     * <br/>
+     * @see <a href="https://developer.hashicorp.com/vault/api-docs/secret/transit#decrypt">https://developer.hashicorp.com/vault/api-docs/secret/transit#decrypt</a>
+     */
+    @NonNull
+    @Override
+    public CompletionStage<SecretKey> decryptEdek(@NonNull VaultEdek edek) {
+
+        var body = Map.of("ciphertext", new String(edek.edek(), StandardCharsets.UTF_8));
+
+        HttpRequest request = null;
+        try {
+            request = createVaultRequest()
+                    .uri(vaultUrl.resolve("v1/transit/decrypt/%s".formatted(edek.kekRef())))
+                    .POST(HttpRequest.BodyPublishers.ofString(new ObjectMapper().writeValueAsString(body)))
+                    .build();
+        }
+        catch (JsonProcessingException e) {
+            return CompletableFuture.failedStage(new KmsException("Failed to build request body for %s".formatted(edek.kekRef())));
+        }
+
+        return vaultClient.sendAsync(request, statusHandler(edek.kekRef(), new JsonBodyHandler<Map<String, Map<String, String>>>()))
+                .thenApply(HttpResponse::body)
+                .thenApply(Supplier::get)
+                .thenApply(x -> x.get("data"))
+                .thenApply(data -> {
+                    var plaintext = data.get("plaintext");
+                    return new SecretKeySpec(Base64.getDecoder().decode(plaintext), AES_KEY_ALGO);
+                });
+    }
+
+    /**
+     * {@inheritDoc}
+     * <br/>
+     * @see <a href="https://developer.hashicorp.com/vault/api-docs/secret/transit#read-key">https://developer.hashicorp.com/vault/api-docs/secret/transit#read-key</a>
+     */
+    @NonNull
+    @Override
+    public CompletableFuture<String> resolveAlias(@NonNull String alias) {
+
+        var request = createVaultRequest()
+                .uri(vaultUrl.resolve("v1/transit/keys/%s".formatted(alias)))
+                .build();
+
+        return vaultClient.sendAsync(request, statusHandler(alias, new JsonBodyHandler<Map<String, Map<String, String>>>()))
+                .thenApply(HttpResponse::body)
+                .thenApply(Supplier::get)
+                .thenApply(x -> x.get("data"))
+                .thenApply(data -> data.get("name"));
+
+    }
+
+    @NonNull
+    @Override
+    public Serde<VaultEdek> edekSerde() {
+        return new VaultEdekSerde();
+    }
+
+    private HttpRequest.Builder createVaultRequest() {
+        return HttpRequest.newBuilder()
+                .header("X-Vault-Token", vaultToken)
+                .header("Accept", "application/json");
+    }
+
+    private static <T> HttpResponse.BodyHandler<T> statusHandler(String keyRef, HttpResponse.BodyHandler<T> handler) {
+        return r -> {
+
+            if (r.statusCode() == 404 || r.statusCode() == 400) {
+                throw new UnknownKeyException("key '%s' is not found.".formatted(keyRef));
+            }
+            else if (r.statusCode() != 200) {
+                throw new KmsException("fail to retrieve key '%s', HTTP status code %d.".formatted(keyRef, r.statusCode()));
+            }
+            return handler.apply(r);
+        };
+    }
+}

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsService.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsService.java
@@ -15,12 +15,15 @@ import io.kroxylicious.proxy.plugin.Plugin;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * {@inheritDoc}
- * <br/>
  * An implementation of the {@link KmsService} interface backed by a remote instance of HashiCorp Vault.
  */
 @Plugin(configType = VaultKmsService.Config.class)
 public class VaultKmsService implements KmsService<VaultKmsService.Config, String, VaultEdek> {
+    /**
+     * Configuration for the Vault KMS service.
+     * @param vaultUrl vault url
+     * @param vaultToken vault token.
+     */
     public record Config(URI vaultUrl,
                          String vaultToken) {
         public Config {

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsService.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsService.java
@@ -17,7 +17,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 /**
  * {@inheritDoc}
  * <br/>
- * An implementation of the {@link KmsService} interface backed by a remote instance of Hashicorp Vault.
+ * An implementation of the {@link KmsService} interface backed by a remote instance of HashiCorp Vault.
  */
 @Plugin(configType = VaultKmsService.Config.class)
 public class VaultKmsService implements KmsService<VaultKmsService.Config, String, VaultEdek> {

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsService.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kms.provider.hashicorp.vault;
+
+import java.net.URI;
+import java.util.Objects;
+
+import io.kroxylicious.kms.service.KmsService;
+import io.kroxylicious.proxy.plugin.Plugin;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * {@inheritDoc}
+ * <br/>
+ * An implementation of the {@link KmsService} interface backed by a remote instance of Hashicorp Vault.
+ */
+@Plugin(configType = VaultKmsService.Config.class)
+public class VaultKmsService implements KmsService<VaultKmsService.Config, String, VaultEdek> {
+    public record Config(URI vaultUrl,
+                         String vaultToken) {
+        public Config {
+            Objects.requireNonNull(vaultUrl);
+            Objects.requireNonNull(vaultToken);
+        }
+    }
+
+    @NonNull
+    @Override
+    public VaultKms buildKms(Config options) {
+        return new VaultKms(options.vaultUrl(), options.vaultToken());
+    }
+
+}

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultResponse.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultResponse.java
@@ -10,39 +10,14 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-class VaultResponse {
-    private Data data = null;
-
-    public Data getData() {
-        return data;
-    }
-
-    public void setData(Data data) {
-        this.data = data;
-    }
+record VaultResponse<D>(D data) {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    static class Data {
+    record ReadKeyData(String name, @JsonProperty("latest_version") int latestVersion) {}
 
-        private String name;
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record DecryptData(String plaintext) {}
 
-        @JsonProperty("latest_version")
-        private int latestVersion;
-
-        public int getLatestVersion() {
-            return latestVersion;
-        }
-
-        public void setLatestVersion(int latestVersion) {
-            this.latestVersion = latestVersion;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public void setName(String name) {
-            this.name = name;
-        }
-    }
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record DataKeyData(String plaintext, String ciphertext) {}
 }

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultResponse.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultResponse.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kms.provider.hashicorp.vault;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class VaultResponse {
+    private Data data = null;
+
+    public Data getData() {
+        return data;
+    }
+
+    public void setData(Data data) {
+        this.data = data;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class Data {
+
+        private String name;
+
+        @JsonProperty("latest_version")
+        private int latestVersion;
+
+        public int getLatestVersion() {
+            return latestVersion;
+        }
+
+        public void setLatestVersion(int latestVersion) {
+            this.latestVersion = latestVersion;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultResponse.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultResponse.java
@@ -6,18 +6,37 @@
 
 package io.kroxylicious.kms.provider.hashicorp.vault;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 record VaultResponse<D>(D data) {
 
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    record ReadKeyData(String name, @JsonProperty("latest_version") int latestVersion) {}
+    VaultResponse {
+        Objects.requireNonNull(data);
+    }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    record DecryptData(String plaintext) {}
+    record ReadKeyData(String name, @JsonProperty("latest_version") int latestVersion) {
+        ReadKeyData {
+            Objects.requireNonNull(name);
+        }
+    }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    record DataKeyData(String plaintext, String ciphertext) {}
+    record DecryptData(String plaintext) {
+        DecryptData {
+            Objects.requireNonNull(plaintext);
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record DataKeyData(String plaintext, String ciphertext) {
+        DataKeyData {
+            Objects.requireNonNull(plaintext);
+            Objects.requireNonNull(ciphertext);
+        }
+    }
 }

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/resources/META-INF/services/io.kroxylicious.kms.service.KmsService
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/resources/META-INF/services/io.kroxylicious.kms.service.KmsService
@@ -4,5 +4,4 @@
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
-io.kroxylicious.kms.provider.kroxylicious.inmemory.UnitTestingKmsService
-io.kroxylicious.kms.provider.kroxylicious.inmemory.IntegrationTestingKmsService
+io.kroxylicious.kms.provider.hashicorp.vault.VaultKmsService

--- a/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/JsonBodyHandlerTest.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/JsonBodyHandlerTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kms.provider.hashicorp.vault;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import io.kroxylicious.kms.provider.hashicorp.vault.VaultResponse.ReadKeyData;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JsonBodyHandlerTest {
+
+    @Test
+    void handleReadKeyResponse() {
+        var bodySubscriber = new JsonBodyHandler<VaultResponse<ReadKeyData>>(new TypeReference<>() {
+        }).apply(null);
+
+        bodySubscriber.onNext(List.of(ByteBuffer.wrap(
+                """
+                        {
+                          "data": {
+                            "name": "foo",
+                            "latest_version": 1
+                          }
+                        }""".getBytes(StandardCharsets.UTF_8))));
+        bodySubscriber.onComplete();
+
+        var stage = bodySubscriber.getBody();
+        assertThat(stage).isCompleted();
+        var supplier = stage.toCompletableFuture().join();
+
+        var expected = new VaultResponse<>(new ReadKeyData("foo", 1));
+
+        assertThat(supplier).extracting(Supplier::get).isEqualTo(expected);
+    }
+
+}

--- a/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/JsonBodyHandlerTest.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/JsonBodyHandlerTest.java
@@ -10,38 +10,114 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
+import io.kroxylicious.kms.provider.hashicorp.vault.VaultResponse.DataKeyData;
+import io.kroxylicious.kms.provider.hashicorp.vault.VaultResponse.DecryptData;
 import io.kroxylicious.kms.provider.hashicorp.vault.VaultResponse.ReadKeyData;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class JsonBodyHandlerTest {
 
-    @Test
-    void handleReadKeyResponse() {
-        var bodySubscriber = new JsonBodyHandler<VaultResponse<ReadKeyData>>(new TypeReference<>() {
-        }).apply(null);
+    static Stream<Arguments> responses() {
+        return Stream.of(
+                Arguments.of(
+                        "readkey",
+                        new TypeReference<VaultResponse<ReadKeyData>>() {
+                        },
+                        """
+                                {
+                                  "data": {
+                                    "name": "foo",
+                                    "latest_version": 1
+                                  }
+                                }""",
+                        new VaultResponse<>(new ReadKeyData("foo", 1))),
+                Arguments.of(
+                        "readkey ignores unknown properties",
+                        new TypeReference<VaultResponse<ReadKeyData>>() {
+                        },
+                        """
+                                {
+                                  "unknown1" : 123,
+                                  "data": {
+                                    "name": "foo",
+                                    "latest_version": 1,
+                                    "unknown2" : 456
+                                  }
+                                }""",
+                        new VaultResponse<>(new ReadKeyData("foo", 1))),
+                Arguments.of(
+                        "decrypt",
+                        new TypeReference<VaultResponse<DecryptData>>() {
+                        },
+                        """
+                                {
+                                  "data": {
+                                    "plaintext": "foo"
+                                  }
+                                }""",
+                        new VaultResponse<>(new DecryptData("foo"))),
+                Arguments.of(
+                        "decrypt ignores unknown properties",
+                        new TypeReference<VaultResponse<DecryptData>>() {
+                        },
+                        """
+                                {
+                                  "data": {
+                                    "plaintext": "foo",
+                                    "unknown1": 123
+                                  }
+                                }""",
+                        new VaultResponse<>(new DecryptData("foo"))),
+                Arguments.of(
+                        "datakey",
+                        new TypeReference<VaultResponse<DataKeyData>>() {
+                        },
+                        """
+                                {
+                                  "data": {
+                                    "plaintext": "plain",
+                                    "ciphertext": "cipher"
+                                  }
+                                }""",
+                        new VaultResponse<>(new DataKeyData("plain", "cipher"))),
+                Arguments.of(
+                        "datakey ignores unknown properties",
+                        new TypeReference<VaultResponse<DataKeyData>>() {
+                        },
+                        """
+                                {
+                                  "data": {
+                                    "plaintext": "plain",
+                                    "ciphertext": "cipher",
+                                    "unknown1": 123
+                                  }
+                                }""",
+                        new VaultResponse<>(new DataKeyData("plain", "cipher")))
 
-        bodySubscriber.onNext(List.of(ByteBuffer.wrap(
-                """
-                        {
-                          "data": {
-                            "name": "foo",
-                            "latest_version": 1
-                          }
-                        }""".getBytes(StandardCharsets.UTF_8))));
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource(value = "responses")
+    <T> void handleResponse(String name, TypeReference<T> typeRef, String input, VaultResponse<T> expected) {
+        var bodySubscriber = new JsonBodyHandler<>(typeRef).apply(null);
+
+        bodySubscriber.onNext(List.of(ByteBuffer.wrap(input.getBytes(StandardCharsets.UTF_8))));
         bodySubscriber.onComplete();
 
         var stage = bodySubscriber.getBody();
         assertThat(stage).isCompleted();
+
         var supplier = stage.toCompletableFuture().join();
-
-        var expected = new VaultResponse<>(new ReadKeyData("foo", 1));
-
         assertThat(supplier).extracting(Supplier::get).isEqualTo(expected);
     }
 

--- a/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdekSerdeTest.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdekSerdeTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kms.provider.hashicorp.vault;
+
+import java.nio.ByteBuffer;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class VaultEdekSerdeTest {
+
+    private final VaultEdekSerde serde = new VaultEdekSerde();
+
+    @Test
+    void shouldRoundTrip() {
+        var edek = new VaultEdek("keyref", new byte[]{ 1, 2, 3 });
+        var buf = ByteBuffer.allocate(serde.sizeOf(edek));
+        serde.serialize(edek, buf);
+        buf.flip();
+        var deserialized = serde.deserialize(buf);
+        assertThat(deserialized).isEqualTo(edek);
+    }
+
+    public static Stream<Arguments> serializedBadKek() {
+        return Stream.of(
+                Arguments.of("empty", new VaultEdek("", new byte[]{ 1, 2, 3 })),
+                Arguments.of("toobig", new VaultEdek("x".repeat(256), new byte[]{ 1, 2, 3 })));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource
+    void serializedBadKek(String name, VaultEdek edek) {
+        assertThatThrownBy(() -> serde.serialize(edek, ByteBuffer.allocate(1000)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    public static Stream<Arguments> deserializeErrors() {
+        return Stream.of(
+                Arguments.of("emptykek", new byte[]{ 0 }),
+                Arguments.of("noekekbytes", new byte[]{ 3, 'A', 'B', 'C' }));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource
+    void deserializeErrors(String name, byte[] serializedBytes) {
+        assertThatThrownBy(() -> serde.deserialize(ByteBuffer.wrap(serializedBytes)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+}

--- a/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdekSerdeTest.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdekSerdeTest.java
@@ -31,7 +31,17 @@ class VaultEdekSerdeTest {
         assertThat(deserialized).isEqualTo(edek);
     }
 
-    public static Stream<Arguments> serializedBadKek() {
+    @Test
+    void sizeOf() {
+        var expectedSize = 1 /* byte to store length of kek */
+                + 6 /* utf-8 kek ref bytes */
+                + 3 /* bytes of the edek */;
+        var edek = new VaultEdek("keyref", new byte[]{ 1, 2, 3 });
+        var size = serde.sizeOf(edek);
+        assertThat(size).isEqualTo(expectedSize);
+    }
+
+    static Stream<Arguments> serializedBadKek() {
         return Stream.of(
                 Arguments.of("empty", new VaultEdek("", new byte[]{ 1, 2, 3 })),
                 Arguments.of("toobig", new VaultEdek("x".repeat(256), new byte[]{ 1, 2, 3 })));
@@ -45,7 +55,7 @@ class VaultEdekSerdeTest {
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
-    public static Stream<Arguments> deserializeErrors() {
+    static Stream<Arguments> deserializeErrors() {
         return Stream.of(
                 Arguments.of("emptykek", new byte[]{ 0 }),
                 Arguments.of("noekekbytes", new byte[]{ 3, 'A', 'B', 'C' }));

--- a/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdekSerdeTest.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdekSerdeTest.java
@@ -40,7 +40,8 @@ class VaultEdekSerdeTest {
     @ParameterizedTest(name = "{0}")
     @MethodSource
     void serializedBadKek(String name, VaultEdek edek) {
-        assertThatThrownBy(() -> serde.serialize(edek, ByteBuffer.allocate(1000)))
+        var buf = ByteBuffer.allocate(1000);
+        assertThatThrownBy(() -> serde.serialize(edek, buf))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -53,7 +54,8 @@ class VaultEdekSerdeTest {
     @ParameterizedTest(name = "{0}")
     @MethodSource
     void deserializeErrors(String name, byte[] serializedBytes) {
-        assertThatThrownBy(() -> serde.deserialize(ByteBuffer.wrap(serializedBytes)))
+        var buf = ByteBuffer.wrap(serializedBytes);
+        assertThatThrownBy(() -> serde.deserialize(buf))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdekTest.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdekTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kms.provider.hashicorp.vault;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VaultEdekTest {
+    @Test
+    void equalsAndHashCode() {
+        var edek1 = new VaultEdek("keyref", new byte[]{ (byte) 1, (byte) 2, (byte) 3 });
+        var edek2 = new VaultEdek("keyref", new byte[]{ (byte) 1, (byte) 2, (byte) 3 });
+        var keyRefDiffer = new VaultEdek("keyrefX", new byte[]{ (byte) 1, (byte) 2, (byte) 3 });
+        var edekBytesDiffer = new VaultEdek("keyref", new byte[]{ (byte) 1, (byte) 2, (byte) 4 });
+
+        assertThat(edek1)
+                .isNotEqualTo(new Object())
+                .isNotEqualTo(null);
+        assertThat(edek1).isEqualTo(edek1);
+
+        assertThat(edek1)
+                .isEqualTo(edek2)
+                .hasSameHashCodeAs(edek2);
+        assertThat(edek2).isEqualTo(edek1);
+
+        assertThat(edek1)
+                .isNotEqualTo(keyRefDiffer)
+                .doesNotHaveSameHashCodeAs(keyRefDiffer);
+
+        assertThat(edek1)
+                .isNotEqualTo(edekBytesDiffer)
+                .doesNotHaveSameHashCodeAs(edekBytesDiffer);
+    }
+
+    @Test
+    void toStringFormation() {
+        var edek = new VaultEdek("keyref", new byte[]{ (byte) 1, (byte) 2, (byte) 3 });
+        assertThat(edek).hasToString("VaultEdek{keyRef=keyref, edek=[1, 2, 3]}");
+    }
+}

--- a/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdekTest.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultEdekTest.java
@@ -19,9 +19,9 @@ class VaultEdekTest {
         var edekBytesDiffer = new VaultEdek("keyref", new byte[]{ (byte) 1, (byte) 2, (byte) 4 });
 
         assertThat(edek1)
+                .isEqualTo(edek1)
                 .isNotEqualTo(new Object())
                 .isNotEqualTo(null);
-        assertThat(edek1).isEqualTo(edek1);
 
         assertThat(edek1)
                 .isEqualTo(edek2)

--- a/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsIT.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsIT.java
@@ -178,7 +178,7 @@ class VaultKmsIT {
         try {
             var execResult = vaultContainer.execInContainer(args);
             int exitCode = execResult.getExitCode();
-            assertThat(exitCode).isEqualTo(0);
+            assertThat(exitCode).isZero();
             var response = new ObjectMapper().readValue(execResult.getStdout(), valueTypeRef);
             return response.data();
         }

--- a/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsIT.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsIT.java
@@ -136,7 +136,7 @@ class VaultKmsIT {
 
     @Test
     void decryptEdekWithUnknownKey() {
-        var secretKeyStage = service.decryptEdek(new VaultEdek("unknown", new byte[]{}));
+        var secretKeyStage = service.decryptEdek(new VaultEdek("unknown", new byte[]{ 1 }));
         assertThat(secretKeyStage)
                 .failsWithin(Duration.ofSeconds(5))
                 .withThrowableThat()

--- a/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsIT.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsIT.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
- * Integration tests for Hashicorp Vault.
+ * Integration tests for HashiCorp Vault.
  * <br/>
  * <h4>TODO</h4>
  * <ul>
@@ -42,8 +42,8 @@ class VaultKmsIT {
     private static final String VAULT_TOKEN = "token";
 
     private static final String HASHICORP_VAULT = "hashicorp/vault:1.15";
+    @SuppressWarnings("rawtypes")
     private VaultContainer vaultContainer;
-    private Config config;
     private VaultKms service;
 
     @BeforeEach
@@ -57,7 +57,7 @@ class VaultKmsIT {
                 .withInitCommand(
                         "secrets enable transit");
         vaultContainer.start();
-        config = new Config(URI.create(vaultContainer.getHttpHostAddress()), VAULT_TOKEN);
+        var config = new Config(URI.create(vaultContainer.getHttpHostAddress()), VAULT_TOKEN);
 
         service = new VaultKmsService().buildKms(config);
     }

--- a/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsIT.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsIT.java
@@ -75,8 +75,9 @@ class VaultKmsIT {
         var keyName = "mykey";
         createKek(keyName);
         var resolved = service.resolveAlias(keyName);
-        assertThat(resolved).succeedsWithin(Duration.ofSeconds(5));
-        assertThat(resolved).isCompletedWithValue(keyName);
+        assertThat(resolved)
+                .succeedsWithin(Duration.ofSeconds(5))
+                .isEqualTo(keyName);
     }
 
     @Test
@@ -99,8 +100,9 @@ class VaultKmsIT {
         var pair = pairStage.toCompletableFuture().join();
 
         var decryptedDekStage = service.decryptEdek(pair.edek());
-        assertThat(decryptedDekStage).succeedsWithin(Duration.ofSeconds(5));
-        assertThat(decryptedDekStage).isCompletedWithValue(pair.dek());
+        assertThat(decryptedDekStage)
+                .succeedsWithin(Duration.ofSeconds(5))
+                .isEqualTo(pair.dek());
     }
 
     @Test
@@ -118,8 +120,9 @@ class VaultKmsIT {
         assertThat(versionAfterRotate).isGreaterThan(originalVersion);
 
         var decryptedDekStage = service.decryptEdek(pair.edek());
-        assertThat(decryptedDekStage).succeedsWithin(Duration.ofSeconds(5));
-        assertThat(decryptedDekStage).isCompletedWithValue(pair.dek());
+        assertThat(decryptedDekStage)
+                .succeedsWithin(Duration.ofSeconds(5))
+                .isEqualTo(pair.dek());
     }
 
     @Test

--- a/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsIT.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsIT.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kms.provider.hashicorp.vault;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.vault.VaultContainer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.kroxylicious.kms.provider.hashicorp.vault.VaultKmsService.Config;
+import io.kroxylicious.kms.provider.hashicorp.vault.VaultResponse.Data;
+import io.kroxylicious.kms.service.DekPair;
+import io.kroxylicious.kms.service.UnknownKeyException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+/**
+ * Integration tests for Hashicorp Vault.
+ * <br/>
+ * <h4>TODO</h4>
+ * <ul>
+ *    <li>test condition such as wrong kek type, expired kek</li>
+ * </ul>
+ */
+class VaultKmsIT {
+
+    private static final String VAULT_TOKEN = "token";
+
+    private static final String HASHICORP_VAULT = "hashicorp/vault:1.15";
+    private VaultContainer vaultContainer;
+    private Config config;
+    private VaultKms service;
+
+    @BeforeEach
+    @SuppressWarnings("resource")
+    void beforeEach() {
+        assumeThat(DockerClientFactory.instance().isDockerAvailable()).withFailMessage("docker unavailable").isTrue();
+
+        vaultContainer = new VaultContainer<>(HASHICORP_VAULT)
+                .withVaultToken(VAULT_TOKEN)
+                .withEnv("VAULT_FORMAT", "json")
+                .withInitCommand(
+                        "secrets enable transit");
+        vaultContainer.start();
+        config = new Config(URI.create(vaultContainer.getHttpHostAddress()), VAULT_TOKEN);
+
+        service = new VaultKmsService().buildKms(config);
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (vaultContainer != null) {
+            vaultContainer.close();
+        }
+    }
+
+    @Test
+    void resolveKeyByName() {
+        var keyName = "mykey";
+        createKek(keyName);
+        var resolved = service.resolveAlias(keyName);
+        assertThat(resolved).succeedsWithin(Duration.ofSeconds(5));
+        assertThat(resolved).isCompletedWithValue(keyName);
+    }
+
+    @Test
+    void resolveWithUnknownKey() {
+        var keyName = "unknown";
+        var resolved = service.resolveAlias(keyName);
+        assertThat(resolved)
+                .failsWithin(Duration.ofSeconds(5))
+                .withThrowableThat()
+                .withCauseInstanceOf(UnknownKeyException.class);
+    }
+
+    @Test
+    void generatedEncryptedDekDecryptsBackToPlain() {
+        String key = "mykey";
+        createKek(key);
+
+        var pairStage = service.generateDekPair(key);
+        assertThat(pairStage).succeedsWithin(Duration.ofSeconds(5));
+        var pair = pairStage.toCompletableFuture().join();
+
+        var decryptedDekStage = service.decryptEdek(pair.edek());
+        assertThat(decryptedDekStage).succeedsWithin(Duration.ofSeconds(5));
+        assertThat(decryptedDekStage).isCompletedWithValue(pair.dek());
+    }
+
+    @Test
+    void decryptDekAfterRotate() {
+        var key = "mykey";
+        var data = createKek(key);
+        var originalVersion = data.getLatestVersion();
+
+        var pairStage = service.generateDekPair(key);
+        assertThat(pairStage).succeedsWithin(Duration.ofSeconds(5));
+        var pair = pairStage.toCompletableFuture().join();
+
+        var updated = rotateKek(data.getName());
+        var versionAfterRotate = updated.getLatestVersion();
+        assertThat(versionAfterRotate).isGreaterThan(originalVersion);
+
+        var decryptedDekStage = service.decryptEdek(pair.edek());
+        assertThat(decryptedDekStage).succeedsWithin(Duration.ofSeconds(5));
+        assertThat(decryptedDekStage).isCompletedWithValue(pair.dek());
+    }
+
+    @Test
+    void generatedDekPairWithUnknownKey() {
+        var pairStage = service.generateDekPair("unknown");
+        assertThat(pairStage)
+                .failsWithin(Duration.ofSeconds(5))
+                .withThrowableThat()
+                .withCauseInstanceOf(UnknownKeyException.class);
+    }
+
+    @Test
+    void decryptEdekWithUnknownKey() {
+        var secretKeyStage = service.decryptEdek(new VaultEdek("unknown", new byte[]{}));
+        assertThat(secretKeyStage)
+                .failsWithin(Duration.ofSeconds(5))
+                .withThrowableThat()
+                .withCauseInstanceOf(UnknownKeyException.class);
+    }
+
+    @Test
+    void edekSerdeRoundTrip() {
+        var key = "mykey";
+        createKek(key);
+
+        var pairStage = service.generateDekPair(key);
+        assertThat(pairStage).succeedsWithin(Duration.ofSeconds(5));
+        var pair = pairStage.toCompletableFuture().join();
+        assertThat(pair).extracting(DekPair::edek).isNotNull();
+
+        var edek = pair.edek();
+        var serde = service.edekSerde();
+        var buf = ByteBuffer.allocate(serde.sizeOf(edek));
+        serde.serialize(edek, buf);
+        buf.flip();
+        var output = serde.deserialize(buf);
+        assertThat(output).isEqualTo(edek);
+
+    }
+
+    private Data readKek(String keyId) {
+        return runVaultCommand("vault", "read", "transit/keys/%s".formatted(keyId));
+    }
+
+    private Data createKek(String keyId) {
+        return runVaultCommand("vault", "write", "-f", "transit/keys/%s".formatted(keyId));
+    }
+
+    private Data rotateKek(String keyId) {
+        return runVaultCommand("vault", "write", "-f", "transit/keys/%s/rotate".formatted(keyId));
+    }
+
+    private Data runVaultCommand(String... args) {
+        try {
+            var execResult = vaultContainer.execInContainer(args);
+            int exitCode = execResult.getExitCode();
+            assertThat(exitCode).isEqualTo(0);
+            var response = new ObjectMapper().readValue(execResult.getStdout(), VaultResponse.class);
+            return response.getData();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException("Failed to run vault command: %s".formatted(Arrays.stream(args).toList()), e);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryKms.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryKms.java
@@ -61,6 +61,7 @@ public class InMemoryKms implements
         this.numAuthBits = numAuthBits;
         try {
             this.aes = KeyGenerator.getInstance(AES_KEY_ALGO);
+            this.aes.init(256); // Required for Java 17 which defaults to a key size of 128.
         }
         catch (NoSuchAlgorithmException e) {
             // This should be impossible, because JCA guarantees that AES is available

--- a/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/UnknownKeyException.java
+++ b/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/UnknownKeyException.java
@@ -13,4 +13,8 @@ public class UnknownKeyException extends KmsException {
     public UnknownKeyException() {
         super();
     }
+
+    public UnknownKeyException(String message) {
+        super(message);
+    }
 }

--- a/kubernetes-examples/topicencryption/base/kafka-persistent.yaml
+++ b/kubernetes-examples/topicencryption/base/kafka-persistent.yaml
@@ -1,0 +1,40 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: my-cluster
+spec:
+  kafka:
+    version: 3.6.0
+    replicas: 3
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+    config:
+      offsets.topic.replication.factor: 2
+      transaction.state.log.replication.factor: 2
+      transaction.state.log.min.isr: 2
+      default.replication.factor: 2
+      min.insync.replicas: 2
+      inter.broker.protocol.version: "3.6"
+    storage:
+      type: jbod
+      volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+  zookeeper:
+    replicas: 1
+    storage:
+      type: persistent-claim
+      size: 100Gi
+      deleteClaim: false

--- a/kubernetes-examples/topicencryption/base/kroxylicious-config.yaml
+++ b/kubernetes-examples/topicencryption/base/kroxylicious-config.yaml
@@ -1,0 +1,36 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kroxylicious-config
+data:
+  config.yaml: |
+    filters:
+    - type: EnvelopeEncryption
+      config:
+        kms: VaultKmsService
+        kmsConfig:
+          vaultUrl: http://vault.vault.svc.cluster.local:8200
+          vaultToken: myroottoken
+        selector: TemplateKekSelector
+        selectorConfig:
+          template: all
+    adminHttp:
+      endpoints:
+        prometheus: {}
+    virtualClusters:
+      devenv1:
+        targetCluster:
+          bootstrap_servers: my-cluster-kafka-bootstrap:9092
+        clusterNetworkAddressConfigProvider:
+          type: PortPerBrokerClusterNetworkAddressConfigProvider
+          config:
+            bootstrapAddress: minikube:30192
+        logNetwork: false
+        logFrames: false

--- a/kubernetes-examples/topicencryption/base/kroxylicious-deployment.yaml
+++ b/kubernetes-examples/topicencryption/base/kroxylicious-deployment.yaml
@@ -1,0 +1,47 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kroxylicious-proxy
+  labels:
+    app: kroxylicious
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kroxylicious
+  template:
+    metadata:
+      labels:
+        app: kroxylicious
+    spec:
+      containers:
+      - name: kroxylicious
+        image: quay.io/kroxylicious/kroxylicious-developer:0.4.0-SNAPSHOT
+        imagePullPolicy: Always
+        args: ["--config", "/opt/kroxylicious/config/config.yaml"]
+        ports:
+        # Tenant devenv1
+        - containerPort: 30192
+        - containerPort: 30193
+        - containerPort: 30194
+        - containerPort: 30195
+        # Tenant devenv2
+        - containerPort: 30292
+        - containerPort: 30293
+        - containerPort: 30294
+        - containerPort: 30295
+        volumeMounts:
+        - name: config-volume
+          mountPath: /opt/kroxylicious/config/config.yaml
+          subPath: config.yaml
+      volumes:
+      - name: config-volume
+        configMap:
+          name: kroxylicious-config

--- a/kubernetes-examples/topicencryption/base/kroxylicious-service.yaml
+++ b/kubernetes-examples/topicencryption/base/kroxylicious-service.yaml
@@ -1,0 +1,63 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kroxylicious-service
+spec:
+  type: NodePort
+  selector:
+    app: kroxylicious
+  ports:
+  - name: port-30192
+    protocol: TCP
+    port: 30192
+    targetPort: 30192
+    nodePort: 30192
+
+  - name: port-30193
+    protocol: TCP
+    port: 30193
+    targetPort: 30193
+    nodePort: 30193
+
+  - name: port-30194
+    protocol: TCP
+    port: 30194
+    targetPort: 30194
+    nodePort: 30194
+
+  - name: port-30195
+    protocol: TCP
+    port: 30195
+    targetPort: 30195
+    nodePort: 30195
+
+  - name: port-30292
+    protocol: TCP
+    port: 30292
+    targetPort: 30292
+    nodePort: 30292
+
+  - name: port-30293
+    protocol: TCP
+    port: 30293
+    targetPort: 30293
+    nodePort: 30293
+
+  - name: port-30294
+    protocol: TCP
+    port: 30294
+    targetPort: 30294
+    nodePort: 30294
+
+  - name: port-30295
+    protocol: TCP
+    port: 30295
+    targetPort: 30295
+    nodePort: 30295

--- a/kubernetes-examples/topicencryption/base/kustomization.yaml
+++ b/kubernetes-examples/topicencryption/base/kustomization.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kafka
+
+resources:
+- kroxylicious-config.yaml
+- kroxylicious-deployment.yaml
+- kroxylicious-service.yaml
+- kafka-persistent.yaml
+

--- a/kubernetes-examples/topicencryption/overlays/minikube/kustomization.yaml
+++ b/kubernetes-examples/topicencryption/overlays/minikube/kustomization.yaml
@@ -4,5 +4,8 @@
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
-io.kroxylicious.kms.provider.kroxylicious.inmemory.UnitTestingKmsService
-io.kroxylicious.kms.provider.kroxylicious.inmemory.IntegrationTestingKmsService
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base

--- a/kubernetes-examples/topicencryption/postinstall.sh
+++ b/kubernetes-examples/topicencryption/postinstall.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+set -eo pipefail
+
+KAF=quay.io/k_wall/kaf
+BOOTSTRAP=my-cluster-kafka-bootstrap:9092
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NOCOLOR='\033[0m'
+
+MINIKUBE_IP=$(minikube ip)
+echo -e  "${YELLOW}Please add/update following link to your '/etc/hosts'.${NOCOLOR}"
+echo -e  "${YELLOW}${MINIKUBE_IP} minikube${NOCOLOR}"
+echo
+
+echo "Use the Vault UI (token myroot) to create an aes256-gcm96 key called 'all'"
+minikube service vault-host -n vault --url | head -1
+echo "or use this command:"
+echo "kubectl exec -n vault vault-0 -- vault write -f transit/keys/all"
+echo
+
+echo "Then use commands like these to explore topic-encryption."
+echo
+
+echo -e "${GREEN}Configure client ${NOCOLOR}"
+echo "kaf config add-cluster topencenv -b minikube:30192"
+echo
+
+echo -e "${GREEN}Do some work in topencenv${NOCOLOR}"
+echo "kaf config use-cluster topencenv"
+echo "kaf topic create billingapp"
+echo "echo 'hello, world' | kaf produce billingapp"
+echo "kaf consume billingapp --group billinggroup"
+echo
+
+echo -e "${GREEN}Finally let's lift the bonnet and take a look at the kafka underneath${NOCOLOR}"
+
+echo "kubectl -n kafka run consumer -ti --image=quay.io/k_wall/kaf --rm=true --restart=Never -- kaf consume billingapp --offset oldest -b ${BOOTSTRAP}"

--- a/kubernetes-examples/topicencryption/postinstall.sh
+++ b/kubernetes-examples/topicencryption/postinstall.sh
@@ -7,7 +7,7 @@
 
 set -eo pipefail
 
-KAF=quay.io/k_wall/kaf
+KAF=quay.io/kroxylicious/kaf
 BOOTSTRAP=my-cluster-kafka-bootstrap:9092
 
 GREEN='\033[0;32m'

--- a/kubernetes-examples/topicencryption/script.txt
+++ b/kubernetes-examples/topicencryption/script.txt
@@ -1,0 +1,151 @@
+====
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+====
+
+This script was used to produce https://asciinema.org/a/kEG5mTwegb8yf9efwAKKT6iRW.
+I used the "Paste Special" feature of iTerm to inject the below text into a terminal session which was being recorded
+with asciinema. The "Paste Special" chunking options were tune to give an appearance of a human typing.
+
+# This demo will look at the Kroxylicious Multi-tenant Feature. It is an incubating feature, so it is not
+# ready for production use. But please try it and send us some feedback.
+
+# let us imagine that a team needs each developer to have their own Kafka Cluster for development work.
+# the team would like to avoid the costs associated with running a cluster per developer.
+
+# we will use Strimzi to deploy a Kafka Cluster to Kubernetes, then use Kroxylicious to expose that single
+# Kafka Cluster as if it were many clusters, with each tenant isolated from one and other.
+
+# the kafka cluster and kroxylicious will be deployed to Kubernetes.
+# on the client side, kaf (https://github.com/birdayz/kaf) will be used to demonstrate the isolation. It will run
+# off-cluster. it will connect to the kroxylicious via a nodeport kubernetes service.
+
+# we'll use a script to install strimzi, create a kafka cluster, and deployment kroxylicious.
+# let's do that now
+
+QUAY_ORG=k_wall ./scripts/run-with-strimzi.sh kubernetes-examples/multitenant
+
+# let's look at what we have running in kube.  It's all in the kubernetes namespace kafka.
+
+kubectl config set-context --current --namespace=kafka
+
+# let's start with kafka cluster.  this is the cluster we'll expose using kroxylicious.
+kubectl get kafka my-cluster
+
+# notice it's got three brokers (replicas)
+
+kubectl get kafka my-cluster -o yaml
+
+# notice also the bootstrap address is my-cluster-kafka-bootstrap.kafka.svc:9092.
+# We'll see the bootstrap address wired in kroxylicious in its configuration.
+
+# Let's see the kroxylicious configuration now.
+
+ kubectl get cm kroxylicious-config -o yaml
+
+# there are a couple of important bits:
+# - the filters with the MultiTenant - this enables the MultiTenant feature
+# - the two 'virtual' cluster definitions, devenv1 and devenv2
+#   - these provide the isolated kafka cluster environment to our developers.
+#   - each virtual cluster has its own bootstrap.
+# notice that both virtual cluster point to (target) our kafka cluster.
+
+# finally there is a nodeport kubernetes service that is exposing kroxylicious to the host
+
+kubectl get service kroxylicious-service
+
+# let's connect kafka clients up to the virtual clusters and do some
+# work to illustrate that the two environments are indeed separate from one and other.
+# later, we'll take a peep directly at the kafka cluster so you'll appreciate how naming is used to
+# achieve the isolation.
+
+
+# we are going to use kaf to create a topic called billingapp, and then publish and consume a message to the topic.
+
+# let's configure kaf to know about devenv1.
+# notice we are using the bootstrap of the first virtual cluster
+
+kaf config add-cluster devenv1 -b minikube:30192
+kaf config select-cluster
+
+# look at the broker topology
+kaf nodes
+# notice these are brokers presented by the virtual cluster, not the real cluster
+
+# now let's create that topic
+kaf topic create billingapp
+
+# confirm the topic exists
+kaf topics
+
+# publish a message to it
+echo 'hello, world' | kaf produce billingapp
+
+# consume it using a group, and commit the offsets
+kaf consume billingapp --group billinggroup --commit
+
+# finally, let's show the group exists
+kaf groups
+
+# Now let's switch to devenv2 and demonstrate devenv2 is independent of devenv1
+
+kaf config add-cluster devenv2 -b minikube:30292
+kaf config select-cluster
+
+# let's look at the broker topology
+kaf nodes
+# notice these are brokers presented by the virtual cluster too, again not the real cluster.
+# notice too, the port numbers are different from those used by devenv1
+
+# let's check the topics and groups. we expect this environment to have none.
+kaf topics
+kaf groups
+
+# now let's create a billingapp topic in this environment too.  like before
+# we'll produce and consume a message to it, but we'll use a different message.
+# like before we'll use the same group name.
+
+# the resources will be independent of those in devenv1 even though they have the
+# same names.
+
+# let's create that topic
+kaf topic create billingapp
+
+# confirm the topic exists
+kaf topics
+
+# publish a message to it, with a message in spanish rather than english
+echo 'hola, mundo' | kaf produce billingapp
+
+# consume it using a group
+kaf consume billingapp --group billinggroup --commit
+
+# okay, time to look beneath the hood at the kafka cluster.  how's the multi-tenancy
+# feature actually wired things up?  Let's look at the topics and groups present on the
+# cluster itself.
+
+# the kafka cluster actually isn't available off cluster, so we'll use an ephemeral pod
+# to query it using the Apache Kafka tooling.
+
+# first the topics
+kubectl -n kafka run listtopics -ti --image=quay.io/strimzi/kafka:0.38.0-kafka-3.6.0 --rm=true --restart=Never -- bin/kafka-topics.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 --list
+# notice how the topics names are prefixed with the virtual cluster's name.
+
+# now, the groups
+kubectl -n kafka run listgroups -ti --image=quay.io/strimzi/kafka:0.38.0-kafka-3.6.0 --rm=true --restart=Never -- bin/kafka-consumer-groups.sh --bootstrap-server my-cluster-kafka-bootstrap:9092 --list
+# notice that the same prefixing has been done.
+
+# let's wrap up.
+# what have we seen?  we've seen a kafka cluster of three brokers presented to the world as if it
+# were two independent kafka clusters.  The MultiTenant filter dynamically rewrites the resource names to
+# create isolation between the tenants.  This will takes place transparently: no extra software on the client or broker
+# and no extra configuration, beyond bootstrap.
+
+# Hope you've found the demo interesting.  If you have questions get in touch via https://kroxylicious.slack.com/
+
+
+
+
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,7 @@
     <modules>
         <module>kroxylicious-kms</module>
         <module>kroxylicious-kms-provider-kroxylicious-inmemory</module>
+        <module>kroxylicious-kms-provider-hashicorp-vault</module>
         <module>kroxylicious-bom</module>
         <module>kroxylicious-api</module>
         <module>kroxylicious-app</module>

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -30,6 +30,8 @@ MINIKUBE=$(resolveCommand minikube)
 export MINIKUBE
 KUSTOMIZE=$(resolveCommand kustomize)
 export KUSTOMIZE
+HELM=$(resolveCommand helm)
+export HELM
 
 if [ "$OS" = 'Darwin' ]; then
   # for MacOS


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

* Implementation of the KMS interface for HasiCorp Vault, with support integration tests.
* `kubernetes-examples/topicencryption` ready to illustrate the topic encryption.  It deploys Hashicorp using the Helm Chart in a mode suitable for development (i.e. auto-unsealed).

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [x] Reference relevant issue(s) and close them after merging
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
