### PR TITLE
Use fabric8 client BOM for consistent dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 
         <!-- Test dependencies -->
         <strimzi.version>0.37.0</strimzi.version>
-        <fabric8.kubernetes.version>6.8.1</fabric8.kubernetes.version>
+        <kubernetes-client.version>6.9.2</kubernetes-client.version>
         <enforcer.api.version>3.4.1</enforcer.api.version>
         <maven.core.version>3.9.5</maven.core.version>
         <awaitility.version>4.2.0</awaitility.version>
@@ -241,6 +241,14 @@
 
             <!-- third party dependencies - test -->
             <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-client-bom</artifactId>
+                <version>${kubernetes-client.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+
+            <dependency>
                 <groupId>com.flipkart.zjsonpatch</groupId>
                 <artifactId>zjsonpatch</artifactId>
                 <version>${zjsonpatch.version}</version>
@@ -283,23 +291,6 @@
                 <version>${mockito.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.fabric8</groupId>
-                <artifactId>kubernetes-client-api</artifactId>
-                <version>${fabric8.kubernetes.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.fabric8</groupId>
-                <artifactId>kubernetes-client</artifactId>
-                <scope>runtime</scope>
-                <version>${fabric8.kubernetes.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.fabric8</groupId>
-                <artifactId>kubernetes-httpclient-jdk</artifactId>
-                <scope>runtime</scope>
-                <version>${fabric8.kubernetes.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.strimzi</groupId>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

Use fabric8 client BOM for consistent dependency management.  

Why: the system-test module and strimzi both have dependencies on different parts the fabric8 client project.  Unless the version number is aligned properly, there can be issues at build or runtime (such as https://github.com/fabric8io/kubernetes-client/issues/5617).    Relying on the fabric8 client BOM should impose version consistency.

_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
