### PR TITLE
Fix #753: quick profile should exclude the building integration and system tests too

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-17:1.15 AS builder
 USER root
 WORKDIR /opt/kroxylicious
 COPY . .
-RUN ./mvnw -B clean verify -Pdist,withAdditionalFilters -Dquick -am -pl !kroxylicious-integration-tests
+RUN ./mvnw -B clean verify -Pdist,withAdditionalFilters -Dquick
 USER 185
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
 
@@ -52,6 +52,4 @@ RUN set -ex; \
         chmod +x /usr/bin/tini; \
     fi
 COPY --from=builder /opt/kroxylicious/kroxylicious-app/target/kroxylicious-app-${KROXYLICIOUS_VERSION}-bin/kroxylicious-app-${KROXYLICIOUS_VERSION}/ /opt/kroxylicious/
-COPY --from=builder /opt/kroxylicious/kroxylicious-filters/kroxylicious-multitenant/target/kroxylicious-multitenant-${KROXYLICIOUS_VERSION}.jar /opt/kroxylicious/libs/
-COPY --from=builder /opt/kroxylicious/kroxylicious-filters/kroxylicious-record-validation/target/kroxylicious-record-validation-${KROXYLICIOUS_VERSION}.jar /opt/kroxylicious/libs/
 ENTRYPOINT ["/usr/bin/tini", "--", "/opt/kroxylicious/bin/kroxylicious-start.sh" ]

--- a/pom.xml
+++ b/pom.xml
@@ -342,10 +342,8 @@
         <module>kroxylicious-integration-test-support</module>
         <module>kroxylicious-filter-test-support</module>
         <module>kroxylicious-runtime</module>
-        <module>kroxylicious-integration-tests</module>
         <module>kroxylicious-filters</module>
         <module>kroxylicious-sample</module>
-        <module>kroxylicious-systemtests</module>
     </modules>
 
 
@@ -667,27 +665,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>enforce-systemtest-isolation</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <bannedDependencies>
-                                    <excludes>
-                                        <exclude>io.kroxylicious:kroxylicious-systemtests</exclude>
-                                    </excludes>
-                                </bannedDependencies>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 
@@ -820,6 +797,21 @@
                                     </rules>
                                 </configuration>
                             </execution>
+                            <execution>
+                                <id>enforce-systemtest-isolation</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <bannedDependencies>
+                                            <excludes>
+                                                <exclude>io.kroxylicious:kroxylicious-systemtests</exclude>
+                                            </excludes>
+                                        </bannedDependencies>
+                                    </rules>
+                                </configuration>
+                            </execution>
                         </executions>
                     </plugin>
                 </plugins>
@@ -909,13 +901,15 @@
             </build>
         </profile>
         <profile>
-            <id>performance</id>
+            <id>test-suites</id>
             <activation>
                 <property>
                     <name>!quick</name>
                 </property>
             </activation>
             <modules>
+                <module>kroxylicious-integration-tests</module>
+                <module>kroxylicious-systemtests</module>
                 <module>performance-tests</module>
             </modules>
         </profile>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

Quick profile should exclude the building integration and system tests too

also: repositioned 'enforce-systemtest-isolation' within the `qa` profile so that it is skipped during quick builds too.

### Additional Context

why: developer productivity


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
