### PR TITLE
Fix #752: remove redundant reinstall of tzdata from Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.4.0
 
+* [#752](https://github.com/kroxylicious/kroxylicious/issues/752): Remove redudant reinstallation of time-zone data in Dockerfile used for Kroxylicious container image
 * [#727](https://github.com/kroxylicious/kroxylicious/pull/727): Tease out simple transform filters into their own module
 * [#738](https://github.com/kroxylicious/kroxylicious/pull/738): Update to Kroxylicious Junit Ext 0.7.0
 * [#723](https://github.com/kroxylicious/kroxylicious/pull/723): Bump com.fasterxml.jackson:jackson-bom from 2.15.3 to 2.16.0 #723

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ ARG KROXYLICIOUS_VERSION
 
 RUN microdnf -y update \
     && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
-    && microdnf reinstall -y tzdata \
     && microdnf clean all
 
 ENV JAVA_HOME /usr/lib/jvm/jre-17


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Refactoring

### Description

The reinstallation of TZ data (`tzdata`) in the Kroxylicious Container image is superfluous.   There's no dependency on it.
OpenJDK depends on `tzdata-java` btw.

```shell
rpm -q --requires java-17-openjdk-headless | grep tz
tzdata-java >= 2023c
```


### Additional Context

why: it is a superfluous step that was never required for Kroxylicious (it was brought over from Strimzi).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [x] Reference relevant issue(s) and close them after merging
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
