### PR TITLE
Code generate assertJ Conditions for Kafka API keys

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="MavenProjectsManager">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,6 +5,7 @@
     <option name="originalFiles">
       <list>
         <option value="$PROJECT_DIR$/pom.xml" />
+        <option value="$PROJECT_DIR$/kroxylicious-systemtests/pom.xml" />
       </list>
     </option>
   </component>

--- a/kroxylicious-filter-test-support/pom.xml
+++ b/kroxylicious-filter-test-support/pom.xml
@@ -52,6 +52,11 @@
             <!-- dependency management sets the scope to test so we have to override it here -->
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/kroxylicious-filter-test-support/pom.xml
+++ b/kroxylicious-filter-test-support/pom.xml
@@ -46,6 +46,12 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <!-- dependency management sets the scope to test so we have to override it here -->
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -88,9 +94,24 @@
                             <outputFilePattern>${templateName}.java</outputFilePattern>
                             <outputPackage>io.kroxylicious.test.requestresponsetestdef</outputPackage>
                             <outputDirectory>${project.build.directory}/generated-sources/krpc</outputDirectory>
-                            <!--
-                            <addToProjectSourceRoots>testCompile</addToProjectSourceRoots>
-                            -->
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-conditions</id>
+                        <goals>
+                            <goal>generate-single</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <messageSpecDirectory>${project.build.directory}/message-specs/common/message
+                            </messageSpecDirectory>
+                            <messageSpecFilter>*{Request,Response}.json</messageSpecFilter>
+                            <templateDirectory>${project.basedir}/src/main/templates</templateDirectory>
+                            <templateNames>KafkaApiAssertJConditions.ftl</templateNames>
+                            <!--suppress MavenModelInspection -->
+                            <outputFilePattern>${messageSpecName}DataCondition.java</outputFilePattern>
+                            <outputPackage>io.kroxylicious.test.condition</outputPackage>
+                            <outputDirectory>${project.build.directory}/generated-sources/krpc</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>
@@ -98,4 +119,3 @@
         </plugins>
     </build>
 </project>
-

--- a/kroxylicious-filter-test-support/pom.xml
+++ b/kroxylicious-filter-test-support/pom.xml
@@ -115,7 +115,7 @@
                             <templateNames>KafkaApiAssertJConditions.ftl</templateNames>
                             <!--suppress MavenModelInspection -->
                             <outputFilePattern>${messageSpecName}DataCondition.java</outputFilePattern>
-                            <outputPackage>io.kroxylicious.test.condition</outputPackage>
+                            <outputPackage>io.kroxylicious.test.condition.kafka</outputPackage>
                             <outputDirectory>${project.build.directory}/generated-sources/krpc</outputDirectory>
                         </configuration>
                     </execution>

--- a/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/test/condition/ApiMessageCondition.java
+++ b/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/test/condition/ApiMessageCondition.java
@@ -34,7 +34,7 @@ public class ApiMessageCondition<X extends ApiMessage> extends Condition<X> {
     }
 
     public ApiMessageCondition(Predicate<X> predicate) {
-        this(predicate, new TextDescription("an Api Message matching a custom predicate" ));
+        this(predicate, new TextDescription("an Api Message matching a custom predicate"));
     }
 
     @Override

--- a/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/test/condition/ApiMessageCondition.java
+++ b/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/test/condition/ApiMessageCondition.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test.condition;
+
+import java.util.function.Predicate;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.assertj.core.api.Condition;
+
+public class ApiMessageCondition<X extends ApiMessage> extends Condition<X> {
+
+    private final Predicate<X> predicate;
+
+    public static <X extends ApiMessage> ApiMessageCondition<X> forApiKey(short expectedApiKey) {
+        return new ApiMessageCondition<>(apiMessage -> apiMessage.apiKey() == expectedApiKey);
+    }
+
+    public static <X extends ApiMessage> ApiMessageCondition<X> forApiKey(ApiKeys expectedApiKey) {
+        return new ApiMessageCondition<>(apiMessage -> ApiKeys.forId(apiMessage.apiKey()) == expectedApiKey);
+    }
+
+    public ApiMessageCondition(Predicate<X> predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public boolean matches(X apiMessage) {
+        if (apiMessage != null) {
+            return predicate.test(apiMessage);
+        }
+        else {
+            return false;
+        }
+    }
+}

--- a/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/test/condition/ApiMessageCondition.java
+++ b/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/test/condition/ApiMessageCondition.java
@@ -11,21 +11,30 @@ import java.util.function.Predicate;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.assertj.core.api.Condition;
+import org.assertj.core.description.Description;
+import org.assertj.core.description.TextDescription;
 
 public class ApiMessageCondition<X extends ApiMessage> extends Condition<X> {
 
     private final Predicate<X> predicate;
 
+    public ApiMessageCondition(Predicate<X> xPredicate, Description description) {
+        super(description);
+        this.predicate = xPredicate;
+    }
+
     public static <X extends ApiMessage> ApiMessageCondition<X> forApiKey(short expectedApiKey) {
-        return new ApiMessageCondition<>(apiMessage -> apiMessage.apiKey() == expectedApiKey);
+        return new ApiMessageCondition<>(apiMessage -> apiMessage.apiKey() == expectedApiKey,
+                new TextDescription("an ApiMessage of type %s (%d)", ApiKeys.forId(expectedApiKey), expectedApiKey));
     }
 
     public static <X extends ApiMessage> ApiMessageCondition<X> forApiKey(ApiKeys expectedApiKey) {
-        return new ApiMessageCondition<>(apiMessage -> ApiKeys.forId(apiMessage.apiKey()) == expectedApiKey);
+        return new ApiMessageCondition<>(apiMessage -> ApiKeys.forId(apiMessage.apiKey()) == expectedApiKey,
+                new TextDescription("an ApiMessage of type %s (%d)", expectedApiKey, expectedApiKey.id));
     }
 
     public ApiMessageCondition(Predicate<X> predicate) {
-        this.predicate = predicate;
+        this(predicate, new TextDescription("an Api Message matching a custom predicate" ));
     }
 
     @Override

--- a/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/test/condition/kafka/ApiMessageCondition.java
+++ b/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/test/condition/kafka/ApiMessageCondition.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-package io.kroxylicious.test.condition;
+package io.kroxylicious.test.condition.kafka;
 
 import java.util.function.Predicate;
 

--- a/kroxylicious-filter-test-support/src/main/templates/KafkaApiAssertJConditions.ftl
+++ b/kroxylicious-filter-test-support/src/main/templates/KafkaApiAssertJConditions.ftl
@@ -11,7 +11,7 @@
 dataClass="${messageSpec.dataClassName}"
 conditionClassName="${dataClass?cap_first}Condition"
 />
-<#-- there is a missmatch in pluralisation between OffsetsForLeader message spec name and the actual Request type -->
+<#-- there is a mismatch in pluralisation between OffsetsForLeader message spec name and the actual Request type -->
 <#if messageSpec.name?starts_with("OffsetForLeader")>
     <#assign requestName = messageSpec.name?replace("Offset", "Offsets") />
 <#else>

--- a/kroxylicious-filter-test-support/src/main/templates/KafkaApiAssertJConditions.ftl
+++ b/kroxylicious-filter-test-support/src/main/templates/KafkaApiAssertJConditions.ftl
@@ -1,0 +1,74 @@
+<#--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<#-- @ftlvariable name="outputPackage" type="java.lang.String" -->
+<#-- @ftlvariable name="messageSpec" type="io.kroxylicious.krpccodegen.schema.MessageSpec" -->
+<#assign
+dataClass="${messageSpec.dataClassName}"
+conditionClassName="${dataClass?cap_first}Condition"
+/>
+<#-- there is a missmatch in pluralisation between OffsetsForLeader message spec name and the actual Request type -->
+<#if messageSpec.name?starts_with("OffsetForLeader")>
+    <#assign requestName = messageSpec.name?replace("Offset", "Offsets") />
+<#else>
+    <#assign requestName = "${messageSpec.name}" />
+</#if>
+<#assign apiMessageVarName="${requestName?uncap_first}" />
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package ${outputPackage};
+
+import java.util.function.Predicate;
+
+import org.apache.kafka.common.message.${dataClass};
+<#if requestName?starts_with("FetchSnapshot")>
+<#--Suppres the import for the FetchSnapshot special snowflakes-->
+<#else>
+import org.apache.kafka.common.requests.${requestName};
+</#if>
+import org.apache.kafka.common.protocol.ApiMessage;
+
+import org.assertj.core.api.Condition;
+import org.assertj.core.description.TextDescription;
+
+public class ${conditionClassName} extends Condition<ApiMessage> {
+
+    private final Predicate<${dataClass}> predicate;
+
+    public ${conditionClassName} (Predicate<${dataClass}> predicate) {
+        super(new TextDescription("a ${requestName} matching the predicate"));
+        this.predicate=predicate;
+    }
+
+    @Override
+    public boolean matches(ApiMessage apiMessage) {
+        <#if requestName?starts_with("FetchSnapshot")>
+        if (apiMessage instanceof ${dataClass}) {
+            ${dataClass} ${apiMessageVarName} = (${dataClass}) apiMessage;
+            return predicate.test(${apiMessageVarName});
+        <#else>
+        if (apiMessage instanceof ${requestName}) {
+            ${requestName} ${apiMessageVarName} = (${requestName}) apiMessage;
+            return predicate.test(${apiMessageVarName}.data());
+        }
+        else if (apiMessage instanceof ${dataClass}) {
+            ${dataClass} ${apiMessageVarName} = (${dataClass}) apiMessage;
+            return predicate.test(${apiMessageVarName});
+        </#if>
+        }
+        else {
+            return false;
+        }
+    }
+
+    public static ${conditionClassName} ${requestName?uncap_first}Matching(Predicate<${dataClass}> predicate) {
+        return new ${conditionClassName}(predicate);
+    }
+}

--- a/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/condition/ApiMessageConditionTest.java
+++ b/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/condition/ApiMessageConditionTest.java
@@ -7,10 +7,9 @@
 package io.kroxylicious.test.condition;
 
 import org.apache.kafka.common.message.ProduceRequestData;
-import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
-import org.apache.kafka.common.requests.ProduceRequest;
+import org.assertj.core.description.Description;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -63,6 +62,18 @@ class ApiMessageConditionTest {
         assertThat(matches).isFalse();
     }
 
+    @Test
+    void shouldSupportCustomDescriptions() {
+        // Given
+        ApiMessageCondition<ProduceRequestData> apiMessageCondition = new ApiMessageCondition<>(o -> false);
+
+        // When
+        final Description description = apiMessageCondition.description();
+
+        // Then
+        assertThat(description).extracting(Description::value).asString().isNotBlank().isEqualTo("an Api Message matching a custom predicate" );
+    }
+
     @ParameterizedTest
     @EnumSource(ApiKeys.class)
     void shouldCreateConditionForApiKeyEnum(ApiKeys apiKey) {
@@ -73,7 +84,7 @@ class ApiMessageConditionTest {
         final boolean matches = apiMessageCondition.matches(produceRequestData);
 
         // Then
-        assertThat(matches).describedAs("expected %s (%s) to return %s for ProduceRequestData", apiKey,  ApiKeys.PRODUCE == apiKey).isEqualTo(ApiKeys.PRODUCE == apiKey);
+        assertThat(matches).describedAs("expected %s (%s) to return %s for ProduceRequestData", apiKey, ApiKeys.PRODUCE == apiKey).isEqualTo(ApiKeys.PRODUCE == apiKey);
     }
 
     @ParameterizedTest
@@ -86,6 +97,42 @@ class ApiMessageConditionTest {
         final boolean matches = apiMessageCondition.matches(produceRequestData);
 
         // Then
-        assertThat(matches).describedAs("expected %s (%s) to return %s for ProduceRequestData", apiKey, apiKey.id,  ApiKeys.PRODUCE == apiKey).isEqualTo(ApiKeys.PRODUCE == apiKey);
+        assertThat(matches).describedAs("expected %s (%s) to return %s for ProduceRequestData", apiKey, apiKey.id, ApiKeys.PRODUCE == apiKey)
+                .isEqualTo(ApiKeys.PRODUCE == apiKey);
     }
+
+    @ParameterizedTest
+    @EnumSource(ApiKeys.class)
+    void shouldCreateCustomDescriptionForApiKeyEnum(ApiKeys apiKey) {
+        // Given
+        ApiMessageCondition<ApiMessage> apiMessageCondition = ApiMessageCondition.forApiKey(apiKey);
+
+        // When
+        final Description description = apiMessageCondition.description();
+
+        // Then
+        assertThat(description).extracting(Description::value)
+                .asString()
+                .isNotBlank()
+                .contains(apiKey.name())
+                .contains(String.valueOf(apiKey.id));
+    }
+
+    @ParameterizedTest
+    @EnumSource(ApiKeys.class)
+    void shouldCreateCustomDescriptionForApiKeyShort(ApiKeys apiKey) {
+        // Given
+        ApiMessageCondition<ApiMessage> apiMessageCondition = ApiMessageCondition.forApiKey(apiKey.id);
+
+        // When
+        final Description description = apiMessageCondition.description();
+
+        // Then
+        assertThat(description).extracting(Description::value)
+                .asString()
+                .isNotBlank()
+                .contains(apiKey.name())
+                .contains(String.valueOf(apiKey.id));
+    }
+
 }

--- a/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/condition/ApiMessageConditionTest.java
+++ b/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/condition/ApiMessageConditionTest.java
@@ -71,7 +71,7 @@ class ApiMessageConditionTest {
         final Description description = apiMessageCondition.description();
 
         // Then
-        assertThat(description).extracting(Description::value).asString().isNotBlank().isEqualTo("an Api Message matching a custom predicate" );
+        assertThat(description).extracting(Description::value).asString().isNotBlank().isEqualTo("an Api Message matching a custom predicate");
     }
 
     @ParameterizedTest

--- a/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/condition/ApiMessageConditionTest.java
+++ b/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/condition/ApiMessageConditionTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test.condition;
+
+import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.requests.ProduceRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApiMessageConditionTest {
+
+    private ProduceRequestData produceRequestData;
+
+    @BeforeEach
+    void setUp() {
+        produceRequestData = new ProduceRequestData();
+    }
+
+    @Test
+    void shouldReturnFalseIfActualIsNull() {
+        // Given
+        ApiMessageCondition<ProduceRequestData> apiMessageCondition = new ApiMessageCondition<>(o -> true);
+
+        // When
+        final boolean matches = apiMessageCondition.matches(null);
+
+        // Then
+        assertThat(matches).isFalse();
+    }
+
+    @Test
+    void shouldReturnPredicateResultTrue() {
+        // Given
+        ApiMessageCondition<ProduceRequestData> apiMessageCondition = new ApiMessageCondition<>(o -> true);
+
+        // When
+        final boolean matches = apiMessageCondition.matches(produceRequestData);
+
+        // Then
+        assertThat(matches).isTrue();
+    }
+
+    @Test
+    void shouldReturnPredicateResultFalse() {
+        // Given
+        ApiMessageCondition<ProduceRequestData> apiMessageCondition = new ApiMessageCondition<>(o -> false);
+
+        // When
+        final boolean matches = apiMessageCondition.matches(produceRequestData);
+
+        // Then
+        assertThat(matches).isFalse();
+    }
+}

--- a/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/condition/ApiMessageConditionTest.java
+++ b/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/condition/ApiMessageConditionTest.java
@@ -7,9 +7,14 @@
 package io.kroxylicious.test.condition;
 
 import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.message.ProduceResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.requests.ProduceRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -56,5 +61,31 @@ class ApiMessageConditionTest {
 
         // Then
         assertThat(matches).isFalse();
+    }
+
+    @ParameterizedTest
+    @EnumSource(ApiKeys.class)
+    void shouldCreateConditionForApiKeyEnum(ApiKeys apiKey) {
+        // Given
+        ApiMessageCondition<ApiMessage> apiMessageCondition = ApiMessageCondition.forApiKey(apiKey);
+
+        // When
+        final boolean matches = apiMessageCondition.matches(produceRequestData);
+
+        // Then
+        assertThat(matches).describedAs("expected %s (%s) to return %s for ProduceRequestData", apiKey,  ApiKeys.PRODUCE == apiKey).isEqualTo(ApiKeys.PRODUCE == apiKey);
+    }
+
+    @ParameterizedTest
+    @EnumSource(ApiKeys.class)
+    void shouldCreateConditionForApiKeyShort(ApiKeys apiKey) {
+        // Given
+        ApiMessageCondition<ApiMessage> apiMessageCondition = ApiMessageCondition.forApiKey(apiKey.id);
+
+        // When
+        final boolean matches = apiMessageCondition.matches(produceRequestData);
+
+        // Then
+        assertThat(matches).describedAs("expected %s (%s) to return %s for ProduceRequestData", apiKey, apiKey.id,  ApiKeys.PRODUCE == apiKey).isEqualTo(ApiKeys.PRODUCE == apiKey);
     }
 }

--- a/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/condition/ApiMessageConditionTest.java
+++ b/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/condition/ApiMessageConditionTest.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
+import io.kroxylicious.test.condition.kafka.ApiMessageCondition;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ApiMessageConditionTest {

--- a/kroxylicious-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterTest.java
@@ -17,8 +17,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.kroxylicious.proxy.filter.FilterContext;
 
-import static io.kroxylicious.test.condition.ApiMessageCondition.forApiKey;
-import static io.kroxylicious.test.condition.ProduceRequestDataCondition.produceRequestMatching;
+import static io.kroxylicious.test.condition.kafka.ApiMessageCondition.forApiKey;
+import static io.kroxylicious.test.condition.kafka.ProduceRequestDataCondition.produceRequestMatching;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.assertArg;
@@ -56,7 +56,7 @@ class MultiTenantTransformationFilterTest {
                         .is(produceRequestMatching(produceRequestData -> produceRequestData.topicData()
                                 .stream()
                                 .hasSameSizeAs(request.topicData())
-                                .allMatch(topicProduceData -> topicProduceData.name().equals("vc1-testTopic")))
+                                .allMatch(topicProduceData -> topicProduceData.name().equals("vc1-testTopic" )))
                         )));
 
     }

--- a/kroxylicious-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterTest.java
@@ -55,8 +55,7 @@ class MultiTenantTransformationFilterTest {
                         .is(forApiKey(ApiKeys.PRODUCE))
                         .is(produceRequestMatching(produceRequestData -> produceRequestData.topicData()
                                 .stream()
-                                .hasSameSizeAs(request.topicData())
-                                .allMatch(topicProduceData -> topicProduceData.name().equals("vc1-testTopic" )))
+                                .allMatch(topicProduceData -> topicProduceData.name().equals("vc1-testTopic")))
                         )));
 
     }

--- a/kroxylicious-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.multitenant;
+
+import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.kroxylicious.proxy.filter.FilterContext;
+
+import static io.kroxylicious.test.condition.ApiMessageCondition.forApiKey;
+import static io.kroxylicious.test.condition.ProduceRequestDataCondition.produceRequestMatching;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.assertArg;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MultiTenantTransformationFilterTest {
+
+    private MultiTenantTransformationFilter multiTenantTransformationFilter;
+    @Mock
+    private FilterContext filterContext;
+
+    @BeforeEach
+    void setUp() {
+        multiTenantTransformationFilter = new MultiTenantTransformationFilter();
+    }
+
+    @Test
+    void shouldReWriteTopic() {
+        // Given
+        when(filterContext.getVirtualClusterName()).thenReturn("vc1");
+        final ProduceRequestData request = new ProduceRequestData();
+        final ProduceRequestData.TopicProduceData topicData = new ProduceRequestData.TopicProduceData();
+        topicData.setName("testTopic");
+        request.topicData().add(topicData);
+        // When
+        multiTenantTransformationFilter.onProduceRequest(
+                ProduceRequestData.HIGHEST_SUPPORTED_VERSION, new RequestHeaderData(), request, filterContext);
+
+        // Then
+        verify(filterContext).forwardRequest(any(RequestHeaderData.class), assertArg(
+                apiMessage -> assertThat(apiMessage)
+                        .is(forApiKey(ApiKeys.PRODUCE))
+                        .is(produceRequestMatching(produceRequestData -> produceRequestData.topicData()
+                                .stream()
+                                .allMatch(topicProduceData -> topicProduceData.name().equals("vc1-testTopic")))
+                        )));
+
+    }
+}

--- a/kroxylicious-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterTest.java
@@ -55,6 +55,7 @@ class MultiTenantTransformationFilterTest {
                         .is(forApiKey(ApiKeys.PRODUCE))
                         .is(produceRequestMatching(produceRequestData -> produceRequestData.topicData()
                                 .stream()
+                                .hasSameSizeAs(request.topicData())
                                 .allMatch(topicProduceData -> topicProduceData.name().equals("vc1-testTopic")))
                         )));
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds custom AssertJ conditions for each of the Kafka Message schemas (code generations FTW)

### Additional Context

The project makes heavy use of AssertJ to create more readable tests however AssertJ has fairly limited support for Kafka messages (understandably) so this PR is a starting point for improving that. It reduces the boiler plate code required to assert that a particular message type is involved and has the required properties. 

For me there are some large unanswered questions.

1. is `kroxylicious-filter-test-support` the right module for this to live within? Should it be its own module or even project (the dependency on the krpc-plugin gets awkward here)?
2. Is generating conditions enough? Should we actually be writing our own[Custom assertions](https://assertj.github.io/doc/#assertj-core-custom-assertions-creation)
3. How can we generate a richer interface that actually understands the messages better. So we could write 
 ```java
 
 verify(filterContext).forwardRequest(any(RequestHeaderData.class), assertArg(
                apiMessage -> assertThat(apiMessage)
                        .is(forApiKey(ApiKeys.PRODUCE))
                        .is(forTopic("vc1-testTopic));"
```

Thee answers to 2 & 3 are probably this is a good start.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
