### PR TITLE
Draft: Obtain a new KeyContext if the old one expires or is exhausted

### DIFF
--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryption.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryption.java
@@ -47,7 +47,7 @@ public class EnvelopeEncryption<K, E> implements FilterFactory<EnvelopeEncryptio
         KmsService<Object, K, E> kmsPlugin = context.pluginInstance(KmsService.class, configuration.kms());
         Kms<K, E> kms = kmsPlugin.buildKms(configuration.kmsConfig());
 
-        var keyManager = new InBandKeyManager<>(kms, BufferPool.allocating());
+        var keyManager = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000);
 
         KekSelectorService<Object, K> ksPlugin = context.pluginInstance(KekSelectorService.class, configuration.selector());
         TopicNameBasedKekSelector<K> kekSelector = ksPlugin.buildSelector(kms, configuration.selectorConfig());

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/KeyContext.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/KeyContext.java
@@ -23,10 +23,14 @@ final class KeyContext implements Destroyable {
     private final long encryptionExpiryNanos;
     private final AtomicInteger remainingEncryptions;
 
+    private final Runnable onFree;
+
     KeyContext(@NonNull ByteBuffer prefix,
                long encryptionExpiryNanos,
                int maxEncryptions,
-               @NonNull AesGcmEncryptor encryptor) {
+               @NonNull AesGcmEncryptor encryptor,
+               Runnable onFree) {
+        this.onFree = onFree;
         if (maxEncryptions <= 0) {
             throw new IllegalArgumentException();
         }
@@ -76,5 +80,9 @@ final class KeyContext implements Destroyable {
     @Override
     public void destroy() throws DestroyFailedException {
         encryptor.destroy();
+    }
+
+    public void free() {
+        onFree.run();
     }
 }

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/KeyContextAllocator.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/KeyContextAllocator.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.inband;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import javax.security.auth.DestroyFailedException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.kroxylicious.filter.encryption.EncryptionException;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+import static java.util.stream.Collectors.toSet;
+
+/**
+ * The idea is the KeyContextAllocator becomes responsible allocating a DEK to
+ * a client that wants to encrypt N records (creating a new DEK if required). The CompletionStage
+ * for a DEK is allocated while there are encryptions and time remaining. A DEK is marked as closed
+ * at allocation time if it's been exhausted or exceeds it's TTL. We use reference counting to attempt to
+ * ensure that the underlying DEK is only destroyed once all clients are finished.
+ * The allocator trusts that clients will use the DEK for the number of encryption operations requested
+ * and expects that clients will cease using the KeyContext after they call `free()` on it. Therefore,
+ * it should be safe to destroy a DEK once all clients have called free() and there are no references to the
+ * DEK.
+ * The allocator can destroy dead DEKs during allocation if there are keys with no references that
+ * have expired or cannot satisfy the number of encryptions requested. The allocator can destroy dead
+ * keys during a call to KeyContext#free() if the free results in the key having zero references.
+ */
+public class KeyContextAllocator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KeyContextAllocator.class);
+    private int dekId = 0;
+
+    private record DekContext(AtomicInteger remainingEncryptions, long expiry, AtomicInteger references, CompletionStage<KeyContext> context,
+                              AtomicBoolean closed) {
+        // this is stateful to provide the atomic operation on remainingEncryptions
+        public boolean maybeAllocate(int numEncryptions, long currentNanos) {
+            if (closed.get()) {
+                return false;
+            }
+            if (currentNanos >= expiry) {
+                return false;
+            }
+            int beforeSubtraction = remainingEncryptions.getAndAdd(-numEncryptions);
+            if (beforeSubtraction == numEncryptions) {
+                // after subtraction there will be 0 available encryptions, so we can close it now
+                closed.set(true);
+            }
+            boolean isAllocated = beforeSubtraction >= numEncryptions;
+            if (isAllocated) {
+                allocate();
+            }
+            return isAllocated;
+        }
+
+        public boolean isDead() {
+            return closed.get() && references.get() <= 0;
+        }
+
+        public void destroy() {
+            context.thenAccept(keyContext -> {
+                try {
+                    keyContext.destroy();
+                }
+                catch (DestroyFailedException e) {
+                    // todo add back in the logic to reduce this expected error logging
+                    LOGGER.warn("Failed to destroy a KeyContext. "
+                            + "This event can happen because the JRE's SecretKeySpec class does not override destroy().", e);
+                }
+            });
+        }
+
+        public void allocate() {
+            this.references.incrementAndGet();
+        }
+
+        public void deallocate() {
+            this.references.decrementAndGet();
+        }
+    }
+
+    private final Map<Integer, DekContext> idToDekContext = new HashMap<>();
+    private final Function<Runnable, CompletionStage<KeyContext>> keyContextFunction;
+    private final int maxEncryptionsPerDek;
+    private final long dekTtlNanos;
+
+    public KeyContextAllocator(Function<Runnable, CompletionStage<KeyContext>> keyContextFunction, int maxEncryptionsPerDek, long dekTtlNanos) {
+        this.keyContextFunction = keyContextFunction;
+        this.maxEncryptionsPerDek = maxEncryptionsPerDek;
+        this.dekTtlNanos = dekTtlNanos;
+    }
+
+    // synchronized to get this working, could come up with something fancier. maybe it's not a big concern as on the hot path the work should mostly
+    // be on the single netty eventloop for the channel.
+    synchronized CompletionStage<KeyContext> allocate(int numEncryptions) {
+        if (numEncryptions > maxEncryptionsPerDek) {
+            throw new EncryptionException("cannot encrypt a batch larger than " + maxEncryptionsPerDek + " requested : " + numEncryptions);
+        }
+        if (numEncryptions < 0) {
+            throw new EncryptionException("cannot encrypt a negative number of records");
+        }
+        DekContext allocated = maybeAllocateExistingDek(numEncryptions);
+        if (allocated == null) {
+            allocated = createAndAllocateNewDek(numEncryptions);
+        }
+        cleanupDeadDeks();
+        return allocated.context;
+    }
+
+    private DekContext createAndAllocateNewDek(int numEncryptions) {
+        int id = dekId++;
+        CompletionStage<KeyContext> contextFuture = keyContextFunction.apply(() -> {
+            this.free(id);
+        });
+        int remainingEncryptions = maxEncryptionsPerDek - numEncryptions;
+        DekContext context = new DekContext(new AtomicInteger(remainingEncryptions), System.nanoTime() + dekTtlNanos, new AtomicInteger(0),
+                contextFuture, new AtomicBoolean(remainingEncryptions == 0));
+        context.allocate();
+        idToDekContext.put(id, context);
+        return context;
+    }
+
+    @Nullable
+    private DekContext maybeAllocateExistingDek(int numEncryptions) {
+        for (DekContext context : idToDekContext.values()) {
+            if (context.maybeAllocate(numEncryptions, System.nanoTime())) {
+                return context;
+            }
+            else {
+                // we mark exhausted/timed-out contexts so that they can be cleaned later. this is because they may still be in use for encryption
+                context.closed.set(true);
+            }
+        }
+        return null;
+    }
+
+    private synchronized void cleanupDeadDeks() {
+        Set<Map.Entry<Integer, DekContext>> dead = idToDekContext.entrySet().stream().filter(e -> e.getValue().isDead()).collect(toSet());
+        for (Map.Entry<Integer, DekContext> contextEntry : dead) {
+            contextEntry.getValue().destroy();
+            idToDekContext.remove(contextEntry.getKey());
+        }
+    }
+
+    private void free(int id) {
+        DekContext dekContext = idToDekContext.get(id);
+        dekContext.deallocate();
+        if (dekContext.isDead()) {
+            cleanupDeadDeks();
+        }
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/InBandKeyManagerTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/InBandKeyManagerTest.java
@@ -8,16 +8,13 @@ package io.kroxylicious.filter.encryption.inband;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import javax.security.auth.DestroyFailedException;
-import javax.security.auth.Destroyable;
 
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
@@ -31,9 +28,10 @@ import io.kroxylicious.kms.provider.kroxylicious.inmemory.UnitTestingKmsService;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class InBandKeyManagerTest {
 
@@ -74,24 +72,10 @@ class InBandKeyManagerTest {
     }
 
     @Test
-    void testDestroy() {
-        AtomicBoolean called = new AtomicBoolean();
-        InBandKeyManager.destroy(new Destroyable() {
-            @Override
-            public void destroy() throws DestroyFailedException {
-                called.set(true);
-                throw new DestroyFailedException("Eeek!");
-            }
-        });
-
-        assertTrue(called.get());
-    }
-
-    @Test
     void shouldEncryptRecordValue() {
         var kmsService = UnitTestingKmsService.newInstance();
         InMemoryKms kms = kmsService.buildKms(new UnitTestingKmsService.Config());
-        var km = new InBandKeyManager<>(kms, BufferPool.allocating());
+        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000);
 
         var kekId = kms.generateKey();
 
@@ -125,7 +109,7 @@ class InBandKeyManagerTest {
     void shouldEncryptRecordValueForMultipleRecords() throws ExecutionException, InterruptedException, TimeoutException {
         var kmsService = UnitTestingKmsService.newInstance();
         InMemoryKms kms = kmsService.buildKms(new UnitTestingKmsService.Config());
-        var km = new InBandKeyManager<>(kms, BufferPool.allocating());
+        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000);
 
         var kekId = kms.generateKey();
 
@@ -154,6 +138,131 @@ class InBandKeyManagerTest {
         assertEquals(initial, decrypted);
     }
 
+    @Test
+    void shouldGenerateNewDekIfOldDekHasNoRemainingEncryptions() throws ExecutionException, InterruptedException, TimeoutException {
+        var kmsService = UnitTestingKmsService.newInstance();
+        InMemoryKms kms = kmsService.buildKms(new UnitTestingKmsService.Config());
+        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 2);
+
+        var kekId = kms.generateKey();
+
+        var value = ByteBuffer.wrap(new byte[]{ 1, 2, 3 });
+        TestingRecord record = new TestingRecord(value);
+
+        var value2 = ByteBuffer.wrap(new byte[]{ 3, 4, 5 });
+        TestingRecord record2 = new TestingRecord(value2);
+
+        List<TestingRecord> encrypted = new ArrayList<>();
+        List<TestingRecord> initial = List.of(record, record2);
+        km.encrypt(new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
+                initial,
+                recordReceivedRecord(encrypted)).toCompletableFuture().get(10, TimeUnit.SECONDS);
+        record.value().rewind();
+        record2.value().rewind();
+
+        // at this point we have encrypted 2 records with the manager set to maximum 2 encryptions per dek
+
+        km.encrypt(new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
+                initial,
+                recordReceivedRecord(encrypted)).toCompletableFuture().get(10, TimeUnit.SECONDS);
+
+        record.value().rewind();
+        record2.value().rewind();
+        List<byte[]> deks = encrypted.stream()
+                .map(testingRecord -> Arrays.stream(testingRecord.headers()).filter(header -> header.key().equals("kroxylicious.io/dek")).findFirst().orElseThrow()
+                        .value())
+                .toList();
+        assertEquals(4, encrypted.size());
+        assertEquals(4, deks.size());
+        assertArrayEquals(deks.get(0), deks.get(1));
+        assertArrayEquals(deks.get(2), deks.get(3));
+        assertFalse(Arrays.equals(deks.get(0), deks.get(2)));
+        assertFalse(Arrays.equals(deks.get(0), deks.get(3)));
+    }
+
+    @Test
+    void shouldGenerateNewDekIfOldOneHasSomeRemainingEncryptionsButNotEnoughForWholeBatch() throws ExecutionException, InterruptedException, TimeoutException {
+        var kmsService = UnitTestingKmsService.newInstance();
+        InMemoryKms kms = kmsService.buildKms(new UnitTestingKmsService.Config());
+        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 3);
+
+        var kekId = kms.generateKey();
+
+        var value = ByteBuffer.wrap(new byte[]{ 1, 2, 3 });
+        TestingRecord record = new TestingRecord(value);
+
+        var value2 = ByteBuffer.wrap(new byte[]{ 3, 4, 5 });
+        TestingRecord record2 = new TestingRecord(value2);
+
+        List<TestingRecord> encrypted = new ArrayList<>();
+        List<TestingRecord> initial = List.of(record, record2);
+        km.encrypt(new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
+                initial,
+                recordReceivedRecord(encrypted)).toCompletableFuture().get(10, TimeUnit.SECONDS);
+        record.value().rewind();
+        record2.value().rewind();
+
+        // at this point we have encrypted 2 records with the manager set to maximum 3 encryptions per dek, so we need a new dek to encrypt 2 more records
+
+        km.encrypt(new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
+                initial,
+                recordReceivedRecord(encrypted)).toCompletableFuture().get(10, TimeUnit.SECONDS);
+
+        record.value().rewind();
+        record2.value().rewind();
+        List<byte[]> deks = encrypted.stream()
+                .map(testingRecord -> Arrays.stream(testingRecord.headers()).filter(header -> header.key().equals("kroxylicious.io/dek")).findFirst().orElseThrow()
+                        .value())
+                .toList();
+        assertEquals(4, encrypted.size());
+        assertEquals(4, deks.size());
+        assertArrayEquals(deks.get(0), deks.get(1));
+        assertArrayEquals(deks.get(2), deks.get(3));
+        assertFalse(Arrays.equals(deks.get(0), deks.get(2)));
+        assertFalse(Arrays.equals(deks.get(0), deks.get(3)));
+    }
+
+    @Test
+    void shouldUseSameDekForMultipleBatches() throws ExecutionException, InterruptedException, TimeoutException {
+        var kmsService = UnitTestingKmsService.newInstance();
+        InMemoryKms kms = kmsService.buildKms(new UnitTestingKmsService.Config());
+        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 4);
+
+        var kekId = kms.generateKey();
+
+        var value = ByteBuffer.wrap(new byte[]{ 1, 2, 3 });
+        TestingRecord record = new TestingRecord(value);
+
+        var value2 = ByteBuffer.wrap(new byte[]{ 3, 4, 5 });
+        TestingRecord record2 = new TestingRecord(value2);
+
+        List<TestingRecord> encrypted = new ArrayList<>();
+        List<TestingRecord> initial = List.of(record, record2);
+        km.encrypt(new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
+                initial,
+                recordReceivedRecord(encrypted)).toCompletableFuture().get(10, TimeUnit.SECONDS);
+        record.value().rewind();
+        record2.value().rewind();
+
+        // at this point we have encrypted 2 records with the manager set to maximum 4 encryptions per dek, so we do not need a new dek to encrypt 2 more records
+
+        km.encrypt(new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)),
+                initial,
+                recordReceivedRecord(encrypted)).toCompletableFuture().get(10, TimeUnit.SECONDS);
+
+        record.value().rewind();
+        record2.value().rewind();
+        List<byte[]> deks = encrypted.stream()
+                .map(testingRecord -> Arrays.stream(testingRecord.headers()).filter(header -> header.key().equals("kroxylicious.io/dek")).findFirst().orElseThrow()
+                        .value())
+                .toList();
+        assertEquals(4, encrypted.size());
+        assertEquals(4, deks.size());
+        assertArrayEquals(deks.get(0), deks.get(1));
+        assertArrayEquals(deks.get(0), deks.get(2));
+        assertArrayEquals(deks.get(0), deks.get(3));
+    }
+
     @NonNull
     private static ByteBuffer copyBytes(ByteBuffer v) {
         byte[] bytes = new byte[v.remaining()];
@@ -166,7 +275,7 @@ class InBandKeyManagerTest {
     void shouldEncryptRecordHeaders() {
         var kmsService = UnitTestingKmsService.newInstance();
         InMemoryKms kms = kmsService.buildKms(new UnitTestingKmsService.Config());
-        var km = new InBandKeyManager<>(kms, BufferPool.allocating());
+        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000);
 
         var kekId = kms.generateKey();
 
@@ -194,7 +303,7 @@ class InBandKeyManagerTest {
     void shouldEncryptRecordHeadersForMultipleRecords() throws ExecutionException, InterruptedException, TimeoutException {
         var kmsService = UnitTestingKmsService.newInstance();
         InMemoryKms kms = kmsService.buildKms(new UnitTestingKmsService.Config());
-        var km = new InBandKeyManager<>(kms, BufferPool.allocating());
+        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000);
 
         var kekId = kms.generateKey();
 

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/KeyContextTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/KeyContextTest.java
@@ -27,8 +27,10 @@ class KeyContextTest {
 
     @Test
     void shouldRejectInvalidNumberOfEncryptions() {
-        assertThrows(IllegalArgumentException.class, () -> new KeyContext(null, 101011, 0, null));
-        assertThrows(IllegalArgumentException.class, () -> new KeyContext(null, 101011, -1, null));
+        assertThrows(IllegalArgumentException.class, () -> new KeyContext(null, 101011, 0, null, () -> {
+        }));
+        assertThrows(IllegalArgumentException.class, () -> new KeyContext(null, 101011, -1, null, () -> {
+        }));
     }
 
     @Test
@@ -38,7 +40,8 @@ class KeyContextTest {
         var pair = kms.generateDekPair(kek).get();
         ByteBuffer prefix = ByteBuffer.wrap(new byte[]{ 1, 2, 3 });
         var context = new KeyContext(prefix, 101011, 2,
-                AesGcmEncryptor.forEncrypt(new AesGcmIvGenerator(new SecureRandom()), pair.dek()));
+                AesGcmEncryptor.forEncrypt(new AesGcmIvGenerator(new SecureRandom()), pair.dek()), () -> {
+                });
 
         assertThrows(IllegalArgumentException.class, () -> context.hasAtLeastRemainingEncryptions(0));
         assertThrows(IllegalArgumentException.class, () -> context.hasAtLeastRemainingEncryptions(-1));
@@ -51,7 +54,8 @@ class KeyContextTest {
         var pair = kms.generateDekPair(kek).get();
         ByteBuffer prefix = ByteBuffer.wrap(new byte[]{ 1, 2, 3 });
         var context = new KeyContext(prefix, 101011, 2,
-                AesGcmEncryptor.forEncrypt(new AesGcmIvGenerator(new SecureRandom()), pair.dek()));
+                AesGcmEncryptor.forEncrypt(new AesGcmIvGenerator(new SecureRandom()), pair.dek()), () -> {
+                });
 
         assertTrue(context.hasAtLeastRemainingEncryptions(1));
 


### PR DESCRIPTION
We need to obtain and use a new DEK when the old one expires or has been exhausted (a DEK can only be used to encrypt some limited number of records).

Currently there is no code to do the refresh and it's tricky to orchestrate the logic using just the existing ConcurrentHashMap.

This is because we want KeyContexts to be destroyed when they are exhausted and all clients have finished using them for encryption. Currently we don't really know if encryption has finished so this PR introduces reference counting to track if anything is still using a context. DEKs are only destroyed when:

1. We are trying to allocate an existing DEK and it is timed out or exhausted AND it has zero references (no client is still using it for encryption)
2. If the DEK was found to be timed out/exhausted on a previous allocation attempt but there were still references, we can destroy it on the last `free()` call.