### PR TITLE
Make KMS responsible for encoding immutable kek id into edek

### DIFF
--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryEdek.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryEdek.java
@@ -8,11 +8,13 @@ package io.kroxylicious.kms.provider.kroxylicious.inmemory;
 
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.UUID;
 
 record InMemoryEdek(
                     int numAuthBits,
                     byte[] iv,
-                    byte[] edek) {
+                    byte[] edek,
+                    UUID kekRef) {
 
     InMemoryEdek {
         if (numAuthBits != 128

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryEdek.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryEdek.java
@@ -13,8 +13,8 @@ import java.util.UUID;
 record InMemoryEdek(
                     int numAuthBits,
                     byte[] iv,
-                    byte[] edek,
-                    UUID kekRef) {
+                    UUID kekRef,
+                    byte[] edek) {
 
     InMemoryEdek {
         if (numAuthBits != 128

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryEdekSerde.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryEdekSerde.java
@@ -15,7 +15,15 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 class InMemoryEdekSerde implements Serde<InMemoryEdek> {
 
-    UUIDSerde uuidSerde = new UUIDSerde();
+    private static final InMemoryEdekSerde INSTANCE = new InMemoryEdekSerde();
+    private final Serde<UUID> uuidSerde = UUIDSerde.instance();
+
+    private InMemoryEdekSerde() {
+    }
+
+    public static Serde<InMemoryEdek> instance() {
+        return INSTANCE;
+    }
 
     @Override
     public InMemoryEdek deserialize(@NonNull ByteBuffer buffer) {

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryEdekSerde.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryEdekSerde.java
@@ -35,7 +35,7 @@ class InMemoryEdekSerde implements Serde<InMemoryEdek> {
         int edekLength = buffer.limit() - buffer.position();
         var edek = new byte[edekLength];
         buffer.get(edek);
-        return new InMemoryEdek(numAuthBits, iv, edek, keyRef);
+        return new InMemoryEdek(numAuthBits, iv, keyRef, edek);
     }
 
     @Override

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryKms.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryKms.java
@@ -206,6 +206,6 @@ public class InMemoryKms implements
     @NonNull
     @Override
     public Serde<InMemoryEdek> edekSerde() {
-        return new InMemoryEdekSerde();
+        return InMemoryEdekSerde.instance();
     }
 }

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryKms.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryKms.java
@@ -112,7 +112,7 @@ public class InMemoryKms implements
         catch (IllegalBlockSizeException | InvalidKeyException e) {
             throw new KmsException(e);
         }
-        return new InMemoryEdek(spec.getTLen(), spec.getIV(), edek, kekRef);
+        return new InMemoryEdek(spec.getTLen(), spec.getIV(), kekRef, edek);
     }
 
     @NonNull

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryKms.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryKms.java
@@ -112,7 +112,7 @@ public class InMemoryKms implements
         catch (IllegalBlockSizeException | InvalidKeyException e) {
             throw new KmsException(e);
         }
-        return new InMemoryEdek(spec.getTLen(), spec.getIV(), edek);
+        return new InMemoryEdek(spec.getTLen(), spec.getIV(), edek, kekRef);
     }
 
     @NonNull
@@ -152,9 +152,9 @@ public class InMemoryKms implements
 
     @NonNull
     @Override
-    public CompletableFuture<SecretKey> decryptEdek(@NonNull UUID kekRef, @NonNull InMemoryEdek edek) {
+    public CompletableFuture<SecretKey> decryptEdek(@NonNull InMemoryEdek edek) {
         try {
-            var kek = lookupKey(kekRef);
+            var kek = lookupKey(edek.kekRef());
             Cipher aesCipher = aesGcm();
             initializeforUnwrap(aesCipher, edek, kek);
             SecretKey key = unwrap(edek, aesCipher);
@@ -191,12 +191,6 @@ public class InMemoryKms implements
         catch (GeneralSecurityException e) {
             throw new KmsException(e);
         }
-    }
-
-    @NonNull
-    @Override
-    public Serde<UUID> keyIdSerde() {
-        return new UUIDSerde();
     }
 
     @NonNull

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/UUIDSerde.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/UUIDSerde.java
@@ -15,6 +15,9 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 class UUIDSerde implements Serde<UUID> {
 
+    private UUIDSerde() {
+    }
+
     @Override
     public UUID deserialize(@NonNull ByteBuffer buffer) {
         var msb = buffer.getLong();
@@ -31,5 +34,11 @@ class UUIDSerde implements Serde<UUID> {
     public void serialize(UUID uuid, @NonNull ByteBuffer buffer) {
         buffer.putLong(uuid.getMostSignificantBits());
         buffer.putLong(uuid.getLeastSignificantBits());
+    }
+
+    private static final UUIDSerde UUID_SERDE = new UUIDSerde();
+
+    public static Serde<UUID> instance() {
+        return UUID_SERDE;
     }
 }

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/UUIDSerde.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/UUIDSerde.java
@@ -15,6 +15,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 class UUIDSerde implements Serde<UUID> {
 
+    private static final UUIDSerde UUID_SERDE = new UUIDSerde();
+
     private UUIDSerde() {
     }
 
@@ -35,8 +37,6 @@ class UUIDSerde implements Serde<UUID> {
         buffer.putLong(uuid.getMostSignificantBits());
         buffer.putLong(uuid.getLeastSignificantBits());
     }
-
-    private static final UUIDSerde UUID_SERDE = new UUIDSerde();
 
     public static Serde<UUID> instance() {
         return UUID_SERDE;

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryEdekSerdeTest.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryEdekSerdeTest.java
@@ -9,6 +9,8 @@ package io.kroxylicious.kms.provider.kroxylicious.inmemory;
 import java.nio.ByteBuffer;
 import java.util.UUID;
 
+import io.kroxylicious.kms.service.Serde;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -20,7 +22,7 @@ class InMemoryEdekSerdeTest {
     void shouldRoundTripAllAllowedAuthBits() {
         for (int bits : new int[]{ 128, 120, 112, 104, 96 }) {
             var edek = new InMemoryEdek(bits, new byte[0], new byte[0], UUID.randomUUID());
-            InMemoryEdekSerde serde = new InMemoryEdekSerde();
+            Serde<InMemoryEdek> serde = InMemoryEdekSerde.instance();
             int size = serde.sizeOf(edek);
             var buffer = ByteBuffer.allocate(size);
             serde.serialize(edek, buffer);

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryEdekSerdeTest.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryEdekSerdeTest.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.kms.provider.kroxylicious.inmemory;
 
 import java.nio.ByteBuffer;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 
@@ -18,7 +19,7 @@ class InMemoryEdekSerdeTest {
     @Test
     void shouldRoundTripAllAllowedAuthBits() {
         for (int bits : new int[]{ 128, 120, 112, 104, 96 }) {
-            var edek = new InMemoryEdek(bits, new byte[0], new byte[0]);
+            var edek = new InMemoryEdek(bits, new byte[0], new byte[0], UUID.randomUUID());
             InMemoryEdekSerde serde = new InMemoryEdekSerde();
             int size = serde.sizeOf(edek);
             var buffer = ByteBuffer.allocate(size);

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryEdekSerdeTest.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryEdekSerdeTest.java
@@ -9,9 +9,9 @@ package io.kroxylicious.kms.provider.kroxylicious.inmemory;
 import java.nio.ByteBuffer;
 import java.util.UUID;
 
-import io.kroxylicious.kms.service.Serde;
-
 import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.kms.service.Serde;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -21,7 +21,7 @@ class InMemoryEdekSerdeTest {
     @Test
     void shouldRoundTripAllAllowedAuthBits() {
         for (int bits : new int[]{ 128, 120, 112, 104, 96 }) {
-            var edek = new InMemoryEdek(bits, new byte[0], new byte[0], UUID.randomUUID());
+            var edek = new InMemoryEdek(bits, new byte[0], UUID.randomUUID(), new byte[0]);
             Serde<InMemoryEdek> serde = InMemoryEdekSerde.instance();
             int size = serde.sizeOf(edek);
             var buffer = ByteBuffer.allocate(size);

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryEdekTest.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryEdekTest.java
@@ -15,18 +15,18 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 class InMemoryEdekTest {
 
-    public static final UUID KEK_REF = UUID.randomUUID();
+    private static final UUID KEK_REF = UUID.randomUUID();
 
     @Test
     void testEqualsAndHashCode() {
         var edek1 = new InMemoryEdek(96, new byte[]{ (byte) 1, (byte) 2, (byte) 3 },
-                new byte[]{ (byte) 4, (byte) 5, (byte) 6 }, KEK_REF);
+                KEK_REF, new byte[]{ (byte) 4, (byte) 5, (byte) 6 });
 
         var edek2 = new InMemoryEdek(96, new byte[]{ (byte) 1, (byte) 2, (byte) 3 },
-                new byte[]{ (byte) 4, (byte) 5, (byte) 6 }, KEK_REF);
+                KEK_REF, new byte[]{ (byte) 4, (byte) 5, (byte) 6 });
 
         var edek3 = new InMemoryEdek(96, new byte[]{ (byte) 4, (byte) 5, (byte) 6 },
-                new byte[]{ (byte) 1, (byte) 2, (byte) 3 }, KEK_REF);
+                KEK_REF, new byte[]{ (byte) 1, (byte) 2, (byte) 3 });
 
         assertEquals(edek1, edek1);
         assertEquals(edek1, edek2);
@@ -46,7 +46,7 @@ class InMemoryEdekTest {
     @Test
     void testToString() {
         var edek1 = new InMemoryEdek(96, new byte[]{ (byte) 1, (byte) 2, (byte) 3 },
-                new byte[]{ (byte) 4, (byte) 5, (byte) 6 }, KEK_REF);
+                KEK_REF, new byte[]{ (byte) 4, (byte) 5, (byte) 6 });
         assertEquals("InMemoryEdek{numAuthBits=96, iv=[1, 2, 3], edek=[4, 5, 6]}", edek1.toString());
 
     }

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryEdekTest.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryEdekTest.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.kms.provider.kroxylicious.inmemory;
 
+import java.util.UUID;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -13,16 +15,18 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 class InMemoryEdekTest {
 
+    public static final UUID KEK_REF = UUID.randomUUID();
+
     @Test
     void testEqualsAndHashCode() {
         var edek1 = new InMemoryEdek(96, new byte[]{ (byte) 1, (byte) 2, (byte) 3 },
-                new byte[]{ (byte) 4, (byte) 5, (byte) 6 });
+                new byte[]{ (byte) 4, (byte) 5, (byte) 6 }, KEK_REF);
 
         var edek2 = new InMemoryEdek(96, new byte[]{ (byte) 1, (byte) 2, (byte) 3 },
-                new byte[]{ (byte) 4, (byte) 5, (byte) 6 });
+                new byte[]{ (byte) 4, (byte) 5, (byte) 6 }, KEK_REF);
 
         var edek3 = new InMemoryEdek(96, new byte[]{ (byte) 4, (byte) 5, (byte) 6 },
-                new byte[]{ (byte) 1, (byte) 2, (byte) 3 });
+                new byte[]{ (byte) 1, (byte) 2, (byte) 3 }, KEK_REF);
 
         assertEquals(edek1, edek1);
         assertEquals(edek1, edek2);
@@ -42,7 +46,7 @@ class InMemoryEdekTest {
     @Test
     void testToString() {
         var edek1 = new InMemoryEdek(96, new byte[]{ (byte) 1, (byte) 2, (byte) 3 },
-                new byte[]{ (byte) 4, (byte) 5, (byte) 6 });
+                new byte[]{ (byte) 4, (byte) 5, (byte) 6 }, KEK_REF);
         assertEquals("InMemoryEdek{numAuthBits=96, iv=[1, 2, 3], edek=[4, 5, 6]}", edek1.toString());
 
     }

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/IntegrationTestingKmsServiceTest.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/IntegrationTestingKmsServiceTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.kms.service.DekPair;
-import io.kroxylicious.kms.service.Serde;
 import io.kroxylicious.kms.service.UnknownAliasException;
 import io.kroxylicious.kms.service.UnknownKeyException;
 
@@ -61,27 +60,6 @@ class IntegrationTestingKmsServiceTest {
         // then
         assertEquals(kek, theSameKms.resolveAlias("myAlias").join());
 
-        IntegrationTestingKmsService.delete(kmsId);
-    }
-
-    @Test
-    void shouldSerializeAndDeserialiseKeks() {
-        // given
-        var kmsId = UUID.randomUUID().toString();
-        var kms = service.buildKms(new IntegrationTestingKmsService.Config(kmsId));
-        var kek = kms.generateKey();
-        assertNotNull(kek);
-
-        // when
-        Serde<UUID> keyIdSerde = kms.keyIdSerde();
-        var buffer = ByteBuffer.allocate(keyIdSerde.sizeOf(kek));
-        keyIdSerde.serialize(kek, buffer);
-        assertFalse(buffer.hasRemaining());
-        buffer.flip();
-        var loadedKek = keyIdSerde.deserialize(buffer);
-
-        // then
-        assertEquals(kek, loadedKek, "Expect the deserialized kek to be equal to the original kek");
         IntegrationTestingKmsService.delete(kmsId);
     }
 
@@ -153,7 +131,7 @@ class IntegrationTestingKmsServiceTest {
         assertNotNull(pair.dek());
 
         // when
-        var decryptedDek = kms.decryptEdek(kek, pair.edek()).join();
+        var decryptedDek = kms.decryptEdek(pair.edek()).join();
 
         // then
         assertEquals(pair.dek(), decryptedDek, "Expect the decrypted DEK to equal the originally generated DEK");

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/UnitTestingKmsServiceTest.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/UnitTestingKmsServiceTest.java
@@ -8,7 +8,6 @@ package io.kroxylicious.kms.provider.kroxylicious.inmemory;
 
 import java.nio.ByteBuffer;
 import java.time.Duration;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -16,7 +15,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.kms.service.DekPair;
-import io.kroxylicious.kms.service.Serde;
 import io.kroxylicious.kms.service.UnknownAliasException;
 import io.kroxylicious.kms.service.UnknownKeyException;
 
@@ -44,25 +42,6 @@ class UnitTestingKmsServiceTest {
     @Test
     void shouldRejectOutOfBoundAuthBits() {
         assertThrows(IllegalArgumentException.class, () -> new UnitTestingKmsService.Config(12, 0));
-    }
-
-    @Test
-    void shouldSerializeAndDeserialiseKeks() {
-        // given
-        var kms = service.buildKms(new UnitTestingKmsService.Config());
-        var kek = kms.generateKey();
-        assertNotNull(kek);
-
-        // when
-        Serde<UUID> keyIdSerde = kms.keyIdSerde();
-        var buffer = ByteBuffer.allocate(keyIdSerde.sizeOf(kek));
-        keyIdSerde.serialize(kek, buffer);
-        assertFalse(buffer.hasRemaining());
-        buffer.flip();
-        var loadedKek = keyIdSerde.deserialize(buffer);
-
-        // then
-        assertEquals(kek, loadedKek, "Expect the deserialized kek to be equal to the original kek");
     }
 
     @Test
@@ -122,7 +101,7 @@ class UnitTestingKmsServiceTest {
         assertNotNull(pair.dek());
 
         // when
-        var decryptedDek = kms.decryptEdek(kek, pair.edek()).join();
+        var decryptedDek = kms.decryptEdek(pair.edek()).join();
 
         // then
         assertEquals(pair.dek(), decryptedDek, "Expect the decrypted DEK to equal the originally generated DEK");

--- a/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/Kms.java
+++ b/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/Kms.java
@@ -23,7 +23,7 @@ public interface Kms<K, E> {
      * Asynchronously generates a new Data Encryption Key (DEK) and returns it together with the same DEK wrapped by the Key Encryption Key (KEK) given
      * by the {@code kekRef},
      * The returned encrypted DEK can later be decrypted with {@link #decryptEdek(Object)}. It is expected that
-     * the returned EDEK contains everything required for decryption including an immutable referenced to the KEK
+     * the returned EDEK contains everything required for decryption including an immutable reference to the KEK
      * @param kekRef The key encryption key used to encrypt the generated data encryption key.
      * @return A completion stage for the wrapped data encryption key.
      * @throws UnknownKeyException If the kek was not known to this KMS.

--- a/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/Kms.java
+++ b/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/Kms.java
@@ -22,7 +22,8 @@ public interface Kms<K, E> {
     /**
      * Asynchronously generates a new Data Encryption Key (DEK) and returns it together with the same DEK wrapped by the Key Encryption Key (KEK) given
      * by the {@code kekRef},
-     * The returned encrypted DEK can later be decrypted with {@link Kms#decryptEdek(Object, Object)}.
+     * The returned encrypted DEK can later be decrypted with {@link #decryptEdek(Object)}. It is expected that
+     * the returned EDEK contains everything required for decryption including an immutable referenced to the KEK
      * @param kekRef The key encryption key used to encrypt the generated data encryption key.
      * @return A completion stage for the wrapped data encryption key.
      * @throws UnknownKeyException If the kek was not known to this KMS.
@@ -34,24 +35,14 @@ public interface Kms<K, E> {
 
     /**
      * Asynchronously decrypts a data encryption key that was {@linkplain #generateDekPair(Object) previously encrypted}.
-     * @param kek The key encryption key.
      * @param edek The encrypted data encryption key.
      * @return A completion stage for the data encryption key
-     * @throws UnknownKeyException If the kek was not known to this KMS.
-     * @throws InvalidKeyUsageException If the given kek was not intended for key wrapping.
+     * @throws UnknownKeyException If the edek was not encrypted by a KEK known to this KMS.
+     * @throws InvalidKeyUsageException If the edek refers to a kek that was not intended for key wrapping.
      * @throws KmsException For other exceptions
      */
     @NonNull
-    CompletionStage<SecretKey> decryptEdek(@NonNull K kek, @NonNull E edek);
-
-    /**
-     * Get a serializer for KEK ids.
-     * It is required that {@code deserialize(serialize(kekId)).equals(kekId)}.
-     *
-     * @return A serializer for KEK ids.
-     */
-    @NonNull
-    Serde<K> keyIdSerde();
+    CompletionStage<SecretKey> decryptEdek(@NonNull E edek);
 
     /**
      * Get a serializer for encrypted DEKs.


### PR DESCRIPTION
1. Removes kek from `Kms#decrypt`
2. Removes `Kms#keyIdSerde()`
3. The in memory KMS encodes/decodes the kek id into the serialized edek

Why:
We want to encourage KMS implementors to include all data they require to deserialize as part of the edek, including the immutable reference to the KEK used to encrypt it. 

This puts it in the control of the KMS implementation how the immutable kek reference is encoded. Some implementations like AWS already include this reference within the ciphertext output when you ask the service to wrap some data, though they recommend supplying it separately as a parameter when calling the unwrap API rather than exclusively relying on the identifiers encoded into the ciphertext. But in theory we could choose to save some bytes by using the provided ciphertext.

Closes #712 
