### PR TITLE
Encryption Filter: Rotate to a new DEK when the old one is exhausted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.4.0
 
+* [#764](https://github.com/kroxylicious/kroxylicious/pull/764): Encryption Filter: Rotate to a new DEK when the old one is exhausted
 * [#752](https://github.com/kroxylicious/kroxylicious/issues/752): Remove redudant reinstallation of time-zone data in Dockerfile used for Kroxylicious container image
 * [#727](https://github.com/kroxylicious/kroxylicious/pull/727): Tease out simple transform filters into their own module
 * [#738](https://github.com/kroxylicious/kroxylicious/pull/738): Update to Kroxylicious Junit Ext 0.7.0

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryption.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryption.java
@@ -47,7 +47,7 @@ public class EnvelopeEncryption<K, E> implements FilterFactory<EnvelopeEncryptio
         KmsService<Object, K, E> kmsPlugin = context.pluginInstance(KmsService.class, configuration.kms());
         Kms<K, E> kms = kmsPlugin.buildKms(configuration.kmsConfig());
 
-        var keyManager = new InBandKeyManager<>(kms, BufferPool.allocating());
+        var keyManager = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000);
 
         KekSelectorService<Object, K> ksPlugin = context.pluginInstance(KekSelectorService.class, configuration.selector());
         TopicNameBasedKekSelector<K> kekSelector = ksPlugin.buildSelector(kms, configuration.selectorConfig());

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/KeyManager.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/KeyManager.java
@@ -36,7 +36,7 @@ public interface KeyManager<K> {
      * Asynchronously decrypt the given {@code kafkaRecords} (if they were, in fact, encrypted), calling the given {@code receiver} with the plaintext
      * @param records The records
      * @param receiver The receiver of the plaintext buffers. The receiver will receive the buffers in the original order and can expect no parallel calls.
-     * @return A completion stage that completes when al the records have been processed.
+     * @return A completion stage that completes when all the records have been processed.
      */
     @NonNull
     CompletionStage<Void> decrypt(@NonNull List<? extends Record> records,

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/KeyManager.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/KeyManager.java
@@ -24,7 +24,7 @@ public interface KeyManager<K> {
      * Asynchronously encrypt the given {@code recordRequests} using the current DEK for the given KEK, calling the given receiver for each encrypted record
      * @param encryptionScheme The encryption scheme.
      * @param records The requests to be encrypted.
-     * @param receiver The receiver of the encrypted buffers. The receiver will recieve the buffers in the original order and can expect no parallel calls.
+     * @param receiver The receiver of the encrypted buffers. The receiver is guaranteed to receive the encrypted buffers sequentially, in the same order as {@code records}, with no possibility of parallel invocation.
      * @return A completion stage that completes when all the records have been processed.
      */
     @NonNull
@@ -35,7 +35,7 @@ public interface KeyManager<K> {
     /**
      * Asynchronously decrypt the given {@code kafkaRecords} (if they were, in fact, encrypted), calling the given {@code receiver} with the plaintext
      * @param records The records
-     * @param receiver The receiver of the plaintext buffers. The receiver will receive the buffers in the original order and can expect no parallel calls.
+     * @param receiver The receiver of the plaintext buffers. The receiver is guaranteed to receive the decrypted buffers sequentially, in the same order as {@code records}, with no possibility of parallel invocation.
      * @return A completion stage that completes when all the records have been processed.
      */
     @NonNull

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/KeyManager.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/KeyManager.java
@@ -24,8 +24,8 @@ public interface KeyManager<K> {
      * Asynchronously encrypt the given {@code recordRequests} using the current DEK for the given KEK, calling the given receiver for each encrypted record
      * @param encryptionScheme The encryption scheme.
      * @param records The requests to be encrypted.
-     * @param receiver The receiver of the encrypted buffers.
-     * @return A completion stage that completes when all the records in the given {@code recordRequests} have been processed.
+     * @param receiver The receiver of the encrypted buffers. The receiver will recieve the buffers in the original order and can expect no parallel calls.
+     * @return A completion stage that completes when all the records have been processed.
      */
     @NonNull
     CompletionStage<Void> encrypt(@NonNull EncryptionScheme<K> encryptionScheme,
@@ -35,8 +35,8 @@ public interface KeyManager<K> {
     /**
      * Asynchronously decrypt the given {@code kafkaRecords} (if they were, in fact, encrypted), calling the given {@code receiver} with the plaintext
      * @param records The records
-     * @param receiver The receiver of the plaintext buffers
-     * @return A completion stage that completes when the record has been processed.
+     * @param receiver The receiver of the plaintext buffers. The receiver will receive the buffers in the original order and can expect no parallel calls.
+     * @return A completion stage that completes when al the records have been processed.
      */
     @NonNull
     CompletionStage<Void> decrypt(@NonNull List<? extends Record> records,

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/Receiver.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/Receiver.java
@@ -19,7 +19,8 @@ public interface Receiver {
      * Receive the ciphertext (encryption) or the plaintext (decryption) associated with the given record..
      *
      * @param kafkaRecord The record on which to base the revised record
-     * @param value The ciphertext or plaintext buffer.
+     * @param value The ciphertext or plaintext buffer. This buffer may be re-used, the implementor should extract all
+     * the bytes they need from the buffer before the end of the accept call.
      */
     void accept(Record kafkaRecord, ByteBuffer value, Header[] headers);
 }

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandKeyManager.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandKeyManager.java
@@ -114,6 +114,7 @@ public class InBandKeyManager<K, E> implements KeyManager<K> {
         return attemptEncrypt(encryptionScheme, records, receiver, 0);
     }
 
+    @SuppressWarnings("java:S2445")
     private CompletionStage<Void> attemptEncrypt(@NonNull EncryptionScheme<K> encryptionScheme, @NonNull List<? extends Record> records,
                                                  @NonNull Receiver receiver, int attempt) {
         if (attempt >= 3) {

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandKeyManager.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandKeyManager.java
@@ -42,6 +42,7 @@ public class InBandKeyManager<K, E> implements KeyManager<K> {
 
     private static final String FIELDS_HEADER_NAME = "kroxylicious.io/encrypted";
     private static final String DEK_HEADER_NAME = "kroxylicious.io/dek";
+    private static final int MAX_ATTEMPTS = 3;
 
     private final Kms<K, E> kms;
     private final BufferPool bufferPool;
@@ -117,7 +118,7 @@ public class InBandKeyManager<K, E> implements KeyManager<K> {
     @SuppressWarnings("java:S2445")
     private CompletionStage<Void> attemptEncrypt(@NonNull EncryptionScheme<K> encryptionScheme, @NonNull List<? extends Record> records,
                                                  @NonNull Receiver receiver, int attempt) {
-        if (attempt >= 3) {
+        if (attempt >= MAX_ATTEMPTS) {
             return CompletableFuture.failedFuture(new EncryptionException("failed to encrypt records after " + attempt + " attempts"));
         }
         return currentDekContext(encryptionScheme.kekId()).thenCompose(keyContext -> {

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandKeyManager.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandKeyManager.java
@@ -137,13 +137,13 @@ public class InBandKeyManager<K, E> implements KeyManager<K> {
         var maxValuePlaintextSize = encryptionScheme.recordFields().contains(RecordField.RECORD_VALUE)
                 ? records.stream().mapToInt(Record::valueSize).max().orElse(-1)
                 : -1;
-        var valueCiphertext = maxValuePlaintextSize >= 0 ? bufferPool.acquire(keyContext.encodedSize(maxValuePlaintextSize)) : null;
+        var sharedValueCiphertextBuffer = maxValuePlaintextSize >= 0 ? bufferPool.acquire(keyContext.encodedSize(maxValuePlaintextSize)) : null;
         try {
-            encryptRecords(encryptionScheme, keyContext, records, fieldsHeader, dekHeader, valueCiphertext, receiver);
+            encryptRecords(encryptionScheme, keyContext, records, fieldsHeader, dekHeader, sharedValueCiphertextBuffer, receiver);
         }
         finally {
-            if (maxValuePlaintextSize >= 0) {
-                bufferPool.release(valueCiphertext);
+            if (sharedValueCiphertextBuffer != null) {
+                bufferPool.release(sharedValueCiphertextBuffer);
             }
         }
         keyContext.recordEncryptions(records.size());

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/KeyContext.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/KeyContext.java
@@ -105,13 +105,11 @@ final class KeyContext implements Destroyable {
         }
         catch (DestroyFailedException e) {
             var cls = destroyable.getClass();
-            LOGGED_DESTROY_FAILED.compute(cls, (k, logged) -> {
-                if (logged == null) {
-                    LOGGER.warn("Failed to destroy an instance of {}. "
-                            + "Note: this message is logged once per class even though there may be many occurrences of this event. "
-                            + "This event can happen because the JRE's SecretKeySpec class does not override destroy().",
-                            cls, e);
-                }
+            LOGGED_DESTROY_FAILED.computeIfAbsent(cls, (c) -> {
+                LOGGER.warn("Failed to destroy an instance of {}. "
+                        + "Note: this message is logged once per class even though there may be many occurrences of this event. "
+                        + "This event can happen because the JRE's SecretKeySpec class does not override destroy().",
+                        c, e);
                 return Boolean.TRUE;
             });
         }

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/KeyContext.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/KeyContext.java
@@ -10,6 +10,7 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import javax.annotation.concurrent.NotThreadSafe;
 import javax.security.auth.DestroyFailedException;
 import javax.security.auth.Destroyable;
 
@@ -19,8 +20,12 @@ import org.slf4j.LoggerFactory;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * A DekContext encapsulates an encryptor.
+ * A Context encapsulates an encryptor for a DEK.
+ * <p>
+ * KeyContext is not threadsafe and access should be externally co-ordinated.
+ * </p>
  */
+@NotThreadSafe
 final class KeyContext implements Destroyable {
     private final AesGcmEncryptor encryptor;
     private final byte[] prefix;

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/InBandKeyManagerTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/InBandKeyManagerTest.java
@@ -15,10 +15,6 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import javax.security.auth.DestroyFailedException;
-import javax.security.auth.Destroyable;
 
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
@@ -36,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class InBandKeyManagerTest {
 
@@ -74,20 +69,6 @@ class InBandKeyManagerTest {
         var x1 = InBandKeyManager.removeInitialHeaders(r2, 1);
         assertEquals(1, x1.length);
         assertEquals(myHeader, x1[0]);
-    }
-
-    @Test
-    void testDestroy() {
-        AtomicBoolean called = new AtomicBoolean();
-        InBandKeyManager.destroy(new Destroyable() {
-            @Override
-            public void destroy() throws DestroyFailedException {
-                called.set(true);
-                throw new DestroyFailedException("Eeek!");
-            }
-        });
-
-        assertTrue(called.get());
     }
 
     @Test

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/KeyContextTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/KeyContextTest.java
@@ -65,6 +65,7 @@ class KeyContextTest {
         assertFalse(output.hasRemaining());
         output.flip();
         bb.flip();
+        context.recordEncryptions(1);
 
         assertTrue(context.hasAtLeastRemainingEncryptions(1));
         assertFalse(context.isExpiredForEncryption(101010));
@@ -77,6 +78,7 @@ class KeyContextTest {
         assertFalse(output.hasRemaining());
         output.flip();
         bb.flip();
+        context.recordEncryptions(1);
 
         assertFalse(context.hasAtLeastRemainingEncryptions(1));
         context.encodedSize(bb.capacity());
@@ -84,7 +86,9 @@ class KeyContextTest {
         var e = assertThrows(ExhaustedDekException.class, () -> context.encode(bb, output));
         assertEquals("No more encryptions", e.getMessage());
 
+        assertTrue(context.isAlive());
         // destroy
         assertThrows(DestroyFailedException.class, context::destroy);
+        assertFalse(context.isAlive());
     }
 }

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/TestingDek.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/TestingDek.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.inband;
+
+import java.util.Arrays;
+
+public record TestingDek(byte[] serializedEdek) {
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TestingDek that = (TestingDek) o;
+        return Arrays.equals(serializedEdek, that.serializedEdek);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(serializedEdek);
+    }
+}

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/IntegrationTestingKmsService.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/IntegrationTestingKmsService.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.crypto.SecretKey;
 
@@ -65,14 +64,12 @@ public class IntegrationTestingKmsService implements KmsService<IntegrationTesti
     @Override
     public InMemoryKms buildKms(Config options) {
         return KMSES.computeIfAbsent(options.name(), ignored -> {
-            var numGeneratedDeks = new AtomicInteger();
             var keys = new ConcurrentHashMap<UUID, SecretKey>();
             var aliases = new ConcurrentHashMap<String, UUID>();
             return new InMemoryKms(12,
                     128,
                     keys,
-                    aliases,
-                    numGeneratedDeks);
+                    aliases);
         });
     }
 

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/UnitTestingKmsService.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/UnitTestingKmsService.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.crypto.SecretKey;
 
@@ -61,8 +60,6 @@ public class UnitTestingKmsService implements KmsService<UnitTestingKmsService.C
 
     }
 
-    private final AtomicInteger numGeneratedDeks = new AtomicInteger();
-
     private final Map<UUID, SecretKey> keys = new ConcurrentHashMap<>();
     private final Map<String, UUID> aliases = new ConcurrentHashMap<>();
 
@@ -72,8 +69,7 @@ public class UnitTestingKmsService implements KmsService<UnitTestingKmsService.C
         return new InMemoryKms(options.numIvBytes(),
                 options.numAuthBits(),
                 keys,
-                aliases,
-                numGeneratedDeks);
+                aliases);
     }
 
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

A hard requirement we have is to stop using a DEK for encryption once it has been used to encrypt a certain amount of records.

Work done with the key context is now synchronized such that only one thread will encrypt OR update the future in the cache when rotation is required. If the key was destroyed while a thread is waiting for the lock it can retry the encrypt as the stage in the cache should have been atomically updated by a previous encrypt call.

Resolves #757 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
