### PR TITLE
Create GitHub release as part of release script and attatch binary distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,17 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 ## 0.4.0
 
 * [#764](https://github.com/kroxylicious/kroxylicious/pull/764): Encryption Filter: Rotate to a new DEK when the old one is exhausted
+* [#696](https://github.com/kroxylicious/kroxylicious/pull/696): Initial work on an Envelope Encryption Filter
 * [#752](https://github.com/kroxylicious/kroxylicious/issues/752): Remove redudant reinstallation of time-zone data in Dockerfile used for Kroxylicious container image
 * [#727](https://github.com/kroxylicious/kroxylicious/pull/727): Tease out simple transform filters into their own module
+* [#628](https://github.com/kroxylicious/kroxylicious/pull/628): Kroxylicious system tests
 * [#738](https://github.com/kroxylicious/kroxylicious/pull/738): Update to Kroxylicious Junit Ext 0.7.0
 * [#723](https://github.com/kroxylicious/kroxylicious/pull/723): Bump com.fasterxml.jackson:jackson-bom from 2.15.3 to 2.16.0 #723
 * [#724](https://github.com/kroxylicious/kroxylicious/pull/724): Bump io.netty.incubator:netty-incubator-transport-native-io_uring from 0.0.23.Final to 0.0.24.Final
 * [#725](https://github.com/kroxylicious/kroxylicious/pull/725): Bump io.netty:netty-bom from 4.1.100.Final to 4.1.101.Final #725
+* [#710](https://github.com/kroxylicious/kroxylicious/pull/710): Rename modules
+* [#709](https://github.com/kroxylicious/kroxylicious/pull/709): Add a KMS service API and an in-memory implementation
+* [#667](https://github.com/kroxylicious/kroxylicious/pull/667): Nested factories
 * [#701](https://github.com/kroxylicious/kroxylicious/pull/701): Bump org.apache.logging.log4j:log4j-bom from 2.21.0 to 2.21.1 #701
 
 ### Changes, deprecations and removals

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -169,9 +169,6 @@ then
     exit
 fi
 
-ORIGINAL_GH_DEFAULT_REPO=$(gh repo set-default -v | (grep -v 'no default repository' || true))
-gh repo set-default $(git remote get-url ${REPOSITORY})
-
 BODY="Release version ${RELEASE_VERSION}"
 
 echo "Create pull request to merge the released version."


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds GitHub release creation to release script (with attached binary distribution), updates changelog with recent changes.

More specifically, the script now also runs a maven command to generate a binary distribution zip+tarball, and then runs [a `gh` CLI command](https://cli.github.com/manual/gh_release_create) to create a release (using the contents of `CHANGELOG.md` as the release notes) with the two binary distribution archives attached.

### Additional Context

This means users will be able to download a binary that they can easily extract and run for Kroxylicious, rather than having to download the sources and build these themselves manually. This is required for finishing the quickstart guides ([kroxylicious/kroxylicious.github.io#13](https://github.com/kroxylicious/kroxylicious.github.io/pull/13)).

I have added recent missing changes to `CHANGELOG.md` because we are using this as the release notes for each release.

The problem with doing release notes this way is that it includes _the entire file_ as the notes (previous version sections included), which means in future we're going to end up with some really long release notes. I think we're going to have to revisit this approach at some point, but for now it's the best we've got given how inadequate the GitHub-provided automatically generated notes are (it just gives you a link to the diff between tags). Perhaps at some point we can have another look at generating a list of all merged PRs since the last release for this purpose, but my experiments with it the past few days have revealed how painful it is to format those results into something useable.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
