### PR TITLE
Encryption Filter: Retry DEK creation. Ensure encryptions after a failed future can succeed

### DIFF
--- a/kroxylicious-filters/kroxylicious-encryption/pom.xml
+++ b/kroxylicious-filters/kroxylicious-encryption/pom.xml
@@ -42,6 +42,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/EncryptorCreationException.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/EncryptorCreationException.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.inband;
+
+public class EncryptorCreationException extends RuntimeException {
+    public EncryptorCreationException(String message) {
+        super(message);
+    }
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/KeyContext.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/KeyContext.java
@@ -33,7 +33,7 @@ final class KeyContext implements Destroyable {
     private int remainingEncryptions;
     private boolean destroyed = false;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(InBandKeyManager.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(KeyContext.class);
     private static final Map<Class<? extends Destroyable>, Boolean> LOGGED_DESTROY_FAILED = new ConcurrentHashMap<>();
 
     KeyContext(@NonNull ByteBuffer serializedEdek,

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <kafka.version>3.6.1</kafka.version>
         <kroxy.extension.version>0.8.0</kroxy.extension.version>
         <log4j.version>2.22.0</log4j.version>
+        <caffeine.version>3.1.8</caffeine.version>
         <picocli.version>4.7.5</picocli.version>
         <netty.version>4.1.101.Final</netty.version>
         <netty.io_uring.version>0.0.24.Final</netty.io_uring.version>
@@ -161,6 +162,12 @@
                 <version>${jackson.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>com.github.ben-manes.caffeine</groupId>
+                <artifactId>caffeine</artifactId>
+                <version>${caffeine.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Previously if the DEK future from the KMS failed it would have been cached for all time and led to all future encryption calls for that KEK to fail.

We also want to give DEK creation naive handling of some simple cases like a failure due to a one-off network issue. So it will now retry the DEK retrieval operation 3 times as part of loading a DEK into the cache.

As I considered how to implement these safely myself Sam said it sounded a lot like the caffeine async loading cache which knows not to cache failed futures. Kafka already depends on caffeine in 3.6.0 so it's a fairly safe dependency to add. Caffeine has already solved the gnarly async problems I was already worrying about.

We will also be able to take advantage of it's LRU and refreshing ability later to manage the cache size and to pre-emptively load a new DEK encrypter while an existing one continues to be used. We could minimise pauses by refreshing in a new DEK when X% of the encryptions have been used.

Note tests now have to supply non-zero timeouts when waiting on futures as the cache is leaning on the fork join pool to farm out the async loading operations.

This isn't tackling everything, we could also have future improvements introducing configurable timeouts to the InBandKeyManager so that oddities like futures from the KMS that never complete are handled.

Closes #765

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
