### PR TITLE
Release prefix buffer after use

### DIFF
--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/KeyContext.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/KeyContext.java
@@ -36,14 +36,14 @@ final class KeyContext implements Destroyable {
     private static final Logger LOGGER = LoggerFactory.getLogger(InBandKeyManager.class);
     private static final Map<Class<? extends Destroyable>, Boolean> LOGGED_DESTROY_FAILED = new ConcurrentHashMap<>();
 
-    KeyContext(@NonNull ByteBuffer prefix,
+    KeyContext(byte[] prefix,
                long encryptionExpiryNanos,
                int maxEncryptions,
                @NonNull AesGcmEncryptor encryptor) {
         if (maxEncryptions <= 0) {
             throw new IllegalArgumentException();
         }
-        this.prefix = prefix.array();
+        this.prefix = prefix;
         this.encryptionExpiryNanos = encryptionExpiryNanos;
         this.remainingEncryptions = maxEncryptions;
         this.encryptor = encryptor;

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/KeyContextTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/KeyContextTest.java
@@ -39,7 +39,7 @@ class KeyContextTest {
         var kek = kms.generateKey();
         var pair = kms.generateDekPair(kek).get();
         ByteBuffer prefix = ByteBuffer.wrap(new byte[]{ 1, 2, 3 });
-        var context = new KeyContext(prefix, 101011, 2,
+        var context = new KeyContext(prefix.array(), 101011, 2,
                 AesGcmEncryptor.forEncrypt(new AesGcmIvGenerator(new SecureRandom()), pair.dek()));
 
         assertThrows(IllegalArgumentException.class, () -> context.hasAtLeastRemainingEncryptions(0));
@@ -66,7 +66,7 @@ class KeyContextTest {
         var kek = kms.generateKey();
         var pair = kms.generateDekPair(kek).get();
         ByteBuffer prefix = ByteBuffer.wrap(new byte[]{ 1, 2, 3 });
-        var context = new KeyContext(prefix, 101011, 2,
+        var context = new KeyContext(prefix.array(), 101011, 2,
                 AesGcmEncryptor.forEncrypt(new AesGcmIvGenerator(new SecureRandom()), pair.dek()));
 
         assertTrue(context.hasAtLeastRemainingEncryptions(1));


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Why:
We should release the buffer in preparation for a real buffer pool implementation. Decided it was better to copy the prefix into a byte[] on heap since this thing will have a long lifetime of it's own, rather than keep a ref to the allocated buffer and release it when the context is destroyed.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
