### PR TITLE
Skip sonar scan during system tests

### DIFF
--- a/kroxylicious-systemtests/pom.xml
+++ b/kroxylicious-systemtests/pom.xml
@@ -22,6 +22,11 @@
         The intention of this module is to test Kroxylicious against a kafka instance deployed in a kubernetes cluster/minikube
         using Strimzi, to simulate a real scenario for end-to-end testing treating Kroxylicious as a black box.
     </description>
+
+    <properties>
+        <sonar.skip>true</sonar.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.fabric8</groupId>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

Skip the sonar scan for systemtests (as we do for perf tests)



### Additional Context

why: we're not running system tests with the sonar ci workflow (by design), so there is no coverage
generate for that module.  the lack of coverage is dragging down the stats for the rest of the project.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
