### PR TITLE
added SKIP_TEARDOWN env variable

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -320,6 +320,8 @@ has been applied ineffectively.
 * `KROXYLICIOUS_VERSION`: version of kroxylicious to be used. Default value: `0.4.0-SNAPSHOT`
 * `KAFKA_VERSION`: kafka version to be used. Default value: `3.6.0`
 * `STRIMZI_URL`: url where to download strimzi. Default value: `khttps://strimzi.io/install/latest?namespace=kafka`
+* `SKIP_TEARDOWN`: variable for development purposes to avoid keep deploying and deleting deployments each run. 
+Default value: `false`
 
 ### Launch system tests
 First of all, the code must be compiled and the distribution artifacts created:

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
@@ -23,6 +23,7 @@ public class Environment {
     private static final String KROXY_VERSION_ENV = "KROXYLICIOUS_VERSION";
     private static final String KROXY_IMAGE_REPO_ENV = "KROXYLICIOUS_IMAGE_REPO";
     private static final String STRIMZI_URL_ENV = "STRIMZI_URL";
+    private static final String SKIP_TEARDOWN_ENV = "SKIP_TEARDOWN";
 
     /**
      * The kafka version default value
@@ -42,6 +43,10 @@ public class Environment {
      * The strimzi installation url for kubernetes.
      */
     public static final String STRIMZI_URL_DEFAULT = "https://strimzi.io/install/latest?namespace=" + Constants.KROXY_DEFAULT_NAMESPACE;
+    /**
+     * The default value for skipping the teardown locally.
+     */
+    public static final String SKIP_TEARDOWN_DEFAULT = "false";
 
     /**
      * KAFKA_VERSION env variable assignment
@@ -60,6 +65,10 @@ public class Environment {
      * KROXY_IMAGE_REPO env variable assignment
      */
     public static final String KROXY_IMAGE_REPO = getOrDefault(KROXY_IMAGE_REPO_ENV, KROXY_IMAGE_REPO_DEFAULT);
+    /**
+     * SKIP_TEARDOWN env variable assignment.
+     */
+    public static final String SKIP_TEARDOWN = getOrDefault(SKIP_TEARDOWN_ENV, SKIP_TEARDOWN_DEFAULT);
 
     private static String getOrDefault(String varName, String defaultValue) {
         return getOrDefault(varName, String::toString, defaultValue);

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/CertManager.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/CertManager.java
@@ -42,6 +42,10 @@ public class CertManager {
      */
     public void deploy() {
         LOGGER.info("Deploy cert manager in {} namespace", Constants.CERT_MANAGER_NAMESPACE);
+        if (kubeClient().getNamespace(Constants.CERT_MANAGER_NAMESPACE) != null) {
+            LOGGER.warn("Skipping cert manager deployment. It is already deployed!");
+            return;
+        }
         deployment.create();
         DeploymentUtils.waitForDeploymentReady(Constants.CERT_MANAGER_NAMESPACE, "cert-manager-webhook");
     }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
@@ -40,10 +40,13 @@ public class Strimzi {
 
     /**
      * Deploy strimzi.
-     * @throws IOException the io exception
      */
-    public void deploy() throws IOException {
+    public void deploy() {
         LOGGER.info("Deploy Strimzi in {} namespace", deploymentNamespace);
+        if (kubeClient().getDeployment(deploymentNamespace, Constants.STRIMZI_DEPLOYMENT_NAME) != null) {
+            LOGGER.warn("Skipping strimzi deployment. It is already deployed!");
+            return;
+        }
         deployment.inNamespace(deploymentNamespace).create();
         DeploymentUtils.waitForDeploymentReady(deploymentNamespace, Constants.STRIMZI_DEPLOYMENT_NAME);
     }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Fixes #735. Added a mechanism to skip teardown for system tests to allow local runs skipping the deployment time. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [X] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [X] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
