### PR TITLE
Update remaining references to old tag

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -317,7 +317,7 @@ has been applied ineffectively.
 
 ### Environment variables
 * `KROXYLICIOUS_IMAGE_REPO`: url to the image of kroxylicious to be used. Default value: `quay.io/kroxylicious/kroxylicious-developer`
-* `KROXYLICIOUS_VERSION`: version of kroxylicious to be used. Default value: `0.4.0-SNAPSHOT`
+* `KROXYLICIOUS_VERSION`: version of kroxylicious to be used. Default value: `0.5.0-SNAPSHOT`
 * `KAFKA_VERSION`: kafka version to be used. Default value: `3.6.0`
 * `STRIMZI_URL`: url where to download strimzi. Default value: `khttps://strimzi.io/install/latest?namespace=kafka`
 * `SKIP_TEARDOWN`: variable for development purposes to avoid keep deploying and deleting deployments each run. 

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
@@ -33,7 +33,7 @@ public class Environment {
     /**
      * The kroxy version default value
      */
-    public static final String KROXY_VERSION_DEFAULT = "0.4.0-SNAPSHOT";
+    public static final String KROXY_VERSION_DEFAULT = "0.5.0-SNAPSHOT";
     /**
      * The url where kroxylicious image lives to be downloaded.
      */

--- a/kubernetes-examples/multitenant/base/kroxylicious-deployment.yaml
+++ b/kubernetes-examples/multitenant/base/kroxylicious-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: kroxylicious
-        image: quay.io/kroxylicious/kroxylicious-developer:0.4.0-SNAPSHOT
+        image: quay.io/kroxylicious/kroxylicious-developer:0.5.0-SNAPSHOT
         imagePullPolicy: Always
         args: ["--config", "/opt/kroxylicious/config/config.yaml"]
         ports:

--- a/kubernetes-examples/portperbroker_plain/base/kroxylicious-deployment.yaml
+++ b/kubernetes-examples/portperbroker_plain/base/kroxylicious-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: kroxylicious
-        image: quay.io/kroxylicious/kroxylicious-developer:0.4.0-SNAPSHOT
+        image: quay.io/kroxylicious/kroxylicious-developer:0.5.0-SNAPSHOT
         imagePullPolicy: Always
         args: ["--config", "/opt/kroxylicious/config/config.yaml"]
         ports:

--- a/kubernetes-examples/snirouting_tls/base/kroxylicious-deployment.yaml
+++ b/kubernetes-examples/snirouting_tls/base/kroxylicious-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: kroxylicious
-        image: quay.io/kroxylicious/kroxylicious-developer:0.4.0-SNAPSHOT
+        image: quay.io/kroxylicious/kroxylicious-developer:0.5.0-SNAPSHOT
         imagePullPolicy: Always
         args: ["--config", "/opt/kroxylicious/config/config.yaml"]
         ports:

--- a/kubernetes-examples/topicencryption/base/kroxylicious-deployment.yaml
+++ b/kubernetes-examples/topicencryption/base/kroxylicious-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: kroxylicious
-        image: quay.io/kroxylicious/kroxylicious-developer:0.4.0-SNAPSHOT
+        image: quay.io/kroxylicious/kroxylicious-developer:0.5.0-SNAPSHOT
         imagePullPolicy: Always
         args: ["--config", "/opt/kroxylicious/config/config.yaml"]
         ports:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

I had trouble starting up the topicencryption example on minikube since it built and pushed an 0.5.0-SNAPSHOT tagged image but the deployments refer to 0.4.0-SNAPSHOT

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
