### PR TITLE
fix: tls key is not taken into account for target cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.5.0
 
+* [#844](https://github.com/kroxylicious/kroxylicious/pull/844): Fix connect to upstream using TLS client authentication
 * [#885](https://github.com/kroxylicious/kroxylicious/pull/885): Bump kroxy.extension.version from 0.8.0 to 0.8.1
 
 ## 0.4.1

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,3 +4,4 @@
 - Francesco Nigro(https://github.com/franz1981)
 - Sam Barker(https://github.com/SamBarker)
 - Francisco Vila(https://github.com/franvila)
+- Anthony Callaert(https://github.com/callaertanthony)

--- a/docs/deploying.adoc
+++ b/docs/deploying.adoc
@@ -237,7 +237,7 @@ virtualClusters:
 <2> File system location of a file containing the trust store's password.
 <3> (Optional) Trust store type. Supported types are: `PKCS12`, `JKS` and `PEM`.  Defaults to Java default key store type (PKCS12).
 
-The following illustrates connection to physical cluster using client credentials over SSL.
+The following illustrates connection to physical cluster using TLS client authentication (aka Mutual TLS).
 
 [source, yaml]
 ----

--- a/docs/deploying.adoc
+++ b/docs/deploying.adoc
@@ -252,7 +252,7 @@ virtualClusters:
         trust:
           storeFile: /opt/cert/client/server.cer
           storeType: PEM
-
+----
 It is also possible to disable trust so that Kroxylicious will connect to any Kafka Cluster regardless of its certificate
 validity.
 

--- a/docs/deploying.adoc
+++ b/docs/deploying.adoc
@@ -237,6 +237,22 @@ virtualClusters:
 <2> File system location of a file containing the trust store's password.
 <3> (Optional) Trust store type. Supported types are: `PKCS12`, `JKS` and `PEM`.  Defaults to Java default key store type (PKCS12).
 
+The following illustrates connection to physical cluster using client credentials over SSL.
+
+[source, yaml]
+----
+virtualClusters:
+  demo:
+    targetCluster:
+      bootstrap_servers: myprivatecluster:9092
+      tls:
+        key:
+          privateKeyFile: /opt/cert/client.key
+          certificateFile: /opt/cert/client.cert
+        trust:
+          storeFile: /opt/cert/client/server.cer
+          storeType: PEM
+
 It is also possible to disable trust so that Kroxylicious will connect to any Kafka Cluster regardless of its certificate
 validity.
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/KeyPair.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/KeyPair.java
@@ -45,4 +45,19 @@ public record KeyPair(String privateKeyFile,
                     e);
         }
     }
+
+    @Override
+    public SslContextBuilder forClient() {
+        try {
+            return SslContextBuilder.forClient()
+                    .keyManager(new File(certificateFile), new File(privateKeyFile),
+                            Optional.ofNullable(keyPasswordProvider).map(PasswordProvider::getProvidedPassword).orElse(null));
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "Error building SSLContext. certificateFile : " + certificateFile + ", privateKeyFile: " + privateKeyFile + ", password present: "
+                            + (keyPasswordProvider != null),
+                    e);
+        }
+    }
+
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/KeyPair.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/KeyPair.java
@@ -52,7 +52,8 @@ public record KeyPair(String privateKeyFile,
             return SslContextBuilder.forClient()
                     .keyManager(new File(certificateFile), new File(privateKeyFile),
                             Optional.ofNullable(keyPasswordProvider).map(PasswordProvider::getProvidedPassword).orElse(null));
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             throw new RuntimeException(
                     "Error building SSLContext. certificateFile : " + certificateFile + ", privateKeyFile: " + privateKeyFile + ", password present: "
                             + (keyPasswordProvider != null),

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/KeyProvider.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/KeyProvider.java
@@ -26,4 +26,6 @@ public interface KeyProvider {
 
     SslContextBuilder forServer();
 
+    SslContextBuilder forClient();
+
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
@@ -160,7 +160,7 @@ public class VirtualCluster implements ClusterNetworkAddressConfigProvider {
     private Optional<SslContext> buildUpstreamSslContext() {
         return targetCluster.tls().map(tls -> {
             try {
-                var sslContextBuilder = tls.key().forClient();
+                var sslContextBuilder = Optional.ofNullable(tls.key()).map(KeyProvider::forClient).orElse(SslContextBuilder.forClient());
                 Optional.ofNullable(tls.trust()).ifPresent(tp -> tp.apply(sslContextBuilder));
                 return sslContextBuilder.build();
             }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
@@ -160,7 +160,7 @@ public class VirtualCluster implements ClusterNetworkAddressConfigProvider {
     private Optional<SslContext> buildUpstreamSslContext() {
         return targetCluster.tls().map(tls -> {
             try {
-                var sslContextBuilder = SslContextBuilder.forClient();
+                var sslContextBuilder = tls.key().forClient();
                 Optional.ofNullable(tls.trust()).ifPresent(tp -> tp.apply(sslContextBuilder));
                 return sslContextBuilder.build();
             }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/KeyPairTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/KeyPairTest.java
@@ -40,7 +40,7 @@ class KeyPairTest {
     }
 
     @Test
-    void serverKeyPairIncorrectKeyPassword() {
+    void keyPairIncorrectKeyPassword() {
         doFailingKeyPairTest(TlsTestConstants.getResourceLocationOnFilesystem("server_encrypted.key"),
                 TlsTestConstants.getResourceLocationOnFilesystem("server.crt"), BADPASS)
                 .hasRootCauseInstanceOf(BadPaddingException.class)
@@ -49,17 +49,35 @@ class KeyPairTest {
     }
 
     @Test
-    void serverKeyPairCertificateNotFound() {
+    void keyPairCertificateNotFound() {
         doFailingKeyPairTest(TlsTestConstants.getResourceLocationOnFilesystem("server.key"), NOT_EXIST, null)
                 .hasRootCauseInstanceOf(CertificateException.class)
                 .hasMessageContaining(NOT_EXIST);
     }
 
     @Test
-    void serverKeyPairKeyNotFound() {
+    void keyPairKeyNotFound() {
         doFailingKeyPairTest(NOT_EXIST, TlsTestConstants.getResourceLocationOnFilesystem("server.crt"), null)
                 .hasRootCauseInstanceOf(KeyException.class)
                 .hasMessageContaining(NOT_EXIST);
+    }
+
+    @Test
+    void clientKeyPair() throws Exception {
+        var keyPair = new KeyPair(TlsTestConstants.getResourceLocationOnFilesystem("server.key"), TlsTestConstants.getResourceLocationOnFilesystem("server.crt"), null);
+        var sslContext = keyPair.forClient().build();
+        assertThat(sslContext).isNotNull();
+        assertThat(sslContext.isClient()).isTrue();
+    }
+
+    @Test
+    void clientKeyPairKeyProtectedWithPassword() throws Exception {
+        var keyPair = new KeyPair(TlsTestConstants.getResourceLocationOnFilesystem("server_encrypted.key"),
+                TlsTestConstants.getResourceLocationOnFilesystem("server.crt"), new InlinePassword("keypass"));
+
+        var sslContext = keyPair.forClient().build();
+        assertThat(sslContext).isNotNull();
+        assertThat(sslContext.isClient()).isTrue();
     }
 
     private AbstractThrowableAssert<?, ? extends Throwable> doFailingKeyPairTest(String serverPrivateKeyFile, String serverCertificateFile,

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/KeyStoreTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/KeyStoreTest.java
@@ -41,6 +41,7 @@ class KeyStoreTest {
                 Arguments.of("Combined key/crt PEM passed as keyStore (KIP-651) with encrypted key", PEM, "server_crt_encrypted_key.pem", null, KEYPASS),
                 Arguments.of("JKS keystore from file", JKS, "server_diff_keypass.jks", KEYSTORE_FILE_PASSWORD, KEYPASS_FILE_PASSWORD));
     }
+
     public static Stream<Arguments> serverWithKeyStore() {
         return withKeyStore();
     }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/KeyStoreTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/KeyStoreTest.java
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 class KeyStoreTest {
 
-    public static Stream<Arguments> serverWithKeyStore() {
+    private static Stream<Arguments> withKeyStore() {
         return Stream.of(
                 Arguments.of("Platform Default Store JKS", null, "server.jks", STOREPASS, null),
                 Arguments.of("JKS store=key", JKS, "server.jks", STOREPASS, null),
@@ -40,6 +40,13 @@ class KeyStoreTest {
                 Arguments.of("Combined key/crt PEM passed as keyStore (KIP-651)", PEM, "server_key_crt.pem", null, null),
                 Arguments.of("Combined key/crt PEM passed as keyStore (KIP-651) with encrypted key", PEM, "server_crt_encrypted_key.pem", null, KEYPASS),
                 Arguments.of("JKS keystore from file", JKS, "server_diff_keypass.jks", KEYSTORE_FILE_PASSWORD, KEYPASS_FILE_PASSWORD));
+    }
+    public static Stream<Arguments> serverWithKeyStore() {
+        return withKeyStore();
+    }
+
+    public static Stream<Arguments> clientWithKeyStore() {
+        return withKeyStore();
     }
 
     @ParameterizedTest(name = "{0}")
@@ -80,6 +87,46 @@ class KeyStoreTest {
                 null);
 
         assertThatCode(keyStore::forServer).hasRootCauseInstanceOf(UnrecoverableKeyException.class);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource()
+    void clientWithKeyStore(String name,
+                            String storeType,
+                            String storeFile, PasswordProvider storePassword, PasswordProvider keyPassword)
+            throws Exception {
+        var keyStore = new KeyStore(getResourceLocationOnFilesystem(storeFile), storePassword, keyPassword, storeType);
+
+        var sslContext = keyStore.forClient().build();
+        assertThat(sslContext).isNotNull();
+        assertThat(sslContext.isClient()).isTrue();
+    }
+
+    @Test
+    void clientKeyStoreFileNotFound() {
+        var keyStore = new KeyStore(NOT_EXIST, null, null, null);
+
+        assertThatCode(keyStore::forClient).hasCauseInstanceOf(IOException.class).hasMessageContaining(NOT_EXIST);
+    }
+
+    @Test
+    void clientKeyStoreIncorrectPassword() {
+        var keyStore = new KeyStore(getResourceLocationOnFilesystem("server.jks"),
+                BADPASS,
+                null,
+                null);
+
+        assertThatCode(keyStore::forClient).hasRootCauseInstanceOf(UnrecoverableKeyException.class);
+    }
+
+    @Test
+    void clientKeyStoreIncorrectKeyPassword() {
+        var keyStore = new KeyStore(getResourceLocationOnFilesystem("server_diff_keypass.jks"),
+                STOREPASS,
+                BADPASS,
+                null);
+
+        assertThatCode(keyStore::forClient).hasRootCauseInstanceOf(UnrecoverableKeyException.class);
     }
 
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

I set this PR as bugfix because my understanding of the documentation is that the connexion from the proxy to a broker can handle an ssl key pair connexion.

Testing kroxylicious shows me that there was an SSL handshake failed error. After reading the source coude, I found that the client connexion doesn't handle the keys.

### Additional Context

To be able to connect to a kafka cluster through ssl.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [x] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
