### PR TITLE
Fix issues in KafkaAuthnHandler

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaAuthnHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaAuthnHandler.java
@@ -785,7 +785,8 @@ public class KafkaAuthnHandler extends ChannelInboundHandlerAdapter {
                 .setMechanisms(enabledMechanisms)
                 .setErrorCode(error.code());
         writeFramedResponse(ctx, data, body);
-
+        // Request to read the following request
+        ctx.channel().read();
     }
 
     private void onSaslAuthenticateRequest(ChannelHandlerContext ctx,
@@ -814,6 +815,7 @@ public class KafkaAuthnHandler extends ChannelInboundHandlerAdapter {
                 .setAuthBytes(bytes);
         // TODO add support for session lifetime
         writeFramedResponse(ctx, data, body);
+        ctx.channel().read();
     }
 
     private static void writeFramedResponse(ChannelHandlerContext ctx,

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaAuthnHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaAuthnHandler.java
@@ -393,6 +393,9 @@ public class KafkaAuthnHandler extends ChannelInboundHandlerAdapter {
         else if (msg instanceof DecodedRequestFrame) {
             handleFramedRequest(ctx, (DecodedRequestFrame<?>) msg);
         }
+        else if (lastSeen == State.AUTHN_SUCCESS) {
+            ctx.fireChannelRead(msg);
+        }
         else {
             throw new IllegalStateException("Unexpected message " + msg.getClass());
         }
@@ -401,7 +404,9 @@ public class KafkaAuthnHandler extends ChannelInboundHandlerAdapter {
     private void handleFramedRequest(ChannelHandlerContext ctx, DecodedRequestFrame<?> frame) throws SaslException {
         switch (frame.apiKey()) {
             case API_VERSIONS:
-                doTransition(ctx.channel(), State.API_VERSIONS);
+                if (lastSeen != State.AUTHN_SUCCESS) {
+                    doTransition(ctx.channel(), State.API_VERSIONS);
+                }
                 ctx.fireChannelRead(frame);
                 return;
             case SASL_HANDSHAKE:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

I set up an SASL authentication with the KafkaAuthnHandler. The ApiVersions and SaslHandshake request work just fine. However, the SaslAuthenticate request is sent but not received by netty. After some debugging, I found that the auto-read config is disabled by the KafkaProxyFrontendHandler.

![Kafka Traffic](https://github.com/kroxylicious/kroxylicious/assets/16633830/38b545d5-564c-48b5-8464-658d62993a7e)

After authentication, kafka client will send an ApiVersions request again that will transition the state from AUTHN_SUCCESS to API_VERSIONS, which I think is inappropriate.

An OpaqueRequestFrame will also be treated as an unexpected message.

```java
    @Override
    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
        if (msg instanceof BareSaslRequest) {
            handleBareRequest(ctx, (BareSaslRequest) msg);
        }
        else if (msg instanceof DecodedRequestFrame) {
            handleFramedRequest(ctx, (DecodedRequestFrame<?>) msg);
        }
        else {
            throw new IllegalStateException("Unexpected message " + msg.getClass());
        }
    }
```

### Additional Context

Set up custom SASL mechanisms with the KafkaAuthnHandler.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [x] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
