### PR TITLE
Vault metrics

### DIFF
--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/Metrics.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/Metrics.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kms.provider.hashicorp.vault;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Tag;
+
+import static io.micrometer.core.instrument.Metrics.counter;
+
+public class Metrics {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Metrics.class);
+
+    public record OperationMetrics(Counter attempt, Counter success, Counter notFound, Counter exception) {
+
+    }
+
+    static final Tag OUTCOME_SUCCESS = Tag.of("outcome", "success");
+    static final Tag OUTCOME_FAILURE = Tag.of("outcome", "failure");
+    static final Tag EXCEPTION_FAILURE = Tag.of("failure", "exception");
+    static final Tag NOT_FOUND_FAILURE = Tag.of("failure", "not_found");
+
+    // the prometheus java SDK requires all the permutations of a meter to have the same set of tags
+    static final Tag EMPTY_FAILURE = Tag.of("failure", "");
+    static final Tag CREATE_DATAKEY_OPERATION = Tag.of("operation", "create_datakey");
+    static final Tag DECRYPT_EDEK_OPERATION = Tag.of("operation", "decrypt_edek");
+    static final Tag RESOLVE_ALIAS_OPERATION = Tag.of("operation", "resolve_alias");
+    static final String OUTCOME_NAME = "kroxylicious_kms_vault_request_outcome_total";
+    static final String ATTEMPT_NAME = "kroxylicious_kms_vault_request_attempt_total";
+    private static OperationMetrics CREATE_DATA_KEY;
+    private static OperationMetrics DECRYPT_EDEK;
+    private static OperationMetrics RESOLVE_ALIAS;
+
+    static {
+        initialize();
+    }
+
+    public static void initialize() {
+        LOG.trace("initializing metric class members");
+
+        CREATE_DATA_KEY = new OperationMetrics(counter(ATTEMPT_NAME, List.of(CREATE_DATAKEY_OPERATION)),
+                counter(OUTCOME_NAME, List.of(CREATE_DATAKEY_OPERATION, OUTCOME_SUCCESS, EMPTY_FAILURE)),
+                counter(OUTCOME_NAME, List.of(CREATE_DATAKEY_OPERATION, OUTCOME_FAILURE, NOT_FOUND_FAILURE)),
+                counter(OUTCOME_NAME, List.of(CREATE_DATAKEY_OPERATION, OUTCOME_FAILURE, EXCEPTION_FAILURE)));
+
+        DECRYPT_EDEK = new OperationMetrics(counter(ATTEMPT_NAME, List.of(DECRYPT_EDEK_OPERATION)),
+                counter(OUTCOME_NAME, List.of(DECRYPT_EDEK_OPERATION, OUTCOME_SUCCESS, EMPTY_FAILURE)),
+                counter(OUTCOME_NAME, List.of(DECRYPT_EDEK_OPERATION, OUTCOME_FAILURE, NOT_FOUND_FAILURE)),
+                counter(OUTCOME_NAME, List.of(DECRYPT_EDEK_OPERATION, OUTCOME_FAILURE, EXCEPTION_FAILURE)));
+
+        RESOLVE_ALIAS = new OperationMetrics(counter(ATTEMPT_NAME, List.of(RESOLVE_ALIAS_OPERATION)),
+                counter(OUTCOME_NAME, List.of(RESOLVE_ALIAS_OPERATION, OUTCOME_SUCCESS, EMPTY_FAILURE)),
+                counter(OUTCOME_NAME, List.of(RESOLVE_ALIAS_OPERATION, OUTCOME_FAILURE, NOT_FOUND_FAILURE)),
+                counter(OUTCOME_NAME, List.of(RESOLVE_ALIAS_OPERATION, OUTCOME_FAILURE, EXCEPTION_FAILURE)));
+    }
+
+    static OperationMetrics createDataKey() {
+        return CREATE_DATA_KEY;
+    }
+
+    static OperationMetrics decryptEdek() {
+        return DECRYPT_EDEK;
+    }
+
+    static OperationMetrics resolveAlias() {
+        return RESOLVE_ALIAS;
+    }
+}

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsService.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsService.java
@@ -30,6 +30,7 @@ public class VaultKmsService implements KmsService<VaultKmsService.Config, Strin
         public Config {
             Objects.requireNonNull(vaultUrl);
             Objects.requireNonNull(vaultToken);
+            Metrics.initialize();
         }
     }
 

--- a/kubernetes-examples/envelope-encryption/README.md
+++ b/kubernetes-examples/envelope-encryption/README.md
@@ -85,3 +85,4 @@ Kafka tooling if you like.
    ```shell { prompt="Now let's consume the same record via the proxy.  This time we'll see the plain-text of the record as Kroxylicious will have decrypted it." }
    kaf -b minikube:30192 consume trades
    ```
+6. Additionally, we can view metrics using `curl minikube:30090/metrics` which will expose some counters exposing the total number of vault operations.

--- a/kubernetes-examples/envelope-encryption/base/kroxylicious/kroxylicious-config.yaml
+++ b/kubernetes-examples/envelope-encryption/base/kroxylicious/kroxylicious-config.yaml
@@ -12,7 +12,7 @@ metadata:
 data:
   config.yaml: |
     adminHttp:
-      port: 9093
+      port: 30090
       endpoints:
         prometheus: {}
     virtualClusters:

--- a/kubernetes-examples/envelope-encryption/base/kroxylicious/kroxylicious-config.yaml
+++ b/kubernetes-examples/envelope-encryption/base/kroxylicious/kroxylicious-config.yaml
@@ -11,6 +11,10 @@ metadata:
   name: kroxylicious-config
 data:
   config.yaml: |
+    adminHttp:
+      port: 9093
+      endpoints:
+        prometheus: {}
     virtualClusters:
       my-cluster-proxy:
         # the virtual cluster is kafka proxy that sits between kafka clients and the real kafka cluster.  clients

--- a/kubernetes-examples/envelope-encryption/base/kroxylicious/kroxylicious-deployment.yaml
+++ b/kubernetes-examples/envelope-encryption/base/kroxylicious/kroxylicious-deployment.yaml
@@ -27,6 +27,7 @@ spec:
         imagePullPolicy: Always
         args: ["--config", "/opt/kroxylicious/config/config.yaml"]
         ports:
+        - containerPort: 30090
         # Tenant devenv1
         - containerPort: 30192
         - containerPort: 30193

--- a/kubernetes-examples/envelope-encryption/base/kroxylicious/kroxylicious-service.yaml
+++ b/kubernetes-examples/envelope-encryption/base/kroxylicious/kroxylicious-service.yaml
@@ -14,6 +14,12 @@ spec:
   selector:
     app: kroxylicious
   ports:
+  - name: port-30090
+    protocol: TCP
+    port: 30090
+    targetPort: 30090
+    nodePort: 30090
+
   - name: port-30192
     protocol: TCP
     port: 30192


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

We want to start making it visible how many API calls are being made to Vault and how many operations are resulting in keys not being found or other exceptions.

Example of the new metrics obtained via the prometheus endpoint:
```
kroxylicious_kms_vault_request_attempt_total{operation="resolve_alias",} 1.0
kroxylicious_kms_vault_request_attempt_total{operation="decrypt_edek",} 1.0
kroxylicious_kms_vault_request_attempt_total{operation="create_datakey",} 1.0
kroxylicious_kms_vault_request_outcome_total{failure="",operation="create_datakey",outcome="success",} 1.0
kroxylicious_kms_vault_request_outcome_total{failure="not_found",operation="decrypt_edek",outcome="failure",} 0.0
kroxylicious_kms_vault_request_outcome_total{failure="",operation="decrypt_edek",outcome="success",} 1.0
kroxylicious_kms_vault_request_outcome_total{failure="exception",operation="create_datakey",outcome="failure",} 0.0
kroxylicious_kms_vault_request_outcome_total{failure="exception",operation="resolve_alias",outcome="failure",} 0.0
kroxylicious_kms_vault_request_outcome_total{failure="not_found",operation="resolve_alias",outcome="failure",} 0.0
kroxylicious_kms_vault_request_outcome_total{failure="not_found",operation="create_datakey",outcome="failure",} 0.0
kroxylicious_kms_vault_request_outcome_total{failure="exception",operation="decrypt_edek",outcome="failure",} 0.0
kroxylicious_kms_vault_request_outcome_total{failure="",operation="resolve_alias",outcome="success",} 1.0
```
The idea is that the sum of the outcomes series for an operation should equal the attempt count for that operation.

Note that this is a limited set of metrics that are registered on startup so that we can start emitting 0.0 values, we do not tag by HTTP status code etc. This helps systems like prometheus alert on changes in each series, there can be issues if you emit no data until the very first occurrence of your error.

We could add HTTP status breakdown in a subsequent PR, or rely on logging to debug failures.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
