### PR TITLE
Kms metrics

### DIFF
--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/InstrumentedKms.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/InstrumentedKms.java
@@ -6,7 +6,6 @@
 
 package io.kroxylicious.filter.encryption;
 
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 
 import javax.crypto.SecretKey;
@@ -73,13 +72,16 @@ public class InstrumentedKms<K, E> implements Kms<K, E> {
             return KmsMetrics.OperationOutcome.SUCCESS;
         }
         else {
-            var toCheck = throwable instanceof CompletionException && throwable.getCause() != null ? throwable.getCause() : throwable;
-            if (toCheck instanceof UnknownKeyException || toCheck instanceof UnknownAliasException) {
+            if (isNotFoundException(throwable) || isNotFoundException(throwable.getCause())) {
                 return KmsMetrics.OperationOutcome.NOT_FOUND;
             }
             else {
                 return KmsMetrics.OperationOutcome.EXCEPTION;
             }
         }
+    }
+
+    private static boolean isNotFoundException(Throwable throwable) {
+        return throwable instanceof UnknownKeyException || throwable instanceof UnknownAliasException;
     }
 }

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/InstrumentedKms.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/InstrumentedKms.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+
+import javax.crypto.SecretKey;
+
+import io.kroxylicious.kms.service.DekPair;
+import io.kroxylicious.kms.service.Kms;
+import io.kroxylicious.kms.service.Serde;
+import io.kroxylicious.kms.service.UnknownAliasException;
+import io.kroxylicious.kms.service.UnknownKeyException;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class InstrumentedKms<K, E> implements Kms<K, E> {
+    private final Kms<K, E> delegate;
+    private final KmsMetrics metrics;
+
+    private InstrumentedKms(Kms<K, E> delegate, KmsMetrics metrics) {
+        this.delegate = delegate;
+        this.metrics = metrics;
+    }
+
+    public static <A, B> Kms<A, B> instrument(Kms<A, B> kms, KmsMetrics metrics) {
+        return new InstrumentedKms<>(kms, metrics);
+    }
+
+    @NonNull
+    @Override
+    public CompletionStage<DekPair<E>> generateDekPair(@NonNull K kekRef) {
+        metrics.countGenerateDekPairAttempt();
+        return delegate.generateDekPair(kekRef).whenComplete((eDekPair, throwable) -> {
+            KmsMetrics.OperationOutcome outcome = classify(throwable);
+            metrics.countGenerateDekPairOutcome(outcome);
+        });
+    }
+
+    @NonNull
+    @Override
+    public CompletionStage<SecretKey> decryptEdek(@NonNull E edek) {
+        metrics.countDecryptEdekAttempt();
+        return delegate.decryptEdek(edek).whenComplete((eDekPair, throwable) -> {
+            KmsMetrics.OperationOutcome outcome = classify(throwable);
+            metrics.countDecryptEdekOutcome(outcome);
+        });
+    }
+
+    @NonNull
+    @Override
+    public CompletionStage<K> resolveAlias(@NonNull String alias) {
+        metrics.countResolveAliasAttempt();
+        return delegate.resolveAlias(alias).whenComplete((eDekPair, throwable) -> {
+            KmsMetrics.OperationOutcome outcome = classify(throwable);
+            metrics.countResolveAliasOutcome(outcome);
+        });
+    }
+
+    @NonNull
+    @Override
+    public Serde<E> edekSerde() {
+        return delegate.edekSerde();
+    }
+
+    private KmsMetrics.OperationOutcome classify(Throwable throwable) {
+        if (throwable == null) {
+            return KmsMetrics.OperationOutcome.SUCCESS;
+        }
+        else {
+            var toCheck = throwable instanceof CompletionException && throwable.getCause() != null ? throwable.getCause() : throwable;
+            if (toCheck instanceof UnknownKeyException || toCheck instanceof UnknownAliasException) {
+                return KmsMetrics.OperationOutcome.NOT_FOUND;
+            }
+            else {
+                return KmsMetrics.OperationOutcome.EXCEPTION;
+            }
+        }
+    }
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/KmsMetrics.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/KmsMetrics.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public interface KmsMetrics {
+    enum OperationOutcome {
+        SUCCESS,
+        EXCEPTION,
+        NOT_FOUND
+    }
+
+    void countGenerateDekPairAttempt();
+
+    void countGenerateDekPairOutcome(@NonNull OperationOutcome outcome);
+
+    void countDecryptEdekAttempt();
+
+    void countDecryptEdekOutcome(@NonNull OperationOutcome outcome);
+
+    void countResolveAliasAttempt();
+
+    void countResolveAliasOutcome(@NonNull OperationOutcome outcome);
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/MicrometerKmsMetrics.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/MicrometerKmsMetrics.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+import java.util.List;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class MicrometerKmsMetrics implements KmsMetrics {
+    public static final String KMS_OPERATION_PREFIX = "kroxylicious_kms_operation";
+    public static final String ATTEMPT_COUNTER_NAME = KMS_OPERATION_PREFIX + "_attempt_total";
+    public static final String OUTCOME_COUNTER_NAME = KMS_OPERATION_PREFIX + "_outcome_total";
+    public static final String OPERATION_TAG_KEY = "operation";
+    public static final Tag OPERATION_GENERATE_DEK_PAIR_TAG = Tag.of(OPERATION_TAG_KEY, "generate_dek_pair");
+    public static final Tag OPERATION_DECRYPT_EDEK_TAG = Tag.of(OPERATION_TAG_KEY, "decrypt_edek");
+    public static final Tag OPERATION_RESOLVE_ALIAS_TAG = Tag.of(OPERATION_TAG_KEY, "resolve_alias");
+    public static final String OUTCOME_TAG_KEY = "outcome";
+    public static final Tag SUCCESS_OUTCOME_TAG = Tag.of(OUTCOME_TAG_KEY, "success");
+    public static final Tag NOT_FOUND_OUTCOME_TAG = Tag.of(OUTCOME_TAG_KEY, "not_found");
+    public static final Tag EXCEPTION_OUTCOME_TAG = Tag.of(OUTCOME_TAG_KEY, "exception");
+    private final Counter generateDekPairAttempts;
+    private final Counter generateDekPairSuccesses;
+    private final Counter generateDekPairExceptions;
+    private final Counter generateDekPairNotFounds;
+    private final Counter decryptEdekAttempts;
+    private final Counter decryptEdekSuccesses;
+    private final Counter decryptEdekNotFounds;
+    private final Counter decryptEdekExceptions;
+    private final Counter resolveAliasAttempt;
+    private final Counter resolveAliasSuccesses;
+    private final Counter resolveAliasNotFounds;
+    private final Counter resolveAliasExceptions;
+
+    private MicrometerKmsMetrics(MeterRegistry registry) {
+        generateDekPairAttempts = attemptCounterForOperation(registry, OPERATION_GENERATE_DEK_PAIR_TAG);
+        generateDekPairSuccesses = outcomeCounterForOperation(registry, OPERATION_GENERATE_DEK_PAIR_TAG, SUCCESS_OUTCOME_TAG);
+        generateDekPairNotFounds = outcomeCounterForOperation(registry, OPERATION_GENERATE_DEK_PAIR_TAG, NOT_FOUND_OUTCOME_TAG);
+        generateDekPairExceptions = outcomeCounterForOperation(registry, OPERATION_GENERATE_DEK_PAIR_TAG, EXCEPTION_OUTCOME_TAG);
+
+        decryptEdekAttempts = attemptCounterForOperation(registry, OPERATION_DECRYPT_EDEK_TAG);
+        decryptEdekSuccesses = outcomeCounterForOperation(registry, OPERATION_DECRYPT_EDEK_TAG, SUCCESS_OUTCOME_TAG);
+        decryptEdekNotFounds = outcomeCounterForOperation(registry, OPERATION_DECRYPT_EDEK_TAG, NOT_FOUND_OUTCOME_TAG);
+        decryptEdekExceptions = outcomeCounterForOperation(registry, OPERATION_DECRYPT_EDEK_TAG, EXCEPTION_OUTCOME_TAG);
+
+        resolveAliasAttempt = attemptCounterForOperation(registry, OPERATION_RESOLVE_ALIAS_TAG);
+        resolveAliasSuccesses = outcomeCounterForOperation(registry, OPERATION_RESOLVE_ALIAS_TAG, SUCCESS_OUTCOME_TAG);
+        resolveAliasNotFounds = outcomeCounterForOperation(registry, OPERATION_RESOLVE_ALIAS_TAG, NOT_FOUND_OUTCOME_TAG);
+        resolveAliasExceptions = outcomeCounterForOperation(registry, OPERATION_RESOLVE_ALIAS_TAG, EXCEPTION_OUTCOME_TAG);
+    }
+
+    public static KmsMetrics create(MeterRegistry registry) {
+        return new MicrometerKmsMetrics(registry);
+    }
+
+    private Counter outcomeCounterForOperation(MeterRegistry registry, Tag operationTag, Tag outcome) {
+        return registry.counter(OUTCOME_COUNTER_NAME, List.of(operationTag, outcome));
+    }
+
+    @NonNull
+    private static Counter attemptCounterForOperation(MeterRegistry registry, Tag operationTag) {
+        return registry.counter(ATTEMPT_COUNTER_NAME, List.of(operationTag));
+    }
+
+    @Override
+    public void countGenerateDekPairAttempt() {
+        generateDekPairAttempts.increment();
+    }
+
+    @Override
+    public void countGenerateDekPairOutcome(@NonNull OperationOutcome outcome) {
+        switch (outcome) {
+            case SUCCESS -> generateDekPairSuccesses.increment();
+            case EXCEPTION -> generateDekPairExceptions.increment();
+            case NOT_FOUND -> generateDekPairNotFounds.increment();
+        }
+    }
+
+    @Override
+    public void countDecryptEdekAttempt() {
+        decryptEdekAttempts.increment();
+    }
+
+    @Override
+    public void countDecryptEdekOutcome(@NonNull OperationOutcome outcome) {
+        switch (outcome) {
+            case SUCCESS -> decryptEdekSuccesses.increment();
+            case EXCEPTION -> decryptEdekExceptions.increment();
+            case NOT_FOUND -> decryptEdekNotFounds.increment();
+        }
+    }
+
+    @Override
+    public void countResolveAliasAttempt() {
+        resolveAliasAttempt.increment();
+    }
+
+    @Override
+    public void countResolveAliasOutcome(@NonNull OperationOutcome outcome) {
+        switch (outcome) {
+            case SUCCESS -> resolveAliasSuccesses.increment();
+            case EXCEPTION -> resolveAliasExceptions.increment();
+            case NOT_FOUND -> resolveAliasNotFounds.increment();
+        }
+    }
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/InstrumentedKmsTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/InstrumentedKmsTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.crypto.SecretKey;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.kroxylicious.kms.service.DekPair;
+import io.kroxylicious.kms.service.Kms;
+import io.kroxylicious.kms.service.Serde;
+import io.kroxylicious.kms.service.UnknownAliasException;
+import io.kroxylicious.kms.service.UnknownKeyException;
+
+import static io.kroxylicious.filter.encryption.KmsMetrics.OperationOutcome.EXCEPTION;
+import static io.kroxylicious.filter.encryption.KmsMetrics.OperationOutcome.NOT_FOUND;
+import static io.kroxylicious.filter.encryption.KmsMetrics.OperationOutcome.SUCCESS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InstrumentedKmsTest {
+
+    @Mock
+    Kms<String, String> kms;
+    @Mock
+    KmsMetrics metrics;
+
+    @Mock
+    SecretKey secretKey;
+
+    @Mock
+    Serde<String> serde;
+
+    @Test
+    public void testResolveAliasSuccess() {
+        Kms<String, String> instrument = InstrumentedKms.instrument(kms, metrics);
+        when(kms.resolveAlias("alias")).thenReturn(CompletableFuture.completedFuture("resolved"));
+        CompletionStage<String> stage = instrument.resolveAlias("alias");
+        assertThat(stage).succeedsWithin(Duration.ZERO);
+        verify(metrics).countResolveAliasAttempt();
+        verify(metrics).countResolveAliasOutcome(SUCCESS);
+    }
+
+    @Test
+    public void testResolveAliasException() {
+        Kms<String, String> instrument = InstrumentedKms.instrument(kms, metrics);
+        when(kms.resolveAlias("alias")).thenReturn(CompletableFuture.failedFuture(new NullPointerException("fail")));
+        CompletionStage<String> stage = instrument.resolveAlias("alias");
+        assertThat(stage).failsWithin(Duration.ZERO);
+        verify(metrics).countResolveAliasAttempt();
+        verify(metrics).countResolveAliasOutcome(EXCEPTION);
+    }
+
+    @Test
+    public void testResolveAliasUnknownAliasException() {
+        Kms<String, String> instrument = InstrumentedKms.instrument(kms, metrics);
+        when(kms.resolveAlias("alias")).thenReturn(CompletableFuture.failedFuture(new UnknownAliasException("unknown")));
+        CompletionStage<String> stage = instrument.resolveAlias("alias");
+        assertThat(stage).failsWithin(Duration.ZERO);
+        verify(metrics).countResolveAliasAttempt();
+        verify(metrics).countResolveAliasOutcome(NOT_FOUND);
+    }
+
+    @Test
+    public void testGenerateDekPairSuccess() {
+        Kms<String, String> instrument = InstrumentedKms.instrument(kms, metrics);
+        DekPair<String> dekPair = new DekPair<>("edek", secretKey);
+        when(kms.generateDekPair("kekRef")).thenReturn(CompletableFuture.completedFuture(dekPair));
+        CompletionStage<DekPair<String>> stage = instrument.generateDekPair("kekRef");
+        assertThat(stage).succeedsWithin(Duration.ZERO).isSameAs(dekPair);
+        verify(metrics).countGenerateDekPairAttempt();
+        verify(metrics).countGenerateDekPairOutcome(SUCCESS);
+    }
+
+    @Test
+    public void testGenerateDekPairException() {
+        Kms<String, String> instrument = InstrumentedKms.instrument(kms, metrics);
+        when(kms.generateDekPair("kekRef")).thenReturn(CompletableFuture.failedFuture(new NullPointerException("fail")));
+        CompletionStage<DekPair<String>> stage = instrument.generateDekPair("kekRef");
+        assertThat(stage).failsWithin(Duration.ZERO);
+        verify(metrics).countGenerateDekPairAttempt();
+        verify(metrics).countGenerateDekPairOutcome(EXCEPTION);
+    }
+
+    @Test
+    public void testGenerateDekPairUnknownKeyException() {
+        Kms<String, String> instrument = InstrumentedKms.instrument(kms, metrics);
+        when(kms.generateDekPair("kekRef")).thenReturn(CompletableFuture.failedFuture(new UnknownKeyException("unknown")));
+        CompletionStage<DekPair<String>> stage = instrument.generateDekPair("kekRef");
+        assertThat(stage).failsWithin(Duration.ZERO);
+        verify(metrics).countGenerateDekPairAttempt();
+        verify(metrics).countGenerateDekPairOutcome(NOT_FOUND);
+    }
+
+    @Test
+    public void testDecryptEdekSuccess() {
+        Kms<String, String> instrument = InstrumentedKms.instrument(kms, metrics);
+        when(kms.decryptEdek("edek")).thenReturn(CompletableFuture.completedFuture(secretKey));
+        CompletionStage<SecretKey> stage = instrument.decryptEdek("edek");
+        assertThat(stage).succeedsWithin(Duration.ZERO).isSameAs(secretKey);
+        verify(metrics).countDecryptEdekAttempt();
+        verify(metrics).countDecryptEdekOutcome(SUCCESS);
+    }
+
+    @Test
+    public void testDecryptEdekException() {
+        Kms<String, String> instrument = InstrumentedKms.instrument(kms, metrics);
+        when(kms.decryptEdek("edek")).thenReturn(CompletableFuture.failedFuture(new NullPointerException("fail")));
+        CompletionStage<SecretKey> stage = instrument.decryptEdek("edek");
+        assertThat(stage).failsWithin(Duration.ZERO);
+        verify(metrics).countDecryptEdekAttempt();
+        verify(metrics).countDecryptEdekOutcome(EXCEPTION);
+    }
+
+    @Test
+    public void testDecryptEdekUnknownKeyException() {
+        Kms<String, String> instrument = InstrumentedKms.instrument(kms, metrics);
+        when(kms.decryptEdek("edek")).thenReturn(CompletableFuture.failedFuture(new UnknownKeyException("unknown")));
+        CompletionStage<SecretKey> stage = instrument.decryptEdek("edek");
+        assertThat(stage).failsWithin(Duration.ZERO);
+        verify(metrics).countDecryptEdekAttempt();
+        verify(metrics).countDecryptEdekOutcome(NOT_FOUND);
+    }
+
+    @Test
+    public void testEdekSerdeDelegation() {
+        Kms<String, String> instrument = InstrumentedKms.instrument(kms, metrics);
+        when(kms.edekSerde()).thenReturn(serde);
+        Serde<String> serde = instrument.edekSerde();
+        assertThat(serde).isSameAs(this.serde);
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/MicrometerKmsMetricsTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/MicrometerKmsMetricsTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MicrometerKmsMetricsTest {
+    public static final String KMS_OPERATION_PREFIX = "kroxylicious_kms_operation";
+    public static final String ATTEMPT_COUNTER_NAME = KMS_OPERATION_PREFIX + "_attempt_total";
+    public static final String OUTCOME_COUNTER_NAME = KMS_OPERATION_PREFIX + "_outcome_total";
+    public static final String OPERATION_TAG_KEY = "operation";
+    public static final Tag OPERATION_GENERATE_DEK_PAIR_TAG = Tag.of(OPERATION_TAG_KEY, "generate_dek_pair");
+    public static final Tag OPERATION_DECRYPT_EDEK_TAG = Tag.of(OPERATION_TAG_KEY, "decrypt_edek");
+    public static final Tag OPERATION_RESOLVE_ALIAS_TAG = Tag.of(OPERATION_TAG_KEY, "resolve_alias");
+    public static final String OUTCOME_TAG_KEY = "outcome";
+    public static final Tag SUCCESS_OUTCOME_TAG = Tag.of(OUTCOME_TAG_KEY, "success");
+    public static final Tag NOT_FOUND_OUTCOME_TAG = Tag.of(OUTCOME_TAG_KEY, "not_found");
+    public static final Tag EXCEPTION_OUTCOME_TAG = Tag.of(OUTCOME_TAG_KEY, "exception");
+    private SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    KmsMetrics kmsMetrics = MicrometerKmsMetrics.create(registry);
+
+    @AfterEach
+    public void teardown() {
+        registry.close();
+    }
+
+    @Test
+    public void testCountDecryptEdekAttempt() {
+        kmsMetrics.countDecryptEdekAttempt();
+        assertCounterValueEquals(ATTEMPT_COUNTER_NAME, List.of(OPERATION_DECRYPT_EDEK_TAG), 1.0d);
+    }
+
+    @Test
+    public void testCountDecryptEdekSuccess() {
+        kmsMetrics.countDecryptEdekOutcome(KmsMetrics.OperationOutcome.SUCCESS);
+        assertCounterValueEquals(OUTCOME_COUNTER_NAME, List.of(OPERATION_DECRYPT_EDEK_TAG, SUCCESS_OUTCOME_TAG), 1.0d);
+    }
+
+    @Test
+    public void testCountDecryptEdekNotFound() {
+        kmsMetrics.countDecryptEdekOutcome(KmsMetrics.OperationOutcome.NOT_FOUND);
+        assertCounterValueEquals(OUTCOME_COUNTER_NAME, List.of(OPERATION_DECRYPT_EDEK_TAG, NOT_FOUND_OUTCOME_TAG), 1.0d);
+    }
+
+    @Test
+    public void testCountDecryptEdekException() {
+        kmsMetrics.countDecryptEdekOutcome(KmsMetrics.OperationOutcome.EXCEPTION);
+        assertCounterValueEquals(OUTCOME_COUNTER_NAME, List.of(OPERATION_DECRYPT_EDEK_TAG, EXCEPTION_OUTCOME_TAG), 1.0d);
+    }
+
+    @Test
+    public void testCountGenerateDekPairAttempt() {
+        kmsMetrics.countGenerateDekPairAttempt();
+        assertCounterValueEquals(ATTEMPT_COUNTER_NAME, List.of(OPERATION_GENERATE_DEK_PAIR_TAG), 1.0d);
+    }
+
+    @Test
+    public void testCountGenerateDekPairSuccess() {
+        kmsMetrics.countGenerateDekPairOutcome(KmsMetrics.OperationOutcome.SUCCESS);
+        assertCounterValueEquals(OUTCOME_COUNTER_NAME, List.of(OPERATION_GENERATE_DEK_PAIR_TAG, SUCCESS_OUTCOME_TAG), 1.0d);
+    }
+
+    @Test
+    public void testCountGenerateDekPairNotFound() {
+        kmsMetrics.countGenerateDekPairOutcome(KmsMetrics.OperationOutcome.NOT_FOUND);
+        assertCounterValueEquals(OUTCOME_COUNTER_NAME, List.of(OPERATION_GENERATE_DEK_PAIR_TAG, NOT_FOUND_OUTCOME_TAG), 1.0d);
+    }
+
+    @Test
+    public void testCountGenerateDekPairException() {
+        kmsMetrics.countGenerateDekPairOutcome(KmsMetrics.OperationOutcome.EXCEPTION);
+        assertCounterValueEquals(OUTCOME_COUNTER_NAME, List.of(OPERATION_GENERATE_DEK_PAIR_TAG, EXCEPTION_OUTCOME_TAG), 1.0d);
+    }
+
+    @Test
+    public void testCountResolveAliasAttempt() {
+        kmsMetrics.countResolveAliasAttempt();
+        assertCounterValueEquals(ATTEMPT_COUNTER_NAME, List.of(OPERATION_RESOLVE_ALIAS_TAG), 1.0d);
+    }
+
+    @Test
+    public void testCountResolveAliasSuccess() {
+        kmsMetrics.countResolveAliasOutcome(KmsMetrics.OperationOutcome.SUCCESS);
+        assertCounterValueEquals(OUTCOME_COUNTER_NAME, List.of(OPERATION_RESOLVE_ALIAS_TAG, SUCCESS_OUTCOME_TAG), 1.0d);
+    }
+
+    @Test
+    public void testCountResolveAliasNotFound() {
+        kmsMetrics.countResolveAliasOutcome(KmsMetrics.OperationOutcome.NOT_FOUND);
+        assertCounterValueEquals(OUTCOME_COUNTER_NAME, List.of(OPERATION_RESOLVE_ALIAS_TAG, NOT_FOUND_OUTCOME_TAG), 1.0d);
+    }
+
+    @Test
+    public void testCountResolveAliasException() {
+        kmsMetrics.countResolveAliasOutcome(KmsMetrics.OperationOutcome.EXCEPTION);
+        assertCounterValueEquals(OUTCOME_COUNTER_NAME, List.of(OPERATION_RESOLVE_ALIAS_TAG, EXCEPTION_OUTCOME_TAG), 1.0d);
+    }
+
+    private void assertCounterValueEquals(String name, Iterable<Tag> tags, double expected) {
+        Counter counter = registry.find(name).tags(tags).counter();
+        assertThat(counter).isNotNull();
+        assertThat(counter.count()).isEqualTo(expected);
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/MicrometerKmsMetricsTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/MicrometerKmsMetricsTest.java
@@ -33,78 +33,78 @@ class MicrometerKmsMetricsTest {
     KmsMetrics kmsMetrics = MicrometerKmsMetrics.create(registry);
 
     @AfterEach
-    public void teardown() {
+    void teardown() {
         registry.close();
     }
 
     @Test
-    public void testCountDecryptEdekAttempt() {
+    void testCountDecryptEdekAttempt() {
         kmsMetrics.countDecryptEdekAttempt();
         assertCounterValueEquals(ATTEMPT_COUNTER_NAME, List.of(OPERATION_DECRYPT_EDEK_TAG), 1.0d);
     }
 
     @Test
-    public void testCountDecryptEdekSuccess() {
+    void testCountDecryptEdekSuccess() {
         kmsMetrics.countDecryptEdekOutcome(KmsMetrics.OperationOutcome.SUCCESS);
         assertCounterValueEquals(OUTCOME_COUNTER_NAME, List.of(OPERATION_DECRYPT_EDEK_TAG, SUCCESS_OUTCOME_TAG), 1.0d);
     }
 
     @Test
-    public void testCountDecryptEdekNotFound() {
+    void testCountDecryptEdekNotFound() {
         kmsMetrics.countDecryptEdekOutcome(KmsMetrics.OperationOutcome.NOT_FOUND);
         assertCounterValueEquals(OUTCOME_COUNTER_NAME, List.of(OPERATION_DECRYPT_EDEK_TAG, NOT_FOUND_OUTCOME_TAG), 1.0d);
     }
 
     @Test
-    public void testCountDecryptEdekException() {
+    void testCountDecryptEdekException() {
         kmsMetrics.countDecryptEdekOutcome(KmsMetrics.OperationOutcome.EXCEPTION);
         assertCounterValueEquals(OUTCOME_COUNTER_NAME, List.of(OPERATION_DECRYPT_EDEK_TAG, EXCEPTION_OUTCOME_TAG), 1.0d);
     }
 
     @Test
-    public void testCountGenerateDekPairAttempt() {
+    void testCountGenerateDekPairAttempt() {
         kmsMetrics.countGenerateDekPairAttempt();
         assertCounterValueEquals(ATTEMPT_COUNTER_NAME, List.of(OPERATION_GENERATE_DEK_PAIR_TAG), 1.0d);
     }
 
     @Test
-    public void testCountGenerateDekPairSuccess() {
+    void testCountGenerateDekPairSuccess() {
         kmsMetrics.countGenerateDekPairOutcome(KmsMetrics.OperationOutcome.SUCCESS);
         assertCounterValueEquals(OUTCOME_COUNTER_NAME, List.of(OPERATION_GENERATE_DEK_PAIR_TAG, SUCCESS_OUTCOME_TAG), 1.0d);
     }
 
     @Test
-    public void testCountGenerateDekPairNotFound() {
+    void testCountGenerateDekPairNotFound() {
         kmsMetrics.countGenerateDekPairOutcome(KmsMetrics.OperationOutcome.NOT_FOUND);
         assertCounterValueEquals(OUTCOME_COUNTER_NAME, List.of(OPERATION_GENERATE_DEK_PAIR_TAG, NOT_FOUND_OUTCOME_TAG), 1.0d);
     }
 
     @Test
-    public void testCountGenerateDekPairException() {
+    void testCountGenerateDekPairException() {
         kmsMetrics.countGenerateDekPairOutcome(KmsMetrics.OperationOutcome.EXCEPTION);
         assertCounterValueEquals(OUTCOME_COUNTER_NAME, List.of(OPERATION_GENERATE_DEK_PAIR_TAG, EXCEPTION_OUTCOME_TAG), 1.0d);
     }
 
     @Test
-    public void testCountResolveAliasAttempt() {
+    void testCountResolveAliasAttempt() {
         kmsMetrics.countResolveAliasAttempt();
         assertCounterValueEquals(ATTEMPT_COUNTER_NAME, List.of(OPERATION_RESOLVE_ALIAS_TAG), 1.0d);
     }
 
     @Test
-    public void testCountResolveAliasSuccess() {
+    void testCountResolveAliasSuccess() {
         kmsMetrics.countResolveAliasOutcome(KmsMetrics.OperationOutcome.SUCCESS);
         assertCounterValueEquals(OUTCOME_COUNTER_NAME, List.of(OPERATION_RESOLVE_ALIAS_TAG, SUCCESS_OUTCOME_TAG), 1.0d);
     }
 
     @Test
-    public void testCountResolveAliasNotFound() {
+    void testCountResolveAliasNotFound() {
         kmsMetrics.countResolveAliasOutcome(KmsMetrics.OperationOutcome.NOT_FOUND);
         assertCounterValueEquals(OUTCOME_COUNTER_NAME, List.of(OPERATION_RESOLVE_ALIAS_TAG, NOT_FOUND_OUTCOME_TAG), 1.0d);
     }
 
     @Test
-    public void testCountResolveAliasException() {
+    void testCountResolveAliasException() {
         kmsMetrics.countResolveAliasOutcome(KmsMetrics.OperationOutcome.EXCEPTION);
         assertCounterValueEquals(OUTCOME_COUNTER_NAME, List.of(OPERATION_RESOLVE_ALIAS_TAG, EXCEPTION_OUTCOME_TAG), 1.0d);
     }

--- a/kubernetes-examples/envelope-encryption/README.md
+++ b/kubernetes-examples/envelope-encryption/README.md
@@ -85,3 +85,4 @@ Kafka tooling if you like.
    ```shell { prompt="Now let's consume the same record via the proxy.  This time we'll see the plain-text of the record as Kroxylicious will have decrypted it." }
    kaf -b minikube:30192 consume trades
    ```
+6. Additionally, we can view metrics using `curl minikube:30090/metrics` which will expose some counters exposing the total number of vault operations.

--- a/kubernetes-examples/envelope-encryption/base/kroxylicious/kroxylicious-config.yaml
+++ b/kubernetes-examples/envelope-encryption/base/kroxylicious/kroxylicious-config.yaml
@@ -11,6 +11,10 @@ metadata:
   name: kroxylicious-config
 data:
   config.yaml: |
+    adminHttp:
+      port: 30090
+      endpoints:
+        prometheus: {}
     virtualClusters:
       my-cluster-proxy:
         # the virtual cluster is kafka proxy that sits between kafka clients and the real kafka cluster.  clients

--- a/kubernetes-examples/envelope-encryption/base/kroxylicious/kroxylicious-deployment.yaml
+++ b/kubernetes-examples/envelope-encryption/base/kroxylicious/kroxylicious-deployment.yaml
@@ -27,6 +27,7 @@ spec:
         imagePullPolicy: Always
         args: ["--config", "/opt/kroxylicious/config/config.yaml"]
         ports:
+        - containerPort: 30090
         # Tenant devenv1
         - containerPort: 30192
         - containerPort: 30193

--- a/kubernetes-examples/envelope-encryption/base/kroxylicious/kroxylicious-service.yaml
+++ b/kubernetes-examples/envelope-encryption/base/kroxylicious/kroxylicious-service.yaml
@@ -14,6 +14,12 @@ spec:
   selector:
     app: kroxylicious
   ports:
+  - name: port-30090
+    protocol: TCP
+    port: 30090
+    targetPort: 30090
+    nodePort: 30090
+
   - name: port-30192
     protocol: TCP
     port: 30192


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds envelope encryption metrics to expose how often we attempt KMS operations and the outcome of them. The metrics are available for scraping at startup, before any client connections are made. The counters look like this in prometheus form:

```
curl minikube:30090/metrics --silent | grep -v '#' | grep kms
kroxylicious_kms_operation_attempt_total{operation="resolve_alias",} 6.0
kroxylicious_kms_operation_attempt_total{operation="decrypt_edek",} 0.0
kroxylicious_kms_operation_attempt_total{operation="generate_dek_pair",} 2.0
kroxylicious_kms_operation_outcome_total{operation="resolve_alias",outcome="exception",} 3.0
kroxylicious_kms_operation_outcome_total{operation="decrypt_edek",outcome="success",} 0.0
kroxylicious_kms_operation_outcome_total{operation="generate_dek_pair",outcome="success",} 2.0
kroxylicious_kms_operation_outcome_total{operation="resolve_alias",outcome="not_found",} 1.0
kroxylicious_kms_operation_outcome_total{operation="generate_dek_pair",outcome="not_found",} 0.0
kroxylicious_kms_operation_outcome_total{operation="decrypt_edek",outcome="exception",} 0.0
kroxylicious_kms_operation_outcome_total{operation="generate_dek_pair",outcome="exception",} 0.0
kroxylicious_kms_operation_outcome_total{operation="decrypt_edek",outcome="not_found",} 0.0
kroxylicious_kms_operation_outcome_total{operation="resolve_alias",outcome="success",} 2.0
```

The sum of the outcomes for an operation should equal the attempt count.

Also includes wiring up the envelope encryption example so prometheus metrics are configured and exposed by minikube so you can curl them from the host.

Implements part of #789
Supercedes #854 where I put these metrics down at the vault level, but this logical level of metricsis more suitable for the filter.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
