### PR TITLE
Quick fix  for stage-release.sh - reset nounset

### DIFF
--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -8,6 +8,8 @@
 set -e
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . "${SCRIPT_DIR}/common.sh"
+# Tmp fix - revert the nounset change made by common to match the expectations of this script.
+set +u
 
 REPOSITORY="origin"
 BRANCH_FROM="main"


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

#827 introduced a defect into stage release - it inadvertently enabled `set -u' which causes problems with stage-release.sh later process.

Ultimately `-u` semantics are what we want, but for expediency I make this temporary fix.



### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
