### PR TITLE
added kafka node pools and configure strimzi to enable KRaft mode

### DIFF
--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
@@ -150,5 +150,7 @@ public interface Constants {
      * Feature gate related constants
      */
     String USE_KRAFT_MODE = "+UseKRaft";
+    String DONT_USE_KRAFT_MODE = "-UseKRaft";
     String USE_KAFKA_NODE_POOLS = "+KafkaNodePools";
+    String DONT_USE_KAFKA_NODE_POOLS = "-KafkaNodePools";
 }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
@@ -145,4 +145,12 @@ public interface Constants {
      * kafka admin client label to identify the admin test client
      */
     String KAFKA_ADMIN_CLIENT_LABEL = "admin-client-cli";
+
+    /**
+     * Feature gate related constants
+     */
+    String USE_KRAFT_MODE = "+UseKRaft";
+    String DONT_USE_KAFKA_NODE_POOLS = "-KafkaNodePools";
+    // kept for upgrade/downgrade tests in KRaft
+    String USE_KAFKA_NODE_POOLS = "+KafkaNodePools";
 }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
@@ -150,7 +150,5 @@ public interface Constants {
      * Feature gate related constants
      */
     String USE_KRAFT_MODE = "+UseKRaft";
-    String DONT_USE_KAFKA_NODE_POOLS = "-KafkaNodePools";
-    // kept for upgrade/downgrade tests in KRaft
     String USE_KAFKA_NODE_POOLS = "+KafkaNodePools";
 }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
@@ -28,11 +28,20 @@ public class Environment {
     private static final String KROXY_IMAGE_REPO_ENV = "KROXYLICIOUS_IMAGE_REPO";
     private static final String STRIMZI_URL_ENV = "STRIMZI_URL";
     private static final String SKIP_TEARDOWN_ENV = "SKIP_TEARDOWN";
+    public static final String STRIMZI_FEATURE_GATES_ENV = "STRIMZI_FEATURE_GATES";
+
+    /**
+     * Determine whether KRaft mode of Kafka cluster is enabled in Cluster Operator or not.
+     * @return true if KRaft mode is enabled, otherwise false
+     */
+    public static boolean isKRaftModeEnabled() {
+        return STRIMZI_FEATURE_GATES.contains(Constants.USE_KRAFT_MODE);
+    }
 
     /**
      * The kafka version default value
      */
-    public static final String KAFKA_VERSION_DEFAULT;
+    private static final String KAFKA_VERSION_DEFAULT;
 
     static {
         KAFKA_VERSION_DEFAULT = determineKafkaVersion();
@@ -41,7 +50,7 @@ public class Environment {
     /**
      * The kroxy version default value
      */
-    public static final String KROXY_VERSION_DEFAULT;
+    private static final String KROXY_VERSION_DEFAULT;
 
     static {
         KROXY_VERSION_DEFAULT = determineKroxyliciousVersion();
@@ -50,16 +59,17 @@ public class Environment {
     /**
      * The url where kroxylicious image lives to be downloaded.
      */
-    public static final String KROXY_IMAGE_REPO_DEFAULT = "quay.io/kroxylicious/kroxylicious-developer";
+    private static final String KROXY_IMAGE_REPO_DEFAULT = "quay.io/kroxylicious/kroxylicious-developer";
 
     /**
      * The strimzi installation url for kubernetes.
      */
-    public static final String STRIMZI_URL_DEFAULT = "https://strimzi.io/install/latest?namespace=" + Constants.KROXY_DEFAULT_NAMESPACE;
+    private static final String STRIMZI_URL_DEFAULT = "https://strimzi.io/install/latest?namespace=" + Constants.KROXY_DEFAULT_NAMESPACE;
     /**
      * The default value for skipping the teardown locally.
      */
-    public static final String SKIP_TEARDOWN_DEFAULT = "false";
+    private static final String SKIP_TEARDOWN_DEFAULT = "false";
+    private static final String STRIMZI_FEATURE_GATES_DEFAULT = "";
 
     /**
      * KAFKA_VERSION env variable assignment
@@ -82,6 +92,8 @@ public class Environment {
      * SKIP_TEARDOWN env variable assignment.
      */
     public static final String SKIP_TEARDOWN = getOrDefault(SKIP_TEARDOWN_ENV, SKIP_TEARDOWN_DEFAULT);
+
+    public static final String STRIMZI_FEATURE_GATES = getOrDefault(STRIMZI_FEATURE_GATES_ENV, STRIMZI_FEATURE_GATES_DEFAULT);
 
     private static String getOrDefault(String varName, String defaultValue) {
         return getOrDefault(varName, String::toString, defaultValue);

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
@@ -31,14 +31,6 @@ public class Environment {
     public static final String STRIMZI_FEATURE_GATES_ENV = "STRIMZI_FEATURE_GATES";
 
     /**
-     * Determine whether KRaft mode of Kafka cluster is enabled in Cluster Operator or not.
-     * @return true if KRaft mode is enabled, otherwise false
-     */
-    public static boolean isKRaftModeEnabled() {
-        return STRIMZI_FEATURE_GATES.contains(Constants.USE_KRAFT_MODE);
-    }
-
-    /**
      * The kafka version default value
      */
     private static final String KAFKA_VERSION_DEFAULT;

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
@@ -48,18 +48,18 @@ public class Strimzi {
      */
     public Strimzi(String deploymentNamespace) throws IOException {
         this.deploymentNamespace = deploymentNamespace;
-        InputStream strimziYaml = DeploymentUtils.getDeploymentFileFromURL(Environment.STRIMZI_URL);
-        InputStream strimziYamlKRaft = configureKRaftModeForStrimzi(strimziYaml);
-        deployment = kubeClient().getClient().load(strimziYamlKRaft);
+        InputStream strimziMultiDocumentYaml = DeploymentUtils.getDeploymentFileFromURL(Environment.STRIMZI_URL);
+        InputStream strimziMultiDocumentYamlKRaft = configureKRaftModeForStrimzi(strimziMultiDocumentYaml);
+        deployment = kubeClient().getClient().load(strimziMultiDocumentYamlKRaft);
     }
 
-    private InputStream configureKRaftModeForStrimzi(InputStream strimziYaml) throws IOException {
+    private InputStream configureKRaftModeForStrimzi(InputStream strimziMultiDocumentYaml) throws IOException {
         YAMLFactory yamlFactory = new YAMLFactory();
         ObjectMapper mapper = new YAMLMapper();
 
-        YAMLParser yamlParser = yamlFactory.createParser(strimziYaml);
+        YAMLParser multiDocumentYamlParser = yamlFactory.createParser(strimziMultiDocumentYaml);
         List<JsonNode> docs = mapper
-                .readValues(yamlParser, new TypeReference<JsonNode>() {
+                .readValues(multiDocumentYamlParser, new TypeReference<JsonNode>() {
                 })
                 .readAll();
         boolean found = false;

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
@@ -30,6 +30,7 @@ import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRec
 import io.kroxylicious.systemtests.Constants;
 import io.kroxylicious.systemtests.Environment;
 import io.kroxylicious.systemtests.utils.DeploymentUtils;
+import io.kroxylicious.systemtests.utils.TestUtils;
 
 import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
 
@@ -78,12 +79,8 @@ public class Strimzi {
                         value = value.replace(Constants.DONT_USE_KRAFT_MODE, Constants.USE_KRAFT_MODE)
                                 .replace(Constants.DONT_USE_KAFKA_NODE_POOLS, Constants.USE_KAFKA_NODE_POOLS);
 
-                        if (!value.contains(Constants.USE_KRAFT_MODE)) {
-                            value = value.concat("," + Constants.USE_KRAFT_MODE);
-                        }
-                        if (!value.contains(Constants.USE_KAFKA_NODE_POOLS)) {
-                            value = value.concat("," + Constants.USE_KAFKA_NODE_POOLS);
-                        }
+                        value = TestUtils.concatStringIfValueDontExist(value, Constants.USE_KRAFT_MODE, ",");
+                        value = TestUtils.concatStringIfValueDontExist(value, Constants.USE_KAFKA_NODE_POOLS, ",");
                     }
                     ((ObjectNode) node).put("value", value);
                     break;

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
@@ -74,7 +74,8 @@ public class Strimzi {
                         String value = node.at("/value").asText();
                         if (value.isEmpty() || value.isBlank()) {
                             value = String.join(",", Constants.USE_KRAFT_MODE, Constants.USE_KAFKA_NODE_POOLS);
-                        } else {
+                        }
+                        else {
                             value = value.replace(Constants.DONT_USE_KRAFT_MODE, Constants.USE_KRAFT_MODE)
                                     .replace(Constants.DONT_USE_KAFKA_NODE_POOLS, Constants.USE_KAFKA_NODE_POOLS);
 

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
@@ -74,7 +74,6 @@ public class Strimzi {
                         ((ObjectNode) node).put("value", String.join(",", Constants.USE_KRAFT_MODE, Constants.USE_KAFKA_NODE_POOLS));
                     }
                 }
-
             }
         }
 

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
@@ -72,6 +72,7 @@ public class Strimzi {
                     if (node.at("/name").asText().equals(Environment.STRIMZI_FEATURE_GATES_ENV)) {
                         found = true;
                         ((ObjectNode) node).put("value", String.join(",", Constants.USE_KRAFT_MODE, Constants.USE_KAFKA_NODE_POOLS));
+                        break;
                     }
                 }
             }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
@@ -71,7 +71,21 @@ public class Strimzi {
                 for (JsonNode node : envNode) {
                     if (node.at("/name").asText().equals(Environment.STRIMZI_FEATURE_GATES_ENV)) {
                         found = true;
-                        ((ObjectNode) node).put("value", String.join(",", Constants.USE_KRAFT_MODE, Constants.USE_KAFKA_NODE_POOLS));
+                        String value = node.at("/value").asText();
+                        if (value.isEmpty() || value.isBlank()) {
+                            value = String.join(",", Constants.USE_KRAFT_MODE, Constants.USE_KAFKA_NODE_POOLS);
+                        } else {
+                            value = value.replace(Constants.DONT_USE_KRAFT_MODE, Constants.USE_KRAFT_MODE)
+                                    .replace(Constants.DONT_USE_KAFKA_NODE_POOLS, Constants.USE_KAFKA_NODE_POOLS);
+
+                            if (!value.contains(Constants.USE_KRAFT_MODE)) {
+                                value = value.concat("," + Constants.USE_KRAFT_MODE);
+                            }
+                            if (!value.contains(Constants.USE_KAFKA_NODE_POOLS)) {
+                                value = value.concat("," + Constants.USE_KAFKA_NODE_POOLS);
+                            }
+                        }
+                        ((ObjectNode) node).put("value", value);
                         break;
                     }
                 }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
@@ -59,25 +59,26 @@ public class Strimzi {
 
         YAMLParser yamlParser = yamlFactory.createParser(strimziYaml);
         List<JsonNode> docs = mapper
-                .readValues(yamlParser, new TypeReference<JsonNode>(){})
+                .readValues(yamlParser, new TypeReference<JsonNode>() {
+                })
                 .readAll();
         boolean found = false;
-        for(JsonNode doc : docs) {
+        for (JsonNode doc : docs) {
             String kind = doc.at("/kind").asText("");
-            if(kind.equals(Constants.DEPLOYMENT)) {
+            if (kind.equals(Constants.DEPLOYMENT)) {
                 ArrayNode arrayNode = (ArrayNode) doc.at("/spec/template/spec/containers");
                 ArrayNode envNode = (ArrayNode) arrayNode.get(0).at("/env");
-                for(JsonNode node : envNode) {
-                    if(node.at("/name").asText().equals(Environment.STRIMZI_FEATURE_GATES_ENV)) {
+                for (JsonNode node : envNode) {
+                    if (node.at("/name").asText().equals(Environment.STRIMZI_FEATURE_GATES_ENV)) {
                         found = true;
-                        ((ObjectNode)node).put("value", String.join(",", Constants.USE_KRAFT_MODE, Constants.USE_KAFKA_NODE_POOLS));
+                        ((ObjectNode) node).put("value", String.join(",", Constants.USE_KRAFT_MODE, Constants.USE_KAFKA_NODE_POOLS));
                     }
                 }
 
             }
         }
 
-        if(!found) {
+        if (!found) {
             throw new InvalidObjectException("STRIMZI_FEATURE_GATES env variable not found in yaml!");
         }
 

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
@@ -63,32 +63,30 @@ public class Strimzi {
                 })
                 .readAll();
         boolean found = false;
-        for (JsonNode doc : docs) {
-            String kind = doc.at("/kind").asText("");
-            if (kind.equals(Constants.DEPLOYMENT)) {
-                ArrayNode arrayNode = (ArrayNode) doc.at("/spec/template/spec/containers");
-                ArrayNode envNode = (ArrayNode) arrayNode.get(0).at("/env");
-                for (JsonNode node : envNode) {
-                    if (node.at("/name").asText().equals(Environment.STRIMZI_FEATURE_GATES_ENV)) {
-                        found = true;
-                        String value = node.at("/value").asText();
-                        if (value.isEmpty() || value.isBlank()) {
-                            value = String.join(",", Constants.USE_KRAFT_MODE, Constants.USE_KAFKA_NODE_POOLS);
-                        }
-                        else {
-                            value = value.replace(Constants.DONT_USE_KRAFT_MODE, Constants.USE_KRAFT_MODE)
-                                    .replace(Constants.DONT_USE_KAFKA_NODE_POOLS, Constants.USE_KAFKA_NODE_POOLS);
-
-                            if (!value.contains(Constants.USE_KRAFT_MODE)) {
-                                value = value.concat("," + Constants.USE_KRAFT_MODE);
-                            }
-                            if (!value.contains(Constants.USE_KAFKA_NODE_POOLS)) {
-                                value = value.concat("," + Constants.USE_KAFKA_NODE_POOLS);
-                            }
-                        }
-                        ((ObjectNode) node).put("value", value);
-                        break;
+        List<JsonNode> deploymentDocs = docs.stream().filter(p -> p.at("/kind").asText("").equals(Constants.DEPLOYMENT)).toList();
+        for (JsonNode doc : deploymentDocs) {
+            ArrayNode arrayNode = (ArrayNode) doc.at("/spec/template/spec/containers");
+            ArrayNode envNode = (ArrayNode) arrayNode.get(0).at("/env");
+            for (JsonNode node : envNode) {
+                if (node.at("/name").asText().equals(Environment.STRIMZI_FEATURE_GATES_ENV)) {
+                    found = true;
+                    String value = node.at("/value").asText();
+                    if (value.isEmpty() || value.isBlank()) {
+                        value = String.join(",", Constants.USE_KRAFT_MODE, Constants.USE_KAFKA_NODE_POOLS);
                     }
+                    else {
+                        value = value.replace(Constants.DONT_USE_KRAFT_MODE, Constants.USE_KRAFT_MODE)
+                                .replace(Constants.DONT_USE_KAFKA_NODE_POOLS, Constants.USE_KAFKA_NODE_POOLS);
+
+                        if (!value.contains(Constants.USE_KRAFT_MODE)) {
+                            value = value.concat("," + Constants.USE_KRAFT_MODE);
+                        }
+                        if (!value.contains(Constants.USE_KAFKA_NODE_POOLS)) {
+                            value = value.concat("," + Constants.USE_KAFKA_NODE_POOLS);
+                        }
+                    }
+                    ((ObjectNode) node).put("value", value);
+                    break;
                 }
             }
         }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/k8s/exception/KubeClusterException.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/k8s/exception/KubeClusterException.java
@@ -31,6 +31,16 @@ public class KubeClusterException extends RuntimeException {
     /**
      * Instantiates a new Kube cluster exception.
      *
+     * @param s the s
+     */
+    public KubeClusterException(String s) {
+        super(s);
+        this.result = null;
+    }
+
+    /**
+     * Instantiates a new Kube cluster exception.
+     *
      * @param cause the cause
      */
     public KubeClusterException(Throwable cause) {
@@ -51,6 +61,15 @@ public class KubeClusterException extends RuntimeException {
          */
         public NotFound(ExecResult result, String s) {
             super(result, s);
+        }
+
+        /**
+         * Instantiates a new Not found.
+         *
+         * @param s the s
+         */
+        public NotFound(String s) {
+            super(s);
         }
     }
 

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/strimzi/KafkaNodePoolTemplates.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/strimzi/KafkaNodePoolTemplates.java
@@ -110,7 +110,8 @@ public class KafkaNodePoolTemplates {
      * @param kafkaReplicas the kafka replicas
      * @return the kafka node pool builder
      */
-    public static KafkaNodePoolBuilder kafkaNodePoolWithControllerRoleAndPersistentStorage(String namespaceName, String nodePoolName, String kafkaClusterName, int kafkaReplicas) {
+    public static KafkaNodePoolBuilder kafkaNodePoolWithControllerRoleAndPersistentStorage(String namespaceName, String nodePoolName, String kafkaClusterName,
+                                                                                           int kafkaReplicas) {
         return kafkaNodePoolWithControllerRole(namespaceName, nodePoolName, kafkaClusterName, kafkaReplicas)
                 .editOrNewSpec()
                 .withNewPersistentClaimStorage()
@@ -129,7 +130,8 @@ public class KafkaNodePoolTemplates {
      * @param kafkaReplicas the kafka replicas
      * @return the kafka node pool builder
      */
-    public static KafkaNodePoolBuilder kafkaNodePoolWithBrokerRoleAndPersistentStorage(String namespaceName, String nodePoolName, String kafkaClusterName, int kafkaReplicas) {
+    public static KafkaNodePoolBuilder kafkaNodePoolWithBrokerRoleAndPersistentStorage(String namespaceName, String nodePoolName, String kafkaClusterName,
+                                                                                       int kafkaReplicas) {
         return kafkaNodePoolWithBrokerRole(namespaceName, nodePoolName, kafkaClusterName, kafkaReplicas)
                 .editOrNewSpec()
                 .withNewPersistentClaimStorage()

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/strimzi/KafkaNodePoolTemplates.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/strimzi/KafkaNodePoolTemplates.java
@@ -6,8 +6,10 @@
 
 package io.kroxylicious.systemtests.templates.strimzi;
 
+import java.util.List;
 import java.util.Map;
 
+import io.strimzi.api.kafka.model.Kafka;
 import io.strimzi.api.kafka.model.nodepool.KafkaNodePoolBuilder;
 import io.strimzi.api.kafka.model.nodepool.ProcessRoles;
 
@@ -40,7 +42,7 @@ public class KafkaNodePoolTemplates {
     }
 
     /**
-     * Kafka node pool with broker role kafka node pool builder.
+     * Kafka node pool with broker role.
      *
      * @param namespaceName the namespace name
      * @param nodePoolName the node pool name
@@ -52,6 +54,88 @@ public class KafkaNodePoolTemplates {
         return defaultKafkaNodePool(namespaceName, nodePoolName, kafkaClusterName, kafkaReplicas)
                 .editOrNewSpec()
                 .addToRoles(ProcessRoles.BROKER)
+                .endSpec();
+    }
+
+    /**
+     * Creates a KafkaNodePoolBuilder for a Kafka instance with both BROKER and CONTROLLER roles.
+     *
+     * @param nodePoolName The name of the node pool.
+     * @param kafka The Kafka instance (Model of Kafka).
+     * @param kafkaNodePoolReplicas The number of kafka broker replicas for the given node pool.
+     * @return KafkaNodePoolBuilder configured with both BROKER and CONTROLLER roles.
+     */
+    public static KafkaNodePoolBuilder kafkaBasedNodePoolWithDualRole(String nodePoolName, Kafka kafka, int kafkaNodePoolReplicas) {
+        return kafkaBasedNodePoolWithRole(nodePoolName, kafka, List.of(ProcessRoles.BROKER, ProcessRoles.CONTROLLER), kafkaNodePoolReplicas);
+    }
+
+    private static KafkaNodePoolBuilder kafkaBasedNodePoolWithRole(String nodePoolName, Kafka kafka, List<ProcessRoles> roles, int kafkaNodePoolReplicas) {
+        return new KafkaNodePoolBuilder()
+                .withNewMetadata()
+                .withName(nodePoolName)
+                .withNamespace(kafka.getMetadata().getNamespace())
+                .withLabels(Map.of(Constants.STRIMZI_CLUSTER_LABEL, kafka.getMetadata().getName()))
+                .endMetadata()
+                .withNewSpec()
+                .withRoles(roles)
+                .withReplicas(kafkaNodePoolReplicas)
+                .withStorage(kafka.getSpec().getKafka().getStorage())
+                .withJvmOptions(kafka.getSpec().getKafka().getJvmOptions())
+                .withResources(kafka.getSpec().getKafka().getResources())
+                .endSpec();
+    }
+
+    /**
+     * Kafka node pool with controller role.
+     *
+     * @param namespaceName the namespace name
+     * @param nodePoolName the node pool name
+     * @param kafkaClusterName the kafka cluster name
+     * @param kafkaReplicas the kafka replicas
+     * @return the kafka node pool builder
+     */
+    public static KafkaNodePoolBuilder kafkaNodePoolWithControllerRole(String namespaceName, String nodePoolName, String kafkaClusterName, int kafkaReplicas) {
+        return defaultKafkaNodePool(namespaceName, nodePoolName, kafkaClusterName, kafkaReplicas)
+                .editOrNewSpec()
+                .addToRoles(ProcessRoles.CONTROLLER)
+                .endSpec();
+    }
+
+    /**
+     * Kafka node pool with controller role and persistent storage.
+     *
+     * @param namespaceName the namespace name
+     * @param nodePoolName the node pool name
+     * @param kafkaClusterName the kafka cluster name
+     * @param kafkaReplicas the kafka replicas
+     * @return the kafka node pool builder
+     */
+    public static KafkaNodePoolBuilder kafkaNodePoolWithControllerRoleAndPersistentStorage(String namespaceName, String nodePoolName, String kafkaClusterName, int kafkaReplicas) {
+        return kafkaNodePoolWithControllerRole(namespaceName, nodePoolName, kafkaClusterName, kafkaReplicas)
+                .editOrNewSpec()
+                .withNewPersistentClaimStorage()
+                .withSize("1Gi")
+                .withDeleteClaim(true)
+                .endPersistentClaimStorage()
+                .endSpec();
+    }
+
+    /**
+     * Kafka node pool with broker role and persistent storage.
+     *
+     * @param namespaceName the namespace name
+     * @param nodePoolName the node pool name
+     * @param kafkaClusterName the kafka cluster name
+     * @param kafkaReplicas the kafka replicas
+     * @return the kafka node pool builder
+     */
+    public static KafkaNodePoolBuilder kafkaNodePoolWithBrokerRoleAndPersistentStorage(String namespaceName, String nodePoolName, String kafkaClusterName, int kafkaReplicas) {
+        return kafkaNodePoolWithBrokerRole(namespaceName, nodePoolName, kafkaClusterName, kafkaReplicas)
+                .editOrNewSpec()
+                .withNewPersistentClaimStorage()
+                .withSize("1Gi")
+                .withDeleteClaim(true)
+                .endPersistentClaimStorage()
                 .endSpec();
     }
 }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/strimzi/KafkaTemplates.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/strimzi/KafkaTemplates.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.systemtests.templates.strimzi;
 
+import io.strimzi.api.ResourceAnnotations;
 import io.strimzi.api.kafka.model.KafkaBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.GenericKafkaListenerBuilder;
 import io.strimzi.api.kafka.model.listener.arraylistener.KafkaListenerType;
@@ -72,6 +73,22 @@ public class KafkaTemplates {
                         .build())
                 .endKafka()
                 .endSpec();
+    }
+
+    /**
+     * Kafka persistent with KRaft annotations.
+     *
+     * @param namespaceName the namespace name
+     * @param clusterName the cluster name
+     * @param kafkaReplicas the kafka replicas
+     * @return the kafka builder
+     */
+    public static KafkaBuilder kafkaPersistentWithKRaftAnnotations(String namespaceName, String clusterName, int kafkaReplicas) {
+        return kafkaPersistent(namespaceName, clusterName, kafkaReplicas, kafkaReplicas)
+                .editMetadata()
+                .addToAnnotations(ResourceAnnotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
+                .addToAnnotations(ResourceAnnotations.ANNO_STRIMZI_IO_KRAFT, "enabled")
+                .endMetadata();
     }
 
     private static KafkaBuilder defaultKafka(String namespaceName, String clusterName, int kafkaReplicas, int zkReplicas) {

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/strimzi/KafkaTemplates.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/strimzi/KafkaTemplates.java
@@ -133,18 +133,6 @@ public class KafkaTemplates {
                 .addToLoggers("zookeeper.root.logger", LogLevel.INFO.name())
                 .endInlineLogging()
                 .endZookeeper()
-                .editEntityOperator()
-                .editUserOperator()
-                .withNewInlineLogging()
-                .addToLoggers("rootLogger.level", LogLevel.INFO.name())
-                .endInlineLogging()
-                .endUserOperator()
-                .editTopicOperator()
-                .withNewInlineLogging()
-                .addToLoggers("rootLogger.level", LogLevel.INFO.name())
-                .endInlineLogging()
-                .endTopicOperator()
-                .endEntityOperator()
                 .endSpec();
     }
 }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
@@ -204,7 +204,7 @@ public class KafkaUtils {
             }
         }
         if (podName.isEmpty() || podName.isBlank()) {
-            throw new KubeClusterException(new Throwable("Kafka cluster name not found!"));
+            throw new KubeClusterException.NotFound("Kafka cluster name not found!");
         }
         kubeClient().getClient().pods().inNamespace(deployNamespace).withName(podName).withGracePeriod(0).delete();
         kubeClient().getClient().pods().inNamespace(deployNamespace).withName(podName).waitUntilCondition(Objects::isNull, 60, TimeUnit.SECONDS);

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
@@ -28,6 +28,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 
 import io.kroxylicious.systemtests.Constants;
 import io.kroxylicious.systemtests.Environment;
+import io.kroxylicious.systemtests.k8s.exception.KubeClusterException;
 
 import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
 import static org.awaitility.Awaitility.await;
@@ -201,6 +202,9 @@ public class KafkaUtils {
                 podUid = pod.getMetadata().getUid();
                 break;
             }
+        }
+        if(podName.isEmpty() || podName.isBlank()) {
+            throw new KubeClusterException(new Throwable("Kafka cluster name not found!"));
         }
         kubeClient().getClient().pods().inNamespace(deployNamespace).withName(podName).withGracePeriod(0).delete();
         kubeClient().getClient().pods().inNamespace(deployNamespace).withName(podName).waitUntilCondition(Objects::isNull, 60, TimeUnit.SECONDS);

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
@@ -203,7 +203,7 @@ public class KafkaUtils {
                 break;
             }
         }
-        if(podName.isEmpty() || podName.isBlank()) {
+        if (podName.isEmpty() || podName.isBlank()) {
             throw new KubeClusterException(new Throwable("Kafka cluster name not found!"));
         }
         kubeClient().getClient().pods().inNamespace(deployNamespace).withName(podName).withGracePeriod(0).delete();

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/TestUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/TestUtils.java
@@ -111,4 +111,23 @@ public class TestUtils {
     public static FileAttribute<Set<PosixFilePermission>> getDefaultPosixFilePermissions() {
         return PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------"));
     }
+
+    /**
+     * Concat string if value don't exist.
+     *
+     * @param originalString the original String
+     * @param stringToConcat the string to concat
+     * @param stringSeparator the string separator
+     * @return the string
+     */
+    public static String concatStringIfValueDontExist(String originalString, String stringToConcat, String stringSeparator) {
+        if (originalString.isEmpty() || originalString.isBlank()) {
+            stringSeparator = "";
+        }
+
+        if (!originalString.contains(stringToConcat)) {
+            originalString = originalString.concat(stringSeparator + stringToConcat);
+        }
+        return originalString;
+    }
 }

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/KroxyliciousST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/KroxyliciousST.java
@@ -36,7 +36,6 @@ class KroxyliciousST extends AbstractST {
     private static final Logger LOGGER = LoggerFactory.getLogger(KroxyliciousST.class);
     private static Kroxylicious kroxylicious;
     private final String clusterName = "my-cluster";
-    protected static final String CONTROLLER_NODE_NAME = "controller";
     protected static final String BROKER_NODE_NAME = "kafka";
 
     /**

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/KroxyliciousST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/KroxyliciousST.java
@@ -16,7 +16,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.Pod;
-import io.strimzi.api.ResourceAnnotations;
 import io.strimzi.api.kafka.model.Kafka;
 
 import io.kroxylicious.systemtests.extensions.KroxyliciousExtension;
@@ -147,12 +146,7 @@ class KroxyliciousST extends AbstractST {
         }
         LOGGER.info("Deploying Kafka in {} namespace", Constants.KROXY_DEFAULT_NAMESPACE);
 
-        Kafka kafka = KafkaTemplates.kafkaPersistent(Constants.KROXY_DEFAULT_NAMESPACE, clusterName, 3, 3)
-                .editMetadata()
-                .addToAnnotations(ResourceAnnotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
-                .addToAnnotations(ResourceAnnotations.ANNO_STRIMZI_IO_KRAFT, "enabled")
-                .endMetadata()
-                .build();
+        Kafka kafka = KafkaTemplates.kafkaPersistentWithKRaftAnnotations(Constants.KROXY_DEFAULT_NAMESPACE, clusterName, 3).build();
 
         resourceManager.createResourceWithWait(
                 KafkaNodePoolTemplates.kafkaBasedNodePoolWithDualRole(BROKER_NODE_NAME, kafka, 3).build(),


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adapt the code to enable to use of KRaft mode when deploying kafka with Strimzi. With that we can save deploying time.

### Additional Context

Fixes #733 

### Checklist

- [X] Write tests
- [X] Make sure all tests pass
- [x] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [X] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [X] Update documentation
- [X] Reference relevant issue(s) and close them after merging
- [X] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
