### PR TITLE
Add utilities for dealing with RecordBatches and MemoryRecords

### DIFF
--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/BatchAwareMemoryRecordsBuilder.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/BatchAwareMemoryRecordsBuilder.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.records;
+
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.record.EndTransactionMarker;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.MemoryRecordsBuilder;
+import org.apache.kafka.common.record.Record;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.record.SimpleRecord;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.utils.ByteBufferOutputStream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A builder of {@link MemoryRecords} that can cope with multiple batches.
+ * (Apache Kafka's own {@link MemoryRecordsBuilder} assumes a single batch).
+ */
+public class BatchAwareMemoryRecordsBuilder {
+
+    public static final Header[] EMPTY_HEADERS = new Header[0];
+
+    private final ByteBufferOutputStream buffer;
+    private MemoryRecordsBuilder builder = null;
+
+    public BatchAwareMemoryRecordsBuilder(
+                                          @NonNull ByteBufferOutputStream buffer) {
+        this.buffer = Objects.requireNonNull(buffer);
+    }
+
+    private boolean haveBatch() {
+        return builder != null;
+    }
+
+    private void checkHasBatch() {
+        if (!haveBatch()) {
+            throw new IllegalStateException("You must start a batch");
+        }
+    }
+
+    /**
+     * Starts a batch
+     * @param magic
+     * @param compressionType
+     * @param timestampType
+     * @param baseOffset
+     * @param logAppendTime
+     * @param producerId
+     * @param producerEpoch
+     * @param baseSequence
+     * @param isTransactional
+     * @param isControlBatch
+     * @param partitionLeaderEpoch
+     * @param deleteHorizonMs
+     * @return this builder
+     */
+    public @NonNull BatchAwareMemoryRecordsBuilder addBatch(byte magic,
+                                                            CompressionType compressionType,
+                                                            TimestampType timestampType,
+                                                            long baseOffset,
+                                                            long logAppendTime,
+                                                            long producerId,
+                                                            short producerEpoch,
+                                                            int baseSequence,
+                                                            boolean isTransactional,
+                                                            boolean isControlBatch,
+                                                            int partitionLeaderEpoch,
+                                                            long deleteHorizonMs) {
+        maybeAppendCurrentBatch();
+        // MRB respects the initial position() of buffer, so this doesn't overwrite anything already in buffer
+        builder = new MemoryRecordsBuilder(buffer,
+                magic,
+                compressionType,
+                timestampType,
+                baseOffset,
+                logAppendTime,
+                producerId,
+                producerEpoch,
+                baseSequence,
+                isTransactional,
+                isControlBatch,
+                partitionLeaderEpoch,
+                0, // TODO think about limiting the size that the buffer can grow to
+                deleteHorizonMs);
+        return this;
+    }
+
+    public BatchAwareMemoryRecordsBuilder addBatch(CompressionType compressionType,
+                                                   TimestampType timestampType,
+                                                   long baseOffset) {
+        return addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
+                compressionType,
+                timestampType,
+                baseOffset,
+                timestampType == TimestampType.LOG_APPEND_TIME ? System.currentTimeMillis() : RecordBatch.NO_TIMESTAMP,
+                RecordBatch.NO_PRODUCER_ID,
+                RecordBatch.NO_PRODUCER_EPOCH,
+                RecordBatch.NO_SEQUENCE,
+                false,
+                false,
+                RecordBatch.NO_PARTITION_LEADER_EPOCH,
+                RecordBatch.NO_TIMESTAMP);
+    }
+
+    /**
+     * Starts a batch, with batch parameters taken from the given {@code templateBatch}.
+     * @param templateBatch The batch to use as a source of batch parameters
+     * @return this builder
+     */
+    public @NonNull BatchAwareMemoryRecordsBuilder addBatchLike(RecordBatch templateBatch) {
+        return addBatch(templateBatch.magic(),
+                templateBatch.compressionType(),
+                templateBatch.timestampType(),
+                templateBatch.baseOffset(),
+                0,
+                templateBatch.producerId(),
+                templateBatch.producerEpoch(),
+                templateBatch.baseSequence(),
+                templateBatch.isTransactional(),
+                templateBatch.isControlBatch(),
+                templateBatch.partitionLeaderEpoch(),
+                templateBatch.deleteHorizonMs().orElse(RecordBatch.NO_TIMESTAMP));
+    }
+
+    private void maybeAppendCurrentBatch() {
+        if (haveBatch()) {
+            appendCurrentBatch();
+        }
+    }
+
+    private void appendCurrentBatch() {
+        // Calling build will write out the (possibly compressed) batch bytes into this.buffer
+        builder.build();
+    }
+
+    /**
+     * Appends a record in the current batch
+     * @param record The record to append
+     * @return This builder
+     */
+    public @NonNull BatchAwareMemoryRecordsBuilder append(SimpleRecord record) {
+        checkHasBatch();
+        if (!builder.hasRoomFor(record.timestamp(), record.key(), record.value(), record.headers())) {
+            throw new RuntimeException();
+        }
+        builder.append(record);
+        return this;
+    }
+
+    /**
+     * Appends a record in the current batch
+     * @param record The record to append
+     * @return This builder
+     */
+    public @NonNull BatchAwareMemoryRecordsBuilder append(Record record) {
+        checkHasBatch();
+        builder.append(record);
+        return this;
+    }
+
+    /**
+     * Appends a record using a different offset in the current batch.
+     * @param offset The offset
+     * @param record The record to append
+     * @return This builder
+     */
+    public BatchAwareMemoryRecordsBuilder appendWithOffset(long offset, Record record) {
+        checkHasBatch();
+        builder.appendWithOffset(offset, record);
+        return this;
+    }
+
+    /**
+     * Append a new record at the given offset in the current batch.
+     * @param offset The absolute offset of the record in the log buffer
+     * @param timestamp The record timestamp
+     * @param key The record key
+     * @param value The record value
+     * @param headers The record headers if there are any
+     * @return This builder
+     */
+    public @NonNull BatchAwareMemoryRecordsBuilder appendWithOffset(long offset, long timestamp, byte[] key, byte[] value, Header[] headers) {
+        checkHasBatch();
+        builder.appendWithOffset(offset, timestamp, key, value, headers);
+        return this;
+    }
+
+    /**
+     * Append a new record at the given offset in the current batch.
+     * @param offset The absolute offset of the record in the log buffer
+     * @param timestamp The record timestamp
+     * @param key The record key
+     * @param value The record value
+     * @param headers The record headers if there are any
+     * @return This builder
+     */
+    public @NonNull BatchAwareMemoryRecordsBuilder appendWithOffset(long offset,
+                                                                    long timestamp,
+                                                                    ByteBuffer key,
+                                                                    ByteBuffer value,
+                                                                    Header[] headers) {
+        checkHasBatch();
+        builder.appendWithOffset(offset, timestamp, key, value, headers);
+        return this;
+    }
+
+    public @NonNull BatchAwareMemoryRecordsBuilder appendControlRecordWithOffset(long offset, @NonNull SimpleRecord record) {
+        checkHasBatch();
+        builder.appendControlRecordWithOffset(offset, record);
+        return this;
+    }
+
+    public @NonNull BatchAwareMemoryRecordsBuilder appendEndTxnMarker(long timestamp,
+                                                                      @NonNull EndTransactionMarker marker) {
+        checkHasBatch();
+        builder.appendEndTxnMarker(timestamp, marker);
+        return this;
+    }
+
+    /**
+     * Builds the memory records
+     * @return the memory records
+     */
+    public @NonNull MemoryRecords build() {
+        maybeAppendCurrentBatch();
+        MemoryRecords memoryRecords = MemoryRecords.readableRecords(buffer.buffer().flip());
+        return memoryRecords;
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/BatchAwareMemoryRecordsBuilder.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/BatchAwareMemoryRecordsBuilder.java
@@ -150,9 +150,6 @@ public class BatchAwareMemoryRecordsBuilder {
      */
     public @NonNull BatchAwareMemoryRecordsBuilder append(SimpleRecord record) {
         checkHasBatch();
-        if (!builder.hasRoomFor(record.timestamp(), record.key(), record.value(), record.headers())) {
-            throw new RuntimeException();
-        }
         builder.append(record);
         return this;
     }
@@ -233,8 +230,7 @@ public class BatchAwareMemoryRecordsBuilder {
      */
     public @NonNull MemoryRecords build() {
         maybeAppendCurrentBatch();
-        MemoryRecords memoryRecords = MemoryRecords.readableRecords(buffer.buffer().flip());
-        return memoryRecords;
+        return MemoryRecords.readableRecords(buffer.buffer().flip());
     }
 
 }

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/BatchAwareMemoryRecordsBuilder.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/BatchAwareMemoryRecordsBuilder.java
@@ -252,6 +252,9 @@ public class BatchAwareMemoryRecordsBuilder implements AutoCloseable {
         return MemoryRecords.readableRecords(buffer);
     }
 
+    /**
+     * Closes this build. This is the same as calling {@link #build()}.
+     */
     @Override
     public void close() {
         build();

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/BatchAwareMemoryRecordsBuilder.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/BatchAwareMemoryRecordsBuilder.java
@@ -128,11 +128,14 @@ public class BatchAwareMemoryRecordsBuilder implements AutoCloseable {
      * @return this builder
      */
     public @NonNull BatchAwareMemoryRecordsBuilder addBatchLike(RecordBatch templateBatch) {
+        TimestampType timestampType = templateBatch.timestampType();
+        long logAppendTime = timestampType == TimestampType.LOG_APPEND_TIME ?
+                templateBatch.maxTimestamp() : RecordBatch.NO_TIMESTAMP;
         return addBatch(templateBatch.magic(),
                 templateBatch.compressionType(),
-                templateBatch.timestampType(),
+                timestampType,
                 templateBatch.baseOffset(),
-                0,
+                logAppendTime,
                 templateBatch.producerId(),
                 templateBatch.producerEpoch(),
                 templateBatch.baseSequence(),

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/BatchAwareMemoryRecordsBuilder.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/BatchAwareMemoryRecordsBuilder.java
@@ -9,6 +9,8 @@ package io.kroxylicious.filter.encryption.records;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 
+import javax.annotation.concurrent.NotThreadSafe;
+
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.EndTransactionMarker;
@@ -21,8 +23,6 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-
-import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * <p>A builder of {@link MemoryRecords} that can cope with multiple batches.
@@ -129,8 +129,7 @@ public class BatchAwareMemoryRecordsBuilder implements AutoCloseable {
      */
     public @NonNull BatchAwareMemoryRecordsBuilder addBatchLike(RecordBatch templateBatch) {
         TimestampType timestampType = templateBatch.timestampType();
-        long logAppendTime = timestampType == TimestampType.LOG_APPEND_TIME ?
-                templateBatch.maxTimestamp() : RecordBatch.NO_TIMESTAMP;
+        long logAppendTime = timestampType == TimestampType.LOG_APPEND_TIME ? templateBatch.maxTimestamp() : RecordBatch.NO_TIMESTAMP;
         return addBatch(templateBatch.magic(),
                 templateBatch.compressionType(),
                 timestampType,

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/BatchAwareMemoryRecordsBuilder.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/BatchAwareMemoryRecordsBuilder.java
@@ -247,11 +247,11 @@ public class BatchAwareMemoryRecordsBuilder implements AutoCloseable {
     public @NonNull MemoryRecords build() {
         boolean needsFlip = builder == null || !builder.isClosed();
         maybeAppendCurrentBatch();
-        ByteBuffer buffer = this.buffer.buffer();
+        ByteBuffer buf = this.buffer.buffer();
         if (needsFlip) {
-            buffer.flip();
+            buf.flip();
         }
-        return MemoryRecords.readableRecords(buffer);
+        return MemoryRecords.readableRecords(buf);
     }
 
     /**

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/MemoryRecordsUtils.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/MemoryRecordsUtils.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.records;
+
+import java.util.Spliterator;
+import java.util.stream.Collector;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.MemoryRecordsBuilder;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.utils.ByteBufferOutputStream;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Utility methods for dealing with {@link MemoryRecords} and {@link MemoryRecordsBuilder}s.
+ * @see RecordBatchUtils
+ */
+public class MemoryRecordsUtils {
+    private MemoryRecordsUtils() {
+    }
+
+    /**
+     * Returns a sequential stream over the batches in a {@link MemoryRecords}.
+     * @param memoryRecords The memoryRecords
+     * @return A stream over the batches in the given {@code memoryRecords}.
+     */
+    public static @NonNull Stream<? extends RecordBatch> batchStream(@NonNull MemoryRecords memoryRecords) {
+        return StreamSupport.stream(
+                () -> memoryRecords.batches().spliterator(),
+                Spliterator.ORDERED | Spliterator.NONNULL,
+                false);
+    }
+
+    /**
+     * Append all the records in the given {@code memoryRecords} to the given {@code memoryRecordsBuilder}
+     * @param memoryRecordsBuilder The build to append to
+     * @param memoryRecords The source of the records
+     * @return The given {@code memoryRecordsBuilder}.
+     */
+    private static BatchAwareMemoryRecordsBuilder appendAll(BatchAwareMemoryRecordsBuilder memoryRecordsBuilder, MemoryRecords memoryRecords) {
+        for (var batch : memoryRecords.batches()) {
+            memoryRecordsBuilder.addBatchLike(batch);
+            for (var record : batch) {
+                memoryRecordsBuilder.append(record);
+            }
+        }
+        return memoryRecordsBuilder;
+    }
+
+    /**
+     * A {@link Collector} "combiner" function for {@link MemoryRecordsBuilder}s.
+     * The records from both arguments will be in the same batch.
+     */
+    /* test */ static BatchAwareMemoryRecordsBuilder combineBuilders(BatchAwareMemoryRecordsBuilder mrb1, BatchAwareMemoryRecordsBuilder mrb2) {
+        return appendAll(mrb1, mrb2.build());
+    }
+
+    /**
+     * Factory method for a Collector that concatenates MemoryRecords.
+     */
+    public static @NonNull Collector<MemoryRecords, BatchAwareMemoryRecordsBuilder, MemoryRecords> concatCollector(@NonNull ByteBufferOutputStream resultBuffer) {
+        return Collector.of(
+                () -> new BatchAwareMemoryRecordsBuilder(resultBuffer),
+                MemoryRecordsUtils::appendAll,
+                MemoryRecordsUtils::combineBuilders,
+                BatchAwareMemoryRecordsBuilder::build);
+    }
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/MemoryRecordsUtils.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/MemoryRecordsUtils.java
@@ -31,9 +31,10 @@ public class MemoryRecordsUtils {
      * @param memoryRecords The memoryRecords
      * @return A stream over the batches in the given {@code memoryRecords}.
      */
-    public static @NonNull Stream<? extends RecordBatch> batchStream(@NonNull MemoryRecords memoryRecords) {
-        return StreamSupport.stream(
-                () -> memoryRecords.batches().spliterator(),
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public static @NonNull Stream<RecordBatch> batchStream(@NonNull MemoryRecords memoryRecords) {
+        return StreamSupport.<RecordBatch> stream(
+                () -> (Spliterator) memoryRecords.batches().spliterator(),
                 Spliterator.ORDERED | Spliterator.NONNULL,
                 false);
     }

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/MemoryRecordsUtils.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/MemoryRecordsUtils.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.filter.encryption.records;
 
+import java.util.Objects;
 import java.util.Spliterator;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
@@ -33,6 +34,7 @@ public class MemoryRecordsUtils {
      */
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static @NonNull Stream<RecordBatch> batchStream(@NonNull MemoryRecords memoryRecords) {
+        Objects.requireNonNull(memoryRecords);
         return StreamSupport.<RecordBatch> stream(
                 () -> (Spliterator) memoryRecords.batches().spliterator(),
                 Spliterator.ORDERED | Spliterator.NONNULL,
@@ -67,6 +69,7 @@ public class MemoryRecordsUtils {
      * Factory method for a Collector that concatenates MemoryRecords.
      */
     public static @NonNull Collector<MemoryRecords, BatchAwareMemoryRecordsBuilder, MemoryRecords> concatCollector(@NonNull ByteBufferOutputStream resultBuffer) {
+        Objects.requireNonNull(resultBuffer);
         return Collector.of(
                 () -> new BatchAwareMemoryRecordsBuilder(resultBuffer),
                 MemoryRecordsUtils::appendAll,

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/MemoryRecordsUtils.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/MemoryRecordsUtils.java
@@ -77,8 +77,8 @@ public class MemoryRecordsUtils {
      * @param resultBuffer
      */
     public static @NonNull Collector<MemoryRecords, BatchAwareMemoryRecordsBuilder, MemoryRecords> concatCollector(
-            Consumer<Runnable> onClose,
-            @NonNull ByteBufferOutputStream resultBuffer) {
+                                                                                                                   Consumer<Runnable> onClose,
+                                                                                                                   @NonNull ByteBufferOutputStream resultBuffer) {
         Objects.requireNonNull(resultBuffer);
         return new Collector<>() {
             @Override

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/RecordBatchUtils.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/RecordBatchUtils.java
@@ -93,12 +93,16 @@ public class RecordBatchUtils {
                                                                                                              ByteBufferOutputStream resultBuffer) {
         return Collector.of(
                 () -> new BatchAwareMemoryRecordsBuilder(resultBuffer).addBatchLike(recordBatch),
-                (builder, record) -> builder.appendWithOffset(
-                        mapper.transformOffset(record),
-                        mapper.transformTimestamp(record),
-                        mapper.transformKey(record),
-                        mapper.transformValue(record),
-                        mapper.transformHeaders(record)),
+                (builder, record) -> {
+                    mapper.init(record);
+                    builder.appendWithOffset(
+                            mapper.transformOffset(record),
+                            mapper.transformTimestamp(record),
+                            mapper.transformKey(record),
+                            mapper.transformValue(record),
+                            mapper.transformHeaders(record));
+                    mapper.resetAfterTransform(record);
+                },
                 MemoryRecordsUtils::combineBuilders,
                 BatchAwareMemoryRecordsBuilder::build);
     }

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/RecordBatchUtils.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/RecordBatchUtils.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.records;
+
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Collector;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.MutableRecordBatch;
+import org.apache.kafka.common.record.Record;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.utils.BufferSupplier;
+import org.apache.kafka.common.utils.ByteBufferOutputStream;
+import org.apache.kafka.common.utils.CloseableIterator;
+
+/**
+ * Utility methods for dealing with {@link RecordBatch}es.
+ * @see MemoryRecordsUtils
+ */
+public class RecordBatchUtils {
+
+    private RecordBatchUtils() {
+    }
+
+    /**
+     * Returns a sequential stream over the records in a batch.
+     * @param batch The record batch
+     * @return A stream over the records in the given {@code batch}.
+     */
+    public static Stream<? extends Record> recordStream(RecordBatch batch) {
+        Spliterator<Record> spliterator;
+        Integer size = batch.countOrNull();
+        int characteristics = Spliterator.ORDERED | Spliterator.NONNULL;
+        if (!(batch instanceof MutableRecordBatch)) {
+            characteristics |= Spliterator.IMMUTABLE;
+        }
+        CloseableIterator<Record> iterator = batch.streamingIterator(BufferSupplier.create());
+        try {
+            if (size != null) {
+                spliterator = Spliterators.spliterator(iterator, size,
+                        characteristics | Spliterator.SIZED | Spliterator.SUBSIZED);
+            }
+            else {
+                spliterator = Spliterators.spliteratorUnknownSize(iterator,
+                        characteristics);
+            }
+
+            Stream<? extends Record> stream;
+            if ((spliterator.characteristics() & Spliterator.IMMUTABLE) != 0) {
+                // Per javadoc on StreamSupport#stream(), then the spliterator is immutable use the non-Supplier factory
+                stream = StreamSupport.stream(spliterator, false);
+            }
+            else {
+                stream = StreamSupport.stream(() -> spliterator, characteristics, false);
+            }
+            return stream.onClose(() -> {
+                iterator.close();
+            });
+        }
+        catch (RuntimeException e) {
+            iterator.close();
+            throw e;
+        }
+    }
+
+    /**
+     * Convert the given {@code recordBatch} into a {@link MemoryRecords}, applying a per-record mapping operation to each record.
+     * @param recordBatch The batch of records to convert
+     * @param mapper The mapping function to apply to the records in the batch
+     * @param resultBuffer A final buffer. This is required to encourage buffer reuse when
+     * callers make multiple invocations of this method.
+     * @return A MemoryRecords containing the mapped records
+     */
+    public static MemoryRecords toMemoryRecords(
+                                                RecordBatch recordBatch,
+                                                RecordTransform mapper,
+                                                ByteBufferOutputStream resultBuffer) {
+        return recordStream(recordBatch)
+                .collect(toMemoryRecordsCollector(recordBatch, mapper, resultBuffer));
+    }
+
+    /**
+     * Factory method for a Collector that applies a mapping function as it builds a {@link MemoryRecords}.
+     */
+    private static Collector<Record, BatchAwareMemoryRecordsBuilder, MemoryRecords> toMemoryRecordsCollector(
+                                                                                                             RecordBatch recordBatch,
+                                                                                                             RecordTransform mapper,
+                                                                                                             ByteBufferOutputStream resultBuffer) {
+        return Collector.of(
+                () -> new BatchAwareMemoryRecordsBuilder(resultBuffer).addBatchLike(recordBatch),
+                (builder, record) -> builder.appendWithOffset(
+                        mapper.transformOffset(record),
+                        mapper.transformTimestamp(record),
+                        mapper.transformKey(record),
+                        mapper.transformValue(record),
+                        mapper.transformHeaders(record)),
+                MemoryRecordsUtils::combineBuilders,
+                BatchAwareMemoryRecordsBuilder::build);
+    }
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/RecordBatchUtils.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/RecordBatchUtils.java
@@ -34,7 +34,7 @@ public class RecordBatchUtils {
      * @param batch The record batch
      * @return A stream over the records in the given {@code batch}.
      */
-    public static Stream<? extends Record> recordStream(RecordBatch batch) {
+    public static Stream<Record> recordStream(RecordBatch batch) {
         Spliterator<Record> spliterator;
         Integer size = batch.countOrNull();
         int characteristics = Spliterator.ORDERED | Spliterator.NONNULL;
@@ -52,7 +52,7 @@ public class RecordBatchUtils {
                         characteristics);
             }
 
-            Stream<? extends Record> stream;
+            Stream<Record> stream;
             if ((spliterator.characteristics() & Spliterator.IMMUTABLE) != 0) {
                 // Per javadoc on StreamSupport#stream(), then the spliterator is immutable use the non-Supplier factory
                 stream = StreamSupport.stream(spliterator, false);
@@ -60,9 +60,7 @@ public class RecordBatchUtils {
             else {
                 stream = StreamSupport.stream(() -> spliterator, characteristics, false);
             }
-            return stream.onClose(() -> {
-                iterator.close();
-            });
+            return stream.onClose(iterator::close);
         }
         catch (RuntimeException e) {
             iterator.close();

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/RecordBatchUtils.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/RecordBatchUtils.java
@@ -6,11 +6,14 @@
 
 package io.kroxylicious.filter.encryption.records;
 
+import java.util.Objects;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MutableRecordBatch;
@@ -34,7 +37,8 @@ public class RecordBatchUtils {
      * @param batch The record batch
      * @return A stream over the records in the given {@code batch}.
      */
-    public static Stream<Record> recordStream(RecordBatch batch) {
+    public static @NonNull Stream<Record> recordStream(@NonNull RecordBatch batch) {
+        Objects.requireNonNull(batch);
         Spliterator<Record> spliterator;
         Integer size = batch.countOrNull();
         int characteristics = Spliterator.ORDERED | Spliterator.NONNULL;
@@ -76,12 +80,17 @@ public class RecordBatchUtils {
      * callers make multiple invocations of this method.
      * @return A MemoryRecords containing the mapped records
      */
-    public static MemoryRecords toMemoryRecords(
-                                                RecordBatch recordBatch,
-                                                RecordTransform mapper,
-                                                ByteBufferOutputStream resultBuffer) {
-        return recordStream(recordBatch)
-                .collect(toMemoryRecordsCollector(recordBatch, mapper, resultBuffer));
+    public static @NonNull MemoryRecords toMemoryRecords(
+                                                         @NonNull RecordBatch recordBatch,
+                                                         @NonNull RecordTransform mapper,
+                                                         @NonNull ByteBufferOutputStream resultBuffer) {
+        Objects.requireNonNull(recordBatch);
+        Objects.requireNonNull(mapper);
+        Objects.requireNonNull(resultBuffer);
+        try (Stream<Record> recordStream = recordStream(recordBatch)) {
+            return recordStream
+                    .collect(toMemoryRecordsCollector(recordBatch, mapper, resultBuffer));
+        }
     }
 
     /**

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/RecordBatchUtils.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/RecordBatchUtils.java
@@ -21,8 +21,6 @@ import java.util.stream.Collector;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MutableRecordBatch;
 import org.apache.kafka.common.record.Record;
@@ -30,6 +28,8 @@ import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.utils.BufferSupplier;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.apache.kafka.common.utils.CloseableIterator;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Utility methods for dealing with {@link RecordBatch}es.
@@ -100,7 +100,8 @@ public class RecordBatchUtils {
         try (Stream<Record> recordStream = recordStream(recordBatch)) {
             return recordStream
                     .collect(toMemoryRecordsCollector(closers::add, recordBatch, mapper, resultBuffer));
-        } finally {
+        }
+        finally {
             closers.forEach(Runnable::run);
         }
     }

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/RecordTransform.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/RecordTransform.java
@@ -25,6 +25,8 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 @NotThreadSafe
 public interface RecordTransform {
 
+    void init(@NonNull Record record);
+
     /**
      * @param record The operand record.
      * @return The offset of the new record.

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/RecordTransform.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/RecordTransform.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.records;
+
+import java.nio.ByteBuffer;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.record.Record;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Represents a transformation from a {@link Record} to (the properties of) a new {@link Record}.
+ * RecordTransforms retain ownership of the {@link ByteBuffer}s returned by their {@code transform*()} methods.
+ * For a given record, once a caller has used those buffers the caller must call
+ * {@link #resetAfterTransform(Record)}.
+ */
+@NotThreadSafe
+public interface RecordTransform {
+
+    /**
+     * @param record The operand record.
+     * @return The offset of the new record.
+     */
+    long transformOffset(@NonNull Record record);
+
+    /**
+     * @param record The operand record.
+     * @return The timestamp of the new record.
+     */
+    long transformTimestamp(@NonNull Record record);
+
+    /**
+     * @param record The operand record.
+     * @return The key of the new record.
+     */
+    @Nullable
+    ByteBuffer transformKey(@NonNull Record record);
+
+    /**
+     * @param record The operand record.
+     * @return The value of the new record.
+     */
+    @Nullable
+    ByteBuffer transformValue(@NonNull Record record);
+
+    /**
+     * @param record The operand record.
+     * @return The headers of the new record. This may be null:
+     * If the caller wants to create a new record from the result it must handle the fact that in
+     * batch magic &gt;= 2 headers are required (but may be empty)
+     * while in batch magic &lt; 2 headers are not permitted (thus must be null).
+     */
+    @Nullable
+    Header[] transformHeaders(@NonNull Record record);
+
+    void resetAfterTransform(@NonNull Record record);
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/RecordTransform.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/RecordTransform.java
@@ -17,10 +17,17 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
- * Represents a transformation from a {@link Record} to (the properties of) a new {@link Record}.
- * RecordTransforms retain ownership of the {@link ByteBuffer}s returned by their {@code transform*()} methods.
- * For a given record, once a caller has used those buffers the caller must call
- * {@link #resetAfterTransform(Record)}.
+ * <p>Represents a transformation from a {@link Record} to (the properties of) a new {@link Record}.
+ *    {@code RecordTransform}s are stateful and retain ownership of the {@link ByteBuffer}s returned
+ *    by their {@code transform*()} methods.</p>
+ *
+ * <p>When transforming a record callers of this interface must:</p>
+ * <ol>
+ *     <li>Transform one record at a time</li>
+ *     <li>Invoke {@link #init(Record)} for that record before any other methods</li>
+ *     <li>Invoke each of the {@code transform*()} methods for that record, as required</li>
+ *     <li>Invoke {@link #resetAfterTransform(Record)} for that record</li>
+ * </ol>
  */
 @NotThreadSafe
 public interface RecordTransform {

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/package-info.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * <p>Utilities for dealing with {@link org.apache.kafka.common.record.Record}s, {@link org.apache.kafka.common.record.RecordBatch}es
+ * and {@link org.apache.kafka.common.record.MemoryRecords}.</p>
+ */
+package io.kroxylicious.filter.encryption.records;

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/BatchAwareMemoryRecordsBuilderTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/BatchAwareMemoryRecordsBuilderTest.java
@@ -53,9 +53,9 @@ class BatchAwareMemoryRecordsBuilderTest {
 
         // Then
         assertThat(StreamSupport.stream(mr.batches().spliterator(), false).count())
-                .isEqualTo(0);
+                .isZero();
         assertThat(StreamSupport.stream(mr.records().spliterator(), false).count())
-                .isEqualTo(0);
+                .isZero();
     }
 
     // Single batch of 0 records
@@ -81,9 +81,9 @@ class BatchAwareMemoryRecordsBuilderTest {
 
         // Then
         assertThat(StreamSupport.stream(mr.batches().spliterator(), false).count())
-                .isEqualTo(0);
+                .isZero();
         assertThat(StreamSupport.stream(mr.records().spliterator(), false).count())
-                .isEqualTo(0);
+                .isZero();
     }
 
     // Single batch of 1 record
@@ -158,7 +158,7 @@ class BatchAwareMemoryRecordsBuilderTest {
         var batch1 = batches.get(0);
         assertThat(batch1.compressionType()).isEqualTo(CompressionType.NONE);
         assertThat(batch1.iterator().next().value()).isEqualTo(ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8)));
-        assertThat(batch1.iterator().next().offset()).isEqualTo(0);
+        assertThat(batch1.iterator().next().offset()).isZero();
 
         var batch2 = batches.get(1);
         assertThat(batch2.compressionType()).isEqualTo(CompressionType.ZSTD);
@@ -251,7 +251,7 @@ class BatchAwareMemoryRecordsBuilderTest {
         var mr1 = builder1.build();
 
         ByteBuffer bb1 = buffer.buffer();
-        assertThat(bb1.position()).isEqualTo(0);
+        assertThat(bb1.position()).isZero();
         assertThat(bb1.capacity()).isEqualTo(80);
 
         var builder2 = new BatchAwareMemoryRecordsBuilder(buffer);
@@ -273,7 +273,7 @@ class BatchAwareMemoryRecordsBuilderTest {
         // Then
         ByteBuffer bb2 = buffer.buffer();
         assertThat(bb1).isSameAs(bb2);
-        assertThat(bb1.position()).isEqualTo(0);
+        assertThat(bb1.position()).isZero();
         assertThat(bb1.capacity()).isEqualTo(80);
 
         assertThat(StreamSupport.stream(mr1.batches().spliterator(), false).count())

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/BatchAwareMemoryRecordsBuilderTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/BatchAwareMemoryRecordsBuilderTest.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.records;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.StreamSupport;
+
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.record.ControlRecordType;
+import org.apache.kafka.common.record.MutableRecordBatch;
+import org.apache.kafka.common.record.Record;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.record.SimpleRecord;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.utils.ByteBufferOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BatchAwareMemoryRecordsBuilderTest {
+
+    // Can't append a record without a batch
+    @Test
+    void shouldRequireABatchBeforeAppend() {
+        // Given
+        var builder = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(100));
+
+        // Then
+        assertThatThrownBy(() -> builder.append((Record) null))
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("You must start a batch");
+    }
+
+    // 0 batches
+    @Test
+    void shouldAllowNoBatches() {
+        // Given
+        var builder = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(100));
+
+        // When
+        var mr = builder.build();
+
+        // Then
+        assertThat(StreamSupport.stream(mr.batches().spliterator(), false).count())
+                .isEqualTo(0);
+        assertThat(StreamSupport.stream(mr.records().spliterator(), false).count())
+                .isEqualTo(0);
+    }
+
+    // Single batch of 0 records
+    @Test
+    void shouldAllowEmptyBatches() {
+        // Given
+        var builder = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(100));
+        builder.addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
+                CompressionType.NONE,
+                TimestampType.CREATE_TIME,
+                0,
+                0,
+                0,
+                (short) 0,
+                0,
+                false,
+                false,
+                0,
+                0);
+
+        // When
+        var mr = builder.build();
+
+        // Then
+        assertThat(StreamSupport.stream(mr.batches().spliterator(), false).count())
+                .isEqualTo(0);
+        assertThat(StreamSupport.stream(mr.records().spliterator(), false).count())
+                .isEqualTo(0);
+    }
+
+    // Single batch of 1 record
+    @Test
+    void shouldSupportNonEmptyBatch() {
+        // Given
+        var builder = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(100));
+        builder.addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
+                CompressionType.NONE,
+                TimestampType.CREATE_TIME,
+                0,
+                0,
+                0,
+                (short) 0,
+                0,
+                false,
+                false,
+                0,
+                0);
+        builder.append(new SimpleRecord("hello".getBytes(StandardCharsets.UTF_8)));
+
+        // When
+        var mr = builder.build();
+
+        // Then
+        assertThat(StreamSupport.stream(mr.batches().spliterator(), false).count())
+                .isEqualTo(1);
+        assertThat(StreamSupport.stream(mr.records().spliterator(), false).count())
+                .isEqualTo(1);
+    }
+
+    // >1 batches
+    @ParameterizedTest
+    @ValueSource(ints = { 1, 1000 })
+    void shouldSupportMultipleBatches(int initialBufferSize) {
+        // Given
+        var builder = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(initialBufferSize));
+        builder.addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
+                CompressionType.NONE,
+                TimestampType.CREATE_TIME,
+                0,
+                0,
+                0,
+                (short) 0,
+                0,
+                false,
+                false,
+                0,
+                0);
+        builder.append(new SimpleRecord("hello".getBytes(StandardCharsets.UTF_8)));
+        builder.addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
+                CompressionType.ZSTD,
+                TimestampType.LOG_APPEND_TIME,
+                1, // not base off
+                0,
+                0,
+                (short) 0,
+                0,
+                false,
+                false,
+                0,
+                0);
+        builder.append(new SimpleRecord("hello2".getBytes(StandardCharsets.UTF_8)));
+
+        // When
+        var mr = builder.build();
+
+        // Then
+        List<MutableRecordBatch> batches = StreamSupport.stream(mr.batches().spliterator(), false).toList();
+        assertThat(batches).hasSize(2);
+
+        var batch1 = batches.get(0);
+        assertThat(batch1.compressionType()).isEqualTo(CompressionType.NONE);
+        assertThat(batch1.iterator().next().value()).isEqualTo(ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8)));
+        assertThat(batch1.iterator().next().offset()).isEqualTo(0);
+
+        var batch2 = batches.get(1);
+        assertThat(batch2.compressionType()).isEqualTo(CompressionType.ZSTD);
+        assertThat(batch2.iterator().next().value()).isEqualTo(ByteBuffer.wrap("hello2".getBytes(StandardCharsets.UTF_8)));
+        assertThat(batch2.iterator().next().offset()).isEqualTo(1);
+
+    }
+
+    // Control batches are propagated
+    @ParameterizedTest
+    @ValueSource(ints = { 1, 1000 })
+    void shouldSupportControlBatches(int initialBufferSize) {
+        // Given
+        var builder = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(initialBufferSize));
+        builder.addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
+                CompressionType.NONE,
+                TimestampType.CREATE_TIME,
+                0,
+                0,
+                0,
+                (short) 0,
+                0,
+                false,
+                false,
+                0,
+                0);
+        builder.append(new SimpleRecord("data-key".getBytes(StandardCharsets.UTF_8), "data-value".getBytes(StandardCharsets.UTF_8)));
+        builder.addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
+                CompressionType.ZSTD,
+                TimestampType.LOG_APPEND_TIME,
+                1,
+                0,
+                0,
+                (short) 0,
+                0,
+                false,
+                true,
+                0,
+                0);
+        SimpleRecord controlRecord = controlRecord();
+        builder.appendControlRecordWithOffset(1, controlRecord);
+
+        // When
+        var mr = builder.build();
+
+        // Then
+        List<MutableRecordBatch> batches = StreamSupport.stream(mr.batches().spliterator(), false).toList();
+        assertThat(batches).hasSize(2);
+
+        var batch1 = batches.get(0);
+        assertThat(batch1.compressionType()).isEqualTo(CompressionType.NONE);
+        assertThat(batch1.iterator().next().value()).isEqualTo(ByteBuffer.wrap("data-value".getBytes(StandardCharsets.UTF_8)));
+
+        var batch2 = batches.get(1);
+        assertThat(batch2.compressionType()).isEqualTo(CompressionType.ZSTD);
+        assertThat(batch2.iterator().next().value()).isEqualTo(controlRecord.value());
+    }
+
+    @NonNull
+    private static SimpleRecord controlRecord() {
+        var key = ControlRecordType.ABORT.recordKey();
+        var bb = ByteBuffer.allocate(key.sizeOf());
+        key.writeTo(bb);
+        SimpleRecord controlRecord = new SimpleRecord(bb.array(), "control-value".getBytes(StandardCharsets.UTF_8));
+        return controlRecord;
+    }
+
+    // we can reuse the ByteBufferOutputStream between instantiations of the builder
+    @Test
+    void shouldSupportBufferReuse() {
+
+        // Given
+        ByteBufferOutputStream buffer = new ByteBufferOutputStream(1);
+
+        // When
+        var builder1 = new BatchAwareMemoryRecordsBuilder(buffer);
+        builder1.addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
+                CompressionType.NONE,
+                TimestampType.CREATE_TIME,
+                0,
+                0,
+                0,
+                (short) 0,
+                0,
+                false,
+                false,
+                0,
+                0)
+                .append(new SimpleRecord("hello1".getBytes(StandardCharsets.UTF_8)));
+        var mr1 = builder1.build();
+
+        ByteBuffer bb1 = buffer.buffer();
+        assertThat(bb1.position()).isEqualTo(0);
+        assertThat(bb1.capacity()).isEqualTo(80);
+
+        var builder2 = new BatchAwareMemoryRecordsBuilder(buffer);
+        builder2.addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
+                CompressionType.NONE,
+                TimestampType.CREATE_TIME,
+                0,
+                0,
+                0,
+                (short) 0,
+                0,
+                false,
+                false,
+                0,
+                0)
+                .append(new SimpleRecord("hello2".getBytes(StandardCharsets.UTF_8)));
+        var mr2 = builder2.build();
+
+        // Then
+        ByteBuffer bb2 = buffer.buffer();
+        assertThat(bb1).isSameAs(bb2);
+        assertThat(bb1.position()).isEqualTo(0);
+        assertThat(bb1.capacity()).isEqualTo(80);
+
+        assertThat(StreamSupport.stream(mr1.batches().spliterator(), false).count())
+                .isEqualTo(1);
+        assertThat(StreamSupport.stream(mr1.records().spliterator(), false).count())
+                .isEqualTo(1);
+        assertThat(StreamSupport.stream(mr2.batches().spliterator(), false).count())
+                .isEqualTo(1);
+        assertThat(StreamSupport.stream(mr2.records().spliterator(), false).count())
+                .isEqualTo(1);
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/MemoryRecordsUtilsTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/MemoryRecordsUtilsTest.java
@@ -45,7 +45,8 @@ class MemoryRecordsUtilsTest {
         // Then
         // Assertions about stream itself
         assertThat(stream.get().isParallel()).isFalse();
-        assertThatThrownBy(() -> stream.get().sorted().toList()).isExactlyInstanceOf(ClassCastException.class);
+        Stream<? extends RecordBatch> s1 = stream.get().sorted();
+        assertThatThrownBy(() -> s1.toList()).isExactlyInstanceOf(ClassCastException.class);
 
         // Assertions about stream contents
         assertThat(stream.get().count()).describedAs("Expect 996 batches").isEqualTo(996);

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/MemoryRecordsUtilsTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/MemoryRecordsUtilsTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.records;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.Record;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.utils.ByteBufferOutputStream;
+import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static io.kroxylicious.filter.encryption.records.BatchAwareMemoryRecordsBuilder.EMPTY_HEADERS;
+import static io.kroxylicious.filter.encryption.records.MemoryRecordsUtils.batchStream;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MemoryRecordsUtilsTest {
+
+    @Test
+    void testBatchStream() {
+        // Given
+        var mrb = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(1));
+        for (long offset = 4L; offset < 1000L; offset++) {
+            mrb.addBatch(CompressionType.NONE, TimestampType.LOG_APPEND_TIME, offset);
+            mrb.appendWithOffset(offset, 123, "a".getBytes(StandardCharsets.UTF_8), null, EMPTY_HEADERS);
+        }
+        var batch = mrb.build();
+
+        // When
+        Supplier<? extends Stream<? extends RecordBatch>> stream = () -> MemoryRecordsUtils.batchStream(batch);
+
+        // Then
+        // Assertions about stream itself
+        assertThat(stream.get().isParallel()).isFalse();
+        assertThatThrownBy(() -> stream.get().sorted().toList()).isExactlyInstanceOf(ClassCastException.class);
+
+        // Assertions about stream contents
+        assertThat(stream.get().count()).describedAs("Expect 996 batches").isEqualTo(996);
+        assertThat(stream.get().flatMap(b -> RecordBatchUtils.recordStream(b)).map(Record::offset).toList()).isEqualTo(LongStream.range(4L, 1000L).boxed().toList());
+        assertThat(stream.get().parallel().flatMap(b -> RecordBatchUtils.recordStream(b)).map(Record::offset).toList())
+                .isEqualTo(LongStream.range(4L, 1000L).boxed().toList());
+        assertThat(stream.get().distinct().flatMap(b -> RecordBatchUtils.recordStream(b)).map(Record::offset).toList())
+                .isEqualTo(LongStream.range(4L, 1000L).boxed().toList());
+    }
+
+    @Test
+    void testCombineBuilders() {
+        var mrb = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(1));
+        for (long offset = 4L; offset < 1000L; offset++) {
+            mrb.addBatch(CompressionType.NONE, TimestampType.LOG_APPEND_TIME, offset);
+            mrb.appendWithOffset(offset, 123, "a".getBytes(StandardCharsets.UTF_8), null, EMPTY_HEADERS);
+        }
+        var templateBatch = mrb.build().firstBatch();
+
+        // Given
+        ByteBufferOutputStream resultBuffer1 = new ByteBufferOutputStream(1000);
+        var mrb1 = new BatchAwareMemoryRecordsBuilder(resultBuffer1);
+        ByteBufferOutputStream resultBuffer = new ByteBufferOutputStream(1000);
+        var mrb2 = new BatchAwareMemoryRecordsBuilder(resultBuffer);
+        mrb1.addBatchLike(templateBatch);
+        mrb2.addBatchLike(templateBatch);
+        for (long offset = 0L; offset < 1000L; offset++) {
+            mrb1.appendWithOffset(offset, 123, "a".getBytes(StandardCharsets.UTF_8), null, EMPTY_HEADERS);
+            mrb2.appendWithOffset(1000L + offset, 123, "a".getBytes(StandardCharsets.UTF_8), null, EMPTY_HEADERS);
+        }
+
+        // When
+        var result = MemoryRecordsUtils.combineBuilders(mrb1, mrb2).build();
+
+        // Then
+        List<? extends RecordBatch> batches = batchStream(result).toList();
+        assertThat(batches).hasSize(2);
+
+        assertThat(offsetsOfBatch(batches.get(0)))
+                .isEqualTo(range(0L, 1000L));
+
+        assertThat(offsetsOfBatch(batches.get(1)))
+                .isEqualTo(range(1000L, 2000L));
+    }
+
+    @NonNull
+    private List<Long> range(long startInclusive, final long endExclusive) {
+        return LongStream.range(startInclusive, endExclusive).boxed().toList();
+    }
+
+    @Test
+    void testConcatCollector() {
+        var mrb = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(1));
+        mrb.addBatch(CompressionType.NONE, TimestampType.CREATE_TIME, 4L);
+        for (long offset = 4L; offset < 1000L; offset++) {
+            mrb.appendWithOffset(offset, 123, "a".getBytes(StandardCharsets.UTF_8), null, EMPTY_HEADERS);
+        }
+        var mr1 = mrb.build();
+
+        mrb = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(1));
+        mrb.addBatch(CompressionType.NONE, TimestampType.CREATE_TIME, 1000L);
+        for (long offset = 1000L; offset < 2000L; offset++) {
+            mrb.appendWithOffset(offset, 123, "a".getBytes(StandardCharsets.UTF_8), null, EMPTY_HEADERS);
+        }
+        var mr2 = mrb.build();
+
+        mrb = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(1));
+        mrb.addBatch(CompressionType.NONE, TimestampType.CREATE_TIME, 2000L);
+        for (long offset = 2000L; offset < 3000L; offset++) {
+            mrb.appendWithOffset(offset, 123, "a".getBytes(StandardCharsets.UTF_8), null, EMPTY_HEADERS);
+        }
+        var mr3 = mrb.build();
+
+        // When
+        MemoryRecords memoryRecords = Stream.of(mr1, mr2, mr3).collect(MemoryRecordsUtils.concatCollector(new ByteBufferOutputStream(100)));
+
+        // Then
+        List<? extends RecordBatch> batches = batchStream(memoryRecords).toList();
+        assertThat(batches).hasSize(3);
+        assertThat(batchStream(memoryRecords).map(RecordBatch::baseOffset).toList())
+                .isEqualTo(List.of(4L, 1000L, 2000L));
+
+        assertThat(offsetsOfBatch(batches.get(0)))
+                .isEqualTo(range(4, 1000L));
+
+        assertThat(offsetsOfBatch(batches.get(1)))
+                .isEqualTo(range(1000L, 2000L));
+
+        assertThat(offsetsOfBatch(batches.get(2)))
+                .isEqualTo(range(2000L, 3000L));
+    }
+
+    @NonNull
+    private List<Long> offsetsOfBatch(RecordBatch batch) {
+        return RecordBatchUtils.recordStream(batch).map(Record::offset).toList();
+    }
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/MemoryRecordsUtilsTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/MemoryRecordsUtilsTest.java
@@ -7,7 +7,6 @@
 package io.kroxylicious.filter.encryption.records;
 
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.LongStream;
@@ -124,9 +123,7 @@ class MemoryRecordsUtilsTest {
         var mr3 = mrb.build();
 
         // When
-        List<Runnable> toClose = new ArrayList<>();
-        MemoryRecords memoryRecords = Stream.of(mr1, mr2, mr3).collect(MemoryRecordsUtils.concatCollector(toClose::add, new ByteBufferOutputStream(100)));
-        toClose.forEach(Runnable::run);
+        MemoryRecords memoryRecords = MemoryRecordsUtils.concat(Stream.of(mr1, mr2, mr3), new ByteBufferOutputStream(100));
 
         // Then
         List<? extends RecordBatch> batches = batchStream(memoryRecords).toList();

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/MemoryRecordsUtilsTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/MemoryRecordsUtilsTest.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.filter.encryption.records;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.LongStream;
@@ -123,7 +124,9 @@ class MemoryRecordsUtilsTest {
         var mr3 = mrb.build();
 
         // When
-        MemoryRecords memoryRecords = Stream.of(mr1, mr2, mr3).collect(MemoryRecordsUtils.concatCollector(new ByteBufferOutputStream(100)));
+        List<Runnable> toClose = new ArrayList<>();
+        MemoryRecords memoryRecords = Stream.of(mr1, mr2, mr3).collect(MemoryRecordsUtils.concatCollector(toClose::add, new ByteBufferOutputStream(100)));
+        toClose.forEach(Runnable::run);
 
         // Then
         List<? extends RecordBatch> batches = batchStream(memoryRecords).toList();

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/MemoryRecordsUtilsTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/MemoryRecordsUtilsTest.java
@@ -40,13 +40,15 @@ class MemoryRecordsUtilsTest {
         var batch = mrb.build();
 
         // When
+        // Use a Supplier so that assertions can terminate the stream they're asserting on
+        // without affecting each other
         Supplier<? extends Stream<? extends RecordBatch>> stream = () -> MemoryRecordsUtils.batchStream(batch);
 
         // Then
         // Assertions about stream itself
         assertThat(stream.get().isParallel()).isFalse();
         Stream<? extends RecordBatch> s1 = stream.get().sorted();
-        assertThatThrownBy(() -> s1.toList()).isExactlyInstanceOf(ClassCastException.class);
+        assertThatThrownBy(() -> s1.toList()).describedAs("RecordBatches are not Comparable").isExactlyInstanceOf(ClassCastException.class);
 
         // Assertions about stream contents
         assertThat(stream.get().count()).describedAs("Expect 996 batches").isEqualTo(996);

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/RecordBatchUtilsTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/RecordBatchUtilsTest.java
@@ -23,7 +23,7 @@ import static io.kroxylicious.filter.encryption.records.BatchAwareMemoryRecordsB
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class RecordBatchUtilsTest {
+class RecordBatchUtilsTest {
 
     @Test
     void testRecordStream() {
@@ -41,7 +41,8 @@ public class RecordBatchUtilsTest {
         // Then
         // Assertions about stream itself
         assertThat(stream.get().isParallel()).isFalse();
-        assertThatThrownBy(() -> stream.get().sorted().toList()).isExactlyInstanceOf(ClassCastException.class);
+        Stream<? extends Record> s1 = stream.get().sorted();
+        assertThatThrownBy(() -> s1.toList()).isExactlyInstanceOf(ClassCastException.class);
 
         // Assertions about stream contents
         assertThat(stream.get().count())

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/RecordBatchUtilsTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/RecordBatchUtilsTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.records;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.record.Record;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.utils.ByteBufferOutputStream;
+import org.junit.jupiter.api.Test;
+
+import static io.kroxylicious.filter.encryption.records.BatchAwareMemoryRecordsBuilder.EMPTY_HEADERS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class RecordBatchUtilsTest {
+
+    @Test
+    void testRecordStream() {
+        // Given
+        var mrb = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(1));
+        mrb.addBatch(CompressionType.NONE, TimestampType.LOG_APPEND_TIME, 4L);
+        for (long offset = 4L; offset < 1000L; offset++) {
+            mrb.appendWithOffset(offset, 123, "a".getBytes(StandardCharsets.UTF_8), null, EMPTY_HEADERS);
+        }
+        var batch = mrb.build().firstBatch();
+
+        // When
+        Supplier<? extends Stream<? extends Record>> stream = () -> RecordBatchUtils.recordStream(batch);
+
+        // Then
+        // Assertions about stream itself
+        assertThat(stream.get().isParallel()).isFalse();
+        assertThatThrownBy(() -> stream.get().sorted().toList()).isExactlyInstanceOf(ClassCastException.class);
+
+        // Assertions about stream contents
+        assertThat(stream.get().count())
+                .describedAs("Expect 996 records")
+                .isEqualTo(996);
+        assertThat(stream.get().map(Record::offset).toList()).isEqualTo(LongStream.range(4L, 1000L).boxed().toList());
+        assertThat(stream.get().parallel().map(Record::offset).toList()).isEqualTo(LongStream.range(4L, 1000L).boxed().toList());
+        assertThat(stream.get().distinct().map(Record::offset).toList()).isEqualTo(LongStream.range(4L, 1000L).boxed().toList());
+    }
+
+    @Test
+    void testToMemoryRecords() {
+        // Given
+        var mrb = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(1));
+        mrb.addBatch(CompressionType.NONE, TimestampType.LOG_APPEND_TIME, 4L);
+        for (long offset = 4L; offset < 1000L; offset++) {
+            mrb.appendWithOffset(offset, 123, "a".getBytes(StandardCharsets.UTF_8), null, EMPTY_HEADERS);
+        }
+        var batch = mrb.build().firstBatch();
+
+        // When
+        var memoryRecords = RecordBatchUtils.toMemoryRecords(batch,
+                new RecordTransform() {
+                    @Override
+                    public long transformOffset(Record record) {
+                        return 1_000_000_000L + record.offset();
+                    }
+
+                    @Override
+                    public long transformTimestamp(Record record) {
+                        return 1_000_000_000L + record.timestamp();
+                    }
+
+                    @Override
+                    public ByteBuffer transformKey(Record record) {
+                        return record.key();
+                    }
+
+                    @Override
+                    public ByteBuffer transformValue(Record record) {
+                        return record.value();
+                    }
+
+                    @Override
+                    public Header[] transformHeaders(Record record) {
+                        return record.headers();
+                    }
+
+                    @Override
+                    public void resetAfterTransform(Record record) {
+
+                    }
+                },
+                new ByteBufferOutputStream(1000));
+
+        // Then
+        assertThat(MemoryRecordsUtils.batchStream(memoryRecords).count()).isEqualTo(1);
+        assertThat(RecordBatchUtils.recordStream(memoryRecords.firstBatch()).map(Record::offset).toList())
+                .isEqualTo(LongStream.range(1_000_000_004L, 1_000_001_000L).boxed().toList());
+    }
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/RecordBatchUtilsTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/RecordBatchUtilsTest.java
@@ -39,13 +39,15 @@ class RecordBatchUtilsTest {
         var batch = mrb.build().firstBatch();
 
         // When
+        // Use a Supplier so that assertions can terminate the stream they're asserting on
+        // without affecting each other
         Supplier<? extends Stream<? extends Record>> stream = () -> RecordBatchUtils.recordStream(batch);
 
         // Then
         // Assertions about stream itself
         assertThat(stream.get().isParallel()).isFalse();
         Stream<? extends Record> s1 = stream.get().sorted();
-        assertThatThrownBy(() -> s1.toList()).isExactlyInstanceOf(ClassCastException.class);
+        assertThatThrownBy(() -> s1.toList()).describedAs("Records are not Comparable").isExactlyInstanceOf(ClassCastException.class);
 
         // Assertions about stream contents
         assertThat(stream.get().count())


### PR DESCRIPTION
### Type of change

Utility methods

### Description

While writing the encryption proxy it's become obvious that using Kafka's own APIs for transforming records and batches exposes filter authors to a number of rough edges. This PR adds some utility methods for making this simpler and safer. In particular:

* Make it easy to use Java's `Stream` API on `MemoryRecords` to access `RecordBatch`es, and on `RecordBatch` to access `Record`s.
* Make it easy to build transformed batches of records while maintaining the batch structure of an input `MemoryRecords` (i.e. don't merge all the batches in a request or response into a single batch)
* Encourage reuse of buffers, rather than, for example, allocating a buffer for each record or batch transformation.

Right now these classes are added to the encryption filter directly, since that's where we expect them to be used initially. But once they've proved useful there we should consider moving them somewhere where they can be used by other filters which handle `BaseRecords`/`MemoryRecords`.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
