### PR TITLE
Share DEK resources across channels

### DIFF
--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/DekAllocator.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/DekAllocator.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import io.kroxylicious.kms.service.DekPair;
+import io.kroxylicious.kms.service.Kms;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+// We want to allocate the same DEK to multiple channels
+public class DekAllocator<K, E> {
+
+    private final long maximumEncryptionsPerDek;
+    private final AsyncLoadingCache<K, DekUsageContext<E>> cache;
+    private static final int MAX_RETRIES = 3;
+
+    record DekUsageContext<E>(DekPair<E> dek, AtomicLong remainingEncryptions, AtomicBoolean closed) {
+
+        DekUsageContext(DekPair<E> dek, long maximumEncryptionsPerDek) {
+            this(dek, new AtomicLong(maximumEncryptionsPerDek), new AtomicBoolean(false));
+        }
+
+        DekPair<E> allocate(long encryptions) {
+            long remaining = remainingEncryptions.addAndGet(-encryptions);
+            if (remaining >= 0) {
+                return dek;
+            }
+            else {
+                throw new ExhaustedException(this);
+            }
+        }
+
+        // returns true if this is the first time it has been closed
+        private boolean close() {
+            boolean closedPrior = closed.getAndSet(true);
+            return !closedPrior;
+        }
+
+    }
+
+    public DekAllocator(@NonNull Kms<K, E> kms) {
+        // following suggested number of invocations from NIST SP.800-38D s8.3
+        this(kms, (long) Math.pow(2, 32));
+    }
+
+    public DekAllocator(@NonNull Kms<K, E> kms, long maximumEncryptionsPerDek) {
+        this.maximumEncryptionsPerDek = maximumEncryptionsPerDek;
+        cache = Caffeine.newBuilder().buildAsync(
+                (key, executor) -> kms.generateDekPair(key).thenApply(dekPair -> new DekUsageContext<>(dekPair, this.maximumEncryptionsPerDek)).toCompletableFuture());
+    }
+
+    @NonNull
+    CompletableFuture<DekPair<E>> allocateDek(@NonNull K kekId, long encryptions) {
+        if (encryptions > maximumEncryptionsPerDek) {
+            return CompletableFuture.failedFuture(new EncryptionException("DekAllocator asked to allocate encryptions above the configured maximum of " + maximumEncryptionsPerDek));
+        }
+        return allocateDek(kekId, encryptions, 0);
+    }
+
+    @NonNull
+    private CompletableFuture<DekPair<E>> allocateDek(@NonNull K kekId, long encryptions, int attempt) {
+        if (attempt == MAX_RETRIES) {
+            return CompletableFuture.failedFuture(new EncryptionException("unable to allocate a DEK after " + MAX_RETRIES + " attempts"));
+        }
+        return cache.get(kekId).thenApply(eDekUsageContext -> eDekUsageContext.allocate(encryptions))
+                .exceptionallyCompose(throwable -> invalidateAndRetry(kekId, throwable, encryptions, attempt + 1));
+    }
+
+    @NonNull
+    private CompletableFuture<DekPair<E>> invalidateAndRetry(@NonNull K kekId, Throwable throwable, long encryptions, int nextAttempt) {
+        if (throwable instanceof ExhaustedException ex) {
+            invalidateAndRetry(kekId, ex);
+        }
+        else if (throwable instanceof CompletionException e && e.getCause() instanceof ExhaustedException cause) {
+            invalidateAndRetry(kekId, cause);
+        }
+        return allocateDek(kekId, encryptions, nextAttempt);
+    }
+
+    private void invalidateAndRetry(@NonNull K kekId, ExhaustedException ex) {
+        // we want to prevent invalidating twice in case another thread has already invalidated and repopulated the cache
+        synchronized (ex.context) {
+            boolean firstClose = ex.context.close();
+            if (firstClose) {
+                cache.synchronous().invalidate(kekId);
+            }
+        }
+    }
+
+    private static class ExhaustedException extends RuntimeException {
+        private final DekUsageContext<?> context;
+
+        private ExhaustedException(DekUsageContext<?> context) {
+            this.context = context;
+        }
+    }
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/DekAllocator.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/DekAllocator.java
@@ -50,11 +50,6 @@ public class DekAllocator<K, E> {
 
     }
 
-    public DekAllocator(@NonNull Kms<K, E> kms) {
-        // following suggested number of invocations from NIST SP.800-38D s8.3
-        this(kms, (long) Math.pow(2, 32));
-    }
-
     public DekAllocator(@NonNull Kms<K, E> kms, long maximumEncryptionsPerDek) {
         this.maximumEncryptionsPerDek = maximumEncryptionsPerDek;
         cache = Caffeine.newBuilder().buildAsync(
@@ -91,12 +86,9 @@ public class DekAllocator<K, E> {
     }
 
     private void invalidate(@NonNull K kekId, ExhaustedException ex) {
-        // we want to prevent invalidating twice in case another thread has already invalidated and repopulated the cache
-        synchronized (ex.context) {
-            boolean firstClose = ex.context.close();
-            if (firstClose) {
-                cache.synchronous().invalidate(kekId);
-            }
+        boolean firstClose = ex.context.close();
+        if (firstClose) {
+            cache.synchronous().invalidate(kekId);
         }
     }
 

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/AesGcmEncryptor.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/AesGcmEncryptor.java
@@ -15,7 +15,6 @@ import javax.annotation.concurrent.NotThreadSafe;
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
-import javax.security.auth.DestroyFailedException;
 import javax.security.auth.Destroyable;
 
 import io.kroxylicious.filter.encryption.EncryptionException;

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/AesGcmEncryptor.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/AesGcmEncryptor.java
@@ -152,21 +152,11 @@ class AesGcmEncryptor implements Destroyable {
     }
 
     @Override
-    public void destroy() throws DestroyFailedException {
+    public void destroy() {
         ivGenerator.destroy();
         Arrays.fill(iv, (byte) 0);
-        try {
-            if (key != null) {
-                key.destroy();
-            }
-        }
-        catch (DestroyFailedException e) {
-            throw new DestroyFailedException("On key of " + key.getClass());
-        }
-        finally {
-            key = null;
-            cipher = null;
-        }
+        key = null;
+        cipher = null;
     }
 
     @Override

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/DekAllocatorTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/DekAllocatorTest.java
@@ -6,19 +6,19 @@
 
 package io.kroxylicious.filter.encryption;
 
-import io.kroxylicious.kms.service.DekPair;
-import io.kroxylicious.kms.service.Kms;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import javax.crypto.SecretKey;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.crypto.SecretKey;
-import java.time.Duration;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutionException;
+import io.kroxylicious.kms.service.DekPair;
+import io.kroxylicious.kms.service.Kms;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/DekAllocatorTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/DekAllocatorTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+import io.kroxylicious.kms.service.DekPair;
+import io.kroxylicious.kms.service.Kms;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.crypto.SecretKey;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DekAllocatorTest {
+
+    public static final int MAXIMUM_ENCRYPTIONS_PER_DEK = 1000;
+    @Mock
+    Kms<Long, Long> kms;
+    @Mock
+    SecretKey secretKey;
+    @Mock
+    SecretKey secretKey2;
+
+    @Test
+    public void testInitialAllocationLessThanMaximumPerDek() {
+        // given
+        DekPair<Long> expected = new DekPair<>(1L, secretKey);
+        when(kms.generateDekPair(1L)).thenReturn(CompletableFuture.completedFuture(expected));
+        DekAllocator<Long, Long> allocator = new DekAllocator<>(kms, MAXIMUM_ENCRYPTIONS_PER_DEK);
+
+        // when
+        CompletableFuture<DekPair<Long>> pair = allocator.allocateDek(1L, 500);
+
+        // then
+        assertThat(pair).succeedsWithin(Duration.ZERO).isSameAs(expected);
+        verify(kms).generateDekPair(1L);
+    }
+
+    @Test
+    public void testSameDekCanBeAllocatedMultipleTimes() {
+        // given
+        DekPair<Long> expected = new DekPair<>(1L, secretKey);
+        when(kms.generateDekPair(1L)).thenReturn(CompletableFuture.completedFuture(expected));
+        DekAllocator<Long, Long> allocator = new DekAllocator<>(kms, MAXIMUM_ENCRYPTIONS_PER_DEK);
+
+        // when
+        CompletableFuture<DekPair<Long>> pair1 = allocator.allocateDek(1L, 500);
+        CompletableFuture<DekPair<Long>> pair2 = allocator.allocateDek(1L, 500);
+
+        // then
+        assertThat(pair1).succeedsWithin(Duration.ZERO).isSameAs(expected);
+        assertThat(pair2).succeedsWithin(Duration.ZERO).isSameAs(expected);
+        verify(kms).generateDekPair(1L);
+    }
+
+    @Test
+    public void testAllocatorGeneratesANewDekIfMaxEncryptionsWouldBeExceeded() {
+        // given
+        DekPair<Long> expected = new DekPair<>(1L, secretKey);
+        DekPair<Long> expected2 = new DekPair<>(4L, secretKey2);
+        when(kms.generateDekPair(1L)).thenReturn(CompletableFuture.completedFuture(expected), CompletableFuture.completedFuture(expected2));
+        DekAllocator<Long, Long> allocator = new DekAllocator<>(kms, MAXIMUM_ENCRYPTIONS_PER_DEK);
+
+        // when
+        CompletableFuture<DekPair<Long>> pair1 = allocator.allocateDek(1L, 500);
+        CompletableFuture<DekPair<Long>> pair2 = allocator.allocateDek(1L, 600);
+
+        // then
+        assertThat(pair1).succeedsWithin(Duration.ZERO).isSameAs(expected);
+        assertThat(pair2).succeedsWithin(Duration.ZERO).isSameAs(expected2);
+        verify(kms, times(2)).generateDekPair(1L);
+    }
+
+    @Test
+    public void testInitialAllocationEqualToMaximumPerDek() {
+        // given
+        DekPair<Long> expected = new DekPair<>(1L, secretKey);
+        when(kms.generateDekPair(1L)).thenReturn(CompletableFuture.completedFuture(expected));
+        DekAllocator<Long, Long> allocator = new DekAllocator<>(kms, MAXIMUM_ENCRYPTIONS_PER_DEK);
+
+        // when
+        CompletableFuture<DekPair<Long>> pair = allocator.allocateDek(1L, 1000);
+
+        // then
+        assertThat(pair).succeedsWithin(Duration.ZERO).isSameAs(expected);
+        verify(kms).generateDekPair(1L);
+    }
+
+    @Test
+    public void testInitialAllocationGreaterThanMaximumPerDek() {
+        // given
+        DekAllocator<Long, Long> allocator = new DekAllocator<>(kms, MAXIMUM_ENCRYPTIONS_PER_DEK);
+
+        // when
+        CompletableFuture<DekPair<Long>> pair = allocator.allocateDek(1L, 1001);
+
+        // then
+        assertThat(pair).failsWithin(Duration.ZERO).withThrowableThat().isInstanceOf(ExecutionException.class)
+                .havingCause().isInstanceOf(EncryptionException.class);
+        verify(kms, never()).generateDekPair(anyLong());
+    }
+
+    @Test
+    public void testDefaultMaxAllocation() {
+        // given
+        DekPair<Long> expected = new DekPair<>(1L, secretKey);
+        when(kms.generateDekPair(1L)).thenReturn(CompletableFuture.completedFuture(expected));
+        DekAllocator<Long, Long> allocator = new DekAllocator<>(kms);
+
+        // when
+        CompletableFuture<DekPair<Long>> pair = allocator.allocateDek(1L, (long) Math.pow(2, 32));
+
+        // then
+        assertThat(pair).succeedsWithin(Duration.ZERO).isSameAs(expected);
+        verify(kms).generateDekPair(1L);
+    }
+
+    @Test
+    public void testDefaultMaxAllocationExceeded() {
+        // given
+        DekAllocator<Long, Long> allocator = new DekAllocator<>(kms);
+
+        // when
+        CompletableFuture<DekPair<Long>> pair = allocator.allocateDek(1L, (long) Math.pow(2, 32) + 1L);
+
+        // then
+        assertThat(pair).failsWithin(Duration.ZERO).withThrowableThat().isInstanceOf(ExecutionException.class)
+                .havingCause().isInstanceOf(EncryptionException.class);
+        verify(kms, never()).generateDekPair(anyLong());
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/DekAllocatorTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/DekAllocatorTest.java
@@ -122,7 +122,7 @@ class DekAllocatorTest {
         // given
         DekPair<Long> expected = new DekPair<>(1L, secretKey);
         when(kms.generateDekPair(1L)).thenReturn(CompletableFuture.completedFuture(expected));
-        DekAllocator<Long, Long> allocator = new DekAllocator<>(kms);
+        DekAllocator<Long, Long> allocator = new DekAllocator<>(kms, (long) Math.pow(2, 32));
 
         // when
         CompletableFuture<DekPair<Long>> pair = allocator.allocateDek(1L, (long) Math.pow(2, 32));
@@ -135,7 +135,7 @@ class DekAllocatorTest {
     @Test
     public void testDefaultMaxAllocationExceeded() {
         // given
-        DekAllocator<Long, Long> allocator = new DekAllocator<>(kms);
+        DekAllocator<Long, Long> allocator = new DekAllocator<>(kms, (long) Math.pow(2, 32));
 
         // when
         CompletableFuture<DekPair<Long>> pair = allocator.allocateDek(1L, (long) Math.pow(2, 32) + 1L);

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionTest.java
@@ -39,7 +39,7 @@ class EnvelopeEncryptionTest {
         doReturn(kekSelector).when(kekSelectorService).buildSelector(any(), any());
 
         ee.initialize(fc, config);
-        var filter = ee.createFilter(fc, config);
+        var filter = ee.createFilter(fc, new EnvelopeEncryption.ApplicationWideState(fc, config));
         assertNotNull(filter);
     }
 

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionTest.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.filter.encryption;
 
 import java.time.Duration;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class EnvelopeEncryptionTest {
 
@@ -32,6 +34,7 @@ class EnvelopeEncryptionTest {
         var kekSelectorService = mock(KekSelectorService.class);
         var kekSelector = mock(TopicNameBasedKekSelector.class);
 
+        when(fc.eventLoop()).thenReturn(new ScheduledThreadPoolExecutor(1));
         doReturn(kmsService).when(fc).pluginInstance(KmsService.class, "KMS");
         doReturn(kms).when(kmsService).buildKms(any());
 

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionTest.java
@@ -42,7 +42,7 @@ class EnvelopeEncryptionTest {
         doReturn(kekSelector).when(kekSelectorService).buildSelector(any(), any());
 
         ee.initialize(fc, config);
-        var filter = ee.createFilter(fc, new EnvelopeEncryption.ApplicationWideState(fc, config));
+        var filter = ee.createFilter(fc, new EnvelopeEncryption.FilterFactoryInstanceScopedState(fc, config));
         assertNotNull(filter);
     }
 

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/AesGcmEncryptorTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/AesGcmEncryptorTest.java
@@ -56,9 +56,11 @@ class AesGcmEncryptorTest {
         var keygen = KeyGenerator.getInstance("AES");
         SecretKey key = keygen.generateKey();
         var enc = AesGcmEncryptor.forEncrypt(new AesGcmIvGenerator(new SecureRandom()), key);
-        assertThrows(DestroyFailedException.class, enc::destroy);
+        enc.destroy();
         // ^^ this is not the behaviour we want, but it's the behaviour we get (from the in memory KMS at least)
         assertTrue(enc.isDestroyed());
+        // since the SecretKey is being shared by other KeyContexts we do not want to destroy it
+        assertFalse(key.isDestroyed());
 
         enc.destroy();
         // once destroyed we expect a 2nd call to not throw

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/InBandKeyManagerTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/InBandKeyManagerTest.java
@@ -69,7 +69,7 @@ class InBandKeyManagerTest {
     void shouldEncryptRecordValue() {
         var kmsService = UnitTestingKmsService.newInstance();
         InMemoryKms kms = kmsService.buildKms(new UnitTestingKmsService.Config());
-        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000, new DekAllocator<>(kms));
+        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000, new DekAllocator<>(kms, (long) Math.pow(2, 32)));
 
         var kekId = kms.generateKey();
 
@@ -103,7 +103,7 @@ class InBandKeyManagerTest {
     void shouldTolerateEncryptingAndDecryptingEmptyRecordValue() {
         var kmsService = UnitTestingKmsService.newInstance();
         InMemoryKms kms = kmsService.buildKms(new UnitTestingKmsService.Config());
-        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000, new DekAllocator<>(kms));
+        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000, new DekAllocator<>(kms, (long) Math.pow(2, 32)));
 
         var kekId = kms.generateKey();
 
@@ -129,7 +129,7 @@ class InBandKeyManagerTest {
     void decryptSupportsUnencryptedRecordValue() {
         var kmsService = UnitTestingKmsService.newInstance();
         InMemoryKms kms = kmsService.buildKms(new UnitTestingKmsService.Config());
-        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000, new DekAllocator<>(kms));
+        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000, new DekAllocator<>(kms, (long) Math.pow(2, 32)));
 
         byte[] recBytes = { 1, 2, 3 };
         TestingRecord record = new TestingRecord(ByteBuffer.wrap(recBytes));
@@ -148,7 +148,7 @@ class InBandKeyManagerTest {
     void nullRecordValuesShouldNotBeModifiedAtEncryptTime() {
         var kmsService = UnitTestingKmsService.newInstance();
         InMemoryKms kms = kmsService.buildKms(new UnitTestingKmsService.Config());
-        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000, new DekAllocator<>(kms));
+        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000, new DekAllocator<>(kms, (long) Math.pow(2, 32)));
 
         var kekId = kms.generateKey();
 
@@ -169,7 +169,7 @@ class InBandKeyManagerTest {
     void nullRecordValuesAreIncompatibleWithHeaderEncryption() {
         var kmsService = UnitTestingKmsService.newInstance();
         InMemoryKms kms = kmsService.buildKms(new UnitTestingKmsService.Config());
-        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000, new DekAllocator<>(kms));
+        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000, new DekAllocator<>(kms, (long) Math.pow(2, 32)));
 
         var kekId = kms.generateKey();
 
@@ -188,7 +188,7 @@ class InBandKeyManagerTest {
     void shouldTolerateEncryptingEmptyBatch() {
         var kmsService = UnitTestingKmsService.newInstance();
         InMemoryKms kms = kmsService.buildKms(new UnitTestingKmsService.Config());
-        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000, new DekAllocator<>(kms));
+        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000, new DekAllocator<>(kms, (long) Math.pow(2, 32)));
 
         var kekId = kms.generateKey();
 
@@ -206,7 +206,7 @@ class InBandKeyManagerTest {
         InMemoryKms kms = kmsService.buildKms(new UnitTestingKmsService.Config());
         var kekId = kms.generateKey();
         // configure 1 encryption per dek but then try to encrypt 2 records, will destroy and retry
-        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 1, new DekAllocator<>(kms));
+        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 1, new DekAllocator<>(kms, (long) Math.pow(2, 32)));
 
         var value = ByteBuffer.wrap(new byte[]{ 1, 2, 3 });
         var value2 = ByteBuffer.wrap(new byte[]{ 4, 5, 6 });
@@ -254,7 +254,7 @@ class InBandKeyManagerTest {
         InMemoryKms spyKms = Mockito.spy(kms);
         doReturn(CompletableFuture.failedFuture(new KmsException("failed to create that DEK"))).when(spyKms).decryptEdek(any());
 
-        var km = new InBandKeyManager<>(spyKms, BufferPool.allocating(), 50000, new DekAllocator<>(spyKms));
+        var km = new InBandKeyManager<>(spyKms, BufferPool.allocating(), 50000, new DekAllocator<>(spyKms, (long) Math.pow(2, 32)));
 
         var value = ByteBuffer.wrap(new byte[]{ 1, 2, 3 });
         var value2 = ByteBuffer.wrap(new byte[]{ 4, 5, 6 });
@@ -319,7 +319,7 @@ class InBandKeyManagerTest {
     void shouldEncryptRecordValueForMultipleRecords() throws ExecutionException, InterruptedException, TimeoutException {
         var kmsService = UnitTestingKmsService.newInstance();
         InMemoryKms kms = kmsService.buildKms(new UnitTestingKmsService.Config());
-        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000, new DekAllocator<>(kms));
+        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000, new DekAllocator<>(kms, (long) Math.pow(2, 32)));
 
         var kekId = kms.generateKey();
 
@@ -435,7 +435,7 @@ class InBandKeyManagerTest {
     void shouldUseSameDekForMultipleBatches() throws ExecutionException, InterruptedException, TimeoutException {
         var kmsService = UnitTestingKmsService.newInstance();
         InMemoryKms kms = kmsService.buildKms(new UnitTestingKmsService.Config());
-        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 4, new DekAllocator<>(kms));
+        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 4, new DekAllocator<>(kms, (long) Math.pow(2, 32)));
 
         var kekId = kms.generateKey();
 
@@ -483,7 +483,7 @@ class InBandKeyManagerTest {
     void shouldEncryptRecordHeaders() {
         var kmsService = UnitTestingKmsService.newInstance();
         InMemoryKms kms = kmsService.buildKms(new UnitTestingKmsService.Config());
-        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000, new DekAllocator<>(kms));
+        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000, new DekAllocator<>(kms, (long) Math.pow(2, 32)));
 
         var kekId = kms.generateKey();
 
@@ -513,7 +513,7 @@ class InBandKeyManagerTest {
     void shouldEncryptRecordHeadersForMultipleRecords() throws ExecutionException, InterruptedException, TimeoutException {
         var kmsService = UnitTestingKmsService.newInstance();
         InMemoryKms kms = kmsService.buildKms(new UnitTestingKmsService.Config());
-        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000, new DekAllocator<>(kms));
+        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000, new DekAllocator<>(kms, (long) Math.pow(2, 32)));
 
         var kekId = kms.generateKey();
 
@@ -546,7 +546,7 @@ class InBandKeyManagerTest {
     void shouldPropagateHeadersInClearWhenNotEncryptingHeaders() {
         var kmsService = UnitTestingKmsService.newInstance();
         InMemoryKms kms = kmsService.buildKms(new UnitTestingKmsService.Config());
-        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000, new DekAllocator<>(kms));
+        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 500_000, new DekAllocator<>(kms, (long) Math.pow(2, 32)));
 
         var kekId = kms.generateKey();
 
@@ -590,7 +590,7 @@ class InBandKeyManagerTest {
 
         var spyKms = Mockito.spy(kms);
 
-        var km = new InBandKeyManager<>(spyKms, BufferPool.allocating(), 50000, new DekAllocator<>(spyKms));
+        var km = new InBandKeyManager<>(spyKms, BufferPool.allocating(), 50000, new DekAllocator<>(spyKms, (long) Math.pow(2, 32)));
 
         byte[] rec1Bytes = { 1, 2, 3 };
         byte[] rec2Bytes = { 4, 5, 6 };
@@ -645,7 +645,7 @@ class InBandKeyManagerTest {
         InMemoryKms kms = kmsService.buildKms(new UnitTestingKmsService.Config());
         var kekId = kms.generateKey();
 
-        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 50000, new DekAllocator<>(kms));
+        var km = new InBandKeyManager<>(kms, BufferPool.allocating(), 50000, new DekAllocator<>(kms, (long) Math.pow(2, 32)));
 
         byte[] rec1Bytes = { 1, 2, 3 };
         byte[] rec2Bytes = { 4, 5, 6 };


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Creating new DEKs for every channel is relatively wasteful. We are taking the cost of making more KMS operations at encrypt and then decrypt time, when more keys have to be unwrapped to decrypt. We can make more effective use of each generated DEK while still keeping the guarantees around only using a DEK for some limited amount of encryption invocations.

This change:
1. Makes KeyManager cached per event-loop, so all EnvelopeEncryptionFilter instances associated with channels registered with this event loop will share an InBandKeyManager
2. Similarly, makes the KekSelector cached per event-loop
3. Makes the KMS instance scoped to the FilterFactory instance so there is one instance created at initialisation time for that FilterFactory instance.
4. Introduces a DekAllocator, also FilterFactory-wide that is used to share DEKs across event-loops

The InBandKeyManager uses the DekAllocator to obtain a DEK that can be used for N encryptions (this amount is configurable in InBandKeyManager). The idea is the InBandKeyManager for an event-loop would request a large allocation of encryption operations that it can use for many messages before asking for another allocation. This number will be dwarfed by the 2^32 recommended max invocations per DEK (edit, recommendation specific to AES) so we can allocate the same DEK many times including handing it out to multiple InBandKeyManager in parallel.

The end result is one DEK can be used by all channels.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
