### PR TITLE
Ensure we execute deferred Filter methods on the eventloop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.5.0
 
+* [#895](https://github.com/kroxylicious/kroxylicious/pull/895): Ensure we execute deferred Filter methods on the eventloop
 * [#896](https://github.com/kroxylicious/kroxylicious/issues/896): In TLS config, use passwordFile as property to accept password material from a file rather than filePath.
 * [#844](https://github.com/kroxylicious/kroxylicious/pull/844): Fix connect to upstream using TLS client authentication
 * [#885](https://github.com/kroxylicious/kroxylicious/pull/885): Bump kroxy.extension.version from 0.8.0 to 0.8.1

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/CorrelationManager.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/CorrelationManager.java
@@ -6,6 +6,7 @@
 package io.kroxylicious.test.client;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -53,6 +54,16 @@ public class CorrelationManager {
      */
     public Correlation getBrokerCorrelation(int correlationId) {
         return brokerRequests.remove(correlationId);
+    }
+
+    public void onChannelClose() {
+        List<Integer> pending = brokerRequests.keySet().stream().toList();
+        for (Integer correlation : pending) {
+            Correlation corr = brokerRequests.get(correlation);
+            if (corr.responseFuture != null) {
+                corr.responseFuture.completeExceptionally(new RuntimeException("channel closed before response received!"));
+            }
+        }
     }
 
     /**

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/KafkaClient.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/KafkaClient.java
@@ -131,6 +131,9 @@ public final class KafkaClient implements AutoCloseable {
 
             ChannelFuture connect = b.connect(host, port);
             connect.addListeners((ChannelFutureListener) channelFuture -> candidate.complete(channelFuture.channel()));
+            connect.channel().closeFuture().addListener(future -> {
+                correlationManager.onChannelClose();
+            });
             return candidate;
         }
         else {

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/MockServerKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/MockServerKroxyliciousTester.java
@@ -110,6 +110,14 @@ public class MockServerKroxyliciousTester extends DefaultKroxyliciousTester {
     }
 
     /**
+     * Get all requests recorded by the MockServer for a given ApiKey
+     * @return requests
+     */
+    public List<Request> getRequestsForApiKey(ApiKeys apiKeys) {
+        return mockServer.getReceivedRequests().stream().filter(request -> request.apiKeys() == apiKeys).toList();
+    }
+
+    /**
      * Close the mocks erver and kroxylicious proxy
      */
     @Override

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/client/CorrelationManagerTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/client/CorrelationManagerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test.client;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CorrelationManagerTest {
+
+    @Test
+    void testPendingFuturesCompletedExceptionallyOnChannelClose() {
+        // given
+        CorrelationManager correlationManager = new CorrelationManager();
+        CompletableFuture<SequencedResponse> responseFuture = new CompletableFuture<>();
+        CompletableFuture<SequencedResponse> responseFuture2 = new CompletableFuture<>();
+        correlationManager.putBrokerRequest((short) 1, (short) 1, 1, responseFuture);
+        correlationManager.putBrokerRequest((short) 1, (short) 1, 2, responseFuture2);
+
+        // when
+        correlationManager.onChannelClose();
+
+        // then
+        assertThat(responseFuture).failsWithin(Duration.ZERO);
+        assertThat(responseFuture2).failsWithin(Duration.ZERO);
+    }
+
+    @Test
+    void testNullFutureToleratedOnChannelClose() {
+        // given
+        CorrelationManager correlationManager = new CorrelationManager();
+        CompletableFuture<SequencedResponse> responseFuture = new CompletableFuture<>();
+        correlationManager.putBrokerRequest((short) 1, (short) 1, 1, responseFuture);
+        correlationManager.putBrokerRequest((short) 1, (short) 1, 2, null);
+
+        // when
+        correlationManager.onChannelClose();
+
+        // then
+        assertThat(responseFuture).failsWithin(Duration.ZERO);
+    }
+
+    @Test
+    void testCorrelationRetrievableOnceOnly() {
+        // given
+        int correlationId = 1;
+        CorrelationManager correlationManager = new CorrelationManager();
+        CompletableFuture<SequencedResponse> responseFuture = new CompletableFuture<>();
+        correlationManager.putBrokerRequest((short) 1, (short) 1, correlationId, responseFuture);
+        CorrelationManager.Correlation brokerCorrelation = correlationManager.getBrokerCorrelation(correlationId);
+        assertThat(brokerCorrelation).isNotNull();
+
+        // when
+        CorrelationManager.Correlation brokerCorrelation2 = correlationManager.getBrokerCorrelation(correlationId);
+
+        // then
+        assertThat(brokerCorrelation2).isNull();
+    }
+
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/FilterIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/FilterIT.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 
 import org.apache.kafka.clients.admin.Admin;
@@ -69,6 +70,7 @@ import io.kroxylicious.testing.kafka.junit5ext.Topic;
 import static io.kroxylicious.UnknownTaggedFields.unknownTaggedFieldsToStrings;
 import static io.kroxylicious.proxy.filter.ApiVersionsMarkingFilter.INTERSECTED_API_VERSION_RANGE_TAG;
 import static io.kroxylicious.proxy.filter.ApiVersionsMarkingFilter.UPSTREAM_API_VERSION_RANGE_TAG;
+import static io.kroxylicious.proxy.filter.RequestResponseMarkingFilter.DISPATCH_THREAD;
 import static io.kroxylicious.proxy.filter.RequestResponseMarkingFilter.FILTER_NAME_TAG;
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
@@ -276,6 +278,74 @@ class FilterIT {
         doSupportsForwardDeferredByAsynchronousRequest(direction,
                 "supportsForwardDeferredByAsynchronousBrokerRequest",
                 ForwardingStyle.ASYNCHRONOUS_REQUEST_TO_BROKER);
+    }
+
+    /**
+     * This is here to test a subtle case, we want to ensure that if a Filter defers some work
+     * and completes that work from some uncontrolled thread, that other Messages enqueued at the
+     * filter are dispatched on the eventloop. Given that the eventloop is dynamically allocated
+     * to the channel, we cannot precisely check what thread we are running on, but we can
+     * assert that the user's Filter method is being invoked from the same thread.
+     */
+    @ParameterizedTest
+    @EnumSource(value = RequestResponseMarkingFilterFactory.Direction.class)
+    void supportAsyncBatchForwarding(RequestResponseMarkingFilterFactory.Direction direction) throws Exception {
+        doSupportsForwardDeferredByAsynchronousBatchRequest(direction,
+                "supportsForwardDeferredByAsynchronousBrokerRequest",
+                ForwardingStyle.ASYNCHRONOUS_DELAYED);
+    }
+
+    private void doSupportsForwardDeferredByAsynchronousBatchRequest(RequestResponseMarkingFilterFactory.Direction direction, String name,
+                                                                     ForwardingStyle forwardingStyle)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        var markingFilter = new FilterDefinitionBuilder(RequestResponseMarkingFilterFactory.class.getName())
+                .withConfig("keysToMark", Set.of(LIST_TRANSACTIONS),
+                        "direction", Set.of(direction),
+                        "name", name,
+                        "forwardingStyle", forwardingStyle)
+                .build();
+        try (var tester = mockKafkaKroxyliciousTester((mockBootstrap) -> proxy(mockBootstrap).addToFilters(markingFilter));
+                var kafkaClient = tester.simpleTestClient()) {
+            tester.addMockResponseForApiKey(new ResponsePayload(LIST_TRANSACTIONS, LIST_TRANSACTIONS.latestVersion(), new ListTransactionsResponseData()));
+            ApiVersionsResponseData apiVersionsResponseData = new ApiVersionsResponseData();
+            apiVersionsResponseData.apiKeys()
+                    .add(new ApiVersionsResponseData.ApiVersion().setApiKey(FETCH.id).setMaxVersion(FETCH.latestVersion()).setMinVersion(FETCH.oldestVersion()));
+            tester.addMockResponseForApiKey(new ResponsePayload(API_VERSIONS, API_VERSIONS.latestVersion(), apiVersionsResponseData));
+
+            // In the ASYNCHRONOUS_REQUEST_TO_BROKER case, the filter will send an async list_group
+            // request to the broker and defer the forward of the list transaction response until the list groups
+            // response arrives.
+            if (forwardingStyle == ForwardingStyle.ASYNCHRONOUS_REQUEST_TO_BROKER) {
+                tester.addMockResponseForApiKey(new ResponsePayload(LIST_GROUPS, LIST_GROUPS.latestVersion(), new ListGroupsResponseData()));
+            }
+
+            var responseAFuture = kafkaClient
+                    .get(new Request(LIST_TRANSACTIONS, LIST_TRANSACTIONS.latestVersion(), "client", new ListTransactionsRequestData()));
+
+            var responseBFuture = kafkaClient
+                    .get(new Request(LIST_TRANSACTIONS, LIST_TRANSACTIONS.latestVersion(), "client", new ListTransactionsRequestData()));
+            Response responseA = responseAFuture.get(5, TimeUnit.SECONDS);
+            Response responseB = responseBFuture.get(5, TimeUnit.SECONDS);
+
+            List<Request> listTransactionRequests = tester.getRequestsForApiKey(LIST_TRANSACTIONS);
+            var requestMessageReceivedByBrokerA = listTransactionRequests.get(0).message();
+            String dispatchThreadA = getDispatchThreadName(direction, responseA, requestMessageReceivedByBrokerA);
+            var requestMessageReceivedByBrokerB = listTransactionRequests.get(1).message();
+            String dispatchThreadB = getDispatchThreadName(direction, responseB, requestMessageReceivedByBrokerB);
+            assertThat(dispatchThreadA).isNotEmpty().containsIgnoringCase("eventloop");
+            assertThat(dispatchThreadB).isNotEmpty().containsIgnoringCase("eventloop")
+                    .describedAs("filter invocations should be dispatched from the same thread").isEqualTo(dispatchThreadA);
+        }
+    }
+
+    private static String getDispatchThreadName(RequestResponseMarkingFilterFactory.Direction direction, Response responseA, ApiMessage requestMessageReceivedByBrokerA) {
+        var responseMessageReceivedByClientA = responseA.payload().message();
+
+        assertThat(requestMessageReceivedByBrokerA).isInstanceOf(ListTransactionsRequestData.class);
+        assertThat(responseMessageReceivedByClientA).isInstanceOf(ListTransactionsResponseData.class);
+
+        var target = direction == RequestResponseMarkingFilterFactory.Direction.REQUEST ? requestMessageReceivedByBrokerA : responseMessageReceivedByClientA;
+        return unknownTaggedFieldsToStrings(target, DISPATCH_THREAD).findFirst().orElse("");
     }
 
     private void doSupportsForwardDeferredByAsynchronousRequest(RequestResponseMarkingFilterFactory.Direction direction, String name,

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -299,11 +299,11 @@ public class FilterHandler extends ChannelDuplexHandler {
             }
             future.completeExceptionally(new TimeoutException("Filter %s was timed-out.".formatted(filterDescriptor())));
         }, timeoutMs, TimeUnit.MILLISECONDS);
-        return future.thenApply(filterResult -> {
+        return future.thenApplyAsync(filterResult -> {
             timeoutFuture.cancel(false);
 
             return filterResult;
-        });
+        }, ctx.executor());
     }
 
     private void deferredResponseCompleted(ResponseFilterResult ignored, Throwable throwable) {


### PR DESCRIPTION
In our thread-safety guarantees javadoc we state:

```
 *   <li>There is a single thread associated with each connection and this association lasts for the lifetime of connection..</li>
 *   <li>Each filter instance is associated with exactly one connection.</li>
 *   <li>Construction of the filter instance and dispatch of the filter methods {@code onXxxRequest} and
 *       {@code onXxxResponse} takes place on that same thread.</li>
```

Currently if a message is enqueued in an instance of `FilterHandler` because there is deferred work in progress, the  subsequent dispatch will be driven by the completion of the previous read or write. This could be driven by an uncontrolled thread (this is in the hands of the Filter author). So we break our promise of dispatching `onXxxRequest` and `onXxxResponse` on the channel's thread.