### PR TITLE
Refactor InBandKeyManager#encrypt to operate on MemoryRecords

### DIFF
--- a/kroxylicious-filter-test-support/pom.xml
+++ b/kroxylicious-filter-test-support/pom.xml
@@ -47,6 +47,10 @@
             <artifactId>kafka-clients</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <!-- dependency management sets the scope to test so we have to override it here -->

--- a/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/record/RecordTestUtilsTest.java
+++ b/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/record/RecordTestUtilsTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test.record;
+
+import org.apache.kafka.common.record.MemoryRecords;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RecordTestUtilsTest {
+
+    @Test
+    void testMemoryRecordsWithAllRecordsDeleted() {
+        MemoryRecords records = RecordTestUtils.memoryRecordsWithAllRecordsRemoved();
+        assertThat(records.firstBatch()).isNotNull();
+        assertThat(records.sizeInBytes()).isPositive();
+        assertThat(records.records()).isEmpty();
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/KeyManager.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/KeyManager.java
@@ -8,8 +8,11 @@ package io.kroxylicious.filter.encryption;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;
+import java.util.function.IntFunction;
 
+import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.Record;
+import org.apache.kafka.common.utils.ByteBufferOutputStream;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -21,18 +24,19 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public interface KeyManager<K> {
 
     /**
-     * Asynchronously encrypt the given {@code recordRequests} using the current DEK for the given KEK, calling the given receiver for each encrypted record
+     * Asynchronously encrypt the given {@code records} using the current DEK for the given KEK returning a MemoryRecords object which will contain all records
+     * transformed according to the {@code encryptionScheme}.
      * @param encryptionScheme The encryption scheme.
-     * @param records The requests to be encrypted.
-     * @param receiver The receiver of the encrypted buffers. The receiver is guaranteed to receive the encrypted buffers sequentially, in the same order as {@code records}, with no possibility of parallel invocation.
-     * @return A completion stage that completes when all the records have been processed.
+     * @param records The MemoryRecords to be encrypted.
+     * @param bufferAllocator Allocator of ByteBufferOutputStream
+     * @return A completion stage that completes with the output MemoryRecords when all the records have been processed and transformed.
      */
     @NonNull
-    CompletionStage<Void> encrypt(@NonNull String topicName,
-                                  int partition,
-                                  @NonNull EncryptionScheme<K> encryptionScheme,
-                                  @NonNull List<? extends Record> records,
-                                  @NonNull Receiver receiver);
+    CompletionStage<MemoryRecords> encrypt(@NonNull String topicName,
+                                           int partition,
+                                           @NonNull EncryptionScheme<K> encryptionScheme,
+                                           @NonNull MemoryRecords records,
+                                           @NonNull IntFunction<ByteBufferOutputStream> bufferAllocator);
 
     /**
      * Asynchronously decrypt the given {@code kafkaRecords} (if they were, in fact, encrypted), calling the given {@code receiver} with the plaintext


### PR DESCRIPTION
### Type of change

- Refactoring
### Description

Why:
We are preparing to make the encrypt aware of the batches within a MemoryRecords instance and preserve the batches along with their metadata. We need to change encrypt to take MemoryRecords and return a CompletionStage<MemoryRecords> so that the batch-preservation can be handled while we encrypt all the records.

Contributes towards #855

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
