### PR TITLE
Fix #896: In TLS config, use passwordFile as property to accept password material from a file rather than filePath.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.5.0
 
+* [#896](https://github.com/kroxylicious/kroxylicious/issues/896): In TLS config, use passwordFile as property to accept password material from a file rather than filePath.
 * [#844](https://github.com/kroxylicious/kroxylicious/pull/844): Fix connect to upstream using TLS client authentication
 * [#885](https://github.com/kroxylicious/kroxylicious/pull/885): Bump kroxy.extension.version from 0.8.0 to 0.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 * [#844](https://github.com/kroxylicious/kroxylicious/pull/844): Fix connect to upstream using TLS client authentication
 * [#885](https://github.com/kroxylicious/kroxylicious/pull/885): Bump kroxy.extension.version from 0.8.0 to 0.8.1
 
+### Changes, deprecations and removals
+
+* When configuring TLS, the property `filePath` for specifying the location of a file providing the password is now
+  deprecated.  Use `passwordFile` instead.
+
 ## 0.4.1
 
 * [#836](https://github.com/kroxylicious/kroxylicious/pull/836): Cache decrypted EDEK and resolved aliases

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
@@ -170,6 +170,43 @@ class ConfigurationTest {
                                         bootstrapAddress: cluster1:9192
                                         brokerAddressPattern: broker-$(nodeId)
                                 """),
+                Arguments.of("Upstream TLS - trust from truststore, password from file",
+                        new ConfigurationBuilder()
+                                .addToVirtualClusters("demo", new VirtualClusterBuilder()
+                                        .withNewTargetCluster()
+                                        .withBootstrapServers("kafka.example:1234")
+                                        .withNewTls()
+                                        .withNewTrustStoreTrust()
+                                        .withStoreFile("/tmp/client.jks")
+                                        .withStoreType("JKS")
+                                        .withNewFilePasswordStoreProvider("/tmp/password.txt")
+                                        .endTrustStoreTrust()
+                                        .endTls()
+                                        .endTargetCluster()
+                                        .withClusterNetworkAddressConfigProvider(
+                                                new ClusterNetworkAddressConfigProviderDefinitionBuilder(
+                                                        "SniRoutingClusterNetworkAddressConfigProvider")
+                                                        .withConfig("bootstrapAddress", "cluster1:9192", "brokerAddressPattern", "broker-$(nodeId)")
+                                                        .build())
+                                        .build())
+                                .build(),
+                        """
+                                virtualClusters:
+                                  demo:
+                                    targetCluster:
+                                      bootstrap_servers: kafka.example:1234
+                                      tls:
+                                         trust:
+                                            storeFile: /tmp/client.jks
+                                            storePassword:
+                                              passwordFile: /tmp/password.txt
+                                            storeType: JKS
+                                    clusterNetworkAddressConfigProvider:
+                                      type: SniRoutingClusterNetworkAddressConfigProvider
+                                      config:
+                                        bootstrapAddress: cluster1:9192
+                                        brokerAddressPattern: broker-$(nodeId)
+                                """),
                 Arguments.of("Upstream TLS - insecure",
                         new ConfigurationBuilder()
                                 .addToVirtualClusters("demo", new VirtualClusterBuilder()

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/FilePassword.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/FilePassword.java
@@ -36,7 +36,7 @@ public record FilePassword(String passwordFile) implements PasswordProvider {
     @Override
     public String toString() {
         return "FilePassword[" +
-                "filePath=" + passwordFile + ']';
+                "passwordFile=" + passwordFile + ']';
     }
 
     @Nullable

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/FilePassword.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/FilePassword.java
@@ -14,34 +14,42 @@ import java.nio.charset.StandardCharsets;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 /**
  * A reference to the file containing a plain text password in UTF-8 encoding.  If the password file
  * contains more than one line, only the characters of the first line are taken to be the password,
  * excluding the line ending.  Subsequent lines are ignored.
  *
- * @param filePath file containing the password,
+ * @param passwordFile file containing the password,
  */
-public record FilePassword(String filePath) implements PasswordProvider {
+public record FilePassword(String passwordFile) implements PasswordProvider {
+
     @JsonCreator
     public FilePassword {}
 
     @Override
     public String getProvidedPassword() {
-        if (filePath == null) {
-            return null;
-        }
-        try (var fr = new BufferedReader(new FileReader(filePath, StandardCharsets.UTF_8))) {
-            return fr.readLine();
-        }
-        catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return readPasswordFile(passwordFile);
     }
 
     @Override
     public String toString() {
         return "FilePassword[" +
-                "filePath=" + filePath + ']';
+                "filePath=" + passwordFile + ']';
+    }
+
+    @Nullable
+    static String readPasswordFile(String passwordFile) {
+        if (passwordFile == null) {
+            return null;
+        }
+        try (var fr = new BufferedReader(new FileReader(passwordFile, StandardCharsets.UTF_8))) {
+            return fr.readLine();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/FilePasswordFilePath.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/FilePasswordFilePath.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config.tls;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A reference to the file containing a plain text password in UTF-8 encoding.  If the password file
+ * contains more than one line, only the characters of the first line are taken to be the password,
+ * excluding the line ending.  Subsequent lines are ignored.
+ *
+ * @param filePath file containing the password,
+ *
+ * @deprecated use FilePassword instead
+ */
+@Deprecated(since = "0.5.0", forRemoval = true)
+public record FilePasswordFilePath(String filePath) implements PasswordProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FilePasswordFilePath.class);
+
+    public FilePasswordFilePath {
+        LOGGER.warn("'filePath' property is deprecated. Use property 'passwordFile' instead.");
+    }
+
+    @Override
+    public String getProvidedPassword() {
+        return FilePassword.readPasswordFile(filePath);
+    }
+
+    @Override
+    public String toString() {
+        return "FilePasswordFilePath[" +
+                "filePath=" + filePath + ']';
+    }
+
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/FilePasswordFilePath.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/FilePasswordFilePath.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
  * @deprecated use FilePassword instead
  */
 @Deprecated(since = "0.5.0", forRemoval = true)
+@SuppressWarnings({ "java:S5738", "java:S1133" }) // java:S5738 warns of the use and need to remove deprecated classes.
 public record FilePasswordFilePath(String filePath) implements PasswordProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FilePasswordFilePath.class);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/PasswordProvider.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/PasswordProvider.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  * A PasswordProvider is an abstract source of a password.
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
-@JsonSubTypes({ @JsonSubTypes.Type(InlinePassword.class), @JsonSubTypes.Type(FilePassword.class) })
+@JsonSubTypes({ @JsonSubTypes.Type(InlinePassword.class), @JsonSubTypes.Type(FilePassword.class), @JsonSubTypes.Type(FilePasswordFilePath.class) })
 public interface PasswordProvider {
     String getProvidedPassword();
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/PasswordProvider.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/PasswordProvider.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
 @JsonSubTypes({ @JsonSubTypes.Type(InlinePassword.class), @JsonSubTypes.Type(FilePassword.class), @JsonSubTypes.Type(FilePasswordFilePath.class) })
+@SuppressWarnings("java:S5738") // java:S5738 warns of the use of the deprecated class.
 public interface PasswordProvider {
     String getProvidedPassword();
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/FilePasswordTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/FilePasswordTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config.tls;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.nio.file.Files;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.Condition;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FilePasswordTest {
+
+    private File file;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        file = File.createTempFile("password", "txt");
+        file.deleteOnExit();
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (file != null) {
+            var ignored = file.delete();
+        }
+    }
+
+    static Stream<Arguments> readPassword() {
+        return Stream.of(
+                Arguments.of("mypassword", "mypassword"),
+                Arguments.of("mypassword\n", "mypassword"),
+                Arguments.of("mypassword\nignores\nadditional lines", "mypassword"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void readPassword(String input, String expected) throws Exception {
+        Files.writeString(file.toPath(), input);
+        var provider = new FilePassword(file.getAbsolutePath());
+        assertThat(provider)
+                .extracting(FilePassword::getProvidedPassword)
+                .isEqualTo(expected);
+    }
+
+    @Test
+    void toStringDoesNotLeakPassword() throws Exception {
+        var password = "mypassword";
+        Files.writeString(file.toPath(), password);
+        var provider = new FilePassword(file.getAbsolutePath());
+        assertThat(provider)
+                .extracting(FilePassword::toString)
+                .doesNotHave(new Condition<>(s -> s.contains(password), "contains password"));
+    }
+
+    @Test
+    void passwordFileNotFound() {
+        assertThat(file.delete()).isTrue();
+
+        var provider = new FilePassword(file.getAbsolutePath());
+        assertThatThrownBy(provider::getProvidedPassword)
+                .hasRootCauseInstanceOf(FileNotFoundException.class);
+    }
+
+    @Test
+
+    void nullFileTreatedAsNullPassword() {
+        assertThat(new FilePassword(null))
+                .extracting(FilePassword::getProvidedPassword)
+                .isNull();
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/KeyStoreTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/KeyStoreTest.java
@@ -19,7 +19,9 @@ import static io.kroxylicious.proxy.config.tls.TlsTestConstants.BADPASS;
 import static io.kroxylicious.proxy.config.tls.TlsTestConstants.JKS;
 import static io.kroxylicious.proxy.config.tls.TlsTestConstants.KEYPASS;
 import static io.kroxylicious.proxy.config.tls.TlsTestConstants.KEYPASS_FILE_PASSWORD;
+import static io.kroxylicious.proxy.config.tls.TlsTestConstants.KEYPASS_FILE_PASSWORD_FILE_PATH;
 import static io.kroxylicious.proxy.config.tls.TlsTestConstants.KEYSTORE_FILE_PASSWORD;
+import static io.kroxylicious.proxy.config.tls.TlsTestConstants.KEYSTORE_FILE_PASSWORD_FILE_PATH;
 import static io.kroxylicious.proxy.config.tls.TlsTestConstants.NOT_EXIST;
 import static io.kroxylicious.proxy.config.tls.TlsTestConstants.PEM;
 import static io.kroxylicious.proxy.config.tls.TlsTestConstants.PKCS_12;
@@ -39,7 +41,9 @@ class KeyStoreTest {
                 Arguments.of("PKCS12", PKCS_12, "server.p12", STOREPASS, null),
                 Arguments.of("Combined key/crt PEM passed as keyStore (KIP-651)", PEM, "server_key_crt.pem", null, null),
                 Arguments.of("Combined key/crt PEM passed as keyStore (KIP-651) with encrypted key", PEM, "server_crt_encrypted_key.pem", null, KEYPASS),
-                Arguments.of("JKS keystore from file", JKS, "server_diff_keypass.jks", KEYSTORE_FILE_PASSWORD, KEYPASS_FILE_PASSWORD));
+                Arguments.of("JKS keystore from file", JKS, "server_diff_keypass.jks", KEYSTORE_FILE_PASSWORD, KEYPASS_FILE_PASSWORD),
+                Arguments.of("JKS keystore from file (deprecated provider)", JKS, "server_diff_keypass.jks", KEYSTORE_FILE_PASSWORD_FILE_PATH,
+                        KEYPASS_FILE_PASSWORD_FILE_PATH));
     }
 
     public static Stream<Arguments> serverWithKeyStore() {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/TlsTestConstants.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/TlsTestConstants.java
@@ -13,11 +13,16 @@ public class TlsTestConstants {
     public static final String PKCS_12 = "PKCS12";
     public static final String PEM = Tls.PEM;
 
-    public static final PasswordProvider STOREPASS = new InlinePassword("storepass");
-    public static final PasswordProvider KEYPASS = new InlinePassword("keypass");
-    public static final PasswordProvider BADPASS = new InlinePassword("badpass");
-    public static final PasswordProvider KEYSTORE_FILE_PASSWORD = new FilePassword(getResourceLocationOnFilesystem("storepass.password"));
-    public static final PasswordProvider KEYPASS_FILE_PASSWORD = new FilePassword(getResourceLocationOnFilesystem("keypass.password"));
+    static final PasswordProvider STOREPASS = new InlinePassword("storepass");
+    static final PasswordProvider KEYPASS = new InlinePassword("keypass");
+    static final PasswordProvider BADPASS = new InlinePassword("badpass");
+    static final PasswordProvider KEYSTORE_FILE_PASSWORD = new FilePassword(getResourceLocationOnFilesystem("storepass.password"));
+    static final PasswordProvider KEYPASS_FILE_PASSWORD = new FilePassword(getResourceLocationOnFilesystem("keypass.password"));
+    @SuppressWarnings("java:S5738") // java:S5738 warns of the use of the deprecated class.
+    static final PasswordProvider KEYSTORE_FILE_PASSWORD_FILE_PATH = new FilePasswordFilePath(getResourceLocationOnFilesystem("storepass.password"));
+    @SuppressWarnings("java:S5738") // java:S5738 warns of the use of the deprecated class.
+    static final PasswordProvider KEYPASS_FILE_PASSWORD_FILE_PATH = new FilePasswordFilePath(getResourceLocationOnFilesystem("keypass.password"));
+
     public static final String NOT_EXIST = "/does/not/exist";
 
     public static String getResourceLocationOnFilesystem(String resource) {

--- a/kubernetes-examples/snirouting_tls/base/kroxylicious/kroxylicious-config.yaml
+++ b/kubernetes-examples/snirouting_tls/base/kroxylicious/kroxylicious-config.yaml
@@ -22,7 +22,7 @@ data:
             trust:
               storeFile: /opt/kroxylicious/trust/ca.p12
               storePassword:
-                filePath: /opt/kroxylicious/trust/ca.password
+                passwordFile: /opt/kroxylicious/trust/ca.password
         clusterNetworkAddressConfigProvider:
           type: SniRoutingClusterNetworkAddressConfigProvider
           config:
@@ -34,4 +34,4 @@ data:
           key:
             storeFile: /opt/kroxylicious/server/key-material/keystore.p12
             storePassword:
-              filePath: /opt/kroxylicious/server/keystore-password/storePassword
+              passwordFile: /opt/kroxylicious/server/keystore-password/storePassword


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Bugfix

### Description

The documentation was out of step with the implementation.  The documentation told the user to use `passwordFile`, whereas the implementation expected `filePath`.  On reflection, I prefered the documentations view.

This PR changes the code to expect `passwordFile`.

* 'filePath' continues to be understood, but is now deprecated.
* added some supporting unit and integration tests that make sure the key store/trust store passwords do work with passwords from files.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [x] Reference relevant issue(s) and close them after merging
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
