### PR TITLE
Use the same filter chain factory for plain and TLS connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.5.0
 
+* [#883](https://github.com/kroxylicious/kroxylicious/pull/883): Ensure we only initialise a filter factory once.
 * [#912](https://github.com/kroxylicious/kroxylicious/pull/912): Bump io.netty:netty-bom from 4.1.104.Final to 4.1.106.Final
 * [#909](https://github.com/kroxylicious/kroxylicious/pull/909): [build] use maven maven-dependency-plugin to detect missing/superfluous dependencies at build time
 * [#895](https://github.com/kroxylicious/kroxylicious/pull/895): Ensure we execute deferred Filter methods on the eventloop

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactory.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactory.java
@@ -23,7 +23,7 @@ public interface FilterFactory<C, I> {
 
     /**
      * Initializes the factory with the specified configuration.
-     * This method is guaranteed to be called at most once, and before any call to
+     * This method is guaranteed to be called at most once for each filter configuration and before any call to
      * {@link #createFilter(FilterFactoryContext, Object)}.
      * This method may provide extra semantic validation of the config,
      * and returns some object (which may be the config, or some other object) which will be passed to {@link #createFilter(FilterFactoryContext, Object)}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/InvocationCountingFilterFactory.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/InvocationCountingFilterFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.filter.FilterFactory;
+import io.kroxylicious.proxy.filter.FilterFactoryContext;
+import io.kroxylicious.proxy.filter.RequestFilter;
+import io.kroxylicious.proxy.plugin.Plugin;
+import io.kroxylicious.proxy.plugin.PluginConfigurationException;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Plugin(configType = InvocationCountingFilterFactory.Config.class)
+public class InvocationCountingFilterFactory implements FilterFactory<InvocationCountingFilterFactory.Config, InvocationCountingFilterFactory.Config> {
+
+    private static final Map<UUID, AtomicInteger> invocationTracker = new ConcurrentHashMap<>();
+
+    @Override
+    public Config initialize(FilterFactoryContext context, Config config) throws PluginConfigurationException {
+        invocationTracker.computeIfAbsent(config.configInstanceId, uuid -> new AtomicInteger(0)).getAndIncrement();
+        return config;
+    }
+
+    @NonNull
+    @Override
+    public Filter createFilter(FilterFactoryContext context, Config initializationData) {
+        return (RequestFilter) (apiKey, header, request, requestFilterContext) -> requestFilterContext.forwardRequest(header, request);
+    }
+
+    public static void assertInvocationCount(UUID configId, int count) {
+        assertThat(invocationTracker.get(configId)).hasValue(count);
+    }
+
+    public record Config(UUID configInstanceId) {
+
+    }
+
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/SingleFilterFactoryInstanceTest.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/SingleFilterFactoryInstanceTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
+import io.kroxylicious.test.tester.MockServerKroxyliciousTester;
+
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
+import static io.kroxylicious.test.tester.KroxyliciousTesters.mockKafkaKroxyliciousTester;
+
+public class SingleFilterFactoryInstanceTest {
+    public static final String INITIALISATION_COUNTER = "configInstanceId";
+    private MockServerKroxyliciousTester mockTester;
+
+    @AfterEach
+    public void afterEach() {
+        if (mockTester != null) {
+            mockTester.close();
+        }
+    }
+
+    @Test
+    void shouldOnlyInitialiseFilterFactoryOnce() {
+        // Given
+        final UUID configInstance = UUID.randomUUID();
+
+        // When
+        mockTester = mockKafkaKroxyliciousTester((mockBootstrap) -> proxy(mockBootstrap)
+                .addToFilters(new FilterDefinitionBuilder("InvocationCountingFilterFactory").withConfig(INITIALISATION_COUNTER, configInstance)
+                        .build()));
+
+        // Then
+        InvocationCountingFilterFactory.assertInvocationCount(configInstance, 1);
+    }
+
+    @Test
+    void shouldInitialiseOncePerConfig() {
+        // Given
+        final UUID configInstanceA = UUID.randomUUID();
+        final UUID configInstanceB = UUID.randomUUID();
+
+        // When
+        mockTester = mockKafkaKroxyliciousTester((mockBootstrap) -> proxy(mockBootstrap)
+                .addToFilters(new FilterDefinitionBuilder("InvocationCountingFilterFactory").withConfig(INITIALISATION_COUNTER, configInstanceA).build())
+                .addToFilters(new FilterDefinitionBuilder("InvocationCountingFilterFactory").withConfig(INITIALISATION_COUNTER, configInstanceB).build()));
+
+        // Then
+        InvocationCountingFilterFactory.assertInvocationCount(configInstanceA, 1);
+        InvocationCountingFilterFactory.assertInvocationCount(configInstanceB, 1);
+    }
+
+}

--- a/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
+++ b/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
@@ -4,3 +4,4 @@ io.kroxylicious.proxy.filter.RequestResponseMarkingFilterFactory
 io.kroxylicious.proxy.filter.OutOfBandSendFilterFactory
 io.kroxylicious.proxy.filter.CompositePrefixingFixedClientIdFilterFactory
 io.kroxylicious.proxy.filter.RejectingCreateTopicFilterFactory
+io.kroxylicious.proxy.InvocationCountingFilterFactory

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -34,6 +34,7 @@ import io.netty.incubator.channel.uring.IOUringEventLoopGroup;
 import io.netty.incubator.channel.uring.IOUringServerSocketChannel;
 import io.netty.util.concurrent.Future;
 
+import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.MicrometerDefinition;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
@@ -105,10 +106,11 @@ public final class KafkaProxy implements AutoCloseable {
 
         maybeStartMetricsListener(adminEventGroup, meterRegistries);
 
+        final FilterChainFactory filterChainFactory = new FilterChainFactory(pfr, config.filters());
         var tlsServerBootstrap = buildServerBootstrap(serverEventGroup,
-                new KafkaProxyInitializer(config.filters(), pfr, true, endpointRegistry, endpointRegistry, false, Map.of()));
+                new KafkaProxyInitializer(filterChainFactory, pfr, true, endpointRegistry, endpointRegistry, false, Map.of()));
         var plainServerBootstrap = buildServerBootstrap(serverEventGroup,
-                new KafkaProxyInitializer(config.filters(), pfr, false, endpointRegistry, endpointRegistry, false, Map.of()));
+                new KafkaProxyInitializer(filterChainFactory, pfr, false, endpointRegistry, endpointRegistry, false, Map.of()));
 
         bindingOperationProcessor.start(plainServerBootstrap, tlsServerBootstrap);
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -27,7 +27,6 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.util.concurrent.Future;
 
 import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
-import io.kroxylicious.proxy.config.FilterDefinition;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
 import io.kroxylicious.proxy.internal.codec.KafkaRequestDecoder;
@@ -53,19 +52,16 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
     private final PluginFactoryRegistry pfr;
     private final FilterChainFactory filterChainFactory;
 
-    public KafkaProxyInitializer(List<FilterDefinition> filters,
-                                 PluginFactoryRegistry pfr,
-                                 boolean tls,
+    public KafkaProxyInitializer(FilterChainFactory filterChainFactory, PluginFactoryRegistry pfr, boolean tls,
                                  VirtualClusterBindingResolver virtualClusterBindingResolver, EndpointReconciler endpointReconciler,
-                                 boolean haproxyProtocol,
-                                 Map<KafkaAuthnHandler.SaslMechanism, AuthenticateCallbackHandler> authnMechanismHandlers) {
+                                 boolean haproxyProtocol, Map<KafkaAuthnHandler.SaslMechanism, AuthenticateCallbackHandler> authnMechanismHandlers) {
         this.pfr = pfr;
         this.endpointReconciler = endpointReconciler;
         this.haproxyProtocol = haproxyProtocol;
         this.authnHandlers = authnMechanismHandlers != null ? authnMechanismHandlers : Map.of();
         this.tls = tls;
         this.virtualClusterBindingResolver = virtualClusterBindingResolver;
-        this.filterChainFactory = new FilterChainFactory(pfr, filters);
+        this.filterChainFactory = filterChainFactory;
     }
 
     @Override


### PR DESCRIPTION
### Type of change


- Bugfix
- Documentation

### Description

Fixes: #883. Use the same filter chain factory for plain and TLS connections.

### Additional Context

There are potential use cases where the distinction between plain and TLS connections could be interesting to filter authors but exposing that distinction through the FilteChainFactory instance is not how we should address that (we would add it too `FilterFactoryContext`).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [x] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
