### PR TITLE
Address asciidoc warning emitted during rendering of the deployment doc

### DIFF
--- a/docs/deploying.adoc
+++ b/docs/deploying.adoc
@@ -86,9 +86,11 @@ If present, it will be replaced by the https://kafka.apache.org/documentation/#b
 For example if your configuration looks like the above and your cluster has three brokers, your Kafka Client will receive
 broker address information like this:
 
+```
 0.  `mybroker-0.mycluster.kafka.com:9193`
 1.  `mybroker-1.mycluster.kafka.com:9194`
 2.  `mybroker-2.mycluster.kafka.com:9194`
+```
 
 NOTE: It is a responsibility for the deployer of Kroxylicious to ensure that the bootstrap and generated broker
 DNS names are resolvable and routable by the Kafka Client.


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Bugfix
- Documentation

### Description

The asciidoc workflow was generating a warning about unexpected numbering of list items.  It automatically renumbered the list from 1, which broke the meaning of what was trying to be conveyed.

```
WARNING: deploying.adoc: line 89: list item index: expected 1, got 0
```


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
