### PR TITLE
Enable section titles/anchors in the rendered documentation

### DIFF
--- a/.github/workflows/asciidoctor-ghpages.yaml
+++ b/.github/workflows/asciidoctor-ghpages.yaml
@@ -11,5 +11,5 @@ jobs:
         uses: manoelcampos/asciidoctor-ghpages-action@v2
         with:
           source_dir: docs/
-          asciidoctor_params: "-r asciidoctor-diagram"
+          asciidoctor_params: "--require asciidoctor-diagram --attribute=sectlinks --attribute=sectanchors"
           post_build: 'find . -name "*.svg" -exec git add -f {} \;'


### PR DESCRIPTION


### Type of change

_Select the type of your PR_

- Documentation

### Description

why: allow readers to easily bookmark/reference documentation content.

https://docs.asciidoctor.org/asciidoc/latest/sections/title-links/

there's no fancy automatic population of the copy/paste buffer. As far as I can see, the user needs to use their browser Copy Link, but I think this is a useful increment.


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
