### PR TITLE
Enable user to configure alternative source of keys for vault KMS client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.5.0
 
+* [#935](https://github.com/kroxylicious/kroxylicious/pull/935): Enable user to configure alternative source of keys for vault KMS client
 * [#787](https://github.com/kroxylicious/kroxylicious/issues/787): Initial documentation for the envelope-encryption feature.
 * [#940](https://github.com/kroxylicious/kroxylicious/issues/940): Support vault namespaces and support secrets transit engine at locations other than /transit
 * [#951](https://github.com/kroxylicious/kroxylicious/pull/951): Include the kroxylicious maintained filters in the dist by default

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/config/JdkTls.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/config/JdkTls.java
@@ -10,7 +10,10 @@ import java.io.FileInputStream;
 import java.security.KeyStore;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
+import java.util.Optional;
 
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
@@ -20,12 +23,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.kroxylicious.proxy.config.tls.InsecureTls;
+import io.kroxylicious.proxy.config.tls.KeyPair;
+import io.kroxylicious.proxy.config.tls.KeyProvider;
+import io.kroxylicious.proxy.config.tls.KeyProviderVisitor;
+import io.kroxylicious.proxy.config.tls.PasswordProvider;
 import io.kroxylicious.proxy.config.tls.Tls;
 import io.kroxylicious.proxy.config.tls.TrustProvider;
 import io.kroxylicious.proxy.config.tls.TrustProviderVisitor;
 import io.kroxylicious.proxy.config.tls.TrustStore;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Builds a JDK SSLContext used for vault communicateion.
@@ -69,8 +77,16 @@ public record JdkTls(Tls tls) {
 
     public SSLContext sslContext() {
         try {
-            if (tls != null && tls.trust() != null) {
-                return customSSLContext(tls.trust());
+            if (tls != null) {
+                TrustManager[] trustManagers = null;
+                KeyManager[] keyManagers = null;
+                if (tls.trust() != null) {
+                    trustManagers = getTrustManagers(tls.trust());
+                }
+                if (tls.key() != null) {
+                    keyManagers = getKeyManagers(tls.key());
+                }
+                return getSslContext(trustManagers, keyManagers);
             }
             else {
                 return SSLContext.getDefault();
@@ -81,17 +97,50 @@ public record JdkTls(Tls tls) {
         }
     }
 
-    @NonNull
-    private SSLContext customSSLContext(TrustProvider trust) {
-        TrustManager[] trustManagers = getTrustManagers(trust);
-        return getSslContext(trustManagers);
+    /* exposed for testing */
+    static KeyManager[] getKeyManagers(KeyProvider key) {
+        return key.accept(new KeyProviderVisitor<>() {
+            @Override
+            public KeyManager[] visit(KeyPair keyPair) {
+                throw new SslConfigurationException("KeyPair is not supported by vault KMS yet");
+            }
+
+            @Override
+            public KeyManager[] visit(io.kroxylicious.proxy.config.tls.KeyStore keyStore) {
+                try {
+                    if (keyStore.isPemType()) {
+                        throw new SslConfigurationException("PEM is not supported by vault KMS yet");
+                    }
+                    KeyStore store = KeyStore.getInstance(keyStore.getType());
+                    try (FileInputStream fileInputStream = new FileInputStream(keyStore.storeFile())) {
+                        char[] storePassword = passwordOrNull(keyStore.storePasswordProvider());
+                        store.load(fileInputStream, storePassword);
+                    }
+                    char[] keyPassword = passwordOrNull(keyStore.keyPasswordProvider());
+                    KeyManagerFactory instance = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+                    instance.init(store, keyPassword);
+                    return instance.getKeyManagers();
+                }
+                catch (Exception e) {
+                    throw new SslConfigurationException(e);
+                }
+            }
+
+            @Nullable
+            private static char[] passwordOrNull(PasswordProvider value) {
+                return Optional.of(value).map(PasswordProvider::getProvidedPassword).map(String::toCharArray).orElse(null);
+            }
+        });
     }
 
     @NonNull
-    private static SSLContext getSslContext(TrustManager[] trustManagers) {
+    private static SSLContext getSslContext(TrustManager[] trustManagers, KeyManager[] keyManagers) {
         try {
+            if (trustManagers == null && keyManagers == null) {
+                return SSLContext.getDefault();
+            }
             SSLContext context = SSLContext.getInstance("TLS");
-            context.init(null, trustManagers, new SecureRandom());
+            context.init(keyManagers, trustManagers, new SecureRandom());
             return context;
         }
         catch (Exception e) {

--- a/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/config/JdkTlsTest.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/config/JdkTlsTest.java
@@ -13,6 +13,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.UUID;
 
+import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
@@ -22,6 +23,8 @@ import org.junit.jupiter.api.Test;
 import io.kroxylicious.kms.provider.hashicorp.vault.CertificateGenerator;
 import io.kroxylicious.proxy.config.tls.InlinePassword;
 import io.kroxylicious.proxy.config.tls.InsecureTls;
+import io.kroxylicious.proxy.config.tls.KeyPair;
+import io.kroxylicious.proxy.config.tls.KeyStore;
 import io.kroxylicious.proxy.config.tls.Tls;
 import io.kroxylicious.proxy.config.tls.TrustStore;
 
@@ -118,9 +121,35 @@ class JdkTlsTest {
     void testPkcs12() {
         CertificateGenerator.Keys keys = CertificateGenerator.generate();
         CertificateGenerator.TrustStore trustStore = keys.pkcs12ClientTruststore();
-        TrustStore store = new TrustStore(trustStore.path().toString(), new InlinePassword(trustStore.password()), "PKCS12");
+        TrustStore store = new TrustStore(trustStore.path().toString(), new InlinePassword(trustStore.password()), trustStore.type());
         TrustManager[] trustManagers = JdkTls.getTrustManagers(store);
         assertThat(trustManagers).isNotEmpty();
+    }
+
+    @Test
+    void testKeyStore() {
+        CertificateGenerator.Keys keys = CertificateGenerator.generate();
+        CertificateGenerator.KeyStore keyStore = keys.jksServerKeystore();
+        KeyStore store = new KeyStore(keyStore.path().toString(), new InlinePassword(keyStore.storePassword()), new InlinePassword(keyStore.keyPassword()),
+                keyStore.type());
+        KeyManager[] trustManagers = JdkTls.getKeyManagers(store);
+        assertThat(trustManagers).isNotEmpty();
+    }
+
+    @Test
+    void testKeyPairNotSupported() {
+        KeyPair store = new KeyPair("/tmp/keypair", "/tmp/cert", null);
+        assertThatThrownBy(() -> {
+            JdkTls.getKeyManagers(store);
+        }).isInstanceOf(SslConfigurationException.class).hasMessageContaining("KeyPair is not supported by vault KMS yet");
+    }
+
+    @Test
+    void testKeyStorePemNotSupported() {
+        KeyStore store = new KeyStore("/tmp/pem", null, null, "PEM");
+        assertThatThrownBy(() -> {
+            JdkTls.getKeyManagers(store);
+        }).isInstanceOf(SslConfigurationException.class).hasMessageContaining("PEM is not supported by vault KMS yet");
     }
 
     @Test

--- a/kroxylicious-kms-provider-hashicorp-vault/src/test/resources/VaultMutualTls.hcl
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/test/resources/VaultMutualTls.hcl
@@ -1,0 +1,7 @@
+listener "tcp" {
+  address       = "0.0.0.0:8202"
+  tls_cert_file      = "/vault/config/cert.pem"
+  tls_key_file       = "/vault/config/key.pem"
+  tls_require_and_verify_client_cert = "true"
+  tls_client_ca_file = "/vault/config/client-cert.pem"
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Enable user to configure alternative source of keys for vault like:

```yaml
tls:
    key:
        storeFile: /opt/cert/server.p12
        storePassword:
            passwordFile: /opt/cert/store.password
        keyPassword:
            passwordFile: /opt/cert/key.password
        storeType: PKCS12
```

Why:
Vault can require TLS client authentication where clients must present certificates proving who they are. These could be private certs so we should support configurable sources of keys.

Note that we do not support PEM keystores or PKCS8 KeyPairs yet. In kroxylicious core we depend on netty to handle parsing PEMS. This PR at least lets us support a source of keys. We can add support for these alternatives later, for now Kroxylicious throws with a message about how they are not supported yet.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
