### PR TITLE
Use the RecordEncryptor on the encryption path

### DIFF
--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandKeyManager.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandKeyManager.java
@@ -225,7 +225,7 @@ public class InBandKeyManager<K, E> implements KeyManager<K> {
         }
         else {
             List<Record> records = StreamSupport.stream(batch.spliterator(), false).toList();
-            if (records.size() == 0) {
+            if (records.isEmpty()) {
                 builder.writeBatch(batch);
             }
             else {

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/KeyContext.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/KeyContext.java
@@ -65,7 +65,7 @@ final class KeyContext implements Destroyable {
     }
 
     public void recordEncryptions(int numEncryptions) {
-        if (numEncryptions <= 0) {
+        if (numEncryptions < 0) {
             throw new IllegalArgumentException();
         }
         remainingEncryptions -= numEncryptions;

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/RecordBatchUtils.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/records/RecordBatchUtils.java
@@ -92,13 +92,9 @@ public class RecordBatchUtils {
         Objects.requireNonNull(recordBatch);
         Objects.requireNonNull(mapper);
         Objects.requireNonNull(builder);
-        // List<Runnable> closers = new ArrayList<>();
         try (Stream<Record> recordStream = recordStream(recordBatch)) {
             return recordStream
                     .collect(toMemoryRecordsCollector(recordBatch, mapper, builder));
-        }
-        finally {
-            // closers.forEach(Runnable::run);
         }
     }
 
@@ -114,7 +110,6 @@ public class RecordBatchUtils {
             public Supplier<BatchAwareMemoryRecordsBuilder> supplier() {
                 return () -> {
                     BatchAwareMemoryRecordsBuilder batchAwareMemoryRecordsBuilder = builder;
-                    // onClose.accept(batchAwareMemoryRecordsBuilder::close);
                     return batchAwareMemoryRecordsBuilder.addBatchLike(recordBatch);
                 };
             }

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/RecordBatchUtilsTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/records/RecordBatchUtilsTest.java
@@ -72,7 +72,7 @@ class RecordBatchUtilsTest {
         MyRecordTransform mapper = new MyRecordTransform();
         var memoryRecords = RecordBatchUtils.toMemoryRecords(batch,
                 mapper,
-                new ByteBufferOutputStream(1000));
+                new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(1000))).build();
 
         // Then
         assertThat(mapper.initCalls).isEqualTo(996);


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This PR actually uses the RecordEncryptor on the encryption path. It's a little more messy than I'd like, because the `Stream`-based API doesn't work as well as anticipated.

