### PR TITLE
System tests can load a dockerconfigjson secret into the working namespace

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -296,8 +296,8 @@ has been applied ineffectively.
 
 ### Environment variables
 * `KROXYLICIOUS_IMAGE_REPO`: url to the image of kroxylicious to be used. Default value: `quay.io/kroxylicious/kroxylicious-developer`
-* `KROXYLICIOUS_VERSION`: version of kroxylicious to be used. Default value: `0.5.0-SNAPSHOT`
-* `KAFKA_VERSION`: kafka version to be used. Default value: `3.6.1`
+* `KROXYLICIOUS_VERSION`: version of kroxylicious to be used. Default value: `${project.version}` in pom file
+* `KAFKA_VERSION`: kafka version to be used. Default value: `${kafka.version}` in pom file
 * `STRIMZI_URL`: url where to download strimzi. Default value: `khttps://strimzi.io/install/latest?namespace=kafka`
 * `SKIP_TEARDOWN`: variable for development purposes to avoid keep deploying and deleting deployments each run. Default value: `false`
 * `CONTAINER_CONFIG_PATH`: directory where `config.json` file is located. This file contains the pull secrets to be used by

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -297,10 +297,12 @@ has been applied ineffectively.
 ### Environment variables
 * `KROXYLICIOUS_IMAGE_REPO`: url to the image of kroxylicious to be used. Default value: `quay.io/kroxylicious/kroxylicious-developer`
 * `KROXYLICIOUS_VERSION`: version of kroxylicious to be used. Default value: `0.5.0-SNAPSHOT`
-* `KAFKA_VERSION`: kafka version to be used. Default value: `3.6.0`
+* `KAFKA_VERSION`: kafka version to be used. Default value: `3.6.1`
 * `STRIMZI_URL`: url where to download strimzi. Default value: `khttps://strimzi.io/install/latest?namespace=kafka`
-* `SKIP_TEARDOWN`: variable for development purposes to avoid keep deploying and deleting deployments each run. 
-Default value: `false`
+* `SKIP_TEARDOWN`: variable for development purposes to avoid keep deploying and deleting deployments each run. Default value: `false`
+* `CONTAINER_CONFIG_PATH`: directory where `config.json` file is located. This file contains the pull secrets to be used by
+the container engine. Default value: `$HOME/.docker/config.json`
+
 
 ### Launch system tests
 First of all, the code must be compiled and the distribution artifacts created:

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
@@ -73,6 +73,11 @@ public interface Constants {
     String SERVICE_KIND = "Service";
 
     /**
+     * Kind of secret
+     */
+    String SECRET_KIND = "Secret";
+
+    /**
      * Load balancer type name.
      */
     String LOAD_BALANCER_TYPE = "LoadBalancer";

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
@@ -29,6 +29,7 @@ public class Environment {
     private static final String STRIMZI_URL_ENV = "STRIMZI_URL";
     private static final String SKIP_TEARDOWN_ENV = "SKIP_TEARDOWN";
     public static final String STRIMZI_FEATURE_GATES_ENV = "STRIMZI_FEATURE_GATES";
+    public static final String CONTAINER_CONFIG_PATH_ENV = "CONTAINER_CONFIG_PATH";
 
     /**
      * The kafka version default value
@@ -62,6 +63,7 @@ public class Environment {
      */
     private static final String SKIP_TEARDOWN_DEFAULT = "false";
     private static final String STRIMZI_FEATURE_GATES_DEFAULT = "";
+    private static final String CONTAINER_CONFIG_PATH_DEFAULT = System.getProperty("user.home") + "/.docker/config.json";
 
     /**
      * KAFKA_VERSION env variable assignment
@@ -86,6 +88,8 @@ public class Environment {
     public static final String SKIP_TEARDOWN = getOrDefault(SKIP_TEARDOWN_ENV, SKIP_TEARDOWN_DEFAULT);
 
     public static final String STRIMZI_FEATURE_GATES = getOrDefault(STRIMZI_FEATURE_GATES_ENV, STRIMZI_FEATURE_GATES_DEFAULT);
+
+    public static final String CONTAINER_CONFIG_PATH = getOrDefault(CONTAINER_CONFIG_PATH_ENV, CONTAINER_CONFIG_PATH_DEFAULT);
 
     private static String getOrDefault(String varName, String defaultValue) {
         return getOrDefault(varName, String::toString, defaultValue);

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/Kroxylicious.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/Kroxylicious.java
@@ -40,7 +40,6 @@ public class Kroxylicious {
         this.deploymentNamespace = deploymentNamespace;
         String kroxyUrl = Environment.KROXY_IMAGE_REPO + (Environment.KROXY_IMAGE_REPO.endsWith(":") ? "" : ":");
         this.containerImage = kroxyUrl + Environment.KROXY_VERSION;
-        //this.containerImage = "brew.registry.redhat.io/rh-osbs/amq-streams-proxy-rhel8:2.7.0-15";
     }
 
     private void createDefaultConfigMap(String clusterName) {
@@ -62,9 +61,8 @@ public class Kroxylicious {
 
     /**
      * Needed for downstream Kroxylicious images
-    */
+     */
     private void createSecrets() {
-        //String configFolder = "/home/fvila/source/github/kroxylicious-fork/config.json";
         String configFolder = Environment.CONTAINER_CONFIG_PATH;
         SecretBuilder secretBuilder = KroxyliciousSecretTemplates.createRegistryCredentialsSecret(configFolder, deploymentNamespace);
         if (secretBuilder != null) {

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/kroxylicious/SecretResource.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/kroxylicious/SecretResource.java
@@ -49,7 +49,7 @@ public class SecretResource implements ResourceType<Secret> {
 
     @Override
     public boolean waitForReadiness(Secret resource) {
-        return true;
+        return resource != null;
     }
 
     /**

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/kroxylicious/SecretResource.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/kroxylicious/SecretResource.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.systemtests.resources.kroxylicious;
+
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretList;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+
+import io.kroxylicious.systemtests.Constants;
+import io.kroxylicious.systemtests.resources.ResourceType;
+
+import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
+
+/**
+ * The type Secret resource.
+ */
+public class SecretResource implements ResourceType<Secret> {
+    @Override
+    public String getKind() {
+        return Constants.SECRET_KIND;
+    }
+
+    @Override
+    public Secret get(String namespace, String name) {
+        return secretClient().inNamespace(namespace).withName(name).get();
+    }
+
+    @Override
+    public void create(Secret resource) {
+        secretClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).create();
+    }
+
+    @Override
+    public void delete(Secret resource) {
+        secretClient().inNamespace(resource.getMetadata().getNamespace()).withName(
+                resource.getMetadata().getName()).withPropagationPolicy(DeletionPropagation.FOREGROUND).delete();
+    }
+
+    @Override
+    public void update(Secret resource) {
+        secretClient().inNamespace(resource.getMetadata().getNamespace()).resource(resource).update();
+    }
+
+    @Override
+    public boolean waitForReadiness(Secret resource) {
+        return true;
+    }
+
+    /**
+     * Secret client mixed operation.
+     *
+     * @return the mixed operation
+     */
+    public static MixedOperation<Secret, SecretList, Resource<Secret>> secretClient() {
+        return kubeClient().getClient().resources(Secret.class, SecretList.class);
+    }
+}

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/manager/ResourceManager.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/manager/ResourceManager.java
@@ -27,6 +27,7 @@ import io.kroxylicious.systemtests.resources.ResourceOperation;
 import io.kroxylicious.systemtests.resources.ResourceType;
 import io.kroxylicious.systemtests.resources.kroxylicious.ConfigMapResource;
 import io.kroxylicious.systemtests.resources.kroxylicious.DeploymentResource;
+import io.kroxylicious.systemtests.resources.kroxylicious.SecretResource;
 import io.kroxylicious.systemtests.resources.kroxylicious.ServiceResource;
 import io.kroxylicious.systemtests.resources.strimzi.KafkaNodePoolResource;
 import io.kroxylicious.systemtests.resources.strimzi.KafkaResource;
@@ -72,7 +73,8 @@ public class ResourceManager {
             new KafkaNodePoolResource(),
             new ServiceResource(),
             new ConfigMapResource(),
-            new DeploymentResource()
+            new DeploymentResource(),
+            new SecretResource()
     };
 
     /**

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/kroxylicious/KroxyliciousSecretTemplates.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/kroxylicious/KroxyliciousSecretTemplates.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.systemtests.templates.kroxylicious;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+
+/**
+ * The type Kroxylicious secret templates.
+ */
+public class KroxyliciousSecretTemplates {
+
+    /**
+     * Create registry credentials secret.
+     *
+     * @param configFolder the config folder
+     * @param namespace the namespace
+     * @return the secret builder
+     */
+    public static SecretBuilder createRegistryCredentialsSecret(String configFolder, String namespace) {
+        if (configFolder != null) {
+            Path configPath = Path.of(configFolder);
+            if (Files.exists(configPath)) {
+                String encoded;
+                try {
+                    encoded = Base64.getEncoder().encodeToString(Files.readAllBytes(configPath));
+                    return new SecretBuilder()
+                            .withNewMetadata()
+                            .withName("regcred")
+                            .withNamespace(namespace)
+                            .endMetadata()
+                            .withType("kubernetes.io/dockerconfigjson")
+                            .addToData(".dockerconfigjson", encoded);
+                }
+                catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/kroxylicious/KroxyliciousSecretTemplates.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/kroxylicious/KroxyliciousSecretTemplates.java
@@ -24,6 +24,8 @@ public class KroxyliciousSecretTemplates {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KroxyliciousSecretTemplates.class);
 
+    private KroxyliciousSecretTemplates() {}
+
     /**
      * Create registry credentials secret.
      *

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/kroxylicious/KroxyliciousSecretTemplates.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/kroxylicious/KroxyliciousSecretTemplates.java
@@ -24,7 +24,8 @@ public class KroxyliciousSecretTemplates {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KroxyliciousSecretTemplates.class);
 
-    private KroxyliciousSecretTemplates() {}
+    private KroxyliciousSecretTemplates() {
+    }
 
     /**
      * Create registry credentials secret.


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

To allow the downstream image to be pulled when deploying kroxylicious in kubernetes, the secrets are needed to be also created in kubernetes.

### Additional Context


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [x] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [x] Update documentation
- [x] Reference relevant issue(s) and close them after merging
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
