### PR TITLE
Logging improvements

### DIFF
--- a/kroxylicious-app/pom.xml
+++ b/kroxylicious-app/pom.xml
@@ -68,6 +68,11 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk-platform-logging</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <scope>runtime</scope>

--- a/kroxylicious-app/src/main/resources/log4j2.yaml
+++ b/kroxylicious-app/src/main/resources/log4j2.yaml
@@ -46,3 +46,8 @@ Configuration:
         additivity: false
         AppenderRef:
           - ref: STDOUT
+      - name: com.github.benmanes.caffeine.cache.LocalAsyncCache
+        level: ERROR
+        additivity: false
+        AppenderRef:
+          - ref: STDOUT

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionFilter.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionFilter.java
@@ -90,7 +90,10 @@ public class EnvelopeEncryptionFilter<K>
                     }).toList();
                     return join(futures).thenApply(x -> request);
                 }).exceptionallyCompose(throwable -> {
-                    log.warn("failed to encrypt records", throwable);
+                    log.atWarn().setMessage("failed to encrypt records, cause message: {}")
+                            .addArgument(throwable.getMessage())
+                            .setCause(log.isDebugEnabled() ? throwable : null)
+                            .log();
                     return CompletableFuture.failedStage(throwable);
                 });
     }
@@ -100,7 +103,10 @@ public class EnvelopeEncryptionFilter<K>
         return maybeDecodeFetch(response.responses(), context)
                 .thenCompose(responses -> context.forwardResponse(header, response.setResponses(responses)))
                 .exceptionallyCompose(throwable -> {
-                    log.warn("failed to decrypt records", throwable);
+                    log.atWarn().setMessage("failed to decrypt records, cause message: {}")
+                            .addArgument(throwable.getMessage())
+                            .setCause(log.isDebugEnabled() ? throwable : null)
+                            .log();
                     return CompletableFuture.failedStage(throwable);
                 });
     }

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionFilterTest.java
@@ -199,8 +199,8 @@ class EnvelopeEncryptionFilterTest {
     void shouldPropagateRequestExceptions() {
         // Given
         var produceRequestData = buildProduceRequestData(new TopicProduceData()
-                        .setName(ENCRYPTED_TOPIC)
-                        .setPartitionData(List.of(new PartitionProduceData().setRecords(makeRecord(HELLO_CIPHER_WORLD)))));
+                .setName(ENCRYPTED_TOPIC)
+                .setPartitionData(List.of(new PartitionProduceData().setRecords(makeRecord(HELLO_CIPHER_WORLD)))));
         RuntimeException exception = new RuntimeException("boom");
         when(kekSelector.selectKek(anySet())).thenReturn(CompletableFuture.failedFuture(exception));
 

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionFilterTest.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.filter.encryption;
 
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -14,6 +15,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.LongStream;
@@ -190,6 +193,40 @@ class EnvelopeEncryptionFilterTest {
         // Then
         verify(context).forwardResponse(any(ResponseHeaderData.class), assertArg(actualFetchResponse -> assertThat(actualFetchResponse)
                 .isInstanceOf(FetchResponseData.class).isEqualTo(fetchResponseData)));
+    }
+
+    @Test
+    void shouldPropagateRequestExceptions() {
+        // Given
+        var produceRequestData = buildProduceRequestData(new TopicProduceData()
+                        .setName(ENCRYPTED_TOPIC)
+                        .setPartitionData(List.of(new PartitionProduceData().setRecords(makeRecord(HELLO_CIPHER_WORLD)))));
+        RuntimeException exception = new RuntimeException("boom");
+        when(kekSelector.selectKek(anySet())).thenReturn(CompletableFuture.failedFuture(exception));
+
+        // When
+        CompletionStage<RequestFilterResult> stage = encryptionFilter.onProduceRequest(ProduceRequestData.HIGHEST_SUPPORTED_VERSION,
+                new RequestHeaderData(), produceRequestData, context);
+
+        // Then
+        assertThat(stage).failsWithin(Duration.ZERO).withThrowableThat().isInstanceOf(ExecutionException.class).havingCause().isSameAs(exception);
+    }
+
+    @Test
+    void shouldPropagateResponseExceptions() {
+        // Given
+        var fetchResponseData = buildFetchResponseData(new FetchableTopicResponse()
+                .setTopic(UNENCRYPTED_TOPIC)
+                .setPartitions(List.of(new PartitionData().setRecords(makeRecord(HELLO_PLAIN_WORLD)))));
+        RuntimeException exception = new RuntimeException("boom");
+        when(keyManager.decrypt(any(), anyInt(), any(), any())).thenReturn(CompletableFuture.failedFuture(exception));
+
+        // When
+        CompletionStage<ResponseFilterResult> stage = encryptionFilter.onFetchResponse(FetchResponseData.HIGHEST_SUPPORTED_VERSION,
+                new ResponseHeaderData(), fetchResponseData, context);
+
+        // Then
+        assertThat(stage).failsWithin(Duration.ZERO).withThrowableThat().isInstanceOf(ExecutionException.class).havingCause().isSameAs(exception);
     }
 
     @Test

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -283,8 +283,14 @@ public class FilterHandler extends ChannelDuplexHandler {
     private <F extends FilterResult> F handleFilteringException(Throwable t, DecodedFrame<?, ?> decodedFrame) {
         if (LOGGER.isWarnEnabled()) {
             var direction = decodedFrame.header() instanceof RequestHeaderData ? "request" : "response";
-            LOGGER.warn("{}: Filter{} for {} {} ended exceptionally - closing connection",
-                    channelDescriptor(), direction, filterDescriptor(), decodedFrame.apiKey(), t);
+            LOGGER.atWarn().setMessage("{}: Filter{} for {} {} ended exceptionally - closing connection. Cause message {}")
+                    .addArgument(channelDescriptor())
+                    .addArgument(direction)
+                    .addArgument(filterDescriptor())
+                    .addArgument(decodedFrame.apiKey())
+                    .addArgument(t.getMessage())
+                    .setCause(LOGGER.isDebugEnabled() ? t : null)
+                    .log();
         }
         closeConnection();
         return null;

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -305,11 +305,9 @@ public class FilterHandler extends ChannelDuplexHandler {
             }
             future.completeExceptionally(new TimeoutException("Filter %s was timed-out.".formatted(filterDescriptor())));
         }, timeoutMs, TimeUnit.MILLISECONDS);
-        return future.thenApplyAsync(filterResult -> {
+        return future.whenComplete((f, throwable) -> {
             timeoutFuture.cancel(false);
-
-            return filterResult;
-        }, ctx.executor());
+        }).thenApplyAsync(filterResult -> filterResult, ctx.executor());
     }
 
     private void deferredResponseCompleted(ResponseFilterResult ignored, Throwable throwable) {

--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,11 @@
                 <version>${slf4j.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-jdk-platform-logging</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest</artifactId>
                 <version>${hamcrest.version}</version>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Closes #919

1. reduce the verbosity of KMS exceptions to remove stack traces under the default configuration
2. include details about the last exception when the ResilientKms ceases retrying
3. route JDK platform logging to slf4j and quieten caffeine logs which dumped stacktraces at warn on async load failure (we have logging to cover failures anyway).
4. redundantly cancel timeout futures in FilterHandler, when the filter failed exceptionally we also saw a timeout log some time later as the timeout was not cancelled on the exceptional path. These logs are misleading.

### Additional Context

We want to expose some level of logging by default when the Filter is completing it's futures exceptionally or failing to communicate with the KMS, but given the frequency of events potentially traversing the proxy we should prefer not to log full stack traces with the default configuration as it will produce a lot of noise. Instead we will logs stack traces at DEBUG level.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
