### PR TITLE
kroxylicious-simple-transform is misparented

### DIFF
--- a/kroxylicious-filters/kroxylicious-simple-transform/pom.xml
+++ b/kroxylicious-filters/kroxylicious-simple-transform/pom.xml
@@ -13,9 +13,9 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.kroxylicious</groupId>
-        <artifactId>kroxylicious-parent</artifactId>
+        <artifactId>kroxylicious-filter-parent</artifactId>
         <version>0.5.0-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>kroxylicious-simple-transform</artifactId>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

kroxylicious-simple-transform pom inherits from the kroxylicious-parent, rather than the filter parent, as was intended.
It means that the module does not benefit from the filters checks imposed by the filter parent.

No functional change.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
