### PR TITLE
VaultKmsTlsIT fails if docker is unavailable

### DIFF
--- a/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsTlsIT.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsTlsIT.java
@@ -54,7 +54,9 @@ class VaultKmsTlsIT {
 
     @AfterEach
     void afterEach() {
-        vaultContainer.close();
+        if (vaultContainer != null) {
+            vaultContainer.close();
+        }
     }
 
     interface KmsCreator {


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

The intent was that the ITs skip test execution if Docker isn't available, rather than failing the test.  In this way, the code base plays nicely with those who don't have Docker installled.

Owing to a tearDown cleanup defect, we don't adhere to this.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
