### PR TITLE
Include the kroxylicious maintained filters in the dist by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.5.0
 
+* [#951](https://github.com/kroxylicious/kroxylicious/pull/951): Include the kroxylicious maintained filters in the dist by default
 * [#910](https://github.com/kroxylicious/kroxylicious/pull/910): Envelope encryption preserve batches within MemoryRecords
 * [#883](https://github.com/kroxylicious/kroxylicious/pull/883): Ensure we only initialise a filter factory once.
 * [#912](https://github.com/kroxylicious/kroxylicious/pull/912): Bump io.netty:netty-bom from 4.1.104.Final to 4.1.106.Final

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -89,18 +89,17 @@ Run the following command to format the source code and organize the imports as 
 mvn process-sources
 ```
 
-Build with the `dist` profile to create distribution artefacts (see [kroxylicious-app](kroxylicious-app)):
+Build with the `dist` profile to create distribution artefacts (see [kroxylicious-app](kroxylicious-app)).
+The distribution includes the Kroxylicious-maintained Filter implementations (located under [kroxylicious-additional-filters](./kroxylicious-additional-filters)).
 
 ```shell
 mvn clean verify -Pdist -Dquick
 ```
 
-The project provides some Kroxylicious-maintained Filter implementations that are not included in the distribution
-by default. To also include the additional filters in the distribution (located under [kroxylicious-additional-filters](./kroxylicious-additional-filters)), 
-activate the `withAdditionalFilters` profile:
+It is possible to omit the Kroxylicious-maintained Filter implementations by disabling the `withAdditionalFilters` profile.
 
 ```shell
-mvn clean install -Pdist -Dquick -PwithAdditionalFilters
+mvn clean install -Pdist -Dquick -P-withAdditionalFilters
 ```
 
 Run the following to add missing license headers e.g. when adding new source files:

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -54,7 +54,7 @@ which targets 21 to access some new language features.
 Build the project like this:
 
 ```shell
-mvn clean install
+mvn clean verify
 ```
 
 The running of the tests can be controlled with the following Maven properties:
@@ -80,7 +80,7 @@ the `container.logs.dir`  system property. When run through Maven this is defaul
 Pass the `-Dquick` option to skip all tests and non-essential plug-ins and create the output artifact as quickly as possible:
 
 ```shell
-mvn clean verify -Dquick
+mvn clean package -Dquick
 ```
 
 Run the following command to format the source code and organize the imports as per the project's conventions:
@@ -93,13 +93,13 @@ Build with the `dist` profile to create distribution artefacts (see [kroxyliciou
 The distribution includes the Kroxylicious-maintained Filter implementations (located under [kroxylicious-additional-filters](./kroxylicious-additional-filters)).
 
 ```shell
-mvn clean verify -Pdist -Dquick
+mvn clean package -Pdist -Dquick
 ```
 
 It is possible to omit the Kroxylicious-maintained Filter implementations by disabling the `withAdditionalFilters` profile.
 
 ```shell
-mvn clean install -Pdist -Dquick -P-withAdditionalFilters
+mvn clean package -Pdist -Dquick -P-withAdditionalFilters
 ```
 
 Run the following to add missing license headers e.g. when adding new source files:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-17:1.15 AS builder
 USER root
 WORKDIR /opt/kroxylicious
 COPY . .
-RUN ./mvnw -B clean verify -Pdist,withAdditionalFilters -Dquick
+RUN ./mvnw -B clean verify -Pdist -Dquick
 USER 185
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM registry.access.redhat.com/ubi9/openjdk-17:1.15 AS builder
 USER root
 WORKDIR /opt/kroxylicious
 COPY . .
-RUN ./mvnw -B clean verify -Pdist -Dquick
+RUN ./mvnw -B clean package -Pdist -Dquick
 USER 185
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
 

--- a/kroxylicious-app/pom.xml
+++ b/kroxylicious-app/pom.xml
@@ -199,6 +199,12 @@
         </profile>
         <profile>
             <id>withAdditionalFilters</id>
+            <activation>
+                <property>
+                    <name>withAdditionalFilters</name>
+                    <value>!false</value>
+                </property>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>io.kroxylicious</groupId>

--- a/kroxylicious-app/pom.xml
+++ b/kroxylicious-app/pom.xml
@@ -209,22 +209,27 @@
                 <dependency>
                     <groupId>io.kroxylicious</groupId>
                     <artifactId>kroxylicious-multitenant</artifactId>
+                    <scope>runtime</scope>
                 </dependency>
                 <dependency>
                     <groupId>io.kroxylicious</groupId>
                     <artifactId>kroxylicious-record-validation</artifactId>
+                    <scope>runtime</scope>
                 </dependency>
                 <dependency>
                     <groupId>io.kroxylicious</groupId>
                     <artifactId>kroxylicious-simple-transform</artifactId>
+                    <scope>runtime</scope>
                 </dependency>
                 <dependency>
                     <groupId>io.kroxylicious</groupId>
                     <artifactId>kroxylicious-encryption</artifactId>
+                    <scope>runtime</scope>
                 </dependency>
                 <dependency>
                     <groupId>io.kroxylicious</groupId>
                     <artifactId>kroxylicious-kms-provider-hashicorp-vault</artifactId>
+                    <scope>runtime</scope>
                 </dependency>
             </dependencies>
         </profile>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Currently, we activate a profile to include the kroxylicious maintained filters in the distributions.  Following discussion on #932, we decided for now, for simplicity sake, we wish the filters and their dependencies to be included by default. 

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
