### PR TITLE
Support HashiCorp Vault namespaces (Enterprise feature) and allow non-standard transit engine names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
   adjust your dependencies as your adopt this release.
 * `io.kroxylicious:kroxylicious-filter-test-support` now contains RecordTestUtils for creating example `Record`, `RecordBatch` and `MemoryRecords`. It also contains 
   assertj assertions for those same classes to enable us to write fluent assertions, accessible via `io.kroxylicious.test.assertj.KafkaAssertions`.
+* The configuration for VaultKMS service has changed.  Instead of the `vaultUrl` config key, the provider now
+  requires `vaultTransitEngineUrl`.  This must provide the complete path to the Transit Engine on the
+  HashiCorp Vault instance (e.g. https://myvault:8200/v1/transit or https://myvault:8200/v1/mynamespace/transit).  
 
 ## 0.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.5.0
 
+* [#940](https://github.com/kroxylicious/kroxylicious/issues/940): Support vault namespaces and support secrets transit engine at locations other than /transit
 * [#951](https://github.com/kroxylicious/kroxylicious/pull/951): Include the kroxylicious maintained filters in the dist by default
 * [#910](https://github.com/kroxylicious/kroxylicious/pull/910): Envelope encryption preserve batches within MemoryRecords
 * [#883](https://github.com/kroxylicious/kroxylicious/pull/883): Ensure we only initialise a filter factory once.

--- a/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultTestKmsFacade.java
+++ b/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultTestKmsFacade.java
@@ -69,7 +69,7 @@ public class VaultTestKmsFacade implements TestKmsFacade<Config, String, VaultEd
 
     @Override
     public Config getKmsServiceConfig() {
-        return new Config(URI.create(vaultContainer.getHttpHostAddress()), VAULT_TOKEN, null);
+        return new Config(URI.create(vaultContainer.getHttpHostAddress()).resolve("v1/transit"), VAULT_TOKEN, null);
     }
 
     private class VaultTestKekManager implements TestKekManager {

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKms.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKms.java
@@ -55,38 +55,33 @@ public class VaultKms implements Kms<String, VaultEdek> {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final String AES_KEY_ALGO = "AES";
     private static final Pattern LEGAL_API_VERSION_REGEX = Pattern.compile("^/?v1/.+");
-    private static final String DEFAULT_TRANSIT_ENGINE = "v1/transit";
     private final Duration timeout;
     private final HttpClient vaultClient;
 
     /**
      * The vault url which will include the path to the transit engine.
      */
-    private final URI vaultUrl;
+    private final URI vaultTransitEngineUrl;
     private final String vaultToken;
 
-    VaultKms(URI vaultUrl, String vaultToken, Duration timeout, SSLContext sslContext) {
-        this.vaultUrl = ensureEndsInSlash(validateAndDefaultUrl(vaultUrl));
+    VaultKms(URI vaultTransitEngineUrl, String vaultToken, Duration timeout, SSLContext sslContext) {
+        this.vaultTransitEngineUrl = ensureEndsInSlash(validateTransitPath(vaultTransitEngineUrl));
         this.vaultToken = vaultToken;
         this.timeout = timeout;
         vaultClient = createClient(sslContext);
     }
 
-    private URI validateAndDefaultUrl(URI vaultUrl) {
-        String path = vaultUrl.getPath();
-        if (path == null || path.isEmpty() || path.equals("/")) {
-            return vaultUrl.resolve(DEFAULT_TRANSIT_ENGINE);
+    private URI validateTransitPath(URI vaultTransitEngineUrl) {
+        String path = vaultTransitEngineUrl.getPath();
+        if (path == null || !LEGAL_API_VERSION_REGEX.matcher(path).matches()) {
+            throw new IllegalArgumentException(("vaultTransitEngineUrl path (%s) must start with v1/ and must specify the complete path to"
+                    + " the transit engine e.g 'v1/transit' or 'v1/mynamespace/transit' if namespaces are in use.").formatted(path));
         }
-        else {
-            if (!LEGAL_API_VERSION_REGEX.matcher(path).matches()) {
-                throw new IllegalArgumentException(("As vaultUrl specifies a path part '%s', it must start with 'v1/' "
-                        + "and must provide the complete path to the transit engine.").formatted(path));
-            }
-            return vaultUrl;
-        }
+        return vaultTransitEngineUrl;
     }
 
     private URI ensureEndsInSlash(URI uri) {
+        // We use #resolve to build the urls for the endpoints, so the path must end in a slash.
         return uri.resolve(uri.getPath() + "/").normalize();
     }
 
@@ -111,7 +106,7 @@ public class VaultKms implements Kms<String, VaultEdek> {
     public CompletionStage<DekPair<VaultEdek>> generateDekPair(@NonNull String kekRef) {
 
         var request = createVaultRequest()
-                .uri(vaultUrl.resolve("datakey/plaintext/%s".formatted(encode(kekRef, UTF_8))))
+                .uri(vaultTransitEngineUrl.resolve("datakey/plaintext/%s".formatted(encode(kekRef, UTF_8))))
                 .POST(HttpRequest.BodyPublishers.noBody())
                 .build();
 
@@ -139,7 +134,7 @@ public class VaultKms implements Kms<String, VaultEdek> {
         var body = createDecryptPostBody(edek);
 
         var request = createVaultRequest()
-                .uri(vaultUrl.resolve("decrypt/%s".formatted(encode(edek.kekRef(), UTF_8))))
+                .uri(vaultTransitEngineUrl.resolve("decrypt/%s".formatted(encode(edek.kekRef(), UTF_8))))
                 .POST(HttpRequest.BodyPublishers.ofString(body))
                 .build();
 
@@ -171,7 +166,7 @@ public class VaultKms implements Kms<String, VaultEdek> {
     public CompletableFuture<String> resolveAlias(@NonNull String alias) {
 
         var request = createVaultRequest()
-                .uri(vaultUrl.resolve("keys/%s".formatted(encode(alias, UTF_8))))
+                .uri(vaultTransitEngineUrl.resolve("keys/%s".formatted(encode(alias, UTF_8))))
                 .build();
 
         return vaultClient.sendAsync(request, statusHandler(alias, new JsonBodyHandler<VaultResponse<ReadKeyData>>(new TypeReference<>() {
@@ -208,7 +203,7 @@ public class VaultKms implements Kms<String, VaultEdek> {
         };
     }
 
-    /* testing */ URI getEngineUri() {
-        return vaultUrl;
+    /* testing */ URI getVaultTransitEngineUri() {
+        return vaultTransitEngineUrl;
     }
 }

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsService.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsService.java
@@ -23,7 +23,7 @@ public class VaultKmsService implements KmsService<Config, String, VaultEdek> {
     @NonNull
     @Override
     public VaultKms buildKms(Config options) {
-        return new VaultKms(options.vaultUrl(), options.vaultToken(), Duration.ofSeconds(20), options.sslContext());
+        return new VaultKms(options.vaultTransitEngineUrl(), options.vaultToken(), Duration.ofSeconds(20), options.sslContext());
     }
 
 }

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/config/Config.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/config/Config.java
@@ -20,15 +20,15 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Configuration for the Vault KMS service.
- * @param vaultUrl vault url
- * @param vaultToken vault token.
+ * @param vaultTransitEngineUrl URL of the Vault Transit Engine e.g. {@code https://myhashicorpvault:8200/v1/transit}
+ * @param vaultToken Vault token.
  */
 public record Config(
-                     @JsonProperty(required = true) URI vaultUrl,
+                     @JsonProperty(value = "vaultTransitEngineUrl", required = true) URI vaultTransitEngineUrl,
                      @JsonProperty(required = true) String vaultToken,
                      Tls tls) {
     public Config {
-        Objects.requireNonNull(vaultUrl);
+        Objects.requireNonNull(vaultTransitEngineUrl);
         Objects.requireNonNull(vaultToken);
     }
 

--- a/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/TestVault.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/TestVault.java
@@ -35,7 +35,7 @@ public class TestVault implements Closeable {
         VaultContainer<?> vault = new VaultContainer<>(HASHICORP_VAULT)
                 .withVaultToken(VAULT_TOKEN)
                 .withEnv("VAULT_FORMAT", "json")
-                .withInitCommand("secrets enable transit");
+                .withInitCommand("secrets enable transit ");
         if (keys != null) {
             // in vault server -dev mode the 8200 port cannot be reconfigured to TLS. So we configure a second listener on a
             // different port. We expose only the tls port to avoid any chance of a misconfigured client pointing at the plain listener.
@@ -48,7 +48,8 @@ public class TestVault implements Closeable {
         }
         vault.start();
         this.vault = vault;
-        endpoint = URI.create(keys == null ? vault.getHttpHostAddress() : String.format("https://%s:%s", vault.getHost(), vault.getMappedPort(TLS_PORT)));
+        endpoint = URI.create(keys == null ? vault.getHttpHostAddress() : String.format("https://%s:%s", vault.getHost(), vault.getMappedPort(TLS_PORT)))
+                .resolve("v1/transit");
     }
 
     public static TestVault startWithTls(CertificateGenerator.Keys keys) {

--- a/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsTest.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsTest.java
@@ -15,13 +15,18 @@ import java.net.http.HttpTimeoutException;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.sun.net.httpserver.HttpServer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class VaultKmsTest {
 
@@ -48,6 +53,44 @@ class VaultKmsTest {
                 .withThrowableOfType(ExecutionException.class)
                 .withCauseInstanceOf(HttpTimeoutException.class);
         httpServer.stop(0);
+    }
+
+    static Stream<Arguments> legalEnginePaths() {
+        var uri = URI.create("https://localhost:1234");
+        return Stream.of(
+                Arguments.of("no path", uri, "/v1/transit/"),
+                Arguments.of("slash only", uri.resolve("/"), "/v1/transit/"),
+                Arguments.of("basic", uri.resolve("v1/transit"), "/v1/transit/"),
+                Arguments.of("trailing slash", uri.resolve("v1/transit/"), "/v1/transit/"),
+                Arguments.of("single namespace", uri.resolve("v1/ns1/transit"), "/v1/ns1/transit/"),
+                Arguments.of("many namespaces", uri.resolve("v1/ns1/ns2/transit"), "/v1/ns1/ns2/transit/"),
+                Arguments.of("non standard engine name", uri.resolve("v1/mytransit"), "/v1/mytransit/"));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource
+    void legalEnginePaths(String name, URI uri, String expected) {
+        var kms = new VaultKms(uri, "token", Duration.ofMillis(500), null);
+        assertThat(kms.getEngineUri())
+                .extracting(URI::getPath)
+                .isEqualTo(expected);
+
+    }
+
+    static Stream<Arguments> illegalEnginePaths() {
+        var uri = URI.create("https://localhost:1234");
+        return Stream.of(
+                Arguments.of("unrecognized version", uri.resolve("v999/transit")),
+                Arguments.of("missing engine", uri.resolve("v1")),
+                Arguments.of("empty engine", uri.resolve("v1/")));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource
+    void illegalEnginePaths(String name, URI uri) {
+        assertThatThrownBy(() -> new VaultKms(uri, "token", Duration.ofMillis(500), null))
+                .isInstanceOf(IllegalArgumentException.class);
+
     }
 
     @Disabled("JDK http client request timeout cancelled after headers received currently, todo add our own timeout future")

--- a/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/config/ConfigParseTest.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/config/ConfigParseTest.java
@@ -30,13 +30,13 @@ class ConfigParseTest {
     void testVaultUrlAndToken() throws IOException {
         String json = """
                 {
-                    "vaultUrl": "http://vault",
+                    "vaultTransitEngineUrl": "http://vault",
                     "vaultToken": "token"
                 }
                 """;
         Config config = readConfig(json);
         assertThat(config.vaultToken()).isEqualTo("token");
-        assertThat(config.vaultUrl()).isEqualTo(URI.create("http://vault"));
+        assertThat(config.vaultTransitEngineUrl()).isEqualTo(URI.create("http://vault"));
     }
 
     @Test
@@ -48,7 +48,7 @@ class ConfigParseTest {
                     }
                     """;
             readConfig(json);
-        }).isInstanceOf(MismatchedInputException.class).hasMessageContaining("vaultUrl");
+        }).isInstanceOf(MismatchedInputException.class).hasMessageContaining("vaultTransitEngineUrl");
     }
 
     @Test
@@ -56,7 +56,7 @@ class ConfigParseTest {
         Assertions.assertThatThrownBy(() -> {
             String json = """
                     {
-                        "vaultUrl": null,
+                        "vaultTransitEngineUrl": null,
                         "vaultToken": "token"
                     }
                     """;
@@ -69,7 +69,7 @@ class ConfigParseTest {
         Assertions.assertThatThrownBy(() -> {
             String json = """
                     {
-                        "vaultUrl": "https://vault"
+                        "vaultTransitEngineUrl": "https://vault"
                     }
                     """;
             readConfig(json);
@@ -81,7 +81,7 @@ class ConfigParseTest {
         Assertions.assertThatThrownBy(() -> {
             String json = """
                     {
-                        "vaultUrl": "https://vault",
+                        "vaultTransitEngineUrl": "https://vault",
                         "vaultToken": null
                     }
                     """;
@@ -93,7 +93,7 @@ class ConfigParseTest {
     void testEmptyTls() throws Exception {
         String json = """
                 {
-                    "vaultUrl": "https://vault",
+                    "vaultTransitEngineUrl": "https://vault",
                     "vaultToken": "token",
                     "tls": {}
                 }
@@ -108,7 +108,7 @@ class ConfigParseTest {
     void testMissingTls() throws Exception {
         String json = """
                 {
-                    "vaultUrl": "https://vault",
+                    "vaultTransitEngineUrl": "https://vault",
                     "vaultToken": "token"
                 }
                 """;
@@ -122,7 +122,7 @@ class ConfigParseTest {
     void testTlsTrust() throws Exception {
         String json = """
                 {
-                    "vaultUrl": "https://vault",
+                    "vaultTransitEngineUrl": "https://vault",
                     "vaultToken": "token",
                     "tls": {
                         "trust": {

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/vault/KubeVaultTestKmsFacade.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/vault/KubeVaultTestKmsFacade.java
@@ -71,7 +71,7 @@ public class KubeVaultTestKmsFacade implements TestKmsFacade<Config, String, Vau
 
     @Override
     public Config getKmsServiceConfig() {
-        return new Config(URI.create(vault.getBootstrap()), Vault.VAULT_ROOT_TOKEN, null);
+        return new Config(URI.create(vault.getBootstrap()).resolve("v1/transit"), Vault.VAULT_ROOT_TOKEN, null);
     }
 
     private class VaultTestKekManager implements TestKekManager {

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/kroxylicious/KroxyliciousConfigMapTemplates.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/kroxylicious/KroxyliciousConfigMapTemplates.java
@@ -71,7 +71,7 @@ public class KroxyliciousConfigMapTemplates {
                   config:
                     kms: VaultKmsService
                     kmsConfig:
-                      vaultUrl: http://%VAULT_SERVICE%.%VAULT_NAMESPACE%.svc.cluster.local:8200
+                      vaultTransitEngineUrl: http://%VAULT_SERVICE%.%VAULT_NAMESPACE%.svc.cluster.local:8200/v1/transit
                       vaultToken: %ROOT_TOKEN%
                     selector: TemplateKekSelector
                     selectorConfig:

--- a/kubernetes-examples/envelope-encryption/base/kroxylicious/kroxylicious-config.yaml
+++ b/kubernetes-examples/envelope-encryption/base/kroxylicious/kroxylicious-config.yaml
@@ -34,7 +34,7 @@ data:
       config:
         kms: VaultKmsService
         kmsConfig:
-          vaultUrl: http://vault.vault.svc.cluster.local:8200
+          vaultTransitEngineUrl: http://vault.vault.svc.cluster.local:8200/v1/transit
           vaultToken: myroottoken
         selector: TemplateKekSelector
         selectorConfig:


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Currently the EnvelopeEncryption filter fails to operate against a HCE.  HCEs make use of the Enterprise namespace feature,
which means the URLs generated by the Kms implementation are wrong.

I took the approach of letting the vaultUrl provide full path to the transit engine.  That gives support for both namespaces, and gives scope to work with non-standard engine path names.

An alternative would have been to let the implementation accept a namespaces configuration parameter, with would be passed to the [X-Vault-Namespace](https://developer.hashicorp.com/vault/docs/enterprise/namespaces#vault-api-and-namespaces) on the request.  A separate parameter would be required to allow for the customisation the name of the transit engine.



### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [x] Reference relevant issue(s) and close them after merging
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
