### PR TITLE
Update DEV_GUIDE and create Strimzi Namespace variable for downstream pipelines

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -301,7 +301,7 @@ has been applied ineffectively.
 * `SKIP_TEARDOWN`: variable for development purposes to avoid keep deploying and deleting deployments each run. Default value: `false`
 * `CONTAINER_CONFIG_PATH`: directory where `config.json` file is located. This file contains the pull secrets to be used by
 the container engine. Default value: `$HOME/.docker/config.json`
-* `STRIMZI_NAMESPACE`: namespace where strimzi is installed. It is useful for downstream pipelines
+* `STRIMZI_NAMESPACE`: namespace where strimzi is installed. It is useful for pipelines
 where strimzi is installed before the STs. Default value: `kafka`
 
 

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -298,10 +298,12 @@ has been applied ineffectively.
 * `KROXYLICIOUS_IMAGE_REPO`: url to the image of kroxylicious to be used. Default value: `quay.io/kroxylicious/kroxylicious-developer`
 * `KROXYLICIOUS_VERSION`: version of kroxylicious to be used. Default value: `${project.version}` in pom file
 * `KAFKA_VERSION`: kafka version to be used. Default value: `${kafka.version}` in pom file
-* `STRIMZI_URL`: url where to download strimzi. Default value: `khttps://strimzi.io/install/latest?namespace=kafka`
+* `STRIMZI_URL`: url where to download strimzi. Default value: `https://strimzi.io/install/latest?namespace=kafka`
 * `SKIP_TEARDOWN`: variable for development purposes to avoid keep deploying and deleting deployments each run. Default value: `false`
 * `CONTAINER_CONFIG_PATH`: directory where `config.json` file is located. This file contains the pull secrets to be used by
 the container engine. Default value: `$HOME/.docker/config.json`
+* `STRIMZI_NAMESPACE`: namespace where strimzi is installed. It is useful for downstream pipelines
+where strimzi is installed before the STs. Default value: `kafka`
 
 
 ### Launch system tests
@@ -332,6 +334,17 @@ KROXYLICIOUS_IMAGE_REPO=<container_registry>/<myorg>/kroxylicious mvn clean inte
 ```shell
 KROXYLICIOUS_IMAGE_REPO=<container_registry>/<myorg>/kroxylicious mvn clean verify -DskiptITs=true -DskiptUTs=true -DskipSTs=false
 ```
+
+### Jenkins pipeline for system tests
+
+When a PR is created and the system tests are needed, if you are a member of
+[Developers](https://github.com/orgs/kroxylicious/teams/developers), you may add the following comment into the PR to trigger the run.
+
+```
+@strimzi-ci run system tests
+```
+
+It will launch the `kroxylicious-system-tests-pr` build, that will insert a comment with a summary into the PR.
 
 ## Rendering documentation
 

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
@@ -32,7 +32,7 @@ public interface Constants {
     /**
      * The default namespace used for kubernetes deployment
      */
-    String KROXY_DEFAULT_NAMESPACE = "kafka";
+    String KAFKA_DEFAULT_NAMESPACE = "kafka";
 
     /**
      * The cert-manager namespace for kubernetes deployment

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
@@ -30,6 +30,7 @@ public class Environment {
     private static final String SKIP_TEARDOWN_ENV = "SKIP_TEARDOWN";
     public static final String STRIMZI_FEATURE_GATES_ENV = "STRIMZI_FEATURE_GATES";
     public static final String CONTAINER_CONFIG_PATH_ENV = "CONTAINER_CONFIG_PATH";
+    public static final String STRIMZI_NAMESPACE_ENV = "STRIMZI_NAMESPACE";
 
     /**
      * The kafka version default value
@@ -57,13 +58,14 @@ public class Environment {
     /**
      * The strimzi installation url for kubernetes.
      */
-    private static final String STRIMZI_URL_DEFAULT = "https://strimzi.io/install/latest?namespace=" + Constants.KROXY_DEFAULT_NAMESPACE;
+    private static final String STRIMZI_URL_DEFAULT = "https://strimzi.io/install/latest?namespace=" + Constants.KAFKA_DEFAULT_NAMESPACE;
     /**
      * The default value for skipping the teardown locally.
      */
     private static final String SKIP_TEARDOWN_DEFAULT = "false";
     private static final String STRIMZI_FEATURE_GATES_DEFAULT = "";
     private static final String CONTAINER_CONFIG_PATH_DEFAULT = System.getProperty("user.home") + "/.docker/config.json";
+    private static final String STRIMZI_NAMESPACE_DEFAULT = Constants.KAFKA_DEFAULT_NAMESPACE;
 
     /**
      * KAFKA_VERSION env variable assignment
@@ -90,6 +92,8 @@ public class Environment {
     public static final String STRIMZI_FEATURE_GATES = getOrDefault(STRIMZI_FEATURE_GATES_ENV, STRIMZI_FEATURE_GATES_DEFAULT);
 
     public static final String CONTAINER_CONFIG_PATH = getOrDefault(CONTAINER_CONFIG_PATH_ENV, CONTAINER_CONFIG_PATH_DEFAULT);
+
+    public static final String STRIMZI_NAMESPACE = getOrDefault(STRIMZI_NAMESPACE_ENV, STRIMZI_NAMESPACE_DEFAULT);
 
     private static String getOrDefault(String varName, String defaultValue) {
         return getOrDefault(varName, String::toString, defaultValue);

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/steps/KafkaSteps.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/steps/KafkaSteps.java
@@ -80,6 +80,6 @@ public class KafkaSteps {
      */
     public static void restartKafkaBroker(String clusterName) {
         clusterName = clusterName + "-kafka";
-        assertThat("Broker has not been restarted successfully!", KafkaUtils.restartBroker(Constants.KROXY_DEFAULT_NAMESPACE, clusterName));
+        assertThat("Broker has not been restarted successfully!", KafkaUtils.restartBroker(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName));
     }
 }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/kroxylicious/KroxyliciousConfigMapTemplates.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/kroxylicious/KroxyliciousConfigMapTemplates.java
@@ -77,7 +77,7 @@ public class KroxyliciousConfigMapTemplates {
                     selectorConfig:
                       template: "${topicName}"
                 """
-                .replace("%NAMESPACE%", Constants.KROXY_DEFAULT_NAMESPACE)
+                .replace("%NAMESPACE%", Constants.KAFKA_DEFAULT_NAMESPACE)
                 .replace("%CLUSTER_NAME%", clusterName)
                 .replace("%KROXY_SERVICE_NAME%", Constants.KROXY_SERVICE_NAME)
                 .replace("%ROOT_TOKEN%", Vault.VAULT_ROOT_TOKEN)
@@ -103,7 +103,7 @@ public class KroxyliciousConfigMapTemplates {
                     logNetwork: false
                     logFrames: false
                 """
-                .replace("%NAMESPACE%", Constants.KROXY_DEFAULT_NAMESPACE)
+                .replace("%NAMESPACE%", Constants.KAFKA_DEFAULT_NAMESPACE)
                 .replace("%CLUSTER_NAME%", clusterName)
                 .replace("%KROXY_SERVICE_NAME%", Constants.KROXY_SERVICE_NAME);
     }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
@@ -155,7 +155,7 @@ public class KafkaUtils {
     public static boolean restartBroker(String deployNamespace, String clusterName) {
         String podName = "";
         String podUid = "";
-        List<Pod> kafkaPods = kubeClient().listPods(Constants.KROXY_DEFAULT_NAMESPACE);
+        List<Pod> kafkaPods = kubeClient().listPods(Constants.KAFKA_DEFAULT_NAMESPACE);
         for (Pod pod : kafkaPods) {
             String tmpName = pod.getMetadata().getName();
             if (tmpName.startsWith(clusterName) && tmpName.endsWith("0")) {

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/AbstractST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/AbstractST.java
@@ -75,9 +75,10 @@ public class AbstractST {
         LOGGER.info(String.format("%s Test Suite - STARTED", testInfo.getTestClass().get().getName()));
         cluster = KubeClusterResource.getInstance();
         certManager = new CertManager();
-        strimziOperator = new Strimzi(Constants.KROXY_DEFAULT_NAMESPACE);
+        strimziOperator = new Strimzi(Environment.STRIMZI_NAMESPACE);
 
-        NamespaceUtils.createNamespaceWithWait(Constants.KROXY_DEFAULT_NAMESPACE);
+        NamespaceUtils.createNamespaceWithWait(Environment.STRIMZI_NAMESPACE);
+        NamespaceUtils.createNamespaceWithWait(Constants.KAFKA_DEFAULT_NAMESPACE);
         strimziOperator.deploy();
         certManager.deploy();
     }
@@ -97,7 +98,8 @@ public class AbstractST {
             if (certManager != null) {
                 certManager.delete();
             }
-            NamespaceUtils.deleteNamespaceWithWait(Constants.KROXY_DEFAULT_NAMESPACE);
+            NamespaceUtils.deleteNamespaceWithWait(Environment.STRIMZI_NAMESPACE);
+            NamespaceUtils.deleteNamespaceWithWait(Constants.KAFKA_DEFAULT_NAMESPACE);
             NamespaceUtils.deleteNamespaceWithWait(Constants.CERT_MANAGER_NAMESPACE);
         }
         else {

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/EnvelopeEncryptionST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/EnvelopeEncryptionST.java
@@ -56,14 +56,14 @@ class EnvelopeEncryptionST extends AbstractST {
             kubeVaultTestKmsFacade.start();
         }
 
-        List<Pod> kafkaPods = kubeClient().listPodsByPrefixInName(Constants.KROXY_DEFAULT_NAMESPACE, clusterName);
+        List<Pod> kafkaPods = kubeClient().listPodsByPrefixInName(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName);
         if (!kafkaPods.isEmpty()) {
             LOGGER.warn("Skipping kafka deployment. It is already deployed!");
             return;
         }
-        LOGGER.info("Deploying Kafka in {} namespace", Constants.KROXY_DEFAULT_NAMESPACE);
+        LOGGER.info("Deploying Kafka in {} namespace", Constants.KAFKA_DEFAULT_NAMESPACE);
 
-        Kafka kafka = KafkaTemplates.kafkaPersistentWithKRaftAnnotations(Constants.KROXY_DEFAULT_NAMESPACE, clusterName, 3).build();
+        Kafka kafka = KafkaTemplates.kafkaPersistentWithKRaftAnnotations(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName, 3).build();
 
         resourceManager.createResourceWithWait(
                 KafkaNodePoolTemplates.kafkaBasedNodePoolWithDualRole(BROKER_NODE_NAME, kafka, 3).build(),
@@ -106,7 +106,7 @@ class EnvelopeEncryptionST extends AbstractST {
         KroxyliciousSteps.produceMessages(namespace, topicName, bootstrap, MESSAGE, numberOfMessages);
 
         LOGGER.info("Then the {} messages are consumed", numberOfMessages);
-        String kafkaBootstrap = clusterName + "-kafka-bootstrap." + Constants.KROXY_DEFAULT_NAMESPACE + ".svc.cluster.local:9092";
+        String kafkaBootstrap = clusterName + "-kafka-bootstrap." + Constants.KAFKA_DEFAULT_NAMESPACE + ".svc.cluster.local:9092";
         String resultEncrypted = KroxyliciousSteps.consumeEncryptedMessages(namespace, topicName, kafkaBootstrap, numberOfMessages, Duration.ofMinutes(2));
         LOGGER.info("Received: " + resultEncrypted);
         assertThat("'" + expectedMessage + "' expected message have not been received!", resultEncrypted.contains(topicName + "vault"));

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/KroxyliciousAppST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/KroxyliciousAppST.java
@@ -39,7 +39,7 @@ public class KroxyliciousAppST extends AbstractST {
     @Test
     void kroxyAppIsRunning() {
         LOGGER.info("Given local Kroxylicious");
-        String clusterIp = kubeClient().getService(Constants.KROXY_DEFAULT_NAMESPACE, clusterName + "-kafka-external-bootstrap").getSpec().getClusterIP();
+        String clusterIp = kubeClient().getService(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName + "-kafka-external-bootstrap").getSpec().getClusterIP();
         kroxyliciousApp = new KroxyliciousApp(clusterIp);
         kroxyliciousApp.waitForKroxyliciousProcess();
         assertThat("Kroxylicious app is not running!", kroxyliciousApp.isRunning());
@@ -50,10 +50,10 @@ public class KroxyliciousAppST extends AbstractST {
      */
     @BeforeAll
     void setupBefore() {
-        assumeTrue(DeploymentUtils.checkLoadBalancerIsWorking(Constants.KROXY_DEFAULT_NAMESPACE), "Load balancer is not working fine, if you are using"
+        assumeTrue(DeploymentUtils.checkLoadBalancerIsWorking(Constants.KAFKA_DEFAULT_NAMESPACE), "Load balancer is not working fine, if you are using"
                 + "minikube please run 'minikube tunnel' before running the tests");
-        LOGGER.info("Deploying Kafka in {} namespace", Constants.KROXY_DEFAULT_NAMESPACE);
-        resourceManager.createResourceWithWait(KafkaTemplates.kafkaPersistentWithExternalIp(Constants.KROXY_DEFAULT_NAMESPACE, clusterName, 3, 3).build());
+        LOGGER.info("Deploying Kafka in {} namespace", Constants.KAFKA_DEFAULT_NAMESPACE);
+        resourceManager.createResourceWithWait(KafkaTemplates.kafkaPersistentWithExternalIp(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName, 3, 3).build());
     }
 
     /**

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/KroxyliciousST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/KroxyliciousST.java
@@ -133,14 +133,14 @@ class KroxyliciousST extends AbstractST {
      */
     @BeforeAll
     void setupBefore() {
-        List<Pod> kafkaPods = kubeClient().listPodsByPrefixInName(Constants.KROXY_DEFAULT_NAMESPACE, clusterName);
+        List<Pod> kafkaPods = kubeClient().listPodsByPrefixInName(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName);
         if (!kafkaPods.isEmpty()) {
             LOGGER.warn("Skipping kafka deployment. It is already deployed!");
             return;
         }
-        LOGGER.info("Deploying Kafka in {} namespace", Constants.KROXY_DEFAULT_NAMESPACE);
+        LOGGER.info("Deploying Kafka in {} namespace", Constants.KAFKA_DEFAULT_NAMESPACE);
 
-        Kafka kafka = KafkaTemplates.kafkaPersistentWithKRaftAnnotations(Constants.KROXY_DEFAULT_NAMESPACE, clusterName, 3).build();
+        Kafka kafka = KafkaTemplates.kafkaPersistentWithKRaftAnnotations(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName, 3).build();
 
         resourceManager.createResourceWithWait(
                 KafkaNodePoolTemplates.kafkaBasedNodePoolWithDualRole(BROKER_NODE_NAME, kafka, 3).build(),

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/extensions/KroxyliciousExtension.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/extensions/KroxyliciousExtension.java
@@ -63,7 +63,7 @@ public class KroxyliciousExtension implements ParameterResolver, BeforeEachCallb
 
     @Override
     public void beforeEach(ExtensionContext extensionContext) {
-        final String k8sNamespace = Constants.KROXY_DEFAULT_NAMESPACE + "-" + UUID.randomUUID().toString().replace("-", "").substring(0, 6);
+        final String k8sNamespace = Constants.KAFKA_DEFAULT_NAMESPACE + "-" + UUID.randomUUID().toString().replace("-", "").substring(0, 6);
         extensionContext.getStore(junitNamespace).put(K8S_NAMESPACE_KEY, k8sNamespace);
         NamespaceUtils.createNamespaceWithWait(k8sNamespace);
     }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Documentation

### Description

Created `STRIMZI_NAMESPACE` env variable to be able to detect if Strimzi has already been installed by the pipeline and not install it if this is the case.

### Additional Context

@im-konge is working on creating the pipeline for all AMQ-Streams product and we need to set the namespace where Strimzi is installed for Kroxylicious and Console.

### Checklist

- [ ] Write tests
- [X] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [X] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
