### PR TITLE
Enable Filters to check if they are currently in dispatch thread

### DIFF
--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactoryContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactoryContext.java
@@ -19,13 +19,20 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public interface FilterFactoryContext {
 
     /**
-     * The event loop that this Filter's channel is assigned to.
+     * @deprecated replaced with {@link #filterThreadExecutor()}
+     * @see #filterThreadExecutor()
+     */
+    @Deprecated(since = "0.5.0", forRemoval = true)
+    ScheduledExecutorService eventLoop();
+
+    /**
+     * An executor service backed by the filter dispatch thread used
+     * to create Filter instances and invoke their methods. It should be
+     * safe to mutate Filter member state from this executor.
      * Null if the factory is not bound to a channel yet.
-     * Should be safe
-     * to mutate Filter members from this executor.
      * @return executor, or null
      */
-    ScheduledExecutorService eventLoop();
+    FilterThreadExecutor filterThreadExecutor();
 
     /**
      * Gets a plugin instance for the given plugin type and name

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterThreadExecutor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterThreadExecutor.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Kroxylicious guarantees that each Filter instance has a single thread associated with it (the same
+ * thread may be shared by many filter instances). The threading model is intended to make it safe to
+ * update Filter state from the methods of the Filter called by the framework. However, if the Filter
+ * hands work off to another thread and wishes to update filter state we lose that safety. So we want
+ * to enable Filter's to access the Filter thread so that they can switch back to a context where it is
+ * safe to update state, or schedule jobs that update filter state.
+ */
+public interface FilterThreadExecutor extends ScheduledExecutorService {
+
+    /**
+     * @return true if current thread is the Filter thread backing this executor
+     */
+    boolean isInFilterThread();
+
+    /**
+     * Create a CompletionStage that will be completed on the Filter Thread. Note that
+     * work chained onto the resulting stage may be executed directly in the calling thread
+     * if the stage is already completed at that point. Following the contract of CompletableFuture
+     * <p>Actions supplied for dependent completions of non-async methods may be performed by the
+     * thread that completes the current CompletableFuture, or by any other caller of a completion method.</p>
+     *
+     * @param inStage
+     * @return a completion stage that will be completed by the Filter Thread
+     * @param <T> result type
+     */
+    default <T> CompletionStage<T> completedOnFilterThread(CompletionStage<T> inStage) {
+        CompletableFuture<T> future = new CompletableFuture<>();
+        inStage.whenComplete((t, throwable) -> {
+            if (isInFilterThread()) {
+                if (throwable == null) {
+                    future.complete(t);
+                }
+                else {
+                    future.completeExceptionally(throwable);
+                }
+            }
+            else {
+                execute(() -> {
+                    if (throwable == null) {
+                        future.complete(t);
+                    }
+                    else {
+                        future.completeExceptionally(throwable);
+                    }
+                });
+            }
+        });
+        return future;
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/RequestResponseMarkingFilter.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/RequestResponseMarkingFilter.java
@@ -33,7 +33,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public class RequestResponseMarkingFilter implements RequestFilter, ResponseFilter {
 
-    public static final int DISPATCH_THREAD = 499;
+    public static final int IN_FILTER_THREAD = 499;
     public static final int FILTER_NAME_TAG = 500;
     private final FilterFactoryContext constructionContext;
     private final String name;
@@ -73,10 +73,9 @@ public class RequestResponseMarkingFilter implements RequestFilter, ResponseFilt
                 .thenCompose(taggedRequest -> context.forwardResponse(header, taggedRequest));
     }
 
-    private static void tagWithDispatchThread(ApiMessage body) {
-        Thread currentThread = Thread.currentThread();
-        String identifier = currentThread.getName() + "::" + currentThread.threadId();
-        body.unknownTaggedFields().add(new RawTaggedField(DISPATCH_THREAD, identifier.getBytes()));
+    private void tagWithDispatchThread(ApiMessage body) {
+        String inDispatchThread = Boolean.toString(constructionContext.filterThreadExecutor().isInFilterThread());
+        body.unknownTaggedFields().add(new RawTaggedField(IN_FILTER_THREAD, inDispatchThread.getBytes(UTF_8)));
     }
 
     private ApiMessage applyTaggedField(ApiMessage body, RequestResponseMarkingFilterFactory.Direction direction, String name) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -16,6 +16,7 @@ import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
 import io.kroxylicious.proxy.filter.FilterFactory;
 import io.kroxylicious.proxy.filter.FilterFactoryContext;
+import io.kroxylicious.proxy.filter.FilterThreadExecutor;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -70,6 +71,11 @@ public class FilterChainFactory {
             FilterFactoryContext context = new FilterFactoryContext() {
                 @Override
                 public ScheduledExecutorService eventLoop() {
+                    return null;
+                }
+
+                @Override
+                public FilterThreadExecutor filterThreadExecutor() {
                     return null;
                 }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/EventLoopFilterThreadExecutor.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/EventLoopFilterThreadExecutor.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.netty.channel.EventLoop;
+
+import io.kroxylicious.proxy.filter.FilterThreadExecutor;
+
+public class EventLoopFilterThreadExecutor implements FilterThreadExecutor {
+
+    private final EventLoop eventLoop;
+
+    public EventLoopFilterThreadExecutor(EventLoop eventLoop) {
+        this.eventLoop = eventLoop;
+    }
+
+    @Override
+    public boolean isInFilterThread() {
+        return eventLoop.inEventLoop();
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        return eventLoop.schedule(command, delay, unit);
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        return eventLoop.schedule(callable, delay, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        return eventLoop.scheduleAtFixedRate(command, initialDelay, period, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        return eventLoop.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+    }
+
+    @Override
+    public void shutdown() {
+        eventLoop.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return eventLoop.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return eventLoop.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return eventLoop.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return eventLoop.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return eventLoop.submit(task);
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return eventLoop.submit(task, result);
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return eventLoop.submit(task);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return eventLoop.invokeAll(tasks);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+        return eventLoop.invokeAll(tasks, timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        return eventLoop.invokeAny(tasks);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return eventLoop.invokeAny(tasks, timeout, unit);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        eventLoop.execute(command);
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/NettyFilterContext.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/NettyFilterContext.java
@@ -11,21 +11,27 @@ import java.util.concurrent.ScheduledExecutorService;
 import io.kroxylicious.proxy.config.PluginFactory;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
 import io.kroxylicious.proxy.filter.FilterFactoryContext;
+import io.kroxylicious.proxy.filter.FilterThreadExecutor;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public class NettyFilterContext implements FilterFactoryContext {
-    private final ScheduledExecutorService eventLoop;
+    private final FilterThreadExecutor eventLoop;
     private final PluginFactoryRegistry pluginFactoryRegistry;
 
-    public NettyFilterContext(ScheduledExecutorService eventLoop,
+    public NettyFilterContext(FilterThreadExecutor filterThreadExecutor,
                               PluginFactoryRegistry pluginFactoryRegistry) {
-        this.eventLoop = eventLoop;
+        this.eventLoop = filterThreadExecutor;
         this.pluginFactoryRegistry = pluginFactoryRegistry;
     }
 
     @Override
     public ScheduledExecutorService eventLoop() {
+        return filterThreadExecutor();
+    }
+
+    @Override
+    public FilterThreadExecutor filterThreadExecutor() {
         return eventLoop;
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -28,6 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoop;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.ByteToMessageDecoder;
@@ -64,6 +65,9 @@ class KafkaProxyInitializerTest {
     @Mock(strictness = Mock.Strictness.LENIENT)
     private SocketChannel channel;
 
+    @Mock
+    private EventLoop eventLoop;
+
     @Mock(strictness = Mock.Strictness.LENIENT)
     private ChannelPipeline channelPipeline;
 
@@ -92,6 +96,7 @@ class KafkaProxyInitializerTest {
         when(channel.pipeline()).thenReturn(channelPipeline);
         when(channel.parent()).thenReturn(serverSocketChannel);
         when(channel.localAddress()).thenReturn(InetSocketAddress.createUnresolved("localhost", 9099));
+        when(channel.eventLoop()).thenReturn(eventLoop);
 
         when(serverSocketChannel.localAddress()).thenReturn(localhost);
         when(vcb.virtualCluster()).thenReturn(virtualCluster);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/EventLoopFilterThreadExecutorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/EventLoopFilterThreadExecutorTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import io.netty.channel.DefaultEventLoop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EventLoopFilterThreadExecutorTest {
+
+    private final DefaultEventLoop eventLoop = new DefaultEventLoop();
+
+    @AfterEach
+    public void after() {
+        eventLoop.shutdownGracefully();
+    }
+
+    @Test
+    public void testWithCompletedFuture() {
+        EventLoopFilterThreadExecutor executor = new EventLoopFilterThreadExecutor(eventLoop);
+        CompletionStage<Long> future = executor.completedOnFilterThread(CompletableFuture.completedFuture(1L));
+        assertThat(future).succeedsWithin(Duration.ZERO).isEqualTo(1L);
+    }
+
+    @Test
+    public void testSuccessOnUncontrolledExecutorSwitchesThread() {
+        EventLoopFilterThreadExecutor executor = new EventLoopFilterThreadExecutor(eventLoop);
+        CompletableFuture<String> threadName = new CompletableFuture<>();
+        CompletionStage<String> stage = executor.completedOnFilterThread(threadName);
+        CompletionStage<Boolean> sameThreadStage = stage.thenApply(s -> {
+            assertInEventLoop(eventLoop);
+            return s.equals(Thread.currentThread().getName());
+        });
+
+        // complete threadname after the chain is established to avoid races where main thread can drive completion
+        CompletableFuture.runAsync(() -> {
+            assertNotInEventLoop(eventLoop);
+            threadName.complete(Thread.currentThread().getName());
+        });
+        assertThat(sameThreadStage).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(false);
+    }
+
+    @Test
+    public void testExceptionOnUncontrolledExecutorSwitchesThread() {
+        EventLoopFilterThreadExecutor executor = new EventLoopFilterThreadExecutor(eventLoop);
+        CompletableFuture<String> threadName = new CompletableFuture<>();
+        CompletionStage<String> stage = executor.completedOnFilterThread(threadName);
+        CompletionStage<String> extractNameFromException = stage.exceptionally(ex -> {
+            assertInEventLoop(eventLoop);
+            if (ex instanceof TestException testException) {
+                return testException.threadName;
+            }
+            else {
+                throw new RuntimeException("unexpected exception: " + ex);
+            }
+        });
+        CompletionStage<Boolean> sameThreadStage = extractNameFromException.thenApply(s -> {
+            assertInEventLoop(eventLoop);
+            return s.equals(Thread.currentThread().getName());
+        });
+
+        // complete threadname after the chain is established to avoid races where main thread can drive completion
+        CompletableFuture.runAsync(() -> {
+            assertNotInEventLoop(eventLoop);
+            threadName.completeExceptionally(new TestException(Thread.currentThread().getName()));
+        });
+        assertThat(sameThreadStage).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(false);
+    }
+
+    @Test
+    public void testExceptionOnEventLoopExecutorRemainsOnThread() {
+        EventLoopFilterThreadExecutor executor = new EventLoopFilterThreadExecutor(eventLoop);
+        CompletableFuture<String> threadName = new CompletableFuture<>();
+        CompletionStage<String> stage = executor.completedOnFilterThread(threadName);
+        CompletionStage<String> extractNameFromException = stage.exceptionally(ex -> {
+            assertInEventLoop(eventLoop);
+            if (ex instanceof TestException testException) {
+                return testException.threadName;
+            }
+            else {
+                throw new RuntimeException("unexpected exception: " + ex);
+            }
+        });
+        CompletionStage<Boolean> sameThreadStage = extractNameFromException.thenApply(s -> {
+            assertInEventLoop(eventLoop);
+            return s.equals(Thread.currentThread().getName());
+        });
+
+        // complete threadname after the chain is established to avoid races where main thread can drive completion
+        CompletableFuture.runAsync(() -> {
+            assertInEventLoop(eventLoop);
+            threadName.completeExceptionally(new TestException(Thread.currentThread().getName()));
+        }, eventLoop);
+        assertThat(sameThreadStage).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(true);
+    }
+
+    @Test
+    public void testSuccessOnEventLoopRemainsOnEventLoop() {
+        EventLoopFilterThreadExecutor executor = new EventLoopFilterThreadExecutor(eventLoop);
+        CompletableFuture<String> threadName = new CompletableFuture<>();
+        CompletionStage<String> stage = executor.completedOnFilterThread(threadName);
+        CompletionStage<Boolean> sameThreadStage = stage.thenApply(s -> {
+            assertInEventLoop(eventLoop);
+            return s.equals(Thread.currentThread().getName());
+        });
+
+        // complete threadname after the chain is established to avoid races where main thread can drive completion
+        CompletableFuture.runAsync(() -> {
+            assertInEventLoop(eventLoop);
+            threadName.complete(Thread.currentThread().getName());
+        }, eventLoop);
+        assertThat(sameThreadStage).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(true);
+    }
+
+    private static void assertNotInEventLoop(DefaultEventLoop eventLoop) {
+        assertThat(eventLoop.inEventLoop()).isFalse();
+    }
+
+    private static void assertInEventLoop(DefaultEventLoop eventLoop) {
+        assertThat(eventLoop.inEventLoop()).isTrue();
+
+    }
+
+    private class TestException extends RuntimeException {
+        private final String threadName;
+
+        TestException(String threadName) {
+            this.threadName = threadName;
+        }
+    }
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Closes #904

Adds
```java
/**
     * An executor service backed by the filter dispatch thread used
     * to create Filter instances and invoke their methods. It should be
     * safe to mutate Filter member state from this executor.
     * Null if the factory is not bound to a channel yet.
     * @return executor, or null
     */
    FilterThreadExecutor filterThreadExecutor();
```

to FilterFactoryContext and deprecates `eventLoop()`.

The new FilterThreadExecutor API is:
```java
public interface FilterThreadExecutor extends ScheduledExecutorService {

    /**
     * @return true if current thread is the Filter thread backing this executor
     */
    boolean isInFilterThread();

    /**
     * Create a CompletionStage that will be completed on the Filter Thread. Note that
     * work chained onto the resulting stage may be executed directly in the calling thread
     * if the stage is already completed at that point. Following the contract of CompletableFuture
     * <p>Actions supplied for dependent completions of non-async methods may be performed by the
     * thread that completes the current CompletableFuture, or by any other caller of a completion method.</p>
     *
     * @param inStage
     * @return a completion stage that will be completed by the Filter Thread
     * @param <T> result type
     */
    <T> CompletionStage<T> completedOnFilterThread(CompletionStage<T> inStage);
}
```

Filters working with asynchronous code may need to be sure that they are executing in the filter dispatch thread where we know it is safe to mutate filter member state. For example if we make an async HTTP request and have a CompleteableFuture that has it's completion driven by the HTTP io thread, we may want to update a Filter's state safely on the dispatch thread.

Being able to check if we are in the dispatch thread will help to make tactical decisions like, "should I do the processing immediately, or switch to the dispatch thread?". The convenience to switch completion back to the Filter thread will also be useful after a Filter hands off work to another Thread and needs to switch back so it can safely mutate filter members or other state taking advantage of the threading model.

The `eventLoop()` method of FilterFactoryContext is deprecated and replaced with `filterThreadExecutor()` because we felt the naming is too netty-centric and we have tried to hide this detail from the Filter implementations as much as we can. We do make guarantees that a Filter instance is associated with, and driven by, a single thread. We call this the Filter Thread.

### Checklist
  
- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
