### PR TITLE
envelope encryption: filter selects topics to encrypt

### DIFF
--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/IncludeExcludeTopicSelector.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/IncludeExcludeTopicSelector.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+@ThreadSafe
+public class IncludeExcludeTopicSelector implements TopicSelector {
+
+    private Map<String, Boolean> selected = new ConcurrentHashMap<>();
+
+    // empty means include all
+    private final Set<String> includeTopics = new HashSet<>();
+
+    // empty means exclude none
+    private final Set<String> excludeTopics = new HashSet<>();
+
+    // empty means include all
+    private final List<String> includePrefixes = new ArrayList<>();
+
+    // empty means exclude none
+    private final List<String> excludePrefixes = new ArrayList<>();
+
+    private final boolean inclusionConfigured;
+    private final boolean exclusionConfigured;
+
+    public IncludeExcludeTopicSelector(@NonNull EnvelopeEncryption.TopicSelectorConfig config) {
+        if (config.includeNames() != null) {
+            includeTopics.addAll(config.includeNames());
+        }
+        if (config.excludeNames() != null) {
+            excludeTopics.addAll(config.excludeNames());
+        }
+        if (config.includeNamePrefixes() != null) {
+            includePrefixes.addAll(config.includeNamePrefixes());
+        }
+        if (config.excludeNamePrefixes() != null) {
+            excludePrefixes.addAll(config.excludeNamePrefixes());
+        }
+        inclusionConfigured = !includePrefixes.isEmpty() || !includeTopics.isEmpty();
+        exclusionConfigured = !excludePrefixes.isEmpty() || !excludeTopics.isEmpty();
+    }
+
+    @Override
+    public boolean select(String topicName) {
+        return selected.computeIfAbsent(topicName, this::isSelected);
+    }
+
+    private @NonNull Boolean isSelected(String topicName) {
+        return !isExcluded(topicName) && isIncluded(topicName);
+    }
+
+    private boolean isIncluded(String topicName) {
+        return !inclusionConfigured || (isIncludedByExactMatch(topicName) || isIncludedByPrefix(topicName));
+    }
+
+    private boolean isExcluded(String topicName) {
+        return exclusionConfigured && (isExcludedByExactMatch(topicName) || isExcludedByPrefix(topicName));
+    }
+
+    private boolean isIncludedByExactMatch(String topicName) {
+        return includeTopics.contains(topicName);
+    }
+
+    private boolean isIncludedByPrefix(String topicName) {
+        return includePrefixes.stream().anyMatch(topicName::startsWith);
+    }
+
+    private boolean isExcludedByPrefix(String topicName) {
+        return excludePrefixes.stream().anyMatch(topicName::startsWith);
+    }
+
+    private boolean isExcludedByExactMatch(String topicName) {
+        return excludeTopics.contains(topicName);
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/KekSelectorService.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/KekSelectorService.java
@@ -17,6 +17,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public interface KekSelectorService<C, K> {
     @NonNull
-    TopicNameBasedKekSelector<K> buildSelector(@NonNull Kms<K, ?> kms, C options);
+    TopicNameBasedKekSelector<K> buildSelector(@NonNull Kms<K, ?> kms, C options, TopicSelector topicSelector);
 
 }

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/TopicSelector.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/TopicSelector.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+public interface TopicSelector {
+    boolean select(String topicName);
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionTest.java
@@ -24,7 +24,7 @@ class EnvelopeEncryptionTest {
 
     @Test
     void shouldInitAndCreateFilter() {
-        EnvelopeEncryption.Config config = new EnvelopeEncryption.Config("KMS", null, "SELECTOR", null);
+        EnvelopeEncryption.Config config = new EnvelopeEncryption.Config("KMS", null, "SELECTOR", null, null);
         var ee = new EnvelopeEncryption<>();
         var fc = mock(FilterFactoryContext.class);
         var kmsService = mock(KmsService.class);
@@ -36,7 +36,7 @@ class EnvelopeEncryptionTest {
         doReturn(kms).when(kmsService).buildKms(any());
 
         doReturn(kekSelectorService).when(fc).pluginInstance(KekSelectorService.class, "SELECTOR");
-        doReturn(kekSelector).when(kekSelectorService).buildSelector(any(), any());
+        doReturn(kekSelector).when(kekSelectorService).buildSelector(any(), any(), any());
 
         ee.initialize(fc, config);
         var filter = ee.createFilter(fc, config);
@@ -45,7 +45,7 @@ class EnvelopeEncryptionTest {
 
     @Test
     void testKmsCacheConfigDefaults() {
-        EnvelopeEncryption.KmsCacheConfig config = new EnvelopeEncryption.Config("vault", 1L, "selector", 1L).kmsCache();
+        EnvelopeEncryption.KmsCacheConfig config = new EnvelopeEncryption.Config("vault", 1L, "selector", 1L, null).kmsCache();
         assertThat(config.decryptedDekCacheSize()).isEqualTo(1000);
         assertThat(config.decryptedDekExpireAfterAccessDuration()).isEqualTo(Duration.ofHours(1));
         assertThat(config.resolvedAliasCacheSize()).isEqualTo(1000);

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/IncludeExcludeTopicSelectorTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/IncludeExcludeTopicSelectorTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IncludeExcludeTopicSelectorTest {
+    static List<EnvelopeEncryption.TopicSelectorConfig> defaultConfigurations() {
+        return List.of(
+                getConfig(null, null, null, null),
+                getConfig(List.of(), List.of(), List.of(), List.of()));
+    }
+
+    @MethodSource("defaultConfigurations")
+    @ParameterizedTest
+    void testAnyTopicSelectedByDefault(EnvelopeEncryption.TopicSelectorConfig config) {
+        TopicSelector selector = new IncludeExcludeTopicSelector(config);
+        assertThat(selector.select("arbitrary")).isTrue();
+    }
+
+    @Test
+    void testInclusionByName() {
+        EnvelopeEncryption.TopicSelectorConfig config = getConfig(List.of("included"), null, null, null);
+        TopicSelector selector = new IncludeExcludeTopicSelector(config);
+        assertThat(selector.select("included")).isTrue();
+        assertThat(selector.select("badman")).isFalse();
+    }
+
+    @Test
+    void testExclusionByName() {
+        EnvelopeEncryption.TopicSelectorConfig config = getConfig(null, List.of("excluded"), null, null);
+        TopicSelector selector = new IncludeExcludeTopicSelector(config);
+        assertThat(selector.select("excluded")).isFalse();
+        assertThat(selector.select("arbitrary")).isTrue();
+    }
+
+    @Test
+    void testInclusionByPrefix() {
+        EnvelopeEncryption.TopicSelectorConfig config = getConfig(null, null, List.of("prefix_"), null);
+        TopicSelector selector = new IncludeExcludeTopicSelector(config);
+        assertThat(selector.select("prefix_a")).isTrue();
+        assertThat(selector.select("prefix_b")).isTrue();
+        assertThat(selector.select("badman")).isFalse();
+    }
+
+    @Test
+    void testExclusionByPrefix() {
+        EnvelopeEncryption.TopicSelectorConfig config = getConfig(null, null, null, List.of("prefix_"));
+        TopicSelector selector = new IncludeExcludeTopicSelector(config);
+        assertThat(selector.select("prefix_a")).isFalse();
+        assertThat(selector.select("prefix_b")).isFalse();
+        assertThat(selector.select("arbitrary")).isTrue();
+    }
+
+    @Test
+    void testInclusionByPrefixOrName() {
+        EnvelopeEncryption.TopicSelectorConfig config = getConfig(List.of("included"), null, List.of("prefix_"), null);
+        TopicSelector selector = new IncludeExcludeTopicSelector(config);
+        assertThat(selector.select("included")).isTrue();
+        assertThat(selector.select("prefix_a")).isTrue();
+        assertThat(selector.select("prefix_b")).isTrue();
+        assertThat(selector.select("badman")).isFalse();
+    }
+
+    @Test
+    void testExclusionByPrefixOrName() {
+        EnvelopeEncryption.TopicSelectorConfig config = getConfig(null, List.of("excluded"), null, List.of("prefix_"));
+        TopicSelector selector = new IncludeExcludeTopicSelector(config);
+        assertThat(selector.select("excluded")).isFalse();
+        assertThat(selector.select("prefix_a")).isFalse();
+        assertThat(selector.select("prefix_b")).isFalse();
+        assertThat(selector.select("arbitrary")).isTrue();
+    }
+
+    @Test
+    void testExclusionBeatsInclusion() {
+        EnvelopeEncryption.TopicSelectorConfig config = getConfig(List.of("excluded"), List.of("excluded"), null, null);
+        TopicSelector selector = new IncludeExcludeTopicSelector(config);
+        assertThat(selector.select("excluded")).isFalse();
+    }
+
+    @Test
+    void testIncludePrefixWithExactExclusion() {
+        EnvelopeEncryption.TopicSelectorConfig config = getConfig(null, List.of("prefix_2"), List.of("prefix_"), null);
+        TopicSelector selector = new IncludeExcludeTopicSelector(config);
+        assertThat(selector.select("prefix_1")).isTrue();
+        assertThat(selector.select("prefix_2")).isFalse();
+        assertThat(selector.select("prefix_3")).isTrue();
+        assertThat(selector.select("arbitrary")).isFalse();
+    }
+
+    @Test
+    void testIncludePrefixWithPrefixExclusion() {
+        EnvelopeEncryption.TopicSelectorConfig config = getConfig(null, null, List.of("prefix_"), List.of("prefix_2"));
+        TopicSelector selector = new IncludeExcludeTopicSelector(config);
+        assertThat(selector.select("prefix_1")).isTrue();
+        assertThat(selector.select("prefix_2")).isFalse();
+        assertThat(selector.select("prefix_21")).isFalse();
+        assertThat(selector.select("prefix_3")).isTrue();
+        assertThat(selector.select("arbitrary")).isFalse();
+    }
+
+    @Test
+    void testIncludePrefixWithPrefixAndExactExclusion() {
+        EnvelopeEncryption.TopicSelectorConfig config = getConfig(null, List.of("prefix_2"), List.of("prefix_"), List.of("prefix_3"));
+        TopicSelector selector = new IncludeExcludeTopicSelector(config);
+        assertThat(selector.select("prefix_1")).isTrue();
+        assertThat(selector.select("prefix_2")).isFalse();
+        assertThat(selector.select("prefix_21")).isTrue();
+        assertThat(selector.select("prefix_31")).isFalse();
+        assertThat(selector.select("prefix_4")).isTrue();
+        assertThat(selector.select("arbitrary")).isFalse();
+    }
+
+    @Test
+    void testExcludePrefixBeatsIncludePrefix() {
+        EnvelopeEncryption.TopicSelectorConfig config = getConfig(null, null, List.of("prefix_"), List.of("prefix_"));
+        TopicSelector selector = new IncludeExcludeTopicSelector(config);
+        assertThat(selector.select("prefix_")).isFalse();
+        assertThat(selector.select("prefix_2")).isFalse();
+    }
+
+    @NonNull
+    private static EnvelopeEncryption.TopicSelectorConfig getConfig(List<String> includeNames, List<String> excludeNames, List<String> includeNamePrefixes,
+                                                                    List<String> excludeNamePrefixes) {
+        return new EnvelopeEncryption.TopicSelectorConfig(includeNames, excludeNames, includeNamePrefixes, excludeNamePrefixes);
+    }
+
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Resolves #811

With this change the User can configure the encryption filter to only apply Encryption logic to specific filters using inclusion/exclusion lists of exact topic names and topic name prefixes.

Example config:
```yaml
    - type: EnvelopeEncryption
      config:
        kms: VaultKmsService
        kmsConfig:
          vaultTransitEngineUrl: http://vault.vault.svc.cluster.local:8200/v1/transit
          vaultToken: myroottoken
        topics:
          includeNames: ["encryptedTopic"]
          excludeNames: ["unencryptedTopic"]
          includeNamePrefixes: ["include_prefix_"]
          excludeNamePrefixes: ["exclude_prefix_"]
        selector: TemplateKekSelector
        selectorConfig:
          template: "${topicName}"
```
Note this is a nonsensical configuration to show the 4 lists.

Selection Logic
1. Topic selection is permissive by default. So all topics would be selected for encryption if `topics` is not set, is set to null, or has only empty/missing/null lists.
2. If `includeNames` or `includeNamePrefixes` is not empty, then the topic must  match an inclusion rule to be selected.
3. If `excludeNames` or `excludeNamePrefixes` is not empty, then the topic must be included and not match any exclusion rules to be selected.
4. Exclusion beats inclusion, so (include["mytopic"], exclude["mytopic"]) would result in mytopic not being selected for inclusion.

More realistic examples:

1. Target only topic `encryptedTopic`, leave everything else unencrypted
```yaml
topics:
  includeNames: ["encryptedTopic"]
```
2. Target only topics with prefix `encrypted_`, leave everything else unencrypted
```yaml
topics:
  includeNamePrefixes: ["encrypted_"]
```
3. Target only topics with prefix `encrypted_` except for `encrypted_special`
```yaml
topics:
  includeNamePrefixes: ["encrypted_"]
  excludeNames: ["encrypted_special"]
```
4. Target all topics except for `always_unencrypted`
```yaml
topics:
  excludeNames: ["always_unencrypted"]
```
5. Target all topics except for topics prefixed `unencrypted_`
```yaml
topics:
  excludeNamePrefixes: ["unencrypted_"]
```
6. Target all topics except for topics prefixed `unencrypted_` and the topic `special_unencrypted`
```yaml
topics:
   excludeNames: ["special_unencrypted"]
  excludeNamePrefixes: ["unencrypted_"]
```

Why:
Currently we rely on the KMS response when resolving aliases to determine if encryption should be applied. We take the existence of the key to mean that we should encrypt. This has some negative implications. Like if most of the topics do NOT have a key then we will hit the KMS on every produce request going through the filter for those unencrypted topics. Also, there are more places where misconfiguration could mean writing unencrypted data to a topic we really hoped would be encrypted (mismatched key name in vault and kek selector).

By making the filter aware of which topics we require encryption for, we can make it an exceptional case that the key is not found in the KMS. This logic may change when we come to using features other than topic name for key selection, but it will likely always be useful to be able to configure which topics need some amount of encryption applied so we can short-circuit for unencrypted topics. We also reduce the cases where unencrypted data could be unexpectedly written because a configuration mismatch and key missing in the KMS would result in exceptions rather than unencrypted data forwarded to the cluster.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
