### PR TITLE
Fix shellcheck error

### DIFF
--- a/kroxylicious-app/src/assembly/run-java.sh
+++ b/kroxylicious-app/src/assembly/run-java.sh
@@ -592,7 +592,7 @@ first_arg=${1:-}
 if [ "${first_arg}" = "options" ]; then
   # Print out options only
   shift
-  options $@
+  options "$@"
   exit 0
 elif [ "${first_arg}" = "run" ]; then
   # Run is the default command, but can be given to allow "options"


### PR DESCRIPTION
### Type of change

- Enhancement
### Description

Contributes to #941

Fixes shellcheck error
```
In run-java.sh line 595:
  options $@
          ^-- SC2068 (error): Double quote array expansions to avoid re-splitting elements.
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
