### PR TITLE
Log connection failures at a level visible by default

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -8,6 +8,7 @@ This document gives a detailed breakdown of the various build processes and opti
   * [Build Prerequisites](#build-prerequisites)
   * [Build](#build)
     * [Formatting the Code](#formatting-the-code)
+    * [Logging Conventions](#logging-conventions)
   * [Run](#run)
     * [Debugging](#debugging)
   * [Building and pushing a Kroxylicious Container Image](#building-and-pushing-a-kroxylicious-container-image)
@@ -116,6 +117,19 @@ No one likes to argue about code formatting in pull requests, as project we take
 3. We apply [Checkstyle](https://checkstyle.org/) validation to the project as well. You can find our [agreed ruleset](etc/checkstyle-custom_checks.xml) in the `etc` folder. We bind checkstyle to the `verify` phase of the build so `mvn clean verify` will validate the code is acceptable. 
 4. We also employ [impsort-maven-plugin](https://code.revelc.net/impsort-maven-plugin/) to keep import order consistent which will re-order imports as part of the maven build.
 5. We also have [formatter-maven-plugin](https://code.revelc.net/formatter-maven-plugin/) which will apply the project code style rules, this is driven from the Eclipse code formatter, as part of the maven build cycle.
+
+### Logging Conventions
+
+We want to be careful with logging large amounts of data, for example stack traces, because we are potentially operating rapidly on many messages. Or Filters may be working at a 
+per-record level, we could generate a huge amount of log data. But we often do not want to completely silence errors as it renders them invisible to the user.
+
+Our convention is to use the slf4j fluent API to log once at a coarse level like WARN, but to only include cause Exceptions if the log level is set to a finer granularity:
+
+```java
+LOGGER.atWarn()
+  .setCause(LOGGER.isDebugEnabled() ? failureCause : null) #only log the full stacktrace at debug
+  .log("Something bad happened with failure message {}. Increase log level to DEBUG for stacktrace", failureCause.getMessage());
+```
 
 ## Run
 

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -138,7 +138,29 @@ KROXYLICIOUS_CLASSPATH="/path/to/any.jar:/path/to/libs/dir/*" kroxylicious-app/t
 ```
 
 ### Debugging
-Logging is turned off by default for better performance. In case you want to debug, logging should be turned on in the `example-proxy-config.yaml` file:
+Build with the `dist` profile as shown above.
+
+To start in debug mode, listening on port `5005`:
+```
+JAVA_ENABLE_DEBUG=true kroxylicious-app/target/kroxylicious-app-*-bin/kroxylicious-app-*/bin/kroxylicious-start.sh -c kroxylicious-app/example-proxy-config.yaml
+```
+To suspend until debugger attaches:
+```
+JAVA_ENABLE_DEBUG=true JAVA_DEBUG_SUSPEND=true  kroxylicious-app/target/kroxylicious-app-*-bin/kroxylicious-app-*/bin/kroxylicious-start.sh -c kroxylicious-app/example-proxy-config.yaml
+```
+To change the debug port
+```
+JAVA_ENABLE_DEBUG=true JAVA_DEBUG_PORT=1234  kroxylicious-app/target/kroxylicious-app-*-bin/kroxylicious-app-*/bin/kroxylicious-start.sh -c kroxylicious-app/example-proxy-config.yaml
+```
+To change the root logger level
+```
+KROXYLICIOUS_ROOT_LOG_LEVEL=DEBUG kroxylicious-app/target/kroxylicious-app-*-bin/kroxylicious-app-*/bin/kroxylicious-start.sh -c kroxylicious-app/example-proxy-config.yaml
+```
+To customise the log4j2 config file edit:
+```
+vim kroxylicious-app/target/kroxylicious-app-*-bin/kroxylicious-app-*/config/log4j2.yaml
+```
+Low level network and frame logging is turned off by default for better performance. In case you want to debug, logging should be turned on in the `example-proxy-config.yaml` file:
 ```yaml
   logNetwork: true
   logFrames: true

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -328,7 +328,7 @@ public class KafkaProxyFrontendHandler
                 Throwable failureCause = future.cause();
                 LOGGER.atWarn()
                         .setCause(LOGGER.isDebugEnabled() ? failureCause : null)
-                        .log("Connection to target cluster on {} failed, closing inbound channel: {}. Increase log level to DEBUG for stacktrace", remote,
+                        .log("Connection to target cluster on {} failed with: {}, closing inbound channel. Increase log level to DEBUG for stacktrace", remote,
                                 failureCause.getMessage());
                 inboundChannel.close();
             }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -325,7 +325,11 @@ public class KafkaProxyFrontendHandler
             else {
                 state = State.FAILED;
                 // Close the connection if the connection attempt has failed.
-                LOGGER.trace("Outbound connect error, closing inbound channel", future.cause());
+                Throwable failureCause = future.cause();
+                LOGGER.atWarn()
+                        .setCause(LOGGER.isDebugEnabled() ? failureCause : null)
+                        .log("Connection to target cluster on {} failed, closing inbound channel: {}. Increase log level to DEBUG for stacktrace", remote,
+                                failureCause.getMessage());
                 inboundChannel.close();
             }
         });


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

If the upstream connection from the proxy to a broker fails we now see an error log at WARN like:
```
kroxy  | 2024-02-12 21:42:16 <epollEventLoopGroup-5-6> WARN  io.kroxylicious.proxy.internal.KafkaProxyFrontendHandler:331 - Connection to target cluster on 127.0.0.1:9092 failed, closing inbound channel: finishConnect(..) failed: Connection refused: /127.0.0.1:9092. Increase log level to DEBUG for stacktrace
```

Addresses #983

Why:
Currently it's a trace level log if there is a connection failure to the upstream broker, for example if the upstream broker advertises itself at an unreachable address. This should be visible by default without swamping the logs with stack traces.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
