### PR TITLE
Test that Vault HttpClient and HttpRequest timeouts are configured

### DIFF
--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKms.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKms.java
@@ -80,7 +80,7 @@ public class VaultKms implements Kms<String, VaultEdek> {
         return uri.resolve(uri.getPath() + "/").normalize();
     }
 
-    private HttpClient createClient(SSLContext sslContext) {
+    /* exposed for testing */ HttpClient createClient(SSLContext sslContext) {
         HttpClient.Builder builder = HttpClient.newBuilder();
         if (sslContext != null) {
             builder.sslContext(sslContext);
@@ -179,7 +179,7 @@ public class VaultKms implements Kms<String, VaultEdek> {
         return new VaultEdekSerde();
     }
 
-    private HttpRequest.Builder createVaultRequest() {
+    /* exposed for testing */ HttpRequest.Builder createVaultRequest() {
         return HttpRequest.newBuilder()
                 .timeout(timeout)
                 .header("X-Vault-Token", vaultToken)


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Why:
Attempting to use a non-routable IP to provoke connection timeouts failed in some developer environments. We can instead test that the objects are configured as we expect and rely on the JDK apis.


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
