### PR TITLE
Per topic encrypt config

### DIFF
--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryption.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryption.java
@@ -84,7 +84,8 @@ public class EnvelopeEncryption<K, E> implements FilterFactory<EnvelopeEncryptio
 
         KekSelectorService<Object, K> ksPlugin = context.pluginInstance(KekSelectorService.class, configuration.selector());
         TopicNameBasedKekSelector<K> kekSelector = ksPlugin.buildSelector(kms, configuration.selectorConfig());
-        return new EnvelopeEncryptionFilter<>(encryptionManager, decryptionManager, kekSelector, executor);
+        TopicNameRouter<TopicNameBasedKekSelector<K>> router = TopicNameRouter.builder(kekSelector).build();
+        return new EnvelopeEncryptionFilter<>(encryptionManager, decryptionManager, router, executor);
     }
 
     @NonNull

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryption.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryption.java
@@ -159,6 +159,7 @@ public class EnvelopeEncryption<K, E> implements FilterFactory<EnvelopeEncryptio
         for (TopicConfiguration topic : configuration.topics) {
             KekSelectorService<Object, K> ksPlugin = context.pluginInstance(KekSelectorService.class, topic.selector());
             TopicNameBasedKekSelector<K> kekSelector = ksPlugin.buildSelector(kms, topic.selectorConfig());
+            // the order of inclusions and exclusions added to the builder matters, includes can negate prior excludes
             topic.includedTopicNames().forEach(topicName -> builder.addIncludeExactNameRoute(topicName, kekSelector));
             topic.includedTopicPrefixes().forEach(prefix -> builder.addIncludePrefixRoute(prefix, kekSelector));
             topic.excludedTopicNames().forEach(builder::addExcludeExactNameRoute);

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/TemplateKekSelector.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/TemplateKekSelector.java
@@ -10,13 +10,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.regex.Pattern;
 
 import io.kroxylicious.kms.service.Kms;
-import io.kroxylicious.kms.service.UnknownAliasException;
 import io.kroxylicious.proxy.plugin.Plugin;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -57,13 +54,6 @@ public class TemplateKekSelector<K> implements KekSelectorService<TemplateKekSel
             var collect = topicNames.stream()
                     .map(
                             topicName -> kms.resolveAlias(evaluateTemplate(topicName))
-                                    .exceptionallyCompose(e -> {
-                                        if (e instanceof UnknownAliasException
-                                                || (e instanceof CompletionException ce && ce.getCause() instanceof UnknownAliasException)) {
-                                            return CompletableFuture.completedFuture(null);
-                                        }
-                                        return CompletableFuture.failedFuture(e);
-                                    })
                                     .thenApply(kekId -> new Pair<>(topicName, kekId)))
                     .toList();
             return EnvelopeEncryptionFilter.join(collect).thenApply(list -> {

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/TopicNameRouter.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/TopicNameRouter.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static java.util.function.Function.identity;
+
+/**
+ * The topic name's router exists to route a topic name to a destination
+ * @param <D>
+ */
+public class TopicNameRouter<D> {
+
+    private TopicNameRouter(List<Route<D>> routes) {
+        Comparator<Route<D>> comparing = Comparator.comparingInt(Route::priority);
+        this.routes = routes.stream().sorted(comparing.reversed()).collect(Collectors.toList());
+    }
+
+    private interface Route<D> {
+
+        boolean test(String topicName);
+
+        int priority();
+
+        D destination();
+    }
+
+    record MatchAny<D>(D destination) implements Route<D> {
+
+        MatchAny {
+            Objects.requireNonNull(destination);
+        }
+
+        @Override
+        public boolean test(String topicName) {
+            return true;
+        }
+
+        @Override
+        public int priority() {
+            return 0;
+        }
+    }
+
+    record MatchExact<D>(String topicName, D destination) implements Route<D> {
+
+        MatchExact {
+            Objects.requireNonNull(topicName);
+            Objects.requireNonNull(destination);
+        }
+
+        @Override
+        public boolean test(String topicName) {
+            return topicName.equals(this.topicName);
+        }
+
+        @Override
+        public int priority() {
+            return Integer.MAX_VALUE;
+        }
+    }
+
+    record MatchPrefix<D>(String topicNamePrefix, D destination) implements Route<D> {
+
+        MatchPrefix {
+            Objects.requireNonNull(topicNamePrefix);
+            Objects.requireNonNull(destination);
+        }
+
+        @Override
+        public boolean test(String topicName) {
+            return topicName.startsWith(topicNamePrefix);
+        }
+
+        @Override
+        public int priority() {
+            return topicNamePrefix.length();
+        }
+    }
+
+    private final List<Route<D>> routes;
+
+    Map<D, Set<String>> route(Set<String> topicName) {
+        Map<String, D> nameToRoute = topicName.stream().collect(Collectors.toMap(identity(), this::route));
+        return invert(nameToRoute);
+    }
+
+    static <A, B> Map<A, Set<B>> invert(Map<B, A> map) {
+        HashMap<A, Set<B>> inverted = new HashMap<>();
+        for (Map.Entry<B, A> entry : map.entrySet()) {
+            Set<B> bs = inverted.computeIfAbsent(entry.getValue(), a -> new HashSet<>());
+            bs.add(entry.getKey());
+        }
+        return inverted;
+    }
+
+    @NonNull
+    private D route(String s) {
+        return routes.stream().filter(dRoute -> dRoute.test(s)).map(Route::destination).findFirst().orElseThrow();
+    }
+
+    static <D> Builder<D> builder(D defaultDestination) {
+        return new Builder<>(defaultDestination);
+    }
+
+    static class Builder<D> {
+        private final List<Route<D>> include = new ArrayList<>();
+        private final List<Route<D>> exclude = new ArrayList<>();
+        private final D defaultDestination;
+
+        Builder(D defaultDestination) {
+            Objects.requireNonNull(defaultDestination);
+            this.defaultDestination = defaultDestination;
+            this.include.add(new MatchAny<>(defaultDestination));
+        }
+
+        TopicNameRouter<D> build() {
+            ArrayList<Route<D>> allRoutes = new ArrayList<>(include);
+            allRoutes.addAll(exclude);
+            return new TopicNameRouter<>(allRoutes);
+        }
+
+        public Builder<D> addIncludeExactNameRoute(String topicName, D destination) {
+            removeExactFromExcludes(topicName);
+            if (containsExactName(topicName, include)) {
+                throw new IllegalStateException(topicName + " already has an inclusion route ");
+            }
+            this.include.add(new MatchExact<>(topicName, destination));
+            return this;
+        }
+
+        private boolean containsExactName(String topicName, List<Route<D>> routes) {
+            return routes.stream().anyMatch(dRoute -> dRoute instanceof TopicNameRouter.MatchExact<D> m && m.topicName.equals(topicName));
+        }
+
+        private boolean containsPrefix(String prefix, List<Route<D>> routes) {
+            return routes.stream().anyMatch(dRoute -> dRoute instanceof TopicNameRouter.MatchPrefix<D> m && m.topicNamePrefix.equals(prefix));
+        }
+
+        public Builder<D> addIncludePrefixRoute(String prefix, D destination) {
+            if (containsPrefix(prefix, include)) {
+                throw new IllegalStateException(prefix + " prefix already has an inclusion route ");
+            }
+            removePrefixFromExcludes(prefix);
+            this.include.add(new MatchPrefix<>(prefix, destination));
+            return this;
+        }
+
+        private void removeExactFromExcludes(String topicName) {
+            this.exclude.removeIf(excludedRoute -> excludedRoute instanceof TopicNameRouter.MatchExact<D> matchExact && matchExact.topicName.equals(topicName));
+        }
+
+        private void removePrefixFromExcludes(String prefix) {
+            this.exclude.removeIf(excludedRoute -> excludedRoute instanceof TopicNameRouter.MatchPrefix<D> matchPrefix && matchPrefix.topicNamePrefix.equals(prefix));
+        }
+
+        public Builder<D> addExcludePrefixRoute(String prefix) {
+            if (!containsPrefix(prefix, include)) {
+                this.exclude.add(new MatchPrefix<>(prefix, defaultDestination));
+            }
+            return this;
+        }
+
+        public Builder<D> addExcludeExactNameRoute(String topicName) {
+            if (!containsExactName(topicName, include)) {
+                this.exclude.add(new MatchExact<>(topicName, defaultDestination));
+            }
+            return this;
+        }
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/TopicNameRouter.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/TopicNameRouter.java
@@ -136,7 +136,7 @@ public class TopicNameRouter<D> {
         }
 
         public Builder<D> addIncludeExactNameRoute(String topicName, D destination) {
-            removeExactFromExcludes(topicName);
+            removeExclustionsMatchedExactly(topicName);
             if (containsExactName(topicName, include)) {
                 throw new IllegalStateException(topicName + " already has an inclusion route ");
             }
@@ -156,17 +156,18 @@ public class TopicNameRouter<D> {
             if (containsPrefix(prefix, include)) {
                 throw new IllegalStateException(prefix + " prefix already has an inclusion route ");
             }
-            removePrefixFromExcludes(prefix);
+            removeExclusionsMatchedByPrefix(prefix);
             this.include.add(new MatchPrefix<>(prefix, destination));
             return this;
         }
 
-        private void removeExactFromExcludes(String topicName) {
+        private void removeExclustionsMatchedExactly(String topicName) {
             this.exclude.removeIf(excludedRoute -> excludedRoute instanceof TopicNameRouter.MatchExact<D> matchExact && matchExact.topicName.equals(topicName));
         }
 
-        private void removePrefixFromExcludes(String prefix) {
-            this.exclude.removeIf(excludedRoute -> excludedRoute instanceof TopicNameRouter.MatchPrefix<D> matchPrefix && matchPrefix.topicNamePrefix.equals(prefix));
+        private void removeExclusionsMatchedByPrefix(String prefix) {
+            this.exclude.removeIf(excludedRoute -> excludedRoute instanceof TopicNameRouter.MatchPrefix<D> matchPrefix && matchPrefix.topicNamePrefix.startsWith(prefix));
+            this.exclude.removeIf(excludedRoute -> excludedRoute instanceof TopicNameRouter.MatchExact<D> matchPrefix && matchPrefix.topicName.startsWith(prefix));
         }
 
         public Builder<D> addExcludePrefixRoute(String prefix) {

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionFilterTest.java
@@ -130,7 +130,8 @@ class EnvelopeEncryptionFilterTest {
 
         when(decryptionManager.decrypt(any(), anyInt(), any(), any())).thenReturn(CompletableFuture.completedFuture(RecordTestUtils.singleElementMemoryRecords("decrypt", "decrypt")));
 
-        encryptionFilter = new EnvelopeEncryptionFilter<>(encryptionManager, decryptionManager, kekSelector, new FilterThreadExecutor(Runnable::run));
+        TopicNameRouter<TopicNameBasedKekSelector<String>> build = TopicNameRouter.builder(kekSelector).build();
+        encryptionFilter = new EnvelopeEncryptionFilter<>(encryptionManager, decryptionManager, build, new FilterThreadExecutor(Runnable::run));
     }
 
     @Test

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionTest.java
@@ -25,7 +25,7 @@ class EnvelopeEncryptionTest {
 
     @Test
     void shouldInitAndCreateFilter() {
-        EnvelopeEncryption.Config config = new EnvelopeEncryption.Config("KMS", null, "SELECTOR", null);
+        EnvelopeEncryption.Config config = new EnvelopeEncryption.Config("KMS", null, "SELECTOR", null, null);
         var ee = new EnvelopeEncryption<>();
         var fc = mock(FilterFactoryContext.class);
         var kmsService = mock(KmsService.class);
@@ -47,7 +47,7 @@ class EnvelopeEncryptionTest {
 
     @Test
     void testKmsCacheConfigDefaults() {
-        EnvelopeEncryption.KmsCacheConfig config = new EnvelopeEncryption.Config("vault", 1L, "selector", 1L).kmsCache();
+        EnvelopeEncryption.KmsCacheConfig config = new EnvelopeEncryption.Config("vault", 1L, "selector", 1L, null).kmsCache();
         assertThat(config.decryptedDekCacheSize()).isEqualTo(1000);
         assertThat(config.decryptedDekExpireAfterAccessDuration()).isEqualTo(Duration.ofHours(1));
         assertThat(config.resolvedAliasCacheSize()).isEqualTo(1000);

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/TopicNameRouterTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/TopicNameRouterTest.java
@@ -78,6 +78,26 @@ class TopicNameRouterTest {
         assertThat(routed).isEqualTo(Map.of(2L, Set.of("a", "ab", "abcd"), 1L, Set.of("other"), 3L, Set.of("abc")));
     }
 
+    @Test
+    void aShorterPrefixIncludedAfterANameWasExcludedOverridesIt() {
+        TopicNameRouter<Long> router = TopicNameRouter.builder(1L)
+                .addIncludePrefixRoute("a", 2L)
+                .addExcludeExactNameRoute("abc")
+                .addIncludePrefixRoute("ab", 3L).build();
+        Map<Long, Set<String>> routed = router.route(Set.of("a", "ab", "abc", "abcd", "other"));
+        assertThat(routed).isEqualTo(Map.of(2L, Set.of("a"), 1L, Set.of("other"), 3L, Set.of("ab", "abc", "abcd")));
+    }
+
+    @Test
+    void aShorterPrefixIncludedAfterALongerPrefixWasExcludedOverridesIt() {
+        TopicNameRouter<Long> router = TopicNameRouter.builder(1L)
+                .addIncludePrefixRoute("a", 2L)
+                .addExcludePrefixRoute("abcd")
+                .addIncludePrefixRoute("abc", 3L).build();
+        Map<Long, Set<String>> routed = router.route(Set.of("a", "ab", "abc", "abcd", "abcde", "other"));
+        assertThat(routed).isEqualTo(Map.of(2L, Set.of("a", "ab"), 1L, Set.of("other"), 3L, Set.of("abc", "abcde", "abcd")));
+    }
+
     /**
      * This is thinking of the case where we might have two configurations like:
      * 1. encrypt prefix abc_def using cipher ChaCha20

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/TopicNameRouterTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/TopicNameRouterTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TopicNameRouterTest {
+
+    @Test
+    void defaultRoute() {
+        TopicNameRouter<Long> router = TopicNameRouter.builder(1L).build();
+        Map<Long, Set<String>> routed = router.route(Set.of("ab"));
+        assertThat(routed).isEqualTo(Map.of(1L, Set.of("ab")));
+    }
+
+    @Test
+    void exactNameRoute() {
+        TopicNameRouter<Long> router = TopicNameRouter.builder(1L).addIncludeExactNameRoute("exact", 2L).build();
+        Map<Long, Set<String>> routed = router.route(Set.of("exact", "other"));
+        assertThat(routed).isEqualTo(Map.of(2L, Set.of("exact"), 1L, Set.of("other")));
+    }
+
+    @Test
+    void exactMultipleRoutesToSameDestination() {
+        TopicNameRouter<Long> router = TopicNameRouter.builder(1L).addIncludeExactNameRoute("a", 2L).addIncludeExactNameRoute("b", 2L).build();
+        Map<Long, Set<String>> routed = router.route(Set.of("a", "b", "other"));
+        assertThat(routed).isEqualTo(Map.of(2L, Set.of("a", "b"), 1L, Set.of("other")));
+    }
+
+    @Test
+    void prefixRoute() {
+        TopicNameRouter<Long> router = TopicNameRouter.builder(1L).addIncludePrefixRoute("ab", 2L).build();
+        Map<Long, Set<String>> routed = router.route(Set.of("ab", "abc", "a", "other"));
+        assertThat(routed).isEqualTo(Map.of(2L, Set.of("ab", "abc"), 1L, Set.of("a", "other")));
+    }
+
+    @Test
+    void excludePrefixRoute() {
+        TopicNameRouter<Long> router = TopicNameRouter.builder(1L).addIncludePrefixRoute("a", 2L).addExcludePrefixRoute("abc").build();
+        Map<Long, Set<String>> routed = router.route(Set.of("a", "ab", "abc", "abcd", "other"));
+        assertThat(routed).isEqualTo(Map.of(2L, Set.of("a", "ab"), 1L, Set.of("abc", "abcd", "other")));
+    }
+
+    @Test
+    void excludeExactRoute() {
+        TopicNameRouter<Long> router = TopicNameRouter.builder(1L).addIncludePrefixRoute("a", 2L).addExcludeExactNameRoute("abc").build();
+        Map<Long, Set<String>> routed = router.route(Set.of("a", "ab", "abc", "abcd", "other"));
+        assertThat(routed).isEqualTo(Map.of(2L, Set.of("a", "ab", "abcd"), 1L, Set.of("abc", "other")));
+    }
+
+    @Test
+    void aPreviouslyExcludedPrefixRouteCanBeReIncludedLater() {
+        TopicNameRouter<Long> router = TopicNameRouter.builder(1L)
+                .addIncludePrefixRoute("a", 2L)
+                .addExcludePrefixRoute("abc")
+                .addIncludePrefixRoute("abc", 3L).build();
+        Map<Long, Set<String>> routed = router.route(Set.of("a", "ab", "abc", "abcd", "other"));
+        assertThat(routed).isEqualTo(Map.of(2L, Set.of("a", "ab"), 1L, Set.of("other"), 3L, Set.of("abc", "abcd")));
+    }
+
+    @Test
+    void aPreviouslyExcludedExactRouteCanBeReIncludedLater() {
+        TopicNameRouter<Long> router = TopicNameRouter.builder(1L)
+                .addIncludePrefixRoute("a", 2L)
+                .addExcludeExactNameRoute("abc")
+                .addIncludeExactNameRoute("abc", 3L).build();
+        Map<Long, Set<String>> routed = router.route(Set.of("a", "ab", "abc", "abcd", "other"));
+        assertThat(routed).isEqualTo(Map.of(2L, Set.of("a", "ab", "abcd"), 1L, Set.of("other"), 3L, Set.of("abc")));
+    }
+
+    /**
+     * This is thinking of the case where we might have two configurations like:
+     * 1. encrypt prefix abc_def using cipher ChaCha20
+     * 2. encrypt prefix abc_ using cipher AES excluding prefix abc_def
+     * It is a little redundant that a later configuration excludes abc_def, but we can unambiguously say
+     * that abc_def should be handled by configuration 1.
+     */
+    @Test
+    void aPreviouslyIncludedExactRouteBeatsAnExclusion() {
+        TopicNameRouter<Long> router = TopicNameRouter.builder(1L)
+                .addIncludeExactNameRoute("abc", 3L)
+                .addIncludePrefixRoute("a", 2L)
+                .addExcludeExactNameRoute("abc").build();
+        Map<Long, Set<String>> routed = router.route(Set.of("a", "ab", "abc", "abcd", "other"));
+        assertThat(routed).isEqualTo(Map.of(2L, Set.of("a", "ab", "abcd"), 1L, Set.of("other"), 3L, Set.of("abc")));
+    }
+
+    @Test
+    void testMoreSpecificPrefixBeatsLessSpecificPrefix() {
+        TopicNameRouter<Long> router = TopicNameRouter.builder(1L).addIncludePrefixRoute("a", 2L).addIncludePrefixRoute("ab", 3L).build();
+        Map<Long, Set<String>> routed = router.route(Set.of("ab", "abc", "a", "other"));
+        assertThat(routed).isEqualTo(Map.of(1L, Set.of("other"), 2L, Set.of("a"), 3L, Set.of("ab", "abc")));
+    }
+
+    @Test
+    void testSamePrefixCannotRouteToMultipleDestinations() {
+        assertThatThrownBy(() -> {
+            TopicNameRouter.builder(1L).addIncludePrefixRoute("a", 2L).addIncludePrefixRoute("ab", 3L).addIncludePrefixRoute("ab", 4L);
+        }).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void testSameExactNameCannotRouteToMultipleDestinations() {
+        assertThatThrownBy(() -> {
+            TopicNameRouter.builder(1L).addIncludeExactNameRoute("a", 2L).addIncludeExactNameRoute("a", 3L);
+        }).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void exactNameRouteBeatsPrefixRoute() {
+        long defaultDestination = 1L;
+        long exactNameDestination = 2L;
+        long prefixDestination = 3L;
+        TopicNameRouter<Long> router = TopicNameRouter.builder(defaultDestination)
+                .addIncludeExactNameRoute("ab", exactNameDestination)
+                .addIncludePrefixRoute("a", prefixDestination)
+                .build();
+        Map<Long, Set<String>> routed = router.route(Set.of("a", "ab", "abc", "other"));
+        assertThat(routed).isEqualTo(Map.of(defaultDestination, Set.of("other"), exactNameDestination, Set.of("ab"), prefixDestination, Set.of("a", "abc")));
+    }
+
+    @Test
+    void defaultRouteRequired() {
+        assertThatThrownBy(() -> {
+            TopicNameRouter.builder(null);
+        }).isInstanceOf(NullPointerException.class);
+    }
+
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Resolves https://github.com/kroxylicious/kroxylicious/issues/811

With this change the User can configure the encryption filter to only apply Encryption logic to specific filters using inclusion/exclusion lists of exact topic names and topic name prefixes.

### Additional Context

Example config:
```yaml
    - type: EnvelopeEncryption
      config:
        kms: VaultKmsService
        kmsConfig:
          vaultTransitEngineUrl: http://vault.vault.svc.cluster.local:8200/v1/transit
          vaultToken: myroottoken
        topics:
        -  includedTopicNames: ["encryptedTopic"]
           excludedTopicNames: ["unencryptedTopic"]
           includedTopicPrefixes: ["include_prefix_"]
           excludedTopicPrefixes: ["exclude_prefix_"]
           selector: TemplateKekSelector
           selectorConfig:
             template: "${topicName}"
```

Note this is a nonsensical configuration to show the 4 lists.

The existing `selector` and `selectorConfig` fields are deprecated. The `topics` field is preferred over them. If only the legacy fields are present then there would be a problem as the meaning of an alias not being found in the KMS has changed. (perhaps we should remove the old fields entirely and document the change instead).

An alias not being found is now considered an exception. If a topic configuration includes topic X then it is expected that we want to encrypt that topic.

Routing Logic
1. Topic routing is exclusive by default. So no topics would be selected for encryption if `topics` is set to an empty list.
2. exact-topic-name matches are the highest priority rule
3. the same exact-topic-name cannot be routed to multiple destinations
4. prefix-matches are lower priority that exact-topic-name
5. longer prefixes are higher priority than shorter prefixes
6. the same prefix cannot be routed to multiple destinations
7. inclusion beats exclusion, so it's okay for configuration 1 to say "include prefix a, but exclude prefix ab", then configuration 2 to say "include prefix ab", topic "ab" would be routed to configuration 2.

The end result is that every topicName should be unambiguously routed to either a kek selector, or the default exclusive behaviour which will map the topicName to null and proceed to treat it as an unencrypted topic.

This PR introduces the `TopicNameRouter`, which aims to deterministically route every topic name to a single destination. The destination is left generic, currently the destination is a TopicNameBasedKekSelector but if we add more configuration to the `TopicConfiguration` like the cipher spec then the thing we are routing to will likely change. By making it generic hopefully the `TopicRouter` won't have to be modified, we will just route different things through it.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
