### PR TITLE
Add test for parcel binary compatibility

### DIFF
--- a/kroxylicious-filters/kroxylicious-encryption/pom.xml
+++ b/kroxylicious-filters/kroxylicious-encryption/pom.xml
@@ -74,6 +74,26 @@
 
         <!-- third party dependencies - test -->
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-kms-provider-kroxylicious-inmemory</artifactId>
             <scope>test</scope>

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/ParcelTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/ParcelTest.java
@@ -6,9 +6,16 @@
 
 package io.kroxylicious.filter.encryption.inband;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import org.apache.kafka.common.header.internals.RecordHeader;
@@ -18,13 +25,20 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.common.reflect.ClassPath;
+
 import io.kroxylicious.filter.encryption.ParcelVersion;
 import io.kroxylicious.filter.encryption.RecordField;
 import io.kroxylicious.filter.encryption.records.BatchAwareMemoryRecordsBuilder;
 import io.kroxylicious.test.record.RecordTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class ParcelTest {
 
@@ -38,7 +52,8 @@ class ParcelTest {
                         new RecordHeader("foo", new byte[]{ 4, 5, 6 }))), // header with non-null value
 
                 Arguments.of(EnumSet.of(RecordField.RECORD_VALUE, RecordField.RECORD_HEADER_VALUES), RecordTestUtils.record((ByteBuffer) null)),
-                Arguments.of(EnumSet.of(RecordField.RECORD_VALUE, RecordField.RECORD_HEADER_VALUES), RecordTestUtils.record(ByteBuffer.wrap(new byte[]{ 1, 2, 3 }))), // no headers
+                Arguments.of(EnumSet.of(RecordField.RECORD_VALUE, RecordField.RECORD_HEADER_VALUES), RecordTestUtils.record(ByteBuffer.wrap(new byte[]{ 1, 2, 3 }))),
+                // no headers
                 Arguments.of(EnumSet.of(RecordField.RECORD_VALUE, RecordField.RECORD_HEADER_VALUES), RecordTestUtils.record(ByteBuffer.wrap(new byte[]{ 1, 2, 3 }),
                         new RecordHeader("foo", null))), // header with null value
                 Arguments.of(EnumSet.of(RecordField.RECORD_VALUE, RecordField.RECORD_HEADER_VALUES), RecordTestUtils.record(ByteBuffer.wrap(new byte[]{ 1, 2, 3 }),
@@ -58,11 +73,127 @@ class ParcelTest {
         buffer.flip();
 
         BatchAwareMemoryRecordsBuilder mockBuilder = Mockito.mock(BatchAwareMemoryRecordsBuilder.class);
-        Parcel.readParcel(ParcelVersion.V1, buffer, record, (v, h) -> {
-            mockBuilder.appendWithOffset(record.offset(), record.timestamp(), record.key(), v, h);
-        });
+        Parcel.readParcel(ParcelVersion.V1, buffer, record, (v, h) -> mockBuilder.appendWithOffset(record.offset(), record.timestamp(), record.key(), v, h));
         verify(mockBuilder).appendWithOffset(record.offset(), record.timestamp(), record.key(), expectedValue, record.headers());
         assertThat(buffer.remaining()).isEqualTo(0);
+    }
+
+    private record Header(@JsonProperty(required = true) ByteBuffer keyBase64, ByteBuffer valueBase64) {}
+
+    private record ParcelContents(ByteBuffer valueBase64, @JsonProperty(required = true) List<ParcelTest.Header> headers) {
+        org.apache.kafka.common.header.Header[] kafkaHeaders() {
+            return this.headers.stream().map(header -> new RecordHeader(header.keyBase64(), header.valueBase64())).toArray(org.apache.kafka.common.header.Header[]::new);
+        }
+    }
+
+    private record Exemplar(ByteBuffer serializedBase64) {}
+
+    private record SerializationOptions(@JsonProperty(required = true) Set<RecordField> recordFields) {}
+
+    private record ParcelSerializationExemplar(@JsonProperty(required = true) ParcelContents originalRecordContents,
+                                               @JsonProperty(required = true) ParcelContents deserializedParcelContents,
+                                               @JsonProperty(required = true) SerializationOptions serializationOptions,
+                                               Map<ParcelVersion, Exemplar> exemplars) {
+
+    }
+
+    private record NamedExemplars(ParcelSerializationExemplar exemplars, String name) {
+        Stream<NamedExemplar> flatten() {
+            ParcelContents originalRecordContents = exemplars.originalRecordContents;
+            ParcelContents deserializedParcelContents = exemplars.deserializedParcelContents;
+            return Arrays.stream(ParcelVersion.values()).map(version -> {
+                Exemplar exemplar = exemplars.exemplars.get(version);
+                return new NamedExemplar(originalRecordContents, deserializedParcelContents, version, exemplar, name, exemplars.serializationOptions);
+            });
+        }
+    }
+
+    private record NamedExemplar(ParcelContents originalRecordContents, ParcelContents deserializedParcelContents, ParcelVersion version, Exemplar exemplar, String name,
+                                 SerializationOptions options) {
+
+        public ByteBuffer serialized() {
+            return exemplar.serializedBase64();
+        }
+
+        public String serializedBase64() {
+            return toBase64(serialized());
+        }
+    }
+
+    private static final Pattern TEST_RESOURCE_FILTER = Pattern.compile("serialization/parcel/.*\\.yaml");
+
+    private static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory());
+
+    private static Stream<Arguments> exemplarStream() throws IOException {
+        return ClassPath.from(ParcelTest.class.getClassLoader()).getResources().stream()
+                .filter(ri -> TEST_RESOURCE_FILTER.matcher(ri.getResourceName()).matches())
+                .map(resourceInfo -> {
+                    try {
+                        ParcelSerializationExemplar parcelSerializationExemplar = MAPPER.reader()
+                                .readValue(resourceInfo.asByteSource().openStream(), ParcelSerializationExemplar.class);
+                        return new NamedExemplars(parcelSerializationExemplar, resourceInfo.getResourceName());
+                    }
+                    catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                })
+                .flatMap(NamedExemplars::flatten)
+                .map(exemplar -> Arguments.of(exemplar.name + " - " + exemplar.version, exemplar));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("exemplarStream")
+    void shouldDeserializeExpectedContentsFromBytes(String name, NamedExemplar exemplar) {
+        failOnVersionWithoutExemplar(exemplar);
+        Record mock = Mockito.mock(Record.class);
+        when(mock.headers()).thenReturn(new org.apache.kafka.common.header.Header[0]);
+        ParcelContents expected = exemplar.deserializedParcelContents;
+        try {
+            Parcel.readParcel(exemplar.version, exemplar.serialized(), mock, (byteBuffer, headers) -> {
+                assertThat(expected.kafkaHeaders()).describedAs("headers").isEqualTo(headers);
+                assertThat(toBase64(byteBuffer)).describedAs("parcel originalRecordContents buffer").isEqualTo(toBase64(expected.valueBase64));
+            });
+        }
+        catch (Exception e) {
+            fail("failed to deserialize parcel from bytes: " + exemplar.serializedBase64(), e);
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("exemplarStream")
+    void shouldSerializeToExpectedBytes(String name, NamedExemplar exemplar) {
+        failOnVersionWithoutExemplar(exemplar);
+        String base64Encoded = serialize(exemplar.originalRecordContents, exemplar.version, exemplar.options);
+        assertThat(base64Encoded).describedAs("serialized parcel").isEqualTo(exemplar.serializedBase64());
+    }
+
+    private static void failOnVersionWithoutExemplar(NamedExemplar exemplar) {
+        if (exemplar.exemplar == null) {
+            try {
+                String base64Encoded = serialize(exemplar.originalRecordContents, exemplar.version, exemplar.options);
+                fail("exemplar had no serialized binary for parcel version " + exemplar.version + ", serialized b64 output for this version is: " + base64Encoded);
+            }
+            catch (Exception e) {
+                fail("exemplar had no serialized binary for parcel version " + exemplar.version + " and serialization with version failed", e);
+            }
+        }
+    }
+
+    private static String serialize(ParcelContents parcelContents, ParcelVersion version, SerializationOptions serializationOptions) {
+        Record record = RecordTestUtils.record(parcelContents.valueBase64(), parcelContents.kafkaHeaders());
+        ByteBuffer parcelBuffer = ByteBuffer.allocate(1024);
+        Parcel.writeParcel(version, serializationOptions.recordFields, record, parcelBuffer);
+        parcelBuffer.flip();
+        return toBase64(parcelBuffer);
+    }
+
+    private static String toBase64(ByteBuffer buffer) {
+        if (buffer == null) {
+            return null;
+        }
+        byte[] dst = new byte[buffer.limit()];
+        buffer.get(dst);
+        return Base64.getEncoder().encodeToString(dst);
     }
 
 }

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/resources/serialization/parcel/header-serialization-disabled.json.yaml
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/resources/serialization/parcel/header-serialization-disabled.json.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+originalRecordContents:
+  valueBase64: aGkgLW4K
+  headers:
+    - keyBase64: aGVsbG8K
+      valueBase64: dGhlcmUK
+deserializedParcelContents:
+  valueBase64: aGkgLW4K
+  headers: []
+serializationOptions:
+  recordFields:
+    - RECORD_VALUE
+exemplars:
+  V1:
+    serializedBase64: DGhpIC1uCgM=

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/resources/serialization/parcel/record-with-header.json.yaml
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/resources/serialization/parcel/record-with-header.json.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+originalRecordContents:
+  valueBase64: aGkgLW4K
+  headers:
+    - keyBase64: aGVsbG8K
+      valueBase64: dGhlcmUK
+deserializedParcelContents:
+  valueBase64: aGkgLW4K
+  headers:
+    - keyBase64: aGVsbG8K
+      valueBase64: dGhlcmUK
+serializationOptions:
+  recordFields:
+    - RECORD_VALUE
+    - RECORD_HEADER_VALUES
+exemplars:
+  V1:
+    serializedBase64: DGhpIC1uCgIGaGVsbG8KDHRoZXJlCg==

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/resources/serialization/parcel/record-with-headers.json.yaml
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/resources/serialization/parcel/record-with-headers.json.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+originalRecordContents:
+  valueBase64: aGkgLW4K
+  headers:
+    - keyBase64: aGVsbG8K
+      valueBase64: dGhlcmUK
+    - keyBase64: YWJjCg==
+      valueBase64: ZGVmCg==
+deserializedParcelContents:
+  valueBase64: aGkgLW4K
+  headers:
+    - keyBase64: aGVsbG8K
+      valueBase64: dGhlcmUK
+    - keyBase64: YWJjCg==
+      valueBase64: ZGVmCg==
+serializationOptions:
+  recordFields:
+    - RECORD_VALUE
+    - RECORD_HEADER_VALUES
+exemplars:
+  V1:
+    serializedBase64: DGhpIC1uCgQGaGVsbG8KDHRoZXJlCgRhYmMKCGRlZgo=

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/resources/serialization/parcel/record-with-null-header-value.json.yaml
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/resources/serialization/parcel/record-with-null-header-value.json.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+originalRecordContents:
+  valueBase64: aGkgLW4K
+  headers:
+    - keyBase64: aGVsbG8K
+      valueBase64: null
+deserializedParcelContents:
+  valueBase64: aGkgLW4K
+  headers:
+    - keyBase64: aGVsbG8K
+      valueBase64: null
+serializationOptions:
+  recordFields:
+    - RECORD_VALUE
+    - RECORD_HEADER_VALUES
+exemplars:
+  V1:
+    serializedBase64: DGhpIC1uCgIGaGVsbG8KAQ==

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/resources/serialization/parcel/record-with-null-value.json.yaml
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/resources/serialization/parcel/record-with-null-value.json.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+originalRecordContents:
+  valueBase64: null
+  headers: []
+deserializedParcelContents:
+  valueBase64: null
+  headers: []
+serializationOptions:
+  recordFields:
+    - RECORD_VALUE
+    - RECORD_HEADER_VALUES
+exemplars:
+  V1:
+    serializedBase64: AQA=

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/resources/serialization/parcel/record-with-value.json.yaml
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/resources/serialization/parcel/record-with-value.json.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+originalRecordContents:
+  valueBase64: aGkgLW4K
+  headers: []
+deserializedParcelContents:
+  valueBase64: aGkgLW4K
+  headers: []
+serializationOptions:
+  recordFields:
+    - RECORD_VALUE
+    - RECORD_HEADER_VALUES
+exemplars:
+  V1:
+    serializedBase64: DGhpIC1uCgA=

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/resources/serialization/parcel/value-and-header-serialization-disabled.json.yaml
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/resources/serialization/parcel/value-and-header-serialization-disabled.json.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+originalRecordContents:
+  valueBase64: aGkgLW4K
+  headers:
+    - keyBase64: aGVsbG8K
+      valueBase64: dGhlcmUK
+deserializedParcelContents:
+  valueBase64: null
+  headers: []
+serializationOptions:
+  recordFields: []
+exemplars:
+  V1:
+    serializedBase64: AwM=

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/resources/serialization/parcel/value-serialization-disabled.json.yaml
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/resources/serialization/parcel/value-serialization-disabled.json.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+originalRecordContents:
+  valueBase64: aGkgLW4K
+  headers:
+    - keyBase64: aGVsbG8K
+      valueBase64: dGhlcmUK
+deserializedParcelContents:
+  valueBase64: null
+  headers:
+    - keyBase64: aGVsbG8K
+      valueBase64: dGhlcmUK
+serializationOptions:
+  recordFields:
+    - RECORD_HEADER_VALUES
+exemplars:
+  V1:
+    serializedBase64: AwIGaGVsbG8KDHRoZXJlCg==


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Contributes to #992, still TODO equivalent tests for Wrapper

We need tests to prove that Kroxylicious can read older binary versions of Parcels. We also need tests to prove that it can write older binary versions. Comparing the output bytes is a blunt tool and will be fiddly to track down the reason for failures, but we must always be able to decode those bytes that we forwarded to Kafka to be stored forever, so starting and ending with the bytes is worth it to prove it really can.

The tests check:
1. an input Record, serialized with specified encryption configuration and parcel version produces expected bytes
2. the serialized bytes can be deserialized to produce the expected record features (Parcel deserializes in terms of value and headers only).

Note that input features may differ from deserialized features becase we can opt to not serialize headers or values despite them being present in the record.

The tests will immediately fail when a new ParcelVersion is added to the enum, requiring a new exemplar to be added for the new version to all existing json exemplars. In this case the test will display the serialized base64 in the failure message (if it can), which could be added to the exemplar file when you are happy with the output.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).