### PR TITLE
Add hardcoded maximum frame size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.5.0
 
-
+* [#997](https://github.com/kroxylicious/kroxylicious/issues/997): Add hardcoded maximum frame size
 * [#782](https://github.com/kroxylicious/kroxylicious/issues/782): Securely handle the HashiCorp Vault Token in Kroxylicious configuration
 * [#973](https://github.com/kroxylicious/kroxylicious/pull/973): Remove deprecated CompositeFilter and it's documentation
 * [#935](https://github.com/kroxylicious/kroxylicious/pull/935): Enable user to configure alternative source of keys for vault KMS client

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
@@ -70,10 +70,13 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     }
 
     private KroxyliciousClients clients() {
+        return clients(onlyVirtualCluster());
+    }
+
+    private String onlyVirtualCluster() {
         int numVirtualClusters = kroxyliciousConfig.virtualClusters().size();
         if (numVirtualClusters == 1) {
-            String onlyCluster = kroxyliciousConfig.virtualClusters().keySet().stream().findFirst().orElseThrow();
-            return clients(onlyCluster);
+            return kroxyliciousConfig.virtualClusters().keySet().stream().findFirst().orElseThrow();
         }
         else {
             throw new AmbiguousVirtualClusterException(
@@ -89,9 +92,21 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     @NonNull
     private Map<String, Object> buildDefaultClientConfiguration(String virtualCluster) {
         Map<String, Object> defaultClientConfig = new HashMap<>();
-        defaultClientConfig.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, KroxyliciousConfigUtils.bootstrapServersFor(virtualCluster, kroxyliciousConfig));
+        defaultClientConfig.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, getBootstrapAddress(virtualCluster));
         configureClientTls(virtualCluster, defaultClientConfig);
         return defaultClientConfig;
+    }
+
+    @Override
+    @NonNull
+    public String getBootstrapAddress() {
+        return getBootstrapAddress(onlyVirtualCluster());
+    }
+
+    @Override
+    @NonNull
+    public String getBootstrapAddress(String virtualCluster) {
+        return KroxyliciousConfigUtils.bootstrapServersFor(virtualCluster, kroxyliciousConfig);
     }
 
     private void configureClientTls(String virtualCluster, Map<String, Object> defaultClientConfig) {

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousTester.java
@@ -252,4 +252,15 @@ public interface KroxyliciousTester extends Closeable {
      * @param clusterName the name of the virtual cluster from which to delete the topics.
      */
     void deleteTopics(String clusterName);
+
+    /**
+     * @return the bootstrap address of the only virtual cluster
+     * @throws AmbiguousVirtualClusterException if this tester is for a Kroxylicious configured with multiple virtual clusters
+     */
+    String getBootstrapAddress();
+
+    /**
+     * @return the bootstrap address of the named virtual cluster
+     */
+    String getBootstrapAddress(String clusterName);
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/FilterIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/FilterIT.java
@@ -18,6 +18,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLSocket;
+
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -89,6 +93,7 @@ import static org.apache.kafka.common.protocol.ApiKeys.METADATA;
 import static org.apache.kafka.common.protocol.ApiKeys.PRODUCE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 @ExtendWith(KafkaClusterExtension.class)
@@ -181,6 +186,20 @@ class FilterIT {
                     .containsExactly(PLAINTEXT);
 
         }
+    }
+
+    @Test
+    void shouldFailFastWhenConnectWithSSLToPlainListener(KafkaCluster cluster) {
+        assertThatThrownBy(() -> {
+            try (var tester = kroxyliciousTester(proxy(cluster))) {
+                String bootstrap = tester.getBootstrapAddress();
+                String[] split = bootstrap.split(":");
+                try (SSLSocket socket = (SSLSocket) SSLContext.getDefault().getSocketFactory().createSocket(split[0], Integer.parseInt(split[1]))) {
+                    socket.setSoTimeout(5000);
+                    socket.startHandshake();
+                }
+            }
+        }).isInstanceOf(SSLHandshakeException.class).hasMessageContaining("Remote host terminated the handshake");
     }
 
     @Test

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -173,7 +173,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
         var dp = new SaslDecodePredicate(!authnHandlers.isEmpty());
         // The decoder, this only cares about the filters
         // because it needs to know whether to decode requests
-        KafkaRequestDecoder decoder = new KafkaRequestDecoder(dp);
+        KafkaRequestDecoder decoder = new KafkaRequestDecoder(dp, virtualCluster.socketFrameMaxSizeBytes());
         pipeline.addLast("requestDecoder", decoder);
         pipeline.addLast("responseEncoder", new KafkaResponseEncoder());
         pipeline.addLast("responseOrderer", new ResponseOrderer());

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/FrameOversizedException.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/FrameOversizedException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.codec;
+
+public class FrameOversizedException extends RuntimeException {
+
+    private final int maxFrameSizeBytes;
+    private final int receivedFrameSizeBytes;
+
+    public FrameOversizedException(int maxFrameSizeBytes, int receivedFrameSizeBytes) {
+        super("received frame with size in bytes: " + receivedFrameSizeBytes + " but maximum size in bytes is: " + maxFrameSizeBytes);
+        this.maxFrameSizeBytes = maxFrameSizeBytes;
+        this.receivedFrameSizeBytes = receivedFrameSizeBytes;
+    }
+
+    public int getMaxFrameSizeBytes() {
+        return maxFrameSizeBytes;
+    }
+
+    public int getReceivedFrameSizeBytes() {
+        return receivedFrameSizeBytes;
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaMessageDecoder.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaMessageDecoder.java
@@ -20,9 +20,12 @@ import io.kroxylicious.proxy.frame.Frame;
  */
 public abstract class KafkaMessageDecoder extends ByteToMessageDecoder {
 
+    private final int socketFrameMaxSize;
+
     protected abstract Logger log();
 
-    public KafkaMessageDecoder() {
+    protected KafkaMessageDecoder(int socketFrameMaxSize) {
+        this.socketFrameMaxSize = socketFrameMaxSize;
     }
 
     @Override
@@ -31,6 +34,9 @@ public abstract class KafkaMessageDecoder extends ByteToMessageDecoder {
             try {
                 int sof = in.readerIndex();
                 int frameSize = in.readInt();
+                if (frameSize > socketFrameMaxSize) {
+                    throw new FrameOversizedException(socketFrameMaxSize, frameSize);
+                }
                 int readable = in.readableBytes();
                 if (log().isTraceEnabled()) { // avoid boxing
                     log().trace("{}: Frame of {} bytes ({} readable)", ctx, frameSize, readable);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoder.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoder.java
@@ -27,8 +27,8 @@ public class KafkaRequestDecoder extends KafkaMessageDecoder {
 
     private final DecodePredicate decodePredicate;
 
-    public KafkaRequestDecoder(DecodePredicate decodePredicate) {
-        super();
+    public KafkaRequestDecoder(DecodePredicate decodePredicate, int socketFrameMaxSize) {
+        super(socketFrameMaxSize);
         this.decodePredicate = decodePredicate;
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseDecoder.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseDecoder.java
@@ -29,8 +29,8 @@ public class KafkaResponseDecoder extends KafkaMessageDecoder {
 
     private final CorrelationManager correlationManager;
 
-    public KafkaResponseDecoder(CorrelationManager correlationManager) {
-        super();
+    public KafkaResponseDecoder(CorrelationManager correlationManager, int socketRequestMaxSizeBytes) {
+        super(socketRequestMaxSizeBytes);
         this.correlationManager = correlationManager;
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
@@ -25,6 +25,7 @@ import io.kroxylicious.proxy.service.HostPort;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class VirtualCluster implements ClusterNetworkAddressConfigProvider {
+    public static final int DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES = 104857600;
     private final String clusterName;
 
     private final TargetCluster targetCluster;
@@ -83,6 +84,10 @@ public class VirtualCluster implements ClusterNetworkAddressConfigProvider {
 
     public boolean isUseTls() {
         return tls.isPresent();
+    }
+
+    public int socketFrameMaxSizeBytes() {
+        return DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES;
     }
 
     @Override

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/ByteBufs.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/ByteBufs.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.codec;
+
+import org.junit.jupiter.api.function.ThrowingConsumer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufOutputStream;
+import io.netty.buffer.Unpooled;
+
+public class ByteBufs {
+
+    public static ByteBuf writeByteBuf(ThrowingConsumer<ByteBufOutputStream> consumer) {
+        try (ByteBufOutputStream stream = new ByteBufOutputStream(Unpooled.buffer())) {
+            consumer.accept(stream);
+            return stream.buffer();
+        }
+        catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/ResponseDecoderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/ResponseDecoderTest.java
@@ -5,21 +5,43 @@
  */
 package io.kroxylicious.proxy.internal.codec;
 
+import java.util.ArrayList;
+
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import io.netty.buffer.ByteBuf;
 
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 import io.kroxylicious.proxy.frame.OpaqueResponseFrame;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static io.kroxylicious.proxy.internal.codec.ByteBufs.writeByteBuf;
+import static io.kroxylicious.proxy.model.VirtualCluster.DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ResponseDecoderTest extends AbstractCodecTest {
 
+    private CorrelationManager mgr;
+    private KafkaResponseDecoder responseDecoder;
+    private int frameMaxSizeBytes;
+
+    @BeforeEach
+    public void setup() {
+        mgr = new CorrelationManager(12);
+        frameMaxSizeBytes = DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES;
+        responseDecoder = createResponseDecoder(mgr, frameMaxSizeBytes);
+    }
+
     @ParameterizedTest
     @MethodSource("requestApiVersions")
     void testApiVersionsExactlyOneFrame_decoded(short apiVersion) {
-        var mgr = new CorrelationManager(12);
         mgr.putBrokerRequest(ApiKeys.API_VERSIONS.id, apiVersion, 52, true, null, null, true);
         assertEquals(52, exactlyOneFrame_decoded(apiVersion,
                 ApiKeys.API_VERSIONS::responseHeaderVersion,
@@ -27,7 +49,7 @@ class ResponseDecoderTest extends AbstractCodecTest {
                 AbstractCodecTest::exampleApiVersionsResponse,
                 AbstractCodecTest::deserializeResponseHeaderUsingKafkaApis,
                 AbstractCodecTest::deserializeApiVersionsResponseUsingKafkaApis,
-                new KafkaResponseDecoder(mgr),
+                responseDecoder,
                 DecodedResponseFrame.class,
                 header -> header.setCorrelationId(12), false),
                 "Unexpected correlation id");
@@ -36,15 +58,72 @@ class ResponseDecoderTest extends AbstractCodecTest {
     @ParameterizedTest
     @MethodSource("requestApiVersions")
     void testApiVersionsExactlyOneFrame_opaque(short apiVersion) throws Exception {
-        var mgr = new CorrelationManager(12);
         mgr.putBrokerRequest(ApiKeys.API_VERSIONS.id, apiVersion, 52, true, null, null, false);
         assertEquals(52, exactlyOneFrame_encoded(apiVersion,
                 ApiKeys.API_VERSIONS::responseHeaderVersion,
                 v -> AbstractCodecTest.exampleResponseHeader(),
                 AbstractCodecTest::exampleApiVersionsResponse,
-                new KafkaResponseDecoder(mgr),
+                responseDecoder,
                 OpaqueResponseFrame.class, false),
                 "Unexpected correlation id");
+    }
+
+    @NonNull
+    private static KafkaResponseDecoder createResponseDecoder(CorrelationManager mgr, int socketFrameMaxSizeBytes) {
+        return new KafkaResponseDecoder(mgr, socketFrameMaxSizeBytes);
+    }
+
+    @Test
+    void shouldThrowIfFirstIntGreaterThanMaxFrameSize() {
+        // given
+        int sentMaxSizeBytes = frameMaxSizeBytes + 1;
+        ByteBuf buffer = toLength5ByteBuf(sentMaxSizeBytes);
+        Assertions.assertThatThrownBy(() -> {
+            // when
+            responseDecoder.decode(null, buffer, new ArrayList<>());
+        }).isInstanceOfSatisfying(FrameOversizedException.class, e -> {
+            // then
+            assertThat(e.getMaxFrameSizeBytes()).isEqualTo(frameMaxSizeBytes);
+            assertThat(e.getReceivedFrameSizeBytes()).isEqualTo(sentMaxSizeBytes);
+        });
+    }
+
+    @Test
+    void shouldNotThrowIfFirstIntLessThanMaxFrameSize() {
+        // given
+        ByteBuf buffer = toLength5ByteBuf(frameMaxSizeBytes - 1);
+        int readerIndexAtStart = buffer.readerIndex();
+        ArrayList<Object> objects = new ArrayList<>();
+
+        // when
+        responseDecoder.decode(null, buffer, objects);
+
+        // then
+        assertThat(objects).isEmpty();
+        assertThat(buffer.readerIndex()).isEqualTo(readerIndexAtStart);
+    }
+
+    @Test
+    void shouldNotThrowIfFirstIntEqualToMaxFrameSize() {
+        // given
+        ByteBuf buffer = toLength5ByteBuf(frameMaxSizeBytes);
+        int readerIndexAtStart = buffer.readerIndex();
+        ArrayList<Object> objects = new ArrayList<>();
+
+        // when
+        responseDecoder.decode(null, buffer, objects);
+
+        // then
+        assertThat(objects).isEmpty();
+        assertThat(buffer.readerIndex()).isEqualTo(readerIndexAtStart);
+    }
+
+    // we need 5 bytes in the buffer for the decoder to read the length out and act on it
+    private static ByteBuf toLength5ByteBuf(int i) {
+        return writeByteBuf(outputStream -> {
+            outputStream.writeInt(i);
+            outputStream.writeByte(1);
+        });
     }
 
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Partially addresses #989

Why:
Currently when a client is configured to use TLS and it connects to a plain proxy listener we interpret it as a Kafka frame and read the first 4 bytes as an int that contains the length of the frame. Rejecting frame sizes larger than 100 Mebibytes happens to catch. The first byte is the TLS handshake ContentType, 22. This means the first four bytes are going to compresi an int greater than 22 << 24 (369098752 in decimal). So our max frame size should blow up on any TLS handshake.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
