### PR TITLE
Shared DEK cache for encryption path

### DIFF
--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryption.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryption.java
@@ -35,7 +35,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * @param <E> The type of encrypted DEK
  */
 @Plugin(configType = EnvelopeEncryption.Config.class)
-public class EnvelopeEncryption<K, E> implements FilterFactory<EnvelopeEncryption.Config, EnvelopeEncryption.SharedServices<K, E>> {
+public class EnvelopeEncryption<K, E> implements FilterFactory<EnvelopeEncryption.Config, SharedEncryptionContext<K, E>> {
 
     private static KmsMetrics kmsMetrics = MicrometerKmsMetrics.create(Metrics.globalRegistry);
 
@@ -62,41 +62,37 @@ public class EnvelopeEncryption<K, E> implements FilterFactory<EnvelopeEncryptio
 
     }
 
-    public record SharedServices<K, E>(
-                                       Kms<K, E> kms,
-                                       EnvelopeEncryption.Config configuration,
-                                       DekManager<K, E> dekManager,
-                                       EncryptionDekCache<K, E> encryptionDekCache) {}
-
     @Override
-    public SharedServices<K, E> initialize(FilterFactoryContext context, Config configuration) throws PluginConfigurationException {
+    public SharedEncryptionContext<K, E> initialize(FilterFactoryContext context,
+                                                    Config configuration)
+            throws PluginConfigurationException {
         Kms<K, E> kms = buildKms(context, configuration);
 
         DekManager<K, E> dekManager = new DekManager<>(ignored -> kms, null, 5_000_000);
-        ScheduledExecutorService filterThreadExecutor = context.eventLoop();
-        EncryptionDekCache<K, E> encryptionDekCache = new EncryptionDekCache<>(dekManager, filterThreadExecutor, EncryptionDekCache.NO_MAX_CACHE_SIZE);
-        return new SharedServices<>(kms, configuration, dekManager, encryptionDekCache);
+        EncryptionDekCache<K, E> encryptionDekCache = new EncryptionDekCache<>(dekManager, null, EncryptionDekCache.NO_MAX_CACHE_SIZE);
+        return new SharedEncryptionContext<>(kms, configuration, dekManager, encryptionDekCache);
     }
 
     @NonNull
     @Override
-    public EnvelopeEncryptionFilter<K> createFilter(FilterFactoryContext context, SharedServices<K, E> shared) {
+    public EnvelopeEncryptionFilter<K> createFilter(FilterFactoryContext context,
+                                                    SharedEncryptionContext<K, E> sharedEncryptionContext) {
 
         ScheduledExecutorService filterThreadExecutor = context.eventLoop();
         FilterThreadExecutor executor = new FilterThreadExecutor(filterThreadExecutor);
-        var encryptionManager = new InBandEncryptionManager<K, E>(shared.dekManager().edekSerde(),
+        var encryptionManager = new InBandEncryptionManager<K, E>(sharedEncryptionContext.dekManager().edekSerde(),
                 1024 * 1024,
                 8 * 1024 * 1024,
-                shared.encryptionDekCache(),
+                sharedEncryptionContext.encryptionDekCache(),
                 executor);
 
-        var decryptionManager = new InBandDecryptionManager<>(shared.dekManager(),
+        var decryptionManager = new InBandDecryptionManager<>(sharedEncryptionContext.dekManager(),
                 executor,
                 null,
                 InBandDecryptionManager.NO_MAX_CACHE_SIZE);
 
-        KekSelectorService<Object, K> ksPlugin = context.pluginInstance(KekSelectorService.class, shared.configuration().selector());
-        TopicNameBasedKekSelector<K> kekSelector = ksPlugin.buildSelector(shared.kms(), shared.configuration().selectorConfig());
+        KekSelectorService<Object, K> ksPlugin = context.pluginInstance(KekSelectorService.class, sharedEncryptionContext.configuration().selector());
+        TopicNameBasedKekSelector<K> kekSelector = ksPlugin.buildSelector(sharedEncryptionContext.kms(), sharedEncryptionContext.configuration().selectorConfig());
         return new EnvelopeEncryptionFilter<>(encryptionManager, decryptionManager, kekSelector, executor);
     }
 

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/SharedEncryptionContext.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/SharedEncryptionContext.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+import java.util.Objects;
+
+import io.kroxylicious.filter.encryption.dek.DekManager;
+import io.kroxylicious.filter.encryption.inband.EncryptionDekCache;
+import io.kroxylicious.kms.service.Kms;
+
+/**
+ * Things which are shared between instances of the filter.
+ * Because they're shared between filter instances, the things shared here must be thread-safe.
+ * @param <K> The type of KEK id.
+ * @param <E> The type of the encrypted DEK.
+ */
+public class SharedEncryptionContext<K, E> {
+    private final Kms<K, E> kms;
+    private final EnvelopeEncryption.Config configuration;
+    private final DekManager<K, E> dekManager;
+    private final EncryptionDekCache<K, E> encryptionDekCache;
+
+    /**
+     * @param kms
+     * @param configuration
+     * @param dekManager
+     * @param encryptionDekCache
+     */
+    SharedEncryptionContext(
+                            Kms<K, E> kms,
+                            EnvelopeEncryption.Config configuration,
+                            DekManager<K, E> dekManager,
+                            EncryptionDekCache<K, E> encryptionDekCache) {
+        this.kms = kms;
+        this.configuration = configuration;
+        this.dekManager = dekManager;
+        this.encryptionDekCache = encryptionDekCache;
+    }
+
+    public Kms<K, E> kms() {
+        return kms;
+    }
+
+    public EnvelopeEncryption.Config configuration() {
+        return configuration;
+    }
+
+    public DekManager<K, E> dekManager() {
+        return dekManager;
+    }
+
+    public EncryptionDekCache<K, E> encryptionDekCache() {
+        return encryptionDekCache;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || obj.getClass() != this.getClass()) {
+            return false;
+        }
+        var that = (SharedEncryptionContext) obj;
+        return Objects.equals(this.kms, that.kms) &&
+                Objects.equals(this.configuration, that.configuration) &&
+                Objects.equals(this.dekManager, that.dekManager) &&
+                Objects.equals(this.encryptionDekCache, that.encryptionDekCache);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(kms, configuration, dekManager, encryptionDekCache);
+    }
+
+    @Override
+    public String toString() {
+        return "SharedEncryptionContext[" +
+                "kms=" + kms + ", " +
+                "configuration=" + configuration + ", " +
+                "dekManager=" + dekManager + ", " +
+                "encryptionDekCache=" + encryptionDekCache + ']';
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/SharedEncryptionContext.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/SharedEncryptionContext.java
@@ -6,8 +6,6 @@
 
 package io.kroxylicious.filter.encryption;
 
-import java.util.Objects;
-
 import io.kroxylicious.filter.encryption.dek.DekManager;
 import io.kroxylicious.filter.encryption.inband.EncryptionDekCache;
 import io.kroxylicious.kms.service.Kms;

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/SharedEncryptionContext.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/SharedEncryptionContext.java
@@ -57,33 +57,4 @@ public class SharedEncryptionContext<K, E> {
         return encryptionDekCache;
     }
 
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == this) {
-            return true;
-        }
-        if (obj == null || obj.getClass() != this.getClass()) {
-            return false;
-        }
-        var that = (SharedEncryptionContext) obj;
-        return Objects.equals(this.kms, that.kms) &&
-                Objects.equals(this.configuration, that.configuration) &&
-                Objects.equals(this.dekManager, that.dekManager) &&
-                Objects.equals(this.encryptionDekCache, that.encryptionDekCache);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(kms, configuration, dekManager, encryptionDekCache);
-    }
-
-    @Override
-    public String toString() {
-        return "SharedEncryptionContext[" +
-                "kms=" + kms + ", " +
-                "configuration=" + configuration + ", " +
-                "dekManager=" + dekManager + ", " +
-                "encryptionDekCache=" + encryptionDekCache + ']';
-    }
-
 }

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/EncryptionDekCache.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/EncryptionDekCache.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.inband;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+
+import io.kroxylicious.filter.encryption.EncryptionScheme;
+import io.kroxylicious.filter.encryption.dek.CipherSpec;
+import io.kroxylicious.filter.encryption.dek.Dek;
+import io.kroxylicious.filter.encryption.dek.DekManager;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+public class EncryptionDekCache<K, E> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EncryptionDekCache.class);
+
+    public static final int NO_MAX_CACHE_SIZE = -1;
+
+    private record CacheKey<K>(K kek, CipherSpec cipherSpec) {}
+
+    private static <K> CacheKey<K> cacheKey(EncryptionScheme<K> encryptionScheme) {
+        return new CacheKey<>(encryptionScheme.kekId(), CipherSpec.AES_128_GCM_128);
+    }
+
+    private final DekManager<K, E> dekManager;
+
+    private final AsyncLoadingCache<CacheKey<K>, Dek<E>> dekCache;
+
+    public EncryptionDekCache(
+                              @NonNull DekManager<K, E> dekManager,
+                              @Nullable Executor dekCacheExecutor,
+                              int dekCacheMaxItems) {
+        this.dekManager = dekManager;
+        Caffeine<Object, Object> cache = Caffeine.newBuilder();
+        if (dekCacheMaxItems != NO_MAX_CACHE_SIZE) {
+            cache = cache.maximumSize(dekCacheMaxItems);
+        }
+        if (dekCacheExecutor != null) {
+            cache = cache.executor(dekCacheExecutor);
+        }
+
+        this.dekCache = cache
+                .removalListener(this::afterCacheEviction)
+                .buildAsync(this::requestGenerateDek);
+    }
+
+    /** Invoked by Caffeine when a DEK needs to be loaded */
+    private CompletableFuture<Dek<E>> requestGenerateDek(@NonNull CacheKey<K> cacheKey,
+                                                         @NonNull Executor executor) {
+        return dekManager.generateDek(cacheKey.kek(), cacheKey.cipherSpec())
+                .thenApply(dek -> {
+                    if (LOGGER.isTraceEnabled()) {
+                        LOGGER.trace("Adding DEK to cache: {}", dek);
+                    }
+                    dek.destroyForDecrypt();
+                    return dek;
+                })
+                .toCompletableFuture();
+    }
+
+    /** Invoked by Caffeine after a DEK is evicted from the cache. */
+    private void afterCacheEviction(@Nullable CacheKey<K> cacheKey,
+                                    @Nullable Dek<E> dek,
+                                    RemovalCause removalCause) {
+        if (dek != null) {
+            dek.destroyForEncrypt();
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.trace("Attempted to destroy DEK: {}", dek);
+            }
+        }
+    }
+
+    public CompletionStage<Dek<E>> get(EncryptionScheme<K> encryptionScheme) {
+        return dekCache.get(cacheKey(encryptionScheme));
+    }
+
+    public void invalidate(EncryptionScheme<K> encryptionScheme) {
+        dekCache.synchronous().invalidate(cacheKey(encryptionScheme));
+    }
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandEncryptionManager.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandEncryptionManager.java
@@ -71,7 +71,6 @@ public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
     * {@link RecordEncryptor#ENCRYPTION_HEADER_NAME} header.
     */
     private final EncryptionVersion encryptionVersion;
-    // private final DekManager<K, E> dekManager;
     private final Serde<E> edekSerde;
     private final EncryptionDekCache<K, E> dekCache;
 
@@ -81,7 +80,7 @@ public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
     public InBandEncryptionManager(@NonNull Serde<E> edekSerde,
                                    int recordBufferInitialBytes,
                                    int recordBufferMaxBytes,
-                                   @NonNull EncryptionDekCache dekCache,
+                                   @NonNull EncryptionDekCache<K, E> dekCache,
                                    @NonNull FilterThreadExecutor filterThreadExecutor) {
         this.filterThreadExecutor = filterThreadExecutor;
         this.encryptionVersion = EncryptionVersion.V1; // TODO read from config

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.kms.service.Kms;
 import io.kroxylicious.kms.service.KmsService;
+import io.kroxylicious.kms.service.Serde;
 import io.kroxylicious.proxy.filter.FilterFactoryContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,16 +33,18 @@ class EnvelopeEncryptionTest {
         var kms = mock(Kms.class);
         var kekSelectorService = mock(KekSelectorService.class);
         var kekSelector = mock(TopicNameBasedKekSelector.class);
+        var edekSerde = mock(Serde.class);
 
         doReturn(kmsService).when(fc).pluginInstance(KmsService.class, "KMS");
         doReturn(kms).when(kmsService).buildKms(any());
         doReturn(mock(ScheduledExecutorService.class)).when(fc).eventLoop();
+        doReturn(edekSerde).when(kms).edekSerde();
 
         doReturn(kekSelectorService).when(fc).pluginInstance(KekSelectorService.class, "SELECTOR");
         doReturn(kekSelector).when(kekSelectorService).buildSelector(any(), any());
 
-        ee.initialize(fc, config);
-        var filter = ee.createFilter(fc, config);
+        var ss = ee.initialize(fc, config);
+        var filter = ee.createFilter(fc, ss);
         assertNotNull(filter);
     }
 

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionTest.java
@@ -43,8 +43,8 @@ class EnvelopeEncryptionTest {
         doReturn(kekSelectorService).when(fc).pluginInstance(KekSelectorService.class, "SELECTOR");
         doReturn(kekSelector).when(kekSelectorService).buildSelector(any(), any());
 
-        var ss = ee.initialize(fc, config);
-        var filter = ee.createFilter(fc, ss);
+        var sec = ee.initialize(fc, config);
+        var filter = ee.createFilter(fc, sec);
         assertNotNull(filter);
     }
 

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/InBandDecryptionManagerTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/InBandDecryptionManagerTest.java
@@ -1014,7 +1014,7 @@ class InBandDecryptionManagerTest {
                 maxEncryptionsPerDek,
                 1024 * 1024,
                 8 * 1024 * 1024,
-                InBandEncryptionManager.NO_MAX_CACHE_SIZE);
+                EncryptionDekCache.NO_MAX_CACHE_SIZE);
     }
 
     @NonNull
@@ -1023,12 +1023,14 @@ class InBandDecryptionManagerTest {
                                                                                        int recordBufferInitialBytes,
                                                                                        int recordBufferMaxBytes,
                                                                                        int maxCacheSize) {
-        return new InBandEncryptionManager<>(new DekManager<UUID, InMemoryEdek>(ignored -> kms, null, maxEncryptionsPerDek),
+
+        DekManager<UUID, InMemoryEdek> uuidInMemoryEdekDekManager = new DekManager<>(ignored -> kms, null, maxEncryptionsPerDek);
+        var cache = new EncryptionDekCache<>(uuidInMemoryEdekDekManager, directExecutor(), maxCacheSize);
+        return new InBandEncryptionManager<>(uuidInMemoryEdekDekManager.edekSerde(),
                 recordBufferInitialBytes,
                 recordBufferMaxBytes,
-                directExecutor(),
-                new FilterThreadExecutor(directExecutor()),
-                maxCacheSize);
+                cache,
+                new FilterThreadExecutor(directExecutor()));
     }
 
     @NonNull


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

* Factor out an EncryptionDekCache from the InBandEncryptionManager.
* Initialize the EncryptionDekCache once-per-filter.
* Don't expose any configs for this yet.

This is one half of the changes required for #775


