### PR TITLE
Share DEKs on the decryption path

### DIFF
--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/SharedEncryptionContext.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/SharedEncryptionContext.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.filter.encryption;
 
 import io.kroxylicious.filter.encryption.dek.DekManager;
+import io.kroxylicious.filter.encryption.inband.DecryptionDekCache;
 import io.kroxylicious.filter.encryption.inband.EncryptionDekCache;
 import io.kroxylicious.kms.service.Kms;
 
@@ -21,6 +22,7 @@ public class SharedEncryptionContext<K, E> {
     private final EnvelopeEncryption.Config configuration;
     private final DekManager<K, E> dekManager;
     private final EncryptionDekCache<K, E> encryptionDekCache;
+    private final DecryptionDekCache<K, E> decryptionDekCache;
 
     /**
      * @param kms
@@ -32,11 +34,13 @@ public class SharedEncryptionContext<K, E> {
                             Kms<K, E> kms,
                             EnvelopeEncryption.Config configuration,
                             DekManager<K, E> dekManager,
-                            EncryptionDekCache<K, E> encryptionDekCache) {
+                            EncryptionDekCache<K, E> encryptionDekCache,
+                            DecryptionDekCache<K, E> decryptionDekCache) {
         this.kms = kms;
         this.configuration = configuration;
         this.dekManager = dekManager;
         this.encryptionDekCache = encryptionDekCache;
+        this.decryptionDekCache = decryptionDekCache;
     }
 
     public Kms<K, E> kms() {
@@ -55,4 +59,7 @@ public class SharedEncryptionContext<K, E> {
         return encryptionDekCache;
     }
 
+    public DecryptionDekCache<K, E> decryptionDekCache() {
+        return decryptionDekCache;
+    }
 }

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DekManager.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DekManager.java
@@ -76,7 +76,7 @@ public class DekManager<K, E> {
      * The returned DEK can only be used for decryption, and only for the given cipher.
      * @param edek The encrypted DEK
      * @param cipherSpec The cipher supported by the returned DEK.
-     * @return A completion state that completes with the {@link Dek}, or
+     * @return A completion stage that completes with the {@link Dek}, or
      * fails if the request to the KMS fails.
      */
     public CompletionStage<Dek<E>> decryptEdek(@NonNull E edek, @NonNull CipherSpec cipherSpec) {

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/DecryptionDekCache.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/DecryptionDekCache.java
@@ -49,15 +49,18 @@ public class DecryptionDekCache<K, E> {
             }
         }
 
+        /** A sentinel for records which are not encrypted */
         @SuppressWarnings({ "rawtypes", "unchecked" })
-        private static final CacheKey NONE = new CacheKey(null, null);
+        private static final CacheKey UNENCRYPTED = new CacheKey(null, null);
 
+        /** Gets the sentinel value for records which are not encrypted */
         @SuppressWarnings("unchecked")
-        static <E> CacheKey<E> none() {
-            return NONE;
+        static <E> CacheKey<E> unencrypted() {
+            return UNENCRYPTED;
         }
 
-        public boolean isNone() {
+        /** Tests whether this cache key is the sentinel value representing unencrypted records */
+        public boolean isUnencrypted() {
             return cipherSpec == null || edek == null;
         }
     }
@@ -88,7 +91,7 @@ public class DecryptionDekCache<K, E> {
      * @return A future
      */
     private CompletableFuture<Dek<E>> loadDek(CacheKey<E> cacheKey, Executor executor) {
-        if (cacheKey == null || cacheKey.isNone()) {
+        if (cacheKey == null || cacheKey.isUnencrypted()) {
             return CompletableFuture.completedFuture(null);
         }
         // This assert is just to appease sonar because it doesn't grok that these things cannot be null due to

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/DecryptionDekCache.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/DecryptionDekCache.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.inband;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+
+import io.kroxylicious.filter.encryption.FilterThreadExecutor;
+import io.kroxylicious.filter.encryption.dek.CipherSpec;
+import io.kroxylicious.filter.encryption.dek.Dek;
+import io.kroxylicious.filter.encryption.dek.DekManager;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * A cache of DEKs used on the decryption path.
+ * @param <K> The type of KEK id.
+ * @param <E> The type of encrypted DEK.
+ */
+public class DecryptionDekCache<K, E> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DecryptionDekCache.class);
+
+    public static final int NO_MAX_CACHE_SIZE = -1;
+    private final DekManager<K, E> dekManager;
+
+    record CacheKey<E>(
+                       @Nullable CipherSpec cipherSpec,
+                       @Nullable E edek) {
+        public CacheKey {
+            if (cipherSpec == null ^ edek == null) {
+                throw new IllegalArgumentException();
+            }
+        }
+
+        @SuppressWarnings({ "rawtypes", "unchecked" })
+        private static final CacheKey NONE = new CacheKey(null, null);
+
+        @SuppressWarnings("unchecked")
+        static <E> CacheKey<E> none() {
+            return NONE;
+        }
+
+        public boolean isNone() {
+            return cipherSpec == null || edek == null;
+        }
+    }
+
+    private final AsyncLoadingCache<CacheKey<E>, Dek<E>> decryptorCache;
+
+    public DecryptionDekCache(@NonNull DekManager<K, E> dekManager,
+                              @Nullable Executor dekCacheExecutor,
+                              int dekCacheMaxItems) {
+        this.dekManager = Objects.requireNonNull(dekManager);
+        Caffeine<Object, Object> cache = Caffeine.<CacheKey<E>, Dek<E>> newBuilder();
+        if (dekCacheMaxItems != NO_MAX_CACHE_SIZE) {
+            cache.maximumSize(dekCacheMaxItems);
+        }
+        if (dekCacheExecutor != null) {
+            cache.executor(dekCacheExecutor);
+        }
+        this.decryptorCache = cache
+                .removalListener(this::afterCacheEviction)
+                .buildAsync(this::loadDek);
+    }
+
+    /**
+     * Invoked by Caffeine when a DEK needs to be loaded.
+     * This method is executed on the {@code dekCacheExecutor} passed to the constructor.
+     * @param cacheKey The cache key
+     * @param executor The executor
+     * @return A future
+     */
+    private CompletableFuture<Dek<E>> loadDek(CacheKey<E> cacheKey, Executor executor) {
+        if (cacheKey == null || cacheKey.isNone()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        // This assert is just to appease sonar because it doesn't grok that these things cannot be null due to
+        // the cacheKey.isNone() check above
+        assert cacheKey.edek() != null && cacheKey.cipherSpec() != null;
+        return dekManager.decryptEdek(cacheKey.edek(), cacheKey.cipherSpec())
+                .toCompletableFuture();
+    }
+
+    /**
+     * Invoked by Caffeine after a DEK is evicted from the cache.
+     * This method is executed on the {@code dekCacheExecutor} passed to the constructor.
+     */
+    private void afterCacheEviction(@Nullable CacheKey<E> cacheKey,
+                                    @Nullable Dek<E> dek,
+                                    RemovalCause removalCause) {
+        if (dek != null) {
+            dek.destroyForDecrypt();
+            if (LOGGER.isTraceEnabled()) {
+                LOGGER.trace("Attempted to destroy DEK: {}", dek);
+            }
+        }
+    }
+
+    /**
+     * Gets the DEKs for all the given cache keys
+     * @param cacheKeys The cache key
+     * @param filterThreadExecutor The filter thread executor
+     * @return A completion stage which completes on the filter thread with the DEKs for the given {@code cacheKeys}.
+     */
+    public @NonNull CompletionStage<Map<CacheKey<E>, Dek<E>>> getAll(@NonNull List<CacheKey<E>> cacheKeys,
+                                                                     @NonNull FilterThreadExecutor filterThreadExecutor) {
+        return filterThreadExecutor.completingOnFilterThread(decryptorCache.getAll(cacheKeys));
+    }
+}

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandDecryptionManager.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandDecryptionManager.java
@@ -149,7 +149,7 @@ public class InBandDecryptionManager<K, E> implements DecryptionManager {
             }
             else {
                 // It's not encrypted, so use sentinels
-                cacheKeys.add(DecryptionDekCache.CacheKey.none());
+                cacheKeys.add(DecryptionDekCache.CacheKey.unencrypted());
                 states.add(DecryptState.none());
             }
         });


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

* Similar to #1001 but for the decryption path
* Factor out `DecryptionDekCache` and instantiated it once for the whole FilterFactory.
* Not quite as clear as #1001 right now because the `CacheKey` isn't an internal concern of the `DecryptionDekCache`.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
