### PR TITLE
New env variables for Strimzi and cert manager installation

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -337,8 +337,8 @@ has been applied ineffectively.
 * `SKIP_TEARDOWN`: variable for development purposes to avoid keep deploying and deleting deployments each run. Default value: `false`
 * `CONTAINER_CONFIG_PATH`: directory where `config.json` file is located. This file contains the pull secrets to be used by
 the container engine. Default value: `$HOME/.docker/config.json`
-* `STRIMZI_NAMESPACE`: namespace where strimzi is installed. It is useful for pipelines
-where strimzi is installed before the STs. Default value: `kafka`
+* `STRIMZI_INSTALLED`: skip strimzi installation if it is already installed. Default value: `false`
+* `CERT_MANAGER_INSTALLED`: skip cert manager installation if it is already installed. Default value: `false`
 
 
 ### Launch system tests

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -337,8 +337,7 @@ has been applied ineffectively.
 * `SKIP_TEARDOWN`: variable for development purposes to avoid keep deploying and deleting deployments each run. Default value: `false`
 * `CONTAINER_CONFIG_PATH`: directory where `config.json` file is located. This file contains the pull secrets to be used by
 the container engine. Default value: `$HOME/.docker/config.json`
-* `STRIMZI_INSTALLED`: skip strimzi installation if it is already installed. Default value: `false`
-* `CERT_MANAGER_INSTALLED`: skip cert manager installation if it is already installed. Default value: `false`
+* `SKIP_STRIMZI_INSTALL`: skip strimzi installation. Default value: `false`
 
 
 ### Launch system tests

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
@@ -30,8 +30,7 @@ public class Environment {
     private static final String SKIP_TEARDOWN_ENV = "SKIP_TEARDOWN";
     public static final String STRIMZI_FEATURE_GATES_ENV = "STRIMZI_FEATURE_GATES";
     private static final String CONTAINER_CONFIG_PATH_ENV = "CONTAINER_CONFIG_PATH";
-    private static final String STRIMZI_INSTALLED_ENV = "STRIMZI_INSTALLED";
-    private static final String CERT_MANAGER_INSTALLED_ENV = "CERT_MANAGER_INSTALLED";
+    private static final String SKIP_STRIMZI_INSTALL_ENV = "SKIP_STRIMZI_INSTALL";
 
     /**
      * The kafka version default value
@@ -66,8 +65,7 @@ public class Environment {
     private static final String SKIP_TEARDOWN_DEFAULT = "false";
     private static final String STRIMZI_FEATURE_GATES_DEFAULT = "";
     private static final String CONTAINER_CONFIG_PATH_DEFAULT = System.getProperty("user.home") + "/.docker/config.json";
-    private static final String CERT_MANAGER_INSTALLED_DEFAULT = "false";
-    private static final String STRIMZI_INSTALLED_DEFAULT = "false";
+    private static final String SKIP_STRIMZI_INSTALL_DEFAULT = "false";
 
     /**
      * KAFKA_VERSION env variable assignment
@@ -95,9 +93,7 @@ public class Environment {
 
     public static final String CONTAINER_CONFIG_PATH = getOrDefault(CONTAINER_CONFIG_PATH_ENV, CONTAINER_CONFIG_PATH_DEFAULT);
 
-    public static final String STRIMZI_INSTALLED = getOrDefault(STRIMZI_INSTALLED_ENV, STRIMZI_INSTALLED_DEFAULT);
-
-    public static final String CERT_MANAGER_INSTALLED = getOrDefault(CERT_MANAGER_INSTALLED_ENV, CERT_MANAGER_INSTALLED_DEFAULT);
+    public static final String SKIP_STRIMZI_INSTALL = getOrDefault(SKIP_STRIMZI_INSTALL_ENV, SKIP_STRIMZI_INSTALL_DEFAULT);
 
     private static String getOrDefault(String varName, String defaultValue) {
         return getOrDefault(varName, String::toString, defaultValue);

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
@@ -87,13 +87,13 @@ public class Environment {
     /**
      * SKIP_TEARDOWN env variable assignment.
      */
-    public static final String SKIP_TEARDOWN = getOrDefault(SKIP_TEARDOWN_ENV, SKIP_TEARDOWN_DEFAULT);
+    public static final boolean SKIP_TEARDOWN = Boolean.parseBoolean(getOrDefault(SKIP_TEARDOWN_ENV, SKIP_TEARDOWN_DEFAULT));
 
     public static final String STRIMZI_FEATURE_GATES = getOrDefault(STRIMZI_FEATURE_GATES_ENV, STRIMZI_FEATURE_GATES_DEFAULT);
 
     public static final String CONTAINER_CONFIG_PATH = getOrDefault(CONTAINER_CONFIG_PATH_ENV, CONTAINER_CONFIG_PATH_DEFAULT);
 
-    public static final String SKIP_STRIMZI_INSTALL = getOrDefault(SKIP_STRIMZI_INSTALL_ENV, SKIP_STRIMZI_INSTALL_DEFAULT);
+    public static final boolean SKIP_STRIMZI_INSTALL = Boolean.parseBoolean(getOrDefault(SKIP_STRIMZI_INSTALL_ENV, SKIP_STRIMZI_INSTALL_DEFAULT));
 
     private static String getOrDefault(String varName, String defaultValue) {
         return getOrDefault(varName, String::toString, defaultValue);

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
@@ -29,8 +29,9 @@ public class Environment {
     private static final String STRIMZI_URL_ENV = "STRIMZI_URL";
     private static final String SKIP_TEARDOWN_ENV = "SKIP_TEARDOWN";
     public static final String STRIMZI_FEATURE_GATES_ENV = "STRIMZI_FEATURE_GATES";
-    public static final String CONTAINER_CONFIG_PATH_ENV = "CONTAINER_CONFIG_PATH";
-    public static final String STRIMZI_NAMESPACE_ENV = "STRIMZI_NAMESPACE";
+    private static final String CONTAINER_CONFIG_PATH_ENV = "CONTAINER_CONFIG_PATH";
+    private static final String STRIMZI_INSTALLED_ENV = "STRIMZI_INSTALLED";
+    private static final String CERT_MANAGER_INSTALLED_ENV = "CERT_MANAGER_INSTALLED";
 
     /**
      * The kafka version default value
@@ -65,7 +66,8 @@ public class Environment {
     private static final String SKIP_TEARDOWN_DEFAULT = "false";
     private static final String STRIMZI_FEATURE_GATES_DEFAULT = "";
     private static final String CONTAINER_CONFIG_PATH_DEFAULT = System.getProperty("user.home") + "/.docker/config.json";
-    private static final String STRIMZI_NAMESPACE_DEFAULT = Constants.KAFKA_DEFAULT_NAMESPACE;
+    private static final String CERT_MANAGER_INSTALLED_DEFAULT = "false";
+    private static final String STRIMZI_INSTALLED_DEFAULT = "false";
 
     /**
      * KAFKA_VERSION env variable assignment
@@ -93,7 +95,9 @@ public class Environment {
 
     public static final String CONTAINER_CONFIG_PATH = getOrDefault(CONTAINER_CONFIG_PATH_ENV, CONTAINER_CONFIG_PATH_DEFAULT);
 
-    public static final String STRIMZI_NAMESPACE = getOrDefault(STRIMZI_NAMESPACE_ENV, STRIMZI_NAMESPACE_DEFAULT);
+    public static final String STRIMZI_INSTALLED = getOrDefault(STRIMZI_INSTALLED_ENV, STRIMZI_INSTALLED_DEFAULT);
+
+    public static final String CERT_MANAGER_INSTALLED = getOrDefault(CERT_MANAGER_INSTALLED_ENV, CERT_MANAGER_INSTALLED_DEFAULT);
 
     private static String getOrDefault(String varName, String defaultValue) {
         return getOrDefault(varName, String::toString, defaultValue);

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/CertManager.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/CertManager.java
@@ -8,10 +8,6 @@ package io.kroxylicious.systemtests.installation.kroxylicious;
 
 import java.io.IOException;
 
-import io.kroxylicious.systemtests.Environment;
-
-import io.kroxylicious.systemtests.utils.NamespaceUtils;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,7 +15,9 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 
 import io.kroxylicious.systemtests.Constants;
+import io.kroxylicious.systemtests.Environment;
 import io.kroxylicious.systemtests.utils.DeploymentUtils;
+import io.kroxylicious.systemtests.utils.NamespaceUtils;
 
 import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
 

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/CertManager.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/CertManager.java
@@ -8,6 +8,10 @@ package io.kroxylicious.systemtests.installation.kroxylicious;
 
 import java.io.IOException;
 
+import io.kroxylicious.systemtests.Environment;
+
+import io.kroxylicious.systemtests.utils.NamespaceUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +46,8 @@ public class CertManager {
      */
     public void deploy() {
         LOGGER.info("Deploy cert manager in {} namespace", Constants.CERT_MANAGER_NAMESPACE);
-        if (kubeClient().getNamespace(Constants.CERT_MANAGER_NAMESPACE) != null) {
+        if (kubeClient().getNamespace(Constants.CERT_MANAGER_NAMESPACE) != null
+            || Environment.CERT_MANAGER_INSTALLED.equalsIgnoreCase("true")) {
             LOGGER.warn("Skipping cert manager deployment. It is already deployed!");
             return;
         }
@@ -55,7 +60,12 @@ public class CertManager {
      * @throws IOException the io exception
      */
     public void delete() throws IOException {
+        if (Environment.CERT_MANAGER_INSTALLED.equalsIgnoreCase("true")) {
+            LOGGER.warn("Skipping cert manager deletion. CERT_MANAGER_INSTALLED was set to true");
+            return;
+        }
         LOGGER.info("Deleting Cert Manager in {} namespace", Constants.CERT_MANAGER_NAMESPACE);
         deployment.withGracePeriod(0).delete();
+        NamespaceUtils.deleteNamespaceWithWait(Constants.CERT_MANAGER_NAMESPACE);
     }
 }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/CertManager.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/CertManager.java
@@ -9,6 +9,8 @@ package io.kroxylicious.systemtests.installation.kroxylicious;
 import java.io.IOException;
 import java.util.List;
 
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,9 +44,11 @@ public class CertManager {
     }
 
     private boolean isDeployed() {
-        List<GenericKubernetesResource> certManagerList = kubeClient().getClient().genericKubernetesResources("apiextensions.k8s.io/v1", "CustomResourceDefinition")
-                .list().getItems().stream().filter(crd -> crd.getMetadata().getLabels().get("app").equalsIgnoreCase("cert-manager")).toList();
-        return !certManagerList.isEmpty();
+        List<Deployment> deployments = kubeClient().getClient().apps().deployments().inAnyNamespace().list().getItems().stream()
+                .filter(deployment -> deployment.getMetadata().getLabels().get("app") != null
+                        && deployment.getMetadata().getLabels().get("app").equalsIgnoreCase("cert-manager")).toList();
+
+        return !deployments.isEmpty();
     }
 
     /**

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/CertManager.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/CertManager.java
@@ -7,16 +7,10 @@
 package io.kroxylicious.systemtests.installation.kroxylicious;
 
 import java.io.IOException;
-import java.util.List;
-
-import io.fabric8.kubernetes.api.model.apps.Deployment;
-
-import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/CertManager.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/CertManager.java
@@ -45,7 +45,7 @@ public class CertManager {
     public void deploy() {
         LOGGER.info("Deploy cert manager in {} namespace", Constants.CERT_MANAGER_NAMESPACE);
         if (kubeClient().getNamespace(Constants.CERT_MANAGER_NAMESPACE) != null
-            || Environment.CERT_MANAGER_INSTALLED.equalsIgnoreCase("true")) {
+                || Environment.CERT_MANAGER_INSTALLED.equalsIgnoreCase("true")) {
             LOGGER.warn("Skipping cert manager deployment. It is already deployed!");
             return;
         }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/CertManager.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/CertManager.java
@@ -45,7 +45,7 @@ public class CertManager {
     public void deploy() {
         LOGGER.info("Deploy cert manager in {} namespace", Constants.CERT_MANAGER_NAMESPACE);
         if (kubeClient().getNamespace(Constants.CERT_MANAGER_NAMESPACE) != null
-                || Environment.CERT_MANAGER_INSTALLED.equalsIgnoreCase("true")) {
+                || Boolean.parseBoolean(Environment.CERT_MANAGER_INSTALLED)) {
             LOGGER.warn("Skipping cert manager deployment. It is already deployed!");
             return;
         }
@@ -58,7 +58,7 @@ public class CertManager {
      * @throws IOException the io exception
      */
     public void delete() throws IOException {
-        if (Environment.CERT_MANAGER_INSTALLED.equalsIgnoreCase("true")) {
+        if (Boolean.parseBoolean(Environment.CERT_MANAGER_INSTALLED)) {
             LOGGER.warn("Skipping cert manager deletion. CERT_MANAGER_INSTALLED was set to true");
             return;
         }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/CertManager.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/CertManager.java
@@ -11,6 +11,8 @@ import java.util.List;
 
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 
+import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,11 +46,7 @@ public class CertManager {
     }
 
     private boolean isDeployed() {
-        List<Deployment> deployments = kubeClient().getClient().apps().deployments().inAnyNamespace().list().getItems().stream()
-                .filter(deployment -> deployment.getMetadata().getLabels().get("app") != null
-                        && deployment.getMetadata().getLabels().get("app").equalsIgnoreCase("cert-manager")).toList();
-
-        return !deployments.isEmpty();
+        return !kubeClient().getClient().apps().deployments().inAnyNamespace().withLabelSelector("app=cert-manager").list().getItems().isEmpty();
     }
 
     /**

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
@@ -101,7 +101,7 @@ public class Strimzi {
     public void deploy() {
         LOGGER.info("Deploy Strimzi in {} namespace", deploymentNamespace);
         if (kubeClient().getDeployment(deploymentNamespace, Constants.STRIMZI_DEPLOYMENT_NAME) != null
-                || Boolean.parseBoolean(Environment.SKIP_STRIMZI_INSTALL)) {
+                || Environment.SKIP_STRIMZI_INSTALL) {
             LOGGER.warn("Skipping strimzi deployment. It is already deployed!");
             return;
         }
@@ -114,7 +114,7 @@ public class Strimzi {
      * @throws IOException the io exception
      */
     public void delete() throws IOException {
-        if (Boolean.parseBoolean(Environment.SKIP_STRIMZI_INSTALL)) {
+        if (Environment.SKIP_STRIMZI_INSTALL) {
             LOGGER.warn("Skipping Strimzi deletion. SKIP_STRIMZI_INSTALL was set to true");
             return;
         }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
@@ -101,7 +101,7 @@ public class Strimzi {
     public void deploy() {
         LOGGER.info("Deploy Strimzi in {} namespace", deploymentNamespace);
         if (kubeClient().getDeployment(deploymentNamespace, Constants.STRIMZI_DEPLOYMENT_NAME) != null
-                || Environment.STRIMZI_INSTALLED.equalsIgnoreCase("true")) {
+                || Boolean.parseBoolean(Environment.STRIMZI_INSTALLED)) {
             LOGGER.warn("Skipping strimzi deployment. It is already deployed!");
             return;
         }
@@ -114,7 +114,7 @@ public class Strimzi {
      * @throws IOException the io exception
      */
     public void delete() throws IOException {
-        if (Environment.STRIMZI_INSTALLED.equalsIgnoreCase("true")) {
+        if (Boolean.parseBoolean(Environment.STRIMZI_INSTALLED)) {
             LOGGER.warn("Skipping Strimzi deletion. STRIMZI_INSTALLED was set to true");
             return;
         }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
@@ -101,7 +101,7 @@ public class Strimzi {
     public void deploy() {
         LOGGER.info("Deploy Strimzi in {} namespace", deploymentNamespace);
         if (kubeClient().getDeployment(deploymentNamespace, Constants.STRIMZI_DEPLOYMENT_NAME) != null
-                || Boolean.parseBoolean(Environment.STRIMZI_INSTALLED)) {
+                || Boolean.parseBoolean(Environment.SKIP_STRIMZI_INSTALL)) {
             LOGGER.warn("Skipping strimzi deployment. It is already deployed!");
             return;
         }
@@ -114,8 +114,8 @@ public class Strimzi {
      * @throws IOException the io exception
      */
     public void delete() throws IOException {
-        if (Boolean.parseBoolean(Environment.STRIMZI_INSTALLED)) {
-            LOGGER.warn("Skipping Strimzi deletion. STRIMZI_INSTALLED was set to true");
+        if (Boolean.parseBoolean(Environment.SKIP_STRIMZI_INSTALL)) {
+            LOGGER.warn("Skipping Strimzi deletion. SKIP_STRIMZI_INSTALL was set to true");
             return;
         }
         LOGGER.info("Deleting Strimzi in {} namespace", deploymentNamespace);

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
@@ -12,8 +12,6 @@ import java.io.InputStream;
 import java.io.InvalidObjectException;
 import java.util.List;
 
-import io.kroxylicious.systemtests.utils.NamespaceUtils;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
@@ -12,6 +12,8 @@ import java.io.InputStream;
 import java.io.InvalidObjectException;
 import java.util.List;
 
+import io.kroxylicious.systemtests.utils.NamespaceUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,7 +102,8 @@ public class Strimzi {
      */
     public void deploy() {
         LOGGER.info("Deploy Strimzi in {} namespace", deploymentNamespace);
-        if (kubeClient().getDeployment(deploymentNamespace, Constants.STRIMZI_DEPLOYMENT_NAME) != null) {
+        if (kubeClient().getDeployment(deploymentNamespace, Constants.STRIMZI_DEPLOYMENT_NAME) != null
+            || Environment.STRIMZI_INSTALLED.equalsIgnoreCase("true")) {
             LOGGER.warn("Skipping strimzi deployment. It is already deployed!");
             return;
         }
@@ -113,6 +116,10 @@ public class Strimzi {
      * @throws IOException the io exception
      */
     public void delete() throws IOException {
+        if (Environment.STRIMZI_INSTALLED.equalsIgnoreCase("true")) {
+            LOGGER.warn("Skipping Strimzi deletion. STRIMZI_INSTALLED was set to true");
+            return;
+        }
         LOGGER.info("Deleting Strimzi in {} namespace", deploymentNamespace);
         deployment.inNamespace(deploymentNamespace).delete();
         DeploymentUtils.waitForDeploymentDeletion(deploymentNamespace, Constants.STRIMZI_DEPLOYMENT_NAME);

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/strimzi/Strimzi.java
@@ -101,7 +101,7 @@ public class Strimzi {
     public void deploy() {
         LOGGER.info("Deploy Strimzi in {} namespace", deploymentNamespace);
         if (kubeClient().getDeployment(deploymentNamespace, Constants.STRIMZI_DEPLOYMENT_NAME) != null
-            || Environment.STRIMZI_INSTALLED.equalsIgnoreCase("true")) {
+                || Environment.STRIMZI_INSTALLED.equalsIgnoreCase("true")) {
             LOGGER.warn("Skipping strimzi deployment. It is already deployed!");
             return;
         }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/vault/Vault.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/vault/Vault.java
@@ -20,12 +20,12 @@ import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.ServicePort;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import io.kroxylicious.systemtests.k8s.exception.KubeClusterException;
 import io.kroxylicious.systemtests.resources.manager.ResourceManager;
 import io.kroxylicious.systemtests.utils.DeploymentUtils;
 import io.kroxylicious.systemtests.utils.NamespaceUtils;
-
-import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
 

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/vault/Vault.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/vault/Vault.java
@@ -20,12 +20,12 @@ import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.ServicePort;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-
 import io.kroxylicious.systemtests.k8s.exception.KubeClusterException;
 import io.kroxylicious.systemtests.resources.manager.ResourceManager;
 import io.kroxylicious.systemtests.utils.DeploymentUtils;
 import io.kroxylicious.systemtests.utils.NamespaceUtils;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
 

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/AbstractST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/AbstractST.java
@@ -75,9 +75,8 @@ public class AbstractST {
         LOGGER.info(String.format("%s Test Suite - STARTED", testInfo.getTestClass().get().getName()));
         cluster = KubeClusterResource.getInstance();
         certManager = new CertManager();
-        strimziOperator = new Strimzi(Environment.STRIMZI_NAMESPACE);
+        strimziOperator = new Strimzi(Constants.KAFKA_DEFAULT_NAMESPACE);
 
-        NamespaceUtils.createNamespaceWithWait(Environment.STRIMZI_NAMESPACE);
         NamespaceUtils.createNamespaceWithWait(Constants.KAFKA_DEFAULT_NAMESPACE);
         strimziOperator.deploy();
         certManager.deploy();
@@ -98,9 +97,7 @@ public class AbstractST {
             if (certManager != null) {
                 certManager.delete();
             }
-            NamespaceUtils.deleteNamespaceWithWait(Environment.STRIMZI_NAMESPACE);
             NamespaceUtils.deleteNamespaceWithWait(Constants.KAFKA_DEFAULT_NAMESPACE);
-            NamespaceUtils.deleteNamespaceWithWait(Constants.CERT_MANAGER_NAMESPACE);
         }
         else {
             LOGGER.warn("Teardown was skipped because SKIP_TEARDOWN was set to '{}'", Environment.SKIP_TEARDOWN);

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/AbstractST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/AbstractST.java
@@ -90,7 +90,7 @@ public class AbstractST {
      */
     @AfterAll
     static void teardown(TestInfo testInfo) throws IOException {
-        if (!Boolean.parseBoolean(Environment.SKIP_TEARDOWN)) {
+        if (!Environment.SKIP_TEARDOWN) {
             if (strimziOperator != null) {
                 strimziOperator.delete();
             }
@@ -100,7 +100,7 @@ public class AbstractST {
             NamespaceUtils.deleteNamespaceWithWait(Constants.KAFKA_DEFAULT_NAMESPACE);
         }
         else {
-            LOGGER.warn("Teardown was skipped because SKIP_TEARDOWN was set to '{}'", Environment.SKIP_TEARDOWN);
+            LOGGER.warn("Teardown was skipped because SKIP_TEARDOWN was set to 'true'");
         }
         LOGGER.info(String.join("", Collections.nCopies(76, "#")));
         LOGGER.info(String.format("%s Test Suite - FINISHED", testInfo.getTestClass().get().getName()));

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/AbstractST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/AbstractST.java
@@ -90,7 +90,7 @@ public class AbstractST {
      */
     @AfterAll
     static void teardown(TestInfo testInfo) throws IOException {
-        if (Environment.SKIP_TEARDOWN.equalsIgnoreCase("false")) {
+        if (!Boolean.parseBoolean(Environment.SKIP_TEARDOWN)) {
             if (strimziOperator != null) {
                 strimziOperator.delete();
             }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

* Created a new env variable:
    * `SKIP_STRIMZI_INSTALL` : skip strimzi installation

* Removed `STRIMZI_NAMESPACE` as the issue with the installation can be covered by the new variable.
* Refactored cert manager deployment detection

### Additional Context

When we have STRIMZI installed in a namespace that is protected in OCP, we cannot detect easily if it was already installed, so we need to create new env variable to easy the pipeline to be executed.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [X] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [X] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
