### PR TITLE
Publish images to Quay kroxylicious/kroxylicious rather than kroxylicious-developer

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -3,7 +3,7 @@
 # Requires repository variables:
 # - REGISTRY_SERVER - the server of the container registry service e.g. `quay.io` or `docker.io`
 # - REGISTRY_USERNAME - - your username on the service (or username of your robot account)
-# - REGISTRY_DESTINATION - the push destination (without tag portion) e.g. `quay.io/<my org>/kroxylicious-developer`
+# - REGISTRY_DESTINATION - the push destination (without tag portion) e.g. `quay.io/<my org>/kroxylicious`
 # and a repository secret
 # - REGISTRY_TOKEN - the access token that corresponds to `REGISTRY_USERNAME`
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.5.0
 
+* [#1004](https://github.com/kroxylicious/kroxylicious/pull/1004): Publish images to Quay kroxylicious/kroxylicious rather than kroxylicious-developer
 * [#997](https://github.com/kroxylicious/kroxylicious/issues/997): Add hardcoded maximum frame size
 * [#782](https://github.com/kroxylicious/kroxylicious/issues/782): Securely handle the HashiCorp Vault Token in Kroxylicious configuration
-* [#973](https://github.com/kroxylicious/kroxylicious/pull/973): Remove deprecated CompositeFilter and it's documentation
+* [#973](https://github.com/kroxylicious/kroxylicious/pull/973): Remove deprecated CompositeFilter and its documentation
 * [#935](https://github.com/kroxylicious/kroxylicious/pull/935): Enable user to configure alternative source of keys for vault KMS client
 * [#787](https://github.com/kroxylicious/kroxylicious/issues/787): Initial documentation for the envelope-encryption feature.
 * [#940](https://github.com/kroxylicious/kroxylicious/issues/940): Support vault namespaces and support secrets transit engine at locations other than /transit
@@ -37,6 +38,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
     token from a file (filename specified by a `passwordFile` field) or inline (`password` field).  The latter is not
     recommended in production environments.
 * The deprecated CompositeFilter interface has been removed.
+* Container images for releases will be published to quay.io/kroxylicious/kroxylicious (rather than kroxylicious-developer)
 
 ## 0.4.1
 

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -330,7 +330,7 @@ has been applied ineffectively.
      Create a public accessible repository within the registry named `kroxylicious`.
 
 ### Environment variables
-* `KROXYLICIOUS_IMAGE_REPO`: url to the image of kroxylicious to be used. Default value: `quay.io/kroxylicious/kroxylicious-developer`
+* `KROXYLICIOUS_IMAGE_REPO`: url to the image of kroxylicious to be used. Default value: `quay.io/kroxylicious/kroxylicious`
 * `KROXYLICIOUS_VERSION`: version of kroxylicious to be used. Default value: `${project.version}` in pom file
 * `KAFKA_VERSION`: kafka version to be used. Default value: `${kafka.version}` in pom file
 * `STRIMZI_URL`: url where to download strimzi. Default value: `https://strimzi.io/install/latest?namespace=kafka`
@@ -429,7 +429,7 @@ and one repository [secret](https://docs.github.com/en/actions/security-guides/u
 
 * `REGISTRY_SERVER` variable - the server of the container registry service e.g. `quay.io` or `docker.io`
 * `REGISTRY_USERNAME` variable - your username on the service (or username of your robot account)
-* `REGISTRY_DESTINATION` variable - the push destination (without tag portion) e.g. `quay.io/<my org>/kroxylicious-developer`
+* `REGISTRY_DESTINATION` variable - the push destination (without tag portion) e.g. `quay.io/<my org>/kroxylicious`
 
 * `REGISTRY_TOKEN` secret - the access token that corresponds to `REGISTRY_USERNAME` 
 

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
@@ -53,7 +53,7 @@ public class Environment {
     /**
      * The url where kroxylicious image lives to be downloaded.
      */
-    private static final String KROXY_IMAGE_REPO_DEFAULT = "quay.io/kroxylicious/kroxylicious-developer";
+    private static final String KROXY_IMAGE_REPO_DEFAULT = "quay.io/kroxylicious/kroxylicious";
 
     /**
      * The strimzi installation url for kubernetes.

--- a/kubernetes-examples/README.md
+++ b/kubernetes-examples/README.md
@@ -44,7 +44,7 @@ where `${kubernetes_example_directory}` is replaced by a path to an example dire
 To use an alternative image for Kroxylicious, set the `KROXYLICIOUS_IMAGE` environment variable.
 
 ```shell
-KROXYLICIOUS_IMAGE=quay.io/kroxylicious/kroxylicious-developer:x.y.z ./scripts/run-example.sh ${kubernetes_example_directory}
+KROXYLICIOUS_IMAGE=quay.io/kroxylicious/kroxylicious:x.y.z ./scripts/run-example.sh ${kubernetes_example_directory}
 ```
 
 This `run-example.sh` script does the following:

--- a/kubernetes-examples/envelope-encryption/base/kroxylicious/kroxylicious-deployment.yaml
+++ b/kubernetes-examples/envelope-encryption/base/kroxylicious/kroxylicious-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: kroxylicious
-        image: quay.io/kroxylicious/kroxylicious-developer:0.4.1
+        image: quay.io/kroxylicious/kroxylicious:0.5.0-SNAPSHOT
         imagePullPolicy: Always
         args: ["--config", "/opt/kroxylicious/config/config.yaml"]
         ports:

--- a/kubernetes-examples/multi-tenant/base/kroxylicious/kroxylicious-deployment.yaml
+++ b/kubernetes-examples/multi-tenant/base/kroxylicious/kroxylicious-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: kroxylicious
-        image: quay.io/kroxylicious/kroxylicious-developer:0.4.1
+        image: quay.io/kroxylicious/kroxylicious:kroxylicious:0.5.0-SNAPSHOT
         imagePullPolicy: Always
         args: ["--config", "/opt/kroxylicious/config/config.yaml"]
         ports:

--- a/kubernetes-examples/portperbroker_plain/base/kroxylicious/kroxylicious-deployment.yaml
+++ b/kubernetes-examples/portperbroker_plain/base/kroxylicious/kroxylicious-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: kroxylicious
-        image: quay.io/kroxylicious/kroxylicious-developer:0.4.1
+        image: quay.io/kroxylicious/kroxylicious:0.5.0-SNAPSHOT
         imagePullPolicy: Always
         args: ["--config", "/opt/kroxylicious/config/config.yaml"]
         ports:

--- a/kubernetes-examples/snirouting_tls/base/kroxylicious/kroxylicious-deployment.yaml
+++ b/kubernetes-examples/snirouting_tls/base/kroxylicious/kroxylicious-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: kroxylicious
-        image: quay.io/kroxylicious/kroxylicious-developer:0.4.1
+        image: quay.io/kroxylicious/kroxylicious:0.5.0-SNAPSHOT
         imagePullPolicy: Always
         args: ["--config", "/opt/kroxylicious/config/config.yaml"]
         ports:

--- a/scripts/run-example.sh
+++ b/scripts/run-example.sh
@@ -6,7 +6,7 @@
 #
 
 set -euo pipefail
-DEFAULT_KROXYLICIOUS_IMAGE='quay.io/kroxylicious/kroxylicious-developer'
+DEFAULT_KROXYLICIOUS_IMAGE='quay.io/kroxylicious/kroxylicious'
 KROXYLICIOUS_IMAGE=${KROXYLICIOUS_IMAGE:-${DEFAULT_KROXYLICIOUS_IMAGE}}
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Refactoring

### Description

We decided in discussion in #597, that at least for the moment, we'd publish release images exclusively to https://quay.io/repository/kroxylicious/kroxylicious.   The release images already include filters such as EnvelopeEncryption, so they are suitable for someone who want to try out the filters.

We'll stop publishing to kroxylicious-developer.


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
