### PR TITLE
Adding Snyk config file and exclusions for the CWE-547 false positive in test-code (InMemoryKms.java)

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,16 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# See https://docs.snyk.io/snyk-cli/scan-and-maintain-projects-using-the-cli/snyk-cli-for-snyk-code/exclude-directories-and-files-from-snyk-code-cli-tests
+
+ignore: {}
+version: v1.25.0
+patch: {}
+exclude:
+  global:
+    # CWE-547 java/HardcodedSecret in InMemoryKms.java,  kroxylicious.inmemory.* is non-production code therefore exclusion is reasonable
+    - >-
+      ./kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryKms.java


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

Adding Snyk config file and exclusion for `InMemoryKms.java` (which is test code) in order to silence CWE-547 false positive.


### Additional Context

Running 

```
snyk code test --severity-threshold=high --json --maven-aggregate-project
```
locally shows the exclusion is effective.


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
