### PR TITLE
Bugfix: containers failing to start in cgroups v2 container

### DIFF
--- a/kroxylicious-app/src/assembly/run-java.sh
+++ b/kroxylicious-app/src/assembly/run-java.sh
@@ -164,7 +164,7 @@ core_limit() {
     if [ -r "${cpu_file}" ]; then
       local cpu_quota cpu_period
       cpu_quota="$(cat ${cpu_file} | awk '{ print $1 }')"
-      cpu_quota="$(cat ${cpu_file} | awk '{ print $2 }')"
+      cpu_period="$(cat ${cpu_file} | awk '{ print $2 }')"
 
       # cfs_quota_us == max --> no restrictions
       if [ "${cpu_quota:-0}" != "max" ]; then


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The script was failing when run in a container due to the unbound variable when we came to use the `cpu_period` in a calculation.

```
[roby@roby kroxylicious]$ docker run quay.io/kroxylicious/kroxylicious-developer:0.5.0-SNAPSHOT
Unable to find image 'quay.io/kroxylicious/kroxylicious-developer:0.5.0-SNAPSHOT' locally
0.5.0-SNAPSHOT: Pulling from kroxylicious/kroxylicious-developer
2f5211d9dccf: Already exists 
95ac063522bb: Pull complete 
bb08e15b96d0: Pull complete 
3711a7982fe2: Pull complete 
Digest: sha256:d15249bdca5b533b5b515bb9083366699864b9986a123abf52925b9642ae2d85
Status: Downloaded newer image for quay.io/kroxylicious/kroxylicious-developer:0.5.0-SNAPSHOT
/opt/kroxylicious/bin/run-java.sh: line 171: cpu_period: unbound variable
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
