### PR TITLE
Use platform default provider when creating the SSLContext for HashiCorp Vault HTTP client.

### DIFF
--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/config/JdkTls.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/config/JdkTls.java
@@ -140,7 +140,7 @@ public record JdkTls(Tls tls) {
             if (trustManagers == null && keyManagers == null) {
                 return SSLContext.getDefault();
             }
-            SSLContext context = SSLContext.getInstance("TLS");
+            var context = SSLContext.getInstance(SSLContext.getDefault().getProtocol());
             context.init(keyManagers, trustManagers, new SecureRandom());
             return context;
         }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

why: until such time that Kroxylicious has its own mechanism for influencing the choice of TLS Protocol (#1006), it should just accept the default from the platform rather than imposing its own choice.

this change also avoid the spurious CWE-326 from the Snyk scanner.

On JDK 17, the has no functional change i.e the SSLContext (context.getDefaultSSLParameters().getProtocols()) still supports TLSv1.3 and TLSv1.2.




_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
