### PR TITLE
Integration test decryption of data

### DIFF
--- a/etc/checkstyle-custom_checks.xml
+++ b/etc/checkstyle-custom_checks.xml
@@ -15,6 +15,7 @@
     <module name="FileTabCharacter" />
 
     <module name="TreeWalker">
+        <module name="SuppressWarningsHolder" />
         <!-- Checks for imports -->
         <module name="AvoidStarImport" />
         <module name="RedundantImport" />
@@ -162,5 +163,5 @@
         <!--The system property is set via Maven-->
         <property name="file" value="${checkstyle.suppressions.file}"/>
     </module>
-
+    <module name="SuppressWarningsFilter" />
 </module>

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/DekManagerTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/DekManagerTest.java
@@ -8,6 +8,7 @@ package io.kroxylicious.filter.encryption.dek;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -26,7 +27,7 @@ class DekManagerTest {
     void testResolveAlias() {
         // Given
         UnitTestingKmsService unitTestingKmsService = UnitTestingKmsService.newInstance();
-        UnitTestingKmsService.Config options = new UnitTestingKmsService.Config(12, 96);
+        UnitTestingKmsService.Config options = new UnitTestingKmsService.Config(12, 96, List.of());
         var kms = unitTestingKmsService.buildKms(options);
         var kekId = kms.generateKey();
         kms.createAlias(kekId, "foo");
@@ -44,7 +45,7 @@ class DekManagerTest {
     void testLimitsNumbersOfEncryptors(CipherSpec cipherSpec) {
         // Given
         UnitTestingKmsService unitTestingKmsService = UnitTestingKmsService.newInstance();
-        UnitTestingKmsService.Config options = new UnitTestingKmsService.Config(12, 96);
+        UnitTestingKmsService.Config options = new UnitTestingKmsService.Config(12, 96, List.of());
         var kms = unitTestingKmsService.buildKms(options);
         var kekId = kms.generateKey();
         kms.createAlias(kekId, "foo");
@@ -62,7 +63,7 @@ class DekManagerTest {
     void testDecryptedEdekIsGoodForDecryptingData(CipherSpec cipherSpec) {
         // Given
         UnitTestingKmsService unitTestingKmsService = UnitTestingKmsService.newInstance();
-        UnitTestingKmsService.Config options = new UnitTestingKmsService.Config(12, 96);
+        UnitTestingKmsService.Config options = new UnitTestingKmsService.Config(12, 96, List.of());
         var kms = unitTestingKmsService.buildKms(options);
         var kekId = kms.generateKey();
         kms.createAlias(kekId, "foo");

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/EnvelopeEncryptionDeserializationCompatibilityIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/EnvelopeEncryptionDeserializationCompatibilityIT.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.encryption;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.kroxylicious.filter.encryption.EncryptionVersion;
+import io.kroxylicious.filter.encryption.EnvelopeEncryption;
+import io.kroxylicious.filter.encryption.TemplateKekSelector;
+import io.kroxylicious.kms.provider.kroxylicious.inmemory.UnitTestingKmsService;
+import io.kroxylicious.proxy.config.FilterDefinition;
+import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.common.ClientConfig;
+import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
+import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * We want to ensure that we can always read data written to Kafka by older versions of
+ * the filter. That means starting from binary injected into the upstream kafka cluster.
+ * We used hard-coded binary data with real examples produced by a filter for a known KEK
+ * id. This gives us confidence that the binary can be decoded. As opposed to constructing
+ * the encrypted data as part of the test code.
+ * We want to check that we can decode each encryption version and each supported cipher.
+ */
+@ExtendWith(KafkaClusterExtension.class)
+class EnvelopeEncryptionDeserializationCompatibilityIT {
+    private static final String ENCRYPTED_AES_TOPIC = "aes-topic";
+    private static final String PRE_EXISTING_AES_KEK_SECRET_BYTES = "FwailFttZJR2Jq43YPhwsKTtuTJQNnPPutrFu9uVPx4=";
+    private static final String PRE_EXISTING_AES_KEK_UUID = "c32d1cef-9c60-4f86-b56b-281684c98ad0";
+    private static final TestCase V1_VALUE_NOT_NULL = new TestCase(EncryptionVersion.V1, "value not null", ENCRYPTED_AES_TOPIC,
+            new SerializedRecord(List.of(new SerializedHeader("kroxylicious.io/encryption", "AQ==")),
+                    "YQ==",
+                    "AE6ADMHU4V/OFRDILMd8AsMtHO+cYE+GtWsoFoTJitA0Y8iY9RZBcQDxGqsIylR5ugQ57JYiqOOwLVPwm6X2t9iT/3VoUjJ/M8xFWpiczFIAT5ZR6To+WDLYniREKe+0/f6lRFsCb/MGEZhfVgkb3g=="),
+            new DeserializedRecord(List.of(), "a", "b"));
+
+    // null values are serialized as-is with no encryption header, we need to forward null on to support tombstoning compacted topics
+    private static final TestCase V1_VALUE_NULL = new TestCase(EncryptionVersion.V1, "value null", ENCRYPTED_AES_TOPIC,
+            new SerializedRecord(List.of(),
+                    "YQ==",
+                    null),
+            new DeserializedRecord(List.of(), "a", null));
+    private static final TestCase V1_OTHER_HEADERS = new TestCase(EncryptionVersion.V1, "other headers are preserved", ENCRYPTED_AES_TOPIC,
+            new SerializedRecord(List.of(new SerializedHeader("kroxylicious.io/encryption", "AQ=="), new SerializedHeader("x", "eQ==")),
+                    "YQ==",
+                    "AE6ADMNIqL7qk5zZDYBSp8MtHO+cYE+GtWsoFoTJitDZbCqfZvPsulMdhpO06acCIQ8unRSmTypxUAuaRyY5rZhrKP+WxohB5BUDHnMPztQAsUYlZQzgsNt3kbv4O7aPzm7Bh9FP2bl8c4fDXH33uA=="),
+            new DeserializedRecord(List.of(new DeserializedHeader("x", "y")), "a", "b"));
+
+    record SerializedHeader(String key, @Nullable String valueBase64) {
+        public byte[] valueBytes() {
+            return valueBase64 == null ? null : Base64.getDecoder().decode(valueBase64);
+        }
+
+        public Header toKafkaHeader() {
+            return new RecordHeader(key, valueBytes());
+        }
+    }
+
+    record SerializedRecord(List<SerializedHeader> headers, @Nullable String keyBase64, @Nullable String valueBase64) {
+        public byte[] keyBytes() {
+            return keyBase64 == null ? null : Base64.getDecoder().decode(keyBase64);
+        }
+
+        public byte[] valueBytes() {
+            return valueBase64 == null ? null : Base64.getDecoder().decode(valueBase64);
+        }
+
+        public Iterable<Header> kafkaHeaders() {
+            return headers.stream().map(SerializedHeader::toKafkaHeader).collect(Collectors.toList());
+        }
+    }
+
+    record DeserializedHeader(String name, @Nullable String value) {
+        public Header kafkaHeader() {
+            return new RecordHeader(name, value == null ? null : value.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    record DeserializedRecord(List<DeserializedHeader> headers, @Nullable String key, @Nullable String value) {
+        public ProducerRecord<String, String> producerRecord(String topic) {
+            return new ProducerRecord<>(topic, 0, key, value, headers.stream().map(DeserializedHeader::kafkaHeader).collect(
+                    Collectors.toList()));
+        }
+    }
+
+    // for now v1 encryption is hardcoded and implicit, in future it should be a configurable aspect of
+    // the filter.
+    record TestCase(EncryptionVersion version, String name, String topic, SerializedRecord serializedRecord, DeserializedRecord expected) {
+        public ProducerRecord<byte[], byte[]> producerRecord() {
+            return new ProducerRecord<>(topic, 0, serializedRecord.keyBytes(), serializedRecord.valueBytes(), serializedRecord.kafkaHeaders());
+        }
+    }
+
+    static Stream<Arguments> testCases() {
+        return Stream.of(V1_VALUE_NOT_NULL, V1_OTHER_HEADERS, V1_VALUE_NULL).map(testCase -> Arguments.of(testCase.version, testCase.name, testCase));
+    }
+
+    @ParameterizedTest(name = "encryption version: {0} - {1}")
+    @MethodSource("testCases")
+    void testRecordsCanBeDeserialized(EncryptionVersion ignoredVersion, String ignoredName, TestCase testCase, KafkaCluster cluster, Producer<byte[], byte[]> producer)
+            throws Exception {
+        producer.send(testCase.producerRecord()).get(5, TimeUnit.SECONDS);
+        try (var tester = kroxyliciousTester(proxy(cluster).addToFilters(buildEncryptionFilterDefinition()))) {
+            Map<String, Object> config = Map.of(ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString(), ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+            Consumer<String, String> consumer = tester.consumer(config);
+            consumer.subscribe(List.of(ENCRYPTED_AES_TOPIC));
+            ConsumerRecords<String, String> poll = consumer.poll(Duration.ofSeconds(5));
+            assertThat(poll.count()).isEqualTo(1);
+            ConsumerRecord<String, String> onlyRecord = poll.iterator().next();
+            assertExpected(testCase.expected, onlyRecord);
+        }
+    }
+
+    private void assertExpected(DeserializedRecord expected, ConsumerRecord<String, String> onlyRecord) {
+        List<DeserializedHeader> actual = StreamSupport.stream(onlyRecord.headers().spliterator(), false)
+                .map(h -> new DeserializedHeader(h.key(), h.value() == null ? null : new String(h.value(), StandardCharsets.UTF_8))).collect(Collectors.toList());
+        assertThat(actual).isEqualTo(expected.headers);
+        assertThat(onlyRecord.key()).isEqualTo(expected.key);
+        assertThat(onlyRecord.value()).isEqualTo(expected.value);
+    }
+
+    @Disabled("convenience to generate serialized data and print it to console, run from IDE")
+    @SuppressWarnings("java:S2699") // no assertions required
+    @ParameterizedTest(name = "encryption version: {0} - {1}")
+    @MethodSource("testCases")
+    void generateData(EncryptionVersion ignoredVersion, String ignoredName, TestCase testCase, KafkaCluster cluster,
+                      @ClientConfig(name = ConsumerConfig.GROUP_ID_CONFIG, value = "encryption") @ClientConfig(name = ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, value = "earliest") Consumer<byte[], byte[]> consumer)
+            throws ExecutionException, InterruptedException, TimeoutException {
+        try (var tester = kroxyliciousTester(proxy(cluster).addToFilters(buildEncryptionFilterDefinition()))) {
+            tester.producer().send(testCase.expected.producerRecord(ENCRYPTED_AES_TOPIC)).get(5, TimeUnit.SECONDS);
+            consumer.subscribe(List.of(ENCRYPTED_AES_TOPIC));
+            ConsumerRecords<byte[], byte[]> poll = consumer.poll(Duration.ofSeconds(5));
+            for (ConsumerRecord<byte[], byte[]> consumerRecord : poll) {
+                print(consumerRecord);
+            }
+        }
+    }
+
+    @SuppressWarnings({ "checkstyle:RegexpSinglelineJava" })
+    private static void print(ConsumerRecord<byte[], byte[]> consumerRecord) {
+        for (Header header : consumerRecord.headers()) {
+            byte[] value = header.value();
+            System.out.println("header: " + header.key() + ":" + base64IfNotNull(value));
+        }
+        System.out.println("key: " + base64IfNotNull(consumerRecord.key()));
+        System.out.println("value: " + base64IfNotNull(consumerRecord.value()));
+    }
+
+    private static String base64IfNotNull(byte[] value) {
+        return value == null ? "null" : Base64.getEncoder().encodeToString(value);
+    }
+
+    private FilterDefinition buildEncryptionFilterDefinition() {
+        byte[] kekSecret = Base64.getDecoder().decode(PRE_EXISTING_AES_KEK_SECRET_BYTES);
+        // when we add support for more ciphers, we could add additional topics with the relevant key material for that cipher
+        List<UnitTestingKmsService.Kek> existingKeks = List.of(
+                new UnitTestingKmsService.Kek(PRE_EXISTING_AES_KEK_UUID, kekSecret, "AES", ENCRYPTED_AES_TOPIC));
+        return new FilterDefinitionBuilder(EnvelopeEncryption.class.getSimpleName())
+                .withConfig("kms", UnitTestingKmsService.class.getSimpleName())
+                .withConfig("kmsConfig", new UnitTestingKmsService.Config(12, 128, existingKeks))
+                .withConfig("selector", TemplateKekSelector.class.getSimpleName())
+                .withConfig("selectorConfig", Map.of("template", "${topicName}"))
+                .build();
+    }
+}

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/pom.xml
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/pom.xml
@@ -33,6 +33,11 @@
             <artifactId>kroxylicious-api</artifactId>
         </dependency>
 
+        <!-- third party dependencies - build and compile -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryKms.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryKms.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Supplier;
 
@@ -50,11 +51,12 @@ public class InMemoryKms implements
     private final Map<String, UUID> aliases;
     private final List<DekPair<InMemoryEdek>> edeksGenerated = new CopyOnWriteArrayList<>();
 
-    InMemoryKms(int numIvBytes, int numAuthBits,
+    InMemoryKms(int numIvBytes,
+                int numAuthBits,
                 Map<UUID, SecretKey> keys,
                 Map<String, UUID> aliases) {
-        this.keys = keys;
-        this.aliases = aliases;
+        this.keys = new ConcurrentHashMap<>(keys);
+        this.aliases = new ConcurrentHashMap<>(aliases);
         this.secureRandom = new SecureRandom();
         this.numIvBytes = numIvBytes;
         this.numAuthBits = numAuthBits;

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/IntegrationTestingKmsService.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/IntegrationTestingKmsService.java
@@ -11,8 +11,6 @@ import java.util.ServiceLoader;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.crypto.SecretKey;
-
 import io.kroxylicious.kms.service.Kms;
 import io.kroxylicious.kms.service.KmsService;
 import io.kroxylicious.proxy.plugin.Plugin;
@@ -63,14 +61,7 @@ public class IntegrationTestingKmsService implements KmsService<IntegrationTesti
     @NonNull
     @Override
     public InMemoryKms buildKms(Config options) {
-        return KMSES.computeIfAbsent(options.name(), ignored -> {
-            var keys = new ConcurrentHashMap<UUID, SecretKey>();
-            var aliases = new ConcurrentHashMap<String, UUID>();
-            return new InMemoryKms(12,
-                    128,
-                    keys,
-                    aliases);
-        });
+        return KMSES.computeIfAbsent(options.name(), ignored -> new InMemoryKms(12, 128, Map.of(), Map.of()));
     }
 
     public static void delete(String name) {

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/UnitTestingKmsService.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/UnitTestingKmsService.java
@@ -6,10 +6,8 @@
 
 package io.kroxylicious.kms.provider.kroxylicious.inmemory;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -51,41 +49,12 @@ public class UnitTestingKmsService implements KmsService<UnitTestingKmsService.C
                 .orElse(null);
     }
 
+    @SuppressWarnings("java:S6218") // we currently don't need equals/hash to consider key contents
     public record Kek(
                       @JsonProperty(required = true) String uuid,
                       @JsonProperty(required = true) byte[] key,
                       @JsonProperty(required = true) String algorithm,
-                      @JsonProperty(required = true) String alias) {
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            Kek kek = (Kek) o;
-            return Objects.equals(uuid, kek.uuid) && Arrays.equals(key, kek.key) && Objects.equals(algorithm, kek.algorithm) && Objects.equals(alias, kek.alias);
-        }
-
-        @Override
-        public int hashCode() {
-            int result = Objects.hash(uuid, algorithm, alias);
-            result = 31 * result + Arrays.hashCode(key);
-            return result;
-        }
-
-        @Override
-        public String toString() {
-            return "Kek{" +
-                    "uuid='" + uuid + '\'' +
-                    ", key=" + Arrays.toString(key) +
-                    ", algorithm='" + algorithm + '\'' +
-                    ", alias='" + alias + '\'' +
-                    '}';
-        }
-    }
+                      @JsonProperty(required = true) String alias) {}
 
     public record Config(
                          int numIvBytes,

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/UnitTestingKmsServiceTest.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/UnitTestingKmsServiceTest.java
@@ -8,6 +8,7 @@ package io.kroxylicious.kms.provider.kroxylicious.inmemory;
 
 import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -36,12 +37,14 @@ class UnitTestingKmsServiceTest {
     @Test
     void shouldRejectOutOfBoundIvBytes() {
         // given
-        assertThrows(IllegalArgumentException.class, () -> new UnitTestingKmsService.Config(0, 128));
+        List<UnitTestingKmsService.Kek> existingKeks = List.of();
+        assertThrows(IllegalArgumentException.class, () -> new UnitTestingKmsService.Config(0, 128, existingKeks));
     }
 
     @Test
     void shouldRejectOutOfBoundAuthBits() {
-        assertThrows(IllegalArgumentException.class, () -> new UnitTestingKmsService.Config(12, 0));
+        List<UnitTestingKmsService.Kek> existingKeks = List.of();
+        assertThrows(IllegalArgumentException.class, () -> new UnitTestingKmsService.Config(12, 0, existingKeks));
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

We must always be able to decode encrypted records written to kafka in the past (as long as we have access to the KEK that encrypted the EDEK). This test proves that given some encrypted binary data in a proxied Kafka cluster, we can decrypt it. Starting from binary is not user-friendly but it gives us strong evidence that we have not broken decryption.

In future this would expand to prove we can decrypt binary data for new encryption versions and ciphers along with checking header and key decryption when we add those features.

Contributes to #992 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
