### PR TITLE
License loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.5.0
 
-* [#1019](https://github.com/kroxylicious/kroxylicious/pull/1019): Stopp logging license header as part of the startup banner. 
+* [#1019](https://github.com/kroxylicious/kroxylicious/pull/1019): Stop logging license header as part of the startup banner. 
 * [#1004](https://github.com/kroxylicious/kroxylicious/pull/1004): Publish images to Quay kroxylicious/kroxylicious rather than kroxylicious-developer
 * [#997](https://github.com/kroxylicious/kroxylicious/issues/997): Add hardcoded maximum frame size
 * [#782](https://github.com/kroxylicious/kroxylicious/issues/782): Securely handle the HashiCorp Vault Token in Kroxylicious configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.5.0
 
+* [#1019](https://github.com/kroxylicious/kroxylicious/pull/1019): Stopp logging license header as part of the startup banner. 
 * [#1004](https://github.com/kroxylicious/kroxylicious/pull/1004): Publish images to Quay kroxylicious/kroxylicious rather than kroxylicious-developer
 * [#997](https://github.com/kroxylicious/kroxylicious/issues/997): Add hardcoded maximum frame size
 * [#782](https://github.com/kroxylicious/kroxylicious/issues/782): Securely handle the HashiCorp Vault Token in Kroxylicious configuration

--- a/kroxylicious-app/src/main/java/io/kroxylicious/app/BannerLogger.java
+++ b/kroxylicious-app/src/main/java/io/kroxylicious/app/BannerLogger.java
@@ -19,27 +19,28 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 public class BannerLogger {
 
-    public static final String DEFAULT_BANNER_LOCATION = "banner.txt";
+    private static final String DEFAULT_BANNER_LOCATION = "banner.txt";
     private final Logger targetLogger;
     private final Supplier<Stream<String>> bannerReader;
     private final Level targetLevel;
 
     public BannerLogger() {
-        this(LoggerFactory.getLogger("io.kroxylicious.proxy.StartupShutdownLogger"),
+        this(getLogger("io.kroxylicious.proxy.StartupShutdownLogger"),
                 new BannerSupplier(DEFAULT_BANNER_LOCATION));
     }
 
     BannerLogger(Logger targetLogger, Supplier<Stream<String>> bannerReader) {
         this.targetLogger = targetLogger;
         this.bannerReader = bannerReader;
-        targetLevel = Level.INFO; // TODO should this be configurable?¡
+        targetLevel = Level.INFO;
     }
 
     public void log() {
@@ -49,16 +50,17 @@ public class BannerLogger {
     @VisibleForTesting
     static class BannerSupplier implements Supplier<Stream<String>> {
 
+        private static final String LICENSE_TXT = "license.txt";
         private final Supplier<Stream<String>> linesSupplier;
         private final Set<String> licenseLines;
 
         BannerSupplier(String resourceName) {
-            this(new FileLinesSupplier(resourceName), new FileLinesSupplier("etc/LICENSE.txt"));
+            this(new FileLinesSupplier(resourceName), new FileLinesSupplier(LICENSE_TXT));
         }
 
         BannerSupplier(Supplier<Stream<String>> bannerLinesSupplier, Supplier<Stream<String>> licenceStream) {
             linesSupplier = bannerLinesSupplier;
-            licenseLines = Stream.concat(Stream.of("===="), licenceStream.get()).collect(Collectors.toSet());
+            licenseLines = licenceStream.get().collect(Collectors.toSet());
         }
 
         @Override

--- a/kroxylicious-app/src/main/resources/license.txt
+++ b/kroxylicious-app/src/main/resources/license.txt
@@ -1,0 +1,6 @@
+====
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+====
+

--- a/kroxylicious-app/src/test/java/io/kroxylicious/app/BannerLoggerTest.java
+++ b/kroxylicious-app/src/test/java/io/kroxylicious/app/BannerLoggerTest.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.app;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -16,8 +18,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 import org.slf4j.spi.LoggingEventBuilder;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -30,10 +34,11 @@ class BannerLoggerTest {
     private LoggingEventBuilder loggingEventBuilder;
 
     private Stream<String> bannerStream = Stream.empty();
+    private Logger testLogger;
 
     @BeforeEach
     void setUp() {
-        Logger testLogger = mock(Logger.class);
+        testLogger = mock(Logger.class);
         when(testLogger.atLevel(any())).thenReturn(loggingEventBuilder);
         bannerLogger = new BannerLogger(testLogger, () -> bannerStream);
     }
@@ -48,6 +53,26 @@ class BannerLoggerTest {
 
         // Then
         verify(loggingEventBuilder).log(anyString());
+    }
+
+    @Test
+    void shouldNotAppendLicenseHeader() {
+        // Given
+        bannerStream = Stream.of("====", "Copyright Kroxylicious Authors.",
+                "Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0", "banner_text");
+        final BannerLogger.BannerSupplier bannerSupplier = new BannerLogger.BannerSupplier(() -> bannerStream, () -> Stream.of("====", "Copyright Kroxylicious Authors.",
+                "Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0"));
+        List<String> actualLines = new ArrayList<>();
+        doAnswer(invocationOnMock -> actualLines.add(invocationOnMock.getArgument(0, String.class)))
+                .when(loggingEventBuilder).log(anyString());
+
+        bannerLogger = new BannerLogger(testLogger, bannerSupplier);
+
+        // When
+        bannerLogger.log();
+
+        // Then
+        assertThat(actualLines).containsOnly("banner_text");
     }
 
     @Test

--- a/kroxylicious-app/src/test/java/io/kroxylicious/app/BannerLoggerTest.java
+++ b/kroxylicious-app/src/test/java/io/kroxylicious/app/BannerLoggerTest.java
@@ -58,7 +58,7 @@ class BannerLoggerTest {
     @Test
     void shouldNotAppendLicenseHeader() {
         // Given
-        bannerStream = Stream.of("====", "Copyright Kroxylicious Authors.",
+        bannerStream = Stream.of("Copyright Kroxylicious Authors.",
                 "Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0", "banner_text");
         final BannerLogger.BannerSupplier bannerSupplier = new BannerLogger.BannerSupplier(() -> bannerStream, () -> Stream.of("====", "Copyright Kroxylicious Authors.",
                 "Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0"));


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

fixes #1008 The new smaller banner demonstrated that the code that was meant to suppress the licence header wasn't actually working.

```shell
/opt/kroxylicious/bin /
exec java -Dlog4j2.configurationFile=/opt/kroxylicious/bin/../config/log4j2.yaml -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005 -XX:+ExitOnOutOfMemoryError -cp /opt/kroxylicious/bin/../libs/* io.kroxylicious.app.Kroxylicious --config=/opt/kroxylicious/config.yaml
/
Listening for transport dt_socket at address: 5005
2024-02-20 02:22:24 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:96 - Kroxylicious is starting
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -                  .:---:.
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -              -*@@@@@@@@@@%++*##*+:
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -            -@@%=:.      :=%@*++#@@%-         :=++- .+%%%#=
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -           -@@-    .        +     *@@-:::---=#@@%@@@@@%=+@@#
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -           #@=    -@+        .     @@@@@@@@@%%%:  +==-   *@@
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -        :*@@@.    .+:              ...                   #@@
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -       #@@*: .                                           @@#
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -      %@@:                                              =@@-
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -     =@@:                                               %@%
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -     *@@                                             :-*@@-
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -     +@@          -                       .:--=**##*%@=@@#
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -     :@@=   .    +@%+-.     ..:--=++*####*#-  =+..:-*@%@@.
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -      %@@   =-    . :=+*****++==-:..  .:-=+@+ #@@@@@@@@@:
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -      :@@+   %=              .:-=+#%@@@@@@%#@#@@-.  :@%.
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -       *@@:  .%%+-:::--=+*#%%*+-:+@@*-:.    -@@%     =
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -        %@%    -*#%%##*=-:       .@@=        .#+
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -     -**%@@-                     -@@-          .      .:
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -    *@@**%@=                     %@@                .*@+
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -    -@@#-                       -@@-              :*@@@#
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -     .*@@#        .             %@%            :+%@@*@@#
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -     :%@%.       .=  =         .@@*. .::==+++#@@@*-  @@*
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -    =@@#         :**#:         :@@@@@@@@@@@#%#=:    *@@.
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -   *@@=                        :@*-:+:.- .--:.     +@@=
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -  %@@: .:                       #%===**#++       :#@@-
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 - :@@+.  -#*-      *=             -.-= :        :#@@*.
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -  =%@@@@@@@@@#=..%+                         :+%@@*:
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -     :::::::+#@@@+                     :=+%@@@*-
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -              *@@  .:=##*+======++*#%@@@@%*=.
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -              :%@@@@@@#*##%%@@@%%##*+=-.
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:45 -                .--:.
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:82 - kroxylicious: 0.5.0-SNAPSHOT
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:82 - commit id: bedaf09e10007070c9ea522f4e5c6dc8895b2d60
2024-02-20 02:22:48 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:82 - commit message: keep our own copy of the licence, so we know what to suppress.
```
### Additional Context



### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
