### PR TITLE
Bugfix: KMS retry logic failing with Null Pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.5.0
 
+* [#1020](https://github.com/kroxylicious/kroxylicious/pull/1020): KMS retry logic failing with Null Pointers
 * [#1019](https://github.com/kroxylicious/kroxylicious/pull/1019): Stop logging license header as part of the startup banner. 
 * [#1004](https://github.com/kroxylicious/kroxylicious/pull/1004): Publish images to Quay kroxylicious/kroxylicious rather than kroxylicious-developer
 * [#997](https://github.com/kroxylicious/kroxylicious/issues/997): Add hardcoded maximum frame size

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/ResilientKms.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/ResilientKms.java
@@ -29,6 +29,7 @@ import io.kroxylicious.kms.service.UnknownKeyException;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.Optional.ofNullable;
 
 public class ResilientKms<K, E> implements Kms<K, E> {
@@ -39,19 +40,19 @@ public class ResilientKms<K, E> implements Kms<K, E> {
     private final BackoffStrategy strategy;
     private final int retries;
 
-    private ResilientKms(Kms<K, E> inner,
-                         ScheduledExecutorService executorService,
-                         BackoffStrategy backoffStrategy,
+    private ResilientKms(@NonNull Kms<K, E> inner,
+                         @NonNull ScheduledExecutorService executorService,
+                         @NonNull BackoffStrategy backoffStrategy,
                          int retries) {
-        this.inner = inner;
-        this.executorService = executorService;
-        strategy = backoffStrategy;
+        this.inner = requireNonNull(inner);
+        this.executorService = requireNonNull(executorService);
+        strategy = requireNonNull(backoffStrategy);
         this.retries = retries;
     }
 
-    public static <K, E> Kms<K, E> wrap(Kms<K, E> delegate,
-                                        ScheduledExecutorService executorService,
-                                        BackoffStrategy strategy,
+    public static <K, E> Kms<K, E> wrap(@NonNull Kms<K, E> delegate,
+                                        @NonNull ScheduledExecutorService executorService,
+                                        @NonNull BackoffStrategy strategy,
                                         int retries) {
         return new ResilientKms<>(delegate, executorService,
                 strategy, retries);

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopeEncryptionTest.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.filter.encryption;
 
 import java.time.Duration;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.junit.jupiter.api.Test;
@@ -56,5 +57,14 @@ class EnvelopeEncryptionTest {
         assertThat(config.resolvedAliasCacheSize()).isEqualTo(1000);
         assertThat(config.resolvedAliasExpireAfterWriteDuration()).isEqualTo(Duration.ofMinutes(10));
         assertThat(config.resolvedAliasRefreshAfterWriteDuration()).isEqualTo(Duration.ofMinutes(8));
+    }
+
+    @Test
+    void testRetryPool() {
+        Future<Thread> thread = EnvelopeEncryption.RETRY_POOL.submit(Thread::currentThread);
+        assertThat(thread).succeedsWithin(Duration.ofSeconds(5)).satisfies(thread1 -> {
+            assertThat(thread1.getName()).isEqualTo("kmsRetry");
+            assertThat(thread1.isDaemon()).isTrue();
+        });
     }
 }

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/ResilientKmsTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/ResilientKmsTest.java
@@ -29,6 +29,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -358,6 +359,34 @@ class ResilientKmsTest {
 
         // then
         assertThat(serde).isSameAs(mockSerde);
+    }
+
+    @Test
+    void testExecutorNotNullable() {
+        Kms<Long, Long> kms = Mockito.mock(Kms.class);
+        Serde mockSerde = mock(Serde.class);
+        when(kms.edekSerde()).thenReturn(mockSerde);
+        BackoffStrategy backoffStrategy = mock(BackoffStrategy.class);
+        assertThatThrownBy(() -> ResilientKms.wrap(kms, null, backoffStrategy, 3))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testInnerKmsNotNullable() {
+        BackoffStrategy backoffStrategy = mock(BackoffStrategy.class);
+        ScheduledExecutorService executor = getMockExecutor();
+        assertThatThrownBy(() -> ResilientKms.wrap(null, executor, backoffStrategy, 3))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testBackoffStrategyNotNullable() {
+        Kms<Long, Long> kms = Mockito.mock(Kms.class);
+        Serde mockSerde = mock(Serde.class);
+        when(kms.edekSerde()).thenReturn(mockSerde);
+        ScheduledExecutorService executor = getMockExecutor();
+        assertThatThrownBy(() -> ResilientKms.wrap(kms, executor, null, 3))
+                .isInstanceOf(NullPointerException.class);
     }
 
     @NonNull

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/FilterIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/FilterIT.java
@@ -147,8 +147,8 @@ class FilterIT {
 
     static ByteBuffer encode(String topicName, ByteBuffer in) {
         var out = ByteBuffer.allocate(in.limit());
-        byte rot = (byte) (topicName.hashCode() % Byte.MAX_VALUE);
         for (int index = 0; index < in.limit(); index++) {
+            byte rot = getRot(topicName, index);
             byte b = in.get(index);
             byte rotated = (byte) (b + rot);
             out.put(index, rotated);
@@ -156,12 +156,18 @@ class FilterIT {
         return out;
     }
 
+    private static byte getRot(String topicName, int index) {
+        char c = topicName.charAt(index % topicName.length());
+        int i = topicName.hashCode() + c;
+        return (byte) (i % Byte.MAX_VALUE);
+    }
+
     static ByteBuffer decode(String topicName, ByteBuffer in) {
         var out = ByteBuffer.allocate(in.limit());
         out.limit(in.limit());
-        byte rot = (byte) -(topicName.hashCode() % Byte.MAX_VALUE);
         for (int index = 0; index < in.limit(); index++) {
             byte b = in.get(index);
+            byte rot = (byte) -getRot(topicName, index);
             byte rotated = (byte) (b + rot);
             out.put(index, rotated);
         }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

With recent refactoring the resilient KMS started being constructed with a null executor service. This caused a failure as soon as we needed to retry.

With this change retries are driven by a single thread shared across the proxies. KMS work currently is done quickly, feeding into an asynchronous call via the java HTTP client. Other KMS implementations would have to be careful not to bog this thread down.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
