### PR TITLE
Experiment with annotations documenting threading

### DIFF
--- a/kroxylicious-annotations/src/main/java/io/kroxylicious/proxy/tag/CompletesOnThread.java
+++ b/kroxylicious-annotations/src/main/java/io/kroxylicious/proxy/tag/CompletesOnThread.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.tag;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.function.Function;
+
+/**
+ * Annotation to document the thread on which an
+ * asynchronous result callback, such as might be passed to
+ * {@link java.util.concurrent.CompletionStage#thenApply(Function)}, will be executed.
+ * The intention is that this annotation is applied to methods which return CompletionStage,
+ * parameters of type CompletionStage, and so on.
+ */
+@Documented
+@Target({ ElementType.TYPE_USE, ElementType.PARAMETER,
+        ElementType.METHOD,
+        ElementType.FIELD,
+        ElementType.LOCAL_VARIABLE,
+        ElementType.RECORD_COMPONENT })
+@Retention(RetentionPolicy.SOURCE)
+public @interface CompletesOnThread {
+    /**
+     * A description of the thread on which the {@link java.util.concurrent.CompletableFuture},
+     * {@link java.util.concurrent.CompletionStage} or other asynchronous result
+     * is completed. Use "*" if the asynchronous result can complete on any thread
+     * (for example on usage in an interface which doesn't define a policy for implementors)
+     * @return
+     */
+    String value();
+}

--- a/kroxylicious-annotations/src/main/java/io/kroxylicious/proxy/tag/RunsOnThread.java
+++ b/kroxylicious-annotations/src/main/java/io/kroxylicious/proxy/tag/RunsOnThread.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.tag;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to document the thread on which the annotated code will be executed.
+ */
+@Documented
+@Target({ ElementType.METHOD,
+        ElementType.CONSTRUCTOR })
+@Retention(RetentionPolicy.SOURCE)
+public @interface RunsOnThread {
+    /**
+     * A description of the thread on which the annotated code is executed
+     * @return
+     */
+    String value();
+}

--- a/kroxylicious-api/pom.xml
+++ b/kroxylicious-api/pom.xml
@@ -80,6 +80,10 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-annotations</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
@@ -15,6 +15,7 @@ import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 
 import io.kroxylicious.proxy.ApiVersionsService;
+import io.kroxylicious.proxy.tag.CompletesOnThread;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -70,6 +71,7 @@ public interface FilterContext {
      * @param request The request to forward to the broker.
      * @return completed filter results.
      */
+    @CompletesOnThread("filter thread")
     CompletionStage<RequestFilterResult> forwardRequest(@NonNull RequestHeaderData header, @NonNull ApiMessage request);
 
     /**
@@ -104,8 +106,8 @@ public interface FilterContext {
      * @see io.kroxylicious.proxy.filter Thread Safety
      */
     @NonNull
-    <M extends ApiMessage> CompletionStage<M> sendRequest(@NonNull RequestHeaderData header,
-                                                          @NonNull ApiMessage request);
+    <M extends ApiMessage> @CompletesOnThread("filter thread") CompletionStage<M> sendRequest(@NonNull RequestHeaderData header,
+                                                                                              @NonNull ApiMessage request);
 
     /**
      * Generates a completed filter results containing the given header and response.  When
@@ -119,6 +121,7 @@ public interface FilterContext {
      * @param response The request to forward to the broker.
      * @return completed filter results.
      */
+    @CompletesOnThread("filter thread")
     CompletionStage<ResponseFilterResult> forwardResponse(@NonNull ResponseHeaderData header, @NonNull ApiMessage response);
 
     /**

--- a/kroxylicious-api/src/main/templates/Kproxy/Filter.ftl
+++ b/kroxylicious-api/src/main/templates/Kproxy/Filter.ftl
@@ -35,6 +35,9 @@ import java.util.concurrent.CompletionStage;
 import org.apache.kafka.common.message.${dataClass};
 import org.apache.kafka.common.message.${headerClass};
 
+import io.kroxylicious.proxy.tag.CompletesOnThread;
+import io.kroxylicious.proxy.tag.RunsOnThread;
+
 /**
  * A stateless filter for ${messageSpec.name}s.
  */
@@ -48,6 +51,7 @@ public interface ${filterClass} extends Filter {
      * @param apiVersion the apiVersion of the message
      * @return true if it should be handled
      */
+    @RunsOnThread("filter thread")
     default boolean shouldHandle${messageSpec.name}(short apiVersion) {
         return true;
     }
@@ -68,6 +72,8 @@ public interface ${filterClass} extends Filter {
      * @see io.kroxylicious.proxy.filter Creating Filter Result objects
      * @see io.kroxylicious.proxy.filter  Thread Safety
      */
+     @RunsOnThread("filter thread")
+     @CompletesOnThread("*")
      CompletionStage<${filterResultClass}> on${messageSpec.name}(short apiVersion, ${headerClass} header, ${dataClass} ${msgType}, FilterContext context);
 
 }

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/DecryptionManager.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/DecryptionManager.java
@@ -12,6 +12,8 @@ import java.util.function.IntFunction;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 
+import io.kroxylicious.proxy.tag.RunsOnThread;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -27,6 +29,7 @@ public interface DecryptionManager {
      * @param bufferAllocator Allocator of ByteBufferOutputStream
      * @return A completion stage that completes with the output MemoryRecords when all the records have been processed and transformed.
      */
+    @RunsOnThread("filter thread")
     @NonNull
     CompletionStage<MemoryRecords> decrypt(
                                            @NonNull String topicName,

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EncryptionManager.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/EncryptionManager.java
@@ -12,6 +12,9 @@ import java.util.function.IntFunction;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 
+import io.kroxylicious.proxy.tag.CompletesOnThread;
+import io.kroxylicious.proxy.tag.RunsOnThread;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -28,6 +31,8 @@ public interface EncryptionManager<K> {
      * @param bufferAllocator Allocator of ByteBufferOutputStream
      * @return A completion stage that completes with the output MemoryRecords when all the records have been processed and transformed.
      */
+    @RunsOnThread("filter thread")
+    @CompletesOnThread("filter thread")
     @NonNull
     CompletionStage<MemoryRecords> encrypt(
                                            @NonNull String topicName,

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/FilterThreadExecutor.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/FilterThreadExecutor.java
@@ -11,6 +11,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 
+import io.kroxylicious.proxy.tag.CompletesOnThread;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -37,7 +39,7 @@ public class FilterThreadExecutor {
      * completed with the result of stage on the Filter thread
      * @param <T> result type
      */
-    public <T> @NonNull CompletionStage<T> completingOnFilterThread(@NonNull CompletionStage<T> stage) {
+    public @CompletesOnThread("filter thread") <T> @NonNull CompletionStage<T> completingOnFilterThread(@CompletesOnThread("*") @NonNull CompletionStage<T> stage) {
         CompletableFuture<T> future = stage.toCompletableFuture();
         if (future.isDone()) {
             return stage;

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DekManager.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DekManager.java
@@ -15,6 +15,7 @@ import javax.crypto.SecretKey;
 import io.kroxylicious.kms.service.Kms;
 import io.kroxylicious.kms.service.KmsService;
 import io.kroxylicious.kms.service.Serde;
+import io.kroxylicious.proxy.tag.CompletesOnThread;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -62,7 +63,7 @@ public class DekManager<K, E> {
      * @return A completion state that completes with the {@link Dek}, or
      * fails if the request to the KMS fails.
      */
-    public CompletionStage<Dek<E>> generateDek(@NonNull K kekRef, @NonNull CipherSpec cipherSpec) {
+    public @CompletesOnThread("*") CompletionStage<Dek<E>> generateDek(@NonNull K kekRef, @NonNull CipherSpec cipherSpec) {
         Objects.requireNonNull(kekRef);
         Objects.requireNonNull(cipherSpec);
         return kms.generateDekPair(kekRef).thenApply(dekPair -> {
@@ -79,7 +80,7 @@ public class DekManager<K, E> {
      * @return A completion stage that completes with the {@link Dek}, or
      * fails if the request to the KMS fails.
      */
-    public CompletionStage<Dek<E>> decryptEdek(@NonNull E edek, @NonNull CipherSpec cipherSpec) {
+    public @CompletesOnThread("*") CompletionStage<Dek<E>> decryptEdek(@NonNull E edek, @NonNull CipherSpec cipherSpec) {
         Objects.requireNonNull(edek);
         Objects.requireNonNull(cipherSpec);
         return kms.decryptEdek(edek).thenApply(key -> new Dek<>(edek, new DestroyableRawSecretKey(key.getAlgorithm(), key.getEncoded()), cipherSpec, 0));

--- a/kroxylicious-kms/pom.xml
+++ b/kroxylicious-kms/pom.xml
@@ -29,6 +29,10 @@
             <artifactId>spotbugs-annotations</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-annotations</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/Kms.java
+++ b/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/Kms.java
@@ -10,6 +10,8 @@ import java.util.concurrent.CompletionStage;
 
 import javax.crypto.SecretKey;
 
+import io.kroxylicious.proxy.tag.CompletesOnThread;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -31,6 +33,7 @@ public interface Kms<K, E> {
      * @throws KmsException For other exceptions.
      */
     @NonNull
+    @CompletesOnThread("*")
     CompletionStage<DekPair<E>> generateDekPair(@NonNull K kekRef);
 
     /**
@@ -42,6 +45,7 @@ public interface Kms<K, E> {
      * @throws KmsException For other exceptions
      */
     @NonNull
+    @CompletesOnThread("*")
     CompletionStage<SecretKey> decryptEdek(@NonNull E edek);
 
     /**
@@ -61,5 +65,6 @@ public interface Kms<K, E> {
      * @throws KmsException For other exceptions.
      */
     @NonNull
+    @CompletesOnThread("*")
     CompletionStage<K> resolveAlias(@NonNull String alias);
 }


### PR DESCRIPTION
This PR adds a couple of annotations for documenting threading semantics, and applies that in various places.

The idea is to be able to record, in a more structured way, what threads are running what code. Some hoped-for benefits of this:

* It makes it easier to document what we're doing, 
* It makes it easier to catch mistakes earlier (e.g. because the threading model is more in-your-face during code review)
* It makes it easier for newbies to understand the threading model, because it's more explicit

On the other hand:

* This relies entirely on discipline to keep up to date: Nothing is validating that the annotations are actually correct. So there's a danger that what's documented subsequently changes (or was just wrong to begin with).

I opened this for discussion. I'm not wedded to merging this. I just wondered whether people think this is useful.