### PR TITLE
Log virtual cluster and metrics binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.5.0
 
+* [#1024](https://github.com/kroxylicious/kroxylicious/pull/1024): Log virtual cluster and metrics binding
 * [#1032](https://github.com/kroxylicious/kroxylicious/pull/1032): Cache unknown alias resolutions temporarily
 * [#1031](https://github.com/kroxylicious/kroxylicious/pull/1031): Fix inconsistently named configuration key in test filter class (FetchResponseTransformationFilter)
 * [#1020](https://github.com/kroxylicious/kroxylicious/pull/1020): KMS retry logic failing with Null Pointers

--- a/kroxylicious-app/src/main/java/io/kroxylicious/app/Kroxylicious.java
+++ b/kroxylicious-app/src/main/java/io/kroxylicious/app/Kroxylicious.java
@@ -61,9 +61,9 @@ public class Kroxylicious implements Callable<Integer> {
         try (InputStream stream = Files.newInputStream(configFile.toPath())) {
 
             Configuration config = configParser.parseConfiguration(stream);
+            printBannerAndVersions();
             try (KafkaProxy kafkaProxy = proxyBuilder.apply(configParser, config)) {
                 kafkaProxy.startup();
-                printBannerAndVersions();
                 kafkaProxy.block();
             }
         }

--- a/kroxylicious-app/src/main/resources/log4j2.yaml
+++ b/kroxylicious-app/src/main/resources/log4j2.yaml
@@ -21,28 +21,8 @@ Configuration:
       AppenderRef:
         - ref: STDOUT
     Logger:
-      - name: io.kroxylicious.proxy.internal.DownstreamNetworkLogger
-        level: INFO
-        additivity: false
-        AppenderRef:
-          - ref: STDOUT
-      - name: io.kroxylicious.proxy.internal.UpstreamNetworkLogger
-        level: INFO
-        additivity: false
-        AppenderRef:
-          - ref: STDOUT
-      - name: io.kroxylicious.proxy.internal.DownstreamFrameLogger
-        level: INFO
-        additivity: false
-        AppenderRef:
-          - ref: STDOUT
-      - name: io.kroxylicious.proxy.internal.UpstreamFrameLogger
-        level: INFO
-        additivity: false
-        AppenderRef:
-          - ref: STDOUT
-      - name: io.kroxylicious.proxy.StartupShutdownLogger
-        level: INFO
+      - name: io.kroxylicious
+        level: "${env:KROXYLICIOUS_APP_LOG_LEVEL:-${env:KROXYLICIOUS_ROOT_LOG_LEVEL:-INFO}}"
         additivity: false
         AppenderRef:
           - ref: STDOUT

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -173,6 +173,7 @@ public final class KafkaProxy implements AutoCloseable {
                     .option(ChannelOption.SO_REUSEADDR, true)
                     .channel(eventGroupConfig.clazz())
                     .childHandler(new AdminHttpInitializer(meterRegistries, adminHttpConfig));
+            LOGGER.info("Binding metrics endpoint: {}:{}", adminHttpConfig.host(), adminHttpConfig.port());
             metricsChannel = metricsBootstrap.bind(adminHttpConfig.host(), adminHttpConfig.port()).sync().channel();
         }
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/NetworkBindRequest.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/NetworkBindRequest.java
@@ -54,11 +54,11 @@ public class NetworkBindRequest extends NetworkBindingOperation<Channel> {
             var bindingAddress = endpoint.bindingAddress();
             ChannelFuture bind;
             if (bindingAddress.isPresent()) {
-                LOGGER.info("Binding {}:{}", bindingAddress.get(), port);
+                LOGGER.debug("Binding {}:{}", bindingAddress.get(), port);
                 bind = serverBootstrap.bind(bindingAddress.get(), port);
             }
             else {
-                LOGGER.info("Binding <any>:{}", port);
+                LOGGER.debug("Binding <any>:{}", port);
                 bind = serverBootstrap.bind(port);
             }
             bind.addListener((ChannelFutureListener) channelFuture -> {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
@@ -68,6 +68,7 @@ public class VirtualCluster implements ClusterNetworkAddressConfigProvider {
         logVirtualClusterSummary(clusterName, targetCluster, clusterNetworkAddressConfigProvider, tls);
     }
 
+    @SuppressWarnings("java:S1874") // the classes are deprecated because we don't want them in the API module
     private static void logVirtualClusterSummary(String clusterName, TargetCluster targetCluster,
                                                  ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider,
                                                  Optional<Tls> tls) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
@@ -13,6 +13,9 @@ import java.util.stream.Collectors;
 
 import javax.net.ssl.SSLException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 
@@ -41,6 +44,8 @@ public class VirtualCluster implements ClusterNetworkAddressConfigProvider {
 
     private final Optional<SslContext> downstreamSslContext;
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(VirtualCluster.class);
+
     public VirtualCluster(String clusterName,
                           TargetCluster targetCluster,
                           ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider,
@@ -60,6 +65,23 @@ public class VirtualCluster implements ClusterNetworkAddressConfigProvider {
         // TODO: https://github.com/kroxylicious/kroxylicious/issues/104 be prepared to reload the SslContext at runtime.
         this.upstreamSslContext = buildUpstreamSslContext();
         this.downstreamSslContext = buildDownstreamSslContext();
+        logVirtualClusterSummary(clusterName, targetCluster, clusterNetworkAddressConfigProvider, tls);
+    }
+
+    private static void logVirtualClusterSummary(String clusterName, TargetCluster targetCluster,
+                                                 ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider,
+                                                 Optional<Tls> tls) {
+        try {
+            var downstreamTls = tls.map(tls1 -> " (TLS)").orElse("");
+            HostPort downstreamBootstrap = clusterNetworkAddressConfigProvider.getClusterBootstrapAddress();
+            var upstreamTls = targetCluster.tls().map(tls1 -> " (TLS)").orElse("");
+            HostPort upstreamHostPort = targetCluster.bootstrapServersList().get(0);
+            LOGGER.info("Virtual Cluster: {}, Downstream {}{} => Upstream {}{}",
+                    clusterName, downstreamBootstrap, downstreamTls, upstreamHostPort, upstreamTls);
+        }
+        catch (Exception e) {
+            LOGGER.warn("Failed to log summary for Virtual Cluster: {}", clusterName, e);
+        }
     }
 
     public String getClusterName() {


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

To improve visibility of what Kroxylicious is doing with port bindings this PR:
1. increases the `io.kroxylicious` log level to INFO.
2. The `io.kroxylicious` log level honours the `KROXYLICIOUS_ROOT_LOG_LEVEL` environment variable, but we also introduce a `KROXYLICIOUS_APP_LOG_LEVEL` environment variable which takes precedence. This new env var only controls the `io.kroxylicious` level.
3. adds logs at virtual cluster configuration time to expose details about where we are routing from and to

The logs are aware of whether SNI/tls is involved.

### Example of SNI

```
2024-02-26 02:23:52 <main> INFO  io.kroxylicious.proxy.model.VirtualCluster:78 - Virtual Cluster: my-cluster-proxy, Downstream mycluster-proxy.kafka:9092 (TLS) => Upstream my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093 (TLS)
```

### Example of plain port per broker
```
2024-02-26 02:52:06 <main> INFO  io.kroxylicious.proxy.model.VirtualCluster:78 - Virtual Cluster: my-cluster-proxy, Downstream minikube:30192 => Upstream my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
