### PR TITLE
Fix inconsistently named configuration key in test filter class (FetchResponseTransformationFilter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.5.0
 
+* 
+* [#1031](https://github.com/kroxylicious/kroxylicious/pull/1031): Fix inconsistently named configuration key in test filter class (FetchResponseTransformationFilter)
 * [#1020](https://github.com/kroxylicious/kroxylicious/pull/1020): KMS retry logic failing with Null Pointers
 * [#1019](https://github.com/kroxylicious/kroxylicious/pull/1019): Stop logging license header as part of the startup banner. 
 * [#1004](https://github.com/kroxylicious/kroxylicious/pull/1004): Publish images to Quay kroxylicious/kroxylicious rather than kroxylicious-developer
@@ -41,6 +43,8 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
     recommended in production environments.
 * The deprecated CompositeFilter interface has been removed.
 * Container images for releases will be published to quay.io/kroxylicious/kroxylicious (rather than kroxylicious-developer)
+* `FetchResponseTransformationFilter` now uses configuration key `transformationConfig` (rather than `config`). This matches
+  the configuration expected by `ProduceRequestTransformationFilter`.
 
 ## 0.4.1
 

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/proxy/filter/simpletransform/FetchResponseTransformationFilterFactory.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/proxy/filter/simpletransform/FetchResponseTransformationFilterFactory.java
@@ -35,11 +35,11 @@ public class FetchResponseTransformationFilterFactory
                                                           Config configuration) {
         var factory = context.pluginInstance(ByteBufferTransformationFactory.class, configuration.transformation());
         Objects.requireNonNull(factory, "Violated contract of FilterCreationContext");
-        return new FetchResponseTransformationFilter(factory.createTransformation(configuration.config()));
+        return new FetchResponseTransformationFilter(factory.createTransformation(configuration.transformationConfig()));
     }
 
     public record Config(@JsonProperty(required = true) @PluginImplName(ByteBufferTransformationFactory.class) String transformation,
-                         @PluginImplConfig(implNameProperty = "transformation") Object config) {
+                         @PluginImplConfig(implNameProperty = "transformation") Object transformationConfig) {
 
     }
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

`ProduceRequestTransformationFilter` expects a `transformationConfig` whereas the filter's companion `FetchResponseTransformationFilter` expects `config`.   They should be configured by the same key.  `transformationConfig` is the better, more descriptive name.


### Additional Context

Consistency.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
