### PR TITLE
Cache unknown alias resolutions for 30 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.5.0
 
-* 
+* [#1032](https://github.com/kroxylicious/kroxylicious/pull/1032): Cache unknown alias resolutions temporarily
 * [#1031](https://github.com/kroxylicious/kroxylicious/pull/1031): Fix inconsistently named configuration key in test filter class (FetchResponseTransformationFilter)
 * [#1020](https://github.com/kroxylicious/kroxylicious/pull/1020): KMS retry logic failing with Null Pointers
 * [#1019](https://github.com/kroxylicious/kroxylicious/pull/1019): Stop logging license header as part of the startup banner. 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

When we ask the KMS to resolve an alias and it responds 404, we do not ask the KMS for that alias again for ~30 seconds.

Why:
As part of #1015 we discovered that there was a big penalty to pushing produce traffic through the Encryption Filter for topics we
do not intend to encrypt.

On the encryption path, for every Produce Request we look for a KEK for every topic in the request. If we have obtained a KEK already we would hit our caches and everything is fine. If there is nothing cached, which is the case when there is no matching KEK in the KMS, then we ask the KMS to resolve an alias. This means we hammer the KMS in the case where we do not want to encrypt the data going through. In our test this pushed Vault's CPU usage up and could start to look like a DOS to users.

This change adds a default 30 seconds of caching for a not-found-alias. Meaning we do not call out to the KMS again to resolve alias X and should therefore take the pressure off. Note this could be amplified by a large number of topics in a production system so it might be good to have a pessimistic default.

Note this is a stopgap because we think the Filter should not be using the KMS response to dictate whether we encrypt, so we want to make the Filter aware of which topics _require_ encryption. This is covered by #811. With this implemented the not-found case would become an error condition and we could lean on our existing exponential backoff logic to slow down requests to the KMS.

edit: we also wanted to make this configurable in case users need to modify it in an emergency. To do this we add an  `experimental` field to carry arbitrary key-value configuration that we are not committed to supporting yet. This makes it explicit that it may not be supported in future.

```yaml
config:
    experimental:
        decryptedDekCacheSize: 2000
        decryptedDekExpireAfterAccessSeconds: 1000
        resolvedAliasCacheSize: 2000
        resolvedAliasExpireAfterWriteSeconds: 2000
        resolvedAliasRefreshAfterWriteSeconds: 1800
        notFoundAliasExpireAfterWriteSeconds: 60
    kms: VaultKmsService
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
