### PR TITLE
Support exact and prefix-based per-topic-name KEK selection templates

### DIFF
--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/TemplateKekSelector.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/TemplateKekSelector.java
@@ -13,12 +13,10 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.regex.Pattern;
 
 import io.kroxylicious.kms.service.Kms;
-import io.kroxylicious.kms.service.UnknownAliasException;
 import io.kroxylicious.proxy.plugin.Plugin;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -106,13 +104,6 @@ public class TemplateKekSelector<K> implements KekSelectorService<TemplateKekSel
                                 }
                                 String alias = evaluateTemplate(template, topicName);
                                 return kms.resolveAlias(alias)
-                                        .exceptionallyCompose(e -> {
-                                            if (e instanceof UnknownAliasException
-                                                    || (e instanceof CompletionException ce && ce.getCause() instanceof UnknownAliasException)) {
-                                                return CompletableFuture.completedFuture(null);
-                                            }
-                                            return CompletableFuture.failedFuture(e);
-                                        })
                                         .thenApply(kekId -> new Pair<>(topicName, kekId));
                             })
                     .toList();

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/TemplateKekSelector.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/TemplateKekSelector.java
@@ -33,20 +33,6 @@ public class TemplateKekSelector<K> implements KekSelectorService<TemplateKekSel
                 throw new IllegalArgumentException("Either topicName or topicNamePrefix (but not both), must be specified");
             }
         }
-
-        // @JsonCreator
-        // public static TopicNameMatcher fromTopicName(
-        // @JsonProperty(value = "topicName", required = true) String topicName,
-        // @JsonProperty(value = "template", required = true) String template) {
-        // return new TopicNameMatcher(topicName, null, template);
-        // }
-
-        // @JsonCreator
-        // public static TopicNameMatcher fromTopicPrefix(
-        // @JsonProperty(value = "topicNamePrefix", required = true) String topicNamePrefix,
-        // @JsonProperty(value = "template", required = true) String template) {
-        // return new TopicNameMatcher(null, topicNamePrefix, template);
-        // }
     }
 
     public record Config(List<TopicNameMatcher> templates) {}
@@ -66,7 +52,7 @@ public class TemplateKekSelector<K> implements KekSelectorService<TemplateKekSel
         private final Kms<K, ?> kms;
 
         KekSelector(@NonNull Kms<K, ?> kms, @NonNull List<TopicNameMatcher> topicNameMatchers) {
-            var templates = new TreeMap<String, String>();
+            var validatedTemplates = new TreeMap<String, String>();
             for (var topicNameMatcher : topicNameMatchers) {
                 var template = topicNameMatcher.template();
                 var matcher = PATTERN.matcher(Objects.requireNonNull(template));
@@ -77,16 +63,16 @@ public class TemplateKekSelector<K> implements KekSelectorService<TemplateKekSel
                     throw new IllegalArgumentException("Unknown template parameter: " + matcher.group(1));
                 }
                 if (topicNameMatcher.topicName() != null && !topicNameMatcher.topicName().isEmpty()) {
-                    templates.put(topicNameMatcher.topicName(), template);
-                    templates.put(topicNameMatcher.topicName() + END_EXACT, null);
+                    validatedTemplates.put(topicNameMatcher.topicName(), template);
+                    validatedTemplates.put(topicNameMatcher.topicName() + END_EXACT, null);
                 }
                 else {
-                    templates.put(topicNameMatcher.topicNamePrefix(), template);
-                    templates.put(topicNameMatcher.topicNamePrefix() + END_PREFIX, null);
+                    validatedTemplates.put(topicNameMatcher.topicNamePrefix(), template);
+                    validatedTemplates.put(topicNameMatcher.topicNamePrefix() + END_PREFIX, null);
                 }
             }
 
-            this.templates = Objects.requireNonNull(templates);
+            this.templates = Objects.requireNonNull(validatedTemplates);
             this.kms = Objects.requireNonNull(kms);
         }
 

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/TemplateKekSelector.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/TemplateKekSelector.java
@@ -7,9 +7,11 @@
 package io.kroxylicious.filter.encryption;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
@@ -20,51 +22,99 @@ import io.kroxylicious.kms.service.UnknownAliasException;
 import io.kroxylicious.proxy.plugin.Plugin;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 @Plugin(configType = TemplateKekSelector.Config.class)
 public class TemplateKekSelector<K> implements KekSelectorService<TemplateKekSelector.Config, K> {
-    public record Config(String template) {}
+
+    public record TopicNameMatcher(String topicName,
+                                   String topicNamePrefix,
+                                   String template) {
+        public TopicNameMatcher {
+            if ((topicName == null || topicName.isEmpty()) == (topicNamePrefix == null)) {
+                throw new IllegalArgumentException("Either topicName or topicNamePrefix (but not both), must be specified");
+            }
+        }
+
+        // @JsonCreator
+        // public static TopicNameMatcher fromTopicName(
+        // @JsonProperty(value = "topicName", required = true) String topicName,
+        // @JsonProperty(value = "template", required = true) String template) {
+        // return new TopicNameMatcher(topicName, null, template);
+        // }
+
+        // @JsonCreator
+        // public static TopicNameMatcher fromTopicPrefix(
+        // @JsonProperty(value = "topicNamePrefix", required = true) String topicNamePrefix,
+        // @JsonProperty(value = "template", required = true) String template) {
+        // return new TopicNameMatcher(null, topicNamePrefix, template);
+        // }
+    }
+
+    public record Config(List<TopicNameMatcher> templates) {}
 
     @NonNull
     @Override
     public TopicNameBasedKekSelector<K> buildSelector(@NonNull Kms<K, ?> kms, Config config) {
-        return new KekSelector<>(kms, config.template());
+        return new KekSelector<>(kms, config.templates());
     }
 
     static class KekSelector<K> extends TopicNameBasedKekSelector<K> {
 
+        private static final char END_EXACT = '\0'; // a char before the smallest allowed character in a topic name
+        private static final char END_PREFIX = '{'; // the char after the largest allowed character in a topic name
         public static final Pattern PATTERN = Pattern.compile("\\$\\{(.*?)}");
-        private final String template;
+        private final TreeMap<String, String> templates;
         private final Kms<K, ?> kms;
 
-        KekSelector(@NonNull Kms<K, ?> kms, @NonNull String template) {
-            var matcher = PATTERN.matcher(Objects.requireNonNull(template));
-            while (matcher.find()) {
-                if (matcher.group(1).equals("topicName")) {
-                    continue;
+        KekSelector(@NonNull Kms<K, ?> kms, @NonNull List<TopicNameMatcher> topicNameMatchers) {
+            var templates = new TreeMap<String, String>();
+            for (var topicNameMatcher : topicNameMatchers) {
+                var template = topicNameMatcher.template();
+                var matcher = PATTERN.matcher(Objects.requireNonNull(template));
+                while (matcher.find()) {
+                    if (matcher.group(1).equals("topicName")) {
+                        continue;
+                    }
+                    throw new IllegalArgumentException("Unknown template parameter: " + matcher.group(1));
                 }
-                throw new IllegalArgumentException("Unknown template parameter: " + matcher.group(1));
+                if (topicNameMatcher.topicName() != null && !topicNameMatcher.topicName().isEmpty()) {
+                    templates.put(topicNameMatcher.topicName(), template);
+                    templates.put(topicNameMatcher.topicName() + END_EXACT, null);
+                }
+                else {
+                    templates.put(topicNameMatcher.topicNamePrefix(), template);
+                    templates.put(topicNameMatcher.topicNamePrefix() + END_PREFIX, null);
+                }
             }
-            this.template = Objects.requireNonNull(template);
+
+            this.templates = Objects.requireNonNull(templates);
             this.kms = Objects.requireNonNull(kms);
         }
 
-        private record Pair<K>(String topicName, K kekId) {}
+        private record Pair<K>(@NonNull String topicName, @Nullable K kekId) {}
 
         @NonNull
         @Override
         public CompletionStage<Map<String, K>> selectKek(@NonNull Set<String> topicNames) {
             var collect = topicNames.stream()
                     .map(
-                            topicName -> kms.resolveAlias(evaluateTemplate(topicName))
-                                    .exceptionallyCompose(e -> {
-                                        if (e instanceof UnknownAliasException
-                                                || (e instanceof CompletionException ce && ce.getCause() instanceof UnknownAliasException)) {
-                                            return CompletableFuture.completedFuture(null);
-                                        }
-                                        return CompletableFuture.failedFuture(e);
-                                    })
-                                    .thenApply(kekId -> new Pair<>(topicName, kekId)))
+                            topicName -> {
+                                String template = lookup(topicName);
+                                if (template == null) {
+                                    return CompletableFuture.completedFuture(new Pair<K>(topicName, null));
+                                }
+                                String alias = evaluateTemplate(template, topicName);
+                                return kms.resolveAlias(alias)
+                                        .exceptionallyCompose(e -> {
+                                            if (e instanceof UnknownAliasException
+                                                    || (e instanceof CompletionException ce && ce.getCause() instanceof UnknownAliasException)) {
+                                                return CompletableFuture.completedFuture(null);
+                                            }
+                                            return CompletableFuture.failedFuture(e);
+                                        })
+                                        .thenApply(kekId -> new Pair<>(topicName, kekId));
+                            })
                     .toList();
             return EnvelopeEncryptionFilter.join(collect).thenApply(list -> {
                 // Note we can't use `java.util.stream...(Collectors.toMap())` to build the map, because it has null values
@@ -77,7 +127,9 @@ public class TemplateKekSelector<K> implements KekSelectorService<TemplateKekSel
             });
         }
 
-        String evaluateTemplate(String topicName) {
+        @NonNull
+        String evaluateTemplate(@NonNull String template, @NonNull String topicName) {
+
             var matcher = PATTERN.matcher(template);
             StringBuilder sb = new StringBuilder();
             while (matcher.find()) {
@@ -92,6 +144,29 @@ public class TemplateKekSelector<K> implements KekSelectorService<TemplateKekSel
             }
             matcher.appendTail(sb);
             return sb.toString();
+        }
+
+        private @Nullable String lookup(@NonNull String topicName) {
+            var geEntry = templates.ceilingEntry(topicName);
+            if (geEntry == null) {
+                return null;
+            }
+            String geKey = geEntry.getKey();
+            if (geKey.equals(topicName)) { // exact match
+                return geEntry.getValue();
+            }
+            if (geKey.endsWith("" + END_EXACT)) { // failed on exact match
+                return null;
+            }
+            else if (geKey.endsWith("{")) {
+                // it might be a prefix match
+                var leEntry = templates.floorEntry(topicName);
+                if (leEntry != null && topicName.startsWith(leEntry.getKey())) {
+                    return leEntry.getValue();
+                }
+                throw new IllegalArgumentException("topicName: " + topicName + ", ge: " + geKey + ", le: " + leEntry);
+            }
+            return null;
         }
     }
 }

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/TopicNameBasedKekSelector.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/TopicNameBasedKekSelector.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.filter.encryption;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
@@ -24,5 +25,5 @@ public abstract class TopicNameBasedKekSelector<K> {
      * @param topicNames A set of topic names
      * @return A completion stage for the map form topic name to KEK id.
      */
-    public abstract @NonNull Map<String, CompletionStage<K>> selectKek(@NonNull Set<String> topicNames);
+    public abstract @NonNull Map<String, CompletionStage<Optional<K>>> selectKek(@NonNull Set<String> topicNames);
 }

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/TopicNameBasedKekSelector.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/TopicNameBasedKekSelector.java
@@ -20,7 +20,7 @@ public abstract class TopicNameBasedKekSelector<K> {
 
     /**
      * Returns a completion stage whose value, on successful completion, is a map from each of the given topic
-     * names to the KEK id to use for encrypting records in that topic.
+     * names to the KEK id to use for encrypting records in that topic, or a null KEK if that topic should not be encrypted.
      * @param topicNames A set of topic names
      * @return A completion stage for the map form topic name to KEK id.
      */

--- a/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/TopicNameBasedKekSelector.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/main/java/io/kroxylicious/filter/encryption/TopicNameBasedKekSelector.java
@@ -24,5 +24,5 @@ public abstract class TopicNameBasedKekSelector<K> {
      * @param topicNames A set of topic names
      * @return A completion stage for the map form topic name to KEK id.
      */
-    public abstract @NonNull CompletionStage<Map<String, K>> selectKek(@NonNull Set<String> topicNames);
+    public abstract @NonNull Map<String, CompletionStage<K>> selectKek(@NonNull Set<String> topicNames);
 }

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/TemplateKekSelectorTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/TemplateKekSelectorTest.java
@@ -14,7 +14,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 

--- a/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/TemplateKekSelectorTest.java
+++ b/kroxylicious-filters/kroxylicious-encryption/src/test/java/io/kroxylicious/filter/encryption/TemplateKekSelectorTest.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -87,20 +88,20 @@ class TemplateKekSelectorTest {
         var mapAssert = assertThat(selector.selectKek(expect.keySet()))
                 .containsOnlyKeys(expect.keySet());
         mapAssert
-                .extractingByKey("my-topic", as(InstanceOfAssertFactories.completionStage(UUID.class)))
+                .extractingByKey("my-topic", as(InstanceOfAssertFactories.completionStage(Optional.class)))
                 .succeedsWithin(Duration.ZERO)
-                .isEqualTo(kek1);
+                .isEqualTo(Optional.of(kek1));
         for (var k : expect.entrySet().stream().filter(e -> kek2.equals(e.getValue())).map(e -> e.getKey()).toList()) {
             mapAssert
-                    .extractingByKey(k, as(InstanceOfAssertFactories.completionStage(UUID.class)))
+                    .extractingByKey(k, as(InstanceOfAssertFactories.completionStage(Optional.class)))
                     .succeedsWithin(Duration.ZERO)
-                    .isEqualTo(kek2);
+                    .isEqualTo(Optional.of(kek2));
         }
         for (var k : expect.entrySet().stream().filter(e -> e.getValue() == null).map(e -> e.getKey()).toList()) {
             mapAssert
-                    .extractingByKey(k, as(InstanceOfAssertFactories.completionStage(UUID.class)))
+                    .extractingByKey(k, as(InstanceOfAssertFactories.completionStage(Optional.class)))
                     .succeedsWithin(Duration.ZERO)
-                    .isNull();
+                    .isEqualTo(Optional.empty());
         }
     }
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/EnvelopeEncryptionFilterIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/EnvelopeEncryptionFilterIT.java
@@ -485,7 +485,9 @@ class EnvelopeEncryptionFilterIT {
                 .withConfig("kms", testKmsFacade.getKmsServiceClass().getSimpleName())
                 .withConfig("kmsConfig", testKmsFacade.getKmsServiceConfig())
                 .withConfig("selector", TemplateKekSelector.class.getSimpleName())
-                .withConfig("selectorConfig", Map.of("template", TEMPLATE_KEK_SELECTOR_PATTERN))
+                .withConfig("selectorConfig", Map.of("templates",
+                        List.of(Map.of("topicNamePrefix", "",
+                                "template", TEMPLATE_KEK_SELECTOR_PATTERN))))
                 .build();
     }
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/EnvelopeEncryptionFilterIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/EnvelopeEncryptionFilterIT.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
@@ -24,6 +25,7 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ResourceNotFoundException;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.ThrowingConsumer;
 import org.junit.jupiter.api.TestTemplate;
@@ -363,6 +365,44 @@ class EnvelopeEncryptionFilterIT {
         }
     }
 
+    @TestTemplate
+    void unknownAliasIsError(KafkaCluster cluster, Topic encryptedTopic, Topic unknownTopic, TestKmsFacade<?, ?, ?> testKmsFacade)
+            throws Exception {
+        var testKekManager = testKmsFacade.getTestKekManager();
+        testKekManager.generateKek(encryptedTopic.name());
+
+        var builder = proxy(cluster);
+        builder.addToFilters(buildEncryptionFilterDefinitionAllTopics(testKmsFacade));
+
+        try (var tester = kroxyliciousTester(builder);
+                var producer = tester.producer(Map.of(
+                        ProducerConfig.LINGER_MS_CONFIG, 1000,
+                        ProducerConfig.BATCH_SIZE_CONFIG, 2,
+                        ProducerConfig.RETRIES_CONFIG, 0,
+                        ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 2000,
+                        ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 8000));
+                var consumer = tester.consumer()) {
+
+            var fut0 = producer.send(new ProducerRecord<>(encryptedTopic.name(), HELLO_SECRET));
+            var fut1 = producer.send(new ProducerRecord<>(unknownTopic.name(), HELLO_WORLD));
+            producer.flush();
+            assertThat(fut0).succeedsWithin(10, TimeUnit.SECONDS);
+            assertThat(fut1).failsWithin(10, TimeUnit.SECONDS)
+                    .withThrowableOfType(ExecutionException.class)
+                    .havingCause()
+                    .isExactlyInstanceOf(ResourceNotFoundException.class)
+                    .withMessage("Encryption key or alias not known to KMS. See proxy logs for details.");
+
+            consumer.subscribe(List.of(encryptedTopic.name(), unknownTopic.name()));
+            var records = consumer.poll(Duration.ofSeconds(2));
+            assertThat(records.iterator())
+                    .toIterable()
+                    .extracting(ConsumerRecord::value)
+                    .contains(HELLO_SECRET)
+                    .doesNotContain(HELLO_WORLD);
+        }
+    }
+
     /**
      * Test that ensures that the record offsets returned by the broker are faithfully relayed to the client.
      * @param cluster underlying kafka cluster
@@ -491,7 +531,9 @@ class EnvelopeEncryptionFilterIT {
                 .build();
     }
 
-    private FilterDefinition buildEncryptionFilterDefinitionOneTopic(TestKmsFacade<?, ?, ?> testKmsFacade, String encryptedTopicName) {
+    private FilterDefinition buildEncryptionFilterDefinitionOneTopic(
+                                                                     TestKmsFacade<?, ?, ?> testKmsFacade,
+                                                                     String encryptedTopicName) {
         return new FilterDefinitionBuilder(EnvelopeEncryption.class.getSimpleName())
                 .withConfig("kms", testKmsFacade.getKmsServiceClass().getSimpleName())
                 .withConfig("kmsConfig", testKmsFacade.getKmsServiceConfig())


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

In addition to the KMS flooding mitigation in #1032, this PR changes how we configure topic name-based KEK selection. 
Rather than using a single template like `template: topic-${topicName}` this allows to specify a list of "template matchers" which either match exactly on the topic name, or on a prefix of the topic name, like this:

```yaml
    templates:
    - topicName: foo
      template: alias-for-${topicName}
    - topicNamePrefix: bar-
      template: alias-bar
```

This, in turn, means we can configure templates for some topics (e.g. `foo` and `bar-whatever`), but not others (`baz`), which allows us to stop treating `UnknownAliasException` the same as "unencrypted", and avoid the need to ask the KMS to resolve aliases for topics which don't need to be encrypted.

There are a few things still to do in this PR:

* [ ] Better validation of the configuration (e.g. error on duplicate `topicNamePrefix`)
* [x] Use an appropriate Kafka error code when a KMS throws `UnknownAliasException`
* [x] A test for the above. The unknown alias should be logged, but not propagated in the krpc error message
* [ ] Fix example configs (e.g in the docs)