### PR TITLE
Encryption rename open-rewrite rule

### DIFF
--- a/kroxylicious-migrations/pom.xml
+++ b/kroxylicious-migrations/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.kroxylicious</groupId>
+        <artifactId>kroxylicious-parent</artifactId>
+        <version>0.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kroxylicious-migrations</artifactId>
+
+</project>

--- a/kroxylicious-migrations/src/main/resources/META-INF/rewrite/rewrite.yaml
+++ b/kroxylicious-migrations/src/main/resources/META-INF/rewrite/rewrite.yaml
@@ -7,10 +7,19 @@
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.kroxylicious.rewrite.maven.EncryptionModuleToRecordEncryption
-displayName: Change Maven dependency example
+displayName: "Update replaced maven artifact io.kroxylicious:kroxylicious-encryption with kroxylicious-record-encryption"
 recipeList:
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
       oldGroupId: io.kroxylicious
       oldArtifactId: kroxylicious-encryption
       newGroupId: io.kroxylicious
       newArtifactId: kroxylicious-record-encryption
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.kroxylicious.rewrite.filterConfig.EnvelopeEncryptionFilterToRecordEncryptionFilter
+displayName: "Replace usages of EnvelopeEncryption Filter in config files with the RecordEncryption Filter"
+recipeList:
+  - org.openrewrite.yaml.ChangeValue:
+      keyPath: $.filters.*.type[?(@ == 'EnvelopeEncryption')]
+      value: RecordEncryption
+

--- a/kroxylicious-migrations/src/main/resources/META-INF/rewrite/rewrite.yaml
+++ b/kroxylicious-migrations/src/main/resources/META-INF/rewrite/rewrite.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.kroxylicious.rewrite.maven.EncryptionModuleToRecordEncryption
+displayName: Change Maven dependency example
+recipeList:
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: io.kroxylicious
+      oldArtifactId: kroxylicious-encryption
+      newGroupId: io.kroxylicious
+      newArtifactId: kroxylicious-record-encryption

--- a/kubernetes-examples/pom.xml
+++ b/kubernetes-examples/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>io.kroxylicious</groupId>
+		<artifactId>kroxylicious-parent</artifactId>
+		<version>0.5.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>kubernetes-examples</artifactId>
+	<packaging>pom</packaging>
+
+	<build>
+		<sourceDirectory>${project.basedir}</sourceDirectory>
+	</build>
+
+	<profiles>
+		<profile>
+			<id>dist</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-assembly-plugin</artifactId>
+						<configuration>
+							<descriptors>
+								<descriptor>${project.basedir}/src/assembly.xml</descriptor>
+							</descriptors>
+						</configuration>
+						<executions>
+							<execution>
+								<id>package-examples</id>
+								<phase>package</phase>
+								<goals>
+									<goal>single</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
+</project>

--- a/kubernetes-examples/src/assembly.xml
+++ b/kubernetes-examples/src/assembly.xml
@@ -1,0 +1,28 @@
+<!--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 https://maven.apache.org/xsd/assembly-2.2.0.xsd">
+	<id>src</id>
+	<formats>
+		<format>tar.gz</format>
+		<format>tar.bz2</format>
+		<format>zip</format>
+	</formats>
+	<fileSets>
+		<fileSet>
+			<directory>${project.basedir}</directory>
+			<includes>
+				<include>**</include>
+			</includes>
+			<excludes>
+				<exclude>src</exclude>
+			</excludes>
+			<useDefaultExcludes>true</useDefaultExcludes>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -398,6 +398,7 @@
         <module>kroxylicious-filters</module>
         <module>kroxylicious-sample</module>
         <module>kroxylicious-migrations</module>
+        <module>kubernetes-examples</module>
     </modules>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -397,6 +397,7 @@
         <module>kroxylicious-runtime</module>
         <module>kroxylicious-filters</module>
         <module>kroxylicious-sample</module>
+        <module>kroxylicious-migrations</module>
     </modules>
 
 


### PR DESCRIPTION
### Type of change


- Enhancement / new feature

### Description

Building on #1043 as it move the maven co-ordinates I thought I'd experiment with an [Open Rewrite](https://docs.openrewrite.org/) which would automatically perform the migration. This PR also adds a rewrite rule to update Kroxylicious config files.

### Additional Context
To test the rule I added a dependency on the old name to the sample pom and asked it to update it.

```shell
mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
  -Drewrite.recipeArtifactCoordinates=io.kroxylicious:kroxylicious-migrations:0.5.0-SNAPSHOT \
  -Drewrite.activeRecipes=io.kroxylicious.rewrite.maven.EncryptionModuleToRecordEncryption \
  -pl :kroxylicious-sample

[INFO] Scanning for projects...
Downloading from central: https://repo.maven.apache.org/maven2/org/openrewrite/maven/rewrite-maven-plugin/maven-metadata.xml
Downloaded from central: https://repo.maven.apache.org/maven2/org/openrewrite/maven/rewrite-maven-plugin/maven-metadata.xml (5.6 kB at 15 kB/s)
[INFO] 
[INFO] ----------------< io.kroxylicious:kroxylicious-sample >-----------------
[INFO] Building Sample filters 0.5.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] >>> rewrite-maven-plugin:5.23.3:run (default-cli) > process-test-classes @ kroxylicious-sample >>>
[INFO] 
[INFO] --- maven-enforcer-plugin:3.4.1:enforce (enforce-plugin-versions) @ kroxylicious-sample ---
[INFO] Rule 0: org.apache.maven.enforcer.rules.RequirePluginVersions passed
[INFO] 
[INFO] --- maven-enforcer-plugin:3.4.1:enforce (enforce-java-versions) @ kroxylicious-sample ---
[INFO] Rule 0: org.apache.maven.enforcer.rules.version.RequireJavaVersion passed
[INFO] 
[INFO] --- maven-enforcer-plugin:3.4.1:enforce (enforce-systemtest-isolation) @ kroxylicious-sample ---
[INFO] Rule 0: org.apache.maven.enforcer.rules.dependency.BannedDependencies passed
[INFO] 
[INFO] --- directory-maven-plugin:1.0:highest-basedir (resolve-rootdir) @ kroxylicious-sample ---
[INFO] Highest basedir set to: /Users/sbarker/development/kroxy/kroxylicious
[INFO] 
[INFO] --- formatter-maven-plugin:2.23.0:format (format-sources) @ kroxylicious-sample ---
[INFO] Processed 6 files in 923ms (Formatted: 0, Skipped: 0, Unchanged: 6, Failed: 0, Readonly: 0)
[INFO] 
[INFO] --- impsort-maven-plugin:1.9.0:sort (sort-imports) @ kroxylicious-sample ---
[INFO] Processed 10 files in 00:00.019 (Already Sorted: 10, Needed Sorting: 0)
[INFO] 
[INFO] --- maven-resources-plugin:3.3.1:resources (default-resources) @ kroxylicious-sample ---
[INFO] Copying 1 resource from src/main/resources to target/classes
[INFO] 
[INFO] --- maven-compiler-plugin:3.12.1:compile (default-compile) @ kroxylicious-sample ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] --- formatter-maven-plugin:2.23.0:format (format-test-sources) @ kroxylicious-sample ---
[INFO] Processed 4 files in 115ms (Formatted: 0, Skipped: 0, Unchanged: 4, Failed: 0, Readonly: 0)
[INFO] 
[INFO] --- maven-resources-plugin:3.3.1:testResources (default-testResources) @ kroxylicious-sample ---
[INFO] Copying 1 resource from src/test/resources to target/test-classes
[INFO] 
[INFO] --- maven-compiler-plugin:3.12.1:testCompile (default-testCompile) @ kroxylicious-sample ---
[INFO] Nothing to compile - all classes are up to date.
[INFO] 
[INFO] <<< rewrite-maven-plugin:5.23.3:run (default-cli) < process-test-classes @ kroxylicious-sample <<<
[INFO] 
[INFO] 
[INFO] --- rewrite-maven-plugin:5.23.3:run (default-cli) @ kroxylicious-sample ---
[INFO] Using active recipe(s) [io.kroxylicious.rewrite.maven.EncryptionModuleToRecordEncryption]
[INFO] Using active styles(s) []
[INFO] Validating active recipes...
[INFO] Project [Sample filters] Resolving Poms...
[WARNING] Failed to download io.kroxylicious:kroxylicious-encryption:0.5.0-SNAPSHOT. Attempted URIs:
  - file:///Users/sbarker/.m2/repository/
[WARNING] Failed to download io.kroxylicious:kroxylicious-encryption:0.5.0-SNAPSHOT. Attempted URIs:
  - file:///Users/sbarker/.m2/repository/
[WARNING] Failed to download io.kroxylicious:kroxylicious-encryption:0.5.0-SNAPSHOT. Attempted URIs:
  - file:///Users/sbarker/.m2/repository/
[WARNING] Failed to download io.kroxylicious:kroxylicious-encryption:0.5.0-SNAPSHOT. Attempted URIs:
  - file:///Users/sbarker/.m2/repository/
[INFO] Project [Sample filters] Parsing source files
[INFO] Running recipe(s)...
[WARNING] Failed to download io.kroxylicious:kroxylicious-bom:0.5.0-SNAPSHOT. Attempted URIs:
  - file:///Users/sbarker/.m2/repository/
[WARNING] Changes have been made to kroxylicious-sample/pom.xml by:
[WARNING]     io.kroxylicious.rewrite.maven.EncryptionModuleToRecordEncryption
[WARNING]         org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId: {oldGroupId=io.kroxylicious, oldArtifactId=kroxylicious-encryption, newGroupId=io.kroxylicious, newArtifactId=kroxylicious-record-encryption}
[WARNING] Please review and commit the results.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  17.187 s
[INFO] Finished at: 2024-02-29T15:49:56+13:00
[INFO] ------------------------------------------------------------------------
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
