### PR TITLE
Add deprecated EnvelopeEncryption filter to ease migration to RecordEncryption filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.5.0
 
+* [#10??](https://github.com/kroxylicious/kroxylicious/pull/10??): Add deprecated EnvelopeEncryption filter to ease migration to RecordEncryption filter
 * [#1043](https://github.com/kroxylicious/kroxylicious/pull/1043): Rename EnvelopeEncryption filter to RecordEncryption
 * [#1029](https://github.com/kroxylicious/kroxylicious/pull/1029): Upgrade to Kafka 3.7.0
 * [#1011](https://github.com/kroxylicious/kroxylicious/pull/1011): Bump io.netty:netty-bom from 4.1.106.Final to 4.1.107.Final

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.5.0
 
-* [#10??](https://github.com/kroxylicious/kroxylicious/pull/10??): Add deprecated EnvelopeEncryption filter to ease migration to RecordEncryption filter
+* [#1049](https://github.com/kroxylicious/kroxylicious/pull/1049): Add deprecated EnvelopeEncryption filter to ease migration to RecordEncryption filter
 * [#1043](https://github.com/kroxylicious/kroxylicious/pull/1043): Rename EnvelopeEncryption filter to RecordEncryption
 * [#1029](https://github.com/kroxylicious/kroxylicious/pull/1029): Upgrade to Kafka 3.7.0
 * [#1011](https://github.com/kroxylicious/kroxylicious/pull/1011): Bump io.netty:netty-bom from 4.1.106.Final to 4.1.107.Final

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ### Changes, deprecations and removals
 
-* **We have renamed the EnvelopeEncryption filter** it is now the **RecordEncryption** filter. As this is a more accurate description of its role. We have not changed the way we deliver the encryption-at-rest we are still using  Envelope Encryption.
+* **We have renamed the EnvelopeEncryption filter** it is now the **RecordEncryption** filter. As this is a more accurate description of its role. We have not changed the way we deliver the encryption-at-rest as we are still using Envelope Encryption. Note we have preserved an `EnvelopeEncryption` factory, albeit deprecated, to avoid runtime failures for users upgrading from `0.4.x`. 
 * When configuring TLS, the property `filePath` for specifying the location of a file providing the password is now
   deprecated.  Use `passwordFile` instead.
 * When configuring TLS, it is no longer valid to pass a null inline password like `"storePassword": {"password": null}` instead use `"storePassword": null`

--- a/docs/available-filters/record-encryption/record-encryption.adoc
+++ b/docs/available-filters/record-encryption/record-encryption.adoc
@@ -134,7 +134,7 @@ The filter is configured as part of the filter chain in the following way:
 [source, yaml]
 ----
 filters:
-- type: EnvelopeEncryption                                        # <1>
+- type: RecordEncryption                                        # <1>
   config:
     kms: <KMS service name>                                       # <2>
     kmsConfig:                                                    # <3>
@@ -143,7 +143,7 @@ filters:
     selectorConfig:                                               # <5>
       ..:
 ----
-<1> The name of the filter. This must be `EnvelopeEncryption`.
+<1> The name of the filter. This must be `RecordEncryption`, the filter was previously known `EnvelopEncryption`.
 <2> The KMS service name.
 <3> Object providing configuration understood by KMS provider.
 <4> The KEK selector service name.

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryption.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryption.java
@@ -16,7 +16,7 @@ import io.kroxylicious.proxy.plugin.Plugin;
  * @param <E> The type of encrypted DEK
  */
 @Deprecated(since = "0.5.0", forRemoval = true)
-@Plugin(configType = EnvelopeEncryption.Config.class)
-public class EnvelopeEncryption<K, E> extends RecordEncryption<K, E> implements FilterFactory<EnvelopeEncryption.Config, SharedEncryptionContext<K, E>> {
+@Plugin(configType = RecordEncryption.Config.class)
+public class EnvelopeEncryption<K, E> extends RecordEncryption<K, E> implements FilterFactory<RecordEncryption.Config, SharedEncryptionContext<K, E>> {
 
 }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryption.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/EnvelopeEncryption.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+import io.kroxylicious.proxy.filter.FilterFactory;
+import io.kroxylicious.proxy.plugin.Plugin;
+
+/**
+ * @deprecated Replaced with {@link io.kroxylicious.filter.encryption.RecordEncryption}
+ * A {@link FilterFactory} for {@link RecordEncryptionFilter}.
+ * @param <K> The key reference
+ * @param <E> The type of encrypted DEK
+ */
+@Deprecated(since = "0.5.0", forRemoval = true)
+@Plugin(configType = EnvelopeEncryption.Config.class)
+public class EnvelopeEncryption<K, E> extends RecordEncryption<K, E> implements FilterFactory<EnvelopeEncryption.Config, SharedEncryptionContext<K, E>> {
+
+}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
@@ -1,1 +1,2 @@
 io.kroxylicious.filter.encryption.RecordEncryption
+io.kroxylicious.filter.encryption.EnvelopeEncryption

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopEncryptionTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopEncryptionTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.kms.service.Kms;
+import io.kroxylicious.kms.service.KmsService;
+import io.kroxylicious.kms.service.Serde;
+import io.kroxylicious.proxy.filter.FilterFactoryContext;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+class EnvelopEncryptionTest {
+
+    @SuppressWarnings({ "removal", "unchecked" })
+    @Test
+    void shouldInitAndCreateFilter() {
+        var config = new RecordEncryption.Config("KMS", null, "SELECTOR", null, null);
+        var ee = new EnvelopeEncryption<>();
+        var fc = mock(FilterFactoryContext.class);
+        var kmsService = mock(KmsService.class);
+        var kms = mock(Kms.class);
+        var kekSelectorService = mock(KekSelectorService.class);
+        var kekSelector = mock(TopicNameBasedKekSelector.class);
+        var edekSerde = mock(Serde.class);
+
+        doReturn(kmsService).when(fc).pluginInstance(KmsService.class, "KMS");
+        doReturn(kms).when(kmsService).buildKms(any());
+        doReturn(mock(ScheduledExecutorService.class)).when(fc).eventLoop();
+        doReturn(edekSerde).when(kms).edekSerde();
+
+        doReturn(kekSelectorService).when(fc).pluginInstance(KekSelectorService.class, "SELECTOR");
+        doReturn(kekSelector).when(kekSelectorService).buildSelector(any(), any());
+
+        var sec = ee.initialize(fc, config);
+        var filter = ee.createFilter(fc, sec);
+        assertNotNull(filter);
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/EnvelopeEncryptionFilterIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/EnvelopeEncryptionFilterIT.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.encryption;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.kroxylicious.filter.encryption.EnvelopeEncryption;
+import io.kroxylicious.filter.encryption.TemplateKekSelector;
+import io.kroxylicious.kms.service.TestKmsFacade;
+import io.kroxylicious.proxy.config.FilterDefinition;
+import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
+import io.kroxylicious.testing.kafka.junit5ext.Topic;
+
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
+import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(KafkaClusterExtension.class)
+@ExtendWith(EnvelopeEncryptionTestInvocationContextProvider.class)
+class EnvelopeEncryptionFilterIT {
+
+    private static final String TEMPLATE_KEK_SELECTOR_PATTERN = "${topicName}";
+    private static final String HELLO_WORLD = "hello world";
+
+    @TestTemplate
+    void roundTripSingleRecord(KafkaCluster cluster, Topic topic, TestKmsFacade<?, ?, ?> testKmsFacade) throws Exception {
+        var testKekManager = testKmsFacade.getTestKekManager();
+        testKekManager.generateKek(topic.name());
+
+        var builder = proxy(cluster);
+
+        builder.addToFilters(buildEncryptionFilterDefinition(testKmsFacade));
+
+        try (var tester = kroxyliciousTester(builder);
+                var producer = tester.producer();
+                var consumer = tester.consumer()) {
+
+            producer.send(new ProducerRecord<>(topic.name(), HELLO_WORLD)).get(5, TimeUnit.SECONDS);
+
+            consumer.subscribe(List.of(topic.name()));
+            var records = consumer.poll(Duration.ofSeconds(2));
+            assertThat(records.iterator())
+                    .toIterable()
+                    .singleElement()
+                    .extracting(ConsumerRecord::value)
+                    .isEqualTo(HELLO_WORLD);
+        }
+    }
+
+    @SuppressWarnings("removal")
+    private FilterDefinition buildEncryptionFilterDefinition(TestKmsFacade<?, ?, ?> testKmsFacade) {
+        return new FilterDefinitionBuilder(EnvelopeEncryption.class.getSimpleName())
+                .withConfig("kms", testKmsFacade.getKmsServiceClass().getSimpleName())
+                .withConfig("kmsConfig", testKmsFacade.getKmsServiceConfig())
+                .withConfig("selector", TemplateKekSelector.class.getSimpleName())
+                .withConfig("selectorConfig", Map.of("template", TEMPLATE_KEK_SELECTOR_PATTERN))
+                .build();
+    }
+}

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/kroxylicious/KroxyliciousConfigMapTemplates.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/kroxylicious/KroxyliciousConfigMapTemplates.java
@@ -71,7 +71,7 @@ public final class KroxyliciousConfigMapTemplates {
                       bootstrap_servers: %CLUSTER_NAME%-kafka-bootstrap.%NAMESPACE%.svc.cluster.local:9092
                     logFrames: false
                 filters:
-                - type: EnvelopeEncryption
+                - type: RecordEncryption
                   config:
                     kms: VaultKmsService
                     kmsConfig:


### PR DESCRIPTION
### Type of change

- Bugfix
- Documentation

### Description

#1043 went for a hard cut over from `EnvelopeEncryption` to `RecordEncryption` this PR provides a deprecated `EnvelopeEncryption` filter to ensure that 0.4.0 configuration files continue to work. 

### Additional Context

I propose we delete this again in the 0.6.0 release.

This PR also caught a couple of additional places where the rename had not taken effect.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [x] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
