### PR TITLE
Bump EncryptionVersion to 2 and warn users about dead alpha format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ### Changes, deprecations and removals
 
+* EncryptionVersion 1 is no longer supported, we found that it had diverged from our design document and have corrected it. From release 0.5.0 we guarantee backwards compatibility from EncryptionVersion 2 onwards.
 * **We have renamed the EnvelopeEncryption filter** it is now the **RecordEncryption** filter. As this is a more accurate description of its role. We have not changed the way we deliver the encryption-at-rest as we are still using Envelope Encryption. Note we have preserved an `EnvelopeEncryption` factory, albeit deprecated, to avoid runtime failures for users upgrading from `0.4.x`. 
 * When configuring TLS, the property `filePath` for specifying the location of a file providing the password is now
   deprecated.  Use `passwordFile` instead.

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/AadSpec.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/AadSpec.java
@@ -25,7 +25,7 @@ public enum AadSpec {
     /**
      * No AAD
      */
-    NONE((byte) 0, EncryptionVersion.V1) {
+    NONE((byte) 0, EncryptionVersion.V1_UNSUPPORTED) {
         @Override
         ByteBuffer computeAad(
                               String topicName,

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/EncryptionVersion.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/EncryptionVersion.java
@@ -18,7 +18,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public enum EncryptionVersion {
 
-    V1((byte) 1, ParcelVersion.V1, WrapperVersion.V1);
+    V1_UNSUPPORTED((byte) 1, ParcelVersion.V1, WrapperVersion.V1_UNSUPPORTED),
+    V2((byte) 2, ParcelVersion.V1, WrapperVersion.V2);
 
     private final ParcelVersion parcelVersion;
     private final WrapperVersion wrapperVersion;
@@ -33,7 +34,10 @@ public enum EncryptionVersion {
     public static EncryptionVersion fromCode(byte code) {
         switch (code) {
             case 1:
-                return V1;
+                // we guarantee backwards compatibility going forward from v2
+                throw new EncryptionException("Deserialization of EncryptionVersion=1 records is not supported by this version of the encryption filter.");
+            case 2:
+                return V2;
             default:
                 throw new EncryptionException("Unknown EncryptionVersion: " + code);
         }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/WrapperVersion.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/WrapperVersion.java
@@ -29,9 +29,34 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * The version of the wrapper schema used to persist information in the wrapper.
  */
 public enum WrapperVersion {
+    V1_UNSUPPORTED {
+        @Override
+        public <E> void writeWrapper(@NonNull Serde<E> edekSerde, @NonNull E edek, @NonNull String topicName, int partitionId, @NonNull RecordBatch batch,
+                                     @NonNull Record kafkaRecord, @NonNull Dek<E>.Encryptor encryptor, @NonNull ParcelVersion parcelVersion, @NonNull AadSpec aadSpec,
+                                     @NonNull Set<RecordField> recordFields, @NonNull ByteBuffer buffer) {
+            throw unsupportedVersionException();
+        }
+
+        @Override
+        public <E> void read(@NonNull ParcelVersion parcelVersion, @NonNull String topicName, int partition, @NonNull RecordBatch batch, @NonNull Record record,
+                             ByteBuffer wrapper, Dek<E>.Decryptor decryptor, @NonNull BiConsumer<ByteBuffer, Header[]> consumer) {
+            throw unsupportedVersionException();
+        }
+
+        @Override
+        public <E, T> T readSpecAndEdek(ByteBuffer wrapper, Serde<E> serde, BiFunction<CipherSpec, E, T> fn) {
+            throw unsupportedVersionException();
+        }
+
+        @NonNull
+        private static EncryptionException unsupportedVersionException() {
+            return new EncryptionException("V1 wrappers are unsupported");
+        }
+    },
+
     /**
      * <pre>
-     * wrapper_v1               = cipher_id
+     * wrapper_v2               = cipher_id
      *                            edek_length
      *                            edek
      *                            aead_id
@@ -47,7 +72,7 @@ public enum WrapperVersion {
      * parcel_ciphertext        = *OCTET                       ; whatever is left in the buffer
      * </pre>
      */
-    V1 {
+    V2 {
 
         @Override
         public <E> void writeWrapper(@NonNull Serde<E> edekSerde,

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandEncryptionManager.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/inband/InBandEncryptionManager.java
@@ -82,7 +82,7 @@ public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
                                    @NonNull EncryptionDekCache<K, E> dekCache,
                                    @NonNull FilterThreadExecutor filterThreadExecutor) {
         this.filterThreadExecutor = filterThreadExecutor;
-        this.encryptionVersion = EncryptionVersion.V1; // TODO read from config
+        this.encryptionVersion = EncryptionVersion.V2; // TODO read from config
         this.edekSerde = Objects.requireNonNull(edekSerde);
         if (recordBufferInitialBytes <= 0) {
             throw new IllegalArgumentException();

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/WrapperVersionTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/WrapperVersionTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.Test;
+
+import static io.kroxylicious.filter.encryption.WrapperVersion.V1_UNSUPPORTED;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WrapperVersionTest {
+
+    @Test
+    void unsupportedWrapperVersionThrowsOnUsage() {
+        assertUnsupported(() -> V1_UNSUPPORTED.writeWrapper(null, null, null, 1, null, null, null, null, null, null, null));
+        assertUnsupported(() -> V1_UNSUPPORTED.read(null, null, 1, null, null, null, null, null));
+        assertUnsupported(() -> V1_UNSUPPORTED.readSpecAndEdek(null, null, null));
+    }
+
+    private void assertUnsupported(ThrowableAssert.ThrowingCallable op) {
+        assertThatThrownBy(op).isInstanceOf(EncryptionException.class).hasMessage("V1 wrappers are unsupported");
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/RecordEncryptorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/inband/RecordEncryptorTest.java
@@ -94,7 +94,7 @@ class RecordEncryptorTest {
     private Record encryptSingleRecord(TestComponents components, Set<RecordField> fields, long offset, long timestamp, String key, String value, Header... headers) {
         var re = new RecordEncryptor(
                 "topic", 0,
-                EncryptionVersion.V1,
+                EncryptionVersion.V2,
                 new EncryptionScheme<>("key", fields),
                 components.edekSerde,
                 ByteBuffer.allocate(100));
@@ -136,11 +136,11 @@ class RecordEncryptorTest {
                 .hasValueNotEqualTo(value)
                 .singleHeader()
                 .hasKeyEqualTo("kroxylicious.io/encryption")
-                .hasValueEqualTo(new byte[]{ 1 });
+                .hasValueEqualTo(new byte[]{ 2 });
 
         // And when
         var rd = new RecordDecryptor("topic", 0);
-        var rt = transformRecord(rd, new DecryptState(EncryptionVersion.V1).withDecryptor(components.decryptor), t);
+        var rt = transformRecord(rd, new DecryptState(EncryptionVersion.V2).withDecryptor(components.decryptor), t);
 
         // Then
         KafkaAssertions.assertThat(rt)
@@ -179,7 +179,7 @@ class RecordEncryptorTest {
         // And when
         var rd = new RecordDecryptor("topic", 0); // index -> new DecryptState(t, EncryptionVersion.V1, DECRYPTOR)
 
-        var rt = transformRecord(rd, new DecryptState(EncryptionVersion.V1).withDecryptor(components.decryptor), t);
+        var rt = transformRecord(rd, new DecryptState(EncryptionVersion.V2).withDecryptor(components.decryptor), t);
 
         // Then
         KafkaAssertions.assertThat(rt)
@@ -246,11 +246,11 @@ class RecordEncryptorTest {
                 .hasValueNotEqualTo(value)
                 .singleHeader()
                 .hasKeyEqualTo("kroxylicious.io/encryption")
-                .hasValueEqualTo(new byte[]{ 1 });
+                .hasValueEqualTo(new byte[]{ 2 });
 
         // And when
         var rd = new RecordDecryptor("topic", 0);
-        var rt = transformRecord(rd, new DecryptState<>(EncryptionVersion.V1).withDecryptor(components.decryptor), t);
+        var rt = transformRecord(rd, new DecryptState<>(EncryptionVersion.V2).withDecryptor(components.decryptor), t);
 
         // Then
         KafkaAssertions.assertThat(rt)

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/RecordEncryptionDeserializationCompatibilityIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/RecordEncryptionDeserializationCompatibilityIT.java
@@ -62,20 +62,20 @@ class RecordEncryptionDeserializationCompatibilityIT {
     private static final String ENCRYPTED_AES_TOPIC = "aes-topic";
     private static final String PRE_EXISTING_AES_KEK_SECRET_BYTES = "FwailFttZJR2Jq43YPhwsKTtuTJQNnPPutrFu9uVPx4=";
     private static final String PRE_EXISTING_AES_KEK_UUID = "c32d1cef-9c60-4f86-b56b-281684c98ad0";
-    private static final TestCase V1_VALUE_NOT_NULL = new TestCase(EncryptionVersion.V1, "value not null", ENCRYPTED_AES_TOPIC,
-            new SerializedRecord(List.of(new SerializedHeader("kroxylicious.io/encryption", "AQ==")),
+    private static final TestCase V2_VALUE_NOT_NULL = new TestCase(EncryptionVersion.V2, "value not null", ENCRYPTED_AES_TOPIC,
+            new SerializedRecord(List.of(new SerializedHeader("kroxylicious.io/encryption", "Ag==")),
                     "YQ==",
                     "AE6ADMHU4V/OFRDILMd8AsMtHO+cYE+GtWsoFoTJitA0Y8iY9RZBcQDxGqsIylR5ugQ57JYiqOOwLVPwm6X2t9iT/3VoUjJ/M8xFWpiczFIAT5ZR6To+WDLYniREKe+0/f6lRFsCb/MGEZhfVgkb3g=="),
             new DeserializedRecord(List.of(), "a", "b"));
 
     // null values are serialized as-is with no encryption header, we need to forward null on to support tombstoning compacted topics
-    private static final TestCase V1_VALUE_NULL = new TestCase(EncryptionVersion.V1, "value null", ENCRYPTED_AES_TOPIC,
+    private static final TestCase V2_VALUE_NULL = new TestCase(EncryptionVersion.V2, "value null", ENCRYPTED_AES_TOPIC,
             new SerializedRecord(List.of(),
                     "YQ==",
                     null),
             new DeserializedRecord(List.of(), "a", null));
-    private static final TestCase V1_OTHER_HEADERS = new TestCase(EncryptionVersion.V1, "other headers are preserved", ENCRYPTED_AES_TOPIC,
-            new SerializedRecord(List.of(new SerializedHeader("kroxylicious.io/encryption", "AQ=="), new SerializedHeader("x", "eQ==")),
+    private static final TestCase V2_OTHER_HEADERS = new TestCase(EncryptionVersion.V2, "other headers are preserved", ENCRYPTED_AES_TOPIC,
+            new SerializedRecord(List.of(new SerializedHeader("kroxylicious.io/encryption", "Ag=="), new SerializedHeader("x", "eQ==")),
                     "YQ==",
                     "AE6ADMNIqL7qk5zZDYBSp8MtHO+cYE+GtWsoFoTJitDZbCqfZvPsulMdhpO06acCIQ8unRSmTypxUAuaRyY5rZhrKP+WxohB5BUDHnMPztQAsUYlZQzgsNt3kbv4O7aPzm7Bh9FP2bl8c4fDXH33uA=="),
             new DeserializedRecord(List.of(new DeserializedHeader("x", "y")), "a", "b"));
@@ -126,7 +126,7 @@ class RecordEncryptionDeserializationCompatibilityIT {
     }
 
     static Stream<Arguments> testCases() {
-        return Stream.of(V1_VALUE_NOT_NULL, V1_OTHER_HEADERS, V1_VALUE_NULL).map(testCase -> Arguments.of(testCase.version, testCase.name, testCase));
+        return Stream.of(V2_VALUE_NOT_NULL, V2_OTHER_HEADERS, V2_VALUE_NULL).map(testCase -> Arguments.of(testCase.version, testCase.name, testCase));
     }
 
     @ParameterizedTest(name = "encryption version: {0} - {1}")


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description
Increase the default `EncryptionVersion` (the version stored in the `kroxylicious.io/encryption` header) to 2.

Also increased WrapperVersion to V2 and leaves an unsupported V1 which throws if it's ever used. This allows us to mark that the None AADSpec is supported since V1.

On the encrypt path data will emit `kroxylicious.io/encryption: encoded(2)` and on the decrypt path we will require it to be 2 to do the decrypt work. A new, specific exception will be thrown if the Proxy is asked to decrypt the v1 protocol.

Why:
We decided that since the serialized data in 0.4.0 didn't align with the design doc that it was unsupported and we would break backwards compatibility, guaranteeing backwards compatibility from 0.5.0. If any users stumble on this they could raise a ticket for us to re-implement v1.

This doesn't cover implementing a robust upgrade process as the encryption version is not user configurable. We will have to add this when we next modify the protocol.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
