### PR TITLE
Sonar builds being unexpectedly cancelled

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -6,7 +6,7 @@ on:
     types: [completed]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### Type of change

- Bugfix
### Description

I've seen PRs stuck awaiting sonar results but the job was cancelled due to parallelism, despite there only being a single Build for that PR.

`github.head_ref` is only set for pull requests, this meant that sonar runs could clobber each other across pull requests where the intent is that we want new sonar builds for a PR to cancel old sonar builds for that PR.

I've tested this on my fork, checking that it doesn't break the sonar run after the `main` build completes and that the parallelism config cancels Sonar runs only for the same PR.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
