### PR TITLE
Log platform information on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.5.0
 
+* [#1066](https://github.com/kroxylicious/kroxylicious/pull/1066): Log platform information on startup
 * [#1050](https://github.com/kroxylicious/kroxylicious/pull/1050): Change AES GCM cipher to require a 256bit key
 * [#1049](https://github.com/kroxylicious/kroxylicious/pull/1049): Add deprecated EnvelopeEncryption filter to ease migration to RecordEncryption filter
 * [#1043](https://github.com/kroxylicious/kroxylicious/pull/1043): Rename EnvelopeEncryption filter to RecordEncryption

--- a/kroxylicious-app/src/main/java/io/kroxylicious/app/Kroxylicious.java
+++ b/kroxylicious-app/src/main/java/io/kroxylicious/app/Kroxylicious.java
@@ -79,8 +79,16 @@ public class Kroxylicious implements Callable<Integer> {
         new BannerLogger().log();
         String[] versions = new VersionProvider().getVersion();
         for (String version : versions) {
-            LOGGER.info(version);
+            LOGGER.info("{}", version);
         }
+        LOGGER.atInfo()
+                .setMessage("Platform: Java {}({}) running on {} {}/{}")
+                .addArgument(Runtime::version)
+                .addArgument(() -> System.getProperty("java.vendor"))
+                .addArgument(() -> System.getProperty("os.name"))
+                .addArgument(() -> System.getProperty("os.version"))
+                .addArgument(() -> System.getProperty("os.arch"))
+                .log();
     }
 
     /**


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Log information about the java version and host on startup.
why: aid problem determination.

### Additional Context

It looks like this:

```
2024-03-05 09:14:50 <main> INFO  io.kroxylicious.proxy.StartupShutdownLogger:91 - Platform: Java 21+35-LTS(Eclipse Adoptium) running on Mac OS X 13.6.3/x86_64
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
