### PR TITLE
Bugfix: pages builds triggered by dependabot merge fail to push changes back to github

### DIFF
--- a/.github/workflows/asciidoctor-ghpages.yaml
+++ b/.github/workflows/asciidoctor-ghpages.yaml
@@ -1,12 +1,17 @@
 name: GitHub Pages Publish
 on:
-  push:
-    branches: [main]
+  workflow_run:
+    workflows: [Main Push Trigger]
+    types: [completed]
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: echo event
+        run: cat $GITHUB_EVENT_PATH
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_commit.id }}
       - name: asciidoctor-ghpages
         uses: manoelcampos/asciidoctor-ghpages-action@v2
         with:

--- a/.github/workflows/asciidoctor-ghpages.yaml
+++ b/.github/workflows/asciidoctor-ghpages.yaml
@@ -3,6 +3,8 @@ on:
   workflow_run:
     workflows: [Main Push Trigger]
     types: [completed]
+concurrency:
+  group: ${{ github.workflow }}
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/main-push-trigger.yaml
+++ b/.github/workflows/main-push-trigger.yaml
@@ -1,0 +1,10 @@
+name: Main Push Trigger
+on:
+  push:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: echo
+        run: echo "action exists only to trigger another workflow to workaround dependabot permissions"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Why:
The build on push to main has a GITHUB_TOKEN with readonly permissions and a secret source of Dependabot. It cannot push the updated ghpages branch to the repo. This is a workaround to instead run a trigger build on main push and then trigger a separate workflow which will have the Actions GITHUB_TOKEN permissions.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
