### PR TITLE
Bugfix: pages build action fails on dependabot PR merge

### DIFF
--- a/.github/workflows/asciidoctor-ghpages.yaml
+++ b/.github/workflows/asciidoctor-ghpages.yaml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.KROXYLICIOUS_GITHUB_READWRITE_TOKEN }}
       - name: asciidoctor-ghpages
         uses: manoelcampos/asciidoctor-ghpages-action@v2
         with:


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Use a PAT to checkout/push which has read/write perms when building Github Pages after commits are pushed to `main`.

Why:
The Dependabot `GITHUB_TOKEN` used by the push action is readonly and it doesn't have permissions to write to kroxylicious when it tries to push the `ghpages` branch.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
