### PR TITLE
Rename metrics and tags

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -54,6 +54,7 @@ public final class KafkaProxy implements AutoCloseable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProxy.class);
     private static final Logger STARTUP_SHUTDOWN_LOGGER = LoggerFactory.getLogger("io.kroxylicious.proxy.StartupShutdownLogger");
+    private static final Metrics METRICS = Metrics.forGlobalRegistry();
 
     private final NetworkBindingOperationProcessor bindingOperationProcessor = new DefaultNetworkBindingOperationProcessor();
     private final EndpointRegistry endpointRegistry = new EndpointRegistry(bindingOperationProcessor);
@@ -121,8 +122,8 @@ public final class KafkaProxy implements AutoCloseable {
 
         // Pre-register counters/summaries to avoid creating them on first request and thus skewing the request latency
         // TODO add a virtual host tag to metrics
-        Metrics.inboundDownstreamMessagesCounter();
-        Metrics.inboundDownstreamDecodedMessagesCounter();
+        METRICS.receivedRequestMessagesCounter();
+        METRICS.decodedRequestMessagesCounter();
         return this;
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoder.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoder.java
@@ -24,6 +24,7 @@ import io.kroxylicious.proxy.internal.util.Metrics;
 public class KafkaRequestDecoder extends KafkaMessageDecoder {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaRequestDecoder.class);
+    private static final Metrics METRICS = Metrics.forGlobalRegistry();
 
     private final DecodePredicate decodePredicate;
 
@@ -57,15 +58,15 @@ public class KafkaRequestDecoder extends KafkaMessageDecoder {
 
         RequestHeaderData header = null;
         final ByteBufAccessorImpl accessor;
-        Metrics.inboundDownstreamMessagesCounter().increment();
+        METRICS.receivedRequestMessagesCounter().increment();
         var decodeRequest = decodePredicate.shouldDecodeRequest(apiKey, apiVersion);
         LOGGER.debug("Decode {}/v{} request? {}, Predicate {} ", apiKey, apiVersion, decodeRequest, decodePredicate);
         boolean decodeResponse = decodePredicate.shouldDecodeResponse(apiKey, apiVersion);
         LOGGER.debug("Decode {}/v{} response? {}, Predicate {}", apiKey, apiVersion, decodeResponse, decodePredicate);
         short headerVersion = apiKey.requestHeaderVersion(apiVersion);
         if (decodeRequest) {
-            Metrics.inboundDownstreamDecodedMessagesCounter().increment();
-            Metrics.payloadSizeBytesUpstreamSummary(apiKey, apiVersion).record(length);
+            METRICS.decodedRequestMessagesCounter().increment();
+            METRICS.payloadSizeBytesRequestSummary(apiKey, apiVersion).record(length);
             if (log().isTraceEnabled()) { // avoid boxing
                 log().trace("{}: headerVersion {}", ctx, headerVersion);
             }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseDecoder.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseDecoder.java
@@ -26,6 +26,7 @@ import io.kroxylicious.proxy.internal.util.Metrics;
 public class KafkaResponseDecoder extends KafkaMessageDecoder {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaResponseDecoder.class);
+    private static final Metrics METRICS = Metrics.forGlobalRegistry();
 
     private final CorrelationManager correlationManager;
 
@@ -70,7 +71,7 @@ public class KafkaResponseDecoder extends KafkaMessageDecoder {
             ApiMessage body = BodyDecoder.decodeResponse(apiKey, apiVersion, accessor);
             log().trace("{}: Body: {}", ctx, body);
             Filter recipient = correlation.recipient();
-            Metrics.payloadSizeBytesDownstreamSummary(apiKey, apiVersion).record(length);
+            METRICS.payloadSizeBytesResponseSummary(apiKey, apiVersion).record(length);
             if (recipient == null) {
                 frame = new DecodedResponseFrame<>(apiVersion, correlationId, header, body);
             }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/util/Metrics.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/util/Metrics.java
@@ -12,49 +12,62 @@ import org.apache.kafka.common.protocol.ApiKeys;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 
-import static io.micrometer.core.instrument.Metrics.counter;
-import static io.micrometer.core.instrument.Metrics.summary;
+import static io.micrometer.core.instrument.Metrics.globalRegistry;
 
 public class Metrics {
 
+    private static final Metrics forGlobalRegistry = new Metrics(globalRegistry);
+
+    private final MeterRegistry registry;
+
+    /* exposed for testing */ Metrics(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
     // creating a constant for all Metrics in the one place so we can easily see what metrics there are
 
-    private static final String KROXYLICIOUS_INBOUND_DOWNSTREAM_MESSAGES = "kroxylicious_inbound_downstream_messages";
+    private static final String KROXYLICIOUS_RECEIVED_MESSAGES_TOTAL = "kroxylicious_received_messages_total";
 
-    private static final String KROXYLICIOUS_INBOUND_DOWNSTREAM_DECODED_MESSAGES = "kroxylicious_inbound_downstream_decoded_messages";
+    private static final String KROXYLICIOUS_DECODED_MESSAGES_TOTAL = "kroxylicious_decoded_messages_total";
 
     private static final String KROXYLICIOUS_PAYLOAD_SIZE_BYTES = "kroxylicious_payload_size_bytes";
+    private static final String MESSAGE_TYPE_TAG = "message_type";
+    private static final String REQUEST_TYPE = "request";
+    private static final String RESPONSE_TYPE = "response";
 
-    private static final String FLOWING_TAG = "flowing";
+    private static final Tag REQUEST_TAG = Tag.of(MESSAGE_TYPE_TAG, REQUEST_TYPE);
 
-    private static final Tag FLOWING_UPSTREAM = Tag.of(FLOWING_TAG, "upstream");
+    private static final Tag RESPONSE_TAG = Tag.of(MESSAGE_TYPE_TAG, RESPONSE_TYPE);
 
-    private static final Tag FLOWING_DOWNSTREAM = Tag.of(FLOWING_TAG, "downstream");
-
-    public static Counter inboundDownstreamMessagesCounter() {
-        return counter(KROXYLICIOUS_INBOUND_DOWNSTREAM_MESSAGES, List.of(FLOWING_DOWNSTREAM));
+    public Counter receivedRequestMessagesCounter() {
+        return registry.counter(KROXYLICIOUS_RECEIVED_MESSAGES_TOTAL, List.of(REQUEST_TAG));
     }
 
-    public static Counter inboundDownstreamDecodedMessagesCounter() {
-        return counter(KROXYLICIOUS_INBOUND_DOWNSTREAM_DECODED_MESSAGES, List.of(FLOWING_DOWNSTREAM));
+    public Counter decodedRequestMessagesCounter() {
+        return registry.counter(KROXYLICIOUS_DECODED_MESSAGES_TOTAL, List.of(REQUEST_TAG));
     }
 
-    public static DistributionSummary payloadSizeBytesUpstreamSummary(ApiKeys apiKey, short apiVersion) {
-        return payloadSizeBytesSummary(apiKey, apiVersion, FLOWING_UPSTREAM);
+    public DistributionSummary payloadSizeBytesRequestSummary(ApiKeys apiKey, short apiVersion) {
+        return payloadSizeBytesSummary(apiKey, apiVersion, REQUEST_TAG);
     }
 
-    public static DistributionSummary payloadSizeBytesDownstreamSummary(ApiKeys apiKey, short apiVersion) {
-        return payloadSizeBytesSummary(apiKey, apiVersion, FLOWING_DOWNSTREAM);
+    public DistributionSummary payloadSizeBytesResponseSummary(ApiKeys apiKey, short apiVersion) {
+        return payloadSizeBytesSummary(apiKey, apiVersion, RESPONSE_TAG);
     }
 
-    private static DistributionSummary payloadSizeBytesSummary(ApiKeys apiKey, short apiVersion, Tag flowing) {
+    private DistributionSummary payloadSizeBytesSummary(ApiKeys apiKey, short apiVersion, Tag messageType) {
         List<Tag> tags = List.of(
-                Tag.of("ApiKey", apiKey.name()),
-                Tag.of("ApiVersion", String.valueOf(apiVersion)),
-                flowing);
-        return summary(KROXYLICIOUS_PAYLOAD_SIZE_BYTES, tags);
+                Tag.of("api_key", apiKey.name()),
+                Tag.of("api_version", String.valueOf(apiVersion)),
+                messageType);
+        return registry.summary(KROXYLICIOUS_PAYLOAD_SIZE_BYTES, tags);
+    }
+
+    public static Metrics forGlobalRegistry() {
+        return forGlobalRegistry;
     }
 
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/util/MetricsTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/util/MetricsTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.util;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MetricsTest {
+
+    @Test
+    void receivedRequestMessagesCounter() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        Metrics metrics = new Metrics(registry);
+        metrics.receivedRequestMessagesCounter().increment();
+        assertThat(registry.find("kroxylicious_received_messages_total").tag("message_type", "request").counter().count()).isEqualTo(1d);
+    }
+
+    @Test
+    void decodedRequestMessagesCounter() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        Metrics metrics = new Metrics(registry);
+        metrics.decodedRequestMessagesCounter().increment();
+        assertThat(registry.find("kroxylicious_decoded_messages_total").tag("message_type", "request").counter().count()).isEqualTo(1d);
+    }
+
+    @Test
+    void payloadSizeBytesRequestSummary() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        Metrics metrics = new Metrics(registry);
+        metrics.payloadSizeBytesRequestSummary(ApiKeys.METADATA, (short) 12).record(3d);
+        DistributionSummary summary = registry.find("kroxylicious_payload_size_bytes")
+                .tag("message_type", "request")
+                .tag("api_key", "METADATA")
+                .tag("api_version", "12")
+                .summary();
+        assertThat(summary).isNotNull();
+        assertThat(summary.count()).isEqualTo(1);
+        assertThat(summary.max()).isEqualTo(3d);
+        assertThat(summary.mean()).isEqualTo(3d);
+    }
+
+    @Test
+    void payloadSizeBytesResponseSummary() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        Metrics metrics = new Metrics(registry);
+        metrics.payloadSizeBytesResponseSummary(ApiKeys.METADATA, (short) 12).record(4d);
+        DistributionSummary summary = registry.find("kroxylicious_payload_size_bytes")
+                .tag("message_type", "response")
+                .tag("api_key", "METADATA")
+                .tag("api_version", "12")
+                .summary();
+        assertThat(summary).isNotNull();
+        assertThat(summary.count()).isEqualTo(1);
+        assertThat(summary.max()).isEqualTo(4d);
+        assertThat(summary.mean()).isEqualTo(4d);
+    }
+
+}


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement / new feature

### Description

Closes #1060 along with aligning the language around request/response to match the request/response split we have for Filters

* kroxylicious_inbound_downstream_messages -> kroxylicious_received_messages_total
* kroxylicious_inbound_downstream_decoded_messages -> kroxylicious_decoded_messages_total
* "flowing" tag removed from all series
* added "message_type" tag with values "request" or "response" to all series
* "ApiKey" tag name -> "api_key"
* "ApiVersion" tag name -> "api_version"

Why:
1. snake case is a recommendation for prometheus series so we figure its best to use them for tags too.
2. since we have Filter apis divided along request/response lines it may be better to have the metric naming align on this, I've called it `message_type`.
3. `_total` suffix is a prometheus recommended convention for simple total counters (was added by the framework prior)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
