### PR TITLE
Break glass: enable decryption of v1 data

### DIFF
--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/EncryptionVersion.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/EncryptionVersion.java
@@ -35,7 +35,7 @@ public enum EncryptionVersion {
         switch (code) {
             case 1:
                 // we guarantee backwards compatibility going forward from v2
-                throw new EncryptionException("Deserialization of EncryptionVersion=1 records is not supported by this version of the encryption filter.");
+                return V1_UNSUPPORTED;
             case 2:
                 return V2;
             default:

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/WrapperVersionTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/WrapperVersionTest.java
@@ -17,8 +17,6 @@ class WrapperVersionTest {
     @Test
     void unsupportedWrapperVersionThrowsOnUsage() {
         assertUnsupported(() -> V1_UNSUPPORTED.writeWrapper(null, null, null, 1, null, null, null, null, null, null, null));
-        assertUnsupported(() -> V1_UNSUPPORTED.read(null, null, 1, null, null, null, null, null));
-        assertUnsupported(() -> V1_UNSUPPORTED.readSpecAndEdek(null, null, null));
     }
 
     private void assertUnsupported(ThrowableAssert.ThrowingCallable op) {


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Creating this as a reference in case we needed to re-enable decryption of v1 encrypted data produced by 0.4.0 or 0.4.1, I've tested it locally by producing encrypted data with 0.4.1 using a key from Vault, then deploying a locally build snapshot image with this change and checking we can consume/decrypt. Further testing would be needed.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
