### PR TITLE
Remove trap in decryption logic for variable length cipher parameters

### DIFF
--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/WrapperVersion.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/WrapperVersion.java
@@ -156,13 +156,13 @@ public enum WrapperVersion {
             var aadSpec = AadSpec.fromPersistentId(wrapper.get());
 
             var parametersBuffer = wrapper.slice();
-            int parametersSize;
             if (cipherSpec.constantParamsSize() == CipherSpec.VARIABLE_SIZE_PARAMETERS) {
-                parametersSize = ByteUtils.readUnsignedVarint(parametersBuffer);
+                // when we implement this we need to read parameterSize from the varint and
+                // ensure the parametersBuffer limit includes the length of the varint and
+                // ensure we include the length of the varint when skipping over the parameters in the wrapper
+                throw new EncryptionException("variable size cipher parameters not supported yet");
             }
-            else {
-                parametersSize = cipherSpec.constantParamsSize();
-            }
+            int parametersSize = cipherSpec.constantParamsSize();
             parametersBuffer.limit(parametersSize);
             var ciphertext = wrapper.position(wrapper.position() + parametersSize).slice();
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

No CipherSpec currently has variable length parameters, however if we were to add a new cipher with variable parameter length the decryption code would blow up. You can prove this by changing the AES cipher to masquerade as a variable length cipher, which blows up our unit tests with buffer underflows.

```
        @Override
        public int constantParamsSize() {
            return VARIABLE_SIZE_PARAMETERS;
        }

        @Override
        int size(AlgorithmParameterSpec parameterSpec) {
            return IV_SIZE_BYTES;
        }
```

It fails because we do not consider the length of the varint when we set the limit on the parameter buffer and we do not consider the length of the varint when we reposition the wrapper buffer, attempting to skip over the parameters.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
