### PR TITLE
Port-per-broker Exposition: make lowest broker id configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## 0.5.0
 
+* [#1074](https://github.com/kroxylicious/kroxylicious/pull/1074): Port-per-broker Exposition: make lowest broker id configurable
 * [#1066](https://github.com/kroxylicious/kroxylicious/pull/1066): Log platform information on startup
 * [#1050](https://github.com/kroxylicious/kroxylicious/pull/1050): Change AES GCM cipher to require a 256bit key
 * [#1049](https://github.com/kroxylicious/kroxylicious/pull/1049): Add deprecated EnvelopeEncryption filter to ease migration to RecordEncryption filter

--- a/docs/deploying.adoc
+++ b/docs/deploying.adoc
@@ -54,6 +54,11 @@ In the `PortPerBroker` scheme, Kroxylicious automatically opens a port for each 
 one port per broker of each target cluster.  So, if you have two virtual clusters, each targeting a Kafka Cluster
 of three brokers, Kroxylicious will bind eight ports in total.
 
+`PortPerBroker` is designed to work best with simplistic configurations. It is preferable if the target cluster has
+sequential, stable broker ids and a known minimum broker id (like 0,1,2 for a cluster of 3 brokers). It can work with
+non-sequential broker ids, but you would have to expose `maxBrokerId - minBrokerId` ports, which could be a huge
+number if your cluster included broker ids `0` and `20000`.
+
 Kroxylicious monitors the broker topology of the target cluster at runtime. It will adjust the number of open ports
 dynamically.  If another broker is added to the Kafka Cluster, Kroxylicious will automatically open a port for it.
 Similarly, if a broker is removed from the Kafka Cluster, Kroxylicious will automatically close the port that was
@@ -70,14 +75,16 @@ clusterNetworkAddressConfigProvider:
     brokerAddressPattern: mybroker-$(nodeId).mycluster.kafka.com # <2>
     brokerStartPort: 9193                                        # <3>
     numberOfBrokerPorts: 3                                       # <4>
-    bindAddress: 192.168.0.1                                     # <5>
+    lowestTargetBrokerId: 1000                                   # <5>
+    bindAddress: 192.168.0.1                                     # <6>
 ----
 <1> The hostname and port of the bootstrap that will be used by the Kafka Clients.
 <2> (Optional) The broker address pattern used to form the broker addresses.  If not defined, it defaults to the
 hostname part of the `bootstrapAddress` and the port number allocated to the broker.
 <3> (Optional) The starting number for broker port range. Defaults to the port of the `bootstrapAddress` plus 1.
 <4> (Optional) The _maximum_ number of brokers of ports that are permitted.  Defaults to 3.
-<5> (Optional) The bind address used when binding the ports. If undefined, all network interfaces will be bound.
+<5> (Optional) The lowest broker id of the target cluster. Defaults to 0. This should be the lowest https://kafka.apache.org/documentation/#brokerconfigs_node.id[`node.id`] (or https://kafka.apache.org/documentation/#brokerconfigs_broker.id[`broker.id`]) defined in the target cluster.
+<6> (Optional) The bind address used when binding the ports. If undefined, all network interfaces will be bound.
 
 The `brokerAddressPattern` configuration parameter understands the replacement token `$(nodeId)`. It is optional.
 If present, it will be replaced by the https://kafka.apache.org/documentation/#brokerconfigs_node.id[`node.id`] (or
@@ -97,7 +104,25 @@ NOTE: It is a responsibility for the deployer of Kroxylicious to ensure that the
 DNS names are resolvable and routable by the Kafka Client.
 
 The `numberOfBrokerPorts` imposes a maximum on the number of brokers that a Kafka Cluster can have. Set this value
-to be as high as the maximum number of brokers that your operational rules allow for a Kafka Cluster.
+to be as high as the maximum number of brokers that your operational rules allow for a Kafka Cluster. 
+
+Note that each broker's id must be greater than or equal to `lowestTargetBrokerId`, and less than `lowestTargetBrokerId + numberOfBrokerPorts`.
+The current strategy for mapping node ids to ports is `nodeId -> brokerStartPort + nodeId - lowestTargetBrokerId`. So a
+configuration like:
+
+[source, yaml]
+----
+clusterNetworkAddressConfigProvider:
+  type: PortPerBrokerClusterNetworkAddressConfigProvider
+  config:
+    bootstrapAddress: mycluster.kafka.com:9192
+    brokerStartPort: 9193
+    numberOfBrokerPorts: 3
+    lowestTargetBrokerId: 1000
+----
+
+can only map broker ids 1000, 1001 and 1002 to ports 9193, 9194 and 9195 respectively. You would have to reconfigure
+`numberOfBrokerPorts` to accommodate new brokers being added to the cluster.
 
 ==== SniRouting scheme
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Closes #1045

For example, if the lowest broker id in the cluster is 1, the configuration:
```
clusterNetworkAddressConfigProvider:
  type: PortPerBrokerClusterNetworkAddressConfigProvider
  config:
    bootstrapAddress: kroxylicious:9092
    firstBrokerId: 1
```
would map broker 1 to port 9093, broker 2 to port 9094 and broker 3 to port 9095

Why:
If a user is working with a cluster where the first broker id is 1 (the default KRaft configuration in the apache kafka distribution sets node.id to 1), if you have `numberOfBrokerPorts` configured to 1 then we cannot map the only broker. Not a very nice user experience. This would also accommodate users who have broker ids starting from a number greater than 0 without having to bind and expose max(BrokerId) ports.

Note:
This is a quick fix for a specific problem, reducing the number of ports required if the lowest node id is greater than zero. Port-per-broker is still only suited to simplistic configurations where the target Kafka cluster has sequential ids and the set of ids is reasonably static. See #902. We will likely need something more sophisticated to handle the nodeId to port mappings.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
