### PR TITLE
Fix topic creation for system tests

### DIFF
--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/steps/KafkaSteps.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/steps/KafkaSteps.java
@@ -23,6 +23,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 public class KafkaSteps {
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaSteps.class);
+    private static final String ADMIN_CLIENT_COMMAND = "admin-client";
+    private static final String TOPIC_COMMAND = "topic";
+    private static final String BOOTSTRAP_ARG = "--bootstrap-server=";
+    private static final String NEVER_POLICY = "Never";
 
     private KafkaSteps() {
     }
@@ -41,14 +45,15 @@ public class KafkaSteps {
         kubeClient().getClient().run().inNamespace(deployNamespace).withNewRunConfig()
                 .withImage(Constants.TEST_CLIENTS_IMAGE)
                 .withName(podName)
-                .withRestartPolicy("Never")
-                .withCommand("admin-client")
-                .withArgs("topic", "create", "--bootstrap-server=" + bootstrap, "--topic=" + topicName, "--topic-partitions=" + partitions,
+                .withRestartPolicy(NEVER_POLICY)
+                .withCommand(ADMIN_CLIENT_COMMAND)
+                .withArgs(TOPIC_COMMAND, "create", BOOTSTRAP_ARG + bootstrap, "--topic=" + topicName, "--topic-partitions=" + partitions,
                         "--topic-rep-factor=" + replicas)
                 .done();
 
-        DeploymentUtils.waitForPodRunSucceeded(deployNamespace, podName, Duration.ofSeconds(30));
-        LOGGER.debug("Admin client pod log: {}", kubeClient().logsInSpecificNamespace(deployNamespace, podName));
+        DeploymentUtils.waitForPodRunSucceeded(deployNamespace, podName, Duration.ofMinutes(1));
+        String log = kubeClient().logsInSpecificNamespace(deployNamespace, podName);
+        LOGGER.debug("Admin client create pod log: {}", log);
     }
 
     /**
@@ -59,18 +64,40 @@ public class KafkaSteps {
      * @param bootstrap the bootstrap
      */
     public static void deleteTopic(String deployNamespace, String topicName, String bootstrap) {
+        if(!isTopicPresent(deployNamespace, topicName, bootstrap)) {
+            LOGGER.warn("Nothing to delete. Topic was not created");
+            return;
+        }
         LOGGER.info("Deleting topic {}", topicName);
         String podName = Constants.KAFKA_ADMIN_CLIENT_LABEL + "-delete";
         kubeClient().getClient().run().inNamespace(deployNamespace).withNewRunConfig()
                 .withImage(Constants.TEST_CLIENTS_IMAGE)
                 .withName(podName)
-                .withRestartPolicy("Never")
-                .withCommand("admin-client")
-                .withArgs("topic", "delete", "--bootstrap-server=" + bootstrap, "--topic=" + topicName)
+                .withRestartPolicy(NEVER_POLICY)
+                .withCommand(ADMIN_CLIENT_COMMAND)
+                .withArgs(TOPIC_COMMAND, "delete", BOOTSTRAP_ARG + bootstrap, "--topic=" + topicName)
                 .done();
 
         DeploymentUtils.waitForPodRunSucceeded(deployNamespace, podName, Duration.ofSeconds(30));
-        LOGGER.debug("Admin client pod log: {}", kubeClient().logsInSpecificNamespace(deployNamespace, podName));
+        String log = kubeClient().logsInSpecificNamespace(deployNamespace, podName);
+        LOGGER.debug("Admin client delete pod log: {}", log);
+    }
+
+    private static boolean isTopicPresent(String deployNamespace, String topicName, String bootstrap) {
+        LOGGER.info("Deleting topic {}", topicName);
+        String podName = Constants.KAFKA_ADMIN_CLIENT_LABEL + "-list";
+        kubeClient().getClient().run().inNamespace(deployNamespace).withNewRunConfig()
+                .withImage(Constants.TEST_CLIENTS_IMAGE)
+                .withName(podName)
+                .withRestartPolicy(NEVER_POLICY)
+                .withCommand(ADMIN_CLIENT_COMMAND)
+                .withArgs(TOPIC_COMMAND, "list", BOOTSTRAP_ARG + bootstrap)
+                .done();
+
+        DeploymentUtils.waitForPodRunSucceeded(deployNamespace, podName, Duration.ofSeconds(30));
+        String log = kubeClient().logsInSpecificNamespace(deployNamespace, podName);
+        LOGGER.debug("Admin client list pod log: {}", log);
+        return log.contains(topicName);
     }
 
     /**


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Increased the timeout to wait for a topic to be created and added a check for topic existence before deleting a topic

### Additional Context

Sometimes the topic creation failed because of a timeout and when the topic was not created, there was another failure when trying to delete it.

### Checklist

- [ ] Write tests
- [X] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
