### PR TITLE
Ensure we set `--dry-run` on the git push when in dry-run mode.

### DIFF
--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -128,6 +128,7 @@ if [[ "${DRY_RUN:-false}" == true ]]; then
     # shellcheck disable=SC2059
     printf "${BLUE}Dry-run mode:${NC} no remote tags or PRs will be created, artefacts will be deployed to: ${DEPLOY_DRY_RUN_DIR}\n"
     MVN_DEPLOY_DRYRUN="-DaltDeploymentRepository=ossrh::file:${DEPLOY_DRY_RUN_DIR}"
+    GIT_DRYRUN="--dry-run"
 else
     MVN_DEPLOY_DRYRUN=""
 fi


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

Fixes an issue where running the stage-release action in dry run mode created the tag. Partially reverts 30ab2bb1cf64da134c1961d75c4ef0317544f13c

### Additional Context


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
