### PR TITLE
Fix multi-tenant example image reference.

### DIFF
--- a/kubernetes-examples/multi-tenant/base/kroxylicious/kroxylicious-deployment.yaml
+++ b/kubernetes-examples/multi-tenant/base/kroxylicious/kroxylicious-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: kroxylicious
-        image: quay.io/kroxylicious/kroxylicious:kroxylicious:0.5.0-SNAPSHOT
+        image: quay.io/kroxylicious/kroxylicious:0.5.0-SNAPSHOT
         imagePullPolicy: Always
         args: ["--config", "/opt/kroxylicious/config/config.yaml"]
         ports:


### PR DESCRIPTION
There was an additional `kroxylicious:` included.

rh-pre-commit.version: 2.0.1
rh-pre-commit.check-secrets: ENABLED

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
