### PR TITLE
`setVersions` -> `updateVersions` we know the source version in all contexts

### DIFF
--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -161,7 +161,7 @@ echo "Deploying release"
 
 # shellcheck disable=SC2086
 # Quoting leads to an extra space which causes maven to barf!
-mvn -q -B -Prelease,dist -DskipTests=true -DreleaseSigningKey="${GPG_KEY}" ${MVN_DEPLOY_DRYRUN} -DprocessAllModules=true deploy
+mvn -q -Prelease,dist -DskipTests=true -DreleaseSigningKey="${GPG_KEY}" ${MVN_DEPLOY_DRYRUN} -DprocessAllModules=true deploy
 
 echo "Release deployed, preparing for development of ${DEVELOPMENT_VERSION}"
 PREPARE_DEVELOPMENT_BRANCH="prepare-development-${RELEASE_DATE}"

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -44,7 +44,7 @@ usage: $0 -k keyid -v version [-b branch] [-r repository] [-s] [-d] [-h]
  -k short key id used to sign the release
  -v version number e.g. 0.3.0
  -b branch to release from (defaults to 'main')
- -n snapshot index to increment when opening main for new development (defaults to '2')
+ -n development version e.g. 0.4.0-SNAPSHOT
  -r the remote name of the kroxylicious repository (defaults to 'origin')
  -s skips validation
  -d dry-run mode


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

An alternative to #1083 

### Additional Context

#1083 checks the current version in all contexts by invoking maven, in every context we need it we know the source version so just pass it in.

```
diff --git a/kubernetes-examples/multi-tenant/base/kroxylicious/kroxylicious-deployment.yaml b/kubernetes-examples/multi-tenant/base/kroxylicious/kroxylicious-deployment.yaml
index 0fbb445ce..c99cc9432 100644
--- a/kubernetes-examples/multi-tenant/base/kroxylicious/kroxylicious-deployment.yaml
+++ b/kubernetes-examples/multi-tenant/base/kroxylicious/kroxylicious-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: kroxylicious
-        image: quay.io/kroxylicious/kroxylicious:kroxylicious:0.5.0
+        image: quay.io/kroxylicious/kroxylicious:kroxylicious:0.6.0-SNAPSHOT
         imagePullPolicy: Always
         args: ["--config", "/opt/kroxylicious/config/config.yaml"]
         ports:
diff --git a/kubernetes-examples/portperbroker_plain/base/kroxylicious/kroxylicious-deployment.yaml b/kubernetes-examples/portperbroker_plain/base/kroxylicious/kroxylicious-deployment.yaml
```
This would allow us to go further and validate expected state, but I'm not sure if we should bother doing so.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
