### PR TITLE
created admin client template to make deployments for topics

### DIFF
--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/steps/KafkaSteps.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/steps/KafkaSteps.java
@@ -6,22 +6,17 @@
 
 package io.kroxylicious.systemtests.steps;
 
-import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-
-import io.kroxylicious.systemtests.Environment;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.kroxylicious.systemtests.Constants;
-import io.kroxylicious.systemtests.utils.DeploymentUtils;
+import io.kroxylicious.systemtests.Environment;
 import io.kroxylicious.systemtests.utils.KafkaUtils;
 
 import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
@@ -33,11 +28,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 public class KafkaSteps {
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaSteps.class);
-    //private static final String ADMIN_CLIENT_COMMAND = "admin-client";
+    // private static final String ADMIN_CLIENT_COMMAND = "admin-client";
     private static final String ADMIN_CLIENT_TEMPLATE = "kafka-admin-client-template.yaml";
     private static final String TOPIC_COMMAND = "topic";
     private static final String BOOTSTRAP_ARG = "--bootstrap-server=";
-    //private static final String NEVER_POLICY = "Never";
+    // private static final String NEVER_POLICY = "Never";
     private static final String NAMESPACE_VAR = "%NAMESPACE%";
     private static final String NAME_VAR = "%NAME%";
     private static final String ARGS_VAR = "%ARGS%";
@@ -99,25 +94,25 @@ public class KafkaSteps {
         LOGGER.debug("Admin client delete pod log: {}", log);
     }
 
-//    public static void deleteTopic2(String deployNamespace, String topicName, String bootstrap) {
-//        if (!topicExists(deployNamespace, topicName, bootstrap)) {
-//            LOGGER.warn("Nothing to delete. Topic was not created");
-//            return;
-//        }
-//        LOGGER.info("Deleting topic {}", topicName);
-//        String podName = Constants.KAFKA_ADMIN_CLIENT_LABEL + "-delete";
-//        kubeClient().getClient().run().inNamespace(deployNamespace).withNewRunConfig()
-//                .withImage(Constants.TEST_CLIENTS_IMAGE)
-//                .withName(podName)
-//                .withRestartPolicy(NEVER_POLICY)
-//                .withCommand(ADMIN_CLIENT_COMMAND)
-//                .withArgs(TOPIC_COMMAND, "delete", BOOTSTRAP_ARG + bootstrap, "--topic=" + topicName)
-//                .done();
-//
-//        DeploymentUtils.waitForPodRunSucceeded(deployNamespace, podName, Duration.ofSeconds(30));
-//        String log = kubeClient().logsInSpecificNamespace(deployNamespace, podName);
-//        LOGGER.debug("Admin client delete pod log: {}", log);
-//    }
+    // public static void deleteTopic2(String deployNamespace, String topicName, String bootstrap) {
+    // if (!topicExists(deployNamespace, topicName, bootstrap)) {
+    // LOGGER.warn("Nothing to delete. Topic was not created");
+    // return;
+    // }
+    // LOGGER.info("Deleting topic {}", topicName);
+    // String podName = Constants.KAFKA_ADMIN_CLIENT_LABEL + "-delete";
+    // kubeClient().getClient().run().inNamespace(deployNamespace).withNewRunConfig()
+    // .withImage(Constants.TEST_CLIENTS_IMAGE)
+    // .withName(podName)
+    // .withRestartPolicy(NEVER_POLICY)
+    // .withCommand(ADMIN_CLIENT_COMMAND)
+    // .withArgs(TOPIC_COMMAND, "delete", BOOTSTRAP_ARG + bootstrap, "--topic=" + topicName)
+    // .done();
+    //
+    // DeploymentUtils.waitForPodRunSucceeded(deployNamespace, podName, Duration.ofSeconds(30));
+    // String log = kubeClient().logsInSpecificNamespace(deployNamespace, podName);
+    // LOGGER.debug("Admin client delete pod log: {}", log);
+    // }
 
     private static boolean topicExists(String deployNamespace, String topicName, String bootstrap) {
         LOGGER.debug("List '{}' topic", topicName);
@@ -136,22 +131,22 @@ public class KafkaSteps {
         return log.contains(topicName);
     }
 
-//    private static boolean topicExists2(String deployNamespace, String topicName, String bootstrap) {
-//        LOGGER.info("Deleting topic {}", topicName);
-//        String podName = Constants.KAFKA_ADMIN_CLIENT_LABEL + "-list";
-//        kubeClient().getClient().run().inNamespace(deployNamespace).withNewRunConfig()
-//                .withImage(Constants.TEST_CLIENTS_IMAGE)
-//                .withName(podName)
-//                .withRestartPolicy(NEVER_POLICY)
-//                .withCommand(ADMIN_CLIENT_COMMAND)
-//                .withArgs(TOPIC_COMMAND, "list", BOOTSTRAP_ARG + bootstrap)
-//                .done();
-//
-//        DeploymentUtils.waitForPodRunSucceeded(deployNamespace, podName, Duration.ofSeconds(30));
-//        String log = kubeClient().logsInSpecificNamespace(deployNamespace, podName);
-//        LOGGER.debug("Admin client list pod log: {}", log);
-//        return log.contains(topicName);
-//    }
+    // private static boolean topicExists2(String deployNamespace, String topicName, String bootstrap) {
+    // LOGGER.info("Deleting topic {}", topicName);
+    // String podName = Constants.KAFKA_ADMIN_CLIENT_LABEL + "-list";
+    // kubeClient().getClient().run().inNamespace(deployNamespace).withNewRunConfig()
+    // .withImage(Constants.TEST_CLIENTS_IMAGE)
+    // .withName(podName)
+    // .withRestartPolicy(NEVER_POLICY)
+    // .withCommand(ADMIN_CLIENT_COMMAND)
+    // .withArgs(TOPIC_COMMAND, "list", BOOTSTRAP_ARG + bootstrap)
+    // .done();
+    //
+    // DeploymentUtils.waitForPodRunSucceeded(deployNamespace, podName, Duration.ofSeconds(30));
+    // String log = kubeClient().logsInSpecificNamespace(deployNamespace, podName);
+    // LOGGER.debug("Admin client list pod log: {}", log);
+    // return log.contains(topicName);
+    // }
 
     /**
      * Restart kafka broker.

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/steps/KafkaSteps.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/steps/KafkaSteps.java
@@ -6,7 +6,16 @@
 
 package io.kroxylicious.systemtests.steps;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import io.kroxylicious.systemtests.Environment;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +25,7 @@ import io.kroxylicious.systemtests.utils.DeploymentUtils;
 import io.kroxylicious.systemtests.utils.KafkaUtils;
 
 import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
+import static io.kroxylicious.systemtests.utils.KafkaUtils.getPodNameByLabel;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
@@ -23,10 +33,15 @@ import static org.hamcrest.MatcherAssert.assertThat;
  */
 public class KafkaSteps {
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaSteps.class);
-    private static final String ADMIN_CLIENT_COMMAND = "admin-client";
+    //private static final String ADMIN_CLIENT_COMMAND = "admin-client";
+    private static final String ADMIN_CLIENT_TEMPLATE = "kafka-admin-client-template.yaml";
     private static final String TOPIC_COMMAND = "topic";
     private static final String BOOTSTRAP_ARG = "--bootstrap-server=";
-    private static final String NEVER_POLICY = "Never";
+    //private static final String NEVER_POLICY = "Never";
+    private static final String NAMESPACE_VAR = "%NAMESPACE%";
+    private static final String NAME_VAR = "%NAME%";
+    private static final String ARGS_VAR = "%ARGS%";
+    private static final String KAFKA_VERSION_VAR = "%KAFKA_VERSION%";
 
     private KafkaSteps() {
     }
@@ -41,17 +56,18 @@ public class KafkaSteps {
      * @param replicas the replicas
      */
     public static void createTopic(String deployNamespace, String topicName, String bootstrap, int partitions, int replicas) {
-        String podName = Constants.KAFKA_ADMIN_CLIENT_LABEL + "-create";
-        kubeClient().getClient().run().inNamespace(deployNamespace).withNewRunConfig()
-                .withImage(Constants.TEST_CLIENTS_IMAGE)
-                .withName(podName)
-                .withRestartPolicy(NEVER_POLICY)
-                .withCommand(ADMIN_CLIENT_COMMAND)
-                .withArgs(TOPIC_COMMAND, "create", BOOTSTRAP_ARG + bootstrap, "--topic=" + topicName, "--topic-partitions=" + partitions,
-                        "--topic-rep-factor=" + replicas)
-                .done();
+        LOGGER.debug("Consuming messages from '{}' topic", topicName);
+        String name = Constants.KAFKA_ADMIN_CLIENT_LABEL + "-create";
+        List<String> args = Arrays.asList(TOPIC_COMMAND, "create", BOOTSTRAP_ARG + bootstrap, "--topic=" + topicName, "--topic-partitions=" + partitions,
+                "--topic-rep-factor=" + replicas);
+        InputStream file = KafkaUtils.replaceStringInResourceFile(ADMIN_CLIENT_TEMPLATE, Map.of(
+                NAMESPACE_VAR, deployNamespace,
+                NAME_VAR, name,
+                ARGS_VAR, String.join("\",\"", args),
+                KAFKA_VERSION_VAR, Environment.KAFKA_VERSION));
 
-        DeploymentUtils.waitForPodRunSucceeded(deployNamespace, podName, Duration.ofSeconds(30));
+        kubeClient().getClient().load(file).inNamespace(deployNamespace).create();
+        String podName = KafkaUtils.getPodNameByLabel(deployNamespace, "app", name, Duration.ofSeconds(30));
         String log = kubeClient().logsInSpecificNamespace(deployNamespace, podName);
         LOGGER.debug("Admin client create pod log: {}", log);
     }
@@ -68,37 +84,74 @@ public class KafkaSteps {
             LOGGER.warn("Nothing to delete. Topic was not created");
             return;
         }
-        LOGGER.info("Deleting topic {}", topicName);
-        String podName = Constants.KAFKA_ADMIN_CLIENT_LABEL + "-delete";
-        kubeClient().getClient().run().inNamespace(deployNamespace).withNewRunConfig()
-                .withImage(Constants.TEST_CLIENTS_IMAGE)
-                .withName(podName)
-                .withRestartPolicy(NEVER_POLICY)
-                .withCommand(ADMIN_CLIENT_COMMAND)
-                .withArgs(TOPIC_COMMAND, "delete", BOOTSTRAP_ARG + bootstrap, "--topic=" + topicName)
-                .done();
+        LOGGER.debug("Deleting '{}' topic", topicName);
+        String name = Constants.KAFKA_ADMIN_CLIENT_LABEL + "-delete";
+        List<String> args = Arrays.asList(TOPIC_COMMAND, "delete", BOOTSTRAP_ARG + bootstrap, "--topic=" + topicName);
+        InputStream file = KafkaUtils.replaceStringInResourceFile(ADMIN_CLIENT_TEMPLATE, Map.of(
+                NAMESPACE_VAR, deployNamespace,
+                NAME_VAR, name,
+                ARGS_VAR, String.join("\",\"", args),
+                KAFKA_VERSION_VAR, Environment.KAFKA_VERSION));
 
-        DeploymentUtils.waitForPodRunSucceeded(deployNamespace, podName, Duration.ofSeconds(30));
+        kubeClient().getClient().load(file).inNamespace(deployNamespace).create();
+        String podName = KafkaUtils.getPodNameByLabel(deployNamespace, "app", name, Duration.ofSeconds(30));
         String log = kubeClient().logsInSpecificNamespace(deployNamespace, podName);
         LOGGER.debug("Admin client delete pod log: {}", log);
     }
 
-    private static boolean topicExists(String deployNamespace, String topicName, String bootstrap) {
-        LOGGER.info("Deleting topic {}", topicName);
-        String podName = Constants.KAFKA_ADMIN_CLIENT_LABEL + "-list";
-        kubeClient().getClient().run().inNamespace(deployNamespace).withNewRunConfig()
-                .withImage(Constants.TEST_CLIENTS_IMAGE)
-                .withName(podName)
-                .withRestartPolicy(NEVER_POLICY)
-                .withCommand(ADMIN_CLIENT_COMMAND)
-                .withArgs(TOPIC_COMMAND, "list", BOOTSTRAP_ARG + bootstrap)
-                .done();
+//    public static void deleteTopic2(String deployNamespace, String topicName, String bootstrap) {
+//        if (!topicExists(deployNamespace, topicName, bootstrap)) {
+//            LOGGER.warn("Nothing to delete. Topic was not created");
+//            return;
+//        }
+//        LOGGER.info("Deleting topic {}", topicName);
+//        String podName = Constants.KAFKA_ADMIN_CLIENT_LABEL + "-delete";
+//        kubeClient().getClient().run().inNamespace(deployNamespace).withNewRunConfig()
+//                .withImage(Constants.TEST_CLIENTS_IMAGE)
+//                .withName(podName)
+//                .withRestartPolicy(NEVER_POLICY)
+//                .withCommand(ADMIN_CLIENT_COMMAND)
+//                .withArgs(TOPIC_COMMAND, "delete", BOOTSTRAP_ARG + bootstrap, "--topic=" + topicName)
+//                .done();
+//
+//        DeploymentUtils.waitForPodRunSucceeded(deployNamespace, podName, Duration.ofSeconds(30));
+//        String log = kubeClient().logsInSpecificNamespace(deployNamespace, podName);
+//        LOGGER.debug("Admin client delete pod log: {}", log);
+//    }
 
-        DeploymentUtils.waitForPodRunSucceeded(deployNamespace, podName, Duration.ofSeconds(30));
+    private static boolean topicExists(String deployNamespace, String topicName, String bootstrap) {
+        LOGGER.debug("List '{}' topic", topicName);
+        String name = Constants.KAFKA_ADMIN_CLIENT_LABEL + "-list";
+        List<String> args = Arrays.asList(TOPIC_COMMAND, "list", BOOTSTRAP_ARG + bootstrap);
+        InputStream file = KafkaUtils.replaceStringInResourceFile(ADMIN_CLIENT_TEMPLATE, Map.of(
+                NAMESPACE_VAR, deployNamespace,
+                NAME_VAR, name,
+                ARGS_VAR, String.join("\",\"", args),
+                KAFKA_VERSION_VAR, Environment.KAFKA_VERSION));
+
+        kubeClient().getClient().load(file).inNamespace(deployNamespace).create();
+        String podName = KafkaUtils.getPodNameByLabel(deployNamespace, "app", name, Duration.ofSeconds(30));
         String log = kubeClient().logsInSpecificNamespace(deployNamespace, podName);
         LOGGER.debug("Admin client list pod log: {}", log);
         return log.contains(topicName);
     }
+
+//    private static boolean topicExists2(String deployNamespace, String topicName, String bootstrap) {
+//        LOGGER.info("Deleting topic {}", topicName);
+//        String podName = Constants.KAFKA_ADMIN_CLIENT_LABEL + "-list";
+//        kubeClient().getClient().run().inNamespace(deployNamespace).withNewRunConfig()
+//                .withImage(Constants.TEST_CLIENTS_IMAGE)
+//                .withName(podName)
+//                .withRestartPolicy(NEVER_POLICY)
+//                .withCommand(ADMIN_CLIENT_COMMAND)
+//                .withArgs(TOPIC_COMMAND, "list", BOOTSTRAP_ARG + bootstrap)
+//                .done();
+//
+//        DeploymentUtils.waitForPodRunSucceeded(deployNamespace, podName, Duration.ofSeconds(30));
+//        String log = kubeClient().logsInSpecificNamespace(deployNamespace, podName);
+//        LOGGER.debug("Admin client list pod log: {}", log);
+//        return log.contains(topicName);
+//    }
 
     /**
      * Restart kafka broker.

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
@@ -95,7 +95,7 @@ public class KafkaUtils {
         return consumeMessages(deployNamespace, topicName, bootstrap, numOfMessages, "key: kroxylicious.io/encryption", timeout);
     }
 
-    private static String getPodNameByLabel(String deployNamespace, String labelKey, String labelValue, Duration timeout) {
+    public static String getPodNameByLabel(String deployNamespace, String labelKey, String labelValue, Duration timeout) {
         await().atMost(timeout).until(() -> {
             var podList = kubeClient().listPods(deployNamespace, labelKey, labelValue);
             return !podList.isEmpty();
@@ -127,7 +127,7 @@ public class KafkaUtils {
         return getPodNameByLabel(deployNamespace, "app", Constants.KAFKA_PRODUCER_CLIENT_LABEL, Duration.ofSeconds(10));
     }
 
-    private static InputStream replaceStringInResourceFile(String resourceTemplateFileName, Map<String, String> replacements) {
+    public static InputStream replaceStringInResourceFile(String resourceTemplateFileName, Map<String, String> replacements) {
         Path path = Path.of(Objects.requireNonNull(KafkaUtils.class
                 .getClassLoader().getResource(resourceTemplateFileName)).getPath());
         Charset charset = StandardCharsets.UTF_8;

--- a/kroxylicious-systemtests/src/test/resources/kafka-admin-client-template.yaml
+++ b/kroxylicious-systemtests/src/test/resources/kafka-admin-client-template.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: %NAME%
+  labels:
+    app: %NAME%
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: %NAME%
+  template:
+    metadata:
+      labels:
+        app: %NAME%
+      name: %NAME%
+      namespace: %NAMESPACE%
+    spec:
+      containers:
+        - name: admin
+          image: quay.io/strimzi-test-clients/test-clients:latest-kafka-%KAFKA_VERSION%
+          command: [ "admin-client" ]
+          args: [ "%ARGS%" ]


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Created admin client template to modify the way to deploy the admin clients to create/delete topics.

### Additional Context

Fixes #1090. 

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
