### PR TITLE
Body decoder now supports older versions of ApiVersionsResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please enumerate **all user-facing** changes using format `<githib issue/pr numb
 
 ## SNAPSHOT
 
+* [#1110](https://github.com/kroxylicious/kroxylicious/pull/1110): Body decoder now supports older versions of ApiVersionsResponse
 * [#1107](https://github.com/kroxylicious/kroxylicious/pull/1107): Replace deprecated FilePasswordFilePath class with @JsonAlias.
 * [#1099](https://github.com/kroxylicious/kroxylicious/pull/1099): Bump io.micrometer:micrometer-bom from 1.12.3 to 1.12.4
 * [#1103](https://github.com/kroxylicious/kroxylicious/pull/1103): Bump com.fasterxml.jackson:jackson-bom from 2.16.1 to 2.17.0

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,3 +5,4 @@
 - Sam Barker(https://github.com/SamBarker)
 - Francisco Vila(https://github.com/franvila)
 - Anthony Callaert(https://github.com/callaertanthony)
+- Zhenyu Luo(https://github.com/luozhenyu)

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/ByteBufAccessor.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/ByteBufAccessor.java
@@ -7,14 +7,52 @@ package io.kroxylicious.proxy.frame;
 
 import java.nio.ByteBuffer;
 
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.protocol.Writable;
 
 import io.netty.buffer.ByteBuf;
 
 /**
- * Provides write access to byte buffer for serializing frames.
+ * Provides read and write access to byte buffer for serializing frames.
  */
-public interface ByteBufAccessor extends Writable {
+public interface ByteBufAccessor extends Readable, Writable {
+
+    @Override
+    byte readByte();
+
+    @Override
+    short readShort();
+
+    @Override
+    int readInt();
+
+    @Override
+    long readLong();
+
+    @Override
+    double readDouble();
+
+    @Override
+    byte[] readArray(int length);
+
+    @Override
+    int readUnsignedVarint();
+
+    @Override
+    ByteBuffer readByteBuffer(int length);
+
+    @Override
+    int readVarint();
+
+    @Override
+    long readVarlong();
+
+    @Override
+    int remaining();
+
+    int readerIndex();
+
+    void readerIndex(int readerIndex);
 
     @Override
     void writeByte(byte val);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/InternalCompletionStage.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/InternalCompletionStage.java
@@ -30,6 +30,10 @@ class InternalCompletionStage<T> implements CompletionStage<T> {
         return completionStage instanceof InternalCompletionStage ? completionStage : new InternalCompletionStage<>(completionStage);
     }
 
+    private <U> CompletionStage<U> unwrap(CompletionStage<U> completionStage) {
+        return completionStage instanceof InternalCompletionStage ? ((InternalCompletionStage<U>) completionStage).getUnderlyingCompletableFuture() : completionStage;
+    }
+
     @Override
     public <U> CompletionStage<U> thenApply(Function<? super T, ? extends U> fn) {
         return wrap(completionStage.thenApply(fn));
@@ -77,107 +81,107 @@ class InternalCompletionStage<T> implements CompletionStage<T> {
 
     @Override
     public <U, V> CompletionStage<V> thenCombine(CompletionStage<? extends U> other, BiFunction<? super T, ? super U, ? extends V> fn) {
-        return wrap(completionStage.thenCombine(other, fn));
+        return wrap(completionStage.thenCombine(unwrap(other), fn));
     }
 
     @Override
     public <U, V> CompletionStage<V> thenCombineAsync(CompletionStage<? extends U> other, BiFunction<? super T, ? super U, ? extends V> fn) {
-        return wrap(completionStage.thenCombineAsync(other, fn));
+        return wrap(completionStage.thenCombineAsync(unwrap(other), fn));
     }
 
     @Override
     public <U, V> CompletionStage<V> thenCombineAsync(CompletionStage<? extends U> other, BiFunction<? super T, ? super U, ? extends V> fn, Executor executor) {
-        return wrap(completionStage.thenCombineAsync(other, fn, executor));
+        return wrap(completionStage.thenCombineAsync(unwrap(other), fn, executor));
     }
 
     @Override
     public <U> CompletionStage<Void> thenAcceptBoth(CompletionStage<? extends U> other, BiConsumer<? super T, ? super U> action) {
-        return wrap(completionStage.thenAcceptBoth(other, action));
+        return wrap(completionStage.thenAcceptBoth(unwrap(other), action));
     }
 
     @Override
     public <U> CompletionStage<Void> thenAcceptBothAsync(CompletionStage<? extends U> other, BiConsumer<? super T, ? super U> action) {
-        return wrap(completionStage.thenAcceptBothAsync(other, action));
+        return wrap(completionStage.thenAcceptBothAsync(unwrap(other), action));
     }
 
     @Override
     public <U> CompletionStage<Void> thenAcceptBothAsync(CompletionStage<? extends U> other, BiConsumer<? super T, ? super U> action, Executor executor) {
-        return wrap(completionStage.thenAcceptBothAsync(other, action, executor));
+        return wrap(completionStage.thenAcceptBothAsync(unwrap(other), action, executor));
     }
 
     @Override
     public CompletionStage<Void> runAfterBoth(CompletionStage<?> other, Runnable action) {
-        return wrap(completionStage.runAfterBoth(other, action));
+        return wrap(completionStage.runAfterBoth(unwrap(other), action));
     }
 
     @Override
     public CompletionStage<Void> runAfterBothAsync(CompletionStage<?> other, Runnable action) {
-        return wrap(completionStage.runAfterBothAsync(other, action));
+        return wrap(completionStage.runAfterBothAsync(unwrap(other), action));
     }
 
     @Override
     public CompletionStage<Void> runAfterBothAsync(CompletionStage<?> other, Runnable action, Executor executor) {
-        return wrap(completionStage.runAfterBothAsync(other, action, executor));
+        return wrap(completionStage.runAfterBothAsync(unwrap(other), action, executor));
     }
 
     @Override
     public <U> CompletionStage<U> applyToEither(CompletionStage<? extends T> other, Function<? super T, U> fn) {
-        return wrap(completionStage.applyToEither(other, fn));
+        return wrap(completionStage.applyToEither(unwrap(other), fn));
     }
 
     @Override
     public <U> CompletionStage<U> applyToEitherAsync(CompletionStage<? extends T> other, Function<? super T, U> fn) {
-        return wrap(completionStage.applyToEitherAsync(other, fn));
+        return wrap(completionStage.applyToEitherAsync(unwrap(other), fn));
     }
 
     @Override
     public <U> CompletionStage<U> applyToEitherAsync(CompletionStage<? extends T> other, Function<? super T, U> fn, Executor executor) {
-        return wrap(completionStage.applyToEitherAsync(other, fn, executor));
+        return wrap(completionStage.applyToEitherAsync(unwrap(other), fn, executor));
     }
 
     @Override
     public CompletionStage<Void> acceptEither(CompletionStage<? extends T> other, Consumer<? super T> action) {
-        return wrap(completionStage.acceptEither(other, action));
+        return wrap(completionStage.acceptEither(unwrap(other), action));
     }
 
     @Override
     public CompletionStage<Void> acceptEitherAsync(CompletionStage<? extends T> other, Consumer<? super T> action) {
-        return wrap(completionStage.acceptEitherAsync(other, action));
+        return wrap(completionStage.acceptEitherAsync(unwrap(other), action));
     }
 
     @Override
     public CompletionStage<Void> acceptEitherAsync(CompletionStage<? extends T> other, Consumer<? super T> action, Executor executor) {
-        return wrap(completionStage.acceptEitherAsync(other, action, executor));
+        return wrap(completionStage.acceptEitherAsync(unwrap(other), action, executor));
     }
 
     @Override
     public CompletionStage<Void> runAfterEither(CompletionStage<?> other, Runnable action) {
-        return wrap(completionStage.runAfterEither(other, action));
+        return wrap(completionStage.runAfterEither(unwrap(other), action));
     }
 
     @Override
     public CompletionStage<Void> runAfterEitherAsync(CompletionStage<?> other, Runnable action) {
-        return wrap(completionStage.runAfterEitherAsync(other, action));
+        return wrap(completionStage.runAfterEitherAsync(unwrap(other), action));
     }
 
     @Override
     public CompletionStage<Void> runAfterEitherAsync(CompletionStage<?> other, Runnable action, Executor executor) {
-        return wrap(completionStage.runAfterEitherAsync(other, action, executor));
+        return wrap(completionStage.runAfterEitherAsync(unwrap(other), action, executor));
     }
 
     @Override
     public <U> CompletionStage<U> thenCompose(Function<? super T, ? extends CompletionStage<U>> fn) {
-        return wrap(completionStage.thenCompose(fn));
+        return wrap(completionStage.thenCompose(fn.andThen(this::unwrap)));
     }
 
     @Override
     public <U> CompletionStage<U> thenComposeAsync(Function<? super T, ? extends CompletionStage<U>> fn) {
-        return wrap(completionStage.thenComposeAsync(fn));
+        return wrap(completionStage.thenComposeAsync(fn.andThen(this::unwrap)));
     }
 
     @Override
     public <U> CompletionStage<U> thenComposeAsync(Function<? super T, ? extends CompletionStage<U>> fn, Executor executor) {
-        return wrap(completionStage.thenComposeAsync(fn, executor));
+        return wrap(completionStage.thenComposeAsync(fn.andThen(this::unwrap), executor));
     }
 
     @Override
@@ -227,17 +231,17 @@ class InternalCompletionStage<T> implements CompletionStage<T> {
 
     @Override
     public CompletionStage<T> exceptionallyCompose(Function<Throwable, ? extends CompletionStage<T>> fn) {
-        return wrap(completionStage.exceptionallyCompose(fn));
+        return wrap(completionStage.exceptionallyCompose(fn.andThen(this::unwrap)));
     }
 
     @Override
     public CompletionStage<T> exceptionallyComposeAsync(Function<Throwable, ? extends CompletionStage<T>> fn) {
-        return wrap(completionStage.exceptionallyComposeAsync(fn));
+        return wrap(completionStage.exceptionallyComposeAsync(fn.andThen(this::unwrap)));
     }
 
     @Override
     public CompletionStage<T> exceptionallyComposeAsync(Function<Throwable, ? extends CompletionStage<T>> fn, Executor executor) {
-        return wrap(completionStage.exceptionallyComposeAsync(fn, executor));
+        return wrap(completionStage.exceptionallyComposeAsync(fn.andThen(this::unwrap), executor));
     }
 
     @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/ByteBufAccessorImpl.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/ByteBufAccessorImpl.java
@@ -7,8 +7,6 @@ package io.kroxylicious.proxy.internal.codec;
 
 import java.nio.ByteBuffer;
 
-import org.apache.kafka.common.protocol.Readable;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 
@@ -23,7 +21,7 @@ import io.kroxylicious.proxy.frame.ByteBufAccessor;
  * depends on NIO ByteBuffer, so copying between ByteBuffer and ByteBuf cannot
  * always be avoided.
  */
-public class ByteBufAccessorImpl implements ByteBufAccessor, Readable {
+public class ByteBufAccessorImpl implements ByteBufAccessor {
 
     private final ByteBuf buf;
 
@@ -176,6 +174,16 @@ public class ByteBufAccessorImpl implements ByteBufAccessor, Readable {
     @Override
     public int remaining() {
         return buf.writerIndex() - buf.readerIndex();
+    }
+
+    @Override
+    public int readerIndex() {
+        return buf.readerIndex();
+    }
+
+    @Override
+    public void readerIndex(int readerIndex) {
+        buf.readerIndex(readerIndex);
     }
 
     @Override

--- a/kroxylicious-runtime/src/main/templates/BodyDecoder.ftl
+++ b/kroxylicious-runtime/src/main/templates/BodyDecoder.ftl
@@ -45,16 +45,14 @@ public class BodyDecoder {
     * @throws IllegalArgumentException if an unhandled ApiKey is encountered
     */
     static ApiMessage decodeRequest(ApiKeys apiKey, short apiVersion, Readable accessor) {
-        switch (apiKey) {
+        return switch (apiKey) {
 <#list messageSpecs as messageSpec>
     <#if messageSpec.type?lower_case == 'request'>
-            case ${retrieveApiKey(messageSpec)}:
-                return new ${messageSpec.name}Data(accessor, apiVersion);
+            case ${retrieveApiKey(messageSpec)} -> new ${messageSpec.name}Data(accessor, apiVersion);
     </#if>
 </#list>
-            default:
-                throw new IllegalArgumentException("Unsupported RPC " + apiKey);
-        }
+            default -> throw new IllegalArgumentException("Unsupported RPC " + apiKey);
+        };
     }
 
     /**
@@ -66,16 +64,14 @@ public class BodyDecoder {
     * @throws IllegalArgumentException if an unhandled ApiKey is encountered
     */
     static ApiMessage decodeResponse(ApiKeys apiKey, short apiVersion, Readable accessor) {
-        switch (apiKey) {
+        return switch (apiKey) {
 <#list messageSpecs as messageSpec>
     <#if messageSpec.type?lower_case == 'response'>
-            case ${retrieveApiKey(messageSpec)}:
-                return new ${messageSpec.name}Data(accessor, apiVersion);
+            case ${retrieveApiKey(messageSpec)} -> new ${messageSpec.name}Data(accessor, apiVersion);
     </#if>
 </#list>
-            default:
-                throw new IllegalArgumentException("Unsupported RPC " + apiKey);
-        }
+            default -> throw new IllegalArgumentException("Unsupported RPC " + apiKey);
+        };
     }
 
 }

--- a/kroxylicious-runtime/src/main/templates/BodyDecoder.ftl
+++ b/kroxylicious-runtime/src/main/templates/BodyDecoder.ftl
@@ -28,7 +28,8 @@ import org.apache.kafka.common.message.${messageSpec.name}Data;
 </#list>
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
-import org.apache.kafka.common.protocol.Readable;
+
+import io.kroxylicious.proxy.frame.ByteBufAccessor;
 
 /**
 * Decodes Kafka Readable into an ApiMessage
@@ -44,7 +45,7 @@ public class BodyDecoder {
     * @return the ApiMessage
     * @throws IllegalArgumentException if an unhandled ApiKey is encountered
     */
-    static ApiMessage decodeRequest(ApiKeys apiKey, short apiVersion, Readable accessor) {
+    static ApiMessage decodeRequest(ApiKeys apiKey, short apiVersion, ByteBufAccessor accessor) {
         return switch (apiKey) {
 <#list messageSpecs as messageSpec>
     <#if messageSpec.type?lower_case == 'request'>
@@ -62,14 +63,37 @@ public class BodyDecoder {
     * @param accessor the accessor for the message bytes
     * @return the ApiMessage
     * @throws IllegalArgumentException if an unhandled ApiKey is encountered
+    * @see <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-511%3A+Collect+and+Expose+Client%27s+Name+and+Version+in+the+Brokers#KIP511:CollectandExposeClient'sNameandVersionintheBrokers-ApiVersionsRequest/ResponseHandling">KIP-511: Collect and Expose Client's Name and Version in the Brokers</a>
+    * ApiVersions Request/Response Handling
     */
-    static ApiMessage decodeResponse(ApiKeys apiKey, short apiVersion, Readable accessor) {
+    static ApiMessage decodeResponse(ApiKeys apiKey, short apiVersion, ByteBufAccessor accessor) {
         return switch (apiKey) {
 <#list messageSpecs as messageSpec>
     <#if messageSpec.type?lower_case == 'response'>
+        <#if messageSpec.name == 'ApiVersionsResponse'>
+            case ${retrieveApiKey(messageSpec)} -> {
+                // KIP-511 when the client receives an unsupported version for the ApiVersionResponse, it fails back to version 0
+                // Use the same algorithm as https://github.com/apache/kafka/blob/a41c10fd49841381b5207c184a385622094ed440/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java#L90-L106
+                int prev = accessor.readerIndex();
+                try {
+                    yield new ${messageSpec.name}Data(accessor, apiVersion);
+                }
+                catch (RuntimeException e) {
+                    accessor.readerIndex(prev);
+                    if (apiVersion != 0) {
+                        yield new ${messageSpec.name}Data(accessor, (short) 0);
+                    }
+                    else {
+                        throw e;
+                    }
+                }
+            }
+        <#else>
             case ${retrieveApiKey(messageSpec)} -> new ${messageSpec.name}Data(accessor, apiVersion);
+        </#if>
     </#if>
 </#list>
+
             default -> throw new IllegalArgumentException("Unsupported RPC " + apiKey);
         };
     }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/ByteBufAccessorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/ByteBufAccessorTest.java
@@ -130,6 +130,15 @@ public class ByteBufAccessorTest {
     }
 
     @Test
+    void testReaderIndex() {
+        var bbuf = Unpooled.buffer(2).writeZero(2);
+        var kp = new ByteBufAccessorImpl(bbuf);
+        assertThat(kp.readerIndex()).isZero();
+        bbuf.readerIndex(1);
+        assertThat(kp.readerIndex()).isEqualTo(1);
+    }
+
+    @Test
     void testWriterIndex() {
         var bbuf = Unpooled.buffer(2);
         var kp = new ByteBufAccessorImpl(bbuf);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

If the upstream is an old kafka cluster that only supports ApiVersions(v0), a RuntimeException will be thrown with the message "non-nullable field apiKeys was serialized as null".

Kafka client falls back to ApiVersions(v0) if parsing fails, but kroxylicious does not.

https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java#L90-L106

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
