### PR TITLE
Enable record validation filter to check that Apicurio global id header is present for keys and values

### DIFF
--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceValidationFilterBuilder.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceValidationFilterBuilder.java
@@ -53,7 +53,8 @@ public class ProduceValidationFilterBuilder {
 
     private static BytebufValidator toValidator(BytebufValidation valueRule) {
         return valueRule.getSyntacticallyCorrectJsonConfig().map(config -> BytebufValidators.jsonSyntaxValidator(config.isValidateObjectKeysUnique()))
-                .orElse(BytebufValidators.allValid());
+                .orElse(valueRule.getApicurioSchemaValidationConfig().map(config -> BytebufValidators.apicurioSchemaValidator())
+                        .orElse(BytebufValidators.allValid()));
     }
 
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/config/ApicurioSchemaValidationConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/config/ApicurioSchemaValidationConfig.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.schema.config;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+// This has an ugly equals/hash but in future we will definitely have configuration for the
+// validation. The equals/hash are required to keep the test happy. We use the presence of
+// this config object to enable checking.
+public class ApicurioSchemaValidationConfig {
+
+    /**
+     * Construct ApicurioSchemaValidationConfig
+     */
+    @JsonCreator
+    public ApicurioSchemaValidationConfig() {
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(1);
+    }
+
+    @Override
+    public String toString() {
+        return "Schema Validation";
+    }
+}

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/config/BytebufValidation.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/config/BytebufValidation.java
@@ -16,7 +16,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Configuration for validating a Bytebuffer holding a value.
  */
 public class BytebufValidation {
+
+    // mutually exclusive with apicurioSchemaValidationConfig
     private final SyntacticallyCorrectJsonConfig syntacticallyCorrectJsonConfig;
+
+    // mutually exclusive with syntacticallyCorrectJsonConfig
+    private final ApicurioSchemaValidationConfig apicurioSchemaValidationConfig;
     private final boolean allowNulls;
     private final boolean allowEmpty;
 
@@ -28,9 +33,14 @@ public class BytebufValidation {
      */
     @JsonCreator
     public BytebufValidation(@JsonProperty("syntacticallyCorrectJson") SyntacticallyCorrectJsonConfig syntacticallyCorrectJsonConfig,
+                             @JsonProperty("hasApicurioSchema") ApicurioSchemaValidationConfig apicurioSchemaValidationConfig,
                              @JsonProperty(value = "allowNulls", defaultValue = "true") Boolean allowNulls,
                              @JsonProperty(value = "allowEmpty", defaultValue = "false") Boolean allowEmpty) {
+        if (syntacticallyCorrectJsonConfig != null && apicurioSchemaValidationConfig != null) {
+            throw new IllegalArgumentException("both syntactically correct json and apicurio schema validation configured");
+        }
         this.syntacticallyCorrectJsonConfig = syntacticallyCorrectJsonConfig;
+        this.apicurioSchemaValidationConfig = apicurioSchemaValidationConfig;
         this.allowNulls = allowNulls == null || allowNulls;
         this.allowEmpty = allowEmpty != null && allowEmpty;
     }
@@ -41,6 +51,14 @@ public class BytebufValidation {
      */
     public Optional<SyntacticallyCorrectJsonConfig> getSyntacticallyCorrectJsonConfig() {
         return Optional.ofNullable(syntacticallyCorrectJsonConfig);
+    }
+
+    /**
+     * Get apicurio schema validation config.
+     * @return optional containing apicurioSchemaValidationConfig if non-null, empty otherwise
+     */
+    public Optional<ApicurioSchemaValidationConfig> getApicurioSchemaValidationConfig() {
+        return Optional.ofNullable(apicurioSchemaValidationConfig);
     }
 
     /**
@@ -68,19 +86,20 @@ public class BytebufValidation {
             return false;
         }
         BytebufValidation that = (BytebufValidation) o;
-        return allowNulls == that.allowNulls && allowEmpty == that.allowEmpty && Objects.equals(syntacticallyCorrectJsonConfig,
-                that.syntacticallyCorrectJsonConfig);
+        return allowNulls == that.allowNulls && allowEmpty == that.allowEmpty && Objects.equals(syntacticallyCorrectJsonConfig, that.syntacticallyCorrectJsonConfig)
+                && Objects.equals(apicurioSchemaValidationConfig, that.apicurioSchemaValidationConfig);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(syntacticallyCorrectJsonConfig, allowNulls, allowEmpty);
+        return Objects.hash(syntacticallyCorrectJsonConfig, apicurioSchemaValidationConfig, allowNulls, allowEmpty);
     }
 
     @Override
     public String toString() {
         return "BytebufValidation{" +
                 "syntacticallyCorrectJsonConfig=" + syntacticallyCorrectJsonConfig +
+                ", apicurioSchemaValidationConfig=" + apicurioSchemaValidationConfig +
                 ", allowNulls=" + allowNulls +
                 ", allowEmpty=" + allowEmpty +
                 '}';

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/AllValidBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/AllValidBytebufValidator.java
@@ -7,6 +7,8 @@
 package io.kroxylicious.proxy.filter.schema.validation.bytebuf;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.apache.kafka.common.record.Record;
 
@@ -15,7 +17,7 @@ import io.kroxylicious.proxy.filter.schema.validation.Result;
 class AllValidBytebufValidator implements BytebufValidator {
 
     @Override
-    public Result validate(ByteBuffer buffer, int length, Record record, boolean isKey) {
-        return Result.VALID;
+    public CompletionStage<Result> validate(ByteBuffer buffer, int length, Record record, boolean isKey) {
+        return CompletableFuture.completedFuture(Result.VALID);
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/BytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/BytebufValidator.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.proxy.filter.schema.validation.bytebuf;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletionStage;
 
 import org.apache.kafka.common.record.Record;
 
@@ -31,5 +32,5 @@ public interface BytebufValidator {
      * @param isKey true if the buffer is the key of the record, false if it is the value of the record
      * @return a valid result if the buffer is valid
      */
-    Result validate(ByteBuffer buffer, int length, Record record, boolean isKey);
+    CompletionStage<Result> validate(ByteBuffer buffer, int length, Record record, boolean isKey);
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/BytebufValidators.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/BytebufValidators.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.proxy.filter.schema.validation.bytebuf;
 
+import io.kroxylicious.proxy.filter.schema.validation.bytebuf.apicurio.ApiCurioSchemaBytebufValidator;
+
 /**
  * Static factory methods for creating/getting ${@link BytebufValidator} instances
  */
@@ -43,5 +45,9 @@ public class BytebufValidators {
      */
     public static BytebufValidator jsonSyntaxValidator(boolean validateObjectKeysUnique) {
         return new JsonSyntaxBytebufValidator(validateObjectKeysUnique);
+    }
+
+    public static BytebufValidator apicurioSchemaValidator() {
+        return new ApiCurioSchemaBytebufValidator();
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSyntaxBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSyntaxBytebufValidator.java
@@ -8,6 +8,7 @@ package io.kroxylicious.proxy.filter.schema.validation.bytebuf;
 
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
 
 import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.utils.ByteBufferInputStream;
@@ -33,7 +34,7 @@ class JsonSyntaxBytebufValidator implements BytebufValidator {
     }
 
     @Override
-    public Result validate(ByteBuffer buffer, int size, Record record, boolean isKey) {
+    public CompletableFuture<Result> validate(ByteBuffer buffer, int size, Record record, boolean isKey) {
         if (buffer == null) {
             throw new IllegalArgumentException("buffer is null");
         }
@@ -47,11 +48,11 @@ class JsonSyntaxBytebufValidator implements BytebufValidator {
             }
             while (parser.nextToken() != null) {
             }
-            return Result.VALID;
+            return CompletableFuture.completedFuture(Result.VALID);
         }
         catch (Exception e) {
             String message = "value was not syntactically correct JSON" + (e.getMessage() != null ? ": " + e.getMessage() : "");
-            return new Result(false, message);
+            return CompletableFuture.completedFuture(new Result(false, message));
         }
     }
 

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/NullEmptyBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/NullEmptyBytebufValidator.java
@@ -7,6 +7,8 @@
 package io.kroxylicious.proxy.filter.schema.validation.bytebuf;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.apache.kafka.common.record.Record;
 
@@ -28,12 +30,12 @@ class NullEmptyBytebufValidator implements BytebufValidator {
     }
 
     @Override
-    public Result validate(ByteBuffer buffer, int length, Record record, boolean isKey) {
+    public CompletionStage<Result> validate(ByteBuffer buffer, int length, Record record, boolean isKey) {
         if (buffer == null) {
-            return result(nullValid, "Null buffer invalid");
+            return CompletableFuture.completedFuture(result(nullValid, "Null buffer invalid"));
         }
         else if (length == 0) {
-            return result(emptyValid, "Empty buffer invalid");
+            return CompletableFuture.completedFuture(result(emptyValid, "Empty buffer invalid"));
         }
         return delegate.validate(buffer, length, record, isKey);
     }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/apicurio/ApiCurioSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/apicurio/ApiCurioSchemaBytebufValidator.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.schema.validation.bytebuf.apicurio;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.record.Record;
+
+import io.kroxylicious.proxy.filter.schema.validation.Result;
+import io.kroxylicious.proxy.filter.schema.validation.bytebuf.BytebufValidator;
+
+public class ApiCurioSchemaBytebufValidator implements BytebufValidator {
+
+    private static final String valueSchemaHeader = "apicurio.value.globalId";
+    private static final String keySchemaHeader = "apicurio.key.globalId";
+
+    @Override
+    public CompletionStage<Result> validate(ByteBuffer buffer, int length, Record record, boolean isKey) {
+        // leave null validation to the NullEmptyBytebufValidator
+        if (buffer == null) {
+            return CompletableFuture.completedFuture(Result.VALID);
+        }
+        String header = isKey ? keySchemaHeader : valueSchemaHeader;
+        Optional<Header> first = Arrays.stream(record.headers()).filter(h -> h.key().equals(header)).findFirst();
+        if (first.isEmpty()) {
+            return CompletableFuture.completedFuture(new Result(false, "record headers did not contain: " + header));
+        }
+        Header header1 = first.get();
+        if (header1.value().length != 8) {
+            return CompletableFuture.completedFuture(new Result(false, "header " + header + " value is not 8 bytes"));
+        }
+        return CompletableFuture.completedFuture(Result.VALID);
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/apicurio/ApiCurioSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/apicurio/ApiCurioSchemaBytebufValidator.java
@@ -20,8 +20,8 @@ import io.kroxylicious.proxy.filter.schema.validation.bytebuf.BytebufValidator;
 
 public class ApiCurioSchemaBytebufValidator implements BytebufValidator {
 
-    private static final String valueSchemaHeader = "apicurio.value.globalId";
-    private static final String keySchemaHeader = "apicurio.key.globalId";
+    private static final String VALUE_SCHEMA_HEADER = "apicurio.value.globalId";
+    private static final String KEY_SCHEMA_HEADER = "apicurio.key.globalId";
 
     @Override
     public CompletionStage<Result> validate(ByteBuffer buffer, int length, Record record, boolean isKey) {
@@ -29,7 +29,7 @@ public class ApiCurioSchemaBytebufValidator implements BytebufValidator {
         if (buffer == null) {
             return CompletableFuture.completedFuture(Result.VALID);
         }
-        String header = isKey ? keySchemaHeader : valueSchemaHeader;
+        String header = isKey ? KEY_SCHEMA_HEADER : VALUE_SCHEMA_HEADER;
         Optional<Header> first = Arrays.stream(record.headers()).filter(h -> h.key().equals(header)).findFirst();
         if (first.isEmpty()) {
             return CompletableFuture.completedFuture(new Result(false, "record headers did not contain: " + header));

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/record/KeyAndValueRecordValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/record/KeyAndValueRecordValidator.java
@@ -6,6 +6,9 @@
 
 package io.kroxylicious.proxy.filter.schema.validation.record;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
 import org.apache.kafka.common.record.Record;
 
 import io.kroxylicious.proxy.filter.schema.validation.Result;
@@ -32,16 +35,16 @@ public class KeyAndValueRecordValidator implements RecordValidator {
     }
 
     @Override
-    public Result validate(Record record) {
+    public CompletionStage<Result> validate(Record record) {
         Result keyValid = keyValidator.validate(record.key(), record.keySize(), record, true);
         if (!keyValid.valid()) {
-            return new Result(false, "Key was invalid: " + keyValid.errorMessage());
+            return CompletableFuture.completedFuture(new Result(false, "Key was invalid: " + keyValid.errorMessage()));
         }
         Result valueValid = valueValidator.validate(record.value(), record.valueSize(), record, false);
         if (!valueValid.valid()) {
-            return new Result(false, "Value was invalid: " + valueValid.errorMessage());
+            return CompletableFuture.completedFuture(new Result(false, "Value was invalid: " + valueValid.errorMessage()));
         }
-        return Result.VALID;
+        return CompletableFuture.completedFuture(Result.VALID);
     }
 
     /**

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/record/RecordValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/record/RecordValidator.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.proxy.filter.schema.validation.record;
 
+import java.util.concurrent.CompletionStage;
+
 import org.apache.kafka.common.record.Record;
 
 import io.kroxylicious.proxy.filter.schema.validation.Result;
@@ -20,5 +22,5 @@ public interface RecordValidator {
      * @param record the record to be validated
      * @return a Result describing if the record is valid and any failure message/exception if it is not.
      */
-    Result validate(Record record);
+    CompletionStage<Result> validate(Record record);
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/request/ProduceRequestValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/request/ProduceRequestValidator.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.proxy.filter.schema.validation.request;
 
+import java.util.concurrent.CompletionStage;
+
 import org.apache.kafka.common.message.ProduceRequestData;
 
 /**
@@ -19,5 +21,5 @@ public interface ProduceRequestValidator {
      * @param request the request
      * @return result describing a validation outcome for all topic partitions and details of records that failed validation
      */
-    ProduceRequestValidationResult validateRequest(ProduceRequestData request);
+    CompletionStage<ProduceRequestValidationResult> validateRequest(ProduceRequestData request);
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/request/RoutingProduceRequestValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/request/RoutingProduceRequestValidator.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.proxy.filter.schema.validation.request;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,9 +57,14 @@ public class RoutingProduceRequestValidator implements ProduceRequestValidator {
 
     @Override
     public CompletionStage<ProduceRequestValidationResult> validateRequest(ProduceRequestData request) {
-        Map<String, TopicValidationResult> collect = request.topicData().stream().collect(
-                Collectors.toMap(ProduceRequestData.TopicProduceData::name, topicProduceData -> getTopicValidator(topicProduceData).validateTopicData(topicProduceData)));
-        return CompletableFuture.completedFuture(new ProduceRequestValidationResult(collect));
+        CompletableFuture<TopicValidationResult>[] results = request.topicData().stream()
+                .map(topicProduceData -> getTopicValidator(topicProduceData).validateTopicData(topicProduceData).toCompletableFuture())
+                .toArray(CompletableFuture[]::new);
+        return CompletableFuture.allOf(results).thenApply(unused -> {
+            Map<String, TopicValidationResult> result = Arrays.stream(results).map(CompletableFuture::join)
+                    .collect(Collectors.toMap(TopicValidationResult::topicName, r -> r));
+            return new ProduceRequestValidationResult(result);
+        });
     }
 
     private TopicValidator getTopicValidator(ProduceRequestData.TopicProduceData topicProduceData) {

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/request/RoutingProduceRequestValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/request/RoutingProduceRequestValidator.java
@@ -12,6 +12,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -53,10 +55,10 @@ public class RoutingProduceRequestValidator implements ProduceRequestValidator {
     }
 
     @Override
-    public ProduceRequestValidationResult validateRequest(ProduceRequestData request) {
+    public CompletionStage<ProduceRequestValidationResult> validateRequest(ProduceRequestData request) {
         Map<String, TopicValidationResult> collect = request.topicData().stream().collect(
                 Collectors.toMap(ProduceRequestData.TopicProduceData::name, topicProduceData -> getTopicValidator(topicProduceData).validateTopicData(topicProduceData)));
-        return new ProduceRequestValidationResult(collect);
+        return CompletableFuture.completedFuture(new ProduceRequestValidationResult(collect));
     }
 
     private TopicValidator getTopicValidator(ProduceRequestData.TopicProduceData topicProduceData) {

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/topic/AllValidTopicValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/topic/AllValidTopicValidator.java
@@ -6,11 +6,14 @@
 
 package io.kroxylicious.proxy.filter.schema.validation.topic;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
 import org.apache.kafka.common.message.ProduceRequestData;
 
 class AllValidTopicValidator implements TopicValidator {
     @Override
-    public TopicValidationResult validateTopicData(ProduceRequestData.TopicProduceData request) {
-        return new AllValidTopicValidationResult(request.name());
+    public CompletionStage<TopicValidationResult> validateTopicData(ProduceRequestData.TopicProduceData request) {
+        return CompletableFuture.completedFuture(new AllValidTopicValidationResult(request.name()));
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/topic/PerRecordTopicValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/topic/PerRecordTopicValidator.java
@@ -8,6 +8,8 @@ package io.kroxylicious.proxy.filter.schema.validation.topic;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.common.message.ProduceRequestData;
@@ -31,9 +33,11 @@ class PerRecordTopicValidator implements TopicValidator {
     }
 
     @Override
-    public TopicValidationResult validateTopicData(ProduceRequestData.TopicProduceData topicProduceData) {
-        return new PerPartitionTopicValidationResult(topicProduceData.name(), topicProduceData.partitionData().stream().collect(Collectors.toMap(
-                ProduceRequestData.PartitionProduceData::index, this::validateTopicPartition)));
+    public CompletionStage<TopicValidationResult> validateTopicData(ProduceRequestData.TopicProduceData topicProduceData) {
+        PerPartitionTopicValidationResult result = new PerPartitionTopicValidationResult(topicProduceData.name(),
+                topicProduceData.partitionData().stream().collect(Collectors.toMap(
+                        ProduceRequestData.PartitionProduceData::index, this::validateTopicPartition)));
+        return CompletableFuture.completedFuture(result);
     }
 
     private PartitionValidationResult validateTopicPartition(ProduceRequestData.PartitionProduceData partitionProduceData) {

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/topic/PerRecordTopicValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/topic/PerRecordTopicValidator.java
@@ -52,9 +52,10 @@ class PerRecordTopicValidator implements TopicValidator {
         List<RecordValidationFailure> failures = new ArrayList<>();
         for (MutableRecordBatch batch : ((MemoryRecords) records).batches()) {
             for (Record record : batch) {
-                Result result = validator.validate(record);
-                if (!result.valid()) {
-                    failures.add(new RecordValidationFailure(recordIndex, result.errorMessage()));
+                // todo make partition validation async to avoid joining
+                CompletableFuture<Result> result = validator.validate(record).toCompletableFuture();
+                if (!result.join().valid()) {
+                    failures.add(new RecordValidationFailure(recordIndex, result.join().errorMessage()));
                 }
                 recordIndex++;
             }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/topic/TopicValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/topic/TopicValidator.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.proxy.filter.schema.validation.topic;
 
+import java.util.concurrent.CompletionStage;
+
 import org.apache.kafka.common.message.ProduceRequestData;
 
 /**
@@ -18,5 +20,5 @@ public interface TopicValidator {
      * @param request the request
      * @return result describing whether any partitions were invalid, and details of any invalid partitions/records
      */
-    TopicValidationResult validateTopicData(ProduceRequestData.TopicProduceData request);
+    CompletionStage<TopicValidationResult> validateTopicData(ProduceRequestData.TopicProduceData request);
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/TestRecords.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/TestRecords.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.schema.validation;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.record.DefaultRecord;
+import org.apache.kafka.common.record.Record;
+import org.apache.kafka.common.utils.ByteBufferOutputStream;
+
+public class TestRecords {
+    public static Record createRecord(String key, String value) {
+        return createRecord(key, value, Record.EMPTY_HEADERS);
+    }
+
+    public static DefaultRecord createRecord(String key, String value, Header[] headers) {
+        ByteBuffer keyBuf = toBufNullable(key);
+        ByteBuffer valueBuf = toBufNullable(value);
+        try (ByteBufferOutputStream bufferOutputStream = new ByteBufferOutputStream(1000); DataOutputStream dataOutputStream = new DataOutputStream(bufferOutputStream)) {
+            DefaultRecord.writeTo(dataOutputStream, 0, 0, keyBuf, valueBuf, headers);
+            dataOutputStream.flush();
+            bufferOutputStream.flush();
+            ByteBuffer buffer = bufferOutputStream.buffer();
+            buffer.flip();
+            return DefaultRecord.readFrom(buffer, 0, 0, 0, 0L);
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static ByteBuffer toBufNullable(String key) {
+        if (key == null) {
+            return null;
+        }
+        byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
+        return ByteBuffer.wrap(keyBytes);
+    }
+}

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/AllValidBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/AllValidBytebufValidatorTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.schema.validation.bytebuf;
+
+import java.time.Duration;
+import java.util.concurrent.CompletionStage;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.filter.schema.validation.Result;
+import io.kroxylicious.proxy.filter.schema.validation.TestRecords;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AllValidBytebufValidatorTest {
+
+    @Test
+    void allValid() {
+        AllValidBytebufValidator allValidBytebufValidator = new AllValidBytebufValidator();
+        CompletionStage<Result> valid = allValidBytebufValidator.validate(null, 0, TestRecords.createRecord("a", "b"), false);
+        assertThat(valid).succeedsWithin(Duration.ZERO).isEqualTo(Result.VALID);
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/apicurio/ApiCurioSchemaBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/apicurio/ApiCurioSchemaBytebufValidatorTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.schema.validation.bytebuf.apicurio;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.record.Record;
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.filter.schema.validation.Result;
+import io.kroxylicious.proxy.filter.schema.validation.TestRecords;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApiCurioSchemaBytebufValidatorTest {
+
+    @Test
+    public void testNullValueAllowed() {
+        Result result = validateValue(new ApiCurioSchemaBytebufValidator(), null, 0, TestRecords.createRecord(null, null));
+        assertThat(result.valid()).isTrue();
+    }
+
+    @Test
+    public void testValueHeaderNotLong() {
+        Header[] headers = { new RecordHeader("apicurio.value.globalId", new byte[]{ 1, 2, 3, 4, 5, 6, 7 }) };
+        ByteBuffer arbitrary = ByteBuffer.allocate(1);
+        Result result = validateValue(new ApiCurioSchemaBytebufValidator(), arbitrary, 0, TestRecords.createRecord(null, null, headers));
+        assertThat(result.valid()).isFalse();
+        assertThat(result.errorMessage()).contains("header apicurio.value.globalId value is not 8 bytes");
+    }
+
+    @Test
+    public void testValueHeaderLong() {
+        Header[] headers = { new RecordHeader("apicurio.value.globalId", new byte[]{ 1, 2, 3, 4, 5, 6, 7, 8 }) };
+        ByteBuffer arbitrary = ByteBuffer.allocate(1);
+        Result result = validateValue(new ApiCurioSchemaBytebufValidator(), arbitrary, 0, TestRecords.createRecord(null, null, headers));
+        assertThat(result.valid()).isTrue();
+    }
+
+    @Test
+    public void testValueHeaderEmpty() {
+        Header[] headers = { new RecordHeader("apicurio.value.globalId", new byte[0]) };
+        ByteBuffer arbitrary = ByteBuffer.allocate(1);
+        Result result = validateValue(new ApiCurioSchemaBytebufValidator(), arbitrary, 0, TestRecords.createRecord(null, null, headers));
+        assertThat(result.valid()).isFalse();
+        assertThat(result.errorMessage()).contains("header apicurio.value.globalId value is not 8 bytes");
+    }
+
+    @Test
+    public void testValueHeaderMissingIsInvalid() {
+        ByteBuffer arbitrary = ByteBuffer.allocate(1);
+        Result result = validateValue(new ApiCurioSchemaBytebufValidator(), arbitrary, arbitrary.limit(), TestRecords.createRecord(null, null));
+        assertThat(result.valid()).isFalse();
+        assertThat(result.errorMessage()).contains("record headers did not contain: apicurio.value.globalId");
+    }
+
+    @Test
+    public void testNullKeyAllowed() {
+        Result result = validateKey(new ApiCurioSchemaBytebufValidator(), null, 0, TestRecords.createRecord(null, null));
+        assertThat(result.valid()).isTrue();
+    }
+
+    @Test
+    public void testKeyHeaderMissingIsInvalid() {
+        ByteBuffer arbitrary = ByteBuffer.allocate(1);
+        Result result = validateKey(new ApiCurioSchemaBytebufValidator(), arbitrary, arbitrary.limit(), TestRecords.createRecord(null, null));
+        assertThat(result.valid()).isFalse();
+        assertThat(result.errorMessage()).contains("record headers did not contain: apicurio.key.globalId");
+    }
+
+    @Test
+    public void testKeyHeaderNotLong() {
+        Header[] headers = { new RecordHeader("apicurio.key.globalId", new byte[]{ 1, 2, 3, 4, 5, 6, 7 }) };
+        ByteBuffer arbitrary = ByteBuffer.allocate(1);
+        Result result = validateKey(new ApiCurioSchemaBytebufValidator(), arbitrary, 0, TestRecords.createRecord(null, null, headers));
+        assertThat(result.valid()).isFalse();
+        assertThat(result.errorMessage()).contains("header apicurio.key.globalId value is not 8 bytes");
+    }
+
+    @Test
+    public void testKeyHeaderLong() {
+        Header[] headers = { new RecordHeader("apicurio.key.globalId", new byte[]{ 1, 2, 3, 4, 5, 6, 7, 8 }) };
+        ByteBuffer arbitrary = ByteBuffer.allocate(1);
+        Result result = validateKey(new ApiCurioSchemaBytebufValidator(), arbitrary, 0, TestRecords.createRecord(null, null, headers));
+        assertThat(result.valid()).isTrue();
+    }
+
+    @Test
+    public void testKeyHeaderEmpty() {
+        Header[] headers = { new RecordHeader("apicurio.key.globalId", new byte[0]) };
+        ByteBuffer arbitrary = ByteBuffer.allocate(1);
+        Result result = validateKey(new ApiCurioSchemaBytebufValidator(), arbitrary, 0, TestRecords.createRecord(null, null, headers));
+        assertThat(result.valid()).isFalse();
+        assertThat(result.errorMessage()).contains("header apicurio.key.globalId value is not 8 bytes");
+    }
+
+    private static Result validateValue(ApiCurioSchemaBytebufValidator apiCurioSchemaBytebufValidator, ByteBuffer buffer, int length, Record record) {
+        return validate(apiCurioSchemaBytebufValidator, buffer, length, record, false);
+    }
+
+    private static Result validateKey(ApiCurioSchemaBytebufValidator apiCurioSchemaBytebufValidator, ByteBuffer buffer, int length, Record record) {
+        return validate(apiCurioSchemaBytebufValidator, buffer, length, record, true);
+    }
+
+    private static Result validate(ApiCurioSchemaBytebufValidator apiCurioSchemaBytebufValidator, ByteBuffer buffer, int length, Record record, boolean isKey) {
+        try {
+            return apiCurioSchemaBytebufValidator.validate(buffer, length, record, isKey).toCompletableFuture().get(5, TimeUnit.SECONDS);
+        }
+        catch (InterruptedException | ExecutionException | TimeoutException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/apicurio/ApiCurioSchemaBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/apicurio/ApiCurioSchemaBytebufValidatorTest.java
@@ -18,102 +18,106 @@ import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.proxy.filter.schema.validation.Result;
 import io.kroxylicious.proxy.filter.schema.validation.TestRecords;
+import io.kroxylicious.proxy.filter.schema.validation.bytebuf.BytebufValidator;
+import io.kroxylicious.proxy.filter.schema.validation.bytebuf.BytebufValidators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ApiCurioSchemaBytebufValidatorTest {
 
+    public static final BytebufValidator APICURIO_SCHEMA_VALIDATOR = BytebufValidators.apicurioSchemaValidator();
+
     @Test
-    public void testNullValueAllowed() {
-        Result result = validateValue(new ApiCurioSchemaBytebufValidator(), null, 0, TestRecords.createRecord(null, null));
+    void testNullValueAllowed() {
+        Result result = validateValue(APICURIO_SCHEMA_VALIDATOR, null, 0, TestRecords.createRecord(null, null));
         assertThat(result.valid()).isTrue();
     }
 
     @Test
-    public void testValueHeaderNotLong() {
+    void testValueHeaderNotLong() {
         Header[] headers = { new RecordHeader("apicurio.value.globalId", new byte[]{ 1, 2, 3, 4, 5, 6, 7 }) };
         ByteBuffer arbitrary = ByteBuffer.allocate(1);
-        Result result = validateValue(new ApiCurioSchemaBytebufValidator(), arbitrary, 0, TestRecords.createRecord(null, null, headers));
+        Result result = validateValue(APICURIO_SCHEMA_VALIDATOR, arbitrary, 0, TestRecords.createRecord(null, null, headers));
         assertThat(result.valid()).isFalse();
         assertThat(result.errorMessage()).contains("header apicurio.value.globalId value is not 8 bytes");
     }
 
     @Test
-    public void testValueHeaderLong() {
+    void testValueHeaderLong() {
         Header[] headers = { new RecordHeader("apicurio.value.globalId", new byte[]{ 1, 2, 3, 4, 5, 6, 7, 8 }) };
         ByteBuffer arbitrary = ByteBuffer.allocate(1);
-        Result result = validateValue(new ApiCurioSchemaBytebufValidator(), arbitrary, 0, TestRecords.createRecord(null, null, headers));
+        Result result = validateValue(APICURIO_SCHEMA_VALIDATOR, arbitrary, 0, TestRecords.createRecord(null, null, headers));
         assertThat(result.valid()).isTrue();
     }
 
     @Test
-    public void testValueHeaderEmpty() {
+    void testValueHeaderEmpty() {
         Header[] headers = { new RecordHeader("apicurio.value.globalId", new byte[0]) };
         ByteBuffer arbitrary = ByteBuffer.allocate(1);
-        Result result = validateValue(new ApiCurioSchemaBytebufValidator(), arbitrary, 0, TestRecords.createRecord(null, null, headers));
+        Result result = validateValue(APICURIO_SCHEMA_VALIDATOR, arbitrary, 0, TestRecords.createRecord(null, null, headers));
         assertThat(result.valid()).isFalse();
         assertThat(result.errorMessage()).contains("header apicurio.value.globalId value is not 8 bytes");
     }
 
     @Test
-    public void testValueHeaderMissingIsInvalid() {
+    void testValueHeaderMissingIsInvalid() {
         ByteBuffer arbitrary = ByteBuffer.allocate(1);
-        Result result = validateValue(new ApiCurioSchemaBytebufValidator(), arbitrary, arbitrary.limit(), TestRecords.createRecord(null, null));
+        Result result = validateValue(APICURIO_SCHEMA_VALIDATOR, arbitrary, arbitrary.limit(), TestRecords.createRecord(null, null));
         assertThat(result.valid()).isFalse();
         assertThat(result.errorMessage()).contains("record headers did not contain: apicurio.value.globalId");
     }
 
     @Test
-    public void testNullKeyAllowed() {
-        Result result = validateKey(new ApiCurioSchemaBytebufValidator(), null, 0, TestRecords.createRecord(null, null));
+    void testNullKeyAllowed() {
+        Result result = validateKey(APICURIO_SCHEMA_VALIDATOR, null, 0, TestRecords.createRecord(null, null));
         assertThat(result.valid()).isTrue();
     }
 
     @Test
-    public void testKeyHeaderMissingIsInvalid() {
+    void testKeyHeaderMissingIsInvalid() {
         ByteBuffer arbitrary = ByteBuffer.allocate(1);
-        Result result = validateKey(new ApiCurioSchemaBytebufValidator(), arbitrary, arbitrary.limit(), TestRecords.createRecord(null, null));
+        Result result = validateKey(APICURIO_SCHEMA_VALIDATOR, arbitrary, arbitrary.limit(), TestRecords.createRecord(null, null));
         assertThat(result.valid()).isFalse();
         assertThat(result.errorMessage()).contains("record headers did not contain: apicurio.key.globalId");
     }
 
     @Test
-    public void testKeyHeaderNotLong() {
+    void testKeyHeaderNotLong() {
         Header[] headers = { new RecordHeader("apicurio.key.globalId", new byte[]{ 1, 2, 3, 4, 5, 6, 7 }) };
         ByteBuffer arbitrary = ByteBuffer.allocate(1);
-        Result result = validateKey(new ApiCurioSchemaBytebufValidator(), arbitrary, 0, TestRecords.createRecord(null, null, headers));
+        Result result = validateKey(APICURIO_SCHEMA_VALIDATOR, arbitrary, 0, TestRecords.createRecord(null, null, headers));
         assertThat(result.valid()).isFalse();
         assertThat(result.errorMessage()).contains("header apicurio.key.globalId value is not 8 bytes");
     }
 
     @Test
-    public void testKeyHeaderLong() {
+    void testKeyHeaderLong() {
         Header[] headers = { new RecordHeader("apicurio.key.globalId", new byte[]{ 1, 2, 3, 4, 5, 6, 7, 8 }) };
         ByteBuffer arbitrary = ByteBuffer.allocate(1);
-        Result result = validateKey(new ApiCurioSchemaBytebufValidator(), arbitrary, 0, TestRecords.createRecord(null, null, headers));
+        Result result = validateKey(APICURIO_SCHEMA_VALIDATOR, arbitrary, 0, TestRecords.createRecord(null, null, headers));
         assertThat(result.valid()).isTrue();
     }
 
     @Test
-    public void testKeyHeaderEmpty() {
+    void testKeyHeaderEmpty() {
         Header[] headers = { new RecordHeader("apicurio.key.globalId", new byte[0]) };
         ByteBuffer arbitrary = ByteBuffer.allocate(1);
-        Result result = validateKey(new ApiCurioSchemaBytebufValidator(), arbitrary, 0, TestRecords.createRecord(null, null, headers));
+        Result result = validateKey(APICURIO_SCHEMA_VALIDATOR, arbitrary, 0, TestRecords.createRecord(null, null, headers));
         assertThat(result.valid()).isFalse();
         assertThat(result.errorMessage()).contains("header apicurio.key.globalId value is not 8 bytes");
     }
 
-    private static Result validateValue(ApiCurioSchemaBytebufValidator apiCurioSchemaBytebufValidator, ByteBuffer buffer, int length, Record record) {
-        return validate(apiCurioSchemaBytebufValidator, buffer, length, record, false);
+    private static Result validateValue(BytebufValidator validator, ByteBuffer buffer, int length, Record record) {
+        return validate(validator, buffer, length, record, false);
     }
 
-    private static Result validateKey(ApiCurioSchemaBytebufValidator apiCurioSchemaBytebufValidator, ByteBuffer buffer, int length, Record record) {
-        return validate(apiCurioSchemaBytebufValidator, buffer, length, record, true);
+    private static Result validateKey(BytebufValidator validator, ByteBuffer buffer, int length, Record record) {
+        return validate(validator, buffer, length, record, true);
     }
 
-    private static Result validate(ApiCurioSchemaBytebufValidator apiCurioSchemaBytebufValidator, ByteBuffer buffer, int length, Record record, boolean isKey) {
+    private static Result validate(BytebufValidator validator, ByteBuffer buffer, int length, Record record, boolean isKey) {
         try {
-            return apiCurioSchemaBytebufValidator.validate(buffer, length, record, isKey).toCompletableFuture().get(5, TimeUnit.SECONDS);
+            return validator.validate(buffer, length, record, isKey).toCompletableFuture().get(5, TimeUnit.SECONDS);
         }
         catch (InterruptedException | ExecutionException | TimeoutException e) {
             throw new RuntimeException(e);

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/record/KeyAndValueRecordValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/record/KeyAndValueRecordValidatorTest.java
@@ -27,7 +27,7 @@ class KeyAndValueRecordValidatorTest {
     @Test
     void testInvalidKey() {
         RecordValidator recordValidator = keyAndValueValidator(INVALID, VALID);
-        Result validate = recordValidator.validate(Mockito.mock(Record.class));
+        Result validate = recordValidator.validate(Mockito.mock(Record.class)).toCompletableFuture().join();
         assertFalse(validate.valid());
         assertEquals("Key was invalid: " + FAIL_MESSAGE, validate.errorMessage());
     }
@@ -35,7 +35,7 @@ class KeyAndValueRecordValidatorTest {
     @Test
     void testInvalidValue() {
         RecordValidator recordValidator = keyAndValueValidator(VALID, INVALID);
-        Result validate = recordValidator.validate(Mockito.mock(Record.class));
+        Result validate = recordValidator.validate(Mockito.mock(Record.class)).toCompletableFuture().join();
         assertFalse(validate.valid());
         assertEquals("Value was invalid: " + FAIL_MESSAGE, validate.errorMessage());
     }
@@ -43,7 +43,7 @@ class KeyAndValueRecordValidatorTest {
     @Test
     void testInvalidKeyAndValue() {
         RecordValidator recordValidator = keyAndValueValidator(INVALID, INVALID);
-        Result validate = recordValidator.validate(Mockito.mock(Record.class));
+        Result validate = recordValidator.validate(Mockito.mock(Record.class)).toCompletableFuture().join();
         assertFalse(validate.valid());
         assertEquals("Key was invalid: " + FAIL_MESSAGE, validate.errorMessage());
     }
@@ -51,7 +51,7 @@ class KeyAndValueRecordValidatorTest {
     @Test
     void testValidKeyAndValue() {
         RecordValidator recordValidator = keyAndValueValidator(VALID, VALID);
-        Result validate = recordValidator.validate(Mockito.mock(Record.class));
+        Result validate = recordValidator.validate(Mockito.mock(Record.class)).toCompletableFuture().join();
         assertTrue(validate.valid());
     }
 

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/record/KeyAndValueRecordValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/record/KeyAndValueRecordValidatorTest.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.proxy.filter.schema.validation.record;
 
+import java.util.concurrent.CompletableFuture;
+
 import org.apache.kafka.common.record.Record;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -21,8 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class KeyAndValueRecordValidatorTest {
 
     public static final String FAIL_MESSAGE = "fail";
-    public static final BytebufValidator INVALID = (buffer, length, record, isKey) -> new Result(false, FAIL_MESSAGE);
-    public static final BytebufValidator VALID = (buffer, length, record, isKey) -> Result.VALID;
+    public static final BytebufValidator INVALID = (buffer, length, record, isKey) -> CompletableFuture.completedFuture(new Result(false, FAIL_MESSAGE));
+    public static final BytebufValidator VALID = (buffer, length, record, isKey) -> CompletableFuture.completedFuture(Result.VALID);
 
     @Test
     void testInvalidKey() {

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/topic/AllValidTopicValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/topic/AllValidTopicValidatorTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.schema.validation.topic;
+
+import java.time.Duration;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.ProduceRequestData;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AllValidTopicValidatorTest {
+
+    public static final String TOPIC_NAME = "topicName";
+
+    @Test
+    void allValid() {
+        AllValidTopicValidator validator = new AllValidTopicValidator();
+        ProduceRequestData.TopicProduceData data = new ProduceRequestData.TopicProduceData();
+        data.setName(TOPIC_NAME);
+        CompletionStage<TopicValidationResult> result = validator.validateTopicData(data);
+        assertThat(result).succeedsWithin(Duration.ZERO).isEqualTo(new AllValidTopicValidationResult(TOPIC_NAME));
+    }
+
+}

--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -123,6 +123,22 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
             <scope>test</scope>
@@ -145,6 +161,21 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j2-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-serdes-avro-serde</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-serde-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-schema-resolver</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- the next two are used by the Netty Leak Detection test -->

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/ApicurioSchemaValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/ApicurioSchemaValidationIT.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.schema.validation;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.InvalidRecordException;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
+
+import io.apicurio.registry.resolver.DefaultSchemaResolver;
+import io.apicurio.registry.serde.SerdeConfig;
+import io.apicurio.registry.serde.avro.AvroKafkaSerializer;
+
+import io.kroxylicious.proxy.BaseIT;
+import io.kroxylicious.proxy.config.ConfigurationBuilder;
+import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
+import io.kroxylicious.proxy.filter.schema.ProduceValidationFilterFactory;
+import io.kroxylicious.test.tester.KroxyliciousTester;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
+import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(KafkaClusterExtension.class)
+class ApicurioSchemaValidationIT extends BaseIT {
+
+    private static final String SCHEMA_JSON = "{\"type\":\"record\",\"name\":\"Greeting\",\"fields\":[{\"name\":\"Message\",\"type\":\"string\"},{\"name\":\"Time\",\"type\":\"long\"}]}";
+    private static final Schema SCHEMA = new Schema.Parser().parse(SCHEMA_JSON);
+    private static final GenericRecord RECORD = createAvroRecord();
+    private static final String TOPIC_NAME = "my-test-topic";
+    private static final String SUBJECT_NAME = "Greeting";
+    public static final String APICURIO_VERSION = "2.5.10.Final";
+    private final GenericContainer<?> container = new GenericContainer<>("apicurio/apicurio-registry-mem:" + APICURIO_VERSION)
+            .withExposedPorts(8080)
+            .waitingFor(new HostPortWaitStrategy().forPorts(8080));
+
+    @BeforeEach
+    public void start() {
+        container.start();
+    }
+
+    @AfterEach
+    public void stop() {
+        container.stop();
+    }
+
+    @Test
+    void testValueWithNoSchemaHeaderRejected(KafkaCluster cluster, Admin admin) {
+        createTopic(admin, TOPIC_NAME, 1);
+        var config = proxyWithApicurioValidationForTopic(cluster, true);
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer()) {
+            ProducerRecord<String, String> recordWithNoSchema = new ProducerRecord<>(TOPIC_NAME, "arbitrary", "arbitrary");
+            Future<RecordMetadata> sendFuture = producer.send(recordWithNoSchema);
+            assertFutureCompletedExceptionally(sendFuture, "Value was invalid: record headers did not contain: apicurio.value.globalId");
+        }
+    }
+
+    @Test
+    void testKeyWithNoSchemaHeaderRejected(KafkaCluster cluster, Admin admin) {
+        createTopic(admin, TOPIC_NAME, 1);
+        var config = proxyWithApicurioValidationForTopic(cluster, false);
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer()) {
+            ProducerRecord<String, String> recordWithNoSchema = new ProducerRecord<>(TOPIC_NAME, "arbitrary", "arbitrary");
+            Future<RecordMetadata> sendFuture = producer.send(recordWithNoSchema);
+            assertFutureCompletedExceptionally(sendFuture, "Key was invalid: record headers did not contain: apicurio.key.globalId");
+        }
+    }
+
+    @Test
+    void testNullRecordAllowed(KafkaCluster cluster, Admin admin) {
+        createTopic(admin, TOPIC_NAME, 1);
+        var config = proxyWithApicurioValidationForTopic(cluster, true);
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer()) {
+            ProducerRecord<String, String> recordWithNullValue = new ProducerRecord<>(TOPIC_NAME, "arbitrary", null);
+            Future<RecordMetadata> sendFuture = producer.send(recordWithNullValue);
+            assertThat(sendFuture).succeedsWithin(5, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void testNullKeyAllowed(KafkaCluster cluster, Admin admin) {
+        createTopic(admin, TOPIC_NAME, 1);
+        var config = proxyWithApicurioValidationForTopic(cluster, false);
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer()) {
+            ProducerRecord<String, String> recordWithNullKey = new ProducerRecord<>(TOPIC_NAME, null, null);
+            Future<RecordMetadata> sendFuture = producer.send(recordWithNullKey);
+            assertThat(sendFuture).succeedsWithin(5, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void testValueEncodedWithSchemaHeaderAccepted(KafkaCluster cluster, Admin admin) {
+        createTopic(admin, TOPIC_NAME, 1);
+        var config = proxyWithApicurioValidationForTopic(cluster, true);
+        try (var tester = kroxyliciousTester(config)) {
+            try (var producer = apicurioAvroValueProducer(tester)) {
+                ProducerRecord<Object, Object> recordWithAvroValue = new ProducerRecord<>(TOPIC_NAME, SUBJECT_NAME, RECORD);
+                Future<RecordMetadata> sendFuture = producer.send(recordWithAvroValue);
+                assertThat(sendFuture).succeedsWithin(5, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    @Test
+    void testKeyEncodedWithSchemaHeaderAccepted(KafkaCluster cluster, Admin admin) {
+        createTopic(admin, TOPIC_NAME, 1);
+
+        var config = proxyWithApicurioValidationForTopic(cluster, false);
+        try (var tester = kroxyliciousTester(config)) {
+            try (var producer = apicurioAvroKeyProducer(tester)) {
+                ProducerRecord<Object, Object> recordWithAvroKey = new ProducerRecord<>(TOPIC_NAME, RECORD, SUBJECT_NAME);
+                Future<RecordMetadata> sendFuture = producer.send(recordWithAvroKey);
+                assertThat(sendFuture).succeedsWithin(5, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    @NonNull
+    private KafkaProducer<Object, Object> apicurioAvroValueProducer(KroxyliciousTester tester) {
+        return apicurioProducer(tester, StringSerializer.class, AvroKafkaSerializer.class);
+    }
+
+    @NonNull
+    private KafkaProducer<Object, Object> apicurioAvroKeyProducer(KroxyliciousTester tester) {
+        return apicurioProducer(tester, AvroKafkaSerializer.class, StringSerializer.class);
+    }
+
+    @NonNull
+    private <T extends Serializer<?>, S extends Serializer<?>> KafkaProducer<Object, Object> apicurioProducer(KroxyliciousTester tester,
+                                                                                                              Class<T> keySerializer,
+                                                                                                              Class<S> valueSerializer) {
+        String registryUrl = "http://" + container.getHost() + ":" + container.getMappedPort(8080) + "/apis/registry/v2";
+        return new KafkaProducer<>(
+                Map.of(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, tester.getBootstrapAddress(),
+                        SerdeConfig.REGISTRY_URL, registryUrl,
+                        SerdeConfig.AUTO_REGISTER_ARTIFACT, Boolean.TRUE,
+                        SerdeConfig.SCHEMA_RESOLVER, DefaultSchemaResolver.class,
+                        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializer,
+                        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializer));
+    }
+
+    private static ConfigurationBuilder proxyWithApicurioValidationForTopic(KafkaCluster cluster, boolean targetValue) {
+        return proxy(cluster)
+                .addToFilters(new FilterDefinitionBuilder(ProduceValidationFilterFactory.class.getName())
+                        .withConfig("rules",
+                                List.of(Map.of("topicNames", List.of(TOPIC_NAME), targetValue ? "valueRule" : "keyRule",
+                                        Map.of("allowsNulls", true, "hasApicurioSchema", Map.of()))))
+                        .build());
+    }
+
+    @NonNull
+    private static GenericRecord createAvroRecord() {
+        GenericRecord record = new GenericData.Record(SCHEMA);
+        Date now = new Date();
+        String message = "Hello!";
+        record.put("Message", message);
+        record.put("Time", now.getTime());
+        return record;
+    }
+
+    private static void assertFutureCompletedExceptionally(Future<RecordMetadata> invalid, String message) {
+        assertThat(invalid).failsWithin(5, TimeUnit.SECONDS)
+                .withThrowableOfType(ExecutionException.class)
+                .withCauseInstanceOf(InvalidRecordException.class)
+                .havingCause().withMessageContaining(message);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,8 @@
 
         <impsort-maven-plugin.goal>sort</impsort-maven-plugin.goal>
 
+        <avro.version>1.11.3</avro.version>
+        <apicurio.version>2.5.10.Final</apicurio.version>
         <freemarker.version>2.3.32</freemarker.version>
         <guava.version>33.1.0-jre</guava.version>
         <hamcrest.version>2.2</hamcrest.version>
@@ -195,6 +197,30 @@
                 <scope>provided</scope>
             </dependency>
 
+            <dependency>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro</artifactId>
+                <version>${avro.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.apicurio</groupId>
+                <artifactId>apicurio-registry-serdes-avro-serde</artifactId>
+                <version>${apicurio.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.apicurio</groupId>
+                <artifactId>apicurio-registry-serde-common</artifactId>
+                <version>${apicurio.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.apicurio</groupId>
+                <artifactId>apicurio-registry-schema-resolver</artifactId>
+                <version>${apicurio.version}</version>
+                <scope>test</scope>
+            </dependency>
             <dependency>
                 <groupId>info.picocli</groupId>
                 <artifactId>picocli</artifactId>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This is a first step towards supporting deeper Apicurio schema registry validation.

1. The validation API is refactored to be asynchronous. This is because we can imagine wanting to make requests out to the Schema Registry while validating a record and do not want to block up the eventloop waiting on a response.
2. Enable validating that:
  i. records with a non-null value must have an `apicurio.value.globalId` header containing 8 bytes
  ii. records with a non-null key must  have an `apicurio.key.globalId` header container 8 bytes

``` yaml
  config:
    rules:
    - topicNames:
      - "my-test-topic"
      valueRule:
        hasApicurioSchema: {}
        allowNulls: true
      keyRule:
        hasApicurioSchema: {}
        allowNulls: true
```
Also note that `hasApicurioSchema` is incompatible with the existing `syntacticallyCorrectJson` and it will throw an exception at configuration time if they are both defined.

The empty object style to enable apicurio validation is a bit awkward currently, but we can foresee adding many configurable options.

Next steps could be:
* Support custom header names (all apicurio headers are user configurable)
* Support content id (should we support topics using a mix of global/content ids?)
* Call out to the registry to check the id points at a live schema, caching the result
* Support ids embedded into the message (apicurio deserializer will check for the headers if enabled, then fallback to looking for embedded id)
* Support 4 byte embedded ids (this is implemented by apicurio for legacy/confluent compatibility reasons)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
