### PR TITLE
Apicurio schema validation json schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ For changes that effect a public API, the [deprecation policy](./DEV_GUIDE.md#de
 Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
+* [#1154](https://github.com/kroxylicious/kroxylicious/pull/1154): Apicurio based schema validation filter
+
 ## 0.6.0
 
 * [#1195](https://github.com/kroxylicious/kroxylicious/pull/1195): SASL OAUTHBEARER validation filter 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,3 +6,4 @@
 - Francisco Vila(https://github.com/franvila)
 - Anthony Callaert(https://github.com/callaertanthony)
 - Zhenyu Luo(https://github.com/luozhenyu)
+- Carles Arnal(https://github.com/carlesarnal)

--- a/docs/available-filters/schema-validation/schema-validation.adoc
+++ b/docs/available-filters/schema-validation/schema-validation.adoc
@@ -1,2 +1,32 @@
-= Schema-validation
+:github: https://github.com/kroxylicious/kroxylicious
+= Schema Validation
 
+== What is it?
+
+Schema validation filter that enables validating records using an existing schema in https://www.apicur.io/registry/[Apicurio Registry].
+
+== How to use the filter
+
+There is just one step to use the filter.
+
+1. <<Configuring virtual clusters>>
+2. Configuring the filter within Kroxylicious.
+
+=== Configuring the filter within Kroxylicious.
+
+[source,yaml]
+filters:
+  - type: ProduceValidationFilterFactory
+    config:
+        rules:
+        - topicNames:
+            - test-topic
+            valueRule:
+                schemaValidationConfig:
+                    apicurioGlobalId: 1
+                    apicurioRegistryUrl: http://localhost:8080
+
+
+The apicurioGlobalId parameter is the global identifier of the schema that will be used to validate the value of the records in test-topic. The second parameter, apicurioRegistryUrl, is the URL of your Apicurio Registry instance.
+
+With this configuration, the values of all the records you produce to the test-topic 1 will be validated using the schema present in Apicurio Registry with global identifier 1.

--- a/kroxylicious-filters/kroxylicious-record-validation/pom.xml
+++ b/kroxylicious-filters/kroxylicious-record-validation/pom.xml
@@ -52,6 +52,10 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-schema-validation-jsonschema</artifactId>
+        </dependency>
 
         <!-- third party dependencies - test -->
         <dependency>

--- a/kroxylicious-filters/kroxylicious-record-validation/pom.xml
+++ b/kroxylicious-filters/kroxylicious-record-validation/pom.xml
@@ -90,7 +90,12 @@
         <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
-            <scope>tes</scope>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/kroxylicious-filters/kroxylicious-record-validation/pom.xml
+++ b/kroxylicious-filters/kroxylicious-record-validation/pom.xml
@@ -54,6 +54,10 @@
         </dependency>
         <dependency>
             <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-schema-resolver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
             <artifactId>apicurio-registry-schema-validation-jsonschema</artifactId>
         </dependency>
 

--- a/kroxylicious-filters/kroxylicious-record-validation/pom.xml
+++ b/kroxylicious-filters/kroxylicious-record-validation/pom.xml
@@ -83,5 +83,10 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
+            <scope>tes</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceValidationFilterBuilder.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceValidationFilterBuilder.java
@@ -17,6 +17,8 @@ import io.kroxylicious.proxy.filter.schema.validation.request.RoutingProduceRequ
 import io.kroxylicious.proxy.filter.schema.validation.topic.TopicValidator;
 import io.kroxylicious.proxy.filter.schema.validation.topic.TopicValidators;
 
+import java.util.Collections;
+
 /**
  * Builds from configuration objects to a ProduceRequestValidator
  */
@@ -48,12 +50,19 @@ public class ProduceValidationFilterBuilder {
 
     private static BytebufValidator getBytebufValidator(BytebufValidation validation) {
         BytebufValidator innerValidator = toValidator(validation);
+
         return BytebufValidators.nullEmptyValidator(validation.isAllowNulls(), validation.isAllowEmpty(), innerValidator);
     }
 
     private static BytebufValidator toValidator(BytebufValidation valueRule) {
-        return valueRule.getSyntacticallyCorrectJsonConfig().map(config -> BytebufValidators.jsonSyntaxValidator(config.isValidateObjectKeysUnique()))
+        return valueRule.getSyntacticallyCorrectJsonConfig()
+                .map(config -> BytebufValidators.jsonSyntaxValidator(config.isValidateObjectKeysUnique(), toSchemaValidator(valueRule)))
                 .orElse(BytebufValidators.allValid());
     }
 
+    private static BytebufValidator toSchemaValidator(BytebufValidation valueRule) {
+        return valueRule.getSchemaValidationConfig()
+                .map(config -> BytebufValidators.jsonSchemaValidator(Collections.emptyMap(), config.useApicurioGlobalId()))
+                .orElse(BytebufValidators.allValid());
+    }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceValidationFilterBuilder.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceValidationFilterBuilder.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.proxy.filter.schema;
 
+import java.util.Collections;
+
 import io.kroxylicious.proxy.filter.schema.config.BytebufValidation;
 import io.kroxylicious.proxy.filter.schema.config.RecordValidationRule;
 import io.kroxylicious.proxy.filter.schema.config.ValidationConfig;
@@ -16,8 +18,6 @@ import io.kroxylicious.proxy.filter.schema.validation.request.ProduceRequestVali
 import io.kroxylicious.proxy.filter.schema.validation.request.RoutingProduceRequestValidator;
 import io.kroxylicious.proxy.filter.schema.validation.topic.TopicValidator;
 import io.kroxylicious.proxy.filter.schema.validation.topic.TopicValidators;
-
-import java.util.Collections;
 
 /**
  * Builds from configuration objects to a ProduceRequestValidator

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceValidationFilterBuilder.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceValidationFilterBuilder.java
@@ -50,7 +50,6 @@ public class ProduceValidationFilterBuilder {
 
     private static BytebufValidator getBytebufValidator(BytebufValidation validation) {
         BytebufValidator innerValidator = toValidator(validation);
-
         return BytebufValidators.nullEmptyValidator(validation.isAllowNulls(), validation.isAllowEmpty(), innerValidator);
     }
 

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceValidationFilterBuilder.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceValidationFilterBuilder.java
@@ -6,8 +6,9 @@
 
 package io.kroxylicious.proxy.filter.schema;
 
-import java.util.Collections;
+import java.util.Map;
 
+import io.apicurio.registry.resolver.SchemaResolverConfig;
 import io.kroxylicious.proxy.filter.schema.config.BytebufValidation;
 import io.kroxylicious.proxy.filter.schema.config.RecordValidationRule;
 import io.kroxylicious.proxy.filter.schema.config.ValidationConfig;
@@ -61,7 +62,7 @@ public class ProduceValidationFilterBuilder {
 
     private static BytebufValidator toSchemaValidator(BytebufValidation valueRule) {
         return valueRule.getSchemaValidationConfig()
-                .map(config -> BytebufValidators.jsonSchemaValidator(Collections.emptyMap(), config.useApicurioGlobalId()))
+                .map(config -> BytebufValidators.jsonSchemaValidator(Map.of(SchemaResolverConfig.REGISTRY_URL, config.apicurioRegistryUrl()), config.useApicurioGlobalId()))
                 .orElse(BytebufValidators.allValid());
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceValidationFilterBuilder.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceValidationFilterBuilder.java
@@ -63,8 +63,8 @@ public class ProduceValidationFilterBuilder {
 
     private static BytebufValidator toSchemaValidator(BytebufValidation valueRule) {
         return valueRule.getSchemaValidationConfig()
-                .map(config -> BytebufValidators.jsonSchemaValidator(Map.of(SchemaResolverConfig.REGISTRY_URL, config.apicurioRegistryUrl()),
-                        config.useApicurioGlobalId()))
+                .map(config -> BytebufValidators.jsonSchemaValidator(Map.of(SchemaResolverConfig.REGISTRY_URL, config.apicurioRegistryUrl().toString()),
+                        config.apicurioGlobalId()))
                 .orElse(BytebufValidators.allValid());
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceValidationFilterBuilder.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/ProduceValidationFilterBuilder.java
@@ -9,6 +9,7 @@ package io.kroxylicious.proxy.filter.schema;
 import java.util.Map;
 
 import io.apicurio.registry.resolver.SchemaResolverConfig;
+
 import io.kroxylicious.proxy.filter.schema.config.BytebufValidation;
 import io.kroxylicious.proxy.filter.schema.config.RecordValidationRule;
 import io.kroxylicious.proxy.filter.schema.config.ValidationConfig;
@@ -62,7 +63,8 @@ public class ProduceValidationFilterBuilder {
 
     private static BytebufValidator toSchemaValidator(BytebufValidation valueRule) {
         return valueRule.getSchemaValidationConfig()
-                .map(config -> BytebufValidators.jsonSchemaValidator(Map.of(SchemaResolverConfig.REGISTRY_URL, config.apicurioRegistryUrl()), config.useApicurioGlobalId()))
+                .map(config -> BytebufValidators.jsonSchemaValidator(Map.of(SchemaResolverConfig.REGISTRY_URL, config.apicurioRegistryUrl()),
+                        config.useApicurioGlobalId()))
                 .orElse(BytebufValidators.allValid());
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/config/BytebufValidation.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/config/BytebufValidation.java
@@ -17,20 +17,24 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class BytebufValidation {
     private final SyntacticallyCorrectJsonConfig syntacticallyCorrectJsonConfig;
+    private final SchemaValidationConfig schemaValidationConfig;
     private final boolean allowNulls;
     private final boolean allowEmpty;
 
     /**
      * Create a new BytebufValidation
      * @param syntacticallyCorrectJsonConfig optional configuration, if non-null indicates ByteBuffer should contain syntactically correct JSON
+     * @param schemaValidationConfig optional configuration, if non-null, indicates ByteBuffer to validate the data using the schema configuration
      * @param allowNulls whether a null byte-buffer should be considered valid
      * @param allowEmpty whether an empty byte-buffer should be considered valid
      */
     @JsonCreator
     public BytebufValidation(@JsonProperty("syntacticallyCorrectJson") SyntacticallyCorrectJsonConfig syntacticallyCorrectJsonConfig,
+                             @JsonProperty("schemaValidation") SchemaValidationConfig schemaValidationConfig,
                              @JsonProperty(value = "allowNulls", defaultValue = "true") Boolean allowNulls,
                              @JsonProperty(value = "allowEmpty", defaultValue = "false") Boolean allowEmpty) {
         this.syntacticallyCorrectJsonConfig = syntacticallyCorrectJsonConfig;
+        this.schemaValidationConfig = schemaValidationConfig;
         this.allowNulls = allowNulls == null || allowNulls;
         this.allowEmpty = allowEmpty != null && allowEmpty;
     }
@@ -41,6 +45,14 @@ public class BytebufValidation {
      */
     public Optional<SyntacticallyCorrectJsonConfig> getSyntacticallyCorrectJsonConfig() {
         return Optional.ofNullable(syntacticallyCorrectJsonConfig);
+    }
+
+    /**
+     * Get schema validation json config
+     * @return optional containing schema validation config if non-null, empty otherwise
+     */
+    public Optional<SchemaValidationConfig> getSchemaValidationConfig() {
+        return Optional.ofNullable(schemaValidationConfig);
     }
 
     /**
@@ -69,18 +81,19 @@ public class BytebufValidation {
         }
         BytebufValidation that = (BytebufValidation) o;
         return allowNulls == that.allowNulls && allowEmpty == that.allowEmpty && Objects.equals(syntacticallyCorrectJsonConfig,
-                that.syntacticallyCorrectJsonConfig);
+                that.syntacticallyCorrectJsonConfig) && Objects.equals(schemaValidationConfig, that.schemaValidationConfig);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(syntacticallyCorrectJsonConfig, allowNulls, allowEmpty);
+        return Objects.hash(syntacticallyCorrectJsonConfig, schemaValidationConfig, allowNulls, allowEmpty);
     }
 
     @Override
     public String toString() {
         return "BytebufValidation{" +
                 "syntacticallyCorrectJsonConfig=" + syntacticallyCorrectJsonConfig +
+                ", schemaValidationConfig=" + schemaValidationConfig +
                 ", allowNulls=" + allowNulls +
                 ", allowEmpty=" + allowEmpty +
                 '}';

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/config/BytebufValidation.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/config/BytebufValidation.java
@@ -30,7 +30,7 @@ public class BytebufValidation {
      */
     @JsonCreator
     public BytebufValidation(@JsonProperty("syntacticallyCorrectJson") SyntacticallyCorrectJsonConfig syntacticallyCorrectJsonConfig,
-                             @JsonProperty("schemaValidation") SchemaValidationConfig schemaValidationConfig,
+                             @JsonProperty("schemaValidationConfig") SchemaValidationConfig schemaValidationConfig,
                              @JsonProperty(value = "allowNulls", defaultValue = "true") Boolean allowNulls,
                              @JsonProperty(value = "allowEmpty", defaultValue = "false") Boolean allowEmpty) {
         this.syntacticallyCorrectJsonConfig = syntacticallyCorrectJsonConfig;

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/config/SchemaValidationConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/config/SchemaValidationConfig.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.schema.config;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Configuration for validating a component ByteBuffer of a ${@link org.apache.kafka.common.record.Record} is valid using the schema in Apicurio Registry.
+ */
+public class SchemaValidationConfig {
+    private final Long useApicurioGlobalId;
+
+    /**
+     * Construct SyntacticallyCorrectJsonConfig
+     * @param useApicurioGlobalId whether we expect the Object keys in the JSON to be unique
+     */
+    @JsonCreator
+    public SchemaValidationConfig(@JsonProperty(value = "useApicurioGlobalId") Long useApicurioGlobalId) {
+        this.useApicurioGlobalId = useApicurioGlobalId;
+    }
+
+    /**
+     * Do we expect the Object keys in the JSON to be unique
+     * @return the configured globalId to be used
+     */
+    public Long useApicurioGlobalId() {
+        return useApicurioGlobalId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SchemaValidationConfig that = (SchemaValidationConfig) o;
+        return Objects.equals(useApicurioGlobalId, that.useApicurioGlobalId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(useApicurioGlobalId);
+    }
+
+    @Override
+    public String toString() {
+        return "SchemaValidationConfig{" +
+                "useApicurioGlobalId=" + useApicurioGlobalId +
+                '}';
+    }
+}

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/config/SchemaValidationConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/config/SchemaValidationConfig.java
@@ -6,54 +6,46 @@
 
 package io.kroxylicious.proxy.filter.schema.config;
 
-import java.util.Objects;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Configuration for validating a component ByteBuffer of a {@link org.apache.kafka.common.record.Record} is valid using the schema in Apicurio Registry.
  */
-public class SchemaValidationConfig {
-    private final Long useApicurioGlobalId;
-
+public record SchemaValidationConfig(String apicurioRegistryUrl, Long useApicurioGlobalId) {
     /**
      * Construct SyntacticallyCorrectJsonConfig
      * @param useApicurioGlobalId whether we expect the Object keys in the JSON to be unique
      */
     @JsonCreator
-    public SchemaValidationConfig(@JsonProperty(value = "useApicurioGlobalId") Long useApicurioGlobalId) {
+    public SchemaValidationConfig(@JsonProperty(value = "apicurioRegistryUrl") String apicurioRegistryUrl,
+                                  @JsonProperty(value = "useApicurioGlobalId") Long useApicurioGlobalId) {
         this.useApicurioGlobalId = useApicurioGlobalId;
+        this.apicurioRegistryUrl = apicurioRegistryUrl;
     }
 
     /**
      * @return the configured globalId to be used
      */
+    @Override
     public Long useApicurioGlobalId() {
         return useApicurioGlobalId;
     }
 
+    /**
+     * @return the apicurio registry url to be used for this validation
+     */
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        SchemaValidationConfig that = (SchemaValidationConfig) o;
-        return Objects.equals(useApicurioGlobalId, that.useApicurioGlobalId);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(useApicurioGlobalId);
+    public String apicurioRegistryUrl() {
+        return apicurioRegistryUrl;
     }
 
     @Override
     public String toString() {
         return "SchemaValidationConfig{" +
                 "useApicurioGlobalId=" + useApicurioGlobalId +
+                ", apicurioRegistryUrl='" + apicurioRegistryUrl + '\'' +
                 '}';
     }
+
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/config/SchemaValidationConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/config/SchemaValidationConfig.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * Configuration for validating a component ByteBuffer of a ${@link org.apache.kafka.common.record.Record} is valid using the schema in Apicurio Registry.
+ * Configuration for validating a component ByteBuffer of a {@link org.apache.kafka.common.record.Record} is valid using the schema in Apicurio Registry.
  */
 public class SchemaValidationConfig {
     private final Long useApicurioGlobalId;
@@ -27,7 +27,6 @@ public class SchemaValidationConfig {
     }
 
     /**
-     * Do we expect the Object keys in the JSON to be unique
      * @return the configured globalId to be used
      */
     public Long useApicurioGlobalId() {

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/config/SchemaValidationConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/config/SchemaValidationConfig.java
@@ -6,21 +6,24 @@
 
 package io.kroxylicious.proxy.filter.schema.config;
 
+import java.net.URL;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Configuration for validating a component ByteBuffer of a {@link org.apache.kafka.common.record.Record} is valid using the schema in Apicurio Registry.
  */
-public record SchemaValidationConfig(String apicurioRegistryUrl, Long useApicurioGlobalId) {
+public record SchemaValidationConfig(URL apicurioRegistryUrl, long apicurioGlobalId) {
     /**
-     * Construct SyntacticallyCorrectJsonConfig
-     * @param useApicurioGlobalId whether we expect the Object keys in the JSON to be unique
+     * Construct SchemaValidationConfig
+     * @param apicurioGlobalId apicurio registry version global identifier to be used for schema validation
+     * @param apicurioRegistryUrl Apicurio Registry instance url
      */
     @JsonCreator
-    public SchemaValidationConfig(@JsonProperty(value = "apicurioRegistryUrl") String apicurioRegistryUrl,
-                                  @JsonProperty(value = "useApicurioGlobalId") Long useApicurioGlobalId) {
-        this.useApicurioGlobalId = useApicurioGlobalId;
+    public SchemaValidationConfig(@JsonProperty(value = "apicurioRegistryUrl", required = true) URL apicurioRegistryUrl,
+                                  @JsonProperty(value = "apicurioGlobalId", required = true) long apicurioGlobalId) {
+        this.apicurioGlobalId = apicurioGlobalId;
         this.apicurioRegistryUrl = apicurioRegistryUrl;
     }
 
@@ -28,22 +31,22 @@ public record SchemaValidationConfig(String apicurioRegistryUrl, Long useApicuri
      * @return the configured globalId to be used
      */
     @Override
-    public Long useApicurioGlobalId() {
-        return useApicurioGlobalId;
+    public long apicurioGlobalId() {
+        return apicurioGlobalId;
     }
 
     /**
      * @return the apicurio registry url to be used for this validation
      */
     @Override
-    public String apicurioRegistryUrl() {
+    public URL apicurioRegistryUrl() {
         return apicurioRegistryUrl;
     }
 
     @Override
     public String toString() {
         return "SchemaValidationConfig{" +
-                "useApicurioGlobalId=" + useApicurioGlobalId +
+                "apicurioGlobalId=" + apicurioGlobalId +
                 ", apicurioRegistryUrl='" + apicurioRegistryUrl + '\'' +
                 '}';
     }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/Result.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/Result.java
@@ -6,6 +6,9 @@
 
 package io.kroxylicious.proxy.filter.schema.validation;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
 /**
  * Result for a validation
  * @param valid whether the input was valid
@@ -16,5 +19,5 @@ public record Result(boolean valid, String errorMessage) {
     /**
      * valid result
      */
-    public static Result VALID = new Result(true, null);
+    public static CompletionStage<Result> VALID = CompletableFuture.completedFuture(new Result(true, null));
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/AllValidBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/AllValidBytebufValidator.java
@@ -7,7 +7,6 @@
 package io.kroxylicious.proxy.filter.schema.validation.bytebuf;
 
 import java.nio.ByteBuffer;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import org.apache.kafka.common.record.Record;
@@ -18,6 +17,6 @@ class AllValidBytebufValidator implements BytebufValidator {
 
     @Override
     public CompletionStage<Result> validate(ByteBuffer buffer, int length, Record record, boolean isKey) {
-        return CompletableFuture.completedFuture(Result.VALID);
+        return Result.VALID;
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/AllValidBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/AllValidBytebufValidator.java
@@ -7,6 +7,8 @@
 package io.kroxylicious.proxy.filter.schema.validation.bytebuf;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.apache.kafka.common.record.Record;
 
@@ -15,7 +17,7 @@ import io.kroxylicious.proxy.filter.schema.validation.Result;
 class AllValidBytebufValidator implements BytebufValidator {
 
     @Override
-    public Result validate(ByteBuffer buffer, int length, Record record, boolean isKey) {
-        return Result.VALID;
+    public CompletionStage<Result> validate(ByteBuffer buffer, int length, Record record, boolean isKey) {
+        return CompletableFuture.completedFuture(Result.VALID);
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/BytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/BytebufValidator.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.proxy.filter.schema.validation.bytebuf;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletionStage;
 
 import org.apache.kafka.common.record.Record;
 
@@ -31,5 +32,5 @@ public interface BytebufValidator {
      * @param isKey true if the buffer is the key of the record, false if it is the value of the record
      * @return a valid result if the buffer is valid
      */
-    Result validate(ByteBuffer buffer, int length, Record record, boolean isKey);
+    CompletionStage<Result> validate(ByteBuffer buffer, int length, Record record, boolean isKey);
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/BytebufValidators.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/BytebufValidators.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.proxy.filter.schema.validation.bytebuf;
 
+import java.util.Map;
+
 /**
  * Static factory methods for creating/getting {@link BytebufValidator} instances
  */
@@ -41,7 +43,15 @@ public class BytebufValidators {
      * @param validateObjectKeysUnique optionally check if JSON Objects contain unique keys
      * @return validator
      */
-    public static BytebufValidator jsonSyntaxValidator(boolean validateObjectKeysUnique) {
-        return new JsonSyntaxBytebufValidator(validateObjectKeysUnique);
+    public static BytebufValidator jsonSyntaxValidator(boolean validateObjectKeysUnique, BytebufValidator delegate) {
+        return new JsonSyntaxBytebufValidator(validateObjectKeysUnique, delegate);
+    }
+
+    /**
+     * get validator that validates if a non-null/non-empty buffer contains data that matches a JSONSchema registered in the Schema Registry
+     * @return validator
+     */
+    public static BytebufValidator jsonSchemaValidator(Map<String, Object> schemaResolverConfig, Long globalId) {
+        return new JsonSchemaBytebufValidator(schemaResolverConfig, globalId);
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSchemaBytebufValidator.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import org.apache.kafka.common.record.Record;
 
 import io.apicurio.registry.resolver.strategy.ArtifactReference;
@@ -30,8 +31,12 @@ public class JsonSchemaBytebufValidator implements BytebufValidator {
 
     @Override
     public CompletionStage<Result> validate(ByteBuffer buffer, int length, Record record, boolean isKey) {
-        JsonValidationResult jsonValidationResult = jsonValidator.validateByArtifactReference(buffer.clear());
-        return jsonValidationResult.success() ? CompletableFuture.completedFuture(Result.VALID)
-                : CompletableFuture.completedFuture(new Result(false, jsonValidationResult.toString()));
+        try {
+            JsonValidationResult jsonValidationResult = jsonValidator.validateByArtifactReference(buffer.clear());
+            return jsonValidationResult.success() ? Result.VALID
+                    : CompletableFuture.completedFuture(new Result(false, jsonValidationResult.toString()));
+        } catch (RuntimeException ex) {
+            return CompletableFuture.completedFuture(new Result(false, ex.getMessage()));
+        }
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSchemaBytebufValidator.java
@@ -28,7 +28,7 @@ public class JsonSchemaBytebufValidator implements BytebufValidator {
 
     @Override
     public Result validate(ByteBuffer buffer, int length, Record record, boolean isKey) {
-        JsonValidationResult jsonValidationResult = jsonValidator.validateByArtifactReference(buffer.array());
+        JsonValidationResult jsonValidationResult = jsonValidator.validateByArtifactReference(buffer);
         return jsonValidationResult.success() ? Result.VALID : new Result(false, jsonValidationResult.toString());
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSchemaBytebufValidator.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import org.apache.kafka.common.record.Record;
 
 import io.apicurio.registry.resolver.strategy.ArtifactReference;
@@ -35,7 +34,8 @@ public class JsonSchemaBytebufValidator implements BytebufValidator {
             JsonValidationResult jsonValidationResult = jsonValidator.validateByArtifactReference(buffer.clear());
             return jsonValidationResult.success() ? Result.VALID
                     : CompletableFuture.completedFuture(new Result(false, jsonValidationResult.toString()));
-        } catch (RuntimeException ex) {
+        }
+        catch (RuntimeException ex) {
             return CompletableFuture.completedFuture(new Result(false, ex.getMessage()));
         }
     }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSchemaBytebufValidator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.schema.validation.bytebuf;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.kafka.common.record.Record;
+
+import io.apicurio.registry.resolver.strategy.ArtifactReference;
+import io.apicurio.schema.validation.json.JsonValidationResult;
+import io.apicurio.schema.validation.json.JsonValidator;
+
+import io.kroxylicious.proxy.filter.schema.validation.Result;
+
+public class JsonSchemaBytebufValidator implements BytebufValidator {
+
+    private final JsonValidator jsonValidator;
+
+    public JsonSchemaBytebufValidator(Map<String, Object> schemaResolverConfig, Long globalId) {
+        this.jsonValidator = new JsonValidator(schemaResolverConfig, Optional.of(ArtifactReference.fromGlobalId(globalId)));
+    }
+
+    @Override
+    public Result validate(ByteBuffer buffer, int length, Record record, boolean isKey) {
+        JsonValidationResult jsonValidationResult = jsonValidator.validateByArtifactReference(buffer.array());
+        return jsonValidationResult.success() ? Result.VALID : new Result(false, jsonValidationResult.toString());
+    }
+}

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSchemaBytebufValidator.java
@@ -9,6 +9,8 @@ package io.kroxylicious.proxy.filter.schema.validation.bytebuf;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.apache.kafka.common.record.Record;
 
@@ -27,8 +29,9 @@ public class JsonSchemaBytebufValidator implements BytebufValidator {
     }
 
     @Override
-    public Result validate(ByteBuffer buffer, int length, Record record, boolean isKey) {
+    public CompletionStage<Result> validate(ByteBuffer buffer, int length, Record record, boolean isKey) {
         JsonValidationResult jsonValidationResult = jsonValidator.validateByArtifactReference(buffer);
-        return jsonValidationResult.success() ? Result.VALID : new Result(false, jsonValidationResult.toString());
+        return jsonValidationResult.success() ? CompletableFuture.completedFuture(Result.VALID)
+                : CompletableFuture.completedFuture(new Result(false, jsonValidationResult.toString()));
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSchemaBytebufValidator.java
@@ -30,7 +30,7 @@ public class JsonSchemaBytebufValidator implements BytebufValidator {
 
     @Override
     public CompletionStage<Result> validate(ByteBuffer buffer, int length, Record record, boolean isKey) {
-        JsonValidationResult jsonValidationResult = jsonValidator.validateByArtifactReference(buffer);
+        JsonValidationResult jsonValidationResult = jsonValidator.validateByArtifactReference(buffer.clear());
         return jsonValidationResult.success() ? CompletableFuture.completedFuture(Result.VALID)
                 : CompletableFuture.completedFuture(new Result(false, jsonValidationResult.toString()));
     }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSyntaxBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSyntaxBytebufValidator.java
@@ -8,6 +8,8 @@ package io.kroxylicious.proxy.filter.schema.validation.bytebuf;
 
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.utils.ByteBufferInputStream;
@@ -35,7 +37,7 @@ class JsonSyntaxBytebufValidator implements BytebufValidator {
     }
 
     @Override
-    public Result validate(ByteBuffer buffer, int size, Record record, boolean isKey) {
+    public CompletionStage<Result> validate(ByteBuffer buffer, int size, Record record, boolean isKey) {
         if (buffer == null) {
             throw new IllegalArgumentException("buffer is null");
         }
@@ -54,7 +56,7 @@ class JsonSyntaxBytebufValidator implements BytebufValidator {
         }
         catch (Exception e) {
             String message = "value was not syntactically correct JSON" + (e.getMessage() != null ? ": " + e.getMessage() : "");
-            return new Result(false, message);
+            return CompletableFuture.completedFuture(new Result(false, message));
         }
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSyntaxBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSyntaxBytebufValidator.java
@@ -25,11 +25,13 @@ import io.kroxylicious.proxy.filter.schema.validation.Result;
  */
 class JsonSyntaxBytebufValidator implements BytebufValidator {
     private final boolean validateObjectKeysUnique;
+    private final BytebufValidator delegate;
 
     static final ObjectMapper mapper = new ObjectMapper().enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
 
-    JsonSyntaxBytebufValidator(boolean validateObjectKeysUnique) {
+    JsonSyntaxBytebufValidator(boolean validateObjectKeysUnique, BytebufValidator delegate) {
         this.validateObjectKeysUnique = validateObjectKeysUnique;
+        this.delegate = delegate;
     }
 
     @Override
@@ -47,12 +49,12 @@ class JsonSyntaxBytebufValidator implements BytebufValidator {
             }
             while (parser.nextToken() != null) {
             }
-            return Result.VALID;
+
+            return delegate.validate(buffer, size, record, isKey);
         }
         catch (Exception e) {
             String message = "value was not syntactically correct JSON" + (e.getMessage() != null ? ": " + e.getMessage() : "");
             return new Result(false, message);
         }
     }
-
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/NullEmptyBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/NullEmptyBytebufValidator.java
@@ -7,6 +7,8 @@
 package io.kroxylicious.proxy.filter.schema.validation.bytebuf;
 
 import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import org.apache.kafka.common.record.Record;
 
@@ -28,17 +30,17 @@ class NullEmptyBytebufValidator implements BytebufValidator {
     }
 
     @Override
-    public Result validate(ByteBuffer buffer, int length, Record record, boolean isKey) {
+    public CompletionStage<Result> validate(ByteBuffer buffer, int length, Record record, boolean isKey) {
         if (buffer == null) {
-            return result(nullValid, "Null buffer invalid");
+            return (result(nullValid, "Null buffer invalid"));
         }
         else if (length == 0) {
-            return result(emptyValid, "Empty buffer invalid");
+            return (result(emptyValid, "Empty buffer invalid"));
         }
         return delegate.validate(buffer, length, record, isKey);
     }
 
-    private Result result(boolean allowed, String message) {
-        return allowed ? Result.VALID : new Result(false, message);
+    private CompletionStage<Result> result(boolean allowed, String message) {
+        return allowed ? CompletableFuture.completedFuture(Result.VALID) : CompletableFuture.completedFuture(new Result(false, message));
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/NullEmptyBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/NullEmptyBytebufValidator.java
@@ -35,7 +35,7 @@ class NullEmptyBytebufValidator implements BytebufValidator {
             return result(nullValid, "Null buffer invalid");
         }
         else if (length == 0) {
-            return (result(emptyValid, "Empty buffer invalid"));
+            return result(emptyValid, "Empty buffer invalid");
         }
         return delegate.validate(buffer, length, record, isKey);
     }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/NullEmptyBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/NullEmptyBytebufValidator.java
@@ -18,7 +18,7 @@ class NullEmptyBytebufValidator implements BytebufValidator {
     private final boolean emptyValid;
     private final BytebufValidator delegate;
 
-     NullEmptyBytebufValidator(boolean nullValid, boolean emptyValid, BytebufValidator delegate) {
+    NullEmptyBytebufValidator(boolean nullValid, boolean emptyValid, BytebufValidator delegate) {
         if (delegate == null) {
             throw new IllegalArgumentException("delegate is null");
         }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/NullEmptyBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/NullEmptyBytebufValidator.java
@@ -32,7 +32,7 @@ class NullEmptyBytebufValidator implements BytebufValidator {
     @Override
     public CompletionStage<Result> validate(ByteBuffer buffer, int length, Record record, boolean isKey) {
         if (buffer == null) {
-            return (result(nullValid, "Null buffer invalid"));
+            return result(nullValid, "Null buffer invalid");
         }
         else if (length == 0) {
             return (result(emptyValid, "Empty buffer invalid"));

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/NullEmptyBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/NullEmptyBytebufValidator.java
@@ -18,7 +18,7 @@ class NullEmptyBytebufValidator implements BytebufValidator {
     private final boolean emptyValid;
     private final BytebufValidator delegate;
 
-    NullEmptyBytebufValidator(boolean nullValid, boolean emptyValid, BytebufValidator delegate) {
+     NullEmptyBytebufValidator(boolean nullValid, boolean emptyValid, BytebufValidator delegate) {
         if (delegate == null) {
             throw new IllegalArgumentException("delegate is null");
         }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/NullEmptyBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/NullEmptyBytebufValidator.java
@@ -41,6 +41,6 @@ class NullEmptyBytebufValidator implements BytebufValidator {
     }
 
     private CompletionStage<Result> result(boolean allowed, String message) {
-        return allowed ? CompletableFuture.completedFuture(Result.VALID) : CompletableFuture.completedFuture(new Result(false, message));
+        return allowed ? Result.VALID : CompletableFuture.completedFuture(new Result(false, message));
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/record/KeyAndValueRecordValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/record/KeyAndValueRecordValidator.java
@@ -54,7 +54,7 @@ public class KeyAndValueRecordValidator implements RecordValidator {
                 return CompletableFuture.completedFuture(new Result(false, "Value was invalid: " + result1.errorMessage()));
             }
             else {
-                return CompletableFuture.completedFuture(Result.VALID);
+                return Result.VALID;
             }
         });
     }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/record/RecordValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/record/RecordValidator.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.proxy.filter.schema.validation.record;
 
+import java.util.concurrent.CompletionStage;
+
 import org.apache.kafka.common.record.Record;
 
 import io.kroxylicious.proxy.filter.schema.validation.Result;
@@ -20,5 +22,5 @@ public interface RecordValidator {
      * @param record the record to be validated
      * @return a Result describing if the record is valid and any failure message/exception if it is not.
      */
-    Result validate(Record record);
+    CompletionStage<Result> validate(Record record);
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/request/ProduceRequestValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/request/ProduceRequestValidator.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.proxy.filter.schema.validation.request;
 
+import java.util.concurrent.CompletionStage;
+
 import org.apache.kafka.common.message.ProduceRequestData;
 
 /**
@@ -19,5 +21,5 @@ public interface ProduceRequestValidator {
      * @param request the request
      * @return result describing a validation outcome for all topic partitions and details of records that failed validation
      */
-    ProduceRequestValidationResult validateRequest(ProduceRequestData request);
+    CompletionStage<ProduceRequestValidationResult> validateRequest(ProduceRequestData request);
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/topic/AllValidTopicValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/topic/AllValidTopicValidator.java
@@ -6,11 +6,14 @@
 
 package io.kroxylicious.proxy.filter.schema.validation.topic;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
 import org.apache.kafka.common.message.ProduceRequestData;
 
 class AllValidTopicValidator implements TopicValidator {
     @Override
-    public TopicValidationResult validateTopicData(ProduceRequestData.TopicProduceData request) {
-        return new AllValidTopicValidationResult(request.name());
+    public CompletionStage<TopicValidationResult> validateTopicData(ProduceRequestData.TopicProduceData request) {
+        return CompletableFuture.completedFuture(new AllValidTopicValidationResult(request.name()));
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/topic/TopicValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/topic/TopicValidator.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.proxy.filter.schema.validation.topic;
 
+import java.util.concurrent.CompletionStage;
+
 import org.apache.kafka.common.message.ProduceRequestData;
 
 /**
@@ -18,5 +20,5 @@ public interface TopicValidator {
      * @param request the request
      * @return result describing whether any partitions were invalid, and details of any invalid partitions/records
      */
-    TopicValidationResult validateTopicData(ProduceRequestData.TopicProduceData request);
+    CompletionStage<TopicValidationResult> validateTopicData(ProduceRequestData.TopicProduceData request);
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSchemaBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSchemaBytebufValidatorTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.schema;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.apache.kafka.common.record.DefaultRecord;
+import org.apache.kafka.common.record.Record;
+import org.apache.kafka.common.utils.ByteBufferOutputStream;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import io.kroxylicious.proxy.filter.schema.validation.Result;
+import io.kroxylicious.proxy.filter.schema.validation.bytebuf.BytebufValidator;
+import io.kroxylicious.proxy.filter.schema.validation.bytebuf.BytebufValidators;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class JsonSchemaBytebufValidatorTest {
+
+    static WireMockServer registryServer;
+
+    private static final String JSON_SCHEMA = """
+            {
+              "$id": "https://example.com/person.schema.json",
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "title": "Person",
+              "type": "object",
+              "properties": {
+                "firstName": {
+                  "type": "string",
+                  "description": "The person's first name."
+                },
+                "lastName": {
+                  "type": "string",
+                  "description": "The person's last name."
+                },
+                "age": {
+                  "description": "Age in years which must be equal to or greater than zero.",
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            }
+            """;
+
+    @BeforeAll
+    public static void initMockRegistry() {
+        registryServer = new WireMockServer(
+                wireMockConfig()
+                        .dynamicPort());
+
+        registryServer.start();
+
+        registryServer.stubFor(
+                get(urlEqualTo("/apis/registry/v2/ids/globalIds/1?dereference=false"))
+                        .willReturn(WireMock.aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(JSON_SCHEMA)));
+
+        registryServer.stubFor(
+                get(urlEqualTo("/apis/registry/v2/ids/globalIds/1/references"))
+                        .willReturn(WireMock.aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("[]")));
+    }
+
+    @AfterAll
+    public static void shutdownMockRegistry() {
+        registryServer.shutdown();
+    }
+
+    @Test
+    void testValueValidated() {
+        BytebufValidator mockValidator = mock(BytebufValidator.class);
+        Record record = createRecord("a", "{\"firstName\":\"a\",\"lastName\":\"b\"}");
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(Map.of("apicurio.registry.url", registryServer.baseUrl()), 1L);
+        Result result = validate(record, validator);
+        assertTrue(result.valid());
+        verifyNoMoreInteractions(mockValidator);
+    }
+
+    @Test
+    void testValueInvalidAgeInvalidated() {
+        BytebufValidator mockValidator = mock(BytebufValidator.class);
+        Record record = createRecord("a", "{\"firstName\":\"a\",\"lastName\":\"b\",\"age\":-3}");
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(Map.of("apicurio.registry.url", registryServer.baseUrl()), 1L);
+        Result result = validate(record, validator);
+        assertFalse(result.valid());
+        verifyNoMoreInteractions(mockValidator);
+    }
+
+    @Test
+    void testInvalidValueInValidated() {
+        BytebufValidator mockValidator = mock(BytebufValidator.class);
+        Record record = createRecord("a", "123");
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(Map.of("apicurio.registry.url", registryServer.baseUrl()), 1L);
+        Result result = validate(record, validator);
+        assertFalse(result.valid());
+        verifyNoMoreInteractions(mockValidator);
+    }
+
+    private static Result validate(Record record, BytebufValidator validator) {
+        return validator.validate(record.value(), record.valueSize(), record, false);
+    }
+
+    private Record createRecord(String key, String value) {
+        ByteBuffer keyBuf = toBufNullable(key);
+        ByteBuffer valueBuf = toBufNullable(value);
+
+        try (ByteBufferOutputStream bufferOutputStream = new ByteBufferOutputStream(1000); DataOutputStream dataOutputStream = new DataOutputStream(bufferOutputStream)) {
+            DefaultRecord.writeTo(dataOutputStream, 0, 0, keyBuf, valueBuf, Record.EMPTY_HEADERS);
+            dataOutputStream.flush();
+            bufferOutputStream.flush();
+            ByteBuffer buffer = bufferOutputStream.buffer();
+            buffer.flip();
+            return DefaultRecord.readFrom(buffer, 0, 0, 0, 0L);
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static ByteBuffer toBufNullable(String key) {
+        if (key == null) {
+            return null;
+        }
+        byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
+        return ByteBuffer.wrap(keyBytes);
+    }
+}

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSchemaBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSchemaBytebufValidatorTest.java
@@ -11,6 +11,9 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.kafka.common.record.DefaultRecord;
 import org.apache.kafka.common.record.Record;
@@ -119,7 +122,12 @@ public class JsonSchemaBytebufValidatorTest {
     }
 
     private static Result validate(Record record, BytebufValidator validator) {
-        return validator.validate(record.value(), record.valueSize(), record, false);
+        try {
+            return validator.validate(record.value(), record.valueSize(), record, false).toCompletableFuture().get(5, TimeUnit.SECONDS);
+        }
+        catch (ExecutionException | InterruptedException | TimeoutException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private Record createRecord(String key, String value) {

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSchemaBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSchemaBytebufValidatorTest.java
@@ -21,6 +21,9 @@ import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -34,10 +37,13 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+@ExtendWith(MockitoExtension.class)
 public class JsonSchemaBytebufValidatorTest {
+
+    @Mock(strictness = Mock.Strictness.LENIENT)
+    BytebufValidator mockValidator;
 
     static WireMockServer registryServer;
 
@@ -93,7 +99,6 @@ public class JsonSchemaBytebufValidatorTest {
 
     @Test
     void testValueValidated() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "{\"firstName\":\"a\",\"lastName\":\"b\"}");
         BytebufValidator validator = BytebufValidators.jsonSchemaValidator(Map.of("apicurio.registry.url", registryServer.baseUrl()), 1L);
         Result result = validate(record, validator);
@@ -103,7 +108,6 @@ public class JsonSchemaBytebufValidatorTest {
 
     @Test
     void testValueInvalidAgeInvalidated() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "{\"firstName\":\"a\",\"lastName\":\"b\",\"age\":-3}");
         BytebufValidator validator = BytebufValidators.jsonSchemaValidator(Map.of("apicurio.registry.url", registryServer.baseUrl()), 1L);
         Result result = validate(record, validator);
@@ -113,7 +117,6 @@ public class JsonSchemaBytebufValidatorTest {
 
     @Test
     void testInvalidValueInValidated() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "123");
         BytebufValidator validator = BytebufValidators.jsonSchemaValidator(Map.of("apicurio.registry.url", registryServer.baseUrl()), 1L);
         Result result = validate(record, validator);

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSyntaxBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSyntaxBytebufValidatorTest.java
@@ -10,6 +10,10 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.kafka.common.record.DefaultRecord;
 import org.apache.kafka.common.record.Record;
@@ -40,7 +44,7 @@ class JsonSyntaxBytebufValidatorTest {
     @BeforeEach
     public void init() {
         MockitoAnnotations.openMocks(this);
-        Mockito.when(mockValidator.validate(any(), anyInt(), any(), anyBoolean())).thenReturn(Result.VALID);
+        Mockito.when(mockValidator.validate(any(), anyInt(), any(), anyBoolean())).thenReturn(CompletableFuture.completedFuture(Result.VALID));
     }
 
     @Test
@@ -189,10 +193,10 @@ class JsonSyntaxBytebufValidatorTest {
     }
 
     @Test
-    void testKeyValidated() {
+    void testKeyValidated() throws ExecutionException, InterruptedException, TimeoutException {
         Record record = createRecord("\"abc\"", "123");
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
-        Result result = validator.validate(record.key(), record.keySize(), record, true);
+        Result result = validator.validate(record.key(), record.keySize(), record, true).toCompletableFuture().get(5, TimeUnit.SECONDS);
         assertTrue(result.valid());
     }
 
@@ -217,7 +221,12 @@ class JsonSyntaxBytebufValidatorTest {
     }
 
     private static Result validate(Record record, BytebufValidator validator) {
-        return validator.validate(record.value(), record.valueSize(), record, false);
+        try {
+            return validator.validate(record.value(), record.valueSize(), record, false).toCompletableFuture().get(5, TimeUnit.SECONDS);
+        }
+        catch (ExecutionException | InterruptedException | TimeoutException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private Record createRecord(String key, String value) {

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSyntaxBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSyntaxBytebufValidatorTest.java
@@ -20,9 +20,11 @@ import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.kroxylicious.proxy.filter.schema.validation.Result;
 import io.kroxylicious.proxy.filter.schema.validation.bytebuf.BytebufValidator;
@@ -34,11 +36,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
+@ExtendWith(MockitoExtension.class)
 class JsonSyntaxBytebufValidatorTest {
 
-    @Mock
+    @Mock(strictness = Mock.Strictness.LENIENT)
     BytebufValidator mockValidator;
 
     @BeforeEach
@@ -53,7 +57,7 @@ class JsonSyntaxBytebufValidatorTest {
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false, mockValidator);
         Result result = validate(record, validator);
         assertFalse(result.valid());
-        verifyNoMoreInteractions(mockValidator);
+        verifyNoInteractions(mockValidator);
     }
 
     @Test
@@ -62,6 +66,7 @@ class JsonSyntaxBytebufValidatorTest {
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
+        verify(mockValidator).validate(any(), anyInt(), any(), anyBoolean());
     }
 
     @Test
@@ -71,7 +76,7 @@ class JsonSyntaxBytebufValidatorTest {
         Result result = validate(record, validator);
         assertFalse(result.valid());
         assertTrue(result.errorMessage().contains("value was not syntactically correct JSON: Duplicate field"));
-        verifyNoMoreInteractions(mockValidator);
+        verifyNoInteractions(mockValidator);
     }
 
     @Test
@@ -81,7 +86,7 @@ class JsonSyntaxBytebufValidatorTest {
         Result result = validate(record, validator);
         assertFalse(result.valid());
         assertTrue(result.errorMessage().contains("value was not syntactically correct JSON: Duplicate field"));
-        verifyNoMoreInteractions(mockValidator);
+        verifyNoInteractions(mockValidator);
     }
 
     @Test
@@ -91,7 +96,7 @@ class JsonSyntaxBytebufValidatorTest {
         Result result = validate(record, validator);
         assertFalse(result.valid());
         assertTrue(result.errorMessage().contains("value was not syntactically correct JSON: Duplicate field"));
-        verifyNoMoreInteractions(mockValidator);
+        verifyNoInteractions(mockValidator);
     }
 
     @Test
@@ -100,6 +105,7 @@ class JsonSyntaxBytebufValidatorTest {
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
+        verify(mockValidator).validate(any(), anyInt(), any(), anyBoolean());
     }
 
     @Test
@@ -108,6 +114,7 @@ class JsonSyntaxBytebufValidatorTest {
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
+        verify(mockValidator).validate(any(), anyInt(), any(), anyBoolean());
     }
 
     @Test
@@ -116,6 +123,7 @@ class JsonSyntaxBytebufValidatorTest {
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
+        verify(mockValidator).validate(any(), anyInt(), any(), anyBoolean());
     }
 
     @Test
@@ -142,6 +150,7 @@ class JsonSyntaxBytebufValidatorTest {
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
+        verify(mockValidator).validate(any(), anyInt(), any(), anyBoolean());
     }
 
     @Test
@@ -150,6 +159,7 @@ class JsonSyntaxBytebufValidatorTest {
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
+        verify(mockValidator).validate(any(), anyInt(), any(), anyBoolean());
     }
 
     @Test
@@ -158,6 +168,7 @@ class JsonSyntaxBytebufValidatorTest {
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
+        verify(mockValidator).validate(any(), anyInt(), any(), anyBoolean());
     }
 
     @Test
@@ -166,6 +177,7 @@ class JsonSyntaxBytebufValidatorTest {
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
+        verify(mockValidator).validate(any(), anyInt(), any(), anyBoolean());
     }
 
     @Test
@@ -190,6 +202,7 @@ class JsonSyntaxBytebufValidatorTest {
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
+        verify(mockValidator).validate(any(), anyInt(), any(), anyBoolean());
     }
 
     @Test
@@ -198,6 +211,7 @@ class JsonSyntaxBytebufValidatorTest {
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validator.validate(record.key(), record.keySize(), record, true).toCompletableFuture().get(5, TimeUnit.SECONDS);
         assertTrue(result.valid());
+        verify(mockValidator).validate(any(), anyInt(), any(), anyBoolean());
     }
 
     @Test
@@ -207,7 +221,7 @@ class JsonSyntaxBytebufValidatorTest {
         assertThrows(IllegalArgumentException.class, () -> {
             validate(record, validator);
         });
-        verifyNoMoreInteractions(mockValidator);
+        verifyNoInteractions(mockValidator);
     }
 
     @Test
@@ -217,7 +231,7 @@ class JsonSyntaxBytebufValidatorTest {
         assertThrows(IllegalArgumentException.class, () -> {
             validate(record, validator);
         });
-        verifyNoMoreInteractions(mockValidator);
+        verifyNoInteractions(mockValidator);
     }
 
     private static Result validate(Record record, BytebufValidator validator) {

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSyntaxBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSyntaxBytebufValidatorTest.java
@@ -14,7 +14,11 @@ import java.nio.charset.StandardCharsets;
 import org.apache.kafka.common.record.DefaultRecord;
 import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 import io.kroxylicious.proxy.filter.schema.validation.Result;
 import io.kroxylicious.proxy.filter.schema.validation.bytebuf.BytebufValidator;
@@ -23,14 +27,24 @@ import io.kroxylicious.proxy.filter.schema.validation.bytebuf.BytebufValidators;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 class JsonSyntaxBytebufValidatorTest {
 
+    @Mock
+    BytebufValidator mockValidator;
+
+    @BeforeEach
+    public void init() {
+        MockitoAnnotations.openMocks(this);
+        Mockito.when(mockValidator.validate(any(), anyInt(), any(), anyBoolean())).thenReturn(Result.VALID);
+    }
+
     @Test
     void testSyntacticallyIncorrectRecordInvalidated() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "b");
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false, mockValidator);
         Result result = validate(record, validator);
@@ -40,17 +54,14 @@ class JsonSyntaxBytebufValidatorTest {
 
     @Test
     void testSyntacticallyCorrectRecordValidated() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "{\"a\":\"a\"}");
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
-        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testDuplicatedObjectKeyInvalidated() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "{\"a\":\"a\",\"a\":\"b\"}");
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
@@ -61,7 +72,6 @@ class JsonSyntaxBytebufValidatorTest {
 
     @Test
     void testDuplicatedObjectKeyInNestedObjectInvalidated() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "{\"inner\":{\"a\":\"a\",\"a\":\"b\"}}");
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
@@ -72,7 +82,6 @@ class JsonSyntaxBytebufValidatorTest {
 
     @Test
     void testDuplicatedObjectKeyInArrayInvalidated() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "[{\"a\":\"a\",\"a\":\"b\"}]");
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
@@ -83,139 +92,112 @@ class JsonSyntaxBytebufValidatorTest {
 
     @Test
     void testNonDuplicatedObjectKeyInArrayValidated() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "[{\"a\":\"a\",\"b\":\"b\"}]");
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
-        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testArrayWithTwoObjectsWithSameKeysValidated() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "[{\"a\":\"a\"},{\"a\":\"a\"}]");
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
-        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testNestedObjectsUsingSameKeysValidated() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "[{\"a\":{\"a\":\"a\"}}]");
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
-        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testNestedObjectsWithDuplicateKeysInvalidated() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "[{\"a\":{\"a\":\"a\",\"a\":\"b\"}}]");
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertFalse(result.valid());
         assertTrue(result.errorMessage().contains("value was not syntactically correct JSON: Duplicate field"));
-        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testDeepObjectsWithDuplicateKeysInvalidated() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "[[[{\"a\":{\"b\":[1,true,null,{\"duplicate\":1,\"duplicate\":1}]}}]]]]");
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertFalse(result.valid());
         assertTrue(result.errorMessage().contains("value was not syntactically correct JSON: Duplicate field"));
-        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testArrayWithTwoObjectsWithSameKeysAndOtherDataValidated() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "[{\"a\":\"a\"},2,{\"a\":\"a\"},\"banana\"]");
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
-        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testNonDuplicatedObjectKeysWithDuplicationValidationEnabled() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "{\"a\":\"b\",\"c\":\"d\"}");
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
-        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testDuplicatedObjectKeyValidatedWithDuplicationValidationDisabled() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "{\"a\":\"a\",\"a\":\"b\"}");
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
-        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testDifferentObjectsCanHaveSameKeyNames() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "{\"a\":{\"a\":1},\"b\":{\"a\":2}}");
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
-        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testTrailingCharactersInvalidated() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "{\"a\":\"a\"}abc");
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false, mockValidator);
         Result result = validate(record, validator);
         assertFalse(result.valid());
-        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testLeadingCharactersInvalidated() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "abc{\"a\":\"a\"}abc");
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false, mockValidator);
         Result result = validate(record, validator);
         assertFalse(result.valid());
-        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testValueValidated() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "123");
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
-        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testKeyValidated() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("\"abc\"", "123");
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validator.validate(record.key(), record.keySize(), record, true);
         assertTrue(result.valid());
-        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testEmptyStringThrows() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "");
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false, mockValidator);
         assertThrows(IllegalArgumentException.class, () -> {
@@ -226,7 +208,6 @@ class JsonSyntaxBytebufValidatorTest {
 
     @Test
     void testNullValueThrows() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", null);
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false, mockValidator);
         assertThrows(IllegalArgumentException.class, () -> {

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSyntaxBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSyntaxBytebufValidatorTest.java
@@ -23,174 +23,216 @@ import io.kroxylicious.proxy.filter.schema.validation.bytebuf.BytebufValidators;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 class JsonSyntaxBytebufValidatorTest {
 
     @Test
     void testSyntacticallyIncorrectRecordInvalidated() {
+        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "b");
-        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false);
+        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false, mockValidator);
         Result result = validate(record, validator);
         assertFalse(result.valid());
+        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testSyntacticallyCorrectRecordValidated() {
+        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "{\"a\":\"a\"}");
-        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false);
+        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
+        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testDuplicatedObjectKeyInvalidated() {
+        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "{\"a\":\"a\",\"a\":\"b\"}");
-        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true);
+        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertFalse(result.valid());
         assertTrue(result.errorMessage().contains("value was not syntactically correct JSON: Duplicate field"));
+        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testDuplicatedObjectKeyInNestedObjectInvalidated() {
+        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "{\"inner\":{\"a\":\"a\",\"a\":\"b\"}}");
-        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true);
+        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertFalse(result.valid());
         assertTrue(result.errorMessage().contains("value was not syntactically correct JSON: Duplicate field"));
+        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testDuplicatedObjectKeyInArrayInvalidated() {
+        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "[{\"a\":\"a\",\"a\":\"b\"}]");
-        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true);
+        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertFalse(result.valid());
         assertTrue(result.errorMessage().contains("value was not syntactically correct JSON: Duplicate field"));
+        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testNonDuplicatedObjectKeyInArrayValidated() {
+        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "[{\"a\":\"a\",\"b\":\"b\"}]");
-        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true);
+        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
+        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testArrayWithTwoObjectsWithSameKeysValidated() {
+        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "[{\"a\":\"a\"},{\"a\":\"a\"}]");
-        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true);
+        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
+        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testNestedObjectsUsingSameKeysValidated() {
+        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "[{\"a\":{\"a\":\"a\"}}]");
-        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true);
+        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
+        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testNestedObjectsWithDuplicateKeysInvalidated() {
+        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "[{\"a\":{\"a\":\"a\",\"a\":\"b\"}}]");
-        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true);
+        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertFalse(result.valid());
         assertTrue(result.errorMessage().contains("value was not syntactically correct JSON: Duplicate field"));
+        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testDeepObjectsWithDuplicateKeysInvalidated() {
+        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "[[[{\"a\":{\"b\":[1,true,null,{\"duplicate\":1,\"duplicate\":1}]}}]]]]");
-        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true);
+        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertFalse(result.valid());
         assertTrue(result.errorMessage().contains("value was not syntactically correct JSON: Duplicate field"));
+        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testArrayWithTwoObjectsWithSameKeysAndOtherDataValidated() {
+        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "[{\"a\":\"a\"},2,{\"a\":\"a\"},\"banana\"]");
-        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true);
+        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
+        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testNonDuplicatedObjectKeysWithDuplicationValidationEnabled() {
+        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "{\"a\":\"b\",\"c\":\"d\"}");
-        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true);
+        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
+        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testDuplicatedObjectKeyValidatedWithDuplicationValidationDisabled() {
+        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "{\"a\":\"a\",\"a\":\"b\"}");
-        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false);
+        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
+        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testDifferentObjectsCanHaveSameKeyNames() {
+        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "{\"a\":{\"a\":1},\"b\":{\"a\":2}}");
-        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true);
+        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
+        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testTrailingCharactersInvalidated() {
+        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "{\"a\":\"a\"}abc");
-        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false);
+        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false, mockValidator);
         Result result = validate(record, validator);
         assertFalse(result.valid());
+        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testLeadingCharactersInvalidated() {
+        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "abc{\"a\":\"a\"}abc");
-        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false);
+        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false, mockValidator);
         Result result = validate(record, validator);
         assertFalse(result.valid());
+        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testValueValidated() {
+        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "123");
-        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true);
+        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validate(record, validator);
         assertTrue(result.valid());
+        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testKeyValidated() {
+        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("\"abc\"", "123");
-        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true);
+        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true, mockValidator);
         Result result = validator.validate(record.key(), record.keySize(), record, true);
         assertTrue(result.valid());
+        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testEmptyStringThrows() {
+        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", "");
-        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false);
+        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false, mockValidator);
         assertThrows(IllegalArgumentException.class, () -> {
             validate(record, validator);
         });
+        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
     void testNullValueThrows() {
+        BytebufValidator mockValidator = mock(BytebufValidator.class);
         Record record = createRecord("a", null);
-        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false);
+        BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false, mockValidator);
         assertThrows(IllegalArgumentException.class, () -> {
             validate(record, validator);
         });
+        verifyNoMoreInteractions(mockValidator);
     }
 
     private static Result validate(Record record, BytebufValidator validator) {

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSyntaxBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSyntaxBytebufValidatorTest.java
@@ -10,7 +10,6 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -48,7 +47,7 @@ class JsonSyntaxBytebufValidatorTest {
     @BeforeEach
     public void init() {
         MockitoAnnotations.openMocks(this);
-        Mockito.when(mockValidator.validate(any(), anyInt(), any(), anyBoolean())).thenReturn(CompletableFuture.completedFuture(Result.VALID));
+        Mockito.when(mockValidator.validate(any(), anyInt(), any(), anyBoolean())).thenReturn(Result.VALID);
     }
 
     @Test

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSyntaxBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSyntaxBytebufValidatorTest.java
@@ -21,8 +21,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.kroxylicious.proxy.filter.schema.validation.Result;
@@ -37,6 +35,8 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class JsonSyntaxBytebufValidatorTest {
@@ -46,8 +46,7 @@ class JsonSyntaxBytebufValidatorTest {
 
     @BeforeEach
     public void init() {
-        MockitoAnnotations.openMocks(this);
-        Mockito.when(mockValidator.validate(any(), anyInt(), any(), anyBoolean())).thenReturn(Result.VALID);
+        when(mockValidator.validate(any(), anyInt(), any(), anyBoolean())).thenReturn(Result.VALID);
     }
 
     @Test
@@ -132,6 +131,7 @@ class JsonSyntaxBytebufValidatorTest {
         Result result = validate(record, validator);
         assertFalse(result.valid());
         assertTrue(result.errorMessage().contains("value was not syntactically correct JSON: Duplicate field"));
+        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
@@ -141,6 +141,7 @@ class JsonSyntaxBytebufValidatorTest {
         Result result = validate(record, validator);
         assertFalse(result.valid());
         assertTrue(result.errorMessage().contains("value was not syntactically correct JSON: Duplicate field"));
+        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test
@@ -193,6 +194,7 @@ class JsonSyntaxBytebufValidatorTest {
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false, mockValidator);
         Result result = validate(record, validator);
         assertFalse(result.valid());
+        verifyNoMoreInteractions(mockValidator);
     }
 
     @Test

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/config/ValidationConfigTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/config/ValidationConfigTest.java
@@ -92,7 +92,7 @@ class ValidationConfigTest {
                 """);
 
         TopicMatchingRecordValidationRule ruleOne = new TopicMatchingRecordValidationRule(Set.of("one"), null,
-                new BytebufValidation(new SyntacticallyCorrectJsonConfig(false), new SchemaValidationConfig(null), true, false));
+                new BytebufValidation(new SyntacticallyCorrectJsonConfig(false), new SchemaValidationConfig(null, null), true, false));
         TopicMatchingRecordValidationRule ruleTwo = new TopicMatchingRecordValidationRule(Set.of("two"), new BytebufValidation(null, null, true, false), null);
         ValidationConfig expected = new ValidationConfig(false, List.of(ruleOne, ruleTwo),
                 new RecordValidationRule(null, new BytebufValidation(null, null, true, false)));
@@ -116,6 +116,7 @@ class ValidationConfigTest {
                         validateObjectKeysUnique: true
                     schemaValidationConfig:
                         useApicurioGlobalId: 1
+                        apicurioRegistryUrl: http://localhost:8080
                     allowNulls: false
                     allowEmpty: true
                 - topicNames:
@@ -126,7 +127,41 @@ class ValidationConfigTest {
                 """);
 
         TopicMatchingRecordValidationRule ruleOne = new TopicMatchingRecordValidationRule(Set.of("one"), null,
-                new BytebufValidation(new SyntacticallyCorrectJsonConfig(true), new SchemaValidationConfig(1L), false, true));
+                new BytebufValidation(new SyntacticallyCorrectJsonConfig(true), new SchemaValidationConfig("http://localhost:8080", 1L), false, true));
+        TopicMatchingRecordValidationRule ruleTwo = new TopicMatchingRecordValidationRule(Set.of("two"), new BytebufValidation(null, null, false, true), null);
+        ValidationConfig expected = new ValidationConfig(true, List.of(ruleOne, ruleTwo), new RecordValidationRule(null, new BytebufValidation(null, null, false, true)));
+        assertEquals(expected, deserialised);
+    }
+
+    @Test
+    void testDecodeInvalidValuesSchemaValidation() throws JsonProcessingException {
+        ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
+        ValidationConfig deserialised = yamlMapper.readerFor(ValidationConfig.class).readValue("""
+                forwardPartialRequests: true
+                defaultRule:
+                  valueRule:
+                    allowNulls: false
+                    allowEmpty: true
+                rules:
+                - topicNames:
+                  - one
+                  valueRule:
+                    syntacticallyCorrectJson:
+                        validateObjectKeysUnique: true
+                    schemaValidationConfig:
+                        useApicurioGlobalId:
+                        apicurioRegistryUrl:
+                    allowNulls: false
+                    allowEmpty: true
+                - topicNames:
+                  - two
+                  keyRule:
+                    allowNulls: false
+                    allowEmpty: true
+                """);
+
+        TopicMatchingRecordValidationRule ruleOne = new TopicMatchingRecordValidationRule(Set.of("one"), null,
+                new BytebufValidation(new SyntacticallyCorrectJsonConfig(true), new SchemaValidationConfig(null, null), false, true));
         TopicMatchingRecordValidationRule ruleTwo = new TopicMatchingRecordValidationRule(Set.of("two"), new BytebufValidation(null, null, false, true), null);
         ValidationConfig expected = new ValidationConfig(true, List.of(ruleOne, ruleTwo), new RecordValidationRule(null, new BytebufValidation(null, null, false, true)));
         assertEquals(expected, deserialised);

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/config/ValidationConfigTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/config/ValidationConfigTest.java
@@ -38,7 +38,8 @@ class ValidationConfigTest {
         TopicMatchingRecordValidationRule ruleOne = new TopicMatchingRecordValidationRule(Set.of("one"), null,
                 new BytebufValidation(new SyntacticallyCorrectJsonConfig(false), null, true, false));
         TopicMatchingRecordValidationRule ruleTwo = new TopicMatchingRecordValidationRule(Set.of("two"), new BytebufValidation(null, null, true, false), null);
-        ValidationConfig expected = new ValidationConfig(false, List.of(ruleOne, ruleTwo), new RecordValidationRule(null, new BytebufValidation(null, null, true, false)));
+        ValidationConfig expected = new ValidationConfig(false, List.of(ruleOne, ruleTwo),
+                new RecordValidationRule(null, new BytebufValidation(null, null, true, false)));
         assertEquals(expected, deserialised);
     }
 
@@ -93,10 +94,10 @@ class ValidationConfigTest {
         TopicMatchingRecordValidationRule ruleOne = new TopicMatchingRecordValidationRule(Set.of("one"), null,
                 new BytebufValidation(new SyntacticallyCorrectJsonConfig(false), new SchemaValidationConfig(null), true, false));
         TopicMatchingRecordValidationRule ruleTwo = new TopicMatchingRecordValidationRule(Set.of("two"), new BytebufValidation(null, null, true, false), null);
-        ValidationConfig expected = new ValidationConfig(false, List.of(ruleOne, ruleTwo), new RecordValidationRule(null, new BytebufValidation(null, null, true, false)));
+        ValidationConfig expected = new ValidationConfig(false, List.of(ruleOne, ruleTwo),
+                new RecordValidationRule(null, new BytebufValidation(null, null, true, false)));
         assertEquals(expected, deserialised);
     }
-
 
     @Test
     void testDecodeNonDefaultValuesSchemaValidation() throws JsonProcessingException {

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/config/ValidationConfigTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/config/ValidationConfigTest.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.proxy.filter.schema.config;
 
+import java.net.MalformedURLException;
+import java.net.URI;
 import java.util.List;
 import java.util.Set;
 
@@ -85,14 +87,13 @@ class ValidationConfigTest {
                   - one
                   valueRule:
                     syntacticallyCorrectJson: {}
-                    schemaValidationConfig: {}
                 - topicNames:
                   - two
                   keyRule: {}
                 """);
 
         TopicMatchingRecordValidationRule ruleOne = new TopicMatchingRecordValidationRule(Set.of("one"), null,
-                new BytebufValidation(new SyntacticallyCorrectJsonConfig(false), new SchemaValidationConfig(null, null), true, false));
+                new BytebufValidation(new SyntacticallyCorrectJsonConfig(false), null, true, false));
         TopicMatchingRecordValidationRule ruleTwo = new TopicMatchingRecordValidationRule(Set.of("two"), new BytebufValidation(null, null, true, false), null);
         ValidationConfig expected = new ValidationConfig(false, List.of(ruleOne, ruleTwo),
                 new RecordValidationRule(null, new BytebufValidation(null, null, true, false)));
@@ -100,7 +101,7 @@ class ValidationConfigTest {
     }
 
     @Test
-    void testDecodeNonDefaultValuesSchemaValidation() throws JsonProcessingException {
+    void testDecodeNonDefaultValuesSchemaValidation() throws JsonProcessingException, MalformedURLException {
         ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
         ValidationConfig deserialised = yamlMapper.readerFor(ValidationConfig.class).readValue("""
                 forwardPartialRequests: true
@@ -115,7 +116,7 @@ class ValidationConfigTest {
                     syntacticallyCorrectJson:
                         validateObjectKeysUnique: true
                     schemaValidationConfig:
-                        useApicurioGlobalId: 1
+                        apicurioGlobalId: 1
                         apicurioRegistryUrl: http://localhost:8080
                     allowNulls: false
                     allowEmpty: true
@@ -127,7 +128,8 @@ class ValidationConfigTest {
                 """);
 
         TopicMatchingRecordValidationRule ruleOne = new TopicMatchingRecordValidationRule(Set.of("one"), null,
-                new BytebufValidation(new SyntacticallyCorrectJsonConfig(true), new SchemaValidationConfig("http://localhost:8080", 1L), false, true));
+                new BytebufValidation(new SyntacticallyCorrectJsonConfig(true), new SchemaValidationConfig(URI.create("http://localhost:8080").toURL(), 1L), false,
+                        true));
         TopicMatchingRecordValidationRule ruleTwo = new TopicMatchingRecordValidationRule(Set.of("two"), new BytebufValidation(null, null, false, true), null);
         ValidationConfig expected = new ValidationConfig(true, List.of(ruleOne, ruleTwo), new RecordValidationRule(null, new BytebufValidation(null, null, false, true)));
         assertEquals(expected, deserialised);
@@ -148,9 +150,6 @@ class ValidationConfigTest {
                   valueRule:
                     syntacticallyCorrectJson:
                         validateObjectKeysUnique: true
-                    schemaValidationConfig:
-                        useApicurioGlobalId:
-                        apicurioRegistryUrl:
                     allowNulls: false
                     allowEmpty: true
                 - topicNames:
@@ -161,7 +160,7 @@ class ValidationConfigTest {
                 """);
 
         TopicMatchingRecordValidationRule ruleOne = new TopicMatchingRecordValidationRule(Set.of("one"), null,
-                new BytebufValidation(new SyntacticallyCorrectJsonConfig(true), new SchemaValidationConfig(null, null), false, true));
+                new BytebufValidation(new SyntacticallyCorrectJsonConfig(true), null, false, true));
         TopicMatchingRecordValidationRule ruleTwo = new TopicMatchingRecordValidationRule(Set.of("two"), new BytebufValidation(null, null, false, true), null);
         ValidationConfig expected = new ValidationConfig(true, List.of(ruleOne, ruleTwo), new RecordValidationRule(null, new BytebufValidation(null, null, false, true)));
         assertEquals(expected, deserialised);

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/config/ValidationConfigTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/config/ValidationConfigTest.java
@@ -36,9 +36,9 @@ class ValidationConfigTest {
                 """);
 
         TopicMatchingRecordValidationRule ruleOne = new TopicMatchingRecordValidationRule(Set.of("one"), null,
-                new BytebufValidation(new SyntacticallyCorrectJsonConfig(false), true, false));
-        TopicMatchingRecordValidationRule ruleTwo = new TopicMatchingRecordValidationRule(Set.of("two"), new BytebufValidation(null, true, false), null);
-        ValidationConfig expected = new ValidationConfig(false, List.of(ruleOne, ruleTwo), new RecordValidationRule(null, new BytebufValidation(null, true, false)));
+                new BytebufValidation(new SyntacticallyCorrectJsonConfig(false), null, true, false));
+        TopicMatchingRecordValidationRule ruleTwo = new TopicMatchingRecordValidationRule(Set.of("two"), new BytebufValidation(null, null, true, false), null);
+        ValidationConfig expected = new ValidationConfig(false, List.of(ruleOne, ruleTwo), new RecordValidationRule(null, new BytebufValidation(null, null, true, false)));
         assertEquals(expected, deserialised);
     }
 
@@ -67,9 +67,9 @@ class ValidationConfigTest {
                 """);
 
         TopicMatchingRecordValidationRule ruleOne = new TopicMatchingRecordValidationRule(Set.of("one"), null,
-                new BytebufValidation(new SyntacticallyCorrectJsonConfig(true), false, true));
-        TopicMatchingRecordValidationRule ruleTwo = new TopicMatchingRecordValidationRule(Set.of("two"), new BytebufValidation(null, false, true), null);
-        ValidationConfig expected = new ValidationConfig(true, List.of(ruleOne, ruleTwo), new RecordValidationRule(null, new BytebufValidation(null, false, true)));
+                new BytebufValidation(new SyntacticallyCorrectJsonConfig(true), null, false, true));
+        TopicMatchingRecordValidationRule ruleTwo = new TopicMatchingRecordValidationRule(Set.of("two"), new BytebufValidation(null, null, false, true), null);
+        ValidationConfig expected = new ValidationConfig(true, List.of(ruleOne, ruleTwo), new RecordValidationRule(null, new BytebufValidation(null, null, false, true)));
         assertEquals(expected, deserialised);
     }
 

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/record/KeyAndValueRecordValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/record/KeyAndValueRecordValidatorTest.java
@@ -24,7 +24,7 @@ class KeyAndValueRecordValidatorTest {
 
     public static final String FAIL_MESSAGE = "fail";
     public static final BytebufValidator INVALID = (buffer, length, record, isKey) -> CompletableFuture.completedFuture(new Result(false, FAIL_MESSAGE));
-    public static final BytebufValidator VALID = (buffer, length, record, isKey) -> CompletableFuture.completedFuture(Result.VALID);
+    public static final BytebufValidator VALID = (buffer, length, record, isKey) -> Result.VALID;
 
     @Test
     void testInvalidKey() {

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/record/KeyAndValueRecordValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/record/KeyAndValueRecordValidatorTest.java
@@ -10,15 +10,16 @@ import java.util.concurrent.CompletableFuture;
 
 import org.apache.kafka.common.record.Record;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import io.kroxylicious.proxy.filter.schema.validation.Result;
 import io.kroxylicious.proxy.filter.schema.validation.bytebuf.BytebufValidator;
 
 import static io.kroxylicious.proxy.filter.schema.validation.record.KeyAndValueRecordValidator.keyAndValueValidator;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 class KeyAndValueRecordValidatorTest {
 
@@ -29,15 +30,14 @@ class KeyAndValueRecordValidatorTest {
     @Test
     void testInvalidKey() {
         RecordValidator recordValidator = keyAndValueValidator(INVALID, VALID);
-      RecordValidator recordValidator = keyAndValueValidator(INVALID, VALID);
-        Assertions.assertThat(recordValidator.validate(mock(Record.class)))
+        assertThat(recordValidator.validate(mock(Record.class)))
                 .isCompletedWithValue(new Result(false, "Key was invalid: " + FAIL_MESSAGE));
     }
 
     @Test
     void testInvalidValue() {
         RecordValidator recordValidator = keyAndValueValidator(VALID, INVALID);
-        Result validate = recordValidator.validate(Mockito.mock(Record.class)).toCompletableFuture().join();
+        Result validate = recordValidator.validate(mock(Record.class)).toCompletableFuture().join();
         assertFalse(validate.valid());
         assertEquals("Value was invalid: " + FAIL_MESSAGE, validate.errorMessage());
     }
@@ -45,7 +45,7 @@ class KeyAndValueRecordValidatorTest {
     @Test
     void testInvalidKeyAndValue() {
         RecordValidator recordValidator = keyAndValueValidator(INVALID, INVALID);
-        Result validate = recordValidator.validate(Mockito.mock(Record.class)).toCompletableFuture().join();
+        Result validate = recordValidator.validate(mock(Record.class)).toCompletableFuture().join();
         assertFalse(validate.valid());
         assertEquals("Key was invalid: " + FAIL_MESSAGE, validate.errorMessage());
     }
@@ -53,7 +53,7 @@ class KeyAndValueRecordValidatorTest {
     @Test
     void testValidKeyAndValue() {
         RecordValidator recordValidator = keyAndValueValidator(VALID, VALID);
-        Result validate = recordValidator.validate(Mockito.mock(Record.class)).toCompletableFuture().join();
+        Result validate = recordValidator.validate(mock(Record.class)).toCompletableFuture().join();
         assertTrue(validate.valid());
     }
 

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/record/KeyAndValueRecordValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/record/KeyAndValueRecordValidatorTest.java
@@ -29,9 +29,9 @@ class KeyAndValueRecordValidatorTest {
     @Test
     void testInvalidKey() {
         RecordValidator recordValidator = keyAndValueValidator(INVALID, VALID);
-        Result validate = recordValidator.validate(Mockito.mock(Record.class)).toCompletableFuture().join();
-        assertFalse(validate.valid());
-        assertEquals("Key was invalid: " + FAIL_MESSAGE, validate.errorMessage());
+      RecordValidator recordValidator = keyAndValueValidator(INVALID, VALID);
+        Assertions.assertThat(recordValidator.validate(mock(Record.class)))
+                .isCompletedWithValue(new Result(false, "Key was invalid: " + FAIL_MESSAGE));
     }
 
     @Test

--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -72,23 +72,11 @@
             <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-kms-provider-aws-kms-test-support</artifactId>
             <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.hamcrest</groupId>
-                    <artifactId>hamcrest-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-kms-provider-hashicorp-vault-test-support</artifactId>
             <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.hamcrest</groupId>
-                    <artifactId>hamcrest-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.kroxylicious</groupId>
@@ -153,6 +141,11 @@
             <artifactId>log4j-slf4j2-impl</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- the next two are used by the Netty Leak Detection test -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
@@ -202,6 +195,26 @@
         <dependency>
             <groupId>io.github.nettyplus</groupId>
             <artifactId>netty-leak-detector-junit-extension</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId> io.apicurio</groupId>
+            <artifactId>apicurio-registry-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId> io.apicurio</groupId>
+            <artifactId>apicurio-registry-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId> io.apicurio</groupId>
+            <artifactId>apicurio-common-rest-client-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -198,17 +198,17 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId> io.apicurio</groupId>
+            <groupId>io.apicurio</groupId>
             <artifactId>apicurio-registry-client</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId> io.apicurio</groupId>
+            <groupId>io.apicurio</groupId>
             <artifactId>apicurio-registry-common</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId> io.apicurio</groupId>
+            <groupId>io.apicurio</groupId>
             <artifactId>apicurio-common-rest-client-common</artifactId>
             <scope>test</scope>
         </dependency>

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSchemaValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSchemaValidationIT.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.schema.validation;
+
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.PortBinding;
+import com.github.dockerjava.api.model.Ports;
+import io.apicurio.registry.rest.client.RegistryClientFactory;
+import io.apicurio.rest.client.util.IoUtil;
+import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
+import io.kroxylicious.proxy.filter.schema.ProduceValidationFilterFactory;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.Future;
+import java.util.function.Consumer;
+
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
+import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(KafkaClusterExtension.class)
+class JsonSchemaValidationIT extends SchemaValidationBaseIT {
+
+    private static final String JSON_SCHEMA_TOPIC_1 = """
+            {
+              "$id": "https://example.com/person.schema.json",
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "title": "Person",
+              "type": "object",
+              "properties": {
+                "firstName": {
+                  "type": "string",
+                  "description": "The person's first name."
+                },
+                "lastName": {
+                  "type": "string",
+                  "description": "The person's last name."
+                },
+                "age": {
+                  "description": "Age in years which must be equal to or greater than zero.",
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            }
+            """;
+
+    private static final String JSON_MESSAGE = "{\"firstName\":\"json1\",\"lastName\":\"json2\"}";
+    private static final String INVALID_AGE_MESSAGE = "{\"firstName\":\"json1\",\"lastName\":\"json2\",\"age\":-3}";
+    private static final String TOPIC_1 = "my-test-topic";
+    private static final String TOPIC_2 = "my-test-topic-2";
+
+    private static final String APICURIO_REGISTRY_HOST = "http://localhost";
+    private static final Integer APICURIO_REGISTRY_PORT = 8081;
+    private static final String APICURIO_REGISTRY_URL = APICURIO_REGISTRY_HOST + ":" + APICURIO_REGISTRY_PORT;
+
+    private static GenericContainer registryContainer;
+
+    @BeforeAll
+    public static void init() throws IOException {
+        //An Apicurio Registry instance is required for this test to work, so we start one using a Generic Container
+        DockerImageName dockerImageName = DockerImageName.parse("quay.io/apicurio/apicurio-registry-mem")
+                .withTag("2.5.11.Final");
+
+        Consumer<CreateContainerCmd> cmd = e -> e.withPortBindings(
+                new PortBinding(Ports.Binding.bindPort(APICURIO_REGISTRY_PORT), new ExposedPort(APICURIO_REGISTRY_PORT)));
+
+        registryContainer = new GenericContainer<>(dockerImageName)
+                .withEnv(Map.of(
+                        "QUARKUS_HTTP_PORT", String.valueOf(APICURIO_REGISTRY_PORT),
+                        "REGISTRY_APIS_V2_DATE_FORMAT", "yyyy-MM-dd'T'HH:mm:ss'Z'"))
+                .withExposedPorts(APICURIO_REGISTRY_PORT)
+                .withCreateContainerCmdModifier(cmd);
+
+        registryContainer.start();
+        registryContainer.waitingFor(Wait.forLogMessage(".*Installed features:*", 1));
+
+        //Preparation: In this test class, a schema already registered in Apicurio Registry with globalId one is expected, so we register it upfront.
+        try (var client = RegistryClientFactory.create(APICURIO_REGISTRY_URL)) {
+            client.createArtifact(null, UUID.randomUUID().toString(), IoUtil.toStream(JSON_SCHEMA_TOPIC_1));
+        }
+    }
+
+    @Test
+    void testValidJsonProduceAccepted(KafkaCluster cluster, Admin admin) throws Exception {
+        assertThat(cluster.getNumOfBrokers()).isOne();
+        createTopic(admin, TOPIC_1, 1);
+
+        var config = proxy(cluster)
+                .addToFilters(new FilterDefinitionBuilder(ProduceValidationFilterFactory.class.getName()).withConfig("rules",
+                                List.of(Map.of("topicNames", List.of(TOPIC_1), "valueRule",
+                                        Map.of("allowsNulls", true,
+                                                "syntacticallyCorrectJson", Map.of("validateObjectKeysUnique", true),
+                                                "schemaValidationConfig", Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "useApicurioGlobalId", 1L)))))
+                        .build());
+
+        try (var tester = kroxyliciousTester(config);
+                var producer = getProducer(tester, 0, 16384);
+                var consumer = getConsumer(tester)) {
+            producer.send(new ProducerRecord<>(TOPIC_1, "my-key", JSON_MESSAGE)).get();
+            consumer.subscribe(Set.of(TOPIC_1));
+            var records = consumer.poll(Duration.ofSeconds(10));
+            assertThat(records.count()).isOne();
+            assertThat(records.iterator().next().value()).isEqualTo(JSON_MESSAGE);
+        }
+    }
+
+    @Test
+    void testInvalidAgeProduceRejectedUsingTopicNames(KafkaCluster cluster, Admin admin) throws Exception {
+        assertThat(cluster.getNumOfBrokers()).isOne();
+        createTopics(admin, new NewTopic(TOPIC_1, 1, (short) 1), new NewTopic(TOPIC_2, 1, (short) 1));
+
+        //Topic 2 has schema validation, invalid data cannot be sent.
+        var config = proxy(cluster)
+                .addToFilters(new FilterDefinitionBuilder(ProduceValidationFilterFactory.class.getName()).withConfig("rules",
+                                List.of(Map.of("topicNames", List.of(TOPIC_2), "valueRule",
+                                        Map.of("allowsNulls", true,
+                                                "syntacticallyCorrectJson", Map.of("validateObjectKeysUnique", true),
+                                                "schemaValidationConfig", Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "useApicurioGlobalId", 1L)))))
+                        .build());
+
+        try (var tester = kroxyliciousTester(config);
+                var producer = getProducer(tester, 0, 16384);
+                var consumer = getConsumer(tester)) {
+            //Topic 2 has schema validation defined, invalid data cannot be produced.
+            Future<RecordMetadata> invalid = producer.send(new ProducerRecord<>(TOPIC_2, "my-key", INVALID_AGE_MESSAGE));
+            assertInvalidRecordExceptionThrown(invalid, "$.age: must have a minimum value of 0");
+
+            //Topic 1 has no schema validation, invalid data is produced.
+            producer.send(new ProducerRecord<>(TOPIC_1, "my-key", INVALID_AGE_MESSAGE)).get();
+            consumer.subscribe(Set.of(TOPIC_1));
+            var records = consumer.poll(Duration.ofSeconds(10));
+            assertThat(records.count()).isOne();
+            assertThat(records.iterator().next().value()).isEqualTo(INVALID_AGE_MESSAGE);
+        }
+    }
+
+    @Test
+    void testNonExistentSchema(KafkaCluster cluster, Admin admin) throws Exception {
+        assertThat(cluster.getNumOfBrokers()).isOne();
+        createTopic(admin, TOPIC_1, 1);
+
+        var config = proxy(cluster)
+                .addToFilters(new FilterDefinitionBuilder(ProduceValidationFilterFactory.class.getName()).withConfig("rules",
+                                List.of(Map.of("topicNames", List.of(TOPIC_1), "valueRule",
+                                        Map.of("allowsNulls", true,
+                                                "syntacticallyCorrectJson", Map.of("validateObjectKeysUnique", true),
+                                                "schemaValidationConfig", Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "useApicurioGlobalId", 3L)))))
+                        .build());
+
+        try (var tester = kroxyliciousTester(config);
+                var producer = getProducer(tester, 0, 16384)) {
+            Future<RecordMetadata> invalid = producer.send(new ProducerRecord<>(TOPIC_1, "my-key", JSON_MESSAGE));
+            assertInvalidRecordExceptionThrown(invalid, "No artifact with ID '3' in group 'null' was found");
+        }
+    }
+
+    @AfterAll
+    public static void stopResources() {
+        if (registryContainer != null && registryContainer.isRunning()) {
+            registryContainer.stop();
+        }
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSyntaxValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSyntaxValidationIT.java
@@ -44,7 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(KafkaClusterExtension.class)
-class JsonSyntaxValidationIT extends BaseIT {
+class JsonSyntaxValidationIT extends SchemaValidationBaseIT {
 
     public static final String SYNTACTICALLY_CORRECT_JSON = "{\"value\":\"json\"}";
     public static final String SYNTACTICALLY_INCORRECT_JSON = "Not Json";
@@ -236,20 +236,4 @@ class JsonSyntaxValidationIT extends BaseIT {
             producer.send(new ProducerRecord<>(TOPIC_1, "my-key", SYNTACTICALLY_CORRECT_JSON)).get();
         }
     }
-
-    private Producer<String, String> getProducer(KroxyliciousTester tester, int linger, int batchSize) {
-        return getProducerWithConfig(tester, Optional.empty(), Map.of(LINGER_MS_CONFIG, linger, ProducerConfig.BATCH_SIZE_CONFIG, batchSize));
-    }
-
-    private Consumer<String, String> getConsumer(KroxyliciousTester tester) {
-        return getConsumerWithConfig(tester, Optional.empty(), Map.of(GROUP_ID_CONFIG, "my-group-id", AUTO_OFFSET_RESET_CONFIG, "earliest"));
-    }
-
-    private static void assertInvalidRecordExceptionThrown(Future<RecordMetadata> invalid, String message) {
-        assertThatThrownBy(() -> {
-            invalid.get(10, TimeUnit.SECONDS);
-        }).isInstanceOf(ExecutionException.class).hasCauseInstanceOf(InvalidRecordException.class).cause()
-                .hasMessageContaining(message);
-    }
-
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSyntaxValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSyntaxValidationIT.java
@@ -8,7 +8,6 @@ package io.kroxylicious.proxy.schema.validation;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -16,28 +15,20 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.producer.Producer;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.common.InvalidRecordException;
 import org.apache.kafka.common.KafkaException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import io.kroxylicious.proxy.BaseIT;
 import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
 import io.kroxylicious.proxy.filter.schema.ProduceValidationFilterFactory;
-import io.kroxylicious.test.tester.KroxyliciousTester;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
 import static java.util.UUID.randomUUID;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
-import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.LINGER_MS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.TRANSACTIONAL_ID_CONFIG;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/SchemaValidationBaseIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/SchemaValidationBaseIT.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.schema.validation;
+
+import io.kroxylicious.proxy.BaseIT;
+import io.kroxylicious.test.tester.KroxyliciousTester;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.InvalidRecordException;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.LINGER_MS_CONFIG;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public abstract class SchemaValidationBaseIT extends BaseIT {
+
+    protected Producer<String, String> getProducer(KroxyliciousTester tester, int linger, int batchSize) {
+        return getProducerWithConfig(tester, Optional.empty(), Map.of(LINGER_MS_CONFIG, linger, ProducerConfig.BATCH_SIZE_CONFIG, batchSize));
+    }
+
+    protected org.apache.kafka.clients.consumer.Consumer<String, String> getConsumer(KroxyliciousTester tester) {
+        return getConsumerWithConfig(tester, Optional.empty(), Map.of(GROUP_ID_CONFIG, "my-group-id", AUTO_OFFSET_RESET_CONFIG, "earliest"));
+    }
+
+    protected static void assertInvalidRecordExceptionThrown(Future<RecordMetadata> invalid, String message) {
+        assertThatThrownBy(() -> {
+            invalid.get(10, TimeUnit.SECONDS);
+        }).isInstanceOf(ExecutionException.class).hasCauseInstanceOf(InvalidRecordException.class).cause()
+                .hasMessageContaining(message);
+    }
+
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/SchemaValidationBaseIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/SchemaValidationBaseIT.java
@@ -6,18 +6,19 @@
 
 package io.kroxylicious.proxy.schema.validation;
 
-import io.kroxylicious.proxy.BaseIT;
-import io.kroxylicious.test.tester.KroxyliciousTester;
-import org.apache.kafka.clients.producer.Producer;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.common.InvalidRecordException;
-
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.InvalidRecordException;
+
+import io.kroxylicious.proxy.BaseIT;
+import io.kroxylicious.test.tester.KroxyliciousTester;
 
 import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <moby-names-generator.version>20.10.1-r0</moby-names-generator.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <apicurio-schema-validation.version>0.0.6</apicurio-schema-validation.version>
+        <apicurio-registry.version>2.5.10.Final</apicurio-registry.version>
         <jose4j.version>0.9.6</jose4j.version>
 
         <!-- Test dependencies -->
@@ -269,6 +270,11 @@
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest</artifactId>
                 <version>${hamcrest.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.apicurio</groupId>
+                <artifactId>apicurio-registry-schema-resolver</artifactId>
+                <version>${apicurio-registry.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.apicurio</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <zjsonpatch.version>0.4.16</zjsonpatch.version>
         <moby-names-generator.version>20.10.1-r0</moby-names-generator.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
+        <apicurio-schema-validation.version>0.0.5</apicurio-schema-validation.version>
         <jose4j.version>0.9.6</jose4j.version>
 
         <!-- Test dependencies -->
@@ -267,6 +268,11 @@
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest</artifactId>
                 <version>${hamcrest.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.apicurio</groupId>
+                <artifactId>apicurio-registry-schema-validation-jsonschema</artifactId>
+                <version>${apicurio-schema-validation.version}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <zjsonpatch.version>0.4.16</zjsonpatch.version>
         <moby-names-generator.version>20.10.1-r0</moby-names-generator.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
-        <apicurio-schema-validation.version>0.0.5</apicurio-schema-validation.version>
+        <apicurio-schema-validation.version>0.0.6</apicurio-schema-validation.version>
         <jose4j.version>0.9.6</jose4j.version>
 
         <!-- Test dependencies -->
@@ -73,6 +73,7 @@
         <bouncycastle.version>1.78.1</bouncycastle.version>
         <apache.commons.version>3.14.0</apache.commons.version>
         <netty-leak-detector-junit-extension.version>0.0.5</netty-leak-detector-junit-extension.version>
+        <wiremock.version>3.5.2</wiremock.version>
     </properties>
 
     <name>Parent POM</name>
@@ -333,6 +334,11 @@
                 <version>${testcontainers.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wiremock</groupId>
+                <artifactId>wiremock</artifactId>
+                <version>${wiremock.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.enforcer</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <apicurio-schema-validation.version>0.0.7</apicurio-schema-validation.version>
         <apicurio-registry.version>2.5.11.Final</apicurio-registry.version>
+        <apicurio-common.version>0.1.18.Final</apicurio-common.version>
         <jose4j.version>0.9.6</jose4j.version>
 
         <!-- Test dependencies -->
@@ -75,6 +76,7 @@
         <apache.commons.version>3.14.0</apache.commons.version>
         <netty-leak-detector-junit-extension.version>0.0.5</netty-leak-detector-junit-extension.version>
         <wiremock.version>3.5.2</wiremock.version>
+        <docker-java.version>3.3.6</docker-java.version>
     </properties>
 
     <name>Parent POM</name>
@@ -272,6 +274,26 @@
                 <version>${hamcrest.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-core</artifactId>
+                <version>${hamcrest.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.apicurio</groupId>
+                <artifactId>apicurio-registry-client</artifactId>
+                <version>${apicurio-registry.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.apicurio</groupId>
+                <artifactId>apicurio-registry-common</artifactId>
+                <version>${apicurio-registry.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.apicurio</groupId>
+                <artifactId>apicurio-common-rest-client-common</artifactId>
+                <version>${apicurio-common.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.apicurio</groupId>
                 <artifactId>apicurio-registry-schema-resolver</artifactId>
                 <version>${apicurio-registry.version}</version>
@@ -340,6 +362,12 @@
                 <version>${testcontainers.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-api</artifactId>
+                <version>${docker-java.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.wiremock</groupId>
@@ -499,7 +527,7 @@
                     <version>2.23.0</version>
                     <configuration>
                         <!--suppress MavenModelInspection -->
-                        <configFile>${rootdir}/etc/eclipse-formatter-config.xml</configFile>
+                        <configFile>/Users/carlesarnal/IdeaProjects/kroxylicious/etc/eclipse-formatter-config.xml</configFile>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -527,7 +527,7 @@
                     <version>2.23.0</version>
                     <configuration>
                         <!--suppress MavenModelInspection -->
-                        <configFile>/Users/carlesarnal/IdeaProjects/kroxylicious/etc/eclipse-formatter-config.xml</configFile>
+                        <configFile>${rootdir}/etc/eclipse-formatter-config.xml</configFile>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
         <zjsonpatch.version>0.4.16</zjsonpatch.version>
         <moby-names-generator.version>20.10.1-r0</moby-names-generator.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
-        <apicurio-schema-validation.version>0.0.6</apicurio-schema-validation.version>
-        <apicurio-registry.version>2.5.10.Final</apicurio-registry.version>
+        <apicurio-schema-validation.version>0.0.7</apicurio-schema-validation.version>
+        <apicurio-registry.version>2.5.11.Final</apicurio-registry.version>
         <jose4j.version>0.9.6</jose4j.version>
 
         <!-- Test dependencies -->


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR adds initial support for an integration between Kroxylicious and Apicurio Registry. It re-uses lots of the work done in the Json syntax validation and introduces the possibility of validating the data against a JSON Schema already available in Apicurio Registry.

A new configuration section has been introduced as follows:

```
forwardPartialRequests: true
                defaultRule:
                  valueRule:
                    allowNulls: false
                    allowEmpty: true
                rules:
                - topicNames:
                  - one
                  valueRule:
                    schemaValidationConfig:
                        useApicurioGlobalId: 1
                    allowNulls: false
                    allowEmpty: true
                - topicNames:
                  - two
                  keyRule:
                    allowNulls: false
                    allowEmpty: true
```

Where, any value sent to the topic `one` must match the schema available using the `globalId` 1 from Apicurio Registry. This is just the first step, and as discussed in https://github.com/kroxylicious/design/discussions/48 there are more possibilities on how to retrieve the schema. 

### Additional Context

I'm creating this early to start the discussion and see if this is the right direction.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [x] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
