### PR TITLE
Fix #1162: allow tenant / resource name prefix separator to be controlled from configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please enumerate **all user-facing** changes using format `<github issue/pr numb
 
 ## SNAPSHOT
  
+* [#1162](https://github.com/kroxylicious/kroxylicious/issues/1162): Fix #1162: allow tenant / resource name prefix separator to be controlled from configuration
 * [#1120](https://github.com/kroxylicious/kroxylicious/pull/1120): Generate API compatability report as part of the release process.
  
 ## 0.5.1

--- a/kroxylicious-filters/kroxylicious-multitenant/pom.xml
+++ b/kroxylicious-filters/kroxylicious-multitenant/pom.xml
@@ -22,14 +22,17 @@
     <packaging>jar</packaging>
 
     <name>Multitenancy filter</name>
-    <description>A filter to implement transparent multitenancy for Apache Kafka
-    </description>
+    <description>A filter to implement transparent multitenancy for Apache Kafka</description>
 
     <dependencies>
         <!-- project dependencies - runtime and compile -->
         <dependency>
             <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
         </dependency>
 
         <!-- project dependencies - test -->

--- a/kroxylicious-filters/kroxylicious-multitenant/pom.xml
+++ b/kroxylicious-filters/kroxylicious-multitenant/pom.xml
@@ -41,12 +41,12 @@
 
         <!-- third party dependencies - runtime and compile -->
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
         </dependency>
 
         <!-- third party dependencies - test -->
@@ -58,11 +58,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j2-impl</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kroxylicious-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterFactory.java
+++ b/kroxylicious-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterFactory.java
@@ -16,6 +16,8 @@ import io.kroxylicious.proxy.plugin.Plugin;
 @Plugin(configType = MultiTenantConfig.class)
 public class MultiTenantTransformationFilterFactory implements FilterFactory<MultiTenantConfig, MultiTenantConfig> {
 
+    private static final MultiTenantConfig DEFAULT_TENANT_CONFIG = new MultiTenantConfig(null);
+
     @Override
     public MultiTenantConfig initialize(FilterFactoryContext context, MultiTenantConfig config) {
         return config;
@@ -23,6 +25,6 @@ public class MultiTenantTransformationFilterFactory implements FilterFactory<Mul
 
     @Override
     public MultiTenantTransformationFilter createFilter(FilterFactoryContext context, MultiTenantConfig configuration) {
-        return new MultiTenantTransformationFilter(Objects.requireNonNullElseGet(configuration, () -> new MultiTenantConfig(null)));
+        return new MultiTenantTransformationFilter(Objects.requireNonNullElse(configuration, DEFAULT_TENANT_CONFIG));
     }
 }

--- a/kroxylicious-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterFactory.java
+++ b/kroxylicious-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterFactory.java
@@ -6,20 +6,23 @@
 
 package io.kroxylicious.proxy.filter.multitenant;
 
+import java.util.Objects;
+
 import io.kroxylicious.proxy.filter.FilterFactory;
 import io.kroxylicious.proxy.filter.FilterFactoryContext;
+import io.kroxylicious.proxy.filter.multitenant.config.MultiTenantConfig;
 import io.kroxylicious.proxy.plugin.Plugin;
 
-@Plugin(configType = Void.class)
-public class MultiTenantTransformationFilterFactory implements FilterFactory<Void, Void> {
+@Plugin(configType = MultiTenantConfig.class)
+public class MultiTenantTransformationFilterFactory implements FilterFactory<MultiTenantConfig, MultiTenantConfig> {
 
     @Override
-    public Void initialize(FilterFactoryContext context, Void config) {
-        return null;
+    public MultiTenantConfig initialize(FilterFactoryContext context, MultiTenantConfig config) {
+        return config;
     }
 
     @Override
-    public MultiTenantTransformationFilter createFilter(FilterFactoryContext context, Void configuration) {
-        return new MultiTenantTransformationFilter();
+    public MultiTenantTransformationFilter createFilter(FilterFactoryContext context, MultiTenantConfig configuration) {
+        return new MultiTenantTransformationFilter(Objects.requireNonNullElseGet(configuration, () -> new MultiTenantConfig(null)));
     }
 }

--- a/kroxylicious-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/config/MultiTenantConfig.java
+++ b/kroxylicious-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/config/MultiTenantConfig.java
@@ -16,7 +16,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * a default is used.
  */
 public record MultiTenantConfig(String prefixResourceNameSeparator) {
+
+    public static final String DEFAULT_SEPARATOR = "-";
+
     public MultiTenantConfig(@JsonProperty(required = false) String prefixResourceNameSeparator) {
-        this.prefixResourceNameSeparator = Objects.requireNonNullElse(prefixResourceNameSeparator, "-");
+        this.prefixResourceNameSeparator = Objects.requireNonNullElse(prefixResourceNameSeparator, DEFAULT_SEPARATOR);
     }
 }

--- a/kroxylicious-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/config/MultiTenantConfig.java
+++ b/kroxylicious-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/config/MultiTenantConfig.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.multitenant.config;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Configuration for the Multi Tenant Filter.
+ * @param prefixResourceNameSeparator separator character used to form the prefixed resource name, if not null
+ * a default is used.
+ */
+public record MultiTenantConfig(String prefixResourceNameSeparator) {
+    public MultiTenantConfig(@JsonProperty(required = false) String prefixResourceNameSeparator) {
+        this.prefixResourceNameSeparator = Objects.requireNonNullElse(prefixResourceNameSeparator, "-");
+    }
+}

--- a/kroxylicious-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterFactoryTest.java
+++ b/kroxylicious-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterFactoryTest.java
@@ -11,6 +11,7 @@ import org.mockito.Mockito;
 
 import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterFactoryContext;
+import io.kroxylicious.proxy.filter.multitenant.config.MultiTenantConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -19,7 +20,7 @@ class MultiTenantFilterFactoryTest {
     @Test
     void testGetInstance() {
         MultiTenantTransformationFilterFactory factory = new MultiTenantTransformationFilterFactory();
-        Filter filter = factory.createFilter(Mockito.mock(FilterFactoryContext.class), null);
+        Filter filter = factory.createFilter(Mockito.mock(FilterFactoryContext.class), Mockito.mock(MultiTenantConfig.class));
         assertThat(filter).isNotNull().isInstanceOf(MultiTenantTransformationFilter.class);
     }
 

--- a/kroxylicious-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterFactoryFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterFactoryFilterTest.java
@@ -39,6 +39,7 @@ import io.kroxylicious.proxy.filter.FilterFactoryContext;
 import io.kroxylicious.proxy.filter.FilterInvoker;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
+import io.kroxylicious.proxy.filter.multitenant.config.MultiTenantConfig;
 import io.kroxylicious.test.requestresponsetestdef.ApiMessageTestDef;
 import io.kroxylicious.test.requestresponsetestdef.RequestResponseTestDef;
 
@@ -69,7 +70,7 @@ class MultiTenantTransformationFilterFactoryFilterTest {
         return resources;
     }
 
-    private final MultiTenantTransformationFilter filter = new MultiTenantTransformationFilter();
+    private final MultiTenantTransformationFilter filter = new MultiTenantTransformationFilter(new MultiTenantConfig(null));
 
     private final FilterInvoker invoker = getOnlyElement(FilterAndInvoker.build(filter)).invoker();
 
@@ -153,6 +154,7 @@ class MultiTenantTransformationFilterFactoryFilterTest {
     @Test
     void testContributor() {
         MultiTenantTransformationFilterFactory factory = new MultiTenantTransformationFilterFactory();
-        assertThat(factory.createFilter(Mockito.mock(FilterFactoryContext.class), null)).isInstanceOf(MultiTenantTransformationFilter.class);
+        assertThat(factory.createFilter(Mockito.mock(FilterFactoryContext.class), Mockito.mock(MultiTenantConfig.class)))
+                .isInstanceOf(MultiTenantTransformationFilter.class);
     }
 }

--- a/kroxylicious-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterTest.java
@@ -6,8 +6,10 @@
 
 package io.kroxylicious.proxy.filter.multitenant;
 
+import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,6 +18,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.multitenant.config.MultiTenantConfig;
+import io.kroxylicious.test.condition.kafka.FetchResponseDataCondition;
 
 import static io.kroxylicious.test.condition.kafka.ApiMessageCondition.forApiKey;
 import static io.kroxylicious.test.condition.kafka.ProduceRequestDataCondition.produceRequestMatching;
@@ -28,17 +32,16 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class MultiTenantTransformationFilterTest {
 
-    private MultiTenantTransformationFilter multiTenantTransformationFilter;
     @Mock
     private FilterContext filterContext;
 
     @BeforeEach
     void setUp() {
-        multiTenantTransformationFilter = new MultiTenantTransformationFilter();
     }
 
     @Test
     void shouldReWriteTopic() {
+        var multiTenantTransformationFilter = new MultiTenantTransformationFilter(new MultiTenantConfig(null));
         // Given
         when(filterContext.getVirtualClusterName()).thenReturn("vc1");
         final ProduceRequestData request = new ProduceRequestData();
@@ -55,8 +58,53 @@ class MultiTenantTransformationFilterTest {
                         .is(forApiKey(ApiKeys.PRODUCE))
                         .is(produceRequestMatching(produceRequestData -> produceRequestData.topicData()
                                 .stream()
-                                .allMatch(topicProduceData -> topicProduceData.name().equals("vc1-testTopic")))
-                        )));
+                                .allMatch(topicProduceData -> topicProduceData.name().equals("vc1-testTopic"))))));
+
+    }
+
+    @Test
+    void produceWithCustomSeparator() {
+        var multiTenantTransformationFilter = new MultiTenantTransformationFilter(new MultiTenantConfig("."));
+        // Given
+        when(filterContext.getVirtualClusterName()).thenReturn("vc1");
+        final ProduceRequestData request = new ProduceRequestData();
+        final ProduceRequestData.TopicProduceData topicData = new ProduceRequestData.TopicProduceData();
+        topicData.setName("testTopic");
+        request.topicData().add(topicData);
+        // When
+        multiTenantTransformationFilter.onProduceRequest(
+                ProduceRequestData.HIGHEST_SUPPORTED_VERSION, new RequestHeaderData(), request, filterContext);
+
+        // Then
+        verify(filterContext).forwardRequest(any(RequestHeaderData.class), assertArg(
+                apiMessage -> assertThat(apiMessage)
+                        .is(forApiKey(ApiKeys.PRODUCE))
+                        .is(produceRequestMatching(produceRequestData -> produceRequestData.topicData()
+                                .stream()
+                                .allMatch(topicProduceData -> topicProduceData.name().equals("vc1.testTopic"))))));
+
+    }
+
+    @Test
+    void fetchWithCustomSeparator() {
+        var multiTenantTransformationFilter = new MultiTenantTransformationFilter(new MultiTenantConfig("."));
+        // Given
+        when(filterContext.getVirtualClusterName()).thenReturn("vc1");
+        var response = new FetchResponseData();
+        var topicResponse = new FetchResponseData.FetchableTopicResponse();
+        topicResponse.setTopic("vc1.testTopic");
+        response.responses().add(topicResponse);
+        // When
+        multiTenantTransformationFilter.onFetchResponse(
+                FetchResponseData.HIGHEST_SUPPORTED_VERSION, new ResponseHeaderData(), response, filterContext);
+
+        // Then
+        verify(filterContext).forwardResponse(any(ResponseHeaderData.class), assertArg(
+                apiMessage -> assertThat(apiMessage)
+                        .is(forApiKey(ApiKeys.FETCH))
+                        .is(FetchResponseDataCondition.fetchResponseMatching(fetchResponseData -> fetchResponseData.responses()
+                                .stream()
+                                .allMatch(topicFetchData -> topicFetchData.topic().equals("testTopic"))))));
 
     }
 }

--- a/kroxylicious-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantTransformationFilterTest.java
@@ -6,14 +6,18 @@
 
 package io.kroxylicious.proxy.filter.multitenant;
 
+import java.util.Objects;
+
 import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -24,6 +28,7 @@ import io.kroxylicious.test.condition.kafka.FetchResponseDataCondition;
 import static io.kroxylicious.test.condition.kafka.ApiMessageCondition.forApiKey;
 import static io.kroxylicious.test.condition.kafka.ProduceRequestDataCondition.produceRequestMatching;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.Mockito.verify;
@@ -32,22 +37,17 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class MultiTenantTransformationFilterTest {
 
+    private static final String VIRTUAL_CLUSTER_NAME = "vc1";
+    private static final String TEST_TOPIC = "testTopic";
     @Mock
     private FilterContext filterContext;
-
-    @BeforeEach
-    void setUp() {
-    }
 
     @Test
     void shouldReWriteTopic() {
         var multiTenantTransformationFilter = new MultiTenantTransformationFilter(new MultiTenantConfig(null));
         // Given
-        when(filterContext.getVirtualClusterName()).thenReturn("vc1");
-        final ProduceRequestData request = new ProduceRequestData();
-        final ProduceRequestData.TopicProduceData topicData = new ProduceRequestData.TopicProduceData();
-        topicData.setName("testTopic");
-        request.topicData().add(topicData);
+        when(filterContext.getVirtualClusterName()).thenReturn(VIRTUAL_CLUSTER_NAME);
+        var request = createProduceRequest(TEST_TOPIC);
         // When
         multiTenantTransformationFilter.onProduceRequest(
                 ProduceRequestData.HIGHEST_SUPPORTED_VERSION, new RequestHeaderData(), request, filterContext);
@@ -62,15 +62,15 @@ class MultiTenantTransformationFilterTest {
 
     }
 
-    @Test
-    void produceWithCustomSeparator() {
-        var multiTenantTransformationFilter = new MultiTenantTransformationFilter(new MultiTenantConfig("."));
+    @ParameterizedTest
+    @ValueSource(strings = { ".", "_", "", "-.-" })
+    @NullSource
+    void produceWithCustomSeparator(String separator) {
+        var expectedServerTopicName = "%s%s%s".formatted(VIRTUAL_CLUSTER_NAME, Objects.requireNonNullElse(separator, MultiTenantConfig.DEFAULT_SEPARATOR), TEST_TOPIC);
+        var multiTenantTransformationFilter = new MultiTenantTransformationFilter(new MultiTenantConfig(separator));
         // Given
-        when(filterContext.getVirtualClusterName()).thenReturn("vc1");
-        final ProduceRequestData request = new ProduceRequestData();
-        final ProduceRequestData.TopicProduceData topicData = new ProduceRequestData.TopicProduceData();
-        topicData.setName("testTopic");
-        request.topicData().add(topicData);
+        when(filterContext.getVirtualClusterName()).thenReturn(VIRTUAL_CLUSTER_NAME);
+        var request = createProduceRequest(TEST_TOPIC);
         // When
         multiTenantTransformationFilter.onProduceRequest(
                 ProduceRequestData.HIGHEST_SUPPORTED_VERSION, new RequestHeaderData(), request, filterContext);
@@ -81,19 +81,18 @@ class MultiTenantTransformationFilterTest {
                         .is(forApiKey(ApiKeys.PRODUCE))
                         .is(produceRequestMatching(produceRequestData -> produceRequestData.topicData()
                                 .stream()
-                                .allMatch(topicProduceData -> topicProduceData.name().equals("vc1.testTopic"))))));
-
+                                .allMatch(topicProduceData -> topicProduceData.name().equals(expectedServerTopicName))))));
     }
 
-    @Test
-    void fetchWithCustomSeparator() {
-        var multiTenantTransformationFilter = new MultiTenantTransformationFilter(new MultiTenantConfig("."));
+    @ParameterizedTest
+    @ValueSource(strings = { ".", "_", "", "-.-" })
+    @NullSource
+    void fetchWithCustomSeparator(String separator) {
+        var serverTopic = "%s%s%s".formatted(VIRTUAL_CLUSTER_NAME, Objects.requireNonNullElse(separator, MultiTenantConfig.DEFAULT_SEPARATOR), TEST_TOPIC);
+        var multiTenantTransformationFilter = new MultiTenantTransformationFilter(new MultiTenantConfig(separator));
         // Given
-        when(filterContext.getVirtualClusterName()).thenReturn("vc1");
-        var response = new FetchResponseData();
-        var topicResponse = new FetchResponseData.FetchableTopicResponse();
-        topicResponse.setTopic("vc1.testTopic");
-        response.responses().add(topicResponse);
+        when(filterContext.getVirtualClusterName()).thenReturn(VIRTUAL_CLUSTER_NAME);
+        var response = createFetchResponseData(serverTopic);
         // When
         multiTenantTransformationFilter.onFetchResponse(
                 FetchResponseData.HIGHEST_SUPPORTED_VERSION, new ResponseHeaderData(), response, filterContext);
@@ -104,7 +103,51 @@ class MultiTenantTransformationFilterTest {
                         .is(forApiKey(ApiKeys.FETCH))
                         .is(FetchResponseDataCondition.fetchResponseMatching(fetchResponseData -> fetchResponseData.responses()
                                 .stream()
-                                .allMatch(topicFetchData -> topicFetchData.topic().equals("testTopic"))))));
-
+                                .allMatch(topicFetchData -> topicFetchData.topic().equals(TEST_TOPIC))))));
     }
+
+    @Test
+    void illegalKafkaResourceCharsInVirtualClusterNameDetected() {
+        var multiTenantTransformationFilter = new MultiTenantTransformationFilter(new MultiTenantConfig(MultiTenantConfig.DEFAULT_SEPARATOR));
+        // Given
+        when(filterContext.getVirtualClusterName()).thenReturn("$badvcn$");
+        var request = createProduceRequest(TEST_TOPIC);
+        var header = new RequestHeaderData();
+        // When
+        assertThatThrownBy(() -> {
+            multiTenantTransformationFilter.onProduceRequest(
+                    ProduceRequestData.HIGHEST_SUPPORTED_VERSION, header, request, filterContext);
+        }).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void illegalKafkaResourceCharsInSeparatorDetected() {
+        var multiTenantTransformationFilter = new MultiTenantTransformationFilter(new MultiTenantConfig("$bad$"));
+        // Given
+        when(filterContext.getVirtualClusterName()).thenReturn(VIRTUAL_CLUSTER_NAME);
+        var request = createProduceRequest(TEST_TOPIC);
+        var header = new RequestHeaderData();
+        // When
+        assertThatThrownBy(() -> {
+            multiTenantTransformationFilter.onProduceRequest(
+                    ProduceRequestData.HIGHEST_SUPPORTED_VERSION, header, request, filterContext);
+        }).isInstanceOf(IllegalStateException.class);
+    }
+
+    private ProduceRequestData createProduceRequest(String topic) {
+        final ProduceRequestData request = new ProduceRequestData();
+        final ProduceRequestData.TopicProduceData topicData = new ProduceRequestData.TopicProduceData();
+        topicData.setName(topic);
+        request.topicData().add(topicData);
+        return request;
+    }
+
+    private FetchResponseData createFetchResponseData(String topic) {
+        var response = new FetchResponseData();
+        var topicResponse = new FetchResponseData.FetchableTopicResponse();
+        topicResponse.setTopic(topic);
+        response.responses().add(topicResponse);
+        return response;
+    }
+
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/multitenant/BaseMultiTenantIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/multitenant/BaseMultiTenantIT.java
@@ -90,6 +90,12 @@ public abstract class BaseMultiTenantIT extends BaseIT {
     }
 
     static ConfigurationBuilder getConfig(KafkaCluster cluster, KeytoolCertificateGenerator certificateGenerator) {
+        return getConfig(cluster, certificateGenerator, null);
+    }
+
+    static ConfigurationBuilder getConfig(KafkaCluster cluster, KeytoolCertificateGenerator certificateGenerator, Map<String, Object> filterConfig) {
+        var filterBuilder = new FilterDefinitionBuilder(MultiTenantTransformationFilterFactory.class.getName());
+        Optional.ofNullable(filterConfig).ifPresent(filterBuilder::withConfig);
         return new ConfigurationBuilder()
                 .addToVirtualClusters(TENANT_1_CLUSTER, new VirtualClusterBuilder()
                         .withNewTargetCluster()
@@ -121,7 +127,7 @@ public abstract class BaseMultiTenantIT extends BaseIT {
                         .endKeyStoreKey()
                         .endTls()
                         .build())
-                .addToFilters(new FilterDefinitionBuilder(MultiTenantTransformationFilterFactory.class.getName()).build());
+                .addToFilters(filterBuilder.build());
     }
 
     Consumer<String, String> getConsumerWithConfig(KroxyliciousTester tester, String virtualCluster, String groupId, Map<String, Object> baseConfig,


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

With this change, the MultiTenantFilter accepts configuration that allows the separator used to separate the tenant prefix
from the kafka resource name to controlled. If the separator is not specified, the default `-` is used.

```yaml
    filters:
    - type: MultiTenantTransformationFilterFactory
      config:
        prefixResourceNameSeparator: "."
```

Currently, there's no validation that the separator character chosen is legal for Kafka.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
