### PR TITLE
Fix performance tests: migrate to Compose V2 and listen on IPv6 addresses

### DIFF
--- a/performance-tests/docker-compose.yaml
+++ b/performance-tests/docker-compose.yaml
@@ -4,7 +4,6 @@
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
-version: '3'
 networks:
   perf_network:
     driver: bridge

--- a/performance-tests/docker-compose.yaml
+++ b/performance-tests/docker-compose.yaml
@@ -32,7 +32,8 @@ services:
       VAULT_DEV_ROOT_TOKEN_ID: token
       VAULT_TOKEN:  token
       VAULT_FORMAT: json
-      VAULT_ADDR: http://0.0.0.0:8200 # TODO - shouldn't need this
+      VAULT_DEV_LISTEN_ADDRESS: "[::]:8200"
+      VAULT_ADDR: http://localhost:8200 # TODO - shouldn't need this
     networks:
       - perf_network
     healthcheck:
@@ -48,7 +49,7 @@ services:
       - "--config"
       - "/opt/kroxylicious/config/config.yaml"
     healthcheck:
-      test: grep 2384 /proc/1/net/tcp  # 0x2384 = 9092
+      test: grep 2384 /proc/1/net/tcp /proc/1/net/tcp6  # 0x2384 = 9092
       interval: 5s
       retries: 5
       timeout: 10s

--- a/performance-tests/perf-tests.sh
+++ b/performance-tests/perf-tests.sh
@@ -32,7 +32,7 @@ PERF_NETWORK=performance-tests_perf_network
 export KAFKA_VERSION KAFKA_TOOL_IMAGE KAFKA_IMAGE KROXYLICIOUS_IMAGE
 
 runDockerCompose () {
-  docker-compose -f "${PERF_TESTS_DIR}"/docker-compose.yaml "${@}"
+  docker compose -f "${PERF_TESTS_DIR}"/docker-compose.yaml "${@}"
 }
 
 doCreateTopic () {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

I have problems when running the performance tests.

1. The latest version of docker does not contains a `docker-compose`. The recommended command-line syntax is docker compose. https://docs.docker.com/compose/migrate/#docker-compose-vs-docker-compose
2. The top-level `version` property in docker-compose.yaml is obsolete. https://docs.docker.com/compose/compose-file/04-version-and-name/
3. The kroxylicious container is unhealthy because the healthcheck will not check IPv6 address
4. The vault container listens on IPv4 address, but the healthcheck checks `localhost:8200` which is resolved as an IPv6 address in my environment

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
