### PR TITLE
Send an ApiVersionsRequest with the client software name and version (authentication offload use-case)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please enumerate **all user-facing** changes using format `<github issue/pr numb
 
 ## SNAPSHOT
 
+* [#1175](https://github.com/kroxylicious/kroxylicious/pull/1175): Send an ApiVersionsRequest with the client software name and version
 * [#1158](https://github.com/kroxylicious/kroxylicious/pull/1158): Bump io.netty:netty-bom from 4.1.108.Final to 4.1.109.Final
 * [#1162](https://github.com/kroxylicious/kroxylicious/issues/1162): Fix #1162: allow tenant / resource name prefix separator to be controlled from configuration
 * [#1120](https://github.com/kroxylicious/kroxylicious/pull/1120): Generate API compatability report as part of the release process.

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ApiVersionsServiceImpl.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ApiVersionsServiceImpl.java
@@ -12,13 +12,13 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
-import org.apache.kafka.common.message.ApiVersionsRequestData;
 import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersion;
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersionCollection;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.ApiVersionsRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +31,7 @@ public class ApiVersionsServiceImpl {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ApiVersionsServiceImpl.class);
     private ApiVersions apiVersions = null;
+    private ApiVersionsRequest apiVersionsRequest = null;
 
     public void updateVersions(String channel, ApiVersionsResponseData upstreamApiVersions) {
         var upstream = upstreamApiVersions.duplicate().apiKeys();
@@ -105,9 +106,9 @@ public class ApiVersionsServiceImpl {
 
         // KIP-511 when the client receives an unsupported version for the ApiVersionResponse, it fails back to version 0
         // Use the same algorithm as https://github.com/apache/kafka/blob/159d25a7df25975694e2e0eb18a8feb125f7c39e/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java#L957-L977
-        var data = new ApiVersionsRequestData();
-        var header = new RequestHeaderData().setRequestApiVersion(data.highestSupportedVersion());
-        return context.<ApiVersionsResponseData> sendRequest(header, data)
+        var request = getApiVersionsRequest();
+        var header = new RequestHeaderData().setRequestApiVersion(request.version());
+        return context.<ApiVersionsResponseData> sendRequest(header, request.data())
                 .thenCompose(response -> {
                     if (response.errorCode() != Errors.NONE.code()) {
                         if (header.requestApiVersion() == 0 || response.errorCode() != Errors.UNSUPPORTED_VERSION.code()) {
@@ -122,7 +123,7 @@ public class ApiVersionsServiceImpl {
                                 maxApiVersion = apiVersion.maxVersion();
                             }
                         }
-                        return context.sendRequest(header.setRequestApiVersion(maxApiVersion), data);
+                        return context.sendRequest(header.setRequestApiVersion(maxApiVersion), request.data());
                     }
                     return CompletableFuture.completedStage(response);
                 })
@@ -130,6 +131,25 @@ public class ApiVersionsServiceImpl {
                     updateVersions(context.channelDescriptor(), response);
                     return apiVersions;
                 });
+    }
+
+    void setApiVersionsRequest(ApiVersionsRequest request) {
+        if (request.hasUnsupportedRequestVersion()) {
+            throw Errors.UNSUPPORTED_VERSION.exception();
+        }
+        if (!request.isValid()) {
+            throw Errors.INVALID_REQUEST.exception();
+        }
+        this.apiVersionsRequest = request;
+    }
+
+    ApiVersionsRequest getApiVersionsRequest() {
+        if (apiVersionsRequest == null) {
+            ApiVersionsRequest.Builder builder = new ApiVersionsRequest.Builder();
+            short version = builder.latestAllowedVersion();
+            apiVersionsRequest = builder.build(version);
+        }
+        return apiVersionsRequest;
     }
 
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -12,11 +12,14 @@ import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.message.ApiVersionsRequestData;
 import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.ApiVersionsResponseDataJsonConverter;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.requests.ApiVersionsRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,6 +52,8 @@ import io.kroxylicious.proxy.internal.codec.KafkaResponseDecoder;
 import io.kroxylicious.proxy.model.VirtualCluster;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
+
+import static org.apache.kafka.common.protocol.ApiKeys.API_VERSIONS;
 
 public class KafkaProxyFrontendHandler
         extends ChannelInboundHandlerAdapter
@@ -220,16 +225,33 @@ public class KafkaProxyFrontendHandler
     private void handleApiVersionsFrame(ChannelHandlerContext ctx, Object msg) {
         state = State.API_VERSIONS;
         DecodedRequestFrame<ApiVersionsRequestData> apiVersionsFrame = (DecodedRequestFrame<ApiVersionsRequestData>) msg;
-        storeApiVersionsFeatures(apiVersionsFrame);
+        ApiVersionsRequest apiVersionsRequest = parseApiVersionsRequest(apiVersionsFrame);
+        try {
+            apiVersionService.setApiVersionsRequest(apiVersionsRequest);
+        }
+        catch (ApiException e) {
+            writeApiVersionsResponse(ctx, apiVersionsFrame, apiVersionsRequest.getErrorResponse(e).data());
+            // Request to read the following request
+            ctx.channel().read();
+            return;
+        }
+        storeApiVersionsFeatures(apiVersionsRequest);
         if (dp.isAuthenticationOffloadEnabled()) {
             // This handler can respond to ApiVersions itself
-            writeApiVersionsResponse(ctx, apiVersionsFrame);
+            writeApiVersionsResponse(ctx, apiVersionsFrame, API_VERSIONS_RESPONSE);
             // Request to read the following request
             ctx.channel().read();
         }
         else {
             bufferMsgAndSelectServer(msg);
         }
+    }
+
+    private ApiVersionsRequest parseApiVersionsRequest(DecodedRequestFrame<ApiVersionsRequestData> apiVersionsFrame) {
+        if (!API_VERSIONS.isVersionSupported(apiVersionsFrame.apiVersion())) {
+            return new ApiVersionsRequest(apiVersionsFrame.body(), (short) 0, apiVersionsFrame.apiVersion());
+        }
+        return new ApiVersionsRequest(apiVersionsFrame.body(), apiVersionsFrame.apiVersion());
     }
 
     private boolean isSubsequentRequestFrame(Object msg) {
@@ -251,8 +273,12 @@ public class KafkaProxyFrontendHandler
     private boolean isInitialDecodedApiVersionsFrame(Object msg) {
         return (state == State.START
                 || state == State.HA_PROXY)
-                && msg instanceof DecodedRequestFrame
-                && ((DecodedRequestFrame<?>) msg).apiKey() == ApiKeys.API_VERSIONS;
+                && isDecodedApiVersionsFrame(msg);
+    }
+
+    private boolean isDecodedApiVersionsFrame(Object msg) {
+        return msg instanceof DecodedRequestFrame<?> frame
+                && frame.apiKey() == ApiKeys.API_VERSIONS;
     }
 
     private void bufferMsgAndSelectServer(Object msg) {
@@ -350,6 +376,18 @@ public class KafkaProxyFrontendHandler
     }
 
     public void forwardOutbound(final ChannelHandlerContext ctx, Object msg) {
+        if (isDecodedApiVersionsFrame(msg)) {
+            DecodedRequestFrame<ApiVersionsRequestData> apiVersionsFrame = (DecodedRequestFrame<ApiVersionsRequestData>) msg;
+            ApiVersionsRequest apiVersionsRequest = parseApiVersionsRequest(apiVersionsFrame);
+            try {
+                apiVersionService.setApiVersionsRequest(apiVersionsRequest);
+            }
+            catch (ApiException e) {
+                writeApiVersionsResponse(inboundCtx, apiVersionsFrame, apiVersionsRequest.getErrorResponse(e).data());
+                return;
+            }
+            storeApiVersionsFeatures(apiVersionsRequest);
+        }
         if (outboundCtx == null) {
             LOGGER.trace("READ on inbound {} ignored because outbound is not active (msg: {})",
                     ctx.channel(), msg);
@@ -378,23 +416,24 @@ public class KafkaProxyFrontendHandler
      * Sends an ApiVersions response from this handler to the client
      * (i.e. prior to having backend connection)
      */
-    private void writeApiVersionsResponse(ChannelHandlerContext ctx, DecodedRequestFrame<ApiVersionsRequestData> frame) {
+    private void writeApiVersionsResponse(ChannelHandlerContext ctx, DecodedRequestFrame<ApiVersionsRequestData> frame,
+                                          ApiMessage response) {
 
         short apiVersion = frame.apiVersion();
         int correlationId = frame.correlationId();
         ResponseHeaderData header = new ResponseHeaderData()
                 .setCorrelationId(correlationId);
         LOGGER.debug("{}: Writing ApiVersions response", ctx.channel());
-        ctx.writeAndFlush(new DecodedResponseFrame<>(
-                apiVersion, correlationId, header, API_VERSIONS_RESPONSE));
+        ctx.writeAndFlush(new DecodedResponseFrame<>(apiVersion, correlationId, header, response));
     }
 
-    private void storeApiVersionsFeatures(DecodedRequestFrame<ApiVersionsRequestData> frame) {
-        // TODO check the format of the strings using a regex
-        // Needed to reproduce the exact behaviour for how a broker handles this
-        // see org.apache.kafka.common.requests.ApiVersionsRequest#isValid()
-        this.clientSoftwareName = frame.body().clientSoftwareName();
-        this.clientSoftwareVersion = frame.body().clientSoftwareVersion();
+    private void storeApiVersionsFeatures(ApiVersionsRequest request) {
+        // KIP-511 client name and version are available since 3
+        if (request.version() >= 3 && request.isValid()) {
+            ApiVersionsRequestData requestData = request.data();
+            this.clientSoftwareName = requestData.clientSoftwareName();
+            this.clientSoftwareVersion = requestData.clientSoftwareVersion();
+        }
     }
 
     public void outboundWritabilityChanged(ChannelHandlerContext outboundCtx) {


### PR DESCRIPTION
### Type of change
- Bugfix
- Enhancement

### Description

_Please describe your pull request_

### Additional Context

1. A v3 ApiVersionsRequest without client software name and version is considered invalid. So ApiVersionsServiceImpl should remember the original client software name and version, and then set it to ApiVersionsRequestData when sending to upstream.
https://github.com/apache/kafka/blob/3.7.0/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsRequest.java#L84-L91

2. `storeApiVersionsFeatures` can not get any client software name or version if the client enables SASL authentication. `storeApiVersionsFeatures` should only accept a v3 ApiVersionsRequest.
https://github.com/apache/kafka/blob/3.7.0/clients/src/main/java/org/apache/kafka/common/security/authenticator/SaslClientAuthenticator.java#L245-L246

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
