### PR TITLE
Adding rate rps and rate mips to the performance test producer results

### DIFF
--- a/performance-tests/perf-tests.sh
+++ b/performance-tests/perf-tests.sh
@@ -55,8 +55,8 @@ doDeleteTopic () {
 
 warmUp() {
   echo -e "${YELLOW}Running warm up${NOCOLOR}"
-  producerPerf $1 $2 "${WARM_UP_NUM_RECORDS_PRE_TEST}" /dev/null > /dev/null
-  consumerPerf $1 $2 "${WARM_UP_NUM_RECORDS_PRE_TEST}" /dev/null > /dev/null
+  producerPerf "$1" "$2" "${WARM_UP_NUM_RECORDS_PRE_TEST}" /dev/null > /dev/null
+  consumerPerf "$1" "$2" "${WARM_UP_NUM_RECORDS_PRE_TEST}" /dev/null > /dev/null
 }
 
 # runs kafka-producer-perf-test.sh transforming the output to an array of objects
@@ -96,7 +96,7 @@ producerPerf() {
                                     ", *(?<percentile999>\\d+[.]?\\d*) ms 99.9th" +
                                     ")?" +
                                     "[.]"; "g")]  |
-                                 {name: $name, values: [.[] | .captures | map( { (.name|tostring): ( .string | tonumber? ) } ) | add | del(..|nulls)]}' > ${OUTPUT}
+                                 {name: $name, values: [.[] | .captures | map( { (.name|tostring): ( .string | tonumber? ) } ) | add | del(..|nulls)]}' > "${OUTPUT}"
 }
 
 consumerPerf() {
@@ -135,7 +135,7 @@ consumerPerf() {
                                         "(?<fetch.time.ms>\\d+[.]?\\d*), " +
                                         "(?<fetch.MB.sec>\\d+[.]?\\d*), " +
                                         "(?<fetch.nMsg.sec>\\d+[.]?\\d*)"; "g")] |
-                                 { name: $name, values: [.[] | .captures | map( { (.name|tostring): ( .string | tonumber? ) } ) | add | del(..|nulls)]}' > ${OUTPUT}
+                                 { name: $name, values: [.[] | .captures | map( { (.name|tostring): ( .string | tonumber? ) } ) | add | del(..|nulls)]}' > "${OUTPUT}"
 }
 
 # expects TEST_NAME, TOPIC, ENDPOINT, PRODUCER_RESULT and CONSUMER_RESULT to be set

--- a/performance-tests/perf-tests.sh
+++ b/performance-tests/perf-tests.sh
@@ -212,7 +212,9 @@ if [[ -n "${KIBANA_OUTPUT_DIR}" && -d "${KIBANA_OUTPUT_DIR}" ]]; then
   do
     DIR=${KIBANA_OUTPUT_DIR}/$(jq -r '.name' ${PRODUCER_RESULT})
     mkdir -p ${DIR}
-    jq '.values | last | [{name: "AVG Latency", unit: "ms", value: .avg_lat_ms},
+    jq '.values | last | [{name: "Rate rps", unit: "rec/s", value: .rate_rps},
+                          {name: "Rate mips", unit: "Mi/s", value: .rate_mips},
+                          {name: "AVG Latency", unit: "ms", value: .avg_lat_ms},
                           {name: "95th Latency", unit: "ms", value: .percentile95},
                           {name: "99th Latency", unit: "ms", value: .percentile99}]' ${PRODUCER_RESULT} > ${DIR}/producer.json
   done


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Added rate rps and rate mips to the results to have more info about how producer performs.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
