### PR TITLE
Push the knowledge of where to consume encrypted records from down.

### DIFF
--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/steps/KroxyliciousSteps.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/steps/KroxyliciousSteps.java
@@ -47,16 +47,19 @@ public class KroxyliciousSteps {
     }
 
     /**
-     * Consume encrypted messages.
+     * Kroxylicious will decrypt the message so to consume an encrypted message we need to read from the underlying Kafka cluster.
      *
-     * @param namespace the namespace
+     * @param clientNamespace where to run the client job
      * @param topicName the topic name
-     * @param bootstrap the bootstrap
+     * @param kafkaClusterName the name of the kafka cluster to read from
+     * @param kafkaNamespace the namespace in which the broker is operating
      * @param numberOfMessages the number of messages
      * @param timeout the timeout
      * @return the string
      */
-    public static String consumeEncryptedMessages(String namespace, String topicName, String bootstrap, int numberOfMessages, Duration timeout) {
-        return KafkaUtils.consumeEncryptedMessageWithTestClients(namespace, topicName, bootstrap, numberOfMessages, timeout);
+    public static String consumeEncryptedMessages(String clientNamespace, String topicName, String kafkaClusterName, String kafkaNamespace, int numberOfMessages,
+                                                  Duration timeout) {
+        String kafkaBootstrap = kafkaClusterName + "-kafka-bootstrap." + kafkaNamespace + ".svc.cluster.local:9092";
+        return KafkaUtils.consumeEncryptedMessageWithTestClients(clientNamespace, topicName, kafkaBootstrap, numberOfMessages, timeout);
     }
 }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/steps/KroxyliciousSteps.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/steps/KroxyliciousSteps.java
@@ -54,12 +54,13 @@ public class KroxyliciousSteps {
      * @param kafkaClusterName the name of the kafka cluster to read from
      * @param kafkaNamespace the namespace in which the broker is operating
      * @param numberOfMessages the number of messages
-     * @param timeout the timeout
+     * @param timeout maximum time to wait for the expectedMessage to appear
+     * @param expectedMessage the message to check for.
      * @return the string
      */
-    public static String consumeEncryptedMessages(String clientNamespace, String topicName, String kafkaClusterName, String kafkaNamespace, int numberOfMessages,
-                                                  Duration timeout) {
+    public static String consumeMessageFromKafkaCluster(String clientNamespace, String topicName, String kafkaClusterName, String kafkaNamespace, int numberOfMessages,
+                                                        Duration timeout, String expectedMessage) {
         String kafkaBootstrap = kafkaClusterName + "-kafka-bootstrap." + kafkaNamespace + ".svc.cluster.local:9092";
-        return KafkaUtils.consumeEncryptedMessageWithTestClients(clientNamespace, topicName, kafkaBootstrap, numberOfMessages, timeout);
+        return KafkaUtils.consumeMessageWithTestClients(clientNamespace, topicName, kafkaBootstrap, expectedMessage, numberOfMessages, timeout);
     }
 }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
@@ -94,22 +94,6 @@ public class KafkaUtils {
     }
 
     /**
-     * Consume encrypted message with test clients.
-     *
-     * @param deployNamespace the deploy namespace
-     * @param topicName the topic name
-     * @param bootstrap the bootstrap
-     * @param numOfMessages the num of messages
-     * @param timeout the timeout
-     * @return the string
-     */
-    public static String consumeEncryptedMessageWithTestClients(String deployNamespace, String topicName, String bootstrap, int numOfMessages, Duration timeout) {
-        String name = Constants.KAFKA_CONSUMER_CLIENT_LABEL;
-        Job testClientJob = TestClientsJobTemplates.defaultTestClientConsumerJob(name, bootstrap, topicName, numOfMessages).build();
-        return consumeMessages(topicName, name, deployNamespace, testClientJob, "key: kroxylicious.io/encryption", timeout);
-    }
-
-    /**
      * Gets pod name by label.
      *
      * @param deployNamespace the deploy namespace

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/RecordEncryptionST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/RecordEncryptionST.java
@@ -105,8 +105,7 @@ class RecordEncryptionST extends AbstractST {
         KroxyliciousSteps.produceMessages(namespace, topicName, bootstrap, MESSAGE, numberOfMessages);
 
         LOGGER.atInfo().setMessage("Then the messages are consumed").log();
-        String kafkaBootstrap = clusterName + "-kafka-bootstrap." + Constants.KAFKA_DEFAULT_NAMESPACE + ".svc.cluster.local:9092";
-        String resultEncrypted = KroxyliciousSteps.consumeEncryptedMessages(namespace, topicName, kafkaBootstrap, numberOfMessages, Duration.ofMinutes(2));
+        String resultEncrypted = KroxyliciousSteps.consumeEncryptedMessages(namespace, topicName, clusterName, Constants.KAFKA_DEFAULT_NAMESPACE, numberOfMessages, Duration.ofMinutes(2));
         LOGGER.atInfo().setMessage("Received: {}").addArgument(resultEncrypted).log();
         assertThat(resultEncrypted)
                 .withFailMessage("expected message have not been received!")

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/RecordEncryptionST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/RecordEncryptionST.java
@@ -105,7 +105,8 @@ class RecordEncryptionST extends AbstractST {
         KroxyliciousSteps.produceMessages(namespace, topicName, bootstrap, MESSAGE, numberOfMessages);
 
         LOGGER.atInfo().setMessage("Then the messages are consumed").log();
-        String resultEncrypted = KroxyliciousSteps.consumeEncryptedMessages(namespace, topicName, clusterName, Constants.KAFKA_DEFAULT_NAMESPACE, numberOfMessages, Duration.ofMinutes(2));
+        String resultEncrypted = KroxyliciousSteps.consumeEncryptedMessages(namespace, topicName, clusterName, Constants.KAFKA_DEFAULT_NAMESPACE, numberOfMessages,
+                Duration.ofMinutes(2));
         LOGGER.atInfo().setMessage("Received: {}").addArgument(resultEncrypted).log();
         assertThat(resultEncrypted)
                 .withFailMessage("expected message have not been received!")

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/RecordEncryptionST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/RecordEncryptionST.java
@@ -105,8 +105,8 @@ class RecordEncryptionST extends AbstractST {
         KroxyliciousSteps.produceMessages(namespace, topicName, bootstrap, MESSAGE, numberOfMessages);
 
         LOGGER.atInfo().setMessage("Then the messages are consumed").log();
-        String resultEncrypted = KroxyliciousSteps.consumeEncryptedMessages(namespace, topicName, clusterName, Constants.KAFKA_DEFAULT_NAMESPACE, numberOfMessages,
-                Duration.ofMinutes(2));
+        String resultEncrypted = KroxyliciousSteps.consumeMessageFromKafkaCluster(namespace, topicName, clusterName, Constants.KAFKA_DEFAULT_NAMESPACE, numberOfMessages,
+                Duration.ofMinutes(2), "key: kroxylicious.io/encryption");
         LOGGER.atInfo().setMessage("Received: {}").addArgument(resultEncrypted).log();
         assertThat(resultEncrypted)
                 .withFailMessage("expected message have not been received!")


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

Consuming messages from the underlying cluster should be a standard option for tests. So lets change the API to do the customisations for us rather than just passing a bootstrap from the tests.

### Additional Context

I was looking at adding additional test coverage for encrypting record keys.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [X] Write tests
- [X] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [X] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
