### PR TITLE
Add an optional message key when producing messages in system tests

### DIFF
--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/KafClient.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/KafClient.java
@@ -7,7 +7,9 @@
 package io.kroxylicious.systemtests.clients;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,6 +20,8 @@ import io.kroxylicious.systemtests.Constants;
 import io.kroxylicious.systemtests.enums.KafkaClientType;
 import io.kroxylicious.systemtests.templates.testclients.TestClientsJobTemplates;
 import io.kroxylicious.systemtests.utils.KafkaUtils;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import static io.kroxylicious.systemtests.k8s.KubeClusterResource.cmdKubeClient;
 import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
@@ -43,13 +47,20 @@ public class KafClient implements KafkaClient {
     }
 
     @Override
-    public void produceMessages(String topicName, String bootstrap, String message, int numOfMessages) {
+    public void produceMessages(String topicName, String bootstrap, String message, @Nullable String messageKey, int numOfMessages) {
         LOGGER.atInfo().setMessage("Producing messages in '{}' topic using kaf").addArgument(topicName).log();
+        final Optional<String> recordKey = Optional.ofNullable(messageKey);
         String name = Constants.KAFKA_PRODUCER_CLIENT_LABEL + "-kaf";
-        List<String> executableCommand = List.of(cmdKubeClient(deployNamespace).toString(), "run", "-i",
+
+        List<String> executableCommand = new ArrayList<>(List.of(cmdKubeClient(deployNamespace).toString(), "run", "-i",
                 "-n", deployNamespace, name,
                 "--image=" + Constants.KAF_CLIENT_IMAGE,
-                "--", "kaf", "-n", String.valueOf(numOfMessages), "-b", bootstrap, "produce", topicName);
+                "--", "kaf", "-n", String.valueOf(numOfMessages), "-b", bootstrap, "produce", topicName));
+        recordKey.ifPresent(key -> {
+            executableCommand.add("--key");
+            executableCommand.add(key);
+        });
+        executableCommand.addAll(List.of("produce", topicName));
 
         KafkaUtils.produceMessagesWithCmd(deployNamespace, executableCommand, message, name, KafkaClientType.KAF.name().toLowerCase());
     }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/KafkaClient.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/KafkaClient.java
@@ -10,6 +10,8 @@ import java.time.Duration;
 
 import io.kroxylicious.systemtests.k8s.exception.KubeClusterException;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 /**
  * The interface Kafka client.
  */
@@ -30,7 +32,20 @@ public interface KafkaClient {
      * @param message the message
      * @param numOfMessages the num of messages
      */
-    void produceMessages(String topicName, String bootstrap, String message, int numOfMessages) throws KubeClusterException;
+    default void produceMessages(String topicName, String bootstrap, String message, int numOfMessages) throws KubeClusterException {
+        produceMessages(topicName, bootstrap, message, null, numOfMessages);
+    }
+
+    /**
+     * Produce messages.
+     *
+     * @param topicName the topic name
+     * @param bootstrap the bootstrap
+     * @param message the message
+     * @param messageKey optional record key for the message. <code>null</code> means don't specify a key
+     * @param numOfMessages the num of messages
+     */
+    void produceMessages(String topicName, String bootstrap, String message, @Nullable String messageKey, int numOfMessages) throws KubeClusterException;
 
     /**
      * Consume messages.

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/KcatClient.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/KcatClient.java
@@ -7,7 +7,9 @@
 package io.kroxylicious.systemtests.clients;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,6 +20,8 @@ import io.kroxylicious.systemtests.Constants;
 import io.kroxylicious.systemtests.enums.KafkaClientType;
 import io.kroxylicious.systemtests.templates.testclients.TestClientsJobTemplates;
 import io.kroxylicious.systemtests.utils.KafkaUtils;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import static io.kroxylicious.systemtests.k8s.KubeClusterResource.cmdKubeClient;
 import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
@@ -43,18 +47,25 @@ public class KcatClient implements KafkaClient {
     }
 
     @Override
-    public void produceMessages(String topicName, String bootstrap, String message, int numOfMessages) {
+    public void produceMessages(String topicName, String bootstrap, String message, @Nullable String messageKey, int numOfMessages) {
+        final Optional<String> recordKey = Optional.ofNullable(messageKey);
+
         StringBuilder msg = new StringBuilder();
         for (int i = 0; i < numOfMessages; i++) {
-            msg.append(message + " - " + i + "\n");
+            recordKey.ifPresent(k -> msg.append(k).append(":"));
+            msg.append(message)
+                    .append(" - ")
+                    .append(i)
+                    .append("\n");
         }
 
         LOGGER.atInfo().setMessage("Producing messages in '{}' topic using kcat").addArgument(topicName).log();
         String name = Constants.KAFKA_PRODUCER_CLIENT_LABEL + "-kcat";
-        List<String> executableCommand = List.of(cmdKubeClient(deployNamespace).toString(), "run", "-i",
+        List<String> executableCommand = new ArrayList<>(List.of(cmdKubeClient(deployNamespace).toString(), "run", "-i",
                 "-n", deployNamespace, name,
                 "--image=" + Constants.KCAT_CLIENT_IMAGE,
-                "--", "-b", bootstrap, "-l", "-t", topicName, "-P");
+                "--", "-b", bootstrap, "-l", "-t", topicName, "-P"));
+        recordKey.ifPresent(ignored -> executableCommand.add("-K :"));
 
         KafkaUtils.produceMessagesWithCmd(deployNamespace, executableCommand, String.valueOf(msg), name, KafkaClientType.KCAT.name().toLowerCase());
     }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/StrimziTestClient.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/StrimziTestClient.java
@@ -7,6 +7,9 @@
 package io.kroxylicious.systemtests.clients;
 
 import java.time.Duration;
+import java.util.Optional;
+
+import org.slf4j.Logger;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,7 +20,10 @@ import io.kroxylicious.systemtests.Constants;
 import io.kroxylicious.systemtests.templates.testclients.TestClientsJobTemplates;
 import io.kroxylicious.systemtests.utils.KafkaUtils;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
+import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * The type Strimzi Test client (java client based CLI).
@@ -25,6 +31,7 @@ import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
 public class StrimziTestClient implements KafkaClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(StrimziTestClient.class);
     private String deployNamespace;
+    private final Logger log = getLogger(StrimziTestClient.class);
 
     /**
      * Instantiates a new Strimzi Test client.
@@ -40,8 +47,9 @@ public class StrimziTestClient implements KafkaClient {
     }
 
     @Override
-    public void produceMessages(String topicName, String bootstrap, String message, int numOfMessages) {
+    public void produceMessages(String topicName, String bootstrap, String message, @Nullable String messageKey, int numOfMessages) {
         LOGGER.atInfo().log("Producing messages using Strimzi Test Client");
+        Optional.ofNullable(messageKey).ifPresent(k -> log.warn("message key specified but its not supported by Strimzi Test Clients"));
         String name = Constants.KAFKA_PRODUCER_CLIENT_LABEL;
         Job testClientJob = TestClientsJobTemplates.defaultTestClientProducerJob(name, bootstrap, topicName, numOfMessages, message).build();
         KafkaUtils.produceMessages(deployNamespace, topicName, name, testClientJob);

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/StrimziTestClient.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/StrimziTestClient.java
@@ -7,9 +7,6 @@
 package io.kroxylicious.systemtests.clients;
 
 import java.time.Duration;
-import java.util.Optional;
-
-import org.slf4j.Logger;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,7 +20,6 @@ import io.kroxylicious.systemtests.utils.KafkaUtils;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
-import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * The type Strimzi Test client (java client based CLI).
@@ -31,7 +27,6 @@ import static org.slf4j.LoggerFactory.getLogger;
 public class StrimziTestClient implements KafkaClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(StrimziTestClient.class);
     private String deployNamespace;
-    private final Logger log = getLogger(StrimziTestClient.class);
 
     /**
      * Instantiates a new Strimzi Test client.
@@ -49,9 +44,8 @@ public class StrimziTestClient implements KafkaClient {
     @Override
     public void produceMessages(String topicName, String bootstrap, String message, @Nullable String messageKey, int numOfMessages) {
         LOGGER.atInfo().log("Producing messages using Strimzi Test Client");
-        Optional.ofNullable(messageKey).ifPresent(k -> log.warn("message key specified but its not supported by Strimzi Test Clients"));
         String name = Constants.KAFKA_PRODUCER_CLIENT_LABEL;
-        Job testClientJob = TestClientsJobTemplates.defaultTestClientProducerJob(name, bootstrap, topicName, numOfMessages, message).build();
+        Job testClientJob = TestClientsJobTemplates.defaultTestClientProducerJob(name, bootstrap, topicName, numOfMessages, message, messageKey).build();
         KafkaUtils.produceMessages(deployNamespace, topicName, name, testClientJob);
     }
 

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/testclients/TestClientsJobTemplates.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/testclients/TestClientsJobTemplates.java
@@ -199,8 +199,7 @@ public class TestClientsJobTemplates {
                 envVar(MESSAGE_VAR, message),
                 envVar(PRODUCER_ACKS_VAR, "all"),
                 envVar(LOG_LEVEL_VAR, "INFO"),
-                envVar(CLIENT_TYPE_VAR, "KafkaProducer"))
-        );
+                envVar(CLIENT_TYPE_VAR, "KafkaProducer")));
         if (messageKey != null) {
             envVars.add(envVar(MESSAGE_KEY_VAR, messageKey));
         }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/testclients/TestClientsJobTemplates.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/testclients/TestClientsJobTemplates.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.systemtests.templates.testclients;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -16,6 +17,8 @@ import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 
 import io.kroxylicious.systemtests.Constants;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 /**
  * The type Test Clients job templates.
  */
@@ -23,6 +26,7 @@ public class TestClientsJobTemplates {
     private static final String BOOTSTRAP_VAR = "BOOTSTRAP_SERVERS";
     private static final String TOPIC_VAR = "TOPIC";
     private static final String MESSAGE_VAR = "MESSAGE";
+    private static final String MESSAGE_KEY_VAR = "MESSAGE_KEY";
     private static final String MESSAGE_COUNT_VAR = "MESSAGE_COUNT";
     private static final String GROUP_ID_VAR = "GROUP_ID";
     private static final String LOG_LEVEL_VAR = "LOG_LEVEL";
@@ -90,13 +94,15 @@ public class TestClientsJobTemplates {
      * @param topicName the topic name
      * @param numOfMessages the num of messages
      * @param message the message
+     * @param messageKey
      * @return the job builder
      */
-    public static JobBuilder defaultTestClientProducerJob(String jobName, String bootstrap, String topicName, int numOfMessages, String message) {
+    public static JobBuilder defaultTestClientProducerJob(String jobName, String bootstrap, String topicName, int numOfMessages, String message,
+                                                          @Nullable String messageKey) {
         return newJobForContainer(jobName,
                 "test-client-producer",
                 Constants.TEST_CLIENTS_IMAGE,
-                testClientsProducerEnvVars(bootstrap, topicName, numOfMessages, message));
+                testClientsProducerEnvVars(bootstrap, topicName, numOfMessages, message, messageKey));
     }
 
     private static JobBuilder newJobForContainer(String jobName, String containerName, String image, List<EnvVar> envVars) {
@@ -184,8 +190,8 @@ public class TestClientsJobTemplates {
                 .build();
     }
 
-    private static List<EnvVar> testClientsProducerEnvVars(String bootstrap, String topicName, int numOfMessages, String message) {
-        return List.of(
+    private static List<EnvVar> testClientsProducerEnvVars(String bootstrap, String topicName, int numOfMessages, String message, @Nullable String messageKey) {
+        List<EnvVar> envVars = new ArrayList<>(List.of(
                 envVar(BOOTSTRAP_VAR, bootstrap),
                 envVar(DELAY_MS_VAR, "500"),
                 envVar(TOPIC_VAR, topicName),
@@ -193,7 +199,12 @@ public class TestClientsJobTemplates {
                 envVar(MESSAGE_VAR, message),
                 envVar(PRODUCER_ACKS_VAR, "all"),
                 envVar(LOG_LEVEL_VAR, "INFO"),
-                envVar(CLIENT_TYPE_VAR, "KafkaProducer"));
+                envVar(CLIENT_TYPE_VAR, "KafkaProducer"))
+        );
+        if (messageKey != null) {
+            envVars.add(envVar(MESSAGE_KEY_VAR, messageKey));
+        }
+        return envVars;
     }
 
     private static List<EnvVar> testClientsConsumerEnvVars(String bootstrap, String topicName, int numOfMessages) {

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
@@ -155,7 +155,7 @@ public class KafkaUtils {
      */
     public static void produceMessageWithTestClients(String deployNamespace, String topicName, String bootstrap, String message, int numOfMessages) {
         String name = Constants.KAFKA_PRODUCER_CLIENT_LABEL;
-        Job testClientJob = TestClientsJobTemplates.defaultTestClientProducerJob(name, bootstrap, topicName, numOfMessages, message).build();
+        Job testClientJob = TestClientsJobTemplates.defaultTestClientProducerJob(name, bootstrap, topicName, numOfMessages, message, null).build();
         produceMessages(deployNamespace, topicName, name, testClientJob);
     }
 


### PR DESCRIPTION


### Type of change

- Enhancement / new feature

### Description

Adds support to (most) of the Kafka clients to include a message key when producing records. 

### Additional Context

For the Record Key encryption work we need the ability to specify the record key when producing messages. 

I think it would require work in Strimzi test clients to support message keys (I don't think it would be too hard)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
