### PR TITLE
adapt framework to use KAFKA_CLIENT for system tests

### DIFF
--- a/kroxylicious-systemtests/pom.xml
+++ b/kroxylicious-systemtests/pom.xml
@@ -132,6 +132,10 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/KafClient.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/KafClient.java
@@ -15,9 +15,7 @@ import org.slf4j.LoggerFactory;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 
 import io.kroxylicious.systemtests.Constants;
-import io.kroxylicious.systemtests.executor.Exec;
-import io.kroxylicious.systemtests.executor.ExecResult;
-import io.kroxylicious.systemtests.k8s.exception.KubeClusterException;
+import io.kroxylicious.systemtests.enums.KafkaClientType;
 import io.kroxylicious.systemtests.templates.testclients.TestClientsJobTemplates;
 import io.kroxylicious.systemtests.utils.KafkaUtils;
 
@@ -53,17 +51,7 @@ public class KafClient implements KafkaClient {
                 "--image=" + Constants.KAF_CLIENT_IMAGE,
                 "--", "kaf", "-n", String.valueOf(numOfMessages), "-b", bootstrap, "produce", topicName);
 
-        LOGGER.atInfo().setMessage("Executing command: {} for running kaf producer").addArgument(executableCommand).log();
-        ExecResult result = Exec.exec(message, executableCommand, Duration.ofSeconds(30), true, false, null);
-
-        String log = kubeClient().logsInSpecificNamespace(deployNamespace, name);
-        if (result.isSuccess()) {
-            LOGGER.atInfo().setMessage("kaf client produce log: {}").addArgument(log).log();
-        }
-        else {
-            LOGGER.atError().setMessage("error producing messages with kaf: {}").addArgument(log).log();
-            throw new KubeClusterException("error producing messages with kaf: " + log);
-        }
+        KafkaUtils.produceMessagesWithCmd(deployNamespace, executableCommand, message, name, KafkaClientType.KAF.name().toLowerCase());
     }
 
     @Override

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/KafClient.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/KafClient.java
@@ -71,6 +71,6 @@ public class KafClient implements KafkaClient {
         String name = Constants.KAFKA_CONSUMER_CLIENT_LABEL + "-kafka-go";
         List<String> args = List.of("kaf", "-b", bootstrap, "consume", topicName);
         Job goClientJob = TestClientsJobTemplates.defaultKafkaGoConsumerJob(name, args).build();
-        return KafkaUtils.consumeMessages(topicName, name, deployNamespace, goClientJob, messageToCheck, timeout);
+        return KafkaUtils.consumeMessages(topicName, name, deployNamespace, goClientJob, messageToCheck, numOfMessages, timeout);
     }
 }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/KafClient.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/KafClient.java
@@ -68,6 +68,7 @@ public class KafClient implements KafkaClient {
 
     @Override
     public String consumeMessages(String topicName, String bootstrap, String messageToCheck, int numOfMessages, Duration timeout) {
+        LOGGER.atInfo().log("Consuming messages using kaf");
         String name = Constants.KAFKA_CONSUMER_CLIENT_LABEL + "-kafka-go";
         List<String> args = List.of("kaf", "-b", bootstrap, "consume", topicName);
         Job goClientJob = TestClientsJobTemplates.defaultKafkaGoConsumerJob(name, args).build();

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/KcatClient.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/KcatClient.java
@@ -73,6 +73,7 @@ public class KcatClient implements KafkaClient {
 
     @Override
     public String consumeMessages(String topicName, String bootstrap, String messageToCheck, int numOfMessages, Duration timeout) {
+        LOGGER.atInfo().log("Consuming messages using kcat");
         String name = Constants.KAFKA_CONSUMER_CLIENT_LABEL + "-kcat";
         List<String> args = List.of("-b", bootstrap, "-t", topicName, "-C", "-c" + numOfMessages);
         Job kCatClientJob = TestClientsJobTemplates.defaultKcatJob(name, args).build();

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/KcatClient.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/KcatClient.java
@@ -76,6 +76,6 @@ public class KcatClient implements KafkaClient {
         String name = Constants.KAFKA_CONSUMER_CLIENT_LABEL + "-kcat";
         List<String> args = List.of("-b", bootstrap, "-t", topicName, "-C", "-c" + numOfMessages);
         Job kCatClientJob = TestClientsJobTemplates.defaultKcatJob(name, args).build();
-        return KafkaUtils.consumeMessages(topicName, name, deployNamespace, kCatClientJob, messageToCheck, timeout);
+        return KafkaUtils.consumeMessages(topicName, name, deployNamespace, kCatClientJob, messageToCheck, numOfMessages, timeout);
     }
 }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/KcatClient.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/KcatClient.java
@@ -15,9 +15,7 @@ import org.slf4j.LoggerFactory;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 
 import io.kroxylicious.systemtests.Constants;
-import io.kroxylicious.systemtests.executor.Exec;
-import io.kroxylicious.systemtests.executor.ExecResult;
-import io.kroxylicious.systemtests.k8s.exception.KubeClusterException;
+import io.kroxylicious.systemtests.enums.KafkaClientType;
 import io.kroxylicious.systemtests.templates.testclients.TestClientsJobTemplates;
 import io.kroxylicious.systemtests.utils.KafkaUtils;
 
@@ -58,17 +56,7 @@ public class KcatClient implements KafkaClient {
                 "--image=" + Constants.KCAT_CLIENT_IMAGE,
                 "--", "-b", bootstrap, "-l", "-t", topicName, "-P");
 
-        LOGGER.atInfo().setMessage("Executing command: {} for running kcat producer").addArgument(executableCommand).log();
-        ExecResult result = Exec.exec(String.valueOf(msg), executableCommand, Duration.ofSeconds(30), true, false, null);
-
-        String log = kubeClient().logsInSpecificNamespace(deployNamespace, name);
-        if (result.isSuccess()) {
-            LOGGER.atInfo().setMessage("kcat client produce log: {}").addArgument(log).log();
-        }
-        else {
-            LOGGER.atError().setMessage("error producing messages with kcat: {}").addArgument(log).log();
-            throw new KubeClusterException("error producing messages with kcat: " + log);
-        }
+        KafkaUtils.produceMessagesWithCmd(deployNamespace, executableCommand, String.valueOf(msg), name, KafkaClientType.KCAT.name().toLowerCase());
     }
 
     @Override

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/StrimziTestClient.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/StrimziTestClient.java
@@ -8,6 +8,9 @@ package io.kroxylicious.systemtests.clients;
 
 import java.time.Duration;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 
 import io.kroxylicious.systemtests.Constants;
@@ -20,6 +23,7 @@ import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
  * The type Strimzi Test client (java client based CLI).
  */
 public class StrimziTestClient implements KafkaClient {
+    private static final Logger LOGGER = LoggerFactory.getLogger(StrimziTestClient.class);
     private String deployNamespace;
 
     /**
@@ -37,6 +41,7 @@ public class StrimziTestClient implements KafkaClient {
 
     @Override
     public void produceMessages(String topicName, String bootstrap, String message, int numOfMessages) {
+        LOGGER.atInfo().log("Producing messages using Strimzi Test Client");
         String name = Constants.KAFKA_PRODUCER_CLIENT_LABEL;
         Job testClientJob = TestClientsJobTemplates.defaultTestClientProducerJob(name, bootstrap, topicName, numOfMessages, message).build();
         KafkaUtils.produceMessages(deployNamespace, topicName, name, testClientJob);
@@ -44,6 +49,7 @@ public class StrimziTestClient implements KafkaClient {
 
     @Override
     public String consumeMessages(String topicName, String bootstrap, String messageToCheck, int numOfMessages, Duration timeout) {
+        LOGGER.atInfo().log("Consuming messages using Strimzi Test Client");
         String name = Constants.KAFKA_CONSUMER_CLIENT_LABEL;
         Job testClientJob = TestClientsJobTemplates.defaultTestClientConsumerJob(name, bootstrap, topicName, numOfMessages).build();
         return KafkaUtils.consumeMessages(topicName, name, deployNamespace, testClientJob, messageToCheck, numOfMessages, timeout);

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/StrimziTestClient.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/StrimziTestClient.java
@@ -46,6 +46,6 @@ public class StrimziTestClient implements KafkaClient {
     public String consumeMessages(String topicName, String bootstrap, String messageToCheck, int numOfMessages, Duration timeout) {
         String name = Constants.KAFKA_CONSUMER_CLIENT_LABEL;
         Job testClientJob = TestClientsJobTemplates.defaultTestClientConsumerJob(name, bootstrap, topicName, numOfMessages).build();
-        return KafkaUtils.consumeMessages(topicName, name, deployNamespace, testClientJob, messageToCheck, timeout);
+        return KafkaUtils.consumeMessages(topicName, name, deployNamespace, testClientJob, messageToCheck, numOfMessages, timeout);
     }
 }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/steps/KroxyliciousSteps.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/steps/KroxyliciousSteps.java
@@ -8,6 +8,7 @@ package io.kroxylicious.systemtests.steps;
 
 import java.time.Duration;
 
+import io.kroxylicious.systemtests.clients.KafkaClients;
 import io.kroxylicious.systemtests.utils.KafkaUtils;
 
 /**
@@ -28,7 +29,7 @@ public class KroxyliciousSteps {
      * @param numberOfMessages the number of messages
      */
     public static void produceMessages(String namespace, String topicName, String bootstrap, String message, int numberOfMessages) {
-        KafkaUtils.produceMessageWithTestClients(namespace, topicName, bootstrap, message, numberOfMessages);
+        KafkaClients.getKafkaClient().inNamespace(namespace).produceMessages(topicName, bootstrap, message, numberOfMessages);
     }
 
     /**
@@ -43,7 +44,7 @@ public class KroxyliciousSteps {
      * @return the string
      */
     public static String consumeMessages(String namespace, String topicName, String bootstrap, String message, int numberOfMessages, Duration timeout) {
-        return KafkaUtils.consumeMessageWithTestClients(namespace, topicName, bootstrap, message, numberOfMessages, timeout);
+        return KafkaClients.getKafkaClient().inNamespace(namespace).consumeMessages(topicName, bootstrap, message, numberOfMessages, timeout);
     }
 
     /**

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
@@ -157,7 +157,7 @@ public class DeploymentUtils {
      */
     public static void waitForDeploymentRunning(String namespaceName, String podName, Duration timeout) {
         LOGGER.info("Waiting for deployment: {}/{} to be running", namespaceName, podName);
-        await().atMost(timeout).pollInterval(Duration.ofMillis(200))
+        await().atMost(timeout).pollInterval(Duration.ofMillis(500))
                 .until(() -> kubeClient().getPod(namespaceName, podName) != null
                         && kubeClient().isDeploymentRunning(namespaceName, podName));
     }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
@@ -227,7 +227,7 @@ public class DeploymentUtils {
     private record TimeoutLoggingEvaluationListener(Supplier<String> messageSupplier) implements ConditionEvaluationListener<PodStatus> {
         @Override
         public void onTimeout(TimeoutEvent timeoutEvent) {
-            LOGGER.atError().setMessage("Run failed! Error: {}").addArgument(messageSupplier).log();
+            LOGGER.atError().setMessage("Timeout! Error: {}").addArgument(messageSupplier).log();
         }
 
         @Override

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
@@ -69,7 +69,7 @@ public class KafkaUtils {
         kubeClient().getClient().batch().v1().jobs().inNamespace(namespace).resource(clientJob).create();
         String podName = KafkaUtils.getPodNameByLabel(namespace, "app", name, Duration.ofSeconds(30));
         String log;
-        try{
+        try {
             log = await().alias("Consumer waiting to receive messages")
                     .ignoreException(KubernetesClientException.class)
                     .atMost(timeout)

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/KroxyliciousST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/KroxyliciousST.java
@@ -9,6 +9,7 @@ package io.kroxylicious.systemtests;
 import java.time.Duration;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,7 +49,6 @@ class KroxyliciousST extends AbstractST {
     @Test
     void produceAndConsumeMessage(String namespace) {
         int numberOfMessages = 1;
-        String expectedMessage = MESSAGE + " - " + (numberOfMessages - 1);
 
         // start Kroxylicious
         LOGGER.atInfo().setMessage("Given Kroxylicious in {} namespace with {} replicas").addArgument(namespace).addArgument(1).log();
@@ -63,10 +63,10 @@ class KroxyliciousST extends AbstractST {
         KroxyliciousSteps.produceMessages(namespace, topicName, bootstrap, MESSAGE, numberOfMessages);
 
         LOGGER.atInfo().setMessage("Then the messages are consumed").log();
-        String result = KroxyliciousSteps.consumeMessages(namespace, topicName, bootstrap, expectedMessage, numberOfMessages, Duration.ofMinutes(2));
+        String result = KroxyliciousSteps.consumeMessages(namespace, topicName, bootstrap, MESSAGE, numberOfMessages, Duration.ofMinutes(2));
         LOGGER.atInfo().setMessage("Received: {}").addArgument(result).log();
 
-        assertThat(result).withFailMessage("expected message have not been received!").contains(expectedMessage);
+        assertThat(StringUtils.countMatches(result, MESSAGE)).withFailMessage("expected messages have not been received!").isEqualTo(numberOfMessages);
     }
 
     /**
@@ -77,7 +77,6 @@ class KroxyliciousST extends AbstractST {
     @Test
     void restartKafkaBrokers(String namespace) {
         int numberOfMessages = 25;
-        String expectedMessage = MESSAGE + " - " + (numberOfMessages - 1);
 
         // start Kroxylicious
         LOGGER.atInfo().setMessage("Given Kroxylicious in {} namespace with {} replicas").addArgument(namespace).addArgument(1).log();
@@ -94,9 +93,9 @@ class KroxyliciousST extends AbstractST {
         KafkaSteps.restartKafkaBroker(clusterName);
 
         LOGGER.atInfo().setMessage("Then the messages are consumed").log();
-        String result = KroxyliciousSteps.consumeMessages(namespace, topicName, bootstrap, expectedMessage, numberOfMessages, Duration.ofMinutes(10));
+        String result = KroxyliciousSteps.consumeMessages(namespace, topicName, bootstrap, MESSAGE, numberOfMessages, Duration.ofMinutes(10));
         LOGGER.atInfo().setMessage("Received: {}").addArgument(result).log();
-        assertThat(result).withFailMessage("expected message have not been received!").contains(expectedMessage);
+        assertThat(StringUtils.countMatches(result, MESSAGE)).withFailMessage("expected messages have not been received!").isEqualTo(numberOfMessages);
     }
 
     /**
@@ -108,7 +107,6 @@ class KroxyliciousST extends AbstractST {
     void kroxyWithReplicas(String namespace) {
         int numberOfMessages = 3;
         int replicas = 3;
-        String expectedMessage = MESSAGE + " - " + (numberOfMessages - 1);
 
         // start Kroxylicious
         LOGGER.atInfo().setMessage("Given Kroxylicious in {} namespace with {} replicas").addArgument(namespace).addArgument(replicas).log();
@@ -125,9 +123,9 @@ class KroxyliciousST extends AbstractST {
         KroxyliciousSteps.produceMessages(namespace, topicName, bootstrap, MESSAGE, numberOfMessages);
 
         LOGGER.atInfo().setMessage("Then the messages are consumed").log();
-        String result = KroxyliciousSteps.consumeMessages(namespace, topicName, bootstrap, expectedMessage, numberOfMessages, Duration.ofMinutes(2));
+        String result = KroxyliciousSteps.consumeMessages(namespace, topicName, bootstrap, MESSAGE, numberOfMessages, Duration.ofMinutes(2));
         LOGGER.atInfo().setMessage("Received: {}").addArgument(result).log();
-        assertThat(result).withFailMessage("expected message have not been received!").contains(expectedMessage);
+        assertThat(StringUtils.countMatches(result, MESSAGE)).withFailMessage("expected messages have not been received!").isEqualTo(numberOfMessages);
     }
 
     @Test
@@ -144,7 +142,6 @@ class KroxyliciousST extends AbstractST {
 
     private void scaleKroxylicious(String namespace, int replicas, int scaleTo) {
         int numberOfMessages = 10;
-        String expectedMessage = MESSAGE + " - " + (numberOfMessages - 1);
 
         // start Kroxylicious
         LOGGER.atInfo().setMessage("Given Kroxylicious in {} namespace with {} replicas").addArgument(namespace).addArgument(replicas).log();
@@ -166,9 +163,9 @@ class KroxyliciousST extends AbstractST {
         assertThat(currentReplicas).withFailMessage("unexpected current scaled replicas").isEqualTo(scaleTo);
 
         LOGGER.atInfo().setMessage("Then the messages are consumed").log();
-        String result = KroxyliciousSteps.consumeMessages(namespace, topicName, bootstrap, expectedMessage, numberOfMessages, Duration.ofMinutes(2));
+        String result = KroxyliciousSteps.consumeMessages(namespace, topicName, bootstrap, MESSAGE, numberOfMessages, Duration.ofMinutes(2));
         LOGGER.atInfo().setMessage("Received: {}").addArgument(result).log();
-        assertThat(result).withFailMessage("expected message have not been received!").contains(expectedMessage);
+        assertThat(StringUtils.countMatches(result, MESSAGE)).withFailMessage("expected messages have not been received!").isEqualTo(numberOfMessages);
     }
 
     /**

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/MetricsST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/MetricsST.java
@@ -70,7 +70,7 @@ class MetricsST extends AbstractST {
         LOGGER.atInfo().setMessage("When {} messages '{}' are sent to the topic '{}'").addArgument(numberOfMessages).addArgument(MESSAGE).addArgument(topicName).log();
         KroxyliciousSteps.produceMessages(namespace, topicName, bootstrap, MESSAGE, numberOfMessages);
         LOGGER.atInfo().setMessage("Then the messages are consumed").log();
-        String result = KroxyliciousSteps.consumeMessages(namespace, topicName, bootstrap, expectedMessage, numberOfMessages, Duration.ofMinutes(2));
+        String result = KroxyliciousSteps.consumeMessages(namespace, topicName, bootstrap, MESSAGE, numberOfMessages, Duration.ofMinutes(2));
         LOGGER.atInfo().setMessage("Received: {}").addArgument(result).log();
         kroxyliciousCollector.collectMetricsFromPods();
         LOGGER.atInfo().setMessage("Metrics: {}").addArgument(kroxyliciousCollector.getCollectedData().values()).log();
@@ -91,7 +91,7 @@ class MetricsST extends AbstractST {
         LOGGER.atInfo().setMessage("When {} messages '{}' are sent to the topic '{}'").addArgument(numberOfMessages).addArgument(MESSAGE).addArgument(topicName).log();
         KroxyliciousSteps.produceMessages(namespace, topicName, bootstrap, MESSAGE, numberOfMessages);
         LOGGER.atInfo().setMessage("Then the messages are consumed").log();
-        String result = KroxyliciousSteps.consumeMessages(namespace, topicName, bootstrap, expectedMessage, numberOfMessages, Duration.ofMinutes(2));
+        String result = KroxyliciousSteps.consumeMessages(namespace, topicName, bootstrap, MESSAGE, numberOfMessages, Duration.ofMinutes(2));
         LOGGER.atInfo().setMessage("Received: {}").addArgument(result).log();
         kroxyliciousCollector.collectMetricsFromPods();
         LOGGER.atInfo().setMessage("Metrics: {}").addArgument(kroxyliciousCollector.getCollectedData().values()).log();

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/NonJVMClientsST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/NonJVMClientsST.java
@@ -9,6 +9,7 @@ package io.kroxylicious.systemtests;
 import java.time.Duration;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,16 +48,15 @@ class NonJVMClientsST extends AbstractST {
      */
     @Test
     void produceAndConsumeWithKcatClients(String namespace) {
-        int numOfMessages = 2;
-        String expectedMessage = MESSAGE + " - " + (numOfMessages - 1);
+        int numberOfMessages = 2;
         LOGGER.atInfo().setMessage("When the message '{}' is sent to the topic '{}'").addArgument(MESSAGE).addArgument(topicName).log();
-        KafkaClients.kcat().inNamespace(namespace).produceMessages(topicName, bootstrap, MESSAGE, numOfMessages);
+        KafkaClients.kcat().inNamespace(namespace).produceMessages(topicName, bootstrap, MESSAGE, numberOfMessages);
 
         LOGGER.atInfo().setMessage("Then the messages are consumed").log();
-        String result = KafkaClients.kcat().inNamespace(namespace).consumeMessages(topicName, bootstrap, expectedMessage, numOfMessages, Duration.ofMinutes(2));
+        String result = KafkaClients.kcat().inNamespace(namespace).consumeMessages(topicName, bootstrap, MESSAGE, numberOfMessages, Duration.ofMinutes(2));
         LOGGER.atInfo().setMessage("Received: {}").addArgument(result).log();
 
-        assertThat(result).withFailMessage("expected message have not been received!").contains(expectedMessage);
+        assertThat(StringUtils.countMatches(result, MESSAGE)).withFailMessage("expected messages have not been received!").isEqualTo(numberOfMessages);
     }
 
     /**
@@ -66,16 +66,15 @@ class NonJVMClientsST extends AbstractST {
      */
     @Test
     void produceAndConsumeWithKafkaGoClients(String namespace) {
-        int numOfMessages = 2;
-        String expectedMessage = MESSAGE;
+        int numberOfMessages = 2;
         LOGGER.atInfo().setMessage("When the message '{}' is sent to the topic '{}'").addArgument(MESSAGE).addArgument(topicName).log();
-        KafkaClients.kaf().inNamespace(namespace).produceMessages(topicName, bootstrap, MESSAGE, numOfMessages);
+        KafkaClients.kaf().inNamespace(namespace).produceMessages(topicName, bootstrap, MESSAGE, numberOfMessages);
 
         LOGGER.atInfo().setMessage("Then the messages are consumed").log();
-        String result = KafkaClients.kaf().inNamespace(namespace).consumeMessages(topicName, bootstrap, expectedMessage, numOfMessages, Duration.ofMinutes(2));
+        String result = KafkaClients.kaf().inNamespace(namespace).consumeMessages(topicName, bootstrap, MESSAGE, numberOfMessages, Duration.ofMinutes(2));
         LOGGER.atInfo().setMessage("Received: {}").addArgument(result).log();
 
-        assertThat(result).withFailMessage("expected message have not been received!").contains(expectedMessage);
+        assertThat(StringUtils.countMatches(result, MESSAGE)).withFailMessage("expected messages have not been received!").isEqualTo(numberOfMessages);
     }
 
     /**
@@ -85,17 +84,16 @@ class NonJVMClientsST extends AbstractST {
      */
     @Test
     void produceWithKcatAndConsumeWithTestClients(String namespace) {
-        int numOfMessages = 2;
-        String expectedMessage = MESSAGE + " - " + (numOfMessages - 1);
+        int numberOfMessages = 2;
         LOGGER.atInfo().setMessage("When the message '{}' is sent to the topic '{}'").addArgument(MESSAGE).addArgument(topicName).log();
-        KafkaClients.kcat().inNamespace(namespace).produceMessages(topicName, bootstrap, MESSAGE, numOfMessages);
+        KafkaClients.kcat().inNamespace(namespace).produceMessages(topicName, bootstrap, MESSAGE, numberOfMessages);
 
         LOGGER.atInfo().setMessage("Then the messages are consumed").log();
-        String result = KafkaClients.strimziTestClient().inNamespace(namespace).consumeMessages(topicName, bootstrap, expectedMessage, numOfMessages,
+        String result = KafkaClients.strimziTestClient().inNamespace(namespace).consumeMessages(topicName, bootstrap, MESSAGE, numberOfMessages,
                 Duration.ofMinutes(2));
         LOGGER.atInfo().setMessage("Received: {}").addArgument(result).log();
 
-        assertThat(result).withFailMessage("expected message have not been received!").contains(expectedMessage);
+        assertThat(StringUtils.countMatches(result, MESSAGE)).withFailMessage("expected messages have not been received!").isEqualTo(numberOfMessages);
     }
 
     /**
@@ -105,16 +103,15 @@ class NonJVMClientsST extends AbstractST {
      */
     @Test
     void produceWithTestClientsAndConsumeWithKcat(String namespace) {
-        int numOfMessages = 2;
-        String expectedMessage = MESSAGE + " - " + (numOfMessages - 1);
+        int numberOfMessages = 2;
         LOGGER.atInfo().setMessage("When the message '{}' is sent to the topic '{}'").addArgument(MESSAGE).addArgument(topicName).log();
-        KafkaClients.strimziTestClient().inNamespace(namespace).produceMessages(topicName, bootstrap, MESSAGE, numOfMessages);
+        KafkaClients.strimziTestClient().inNamespace(namespace).produceMessages(topicName, bootstrap, MESSAGE, numberOfMessages);
 
         LOGGER.atInfo().setMessage("Then the messages are consumed").log();
-        String result = KafkaClients.kcat().inNamespace(namespace).consumeMessages(topicName, bootstrap, expectedMessage, numOfMessages, Duration.ofMinutes(2));
+        String result = KafkaClients.kcat().inNamespace(namespace).consumeMessages(topicName, bootstrap, MESSAGE, numberOfMessages, Duration.ofMinutes(2));
         LOGGER.atInfo().setMessage("Received: {}").addArgument(result).log();
 
-        assertThat(result).withFailMessage("expected message have not been received!").contains(expectedMessage);
+        assertThat(StringUtils.countMatches(result, MESSAGE)).withFailMessage("expected messages have not been received!").isEqualTo(numberOfMessages);
     }
 
     /**
@@ -124,17 +121,16 @@ class NonJVMClientsST extends AbstractST {
      */
     @Test
     void produceWithKafkaGoAndConsumeWithTestClients(String namespace) {
-        int numOfMessages = 2;
-        String expectedMessage = MESSAGE;
+        int numberOfMessages = 2;
         LOGGER.atInfo().setMessage("When the message '{}' is sent to the topic '{}'").addArgument(MESSAGE).addArgument(topicName).log();
-        KafkaClients.kaf().inNamespace(namespace).produceMessages(topicName, bootstrap, MESSAGE, numOfMessages);
+        KafkaClients.kaf().inNamespace(namespace).produceMessages(topicName, bootstrap, MESSAGE, numberOfMessages);
 
         LOGGER.atInfo().setMessage("Then the messages are consumed").log();
-        String result = KafkaClients.strimziTestClient().inNamespace(namespace).consumeMessages(topicName, bootstrap, expectedMessage, numOfMessages,
+        String result = KafkaClients.strimziTestClient().inNamespace(namespace).consumeMessages(topicName, bootstrap, MESSAGE, numberOfMessages,
                 Duration.ofMinutes(2));
         LOGGER.atInfo().setMessage("Received: {}").addArgument(result).log();
 
-        assertThat(result).withFailMessage("expected message have not been received!").contains(expectedMessage);
+        assertThat(StringUtils.countMatches(result, MESSAGE)).withFailMessage("expected messages have not been received!").isEqualTo(numberOfMessages);
     }
 
     /**
@@ -144,16 +140,15 @@ class NonJVMClientsST extends AbstractST {
      */
     @Test
     void produceWithTestClientsAndConsumeWithKafkaGo(String namespace) {
-        int numOfMessages = 2;
-        String expectedMessage = MESSAGE + " - " + (numOfMessages - 1);
+        int numberOfMessages = 2;
         LOGGER.atInfo().setMessage("When the message '{}' is sent to the topic '{}'").addArgument(MESSAGE).addArgument(topicName).log();
-        KafkaClients.strimziTestClient().inNamespace(namespace).produceMessages(topicName, bootstrap, MESSAGE, numOfMessages);
+        KafkaClients.strimziTestClient().inNamespace(namespace).produceMessages(topicName, bootstrap, MESSAGE, numberOfMessages);
 
         LOGGER.atInfo().setMessage("Then the messages are consumed").log();
-        String result = KafkaClients.kaf().inNamespace(namespace).consumeMessages(topicName, bootstrap, expectedMessage, numOfMessages, Duration.ofMinutes(2));
+        String result = KafkaClients.kaf().inNamespace(namespace).consumeMessages(topicName, bootstrap, MESSAGE, numberOfMessages, Duration.ofMinutes(2));
         LOGGER.atInfo().setMessage("Received: {}").addArgument(result).log();
 
-        assertThat(result).withFailMessage("expected message have not been received!").contains(expectedMessage);
+        assertThat(StringUtils.countMatches(result, MESSAGE)).withFailMessage("expected messages have not been received!").isEqualTo(numberOfMessages);
     }
 
     @BeforeEach

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/RecordEncryptionST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/RecordEncryptionST.java
@@ -9,6 +9,7 @@ package io.kroxylicious.systemtests;
 import java.time.Duration;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -116,16 +117,13 @@ class RecordEncryptionST extends AbstractST {
     @Test
     void produceAndConsumeMessage(String namespace) {
         int numberOfMessages = 1;
-        String expectedMessage = MESSAGE + " - " + (numberOfMessages - 1);
 
         LOGGER.atInfo().setMessage("When {} messages '{}' are sent to the topic '{}'").addArgument(numberOfMessages).addArgument(MESSAGE).addArgument(topicName).log();
         KroxyliciousSteps.produceMessages(namespace, topicName, bootstrap, MESSAGE, numberOfMessages);
 
         LOGGER.atInfo().setMessage("Then the messages are consumed").log();
-        String result = KroxyliciousSteps.consumeMessages(namespace, topicName, bootstrap, expectedMessage, numberOfMessages, Duration.ofMinutes(2));
+        String result = KroxyliciousSteps.consumeMessages(namespace, topicName, bootstrap, MESSAGE, numberOfMessages, Duration.ofMinutes(2));
         LOGGER.atInfo().setMessage("Received: {}").addArgument(result).log();
-        assertThat(result)
-                .withFailMessage("expected message have not been received!")
-                .contains(expectedMessage);
+        assertThat(StringUtils.countMatches(result, MESSAGE)).withFailMessage("expected messages have not been received!").isEqualTo(numberOfMessages);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <commons.io.version>2.16.1</commons.io.version>
         <testcontainers.version>1.19.7</testcontainers.version>
         <bouncycastle.version>1.78.1</bouncycastle.version>
+        <apache.commons.version>3.14.0</apache.commons.version>
     </properties>
 
     <name>Parent POM</name>
@@ -356,6 +357,12 @@
                 <artifactId>bcprov-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
                 <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${apache.commons.version}</version>
+                <scope>compile</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

In order to be able to run all test suites for any of the supported kafka clients (librdkafka, sarama, strimzi-test-client) we need to adapt the framework to do so.
Also some improvements needed to be done:
* Taken into account `numberOfMessages` to stop consuming messages
* Do not throw an exception if the timeout is reached when consuming messages. The decision of the error must be done by the test case itself (we can perform error test cases).

### Additional Context

Part of #1167. Modifications into the strimzi-ci repo must be done to be able to run smoke tests for PRs and all test cases for each kafka client when merging the code.

### Checklist

- [X] Write tests
- [X] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
