### PR TITLE
Write all bytes from a byteBuffer in a single shot rather than iterating byte at a time

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/ByteBufAccessorImpl.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/ByteBufAccessorImpl.java
@@ -223,9 +223,7 @@ public class ByteBufAccessorImpl implements ByteBufAccessor {
 
     @Override
     public void writeByteBuffer(ByteBuffer byteBuffer) {
-        while (byteBuffer.hasRemaining()) {
-            buf.writeByte(byteBuffer.get());
-        }
+        buf.writeBytes(byteBuffer);
     }
 
     @Override


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

Write all bytes from a byteBuffer in a single shot rather than iterating byte at a time

### Additional Context

More low hanging fruit form #1181 flame graphs.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
