### PR TITLE
re-use the secureRandom between invocations of Aes.paramSupplier.

### DIFF
--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/Aes.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/Aes.java
@@ -27,11 +27,13 @@ public class Aes implements CipherManager {
     private final String transformation;
     private final byte serializedId;
     private final CipherSpec spec;
+    private final SecureRandom rng;
 
     private Aes(String transformation, byte serializedId, CipherSpec spec) {
         this.transformation = transformation;
         this.serializedId = serializedId;
         this.spec = spec;
+        rng = new SecureRandom();
     }
 
     @Override
@@ -61,7 +63,7 @@ public class Aes implements CipherManager {
 
     @Override
     public Supplier<AlgorithmParameterSpec> paramSupplier() {
-        var generator = new Wrapping96BitCounter(new SecureRandom());
+        var generator = new Wrapping96BitCounter(rng);
         var iv = new byte[IV_SIZE_BYTES];
         return () -> {
             generator.generateIv(iv);


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature
- Refactoring

### Description

Shared secure random between invocations to avoid repeated costly initialisations

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
