### PR TITLE
OauthBearer validation filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#1195](https://github.com/kroxylicious/kroxylicious/pull/1195): SASL OAUTHBEARER validation filter 
 * [#1076](https://github.com/kroxylicious/kroxylicious/issues/1076): AWS KMS implementation for Record Encryption
 * [#1201](https://github.com/kroxylicious/kroxylicious/pull/1201): Bump com.fasterxml.jackson:jackson-bom from 2.17.0 to 2.17.1
 * [#1158](https://github.com/kroxylicious/kroxylicious/pull/1158): Bump io.netty:netty-bom from 4.1.108.Final to 4.1.109.Final
@@ -211,4 +212,3 @@ The names used to identify micrometer configuration hooks in configuration have 
 - 
 #### CVE Fixes
 CVE-2023-44487 [#675](https://github.com/kroxylicious/kroxylicious/pull/675)
-

--- a/docs/available-filters.adoc
+++ b/docs/available-filters.adoc
@@ -7,10 +7,9 @@ The following filters are provided built-in as part of the distribution.
 include::available-filters/record-encryption/record-encryption.adoc[leveloffset=2]
 include::available-filters/multi-tenancy/multi-tenancy.adoc[leveloffset=2]
 include::available-filters//schema-validation/schema-validation.adoc[leveloffset=2]
+include::available-filters/oauthbearer/oauthbearer.adoc[leveloffset=2]
 
 == Community filters
 
 Community contributed filters are showcased in the
 https://github.com/kroxylicious/kroxylicious-community-gallery[Community Gallery].
-
-

--- a/docs/available-filters/oauthbearer/oauthbearer.adoc
+++ b/docs/available-filters/oauthbearer/oauthbearer.adoc
@@ -46,6 +46,8 @@ filters:
       subClaimName: sub                     #<6>
       authenticateBackOffMaxMs: 60000       #<7>
       authenticateCacheMaxSize: 1000        #<8>
+      expectedAudience: https://first.audience, https//second.audience #<9>
+      expectedIssuer: https://your-domain.auth/ #<10>
 ----
 
 <1> The OAuth/OIDC provider URL from which the provider's JWKS (JSON Web Key Set) can be retrieved.
@@ -56,5 +58,7 @@ filters:
 <6> This (optional) setting can provide a different name to use for the subject included in the JWT payload's claims.
 <7> The (optional) maximum value in milliseconds to limit the client sending authenticate request. Setting 0 will never limit the client. Otherwise, an exponential delay is added to each authenticate request until the authenticateBackOffMaxMs has been reached.
 <8> The (optional) maximum number of failed tokens kept in cache.
+<9> The (optional) comma-delimited setting for the broker to use to verify that the JWT was issued for one of the expected audiences.
+<10> The (optional) setting for the broker to use to verify that the JWT was created by the expected issuer.
 
 Note: OauthBearer config follows https://kafka.apache.org/documentation/#security_ssl[kafka's properties]

--- a/docs/available-filters/oauthbearer/oauthbearer.adoc
+++ b/docs/available-filters/oauthbearer/oauthbearer.adoc
@@ -1,0 +1,60 @@
+= OAUTHBEARER validation
+
+== What is it?
+
+OauthBearerValidation filter enables a validation on the JWT token received from client before forwarding it to cluster.
+
+If the token is not validated, then the request is short-circuited.
+It reduces resource consumption on the cluster when a client sends too many invalid SASL requests.
+
+[mermaid]
+....
+sequenceDiagram
+    Client->>Kroxylicious: Handshake request
+    Kroxylicious->>Cluster: Forward Handshake request
+    Cluster-->>Kroxylicious: Handshake response
+    Kroxylicious-->>Client: Handshake response
+    Client->>Kroxylicious: Authenticate request
+    Kroxylicious->>Kroxylicious: Validate token
+    break Token validation fails
+        Kroxylicious->>Client: Invalid token
+    end
+    Kroxylicious->>Cluster: Authenticate request
+    Cluster-->>Kroxylicious: Authenticate response
+    Kroxylicious-->>Client: Authenticate response
+....
+
+== How to use the filter
+
+There are two steps to using the filter.
+
+1. <<Configuring virtual clusters>>
+2. Configuring the filter within Kroxylicious.
+
+=== Configuring the filter within Kroxylicious.
+
+[source, yaml]
+----
+filters:
+  - type: OauthBearerValidation
+    config:
+      jwksEndpointUrl: https://oauth/JWKS   #<1>
+      jwksEndpointRefreshMs: 3600000        #<2>
+      jwksEndpointRetryBackoffMs: 100       #<3>
+      jwksEndpointRetryBackoffMaxMs: 10000  #<4>
+      scopeClaimName: scope                 #<5>
+      subClaimName: sub                     #<6>
+      authenticateBackOffMaxMs: 60000       #<7>
+      authenticateCacheMaxSize: 1000        #<8>
+----
+
+<1> The OAuth/OIDC provider URL from which the provider's JWKS (JSON Web Key Set) can be retrieved.
+<2> The (optional) value in milliseconds for the broker to wait between refreshing its JWKS (JSON Web Key Set) cache that contains the keys to verify the signature of the JWT.
+<3> The (optional) value in milliseconds for the initial wait between JWKS (JSON Web Key Set) retrieval attempts from the external authentication provider.
+<4> The (optional) value in milliseconds for the maximum wait between attempts to retrieve the JWKS (JSON Web Key Set) from the external authentication provider.
+<5> This (optional) setting can provide a different name to use for the scope included in the JWT payload's claims.
+<6> This (optional) setting can provide a different name to use for the subject included in the JWT payload's claims.
+<7> The (optional) maximum value in milliseconds to limit the client sending authenticate request. Setting 0 will never limit the client. Otherwise, an exponential delay is added to each authenticate request until the authenticateBackOffMaxMs has been reached.
+<8> The (optional) maximum number of failed tokens kept in cache.
+
+Note: OauthBearer config follows https://kafka.apache.org/documentation/#security_ssl[kafka's properties]

--- a/kroxylicious-app/pom.xml
+++ b/kroxylicious-app/pom.xml
@@ -245,6 +245,11 @@
                     <artifactId>kroxylicious-kms-provider-aws-kms</artifactId>
                     <scope>runtime</scope>
                 </dependency>
+                <dependency>
+                    <groupId>io.kroxylicious</groupId>
+                    <artifactId>kroxylicious-oauthbearer-validation</artifactId>
+                    <scope>runtime</scope>
+                </dependency>
             </dependencies>
         </profile>
     </profiles>

--- a/kroxylicious-bom/pom.xml
+++ b/kroxylicious-bom/pom.xml
@@ -171,6 +171,12 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>io.kroxylicious</groupId>
+                <artifactId>kroxylicious-oauthbearer-validation</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
             <!-- testing dependencies -->
             <!-- note scope is *not* set at this level -->
             <dependency>

--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/pom.xml
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/pom.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.kroxylicious</groupId>
+        <artifactId>kroxylicious-filter-parent</artifactId>
+        <version>0.6.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>kroxylicious-oauthbearer-validation</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Oauthbearer filter</name>
+    <description>Pre-validate oauth token before sending it to upstream kafka</description>
+
+    <dependencies>
+        <!-- project dependencies - runtime and compile -->
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-api</artifactId>
+        </dependency>
+
+        <!-- third party dependencies - runtime and compile  -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.bitbucket.b_c</groupId>
+            <artifactId>jose4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- project dependencies - test -->
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-annotations</artifactId>
+        </dependency>
+      <dependency>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-annotations</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>com.github.ben-manes.caffeine</groupId>
+        <artifactId>caffeine</artifactId>
+      </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>analyze</id>
+                        <configuration>
+                            <ignoredUnusedDeclaredDependencies>
+                                <ignoredUnusedDeclaredDependency>org.bitbucket.b_c:jose4j</ignoredUnusedDeclaredDependency>
+                                <ignoredUnusedDeclaredDependency>io.kroxylicious:kroxylicious-annotations</ignoredUnusedDeclaredDependency>
+                            </ignoredUnusedDeclaredDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/pom.xml
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/pom.xml
@@ -97,6 +97,11 @@
         <groupId>com.github.ben-manes.caffeine</groupId>
         <artifactId>caffeine</artifactId>
       </dependency>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-filter-test-support</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidation.java
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidation.java
@@ -71,8 +71,8 @@ public class OauthBearerValidation implements FilterFactory<OauthBearerValidatio
                         : SaslConfigs.DEFAULT_SASL_OAUTHBEARER_SCOPE_CLAIM_NAME,
                 config.subClaimName() != null && !config.subClaimName().trim().isEmpty() ? config.subClaimName() : SaslConfigs.DEFAULT_SASL_OAUTHBEARER_SUB_CLAIM_NAME,
                 config.authenticateBackOffMaxMs() != null && config.authenticateBackOffMaxMs() >= 0L ? config.authenticateBackOffMaxMs() : 60000L,
-                config.authenticateCacheMaxSize() != null && config.authenticateCacheMaxSize() > 0L ? config.authenticateCacheMaxSize()
-                        : 1000L);
+                config.authenticateCacheMaxSize() != null && config.authenticateCacheMaxSize() > 0L ? config.authenticateCacheMaxSize() : 1000L,
+                config.expectedAudience() != null && !config.expectedAudience().isEmpty() ? config.expectedAudience() : null);
         oauthHandler.configure(
                 createSaslConfigMap(configWithDefaults),
                 OAUTHBEARER_MECHANISM,
@@ -105,7 +105,8 @@ public class OauthBearerValidation implements FilterFactory<OauthBearerValidatio
                          @JsonProperty String scopeClaimName,
                          @JsonProperty String subClaimName,
                          @JsonProperty Long authenticateBackOffMaxMs,
-                         @JsonProperty Long authenticateCacheMaxSize) {}
+                         @JsonProperty Long authenticateCacheMaxSize,
+                         @JsonProperty List<String> expectedAudience) {}
 
     private Map<String, ?> createSaslConfigMap(Config config) {
         return Map.of(
@@ -114,7 +115,8 @@ public class OauthBearerValidation implements FilterFactory<OauthBearerValidatio
                 SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS, config.jwksEndpointRetryBackoffMs(),
                 SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS, config.jwksEndpointRetryBackoffMaxMs(),
                 SaslConfigs.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME, config.scopeClaimName(),
-                SaslConfigs.SASL_OAUTHBEARER_SUB_CLAIM_NAME, config.subClaimName());
+                SaslConfigs.SASL_OAUTHBEARER_SUB_CLAIM_NAME, config.subClaimName(),
+                SaslConfigs.SASL_OAUTHBEARER_EXPECTED_AUDIENCE, config.expectedAudience());
     }
 
     private List<AppConfigurationEntry> createDefaultJaasConfig() {

--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidation.java
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidation.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.oauthbearer;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.security.auth.login.AppConfigurationEntry;
+
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler;
+import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerSaslServerProvider;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+
+import io.kroxylicious.proxy.filter.FilterFactory;
+import io.kroxylicious.proxy.filter.FilterFactoryContext;
+import io.kroxylicious.proxy.filter.oauthbearer.sasl.ExponentialJitterBackoffStrategy;
+import io.kroxylicious.proxy.plugin.Plugin;
+import io.kroxylicious.proxy.plugin.PluginConfigurationException;
+import io.kroxylicious.proxy.plugin.Plugins;
+import io.kroxylicious.proxy.tag.VisibleForTesting;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule.OAUTHBEARER_MECHANISM;
+
+@Plugin(configType = OauthBearerValidation.Config.class)
+public class OauthBearerValidation implements FilterFactory<OauthBearerValidation.Config, SharedOauthBearerValidationContext> {
+
+    @SuppressWarnings("unused")
+    @VisibleForTesting
+    public OauthBearerValidation() {
+        this.oauthHandler = new OAuthBearerValidatorCallbackHandler();
+    }
+
+    public OauthBearerValidation(OAuthBearerValidatorCallbackHandler oauthHandler) {
+        this.oauthHandler = oauthHandler;
+    }
+
+    private final OAuthBearerValidatorCallbackHandler oauthHandler;
+
+    static {
+        OAuthBearerSaslServerProvider.initialize();
+    }
+
+    @Override
+    @SuppressWarnings("java:S2245") // secure randomization not needed for exponential backoff
+    public SharedOauthBearerValidationContext initialize(FilterFactoryContext context, Config config) throws PluginConfigurationException {
+        Plugins.requireConfig(this, config);
+        Config configWithDefaults = new Config(
+                config.jwksEndpointUrl,
+                config.jwksEndpointRefreshMs() != null && config.jwksEndpointRefreshMs() >= 0L ? config.jwksEndpointRefreshMs()
+                        : SaslConfigs.DEFAULT_SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS,
+                config.jwksEndpointRetryBackoffMs() != null && config.jwksEndpointRetryBackoffMs() >= 0L ? config.jwksEndpointRetryBackoffMs()
+                        : SaslConfigs.DEFAULT_SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS,
+                config.jwksEndpointRetryBackoffMaxMs() != null && config.jwksEndpointRetryBackoffMaxMs() > 0L ? config.jwksEndpointRetryBackoffMaxMs()
+                        : SaslConfigs.DEFAULT_SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS,
+                config.scopeClaimName() != null && !config.scopeClaimName().trim().isEmpty() ? config.scopeClaimName()
+                        : SaslConfigs.DEFAULT_SASL_OAUTHBEARER_SCOPE_CLAIM_NAME,
+                config.subClaimName() != null && !config.subClaimName().trim().isEmpty() ? config.subClaimName() : SaslConfigs.DEFAULT_SASL_OAUTHBEARER_SUB_CLAIM_NAME,
+                config.authenticateBackOffMaxMs() != null && config.authenticateBackOffMaxMs() >= 0L ? config.authenticateBackOffMaxMs() : 60000L,
+                config.authenticateCacheMaxSize() != null && config.authenticateCacheMaxSize() > 0L ? config.authenticateCacheMaxSize()
+                        : 1000L);
+        oauthHandler.configure(
+                createSaslConfigMap(configWithDefaults),
+                OAUTHBEARER_MECHANISM,
+                createDefaultJaasConfig());
+        LoadingCache<String, AtomicInteger> rateLimiter = Caffeine.newBuilder()
+                .expireAfterWrite(configWithDefaults.authenticateBackOffMaxMs(), TimeUnit.MILLISECONDS)
+                .maximumSize(configWithDefaults.authenticateCacheMaxSize())
+                .build(key -> new AtomicInteger(0));
+        ExponentialJitterBackoffStrategy backoffStrategy = new ExponentialJitterBackoffStrategy(Duration.ofMillis(500), Duration.ofSeconds(5), 2d,
+                ThreadLocalRandom.current());
+        return new SharedOauthBearerValidationContext(configWithDefaults, backoffStrategy, rateLimiter, oauthHandler);
+    }
+
+    @NonNull
+    @Override
+    public OauthBearerValidationFilter createFilter(FilterFactoryContext context, SharedOauthBearerValidationContext sharedContext) {
+        return new OauthBearerValidationFilter(context.eventLoop(), sharedContext);
+    }
+
+    @Override
+    public void close(SharedOauthBearerValidationContext sharedContext) {
+        oauthHandler.close();
+    }
+
+    public record Config(
+                         @JsonProperty(required = true) URI jwksEndpointUrl,
+                         @JsonProperty Long jwksEndpointRefreshMs,
+                         @JsonProperty Long jwksEndpointRetryBackoffMs,
+                         @JsonProperty Long jwksEndpointRetryBackoffMaxMs,
+                         @JsonProperty String scopeClaimName,
+                         @JsonProperty String subClaimName,
+                         @JsonProperty Long authenticateBackOffMaxMs,
+                         @JsonProperty Long authenticateCacheMaxSize) {}
+
+    private Map<String, ?> createSaslConfigMap(Config config) {
+        return Map.of(
+                SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL, config.jwksEndpointUrl().toString(),
+                SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS, config.jwksEndpointRefreshMs(),
+                SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS, config.jwksEndpointRetryBackoffMs(),
+                SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS, config.jwksEndpointRetryBackoffMaxMs(),
+                SaslConfigs.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME, config.scopeClaimName(),
+                SaslConfigs.SASL_OAUTHBEARER_SUB_CLAIM_NAME, config.subClaimName());
+    }
+
+    private List<AppConfigurationEntry> createDefaultJaasConfig() {
+        return List.of(new AppConfigurationEntry("OAuthBearerLoginModule", AppConfigurationEntry.LoginModuleControlFlag.REQUIRED, Map.of()));
+    }
+}

--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationFilter.java
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationFilter.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.proxy.filter.oauthbearer;
 
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
@@ -168,7 +169,11 @@ public class OauthBearerValidationFilter
 
     private byte[] doAuthenticate(byte[] authBytes) throws SaslException {
         try {
-            return this.saslServer.evaluateResponse(authBytes);
+            byte[] bytes = this.saslServer.evaluateResponse(authBytes);
+            if (!this.saslServer.isComplete()) {
+                throw new SaslAuthenticationException("SASL failed : " + new String(bytes, StandardCharsets.UTF_8));
+            }
+            return bytes;
         }
         finally {
             this.saslServer.dispose();

--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationFilter.java
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationFilter.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.oauthbearer;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.HexFormat;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import javax.security.sasl.Sasl;
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
+
+import org.apache.kafka.common.errors.SaslAuthenticationException;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.message.SaslAuthenticateRequestData;
+import org.apache.kafka.common.message.SaslAuthenticateResponseData;
+import org.apache.kafka.common.message.SaslHandshakeRequestData;
+import org.apache.kafka.common.message.SaslHandshakeResponseData;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.benmanes.caffeine.cache.LoadingCache;
+
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.RequestFilterResult;
+import io.kroxylicious.proxy.filter.ResponseFilterResult;
+import io.kroxylicious.proxy.filter.SaslAuthenticateRequestFilter;
+import io.kroxylicious.proxy.filter.SaslAuthenticateResponseFilter;
+import io.kroxylicious.proxy.filter.SaslHandshakeRequestFilter;
+import io.kroxylicious.proxy.filter.oauthbearer.sasl.BackoffStrategy;
+import io.kroxylicious.proxy.tag.VisibleForTesting;
+
+import static org.apache.kafka.common.protocol.Errors.NONE;
+import static org.apache.kafka.common.protocol.Errors.SASL_AUTHENTICATION_FAILED;
+import static org.apache.kafka.common.protocol.Errors.UNKNOWN_SERVER_ERROR;
+import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule.OAUTHBEARER_MECHANISM;
+
+/**
+ * OauthBearerValidation filter enables a validation on the JWT token received from client before forwarding it to cluster.
+ * <p>
+ * If the token is not validated, then the request is short-circuited.
+ * It reduces resource consumption on the cluster when a client sends too many invalid SASL requests.
+ */
+public class OauthBearerValidationFilter
+        implements SaslHandshakeRequestFilter, SaslAuthenticateRequestFilter,
+        SaslAuthenticateResponseFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OauthBearerValidationFilter.class);
+
+    private final ScheduledExecutorService executorService;
+    private final BackoffStrategy strategy;
+    private final LoadingCache<String, AtomicInteger> rateLimiter;
+    private final OAuthBearerValidatorCallbackHandler oauthHandler;
+    private SaslServer saslServer;
+
+    private boolean validateAuthentication = false;
+
+    public OauthBearerValidationFilter(ScheduledExecutorService executorService, SharedOauthBearerValidationContext sharedContext) {
+        this.executorService = executorService;
+        this.strategy = sharedContext.backoffStrategy();
+        this.rateLimiter = sharedContext.rateLimiter();
+        this.oauthHandler = sharedContext.oauthHandler();
+    }
+
+    /**
+     * Init the SaslServer for downstream SASL
+     */
+    @Override
+    public CompletionStage<RequestFilterResult> onSaslHandshakeRequest(short apiVersion, RequestHeaderData header, SaslHandshakeRequestData request,
+                                                                       FilterContext context) {
+        try {
+            if (OAUTHBEARER_MECHANISM.equals(request.mechanism())) {
+                this.saslServer = Sasl.createSaslServer(OAUTHBEARER_MECHANISM, "kafka", null, null, this.oauthHandler);
+                this.validateAuthentication = true;
+            }
+        }
+        catch (SaslException e) {
+            LOGGER.debug("SASL error : {}", e.getMessage(), e);
+            return context.requestFilterResultBuilder()
+                    .shortCircuitResponse(new SaslHandshakeResponseData().setErrorCode(UNKNOWN_SERVER_ERROR.code()))
+                    .withCloseConnection()
+                    .completed();
+        }
+        return context.forwardRequest(header, request);
+    }
+
+    @Override
+    public CompletionStage<RequestFilterResult> onSaslAuthenticateRequest(short apiVersion, RequestHeaderData header,
+                                                                          SaslAuthenticateRequestData request, FilterContext context) {
+        if (!validateAuthentication) {
+            // client is already authenticated or is not using OAUTHBEARER mechanism, we can forward the request to cluster
+            return context.forwardRequest(header, request);
+        }
+        else {
+            return authenticate(request.authBytes())
+                    .thenCompose(bytes -> context.forwardRequest(header, request))
+                    .exceptionallyCompose(e -> {
+                        if (e.getCause() instanceof SaslAuthenticationException) {
+                            SaslAuthenticateResponseData failedResponse = new SaslAuthenticateResponseData()
+                                    .setErrorCode(SASL_AUTHENTICATION_FAILED.code())
+                                    .setErrorMessage(e.getMessage())
+                                    .setAuthBytes(request.authBytes());
+                            LOGGER.debug("SASL Authentication failed : {}", e.getMessage(), e);
+                            return context.requestFilterResultBuilder().shortCircuitResponse(failedResponse).withCloseConnection().completed();
+                        }
+                        else {
+                            LOGGER.debug("SASL error : {}", e.getMessage(), e);
+                            return context.requestFilterResultBuilder()
+                                    .shortCircuitResponse(
+                                            new SaslAuthenticateResponseData()
+                                                    .setErrorCode(UNKNOWN_SERVER_ERROR.code())
+                                                    .setAuthBytes(request.authBytes()))
+                                    .withCloseConnection()
+                                    .completed();
+                        }
+                    });
+        }
+    }
+
+    @Override
+    public CompletionStage<ResponseFilterResult> onSaslAuthenticateResponse(short apiVersion, ResponseHeaderData header,
+                                                                            SaslAuthenticateResponseData response, FilterContext context) {
+        if (response.errorCode() == NONE.code()) {
+            this.validateAuthentication = false;
+        }
+        return context.forwardResponse(header, response);
+    }
+
+    private CompletionStage<byte[]> authenticate(byte[] authBytes) {
+        String digest;
+        try {
+            digest = digestBytes(authBytes);
+        }
+        catch (NoSuchAlgorithmException e) {
+            return CompletableFuture.failedStage(e);
+        }
+        Duration delay = strategy.getDelay(rateLimiter.get(digest).get());
+        return schedule(() -> {
+            try {
+                return CompletableFuture.completedStage(doAuthenticate(authBytes));
+            }
+            catch (Exception e) {
+                return CompletableFuture.failedStage(e);
+            }
+        }, delay)
+                .whenComplete((bytes, e) -> {
+                    if (e != null) {
+                        rateLimiter.get(digest).incrementAndGet();
+                    }
+                    else {
+                        rateLimiter.invalidate(digest);
+                    }
+                });
+    }
+
+    private byte[] doAuthenticate(byte[] authBytes) throws SaslException {
+        try {
+            return this.saslServer.evaluateResponse(authBytes);
+        }
+        finally {
+            this.saslServer.dispose();
+        }
+    }
+
+    @SuppressWarnings("java:S1602") // not able to test the scheduled lambda otherwise
+    private <A> CompletionStage<A> schedule(Supplier<CompletionStage<A>> operation, Duration duration) {
+        if (duration.equals(Duration.ZERO)) {
+            return operation.get();
+        }
+        CompletableFuture<A> future = new CompletableFuture<>();
+        executorService.schedule(() -> {
+            operation.get().whenComplete((a, throwable) -> {
+                if (throwable != null) {
+                    future.completeExceptionally(throwable);
+                }
+                else {
+                    future.complete(a);
+                }
+            });
+        }, duration.toMillis(), TimeUnit.MILLISECONDS);
+        return future;
+    }
+
+    @VisibleForTesting
+    public static String digestBytes(byte[] input) throws NoSuchAlgorithmException {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+
+        byte[] hashBytes = digest.digest(input);
+
+        return HexFormat.of().formatHex(hashBytes);
+
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/SharedOauthBearerValidationContext.java
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/SharedOauthBearerValidationContext.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.oauthbearer;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler;
+
+import com.github.benmanes.caffeine.cache.LoadingCache;
+
+import io.kroxylicious.proxy.filter.oauthbearer.sasl.BackoffStrategy;
+
+public record SharedOauthBearerValidationContext(
+                                                 OauthBearerValidation.Config config,
+                                                 BackoffStrategy backoffStrategy,
+                                                 LoadingCache<String, AtomicInteger> rateLimiter,
+                                                 OAuthBearerValidatorCallbackHandler oauthHandler) {}

--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/sasl/BackoffStrategy.java
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/sasl/BackoffStrategy.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.oauthbearer.sasl;
+
+import java.time.Duration;
+
+public interface BackoffStrategy {
+
+    /**
+     * Decides how long to delay the next attempt at an action given it has attempted
+     * for N consecutive times in the past.
+     * @param attempts count of attempts, must be 0 or greater
+     * @return how long to delay
+     * @throws IllegalArgumentException if failures less than 0
+     */
+    Duration getDelay(int attempts);
+}

--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/sasl/ExponentialJitterBackoffStrategy.java
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/sasl/ExponentialJitterBackoffStrategy.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.oauthbearer.sasl;
+
+import java.time.Duration;
+import java.util.Random;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class ExponentialJitterBackoffStrategy implements BackoffStrategy {
+
+    @NonNull
+    private final Duration initialDelay;
+    @NonNull
+    private final Duration maximumDelay;
+    private final double multiplier;
+    private final Random random;
+
+    public ExponentialJitterBackoffStrategy(@NonNull Duration initialDelay,
+                                            @NonNull Duration maximumDelay,
+                                            double multiplier,
+                                            Random random) {
+        if (multiplier <= 1.0d) {
+            throw new IllegalArgumentException("multiplier must be greater than one");
+        }
+        if (initialDelay.compareTo(Duration.ZERO) <= 0) {
+            throw new IllegalArgumentException("initialDelay must be greater than zero");
+        }
+        if (maximumDelay.compareTo(Duration.ZERO) <= 0) {
+            throw new IllegalArgumentException("maximumDelay must be greater than zero");
+        }
+        if (random == null) {
+            throw new IllegalArgumentException("random must be non-null");
+        }
+        this.initialDelay = initialDelay;
+        this.maximumDelay = maximumDelay;
+        this.multiplier = multiplier;
+        this.random = random;
+    }
+
+    @Override
+    public Duration getDelay(int attempts) {
+        if (attempts < 0) {
+            throw new IllegalArgumentException("attempts is negative");
+        }
+        if (attempts == 0) {
+            return Duration.ZERO;
+        }
+        Duration backoff = getExponentialBackoff(attempts);
+        backoff = backoff.plus(getRandomJitter(attempts, backoff));
+        return backoff.compareTo(maximumDelay) < 0 ? backoff : maximumDelay;
+    }
+
+    private Duration getRandomJitter(int attempts, Duration backoff) {
+        Duration prior = getExponentialBackoff(attempts - 1);
+        long maxJitter = backoff.toMillis() - prior.toMillis();
+        return maxJitter == 0 ? Duration.ZERO : Duration.ofMillis(this.random.nextLong() % maxJitter);
+    }
+
+    private Duration getExponentialBackoff(int attempts) {
+        if (attempts == 0) {
+            return Duration.ZERO;
+        }
+        return Duration.ofMillis((long) (initialDelay.toMillis() * (Math.pow(multiplier, (double) attempts - 1))));
+    }
+}

--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
@@ -1,0 +1,1 @@
+io.kroxylicious.proxy.filter.oauthbearer.OauthBearerValidation

--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationFilterTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.oauthbearer;
+
+import java.time.Duration;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.security.sasl.Sasl;
+import javax.security.sasl.SaslException;
+import javax.security.sasl.SaslServer;
+
+import org.apache.kafka.common.errors.SaslAuthenticationException;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.message.SaslAuthenticateRequestData;
+import org.apache.kafka.common.message.SaslAuthenticateResponseData;
+import org.apache.kafka.common.message.SaslHandshakeRequestData;
+import org.apache.kafka.common.message.SaslHandshakeResponseData;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.github.benmanes.caffeine.cache.LoadingCache;
+
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.RequestFilterResultBuilder;
+import io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage;
+import io.kroxylicious.proxy.filter.filterresultbuilder.TerminalStage;
+import io.kroxylicious.proxy.filter.oauthbearer.sasl.BackoffStrategy;
+
+import static org.apache.kafka.common.protocol.Errors.SASL_AUTHENTICATION_FAILED;
+import static org.apache.kafka.common.protocol.Errors.UNKNOWN_SERVER_ERROR;
+import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule.OAUTHBEARER_MECHANISM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.assertArg;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mock.Strictness.LENIENT;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OauthBearerValidationFilterTest {
+
+    @Mock(strictness = LENIENT)
+    private FilterContext context;
+
+    @Mock
+    private RequestFilterResultBuilder builder;
+
+    @Mock
+    private SharedOauthBearerValidationContext sharedContext;
+
+    @Mock
+    private ScheduledExecutorService executor;
+
+    @Mock
+    private LoadingCache<String, AtomicInteger> rateLimiter;
+
+    @Mock
+    private OAuthBearerValidatorCallbackHandler oauthHandler;
+
+    @Mock
+    private BackoffStrategy strategy;
+
+    @Mock
+    private SaslServer saslServer;
+
+    private OauthBearerValidationFilter filter;
+
+    @BeforeEach
+    void init() {
+        when(sharedContext.rateLimiter()).thenReturn(rateLimiter);
+        when(sharedContext.oauthHandler()).thenReturn(oauthHandler);
+        when(sharedContext.backoffStrategy()).thenReturn(strategy);
+        filter = new OauthBearerValidationFilter(executor, sharedContext);
+    }
+
+    @Test
+    void mustForwardNotOauthBearerSasl() {
+        // given
+        byte[] givenBytes = "just_to_compare".getBytes();
+        SaslHandshakeRequestData givenHandshakeRequest = new SaslHandshakeRequestData().setMechanism("PLAIN");
+        SaslAuthenticateRequestData givenAuthenticateRequest = new SaslAuthenticateRequestData().setAuthBytes(givenBytes);
+
+        // when
+        filter.onSaslHandshakeRequest(SaslHandshakeRequestData.HIGHEST_SUPPORTED_VERSION, new RequestHeaderData(), givenHandshakeRequest, context);
+        filter.onSaslAuthenticateRequest(SaslAuthenticateRequestData.HIGHEST_SUPPORTED_VERSION, new RequestHeaderData(), givenAuthenticateRequest, context);
+
+        // then
+        verify(context).forwardRequest(any(RequestHeaderData.class), eq(givenHandshakeRequest));
+        verify(context).forwardRequest(any(RequestHeaderData.class), eq(givenAuthenticateRequest));
+        verifyNoInteractions(executor, rateLimiter, strategy);
+    }
+
+    @Test
+    void mustHandleSaslOauthBearer() throws Exception {
+        // given
+        byte[] givenBytes = "just_to_compare".getBytes();
+        SaslHandshakeRequestData givenHandshakeRequest = new SaslHandshakeRequestData().setMechanism(OAUTHBEARER_MECHANISM);
+        SaslAuthenticateRequestData givenAuthenticateRequest = new SaslAuthenticateRequestData().setAuthBytes(givenBytes);
+        String digest = OauthBearerValidationFilter.digestBytes(givenBytes);
+        when(rateLimiter.get(digest)).thenReturn(new AtomicInteger(0));
+        when(strategy.getDelay(0)).thenReturn(Duration.ZERO);
+
+        // when
+        try (MockedStatic<Sasl> dummy = mockStatic(Sasl.class)) {
+            dummy.when(() -> Sasl.createSaslServer(OAUTHBEARER_MECHANISM, "kafka", null, null, oauthHandler))
+                    .thenReturn(saslServer);
+            filter.onSaslHandshakeRequest(SaslHandshakeRequestData.HIGHEST_SUPPORTED_VERSION, new RequestHeaderData(), givenHandshakeRequest, context);
+        }
+        filter.onSaslAuthenticateRequest(SaslAuthenticateRequestData.HIGHEST_SUPPORTED_VERSION, new RequestHeaderData(), givenAuthenticateRequest, context);
+
+        // then
+        verify(context).forwardRequest(any(RequestHeaderData.class), eq(givenHandshakeRequest));
+        verify(context).forwardRequest(any(RequestHeaderData.class), eq(givenAuthenticateRequest));
+        verifyNoInteractions(executor);
+    }
+
+    @Test
+    void mustShortCircuitFailedInitSasl() {
+        SaslHandshakeRequestData givenHandshakeRequest = new SaslHandshakeRequestData().setMechanism(OAUTHBEARER_MECHANISM);
+        mockBuilder();
+
+        try (MockedStatic<Sasl> dummy = mockStatic(Sasl.class)) {
+            dummy.when(() -> Sasl.createSaslServer(OAUTHBEARER_MECHANISM, "kafka", null, null, oauthHandler))
+                    .thenThrow(new SaslException());
+            filter.onSaslHandshakeRequest(SaslHandshakeRequestData.HIGHEST_SUPPORTED_VERSION, new RequestHeaderData(), givenHandshakeRequest, context);
+        }
+
+        verify(builder).shortCircuitResponse(assertArg(actualResponse -> {
+            assertThat(actualResponse).isInstanceOf(SaslHandshakeResponseData.class);
+            assertThat(((SaslHandshakeResponseData) actualResponse).errorCode()).isEqualTo(UNKNOWN_SERVER_ERROR.code());
+        }));
+    }
+
+    @Test
+    void mustLetPassWhenAlreadyAuthenticated() {
+        byte[] givenBytes = "just_to_compare".getBytes();
+        SaslAuthenticateResponseData givenAuthenticateResponse = new SaslAuthenticateResponseData().setAuthBytes(givenBytes);
+        SaslAuthenticateRequestData givenAuthenticateRequest = new SaslAuthenticateRequestData().setAuthBytes(givenBytes);
+
+        filter.onSaslAuthenticateResponse(SaslAuthenticateResponseData.HIGHEST_SUPPORTED_VERSION, new ResponseHeaderData(), givenAuthenticateResponse, context);
+        filter.onSaslAuthenticateRequest(SaslAuthenticateRequestData.HIGHEST_SUPPORTED_VERSION, new RequestHeaderData(), givenAuthenticateRequest, context);
+
+        verify(context).forwardResponse(any(ResponseHeaderData.class), eq(givenAuthenticateResponse));
+        verify(context).forwardRequest(any(RequestHeaderData.class), eq(givenAuthenticateRequest));
+        verifyNoInteractions(executor, rateLimiter, strategy);
+    }
+
+    @Test
+    void willShortCircuitResponseOnTokenValidationFailed() throws Exception {
+        // given
+        byte[] givenBytes = "just_to_compare".getBytes();
+        SaslHandshakeRequestData givenHandshakeRequest = new SaslHandshakeRequestData().setMechanism(OAUTHBEARER_MECHANISM);
+        SaslAuthenticateRequestData givenAuthenticateRequest = new SaslAuthenticateRequestData().setAuthBytes(givenBytes);
+        when(saslServer.evaluateResponse(givenBytes)).thenThrow(new SaslAuthenticationException("Authentication failed"));
+        mockBuilder();
+        String digest = OauthBearerValidationFilter.digestBytes(givenBytes);
+        when(rateLimiter.get(digest)).thenReturn(new AtomicInteger(0));
+        when(strategy.getDelay(0)).thenReturn(Duration.ZERO);
+
+        // when
+        try (MockedStatic<Sasl> dummy = mockStatic(Sasl.class)) {
+            dummy.when(() -> Sasl.createSaslServer(OAUTHBEARER_MECHANISM, "kafka", null, null, oauthHandler))
+                    .thenReturn(saslServer);
+            filter.onSaslHandshakeRequest(SaslHandshakeRequestData.HIGHEST_SUPPORTED_VERSION, new RequestHeaderData(), givenHandshakeRequest, context);
+        }
+        filter.onSaslAuthenticateRequest(
+                SaslAuthenticateRequestData.HIGHEST_SUPPORTED_VERSION, new RequestHeaderData(), givenAuthenticateRequest, context);
+
+        // then
+        verify(builder).shortCircuitResponse(assertArg(actualResponse -> {
+            assertThat(actualResponse).isInstanceOf(SaslAuthenticateResponseData.class);
+            assertThat(((SaslAuthenticateResponseData) actualResponse).errorCode()).isEqualTo(SASL_AUTHENTICATION_FAILED.code());
+        }));
+    }
+
+    @Test
+    void mustDelayWhenSecondFailedAuthentication() throws Exception {
+        // given
+        byte[] givenBytes = "just_to_compare".getBytes();
+        SaslHandshakeRequestData givenHandshakeRequest = new SaslHandshakeRequestData().setMechanism(OAUTHBEARER_MECHANISM);
+        SaslAuthenticateRequestData givenAuthenticateRequest = new SaslAuthenticateRequestData().setAuthBytes(givenBytes);
+        when(saslServer.evaluateResponse(givenBytes)).thenThrow(new SaslAuthenticationException("Authentication failed"));
+        mockBuilder();
+        AtomicInteger attempts = new AtomicInteger(0);
+        String digest = OauthBearerValidationFilter.digestBytes(givenBytes);
+        when(rateLimiter.get(digest)).thenReturn(attempts);
+        when(strategy.getDelay(0)).thenReturn(Duration.ZERO);
+        when(strategy.getDelay(1)).thenReturn(Duration.ofMillis(1));
+        when(executor.schedule(any(Runnable.class), anyLong(), any())).thenAnswer(invocationOnMock -> {
+            Runnable argument = invocationOnMock.getArgument(0);
+            argument.run();
+            return null;
+        });
+
+        // when
+        try (MockedStatic<Sasl> dummy = mockStatic(Sasl.class)) {
+            dummy.when(() -> Sasl.createSaslServer(OAUTHBEARER_MECHANISM, "kafka", null, null, oauthHandler))
+                    .thenReturn(saslServer);
+            filter.onSaslHandshakeRequest(SaslHandshakeRequestData.HIGHEST_SUPPORTED_VERSION, new RequestHeaderData(), givenHandshakeRequest, context);
+        }
+        filter.onSaslAuthenticateRequest(
+                SaslAuthenticateRequestData.HIGHEST_SUPPORTED_VERSION, new RequestHeaderData(), givenAuthenticateRequest, context);
+        filter.onSaslAuthenticateRequest(
+                SaslAuthenticateRequestData.HIGHEST_SUPPORTED_VERSION, new RequestHeaderData(), givenAuthenticateRequest, context);
+
+        // then
+        verify(builder, times(2)).shortCircuitResponse(assertArg(actualResponse -> {
+            assertThat(actualResponse).isInstanceOf(SaslAuthenticateResponseData.class);
+            assertThat(((SaslAuthenticateResponseData) actualResponse).errorCode()).isEqualTo(SASL_AUTHENTICATION_FAILED.code());
+        }));
+    }
+
+    @Test
+    void willShortCircuitResponseWhenSaslFailed() throws Exception {
+        // given
+        doThrow(new SaslException("SASL failed")).when(saslServer).dispose();
+        byte[] givenBytes = "just_to_compare".getBytes();
+        SaslHandshakeRequestData givenHandshakeRequest = new SaslHandshakeRequestData().setMechanism(OAUTHBEARER_MECHANISM);
+        SaslAuthenticateRequestData givenAuthenticateRequest = new SaslAuthenticateRequestData().setAuthBytes(givenBytes);
+        mockBuilder();
+        String digest = OauthBearerValidationFilter.digestBytes(givenBytes);
+        when(rateLimiter.get(digest)).thenReturn(new AtomicInteger(0));
+        when(strategy.getDelay(0)).thenReturn(Duration.ZERO);
+
+        // when
+        try (MockedStatic<Sasl> dummy = mockStatic(Sasl.class)) {
+            dummy.when(() -> Sasl.createSaslServer(OAUTHBEARER_MECHANISM, "kafka", null, null, oauthHandler))
+                    .thenReturn(saslServer);
+            filter.onSaslHandshakeRequest(SaslHandshakeRequestData.HIGHEST_SUPPORTED_VERSION, new RequestHeaderData(), givenHandshakeRequest, context);
+        }
+        filter.onSaslAuthenticateRequest(
+                SaslAuthenticateRequestData.HIGHEST_SUPPORTED_VERSION, new RequestHeaderData(), givenAuthenticateRequest, context);
+
+        // then
+        verify(builder).shortCircuitResponse(assertArg(actualResponse -> {
+            assertThat(actualResponse).isInstanceOf(SaslAuthenticateResponseData.class);
+            assertEquals(UNKNOWN_SERVER_ERROR.code(), ((SaslAuthenticateResponseData) actualResponse).errorCode());
+        }));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void mockBuilder() {
+        var closeOrTerminalStage = mock(CloseOrTerminalStage.class);
+        when(closeOrTerminalStage.withCloseConnection()).thenReturn(mock(TerminalStage.class));
+        when(builder.shortCircuitResponse(any())).thenReturn(closeOrTerminalStage);
+        when(context.requestFilterResultBuilder()).thenReturn(builder);
+    }
+}

--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationTest.java
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.oauthbearer;
+
+import java.net.URI;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import io.kroxylicious.proxy.filter.FilterFactoryContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.assertArg;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OauthBearerValidationTest {
+
+    @Mock
+    private FilterFactoryContext ffc;
+
+    @Mock
+    private OAuthBearerValidatorCallbackHandler callbackHandler;
+
+    @Mock
+    private ScheduledExecutorService executor;
+
+    @Test
+    void mustProvideDefaultValuesForConfig() throws Exception {
+        ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
+        OauthBearerValidation.Config yamlConfig = yamlMapper.readerFor(OauthBearerValidation.Config.class).readValue("""
+                jwksEndpointUrl: https://jwks.endpoint
+                """);
+
+        assertThat(yamlConfig).isEqualTo(defaultConfig());
+    }
+
+    @Test
+    @SuppressWarnings("java:S5838")
+    void mustInitAndCreateFilterWithDefaultsNull() throws Exception {
+        mustInitAndCreateFilter(defaultConfig());
+    }
+
+    @Test
+    void mustInitAndCreateFilterWithNegativeAndEmptyValues() throws Exception {
+        OauthBearerValidation.Config config = new OauthBearerValidation.Config(
+                new URI("https://jwks.endpoint"),
+                -1L,
+                -1L,
+                -1L,
+                "",
+                " ",
+                -1L,
+                -1L);
+        mustInitAndCreateFilter(config);
+    }
+
+    @Test
+    @SuppressWarnings("java:S5838")
+    void mustInitAndCreateFilterFromConfig() throws Exception {
+        // given
+        when(ffc.eventLoop()).thenReturn(executor);
+        OauthBearerValidation oauthBearerValidation = new OauthBearerValidation(callbackHandler);
+        OauthBearerValidation.Config config = new OauthBearerValidation.Config(
+                new URI("https://jwks.endpoint"),
+                10000L,
+                20000L,
+                30000L,
+                "otherScope",
+                "otherClaim",
+                10000L,
+                500L);
+
+        // when
+        SharedOauthBearerValidationContext sharedContext = oauthBearerValidation.initialize(ffc, config);
+        OauthBearerValidationFilter filter = oauthBearerValidation.createFilter(ffc, sharedContext);
+
+        // then
+        verify(callbackHandler).configure(
+                assertArg(configMap -> {
+                    assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL)).isEqualTo("https://jwks.endpoint");
+                    assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS)).isEqualTo(10000L);
+                    assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS)).isEqualTo(20000L);
+                    assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS)).isEqualTo(30000L);
+                    assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME)).isEqualTo("otherScope");
+                    assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_SUB_CLAIM_NAME)).isEqualTo("otherClaim");
+                }),
+                eq("OAUTHBEARER"),
+                anyList());
+        assertThat(filter).isNotNull();
+        assertThat(config.authenticateBackOffMaxMs()).isEqualTo(10000);
+    }
+
+    @Test
+    void mustCloseOauthHandler() throws Exception {
+        // given
+        OauthBearerValidation oauthBearerValidation = new OauthBearerValidation(callbackHandler);
+
+        // when
+        oauthBearerValidation.close(oauthBearerValidation.initialize(ffc, defaultConfig()));
+
+        // then
+        verify(callbackHandler).close();
+    }
+
+    @SuppressWarnings("java:S5838")
+    void mustInitAndCreateFilter(OauthBearerValidation.Config config) {
+        // given
+        OauthBearerValidation oauthBearerValidation = new OauthBearerValidation(callbackHandler);
+        when(ffc.eventLoop()).thenReturn(executor);
+
+        // when
+        SharedOauthBearerValidationContext sharedContext = oauthBearerValidation.initialize(ffc, config);
+        OauthBearerValidationFilter filter = oauthBearerValidation.createFilter(ffc, sharedContext);
+
+        // then
+        verify(callbackHandler).configure(
+                assertArg(configMap -> {
+                    assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_URL)).isEqualTo("https://jwks.endpoint");
+                    assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS))
+                            .isEqualTo(SaslConfigs.DEFAULT_SASL_OAUTHBEARER_JWKS_ENDPOINT_REFRESH_MS);
+                    assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS))
+                            .isEqualTo(SaslConfigs.DEFAULT_SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MS);
+                    assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS))
+                            .isEqualTo(SaslConfigs.DEFAULT_SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS);
+                    assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME)).isEqualTo(SaslConfigs.DEFAULT_SASL_OAUTHBEARER_SCOPE_CLAIM_NAME);
+                    assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_SUB_CLAIM_NAME)).isEqualTo(SaslConfigs.DEFAULT_SASL_OAUTHBEARER_SUB_CLAIM_NAME);
+                }),
+                eq("OAUTHBEARER"),
+                anyList());
+        assertThat(filter).isNotNull();
+        assertThat(sharedContext.config().authenticateBackOffMaxMs()).isEqualTo(60000);
+        assertThat(sharedContext.config().authenticateCacheMaxSize()).isEqualTo(1000);
+    }
+
+    private OauthBearerValidation.Config defaultConfig() throws Exception {
+        return new OauthBearerValidation.Config(
+                new URI("https://jwks.endpoint"),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
+    }
+}

--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationTest.java
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationTest.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.proxy.filter.oauthbearer;
 
 import java.net.URI;
+import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.kafka.common.config.SaslConfigs;
@@ -66,7 +67,9 @@ class OauthBearerValidationTest {
                 "",
                 " ",
                 -1L,
-                -1L);
+                -1L,
+                null,
+                null);
         mustInitAndCreateFilter(config);
     }
 
@@ -84,7 +87,9 @@ class OauthBearerValidationTest {
                 "otherScope",
                 "otherClaim",
                 10000L,
-                500L);
+                500L,
+                "https://first.audience, https://second.audience",
+                "https://issuer.endpoint");
 
         // when
         SharedOauthBearerValidationContext sharedContext = oauthBearerValidation.initialize(ffc, config);
@@ -99,6 +104,8 @@ class OauthBearerValidationTest {
                     assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS)).isEqualTo(30000L);
                     assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME)).isEqualTo("otherScope");
                     assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_SUB_CLAIM_NAME)).isEqualTo("otherClaim");
+                    assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_EXPECTED_AUDIENCE)).isEqualTo(List.of("https://first.audience", "https://second.audience"));
+                    assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_EXPECTED_ISSUER)).isEqualTo("https://issuer.endpoint");
                 }),
                 eq("OAUTHBEARER"),
                 anyList());
@@ -151,6 +158,8 @@ class OauthBearerValidationTest {
     private OauthBearerValidation.Config defaultConfig() throws Exception {
         return new OauthBearerValidation.Config(
                 new URI("https://jwks.endpoint"),
+                null,
+                null,
                 null,
                 null,
                 null,

--- a/kroxylicious-filters/pom.xml
+++ b/kroxylicious-filters/pom.xml
@@ -27,6 +27,7 @@
         <module>kroxylicious-multitenant</module>
         <module>kroxylicious-record-validation</module>
         <module>kroxylicious-simple-transform</module>
+        <module>kroxylicious-oauthbearer-validation</module>
     </modules>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <zjsonpatch.version>0.4.16</zjsonpatch.version>
         <moby-names-generator.version>20.10.1-r0</moby-names-generator.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
+        <jose4j.version>0.9.6</jose4j.version>
 
         <!-- Test dependencies -->
         <strimzi.version>0.41.0</strimzi.version>
@@ -266,6 +267,12 @@
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest</artifactId>
                 <version>${hamcrest.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.bitbucket.b_c</groupId>
+                <artifactId>jose4j</artifactId>
+                <version>${jose4j.version}</version>
             </dependency>
 
             <!-- third party dependencies - test -->


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This pull request has the intention to introduce OauthBearer management into Kroxylicious.
Two ideas for this :
- Add a new `OauthBearerFilter` to check if a token is valid before sending it to upstream.
- Re-enable `AuthnHandler` and add `OAUTHBEARER`.

### Additional Context

- `OauthBearerFilter` is simple and really useful for a Kafka proxy, it helps relieve the upstream kafka when downstream tried too many invalid authentications.If token is valid, it just forward the SASL request to upstream, letting upstream kafka do it again and self manage RBAC.
-  The second method is to fully delegate the SASL connection to Kroxylicious. Kroxylicious will catch all SASL requests and handle the connection. Then, it uses another self connection to upstream, using this new upstream role.
	It requires to have RBAC management I think, otherwise, the use case is just to proxy `OAUTHBEARER` to `ANY` connection, loosing the `OAUTHBEARER` principal user and using another one from the upstream connection (or no one if no authentication configured.
	`AuthnHandler` is more tricky, at this time, it doesn't give the possibility to handle different `OAUTHBEARER` configs by `VirtualCluster`, so I think a refactor is required on this part.
Edit : I moved the SASL connection part to another PR : https://github.com/kroxylicious/kroxylicious/pull/1206

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [x] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
