### PR TITLE
netty-leak-detector version to dependency management.

### DIFF
--- a/kroxylicious-integration-test-support/pom.xml
+++ b/kroxylicious-integration-test-support/pom.xml
@@ -75,11 +75,6 @@
             <artifactId>moby-names-generator</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.github.nettyplus</groupId>
-            <artifactId>netty-leak-detector-junit-extension</artifactId>
-            <version>0.0.5</version>
-        </dependency>
-        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
         </dependency>
@@ -194,7 +189,6 @@
                             <ignoredUnusedDeclaredDependencies>
                                 <ignoredUnusedDeclaredDependency>io.sundr:builder-annotations</ignoredUnusedDeclaredDependency>
                                 <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j2-impl</ignoredUnusedDeclaredDependency>
-                                <ignoredUnusedDeclaredDependency>io.github.nettyplus:netty-leak-detector-junit-extension</ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
                             <ignoredDependencies>
                                 <!-- sundrio generates code that depends on jackson annotations/core, so we need compile scoped dependencies to let the generated code compile -->

--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -191,7 +191,6 @@
         <dependency>
             <groupId>io.github.nettyplus</groupId>
             <artifactId>netty-leak-detector-junit-extension</artifactId>
-            <version>0.0.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -364,6 +364,12 @@
                 <version>${apache.commons.version}</version>
                 <scope>compile</scope>
             </dependency>
+            <dependency>
+                <groupId>io.github.nettyplus</groupId>
+                <artifactId>netty-leak-detector-junit-extension</artifactId>
+                <version>0.0.5</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <testcontainers.version>1.19.7</testcontainers.version>
         <bouncycastle.version>1.78.1</bouncycastle.version>
         <apache.commons.version>3.14.0</apache.commons.version>
+        <netty-leak-detector-junit-extension.version>0.0.5</netty-leak-detector-junit-extension.version>
     </properties>
 
     <name>Parent POM</name>
@@ -367,7 +368,7 @@
             <dependency>
                 <groupId>io.github.nettyplus</groupId>
                 <artifactId>netty-leak-detector-junit-extension</artifactId>
-                <version>0.0.5</version>
+                <version>${netty-leak-detector-junit-extension.version}</version>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

shuffle netty-leak-detector version to dependency management. Also removes the dependency from test-support as we don't actually use it there.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
