### PR TITLE
Range aware port per broker exposition

### DIFF
--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousConfigUtils.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousConfigUtils.java
@@ -11,6 +11,7 @@ import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.PortPerBrokerClusterNetworkAddressConfigProvider;
+import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 
@@ -92,6 +93,9 @@ public class KroxyliciousConfigUtils {
         // actual bootstrap after the proxy is started. The provider might support dynamic ports (port 0), so querying the
         // config might not work.
         if (provider.config() instanceof PortPerBrokerClusterNetworkAddressConfigProviderConfig c) {
+            return c.getBootstrapAddress().toString();
+        }
+        if (provider.config() instanceof RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig c) {
             return c.getBootstrapAddress().toString();
         }
         else if (provider.config() instanceof SniRoutingClusterNetworkAddressConfigProviderConfig c) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/IndexedIntInterval.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/IndexedIntInterval.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
+
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * A non-empty integer interval. The index for each value is the 0-based position of the
+ * value in the interval from smallest to largest.
+ * @param startInclusive the inclusive start integer
+ * @param endExclusive the exclusive end integer
+ */
+record IndexedIntInterval(int startInclusive, int endExclusive) implements IndexedIntSet {
+
+    private static final String START_INCLUSIVE = "[";
+    private static final String START_EXCLUSIVE = "(";
+    private static final String END_INCLUSIVE = "]";
+    private static final String END_EXCLUSIVE = ")";
+    private static final String INTEGER_GROUP = "(\\d*)";
+    private static final String END_INCLUSIVITY_GROUP = "([" + END_EXCLUSIVE + Pattern.quote(END_INCLUSIVE) + "])";
+    private static final String START_INCLUSIVITY_GROUP = "([" + Pattern.quote(START_INCLUSIVE) + START_EXCLUSIVE + "])";
+    static Pattern INTERVAL_PATTERN = Pattern.compile("^" + START_INCLUSIVITY_GROUP + INTEGER_GROUP + "," + INTEGER_GROUP + END_INCLUSIVITY_GROUP + "$");
+
+    IndexedIntInterval {
+        if (endExclusive <= startInclusive) {
+            throw new IllegalArgumentException("endExclusive " + endExclusive + " less than or equal to startInclusive " + startInclusive);
+        }
+    }
+
+    @Override
+    public int indexOf(int integer) {
+        return contains(integer) ? integer - startInclusive : -1;
+    }
+
+    @Override
+    public boolean contains(int integer) {
+        return integer >= startInclusive && integer < endExclusive;
+    }
+
+    @Override
+    public int size() {
+        return endExclusive - startInclusive;
+    }
+
+    enum Inclusivity {
+        INCLUSIVE {
+            @Override
+            public int toStartInclusive(int value) {
+                return value;
+            }
+
+            @Override
+            public int toEndExclusive(int value) {
+                return value + 1;
+            }
+        },
+        EXCLUSIVE {
+            @Override
+            public int toStartInclusive(int value) {
+                return value + 1;
+            }
+
+            @Override
+            public int toEndExclusive(int value) {
+                return value;
+            }
+        };
+
+        public abstract int toStartInclusive(int value);
+
+        public abstract int toEndExclusive(int value);
+    }
+
+    /**
+     * Parse an integer range spec like [0,1). Square brackets are inclusive, round are exclusive. e.g.
+     * <ul>
+     *     <li>[1,3] -> (1,2,3)</li>
+     *     <li>(1,3] -> (2,3)</li>
+     *     <li>[1,3) -> (1,2)</li>
+     *     <li>(1,3) -> (2)</li>
+     * </ul>
+     * @param intervalSpec range spec string
+     * @return IndexedIntSet for specified range
+     * @throws IllegalArgumentException if the end of the range is before the start, e.g. [1,1) or [2,1]
+     */
+    static IndexedIntSet parse(String intervalSpec) {
+        Matcher matcher = INTERVAL_PATTERN.matcher(intervalSpec);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("range string " + intervalSpec + " did not match " + INTERVAL_PATTERN.pattern());
+        }
+
+        Inclusivity startInclusivity = toInclusivity(matcher.group(1));
+        int startValue = Integer.parseInt(matcher.group(2));
+        int endValue = Integer.parseInt(matcher.group(3));
+        Inclusivity endInclusivity = toInclusivity(matcher.group(4));
+        return new IndexedIntInterval(startInclusivity.toStartInclusive(startValue), endInclusivity.toEndExclusive(endValue));
+    }
+
+    private static Inclusivity toInclusivity(String inclusivity) {
+        if (inclusivity.equals(START_INCLUSIVE) || inclusivity.equals(END_INCLUSIVE)) {
+            return Inclusivity.INCLUSIVE;
+        }
+        else if (inclusivity.equals(START_EXCLUSIVE) || inclusivity.equals(END_EXCLUSIVE)) {
+            return Inclusivity.EXCLUSIVE;
+        }
+        else {
+            throw new IllegalArgumentException("input " + inclusivity + " did not map to an inclusivity value");
+        }
+    }
+
+    @Override
+    public Set<Integer> values() {
+        return IntStream.range(startInclusive, endExclusive).boxed().collect(Collectors.toSet());
+    }
+
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/IndexedIntSet.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/IndexedIntSet.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
+
+import java.util.Collection;
+import java.util.Set;
+
+/**
+ * Represents a set of distinct integers with a stable index from each of its values
+ * to a distinct integer in the range [0, size). Any set of integers can build a
+ * deterministic index by sorting the values and then using the position of each value
+ * as its index.
+ */
+public interface IndexedIntSet {
+
+    /**
+     * Returns the index for this value. Each value will have a unique index in the
+     * range [0, size).
+     * @param integer value
+     * @return index index for value
+     */
+    int indexOf(int integer);
+
+    /**
+     * Returns true if this set contains the specified integer.
+     * @param integer integer whose presence in this collection is to be tested
+     * @return true if this set contains the specified element
+     */
+    boolean contains(int integer);
+
+    /**
+     * Returns the number of integers in this set
+     * @return the number of integers in this set
+     */
+    int size();
+
+    /**
+     * Returns the set of values
+     * @return values
+     */
+    Set<Integer> values();
+
+    /**
+     * <p>Union multiple indexed int sets. The Unioned set orders the aggregate set of values and
+     * indexes them based on their position. So if we union [4,5] and [1,2], the index of 1 is 0
+     * and the index of 4 is 2.</p>
+     * <p>Each value in the union must exist in exactly one of the component sets. This
+     * differs from a regular set union.</p>
+     * @param sets indexed int sets to be unioned
+     * @return IndexedIntSet the union set
+     * @throws IllegalArgumentException if any integer is present in more than one input set
+     */
+    static IndexedIntSet distinctUnion(Collection<IndexedIntSet> sets) {
+        return IndexedIntSetDistinctUnion.union(sets);
+    }
+
+    /**
+     * Parse an integer range spec like [0,1). Square brackets are inclusive, round are exclusive. e.g.
+     * <ul>
+     *     <li>[1,3] -> (1,2,3)</li>
+     *     <li>(1,3] -> (2,3)</li>
+     *     <li>[1,3) -> (1,2)</li>
+     *     <li>(1,3) -> (2)</li>
+     * </ul>
+     * @param intervalSpec range spec string
+     * @return IndexedIntSet for specified range
+     * @throws IllegalArgumentException if the end of the range is before the start, e.g. [1,1) or [2,1]
+     */
+    static IndexedIntSet parseInterval(String intervalSpec) {
+        return IndexedIntInterval.parse(intervalSpec);
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/IndexedIntSetDistinctUnion.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/IndexedIntSetDistinctUnion.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * <p>Union multiple indexed int sets. The Unioned set orders the aggregate set of values and
+ * indexes them based on their position. So if we union [4,5] and [1,2], the index of 1 is 0
+ * and the index of 4 is 2.</p>
+ * <p>Each value in the union must exist in exactly one of the component sets. This
+ * differs from a regular set union.</p>
+ */
+record IndexedIntSetDistinctUnion(Map<Integer, Integer> index) implements IndexedIntSet {
+
+    static IndexedIntSet union(Collection<IndexedIntSet> intIntervals) {
+        return new IndexedIntSetDistinctUnion(index(intIntervals));
+    }
+
+    static Map<Integer, Integer> index(Collection<IndexedIntSet> intIntervals) {
+        int[] ints = intIntervals.stream().flatMapToInt(indexedIntSet -> indexedIntSet.values().stream().mapToInt(value -> value)).distinct().sorted().toArray();
+        Map<Integer, Integer> map = new HashMap<>();
+        for (int i = 0; i < ints.length; i++) {
+            map.put(ints[i], i);
+        }
+        int expectedSize = intIntervals.stream().mapToInt(IndexedIntSet::size).sum();
+        if (map.size() != expectedSize) {
+            throw new IllegalArgumentException("size of union index less that the sum of it's parts, indexes overlap: " + intIntervals);
+        }
+        return map;
+    }
+
+    @Override
+    public int indexOf(int integer) {
+        return index.getOrDefault(integer, -1);
+    }
+
+    @Override
+    public boolean contains(int integer) {
+        return index.containsKey(integer);
+    }
+
+    @Override
+    public int size() {
+        return index.size();
+    }
+
+    @Override
+    public Set<Integer> values() {
+        return index.keySet().stream().mapToInt(i -> i).boxed().collect(Collectors.toSet());
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
+import io.kroxylicious.proxy.service.HostPort;
+
+import static io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.BrokerAddressPatternUtils.EXPECTED_TOKEN_SET;
+import static io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.BrokerAddressPatternUtils.validatePortSpecifier;
+import static io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.BrokerAddressPatternUtils.validateStringContainsOnlyExpectedTokens;
+
+public class RangeAwarePortPerNodeClusterNetworkAddressConfigProvider implements ClusterNetworkAddressConfigProvider {
+
+    private final HostPort bootstrapAddress;
+    private final String nodeAddressPattern;
+    private final int nodeStartPort;
+    private final Set<Integer> exclusivePorts;
+    private final IndexedIntSet nodeIdIndex;
+
+    /**
+     * Creates the provider.
+     *
+     * @param config configuration
+     */
+    public RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig config) {
+        this.bootstrapAddress = config.bootstrapAddress;
+        this.nodeAddressPattern = config.nodeAddressPattern;
+        this.nodeStartPort = config.nodeStartPort;
+        this.nodeIdIndex = config.nodeIdIndex;
+
+        int nodeEndPortExclusive = nodeStartPort + config.nodeIdIndex.size();
+        var exclusivePorts = IntStream.range(nodeStartPort, nodeEndPortExclusive).boxed().collect(Collectors.toCollection(HashSet::new));
+        exclusivePorts.add(bootstrapAddress.port());
+        this.exclusivePorts = Collections.unmodifiableSet(exclusivePorts);
+    }
+
+    @Override
+    public HostPort getClusterBootstrapAddress() {
+        return this.bootstrapAddress;
+    }
+
+    @Override
+    public HostPort getBrokerAddress(int nodeId) throws IllegalArgumentException {
+        if (!nodeIdIndex.contains(nodeId)) {
+            throw new IllegalArgumentException(
+                    "Cannot generate node address for node id %d as it is not contained in the ranges defined for provider with downstream bootstrap %s"
+                            .formatted(
+                                    nodeId,
+                                    bootstrapAddress));
+        }
+        int port = nodeStartPort + nodeIdIndex.indexOf(nodeId);
+        return new HostPort(BrokerAddressPatternUtils.replaceLiteralNodeId(nodeAddressPattern, nodeId), port);
+    }
+
+    @Override
+    public Set<Integer> getExclusivePorts() {
+        return this.exclusivePorts;
+    }
+
+    @Override
+    public Map<Integer, HostPort> discoveryAddressMap() {
+        return nodeIdIndex.values().stream()
+                .collect(Collectors.toMap(Function.identity(), this::getBrokerAddress));
+    }
+
+    /**
+     * @param name arbitrary name for this range, no functional purpose
+     * @param range interval spec
+     * @see IndexedIntSet#parseInterval(String)
+     */
+    public record Range(String name, String range) {};
+
+    /**
+     * Creates the configuration for this provider.
+     */
+    public static class RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig {
+        private final HostPort bootstrapAddress;
+        private final String nodeAddressPattern;
+        private final int nodeStartPort;
+        private final IndexedIntSet nodeIdIndex;
+
+        public RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig(@JsonProperty(required = true) HostPort bootstrapAddress,
+                                                                              @JsonProperty(required = false) String nodeAddressPattern,
+                                                                              @JsonProperty(required = false) Integer nodeStartPort,
+                                                                              @JsonProperty(required = true) List<Range> nodeIdRanges) {
+            Objects.requireNonNull(bootstrapAddress, "bootstrapAddress cannot be null");
+            if (nodeIdRanges.isEmpty()) {
+                throw new IllegalArgumentException("node id ranges empty");
+            }
+            this.bootstrapAddress = bootstrapAddress;
+            this.nodeAddressPattern = nodeAddressPattern != null ? nodeAddressPattern : bootstrapAddress.host();
+            this.nodeStartPort = nodeStartPort != null ? nodeStartPort : (bootstrapAddress.port() + 1);
+            Stream<IndexedIntSet> rangeSets = nodeIdRanges.stream().map(range -> IndexedIntSet.parseInterval(range.range));
+            nodeIdIndex = IndexedIntSet.distinctUnion(rangeSets.toList());
+
+            if (this.nodeAddressPattern.isBlank()) {
+                throw new IllegalArgumentException("nodeAddressPattern cannot be blank");
+            }
+
+            validatePortSpecifier(this.nodeAddressPattern, s -> {
+                throw new IllegalArgumentException("nodeAddressPattern cannot have port specifier.  Found port : " + s + " within " + this.nodeAddressPattern);
+            });
+
+            if (this.nodeStartPort < 1) {
+                throw new IllegalArgumentException("nodeStartPort cannot be less than 1");
+            }
+            int numberOfNodePorts = nodeIdIndex.size();
+            IntStream.range(this.nodeStartPort, this.nodeStartPort + numberOfNodePorts).filter(i -> i == bootstrapAddress.port()).findFirst().ifPresent(i -> {
+                throw new IllegalArgumentException("the port used by the bootstrap address (%d) collides with the node port range".formatted(bootstrapAddress.port()));
+            });
+
+            validateStringContainsOnlyExpectedTokens(this.nodeAddressPattern, EXPECTED_TOKEN_SET, (token) -> {
+                throw new IllegalArgumentException("nodeAddressPattern contains an unexpected replacement token '" + token + "'");
+            });
+        }
+
+        public HostPort getBootstrapAddress() {
+            return bootstrapAddress;
+        }
+    }
+
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/RangeAwarePortPerNodeContributor.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/RangeAwarePortPerNodeContributor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
+
+import io.kroxylicious.proxy.clusternetworkaddressconfigprovider.ClusterNetworkAddressConfigProviderContributor;
+import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig;
+import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
+import io.kroxylicious.proxy.service.Context;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class RangeAwarePortPerNodeContributor implements
+        ClusterNetworkAddressConfigProviderContributor<RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig> {
+
+    @NonNull
+    @Override
+    public boolean requiresConfiguration() {
+        return true;
+    }
+
+    @NonNull
+    @Override
+    public Class<? extends ClusterNetworkAddressConfigProvider> getServiceType() {
+        return RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.class;
+    }
+
+    @NonNull
+    @Override
+    public Class<RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig> getConfigType() {
+        return RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig.class;
+    }
+
+    @NonNull
+    @Override
+    public ClusterNetworkAddressConfigProvider createInstance(Context<RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig> context) {
+        return new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(context.getConfig());
+    }
+
+}

--- a/kroxylicious-runtime/src/main/resources/META-INF/services/io.kroxylicious.proxy.clusternetworkaddressconfigprovider.ClusterNetworkAddressConfigProviderContributor
+++ b/kroxylicious-runtime/src/main/resources/META-INF/services/io.kroxylicious.proxy.clusternetworkaddressconfigprovider.ClusterNetworkAddressConfigProviderContributor
@@ -1,2 +1,3 @@
 io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.PortPerBrokerContributor
+io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.RangeAwarePortPerNodeContributor
 io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.SniRoutingContributor

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/IndexedIntIntervalTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/IndexedIntIntervalTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
+
+import org.junit.jupiter.api.Test;
+
+import static io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.IndexedIntInterval.INTERVAL_PATTERN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class IndexedIntIntervalTest {
+
+    @Test
+    void invalidInputs() {
+        assertDoesNotMatchIntervalPattern("z1,3]");
+        assertDoesNotMatchIntervalPattern("[a,3]");
+        assertDoesNotMatchIntervalPattern("[0|3]");
+        assertDoesNotMatchIntervalPattern("[1,a]");
+        assertDoesNotMatchIntervalPattern("[1,3.");
+    }
+
+    @Test
+    void bothInclusive() {
+        IndexedIntSet intInterval = IndexedIntSet.parseInterval("[1,3]");
+        int[] array = intInterval.values().stream().mapToInt(value -> value).toArray();
+        assertThat(array).containsExactly(1, 2, 3);
+    }
+
+    @Test
+    void endMustBeAfterStart() {
+        assertThatThrownBy(() -> IndexedIntInterval.parse("[1,1)")).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("endExclusive 1 less than or equal to startInclusive 1");
+        assertThatThrownBy(() -> IndexedIntInterval.parse("[1,0)")).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("endExclusive 0 less than or equal to startInclusive 1");
+    }
+
+    @Test
+    void bothExclusive() {
+        IndexedIntSet intInterval = IndexedIntSet.parseInterval("(1,4)");
+        int[] array = intInterval.values().stream().mapToInt(value -> value).toArray();
+        assertThat(array).containsExactly(2, 3);
+    }
+
+    @Test
+    void exclusiveStartInclusiveEnd() {
+        IndexedIntSet intInterval = IndexedIntSet.parseInterval("(1,3]");
+        int[] array = intInterval.values().stream().mapToInt(value -> value).toArray();
+        assertThat(array).containsExactly(2, 3);
+    }
+
+    @Test
+    void inclusiveStartExclusiveEnd() {
+        IndexedIntSet intInterval = IndexedIntSet.parseInterval("[0,3)");
+        int[] array = intInterval.values().stream().mapToInt(value -> value).toArray();
+        assertThat(array).containsExactly(0, 1, 2);
+    }
+
+    @Test
+    void testContains() {
+        IndexedIntSet intInterval = IndexedIntSet.parseInterval("[1,2]");
+        assertThat(intInterval.contains(-1)).isFalse();
+        assertThat(intInterval.contains(0)).isFalse();
+        assertThat(intInterval.contains(1)).isTrue();
+        assertThat(intInterval.contains(2)).isTrue();
+        assertThat(intInterval.contains(3)).isFalse();
+    }
+
+    @Test
+    void testSize() {
+        IndexedIntSet intInterval = IndexedIntSet.parseInterval("[1,2]");
+        assertThat(intInterval.size()).isEqualTo(2);
+    }
+
+    @Test
+    void testIndexOf() {
+        IndexedIntSet intInterval = IndexedIntSet.parseInterval("[1,2]");
+        assertThat(intInterval.indexOf(0)).isEqualTo(-1);
+        assertThat(intInterval.indexOf(1)).isEqualTo(0);
+        assertThat(intInterval.indexOf(2)).isEqualTo(1);
+        assertThat(intInterval.indexOf(3)).isEqualTo(-1);
+    }
+
+    private static void assertDoesNotMatchIntervalPattern(String input) {
+        assertThatThrownBy(() -> IndexedIntSet.parseInterval(input)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("range string " + input + " did not match " + INTERVAL_PATTERN.pattern());
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/IndexedIntSetDistinctUnionTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/IndexedIntSetDistinctUnionTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class IndexedIntSetDistinctUnionTest {
+
+    @Test
+    void indexOf() {
+        IndexedIntSet union = IndexedIntSet.distinctUnion(Set.of(new IndexedIntInterval(1, 3), new IndexedIntInterval(4, 6)));
+        assertThat(union.indexOf(0)).isEqualTo(-1);
+        assertThat(union.indexOf(1)).isEqualTo(0);
+        assertThat(union.indexOf(2)).isEqualTo(1);
+        assertThat(union.indexOf(3)).isEqualTo(-1);
+        assertThat(union.indexOf(4)).isEqualTo(2);
+        assertThat(union.indexOf(5)).isEqualTo(3);
+        assertThat(union.indexOf(6)).isEqualTo(-1);
+    }
+
+    @Test
+    void contains() {
+        IndexedIntSet union = IndexedIntSet.distinctUnion(Set.of(new IndexedIntInterval(1, 3), new IndexedIntInterval(4, 6)));
+        assertThat(union.contains(0)).isFalse();
+        assertThat(union.contains(1)).isTrue();
+        assertThat(union.contains(2)).isTrue();
+        assertThat(union.contains(3)).isFalse();
+        assertThat(union.contains(4)).isTrue();
+        assertThat(union.contains(5)).isTrue();
+        assertThat(union.contains(6)).isFalse();
+    }
+
+    @Test
+    void size() {
+        IndexedIntSet union = IndexedIntSet.distinctUnion(Set.of(new IndexedIntInterval(1, 3), new IndexedIntInterval(4, 6)));
+        assertThat(union.size()).isEqualTo(4);
+    }
+
+    @Test
+    void distinctness() {
+        Set<IndexedIntSet> sets = Set.of(new IndexedIntInterval(1, 3), new IndexedIntInterval(2, 4));
+        assertThatThrownBy(() -> IndexedIntSet.distinctUnion(sets))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("size of union index less that the sum of it's parts, indexes overlap");
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/RangeAwarePortPerNodeClusterNetworkAddressConfigProviderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/RangeAwarePortPerNodeClusterNetworkAddressConfigProviderTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.Range;
+import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig;
+import io.kroxylicious.proxy.service.HostPort;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RangeAwarePortPerNodeClusterNetworkAddressConfigProviderTest {
+
+    public static final String BOOTSTRAP_HOST = "cluster.kafka.example.com";
+    private static final String BOOTSTRAP = BOOTSTRAP_HOST + ":1235";
+
+    @Test
+    void rangesMustBeNonEmpty() {
+        assertThatThrownBy(() -> new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(
+                getConfig(List.of()))).isInstanceOf(IllegalArgumentException.class).hasMessage("node id ranges empty");
+    }
+
+    @Test
+    void brokerAddressSingleRange() {
+        RangeAwarePortPerNodeClusterNetworkAddressConfigProvider provider = new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(
+                getConfig(List.of(new Range("brokers", "[0,1]"))));
+        assertThat(provider.getBrokerAddress(0)).isEqualTo(new HostPort("broker0.kafka.example.com", 1236));
+        assertThat(provider.getBrokerAddress(1)).isEqualTo(new HostPort("broker1.kafka.example.com", 1237));
+    }
+
+    @Test
+    void brokerAddressPortsInferredFromBootstrapIfNotExplicitlySupplied() {
+        List<Range> ranges = List.of(new Range("brokers", "[0,1]"));
+        HostPort bootstrapAddress = HostPort.parse(BOOTSTRAP);
+        RangeAwarePortPerNodeClusterNetworkAddressConfigProvider provider = new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(
+                new RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig(
+                        bootstrapAddress, "broker$(nodeId).kafka.example.com",
+                        null, ranges));
+        assertThat(provider.getBrokerAddress(0)).isEqualTo(new HostPort("broker0.kafka.example.com", 1236));
+        assertThat(provider.getBrokerAddress(1)).isEqualTo(new HostPort("broker1.kafka.example.com", 1237));
+    }
+
+    @Test
+    void brokerAddressInferredFromBootstrapIfNotExplicitlySupplied() {
+        List<Range> ranges = List.of(new Range("brokers", "[0,1]"));
+        HostPort bootstrapAddress = HostPort.parse(BOOTSTRAP);
+        RangeAwarePortPerNodeClusterNetworkAddressConfigProvider provider = new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(
+                new RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig(
+                        bootstrapAddress, null,
+                        null, ranges));
+        assertThat(provider.getBrokerAddress(0)).isEqualTo(new HostPort(BOOTSTRAP_HOST, 1236));
+        assertThat(provider.getBrokerAddress(1)).isEqualTo(new HostPort(BOOTSTRAP_HOST, 1237));
+    }
+
+    @Test
+    void nodeAddressPatternCannotBeBlank() {
+        assertThatThrownBy(() -> new RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig(
+                HostPort.parse(BOOTSTRAP), "",
+                null, List.of(new Range("brokers", "[0,1]"))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("nodeAddressPattern cannot be blank");
+    }
+
+    @Test
+    void nodeAddressPatternCannotContainUnexpectedReplacementPatterns() {
+        assertThatThrownBy(() -> new RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig(
+                HostPort.parse(BOOTSTRAP), "node-$(typoedNodeId).broker.com",
+                null, List.of(new Range("brokers", "[0,1]"))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("nodeAddressPattern contains an unexpected replacement token '$(typoedNodeId)'");
+    }
+
+    @Test
+    void nodeAddressPatternCannotContainPort() {
+        assertThatThrownBy(() -> new RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig(
+                HostPort.parse(BOOTSTRAP), "localhost:8080",
+                null, List.of(new Range("brokers", "[0,1]"))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("nodeAddressPattern cannot have port specifier.  Found port : 8080 within localhost:8080");
+    }
+
+    @Test
+    void nodeStartPortCannotBeLessThanOne() {
+        assertThatThrownBy(() -> new RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig(
+                HostPort.parse(BOOTSTRAP), "localhost",
+                0, List.of(new Range("brokers", "[0,1]"))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("nodeStartPort cannot be less than 1");
+    }
+
+    @Test
+    void nodePortRangeCannotCollideWithBootstrapPort() {
+        assertThatThrownBy(() -> new RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig(
+                HostPort.parse(BOOTSTRAP_HOST + ":1235"), "localhost",
+                // node id 1 will be assigned port 1235 and collide with bootstrap
+                1234, List.of(new Range("brokers", "[0,2]"))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("the port used by the bootstrap address (1235) collides with the node port range");
+    }
+
+    @Test
+    void getClusterBootstrap() {
+        List<Range> ranges = List.of(new Range("brokers", "[0,1]"));
+        HostPort bootstrapAddress = HostPort.parse(BOOTSTRAP);
+        RangeAwarePortPerNodeClusterNetworkAddressConfigProvider provider = new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(
+                new RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig(
+                        bootstrapAddress, "broker$(nodeId).kafka.example.com",
+                        1236, ranges));
+        assertThat(provider.getClusterBootstrapAddress()).isEqualTo(bootstrapAddress);
+    }
+
+    @Test
+    void exclusivePortsSingleRange() {
+        RangeAwarePortPerNodeClusterNetworkAddressConfigProvider provider = new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(
+                getConfig(List.of(new Range("brokers", "[0,1]"))));
+        assertThat(provider.getExclusivePorts()).containsExactly(1235, 1236, 1237);
+    }
+
+    @Test
+    void discoveryAddressMapSingleRange() {
+        RangeAwarePortPerNodeClusterNetworkAddressConfigProvider provider = new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(
+                getConfig(List.of(new Range("brokers", "[0,1]"))));
+
+        Map<Integer, HostPort> expected = Map.of(
+                0, new HostPort("broker0.kafka.example.com", 1236),
+                1, new HostPort("broker1.kafka.example.com", 1237));
+        assertThat(provider.discoveryAddressMap()).isEqualTo(expected);
+    }
+
+    @Test
+    void brokerAddressMultipleRanges() {
+        RangeAwarePortPerNodeClusterNetworkAddressConfigProvider provider = new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(
+                getConfig(List.of(new Range("brokers", "[0,1]"), new Range("controllers", "[3,4]"))));
+        assertThat(provider.getBrokerAddress(0)).isEqualTo(new HostPort("broker0.kafka.example.com", 1236));
+        assertThat(provider.getBrokerAddress(1)).isEqualTo(new HostPort("broker1.kafka.example.com", 1237));
+        assertThat(provider.getBrokerAddress(3)).isEqualTo(new HostPort("broker3.kafka.example.com", 1238));
+        assertThat(provider.getBrokerAddress(4)).isEqualTo(new HostPort("broker4.kafka.example.com", 1239));
+    }
+
+    @Test
+    void brokerAddressUnknownNodeId() {
+        RangeAwarePortPerNodeClusterNetworkAddressConfigProvider provider = new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(
+                getConfig(List.of(new Range("brokers", "[0,1]"), new Range("controllers", "[3,4]"))));
+        String expectedMessage = "Cannot generate node address for node id 5 as it is not contained in the ranges defined for provider with downstream bootstrap "
+                + BOOTSTRAP;
+        assertThatThrownBy(() -> provider.getBrokerAddress(5)).isInstanceOf(IllegalArgumentException.class).hasMessage(expectedMessage);
+    }
+
+    @Test
+    void discoveryAddressMapMultipleRanges() {
+        RangeAwarePortPerNodeClusterNetworkAddressConfigProvider provider = new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(
+                getConfig(List.of(new Range("brokers", "[0,1]"), new Range("controllers", "[3,4]"))));
+
+        Map<Integer, HostPort> expected = Map.of(
+                0, new HostPort("broker0.kafka.example.com", 1236),
+                1, new HostPort("broker1.kafka.example.com", 1237),
+                3, new HostPort("broker3.kafka.example.com", 1238),
+                4, new HostPort("broker4.kafka.example.com", 1239));
+        assertThat(provider.discoveryAddressMap()).isEqualTo(expected);
+    }
+
+    @Test
+    void exclusivePortsMultipleRanges() {
+        RangeAwarePortPerNodeClusterNetworkAddressConfigProvider provider = new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(
+                getConfig(List.of(new Range("brokers", "[0,1]"), new Range("controllers", "[3,4]"))));
+        assertThat(provider.getExclusivePorts()).containsExactly(1235, 1236, 1237, 1238, 1239);
+    }
+
+    private static @NonNull RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig getConfig(List<Range> ranges) {
+        HostPort bootstrapAddress = HostPort.parse(BOOTSTRAP);
+        return new RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig(
+                bootstrapAddress, "broker$(nodeId).kafka.example.com",
+                1236, ranges);
+    }
+
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Add RangeAwarePortPerNodeClusterNetworkAddressConfigProvider
 
Mitigates #902
 
This new implementation introduces the concept of Node Id Ranges and enables you to configure multiple such ranges for your virtual cluster. Enabling a deterministic mapping of node ids to proxy ports even when there are large gaps between the ranges.
    
Ranges are specified in interval notation with square brackets for inclusive and round brackets for inclusive.

Each node id in the union of all the ranges (the ranges must be distinct and not intersect) is deterministically mapped to a port. To do this we effectively sort all the nodeIds into an ascending list and use the position in the list as an offset we then add to the start port.

For example if I configure a virtual cluster with:
 
```
nodeStartPort: 9000
nodeIdRanges:
  - name: brokers
    range: [4,6)
  - name: controllers
    range: [1,2]
```
Then the ports will be mapped as follows:
- node 1 -> port 9000
- node 2 -> port 9001
- node 4 -> port 9002
- node 5 -> port 9003
    
Why:
Currently there are numerous drawbacks to using the PortPerBroker exposition scheme. If the lowest broker id is N and the highest is M then we must expose M-N deterministically map each node id to a port. So if you have two nodes with ids 100000 and 200000 you need 100000 ports mapped so that we can say startPort+0 is node 100000 and startPort+100000 is node id 200000.    

Also with the advent of KRaft we now may have to contend with two distinct and evolving sets of node ids, a controller pool and a broker pool. If there is a significant gap between them we have the same problem as above.
    
This enables us to represent clusters with highly variable node ids using a more compact set of ports.
    
Note it still does not solve other issues, like some users regulurly introduce new nodes and remove old ones in their target cluster as part of upgrades.  Leading to eternal growth of node ids. To handle this in a better way we think the Proxy would need to be able to discover the target topology.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
