### PR TITLE
update run-example script to use helm to install strimzi

### DIFF
--- a/scripts/run-example.sh
+++ b/scripts/run-example.sh
@@ -8,6 +8,7 @@
 set -euo pipefail
 DEFAULT_KROXYLICIOUS_IMAGE='quay.io/kroxylicious/kroxylicious'
 KROXYLICIOUS_IMAGE=${KROXYLICIOUS_IMAGE:-${DEFAULT_KROXYLICIOUS_IMAGE}}
+STRIMZI_VERSION=$(./mvnw org.apache.maven.plugins:maven-help-plugin:3.4.0:evaluate -Dexpression=strimzi.version -q -DforceStdout)
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . "${SCRIPT_DIR}/common.sh"
@@ -93,8 +94,7 @@ fi
 
 # Install strimzi
 ${KUBECTL} create namespace kafka 2>/dev/null || true
-${KUBECTL} apply -f 'https://strimzi.io/install/latest?namespace=kafka' -n kafka
-${KUBECTL} wait deployment strimzi-cluster-operator --for=condition=Available=True --timeout=300s -n kafka
+${HELM} install strimzi-cluster-operator --namespace kafka --timeout 120s --version "${STRIMZI_VERSION}" oci://quay.io/strimzi-helm/strimzi-kafka-operator --set replicas=1 --wait
 echo -e "${GREEN}Strimzi installed.${NOCOLOR}"
 
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes #1212. We need to refactor `run-example.sh` script to use helm and select the version of strimzi that we are installing instead of installing always the latest version.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
