### PR TITLE
Range-aware Port Per Node with integer configuration 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ Format `<github issue/pr number>: <short description>`.
 * [#1158](https://github.com/kroxylicious/kroxylicious/pull/1158): Bump io.netty:netty-bom from 4.1.108.Final to 4.1.109.Final
 * [#1162](https://github.com/kroxylicious/kroxylicious/issues/1162): Fix #1162: allow tenant / resource name prefix separator to be controlled from configuration
 * [#1120](https://github.com/kroxylicious/kroxylicious/pull/1120): Generate API compatability report as part of the release process.
+* [#1220](https://github.com/kroxylicious/kroxylicious/pull/1220): Range-aware Port Per Node with integer configuration
+
+
+### Changes, deprecations and removals
+
+* RangeAwarePortPerNodeClusterNetworkAddressConfigProvider is a new ClusterNetworkAddressConfigProvider that is capable of modelling
+more target topologies using a compact set of ports. Users can declare multiple ranges of node ids that exist in the target cluster
+and the proxy will map those ranges on to a minimal set of proxy ports. See the [Virtual Cluster configuration docs](https://kroxylicious.io/kroxylicious/#_rangeawareportpernode_scheme)
+for more information.
  
 ## 0.5.1
 

--- a/docs/deploying.adoc
+++ b/docs/deploying.adoc
@@ -124,6 +124,92 @@ clusterNetworkAddressConfigProvider:
 can only map broker ids 1000, 1001 and 1002 to ports 9193, 9194 and 9195 respectively. You would have to reconfigure
 `numberOfBrokerPorts` to accommodate new brokers being added to the cluster.
 
+==== RangeAwarePortPerNode scheme
+
+The original PortPerBroker scheme has the limitation that we only control the lowest target brokerId and a maximum
+number of brokers. We then expect all brokerIds to fall into the range [lowestBrokerId, lowestBrokerId + maxBrokerCount)
+We must be able to map every possible broker id to a unique port so that in a cluster of Kroxylicious proxies all
+members will deterministically map nodeId X to a port Y. Meaning that we may need to allocate many ports that are
+not required if there are large gaps between nodeIds in the target cluster.
+
+The Range Aware Port Per Node schema introduces the idea of Node ID Ranges, allowing you to model what nodeId ranges exist in
+the target cluster so that the proxy can expose a more compact number of ports but still retain this deterministic mapping
+from nodeId to port.
+
+Aside from how it maps nodeIds to ports it behaves the same as Port-Per-Broker.
+
+[source, yaml]
+----
+clusterNetworkAddressConfigProvider:
+  type: RangeAwarePortPerNodeClusterNetworkAddressConfigProvider
+  config:
+    bootstrapAddress: mycluster.kafka.com:9192                   # <1>
+    brokerAddressPattern: mybroker-$(nodeId).mycluster.kafka.com # <2>
+    brokerStartPort: 9193                                        # <3>
+    nodeIdRanges:                                                # <4>
+      - name: brokers                                            # <5>
+        range:
+          startInclusive: 0                                      # <6>
+          endExclusive: 3                                        # <7>
+----
+<1> The hostname and port of the bootstrap that will be used by the Kafka Clients.
+<2> (Optional) The broker address pattern used to form the broker addresses.  If not defined, it defaults to the
+hostname part of the `bootstrapAddress` and the port number allocated to the broker.
+<3> (Optional) The starting number for broker port range. Defaults to the port of the `bootstrapAddress` plus 1.
+<4> The list of Node ID rangers, must be non-empty.
+<5> Name of the range, must be unique within the nodeIdRanges list.
+<6> Start of the range (inclusive)
+<7> End of the range (exclusive). Must be greater than startInclusive, empty ranges are not allowed.
+
+NodeIdRanges must be distinct, a nodeId cannot be part of more than one range.
+
+The `brokerAddressPattern` configuration parameter understands the replacement token `$(nodeId)`. It is optional.
+If present, it will be replaced by the https://kafka.apache.org/documentation/#brokerconfigs_node.id[`node.id`] (or
+`broker.id`) assigned to the broker of the target cluster.
+
+For example: if I have a target cluster using KRaft that looks like:
+
+- nodeId: 0, roles: controller
+- nodeId: 1, roles: controller
+- nodeId: 2, roles: controller
+- nodeId: 1000, roles: broker
+- nodeId: 1001, roles: broker
+- nodeId: 1002, roles: broker
+- nodeId: 99999, roles: broker
+
+Then we can model this as three Node Id Ranges:
+
+[source, yaml]
+----
+    clusterNetworkAddressConfigProvider:
+      type: RangeAwarePortPerNodeClusterNetworkAddressConfigProvider
+      config:
+        bootstrapAddress: mycluster.kafka.com:9192
+        nodeIdRanges:
+          - name: controller
+            range:
+              startInclusive: 0
+              endExclusive: 3
+          - name: brokers
+            range:
+              startInclusive: 1000
+              endExclusive: 1003
+          - name: broker-outlier
+            range:
+              startInclusive: 99999
+              endExclusive: 100000
+----
+
+Which will result in this mapping from nodeId to Port
+
+- nodeId: 0 -> port 9193
+- nodeId: 1 -> port 9194
+- nodeId: 2 -> port 9195
+- nodeId: 1000 -> port 9196
+- nodeId: 1001 -> port 9197
+- nodeId: 1002 -> port 9198
+- nodeId: 99999 -> port 9199
+
 ==== SniRouting scheme
 
 In the `SniRouting` scheme, Kroxylicious uses SNI information to route traffic to either the boostrap or individual

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousConfigUtils.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousConfigUtils.java
@@ -11,6 +11,7 @@ import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.PortPerBrokerClusterNetworkAddressConfigProvider;
+import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 
@@ -92,6 +93,9 @@ public class KroxyliciousConfigUtils {
         // actual bootstrap after the proxy is started. The provider might support dynamic ports (port 0), so querying the
         // config might not work.
         if (provider.config() instanceof PortPerBrokerClusterNetworkAddressConfigProviderConfig c) {
+            return c.getBootstrapAddress().toString();
+        }
+        if (provider.config() instanceof RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig c) {
             return c.getBootstrapAddress().toString();
         }
         else if (provider.config() instanceof SniRoutingClusterNetworkAddressConfigProviderConfig c) {

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ExpositionIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ExpositionIT.java
@@ -43,6 +43,9 @@ import io.kroxylicious.proxy.config.ClusterNetworkAddressConfigProviderDefinitio
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.PortPerBrokerClusterNetworkAddressConfigProvider;
+import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.RangeAwarePortPerNodeClusterNetworkAddressConfigProvider;
+import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.IntRangeSpec;
+import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.NamedRangeSpec;
 import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.SniRoutingClusterNetworkAddressConfigProvider;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.test.tester.KroxyliciousTester;
@@ -190,6 +193,67 @@ class ExpositionIT extends BaseIT {
                     createTopic(admin, TOPIC + i, 1);
                 }
             }
+        }
+    }
+
+    @Test
+    void exposesClusterOfTwoBrokersWithRangeAwarePortPerNode(@BrokerCluster(numBrokers = 2) KafkaCluster cluster) throws Exception {
+        var builder = new ConfigurationBuilder()
+                .addToVirtualClusters("demo", new VirtualClusterBuilder()
+                        .withNewTargetCluster()
+                        .withBootstrapServers(cluster.getBootstrapServers())
+                        .endTargetCluster()
+                        .withClusterNetworkAddressConfigProvider(
+                                new ClusterNetworkAddressConfigProviderDefinitionBuilder(RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.class.getName())
+                                        .withConfig("bootstrapAddress", PROXY_ADDRESS)
+                                        .withConfig("nodeIdRanges", List.of(new NamedRangeSpec("nodes", new IntRangeSpec(0, 2))))
+                                        .build())
+                        .build());
+
+        var brokerEndpoints = Map.of(0, "localhost:" + (PROXY_ADDRESS.port() + 1), 1, "localhost:" + (PROXY_ADDRESS.port() + 2));
+
+        try (var tester = kroxyliciousTester(builder)) {
+
+            try (var admin = CloseableAdmin.create(Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, PROXY_ADDRESS.toString()))) {
+                var nodes = await().atMost(Duration.ofSeconds(5)).until(() -> admin.describeCluster().nodes().get(),
+                        n -> n.size() == cluster.getNumOfBrokers());
+                var unique = nodes.stream().collect(Collectors.toMap(Node::id, ExpositionIT::toAddress));
+                assertThat(unique).containsExactlyInAnyOrderEntriesOf(brokerEndpoints);
+            }
+
+            verifyAllBrokersAvailableViaProxy(tester, cluster);
+        }
+    }
+
+    @Test
+    void exposesClusterOfTwoBrokersWithIdGapWithRangeAwarePortPerNode(@BrokerCluster(numBrokers = 2) KafkaCluster cluster) throws Exception {
+        cluster.addBroker();
+        cluster.removeBroker(1);
+        var builder = new ConfigurationBuilder()
+                .addToVirtualClusters("demo", new VirtualClusterBuilder()
+                        .withNewTargetCluster()
+                        .withBootstrapServers(cluster.getBootstrapServers())
+                        .endTargetCluster()
+                        .withClusterNetworkAddressConfigProvider(
+                                new ClusterNetworkAddressConfigProviderDefinitionBuilder(RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.class.getName())
+                                        .withConfig("bootstrapAddress", PROXY_ADDRESS)
+                                        .withConfig("nodeIdRanges",
+                                                List.of(new NamedRangeSpec("node-0", new IntRangeSpec(0, 1)), new NamedRangeSpec("node-2", new IntRangeSpec(2, 3))))
+                                        .build())
+                        .build());
+
+        var brokerEndpoints = Map.of(0, "localhost:" + (PROXY_ADDRESS.port() + 1), 2, "localhost:" + (PROXY_ADDRESS.port() + 2));
+
+        try (var tester = kroxyliciousTester(builder)) {
+
+            try (var admin = CloseableAdmin.create(Map.of(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, PROXY_ADDRESS.toString()))) {
+                var nodes = await().atMost(Duration.ofSeconds(5)).until(() -> admin.describeCluster().nodes().get(),
+                        n -> n.size() == cluster.getNumOfBrokers());
+                var unique = nodes.stream().collect(Collectors.toMap(Node::id, ExpositionIT::toAddress));
+                assertThat(unique).containsExactlyInAnyOrderEntriesOf(brokerEndpoints);
+            }
+
+            verifyAllBrokersAvailableViaProxy(tester, cluster);
         }
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/Range.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/Range.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
+
+import java.util.Objects;
+import java.util.stream.IntStream;
+
+import io.kroxylicious.proxy.tag.VisibleForTesting;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Represents the set of integers between two integer endpoints. So the Range
+ * with startInclusive 1 and endExclusive 3 contains the integers 1 and 2.
+ * A Range must be non-empty, endExclusive must be greater than startInclusive
+ */
+public record Range(int startInclusive, int endExclusive) {
+
+    /**
+     * Constructs a Range
+     * @param startInclusive the (inclusive) initial value
+     * @param endExclusive the exclusive upper bound
+     * @throws IllegalArgumentException if end is before start
+     */
+    public Range {
+        if (endExclusive <= startInclusive) {
+            throw new IllegalArgumentException(
+                    "end of range: " + endExclusive + " (exclusive) is before start of range: " + startInclusive + " (inclusive)");
+        }
+    }
+
+    /**
+     * Provides a Stream of values contained in the range
+     * @return stream of values
+     */
+    @NonNull
+    public IntStream values() {
+        return IntStream.range(startInclusive, endExclusive);
+    }
+
+    /**
+     * Returns true if this range's end is before the start of another range. ie they do not overlap
+     * @param range range to compare
+     * @return true if this range ends before the start of other range
+     */
+    @VisibleForTesting
+    boolean isEndBeforeStartOf(@NonNull Range range) {
+        Objects.requireNonNull(range, "range to compare with is null");
+        return this.endExclusive <= range.startInclusive;
+    }
+
+    /**
+     * Return true if this range does not overlap with other range. If either range
+     * ends before the other starts then they must not overlap.
+     * @param range range to compare
+     * @return true if this range does not overlap with other range
+     */
+    public boolean isDistinctFrom(@NonNull Range range) {
+        Objects.requireNonNull(range, "range to compare with is null");
+        return isEndBeforeStartOf(range) || range.isEndBeforeStartOf(this);
+    }
+
+    @Override
+    public String toString() {
+        return "[" + startInclusive + "," + endExclusive + ")";
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
+import io.kroxylicious.proxy.service.HostPort;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.BrokerAddressPatternUtils.EXPECTED_TOKEN_SET;
+import static io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.BrokerAddressPatternUtils.validatePortSpecifier;
+import static io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.BrokerAddressPatternUtils.validateStringContainsOnlyExpectedTokens;
+
+/**
+ * A ClusterNetworkAddressConfigProvider implementation that uses a separate port per broker endpoint and that is aware of
+ * distinct ranges of nodeIds present in the target cluster. Upstream nodeIds are mapped to a compact set of ports.
+ * <br/>
+ * The following configuration is supported:
+ * <ul>
+ *    <li>{@code bootstrapAddress} (required) a {@link HostPort} defining the host and port of the bootstrap address.</li>
+ *    <li>{@code brokerAddressPattern} (optional) an address pattern used to form broker addresses.  It is addresses made from this pattern that are returned to the kafka
+ *    client in the Metadata response so must be resolvable by the client.  One pattern is supported: {@code $(nodeId)} which interpolates the node id into the address.
+ *    If brokerAddressPattern is omitted, it defaulted it based on the host name of {@code bootstrapAddress}.</li>
+ *    <li>{@code brokerStartPort} (optional) defines the starting range of port number that will be assigned to the brokers.  If omitted, it is defaulted to
+ *    the port number of {@code bootstrapAddress + 1}.</li>
+ *    <li>{@code nodeIdRanges} (required) defines the node id ranges present in the target cluster</li>
+ * </ul>
+ */
+public class RangeAwarePortPerNodeClusterNetworkAddressConfigProvider implements ClusterNetworkAddressConfigProvider {
+
+    private final HostPort bootstrapAddress;
+    private final String nodeAddressPattern;
+    private final Set<Integer> exclusivePorts;
+    private final Map<Integer, Integer> nodeIdToPort;
+
+    /**
+     * Creates the provider.
+     *
+     * @param config configuration
+     */
+    public RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig config) {
+        this.bootstrapAddress = config.bootstrapAddress;
+        this.nodeAddressPattern = config.nodeAddressPattern;
+        this.nodeIdToPort = config.nodeIdToPort;
+        var allExclusivePorts = new HashSet<>(nodeIdToPort.values());
+        allExclusivePorts.add(bootstrapAddress.port());
+        this.exclusivePorts = Collections.unmodifiableSet(allExclusivePorts);
+    }
+
+    @Override
+    public HostPort getClusterBootstrapAddress() {
+        return this.bootstrapAddress;
+    }
+
+    @Override
+    public HostPort getBrokerAddress(int nodeId) throws IllegalArgumentException {
+        if (!nodeIdToPort.containsKey(nodeId)) {
+            throw new IllegalArgumentException(
+                    "Cannot generate node address for node id %d as it is not contained in the ranges defined for provider with downstream bootstrap %s"
+                            .formatted(
+                                    nodeId,
+                                    bootstrapAddress));
+        }
+        int port = nodeIdToPort.get(nodeId);
+        return new HostPort(BrokerAddressPatternUtils.replaceLiteralNodeId(nodeAddressPattern, nodeId), port);
+    }
+
+    @Override
+    public Set<Integer> getExclusivePorts() {
+        return this.exclusivePorts;
+    }
+
+    @Override
+    public Map<Integer, HostPort> discoveryAddressMap() {
+        return nodeIdToPort.keySet().stream()
+                .collect(Collectors.toMap(Function.identity(), this::getBrokerAddress));
+    }
+
+    /**
+     * @param startInclusive the (inclusive) initial value
+     * @param endExclusive the exclusive upper bound
+     */
+    public record IntRangeSpec(@JsonInclude(JsonInclude.Include.ALWAYS) @JsonProperty(required = true) int startInclusive,
+                               @JsonInclude(JsonInclude.Include.ALWAYS) @JsonProperty(required = true) int endExclusive) {
+
+        public Range range() {
+            return new Range(startInclusive, endExclusive);
+        }
+    }
+
+    private record NamedRange(@NonNull String name, @NonNull Range range) {
+        public NamedRange {
+            Objects.requireNonNull(name, "name was null");
+            Objects.requireNonNull(range, "range was null");
+        }
+
+        public boolean isDistinctFrom(NamedRange rangeB) {
+            return range.isDistinctFrom(rangeB.range);
+        }
+
+        @Override
+        public String toString() {
+            return name + ":" + range;
+        }
+    }
+
+    /**
+     * @param name the name of this range
+     * @param rangeSpec specification of the range
+     */
+    public record NamedRangeSpec(@JsonProperty(required = true) String name,
+                                 @JsonProperty(required = true, value = "range") IntRangeSpec rangeSpec) {
+
+        NamedRange range() {
+            return new NamedRange(name, tryBuildRange());
+        }
+
+        private Range tryBuildRange() {
+            try {
+                return rangeSpec.range();
+            }
+            catch (Exception e) {
+                throw new IllegalArgumentException("invalid nodeIdRange: " + name + ", " + e.getMessage(), e);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return name + ":" + rangeSpec.range();
+        }
+    }
+
+    /**
+     * Creates the configuration for this provider.
+     */
+    public static class RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig {
+        private final HostPort bootstrapAddress;
+        private final String nodeAddressPattern;
+        private final int nodeStartPort;
+        @JsonIgnore
+        private final Map<Integer, Integer> nodeIdToPort;
+        @SuppressWarnings("java:S1068") // included so Jackson can serialize/deserialize this with fidelity
+        private final List<NamedRangeSpec> nodeIdRanges;
+
+        public RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig(@JsonProperty(required = true) HostPort bootstrapAddress,
+                                                                              @JsonProperty(required = false) String nodeAddressPattern,
+                                                                              @JsonProperty(required = false) Integer nodeStartPort,
+                                                                              @JsonProperty(required = true) List<NamedRangeSpec> nodeIdRanges) {
+            Objects.requireNonNull(bootstrapAddress, "bootstrapAddress cannot be null");
+            if (nodeIdRanges.isEmpty()) {
+                throw new IllegalArgumentException("node id ranges empty");
+            }
+            this.bootstrapAddress = bootstrapAddress;
+            this.nodeAddressPattern = nodeAddressPattern != null ? nodeAddressPattern : bootstrapAddress.host();
+            verifyNodeAddressPattern();
+            this.nodeStartPort = nodeStartPort != null ? nodeStartPort : (bootstrapAddress.port() + 1);
+            if (this.nodeStartPort < 1) {
+                throw new IllegalArgumentException("nodeStartPort cannot be less than 1");
+            }
+            List<NamedRange> namedRanges = nodeIdRanges.stream().map(NamedRangeSpec::range).toList();
+            verifyRangeNamesAreUnique(namedRanges);
+            verifyRangesAreDistinct(namedRanges);
+            nodeIdToPort = mapNodeIdToPort(namedRanges, this.nodeStartPort);
+            int numberOfNodePorts = nodeIdToPort.size();
+            if (this.nodeStartPort + numberOfNodePorts - 1 > 65535) {
+                throw new IllegalArgumentException("The maximum port mapped exceeded 65535");
+            }
+            verifyNoRangeContainsBootstrapPort(bootstrapAddress, namedRanges);
+            this.nodeIdRanges = nodeIdRanges;
+        }
+
+        private void verifyNoRangeContainsBootstrapPort(HostPort bootstrapAddress, List<NamedRange> namedRanges) {
+            for (NamedRange namedRange : namedRanges) {
+                namedRange.range().values().forEach(value -> {
+                    if (Objects.equals(this.nodeIdToPort.get(value), this.bootstrapAddress.port())) {
+                        Range range = namedRange.range;
+                        var portRange = new Range(range.startInclusive() + this.nodeStartPort, range.endExclusive() + this.nodeStartPort);
+                        throw new IllegalArgumentException(
+                                "the port used by the bootstrap address (%d) collides with the node id range: %s mapped to ports %s".formatted(bootstrapAddress.port(),
+                                        namedRange, portRange));
+                    }
+                });
+            }
+        }
+
+        private void verifyNodeAddressPattern() {
+            if (this.nodeAddressPattern.isBlank()) {
+                throw new IllegalArgumentException("nodeAddressPattern cannot be blank");
+            }
+            validatePortSpecifier(this.nodeAddressPattern, s -> {
+                throw new IllegalArgumentException("nodeAddressPattern cannot have port specifier.  Found port : " + s + " within " + this.nodeAddressPattern);
+            });
+            validateStringContainsOnlyExpectedTokens(this.nodeAddressPattern, EXPECTED_TOKEN_SET, token -> {
+                throw new IllegalArgumentException("nodeAddressPattern contains an unexpected replacement token '" + token + "'");
+            });
+        }
+
+        private static void verifyRangeNamesAreUnique(List<NamedRange> namedRanges) {
+            Map<String, List<NamedRange>> collect = namedRanges.stream().collect(Collectors.groupingBy(namedRange -> namedRange.name));
+            List<String> nonUniqueNames = collect.entrySet().stream().filter(stringListEntry -> stringListEntry.getValue().size() > 1).map(Map.Entry::getKey).toList();
+            if (!nonUniqueNames.isEmpty()) {
+                throw new IllegalArgumentException("non-unique nodeIdRange names discovered: " + nonUniqueNames);
+            }
+        }
+
+        private static Map<Integer, Integer> mapNodeIdToPort(List<NamedRange> ranges, Integer nodeStartPort) {
+            IntStream unsortedNodeIds = ranges.stream().flatMapToInt(rangeSpec -> rangeSpec.range().values());
+            List<Integer> ascendingNodeIds = unsortedNodeIds.distinct().sorted().boxed().toList();
+            Map<Integer, Integer> nodeIdToPort = new HashMap<>();
+            for (int offset = 0; offset < ascendingNodeIds.size(); offset++) {
+                nodeIdToPort.put(ascendingNodeIds.get(offset), nodeStartPort + offset);
+            }
+            return nodeIdToPort;
+        }
+
+        public HostPort getBootstrapAddress() {
+            return bootstrapAddress;
+        }
+
+        private record RangeCollision(NamedRange a, NamedRange b) {
+            @Override
+            public String toString() {
+                return "'" + a + "' collides with '" + b + "'";
+            }
+        }
+
+        private static void verifyRangesAreDistinct(List<NamedRange> ranges) {
+            Collection<RangeCollision> collisions = new ArrayList<>();
+            for (int i = 0; i < ranges.size(); i++) {
+                for (int j = 0; j < ranges.size(); j++) {
+                    // this is to compare unique, non-identical indices only once. ie we compare 2,3 but not 3,2
+                    if (j > i) {
+                        NamedRange rangeA = ranges.get(i);
+                        NamedRange rangeB = ranges.get(j);
+                        if (!rangeA.isDistinctFrom(rangeB)) {
+                            collisions.add(new RangeCollision(rangeA, rangeB));
+                        }
+                    }
+                }
+            }
+            if (!collisions.isEmpty()) {
+                throw new IllegalArgumentException("some nodeIdRanges collided (one or more node ids are duplicated in the following ranges): "
+                        + collisions.stream().map(RangeCollision::toString).collect(Collectors.joining(", ")));
+            }
+        }
+    }
+
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/RangeAwarePortPerNodeContributor.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/RangeAwarePortPerNodeContributor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
+
+import io.kroxylicious.proxy.clusternetworkaddressconfigprovider.ClusterNetworkAddressConfigProviderContributor;
+import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig;
+import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
+import io.kroxylicious.proxy.service.Context;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class RangeAwarePortPerNodeContributor implements
+        ClusterNetworkAddressConfigProviderContributor<RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig> {
+
+    @NonNull
+    @Override
+    public boolean requiresConfiguration() {
+        return true;
+    }
+
+    @NonNull
+    @Override
+    public Class<? extends ClusterNetworkAddressConfigProvider> getServiceType() {
+        return RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.class;
+    }
+
+    @NonNull
+    @Override
+    public Class<RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig> getConfigType() {
+        return RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig.class;
+    }
+
+    @NonNull
+    @Override
+    public ClusterNetworkAddressConfigProvider createInstance(Context<RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig> context) {
+        return new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(context.getConfig());
+    }
+
+}

--- a/kroxylicious-runtime/src/main/resources/META-INF/services/io.kroxylicious.proxy.clusternetworkaddressconfigprovider.ClusterNetworkAddressConfigProviderContributor
+++ b/kroxylicious-runtime/src/main/resources/META-INF/services/io.kroxylicious.proxy.clusternetworkaddressconfigprovider.ClusterNetworkAddressConfigProviderContributor
@@ -1,2 +1,3 @@
 io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.PortPerBrokerContributor
+io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.RangeAwarePortPerNodeContributor
 io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.SniRoutingContributor

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -72,6 +72,23 @@ class ConfigParserTest {
                                 brokerAddressPattern: localhost
                                 brokerStartPort: 9193
                         """),
+                Arguments.of("Virtual cluster (RangeAwarePortPerBroker)", """
+                        virtualClusters:
+                          demo1:
+                            targetCluster:
+                              bootstrap_servers: kafka.example:1234
+                            clusterNetworkAddressConfigProvider:
+                              type: RangeAwarePortPerNodeClusterNetworkAddressConfigProvider
+                              config:
+                                bootstrapAddress: cluster1:9192
+                                nodeAddressPattern: localhost
+                                nodeStartPort: 9193
+                                nodeIdRanges:
+                                  - name: brokers
+                                    range:
+                                      startInclusive: 0
+                                      endExclusive: 3
+                        """),
                 Arguments.of("Virtual cluster (SniRouting)", """
                         virtualClusters:
                           demo1:

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/RangeAwarePortPerNodeClusterNetworkAddressConfigProviderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/RangeAwarePortPerNodeClusterNetworkAddressConfigProviderTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.IntRangeSpec;
+import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.NamedRangeSpec;
+import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig;
+import io.kroxylicious.proxy.service.HostPort;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RangeAwarePortPerNodeClusterNetworkAddressConfigProviderTest {
+
+    public static final String BOOTSTRAP_HOST = "cluster.kafka.example.com";
+    private static final String BOOTSTRAP = BOOTSTRAP_HOST + ":1235";
+    private static final HostPort BOOSTRAP_HOSTPORT = HostPort.parse(BOOTSTRAP);
+
+    @Test
+    void rangesMustBeNonEmpty() {
+        List<NamedRangeSpec> empty = List.of();
+        assertThatThrownBy(() -> getConfig(empty))
+                .isInstanceOf(IllegalArgumentException.class).hasMessage("node id ranges empty");
+    }
+
+    @Test
+    void brokerAddressSingleRange() {
+        RangeAwarePortPerNodeClusterNetworkAddressConfigProvider provider = new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(
+                getConfig(List.of(new NamedRangeSpec("brokers", new IntRangeSpec(0, 2)))));
+        assertThat(provider.getBrokerAddress(0)).isEqualTo(new HostPort("broker0.kafka.example.com", 1236));
+        assertThat(provider.getBrokerAddress(1)).isEqualTo(new HostPort("broker1.kafka.example.com", 1237));
+    }
+
+    @Test
+    void brokerAddressPortsInferredFromBootstrapIfNotExplicitlySupplied() {
+        List<NamedRangeSpec> namedRangeSpecs = List.of(new NamedRangeSpec("brokers", new IntRangeSpec(0, 2)));
+        RangeAwarePortPerNodeClusterNetworkAddressConfigProvider provider = new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(
+                new RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig(
+                        BOOSTRAP_HOSTPORT, "broker$(nodeId).kafka.example.com",
+                        null, namedRangeSpecs));
+        assertThat(provider.getBrokerAddress(0)).isEqualTo(new HostPort("broker0.kafka.example.com", 1236));
+        assertThat(provider.getBrokerAddress(1)).isEqualTo(new HostPort("broker1.kafka.example.com", 1237));
+    }
+
+    @Test
+    void brokerAddressInferredFromBootstrapIfNotExplicitlySupplied() {
+        List<NamedRangeSpec> namedRangeSpecs = List.of(new NamedRangeSpec("brokers", new IntRangeSpec(0, 2)));
+        RangeAwarePortPerNodeClusterNetworkAddressConfigProvider provider = new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(
+                new RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig(
+                        BOOSTRAP_HOSTPORT, null,
+                        null, namedRangeSpecs));
+        assertThat(provider.getBrokerAddress(0)).isEqualTo(new HostPort(BOOTSTRAP_HOST, 1236));
+        assertThat(provider.getBrokerAddress(1)).isEqualTo(new HostPort(BOOTSTRAP_HOST, 1237));
+    }
+
+    @Test
+    void nodeAddressPatternCannotBeBlank() {
+        List<NamedRangeSpec> rangeSpecs = List.of(new NamedRangeSpec("brokers", new IntRangeSpec(0, 2)));
+        assertThatThrownBy(() -> new RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig(
+                BOOSTRAP_HOSTPORT, "",
+                null, rangeSpecs))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("nodeAddressPattern cannot be blank");
+    }
+
+    @Test
+    void nodeAddressPatternCannotContainUnexpectedReplacementPatterns() {
+        List<NamedRangeSpec> rangeSpecs = List.of(new NamedRangeSpec("brokers", new IntRangeSpec(0, 2)));
+        assertThatThrownBy(() -> new RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig(
+                BOOSTRAP_HOSTPORT, "node-$(typoedNodeId).broker.com",
+                null, rangeSpecs))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("nodeAddressPattern contains an unexpected replacement token '$(typoedNodeId)'");
+    }
+
+    @Test
+    void nodeAddressPatternCannotContainPort() {
+        List<NamedRangeSpec> rangeSpecs = List.of(new NamedRangeSpec("brokers", new IntRangeSpec(0, 2)));
+        assertThatThrownBy(() -> new RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig(
+                BOOSTRAP_HOSTPORT, "localhost:8080",
+                null, rangeSpecs))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("nodeAddressPattern cannot have port specifier.  Found port : 8080 within localhost:8080");
+    }
+
+    @Test
+    void nodeStartPortCannotBeLessThanOne() {
+        List<NamedRangeSpec> rangeSpecs = List.of(new NamedRangeSpec("brokers", new IntRangeSpec(0, 2)));
+        assertThatThrownBy(() -> new RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig(
+                BOOSTRAP_HOSTPORT, "localhost",
+                0, rangeSpecs))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("nodeStartPort cannot be less than 1");
+    }
+
+    @Test
+    void nodePortRangeCannotCollideWithBootstrapPort() {
+        List<NamedRangeSpec> rangeSpecs = List.of(new NamedRangeSpec("brokers", new IntRangeSpec(0, 3)));
+        HostPort bootstrapAddress = HostPort.parse(BOOTSTRAP_HOST + ":1235");
+        assertThatThrownBy(() -> new RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig(
+                bootstrapAddress, "localhost",
+                // node id 1 will be assigned port 1235 and collide with bootstrap
+                1234, rangeSpecs))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("the port used by the bootstrap address (1235) collides with the node id range: brokers:[0,3) mapped to ports [1234,1237)");
+    }
+
+    @Test
+    void getClusterBootstrap() {
+        List<NamedRangeSpec> namedRangeSpecs = List.of(new NamedRangeSpec("brokers", new IntRangeSpec(0, 2)));
+        RangeAwarePortPerNodeClusterNetworkAddressConfigProvider provider = new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(
+                new RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig(
+                        BOOSTRAP_HOSTPORT, "broker$(nodeId).kafka.example.com",
+                        1236, namedRangeSpecs));
+        assertThat(provider.getClusterBootstrapAddress()).isEqualTo(BOOSTRAP_HOSTPORT);
+    }
+
+    @Test
+    void exclusivePortsSingleRange() {
+        RangeAwarePortPerNodeClusterNetworkAddressConfigProvider provider = new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(
+                getConfig(List.of(new NamedRangeSpec("brokers", new IntRangeSpec(0, 2)))));
+        assertThat(provider.getExclusivePorts()).containsExactly(1235, 1236, 1237);
+    }
+
+    @Test
+    void discoveryAddressMapSingleRange() {
+        RangeAwarePortPerNodeClusterNetworkAddressConfigProvider provider = new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(
+                getConfig(List.of(new NamedRangeSpec("brokers", new IntRangeSpec(0, 2)))));
+
+        Map<Integer, HostPort> expected = Map.of(
+                0, new HostPort("broker0.kafka.example.com", 1236),
+                1, new HostPort("broker1.kafka.example.com", 1237));
+        assertThat(provider.discoveryAddressMap()).isEqualTo(expected);
+    }
+
+    @Test
+    void brokerAddressMultipleRanges() {
+        RangeAwarePortPerNodeClusterNetworkAddressConfigProvider provider = new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(
+                getConfig(List.of(new NamedRangeSpec("brokers", new IntRangeSpec(0, 2)), new NamedRangeSpec("controllers", new IntRangeSpec(3, 5)))));
+        assertThat(provider.getBrokerAddress(0)).isEqualTo(new HostPort("broker0.kafka.example.com", 1236));
+        assertThat(provider.getBrokerAddress(1)).isEqualTo(new HostPort("broker1.kafka.example.com", 1237));
+        assertThat(provider.getBrokerAddress(3)).isEqualTo(new HostPort("broker3.kafka.example.com", 1238));
+        assertThat(provider.getBrokerAddress(4)).isEqualTo(new HostPort("broker4.kafka.example.com", 1239));
+    }
+
+    @Test
+    void brokerAddressUnknownNodeId() {
+        RangeAwarePortPerNodeClusterNetworkAddressConfigProvider provider = new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(
+                getConfig(List.of(new NamedRangeSpec("brokers", new IntRangeSpec(0, 2)), new NamedRangeSpec("controllers", new IntRangeSpec(3, 5)))));
+        String expectedMessage = "Cannot generate node address for node id 5 as it is not contained in the ranges defined for provider with downstream bootstrap "
+                + BOOTSTRAP;
+        assertThatThrownBy(() -> provider.getBrokerAddress(5)).isInstanceOf(IllegalArgumentException.class).hasMessage(expectedMessage);
+    }
+
+    @Test
+    void discoveryAddressMapMultipleRanges() {
+        RangeAwarePortPerNodeClusterNetworkAddressConfigProvider provider = new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(
+                getConfig(List.of(new NamedRangeSpec("brokers", new IntRangeSpec(0, 2)), new NamedRangeSpec("controllers", new IntRangeSpec(3, 5)))));
+
+        Map<Integer, HostPort> expected = Map.of(
+                0, new HostPort("broker0.kafka.example.com", 1236),
+                1, new HostPort("broker1.kafka.example.com", 1237),
+                3, new HostPort("broker3.kafka.example.com", 1238),
+                4, new HostPort("broker4.kafka.example.com", 1239));
+        assertThat(provider.discoveryAddressMap()).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> overlappingNodeIdRangesAreInvalid() {
+        Arguments twoRangesWithOverlap = Arguments.arguments(
+                List.of(new NamedRangeSpec("brokers", new IntRangeSpec(0, 2)), new NamedRangeSpec("controllers", new IntRangeSpec(1, 2))),
+                "some nodeIdRanges collided (one or more node ids are duplicated in the following ranges): 'brokers:[0,2)' collides with 'controllers:[1,2)'");
+        Arguments threeRangesWithFirstAndLastOverlap = Arguments.arguments(
+                List.of(new NamedRangeSpec("brokers", new IntRangeSpec(0, 2)), new NamedRangeSpec("controllers", new IntRangeSpec(7, 8)),
+                        new NamedRangeSpec("other", new IntRangeSpec(1, 2))),
+                "some nodeIdRanges collided (one or more node ids are duplicated in the following ranges): 'brokers:[0,2)' collides with 'other:[1,2)'");
+        Arguments multipleOverlaps = Arguments.arguments(
+                List.of(new NamedRangeSpec("brokers", new IntRangeSpec(0, 2)), new NamedRangeSpec("controllers", new IntRangeSpec(1, 4)),
+                        new NamedRangeSpec("other", new IntRangeSpec(3, 5))),
+                "some nodeIdRanges collided (one or more node ids are duplicated in the following ranges): 'brokers:[0,2)' collides with 'controllers:[1,4)', 'controllers:[1,4)' collides with 'other:[3,5)'");
+        return Stream.of(twoRangesWithOverlap, threeRangesWithFirstAndLastOverlap, multipleOverlaps);
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void overlappingNodeIdRangesAreInvalid(List<NamedRangeSpec> namedRangeSpecs, String expectedException) {
+        assertThatThrownBy(() -> getConfig(namedRangeSpecs))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(expectedException);
+    }
+
+    @Test
+    void rangeMustBeNonEmpty() {
+        List<NamedRangeSpec> emptyRange = List.of(new NamedRangeSpec("brokers", new IntRangeSpec(0, 0)));
+        assertThatThrownBy(() -> getConfig(emptyRange))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("invalid nodeIdRange: brokers, end of range: 0 (exclusive) is before start of range: 0 (inclusive)");
+    }
+
+    @Test
+    void rangesMustHaveUniqueNames() {
+        List<NamedRangeSpec> emptyRange = List.of(new NamedRangeSpec("brokers", new IntRangeSpec(0, 1)), new NamedRangeSpec("brokers", new IntRangeSpec(1, 2)));
+        assertThatThrownBy(() -> getConfig(emptyRange))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("non-unique nodeIdRange names discovered: [brokers]");
+    }
+
+    @Test
+    void exclusivePortsMultipleRanges() {
+        RangeAwarePortPerNodeClusterNetworkAddressConfigProvider provider = new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider(
+                getConfig(List.of(new NamedRangeSpec("brokers", new IntRangeSpec(0, 2)), new NamedRangeSpec("controllers", new IntRangeSpec(3, 5)))));
+        assertThat(provider.getExclusivePorts()).containsExactly(1235, 1236, 1237, 1238, 1239);
+    }
+
+    @Test
+    void allNodeIdsMustBeMappableToAValidPort() {
+        List<NamedRangeSpec> ranges = List.of(new NamedRangeSpec("brokers", new IntRangeSpec(0, 65535)));
+        HostPort bootstrapAddress = HostPort.parse(BOOTSTRAP_HOST + ":1");
+        assertThatThrownBy(() -> {
+            getConfig(ranges, 2, bootstrapAddress);
+        })
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("The maximum port mapped exceeded 65535");
+    }
+
+    private static @NonNull RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig getConfig(List<NamedRangeSpec> namedRangeSpecs) {
+        return getConfig(namedRangeSpecs, 1236, BOOSTRAP_HOSTPORT);
+    }
+
+    private static @NonNull RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig getConfig(
+                                                                                                     List<NamedRangeSpec> namedRangeSpecs, int nodeStartPort,
+                                                                                                     HostPort bootstrapAddress) {
+        return new RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig(
+                bootstrapAddress, "broker$(nodeId).kafka.example.com",
+                nodeStartPort, namedRangeSpecs);
+    }
+
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/RangeTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/RangeTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class RangeTest {
+
+    @Test
+    void contains() {
+        assertThat(new Range(1, 4).values()).containsExactlyInAnyOrder(1, 2, 3);
+    }
+
+    @Test
+    void oneItemRange() {
+        assertThat(new Range(1, 2).values()).containsExactlyInAnyOrder(1);
+    }
+
+    @Test
+    void endBeforeStartIllegal() {
+        assertThatThrownBy(() -> new Range(1, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("end of range: 1 (exclusive) is before start of range: 1 (inclusive)");
+    }
+
+    static Stream<Arguments> isEndBeforeStartOf() {
+        return Stream.of(
+                arguments(new Range(0, 1), new Range(1, 2), true),
+                arguments(new Range(0, 1), new Range(2, 3), true),
+                arguments(new Range(4, 5), new Range(2, 3), false),
+                arguments(new Range(3, 5), new Range(2, 4), false),
+                arguments(new Range(0, 2), new Range(1, 2), false),
+                arguments(new Range(0, 3), new Range(1, 2), false),
+                arguments(new Range(0, 4), new Range(1, 2), false));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void isEndBeforeStartOf(Range a, Range b, boolean expected) {
+        assertThat(a.isEndBeforeStartOf(b)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> isDistinctFrom() {
+        return Stream.of(
+                arguments(new Range(0, 1), new Range(1, 2), true),
+                arguments(new Range(0, 1), new Range(2, 3), true),
+                arguments(new Range(4, 5), new Range(2, 3), true),
+                arguments(new Range(3, 5), new Range(2, 4), false),
+                arguments(new Range(0, 2), new Range(1, 2), false),
+                arguments(new Range(0, 3), new Range(1, 2), false),
+                arguments(new Range(0, 4), new Range(1, 2), false));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void isDistinctFrom(Range a, Range b, boolean expected) {
+        assertThat(a.isDistinctFrom(b)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> intersection() {
+        return Stream.of(
+                arguments(new Range(3, 5), new Range(2, 4), new Range(3, 4)),
+                arguments(new Range(3, 5), new Range(3, 5), new Range(3, 5)),
+                arguments(new Range(0, 2), new Range(1, 2), new Range(1, 2)),
+                arguments(new Range(0, 3), new Range(1, 2), new Range(1, 2)),
+                arguments(new Range(0, 4), new Range(1, 2), new Range(1, 2)));
+    }
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Mitigates #902

This new implementation introduces the concept of Node Id Ranges and enables you to configure multiple such ranges for your virtual cluster. Enabling a deterministic mapping of node ids to proxy ports even when there are large gaps between the ranges.

It is implemented as a new ClusterNetworkAddressConfigProvider of type `RangeAwarePortPerNodeClusterNetworkAddressConfigProvider`

configured like:

``` yaml
virtualClusters:
  demo:
    targetCluster:
      bootstrap_servers: localhost:9092
    clusterNetworkAddressConfigProvider:
      type: RangeAwarePortPerNodeClusterNetworkAddressConfigProvider
      config:
        bootstrapAddress: localhost:9192
        nodeIdRanges:
          - name: brokers
            range:
              startInclusive: 0
              endExclusive: 3
```

For example if I configure a virtual cluster with:

```yaml
nodeStartPort: 9000
nodeIdRanges:
  - name: brokers
    range:
      startInclusive: 4
      endExclusive: 6
  - name: controllers
    range:
       startInclusive: 1
       endExclusive: 3
```
Then the ports will be mapped as follows:
- node 1 -> port 9000
- node 2 -> port 9001
- node 4 -> port 9002
- node 5 -> port 9003

Why:
Currently there are numerous drawbacks to using the PortPerBroker exposition scheme. If the lowest broker id is N and the highest is M then we must expose M-N ports so that we can deterministically map each node id to a port. So if you have two nodes with ids 100000 and 200000 you need 100000 ports mapped so that we can say startPort+0 is node 100000 and startPort+100000 is node id 200000.

Also with the advent of KRaft we now may have to contend with two distinct and evolving sets of node ids, a controller pool and a broker pool. If there is a significant gap between them we have the same problem as above.

This enables us to represent clusters with highly variable node ids using a more compact set of ports.

Note it still does not solve other issues, like some users regulurly introduce new nodes and remove old ones in their target cluster as part of upgrades.  Leading to eternal growth of node ids. To handle this in a better way we think the Proxy would need to be able to discover the target topology.

This is an alternative to #1210 where we used a mathematical interval notation to represent the range. That implementation brings in the complexity of parsing/regexing and reinventing what Guava has implemented. Maybe we should start with this simpler alternative and could introduce a `range` String to the `RangeSpec` later, which should be a small PR on top of the existing code to parse from String -> Range. 

This alternative also gives us type safety on the integers through Jackson. The implementation has been simplified to separate the Range as a concept from any idea of indexing the node ids in the range. It borrows the term Range from guava and the JDK Stream api, it seems like the most common term for this.

The existing PortPerBroker scheme is also refactored to be implemented using the Range aware implementation, treating it as a single-range configuration.

## Config Validations

1. Ranges must not overlap, node ids must belong to exactly one specified range
    ```yaml
            nodeIdRanges:
              - name: brokers
                range:
                  startInclusive: 0
                  endExclusive: 3
              - name: controllers
                range:
                  startInclusive: 2
                  endExclusive: 4
    ```
    causes the proxy to not start with:
    > Caused by: java.lang.IllegalArgumentException: some nodeIdRanges collided (one or more node ids are present in multiple ranges): 'brokers:[0,3)' collides with 'controllers:[2,4)'
2. Ranges must have unique names
    ```yaml
            nodeIdRanges:
              - name: brokers
                range:
                  startInclusive: 0
                  endExclusive: 3
              - name: brokers
                range:
                  startInclusive: 3
                  endExclusive: 4
    ```
    causes the proxy to not start with:
    > Caused by: java.lang.IllegalArgumentException: non-unique nodeIdRange names discovered: [brokers]
3. Ranges must not be empty
    ```yaml
            nodeIdRanges:
              - name: brokers
                range:
                  startInclusive: 0
                  endExclusive: 0
    ```
    causes the proxy to not start with:
    > Caused by: java.lang.IllegalArgumentException: invalid nodeIdRange: brokers, end of range: 0 (exclusive) is before start of range: 0 (inclusive)
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
