### PR TITLE
Add FilterFactory.close, fixing #1208

### DIFF
--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactory.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactory.java
@@ -14,19 +14,27 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * <p>FilterFactories are:</p>
  * <ul>
  * <li>{@linkplain java.util.ServiceLoader service} implementations provided by filter authors</li>
- * <li>called by the proxy runtime to create instances of filters</li>
+ * <li>called by the proxy runtime to {@linkplain #createFilter(FilterFactoryContext, Object) create} filter instances</li>
  * </ul>
+ *
+ * <p>The proxy runtime guarantees that:</p>
+ * <ol>
+ *     <li>instances will be {@linkplain  #initialize(FilterFactoryContext, Object) initialized} before any attempt to {@linkplain  #createFilter(FilterFactoryContext, Object) create} filter instances,</li>
+ *     <li>instances that are successfully initialized will eventually be {@linkplain #close() closed},</li>
+ *     <li>no attempts to create filter instances will be made once a {@code FilterFactory} instance is closed.</li>
+ * </ol>
+ *
  * @param <C> the type of configuration used to create the {@code Filter}. Use {@link Void} if the {@code Filter} is not configurable.
  * @param <I> The type of the initialization data
  */
-public interface FilterFactory<C, I> {
+public interface FilterFactory<C, I> extends AutoCloseable {
 
     /**
      * Initializes the factory with the specified configuration.
      * This method is guaranteed to be called at most once for each filter configuration and before any call to
      * {@link #createFilter(FilterFactoryContext, Object)}.
      * This method may provide extra semantic validation of the config,
-     * and returns some object (which may be the config, or some other object) which will be passed to {@link #createFilter(FilterFactoryContext, Object)}
+     * and returns some object (which may be the config, or some other object) which will be passed to {@link #createFilter(FilterFactoryContext, Object)}.
      *
      * @param context context
      * @param config configuration
@@ -44,4 +52,12 @@ public interface FilterFactory<C, I> {
     @NonNull
     Filter createFilter(FilterFactoryContext context, I initializationData);
 
+    /**
+     * Called by the runtime to release any resources held by this factory.
+     * This is guaranteed to be called if an instance has been {@linkplain #initialize(FilterFactoryContext, Object) initialized}.
+     * Once this method has been called {@link #createFilter(FilterFactoryContext, Object)} won't be called again.
+     */
+    @Override
+    default void close() {
+    }
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactory.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactory.java
@@ -20,24 +20,30 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * <p>The proxy runtime guarantees that:</p>
  * <ol>
  *     <li>instances will be {@linkplain  #initialize(FilterFactoryContext, Object) initialized} before any attempt to {@linkplain  #createFilter(FilterFactoryContext, Object) create} filter instances,</li>
- *     <li>instances that are successfully initialized will eventually be {@linkplain #close() closed},</li>
- *     <li>no attempts to create filter instances will be made once a {@code FilterFactory} instance is closed.</li>
+ *     <li>instances will eventually be {@linkplain #close(Object)} closed} if and only if they were successfully initialized,</li>
+ *     <li>no attempts to create filter instances will be made once a {@code FilterFactory} instance is closed,</li>
+ *     <li>instances will be initialized and closed on the same thread.</li>
  * </ol>
+ * <p>Filter instance creation can happen on a different thread than initialization or cleanup.
+ * It is suggested to pass state using via the return value from {@link #createFilter(FilterFactoryContext, Object)} rather than
+ * relying on synchronization within a filter factory implementation.</p>
  *
  * @param <C> the type of configuration used to create the {@code Filter}. Use {@link Void} if the {@code Filter} is not configurable.
  * @param <I> The type of the initialization data
  */
-public interface FilterFactory<C, I> extends AutoCloseable {
+public interface FilterFactory<C, I> {
 
     /**
-     * Initializes the factory with the specified configuration.
-     * This method is guaranteed to be called at most once for each filter configuration and before any call to
+     * <p>Initializes the factory with the specified configuration.</p>
+     *
+     * <p>This method is guaranteed to be called at most once for each filter configuration and before any call to
      * {@link #createFilter(FilterFactoryContext, Object)}.
      * This method may provide extra semantic validation of the config,
      * and returns some object (which may be the config, or some other object) which will be passed to {@link #createFilter(FilterFactoryContext, Object)}.
      *
      * @param context context
      * @param config configuration
+     * @return A configuration state object, specific to the given {@code config}, which will be passed to the other methods of this interface.
      * @throws PluginConfigurationException when the configuration is invalid
      */
     I initialize(FilterFactoryContext context, C config) throws PluginConfigurationException;
@@ -45,19 +51,23 @@ public interface FilterFactory<C, I> extends AutoCloseable {
     /**
      * Creates an instance of the Filter.
      *
+     * <p>This can be called on a different thread from {@link #initialize(FilterFactoryContext, Object)} and {@link #close(I)}.
+     * Implementors should either use the {@code initializationData} to pass state from {@link #initialize(FilterFactoryContext, Object)}
+     * or use appropriate synchronization.</p>
+     *
      * @param context The runtime context for the filter's creation.
-     * @param initializationData The result of the call to {@link #initialize(FilterFactoryContext, Object)}
+     * @param initializationData The initialization data that was returned from {@link #initialize(FilterFactoryContext, Object)}.
      * @return the Filter instance.
      */
     @NonNull
     Filter createFilter(FilterFactoryContext context, I initializationData);
 
     /**
-     * Called by the runtime to release any resources held by this factory.
-     * This is guaranteed to be called if an instance has been {@linkplain #initialize(FilterFactoryContext, Object) initialized}.
+     * Called by the runtime to release any resources associated with the given {@code initializationData}.
+     * This is guaranteed to eventually be called for each successful call to {@link #initialize(FilterFactoryContext, Object)}.
      * Once this method has been called {@link #createFilter(FilterFactoryContext, Object)} won't be called again.
+     * @param initializationData The initialization data that was returned from {@link #initialize(FilterFactoryContext, Object)}.
      */
-    @Override
-    default void close() {
+    default void close(I initializationData) {
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -207,8 +207,9 @@ public final class KafkaProxy implements AutoCloseable {
 
     /**
      * Shuts down a running proxy.
+     * @throws InterruptedException
      */
-    private void shutdown() {
+    public void shutdown() throws InterruptedException {
         if (!running.getAndSet(false)) {
             throw new IllegalStateException("This proxy is not running");
         }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -125,7 +125,8 @@ public class FilterChainFactory implements AutoCloseable {
     @Override
     public void close() {
         RuntimeException firstThrown = null;
-        for (Wrapper wrapper : initialized.reversed()) {
+        for (int i = initialized.size() - 1; i >= 0; i--) {
+            Wrapper wrapper = initialized.get(i);
             try {
                 wrapper.close();
             }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -125,7 +125,7 @@ public class FilterChainFactory implements AutoCloseable {
     @Override
     public void close() {
         RuntimeException firstThrown = null;
-        for (Wrapper wrapper : initialized) {
+        for (Wrapper wrapper : initialized.reversed()) {
             try {
                 wrapper.close();
             }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -32,7 +32,7 @@ public class FilterChainFactory implements AutoCloseable {
 
         private final FilterFactory<? super Object, ? super Object> filterFactory;
         private final Object config;
-        private static Object initResult;
+        private final Object initResult;
         private boolean closed;
 
         private Wrapper(FilterFactoryContext context,

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -10,12 +10,15 @@ import java.util.Map;
 
 import io.kroxylicious.proxy.config.admin.AdminHttpConfiguration;
 
-public record Configuration(AdminHttpConfiguration adminHttp,
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+public record Configuration(@Nullable AdminHttpConfiguration adminHttp,
                             Map<String, VirtualCluster> virtualClusters,
                             List<FilterDefinition> filters,
                             List<MicrometerDefinition> micrometer,
                             boolean useIoUring) {
-    public AdminHttpConfiguration adminHttpConfig() {
+    public @Nullable AdminHttpConfiguration adminHttpConfig() {
         return adminHttp();
     }
 
@@ -27,7 +30,7 @@ public record Configuration(AdminHttpConfiguration adminHttp,
         return useIoUring();
     }
 
-    public List<io.kroxylicious.proxy.model.VirtualCluster> virtualClusterModel() {
+    public @NonNull List<io.kroxylicious.proxy.model.VirtualCluster> virtualClusterModel() {
         return virtualClusters.entrySet().stream()
                 .map(entry -> entry.getValue().toVirtualClusterModel(entry.getKey()))
                 .toList();

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/PluginFactory.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/PluginFactory.java
@@ -11,7 +11,7 @@ import io.kroxylicious.proxy.plugin.UnknownPluginInstanceException;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * A PluginFactory is able to resolve reference to a plugin implementation (ie. a name) to that implementation.
+ * A PluginFactory is able to resolve references to a plugin implementation (i.e. a name) to that implementation.
  * @param <P> The plugin type
  */
 public interface PluginFactory<P> {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
@@ -261,13 +261,15 @@ class FilterChainFactoryTest {
     @Test
     void shouldPropagateFilterInitializeException() {
         // Given
-        var numInitialize1 = new Counter();
-        var numClose1 = new Counter();
-        var numInitialize2 = new Counter();
-        var numClose2 = new Counter();
+        var onInitialize1 = new Counter();
+        var onClose1 = new Counter();
+        var onInitialize2 = new Counter();
+        var onClose2 = new Counter();
         List<FilterDefinition> list = List.of(
-                new FilterDefinition(FlakyFactory.class.getName(), new FlakyConfig(null, null, null, numInitialize1::increment, numClose1::increment)),
-                new FilterDefinition(FlakyFactory.class.getName(), new FlakyConfig("foo", null, null, numInitialize2::increment, numClose2::increment)));
+                new FilterDefinition(FlakyFactory.class.getName(), new FlakyConfig(null, null, null,
+                        onInitialize1::increment, onClose1::increment)),
+                new FilterDefinition(FlakyFactory.class.getName(), new FlakyConfig("foo", null, null,
+                        onInitialize2::increment, onClose2::increment)));
 
         // When
 
@@ -277,29 +279,31 @@ class FilterChainFactoryTest {
                 .cause()
                 .isExactlyInstanceOf(RuntimeException.class)
                 .hasMessage("foo");
-        assertThat(numInitialize1.count).isEqualTo(1);
-        assertThat(numClose1.count).isEqualTo(1);
-        assertThat(numInitialize2.count).isZero();
-        assertThat(numClose2.count).isZero();
+        assertThat(onInitialize1.count).isEqualTo(1);
+        assertThat(onClose1.count).isEqualTo(1);
+        assertThat(onInitialize2.count).isZero();
+        assertThat(onClose2.count).isZero();
     }
 
     @Test
     void shouldPropagateFilterCreateException() {
         // Given
-        var numInitialize1 = new Counter();
-        var numClose1 = new Counter();
-        var numInitialize2 = new Counter();
-        var numClose2 = new Counter();
+        var onInitialize1 = new Counter();
+        var onClose1 = new Counter();
+        var onInitialize2 = new Counter();
+        var onClose2 = new Counter();
         List<FilterDefinition> list = List.of(
-                new FilterDefinition(FlakyFactory.class.getName(), new FlakyConfig(null, null, null, numInitialize1::increment, numClose1::increment)),
-                new FilterDefinition(FlakyFactory.class.getName(), new FlakyConfig(null, "foo", null, numInitialize2::increment, numClose2::increment)));
+                new FilterDefinition(FlakyFactory.class.getName(), new FlakyConfig(null, null, null,
+                        onInitialize1::increment, onClose1::increment)),
+                new FilterDefinition(FlakyFactory.class.getName(), new FlakyConfig(null, "foo", null,
+                        onInitialize2::increment, onClose2::increment)));
         NettyFilterContext context = new NettyFilterContext(eventLoop, pfr);
 
         try (var fcf = new FilterChainFactory(pfr, list)) {
-            assertThat(numInitialize1.count).isEqualTo(1);
-            assertThat(numClose1.count).isZero();
-            assertThat(numInitialize2.count).isEqualTo(1);
-            assertThat(numClose2.count).isZero();
+            assertThat(onInitialize1.count).isEqualTo(1);
+            assertThat(onClose1.count).isZero();
+            assertThat(onInitialize2.count).isEqualTo(1);
+            assertThat(onClose2.count).isZero();
             // When
 
             // Then
@@ -309,57 +313,57 @@ class FilterChainFactoryTest {
                     .isExactlyInstanceOf(RuntimeException.class)
                     .hasMessage("foo");
 
-            assertThat(numInitialize1.count).isEqualTo(1);
-            assertThat(numClose1.count).isZero();
-            assertThat(numInitialize2.count).isEqualTo(1);
-            assertThat(numClose2.count).isZero();
+            assertThat(onInitialize1.count).isEqualTo(1);
+            assertThat(onClose1.count).isZero();
+            assertThat(onInitialize2.count).isEqualTo(1);
+            assertThat(onClose2.count).isZero();
         }
-        assertThat(numInitialize1.count).isEqualTo(1);
-        assertThat(numClose1.count).isEqualTo(1);
-        assertThat(numInitialize2.count).isEqualTo(1);
-        assertThat(numClose2.count).isEqualTo(1);
+        assertThat(onInitialize1.count).isEqualTo(1);
+        assertThat(onClose1.count).isEqualTo(1);
+        assertThat(onInitialize2.count).isEqualTo(1);
+        assertThat(onClose2.count).isEqualTo(1);
 
     }
 
     @Test
     void shouldPropagateFilterCloseException() {
         // Given
-        var numInitialize1 = new Counter();
-        var numClose1 = new Counter();
-        var numInitialize2 = new Counter();
-        var numClose2 = new Counter();
+        var onInitialize1 = new Counter();
+        var onClose1 = new Counter();
+        var onInitialize2 = new Counter();
+        var onClose2 = new Counter();
         List<FlakyConfig> initializeOrder = new ArrayList<>();
         List<FlakyConfig> closeOrder = new ArrayList<>();
         FlakyConfig flakyConfig1 = new FlakyConfig(null, null, null,
-                ((Consumer<FlakyConfig>) numInitialize1::increment).andThen(initializeOrder::add),
-                ((Consumer<FlakyConfig>) numClose1::increment).andThen(closeOrder::add));
+                ((Consumer<FlakyConfig>) onInitialize1::increment).andThen(initializeOrder::add),
+                ((Consumer<FlakyConfig>) onClose1::increment).andThen(closeOrder::add));
         FlakyConfig flakyConfig2 = new FlakyConfig(null, null, "foo",
-                ((Consumer<FlakyConfig>) numInitialize2::increment).andThen(initializeOrder::add),
-                ((Consumer<FlakyConfig>) numClose2::increment).andThen(closeOrder::add));
+                ((Consumer<FlakyConfig>) onInitialize2::increment).andThen(initializeOrder::add),
+                ((Consumer<FlakyConfig>) onClose2::increment).andThen(closeOrder::add));
         List<FilterDefinition> list = List.of(
                 new FilterDefinition(FlakyFactory.class.getName(), flakyConfig1),
                 new FilterDefinition(FlakyFactory.class.getName(), flakyConfig2));
         try (var fcf = new FilterChainFactory(pfr, list)) {
             // When
-            assertThat(numInitialize1.count).isEqualTo(1);
-            assertThat(numClose1.count).isZero();
-            assertThat(numInitialize2.count).isEqualTo(1);
-            assertThat(numClose2.count).isZero();
+            assertThat(onInitialize1.count).isEqualTo(1);
+            assertThat(onClose1.count).isZero();
+            assertThat(onInitialize2.count).isEqualTo(1);
+            assertThat(onClose2.count).isZero();
             assertThat(initializeOrder).isEqualTo(List.of(flakyConfig1, flakyConfig2));
 
             // Then
             assertThatThrownBy(fcf::close)
                     .isExactlyInstanceOf(RuntimeException.class)
                     .hasMessage("foo");
-            assertThat(numInitialize1.count).isEqualTo(1);
-            assertThat(numClose1.count).isEqualTo(1);
-            assertThat(numInitialize2.count).isEqualTo(1);
-            assertThat(numClose2.count).isEqualTo(1);
+            assertThat(onInitialize1.count).isEqualTo(1);
+            assertThat(onClose1.count).isEqualTo(1);
+            assertThat(onInitialize2.count).isEqualTo(1);
+            assertThat(onClose2.count).isEqualTo(1);
         }
-        assertThat(numInitialize1.count).isEqualTo(1);
-        assertThat(numClose1.count).isEqualTo(1);
-        assertThat(numInitialize2.count).isEqualTo(1);
-        assertThat(numClose2.count).isEqualTo(1);
+        assertThat(onInitialize1.count).isEqualTo(1);
+        assertThat(onClose1.count).isEqualTo(1);
+        assertThat(onInitialize2.count).isEqualTo(1);
+        assertThat(onClose2.count).isEqualTo(1);
 
         assertThat(closeOrder).isEqualTo(List.of(flakyConfig2, flakyConfig1));
     }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/FlakyConfig.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/FlakyConfig.java
@@ -12,20 +12,19 @@ public final class FlakyConfig {
     private final String initializeExceptionMsg;
     private final String createExceptionMsg;
     private final String closeExceptionMsg;
-
-    private final Consumer<FlakyConfig> closeOrder;
-    private final Consumer<FlakyConfig> initializeOrder;
+    private final Consumer<FlakyConfig> onClose;
+    private final Consumer<FlakyConfig> onInitialize;
 
     public FlakyConfig(String initializeExceptionMsg,
                        String createExceptionMsg,
                        String closeExceptionMsg,
-                       Consumer<FlakyConfig> initializeOrder,
+                       Consumer<FlakyConfig> onInitialize,
                        Consumer<FlakyConfig> closeOrder) {
         this.initializeExceptionMsg = initializeExceptionMsg;
         this.createExceptionMsg = createExceptionMsg;
         this.closeExceptionMsg = closeExceptionMsg;
-        this.initializeOrder = initializeOrder;
-        this.closeOrder = closeOrder;
+        this.onInitialize = onInitialize;
+        this.onClose = closeOrder;
     }
 
     public String initializeExceptionMsg() {
@@ -41,10 +40,10 @@ public final class FlakyConfig {
     }
 
     public void onClose() {
-        closeOrder.accept(this);
+        onClose.accept(this);
     }
 
     public void onInitialize() {
-        initializeOrder.accept(this);
+        onInitialize.accept(this);
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/FlakyConfig.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/FlakyConfig.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+public record FlakyConfig(String initializeExceptionMsg,
+                          String createExceptionMsg,
+                          String closeExceptionMsg) {
+
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/FlakyConfig.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/FlakyConfig.java
@@ -8,6 +8,4 @@ package io.kroxylicious.proxy.internal.filter;
 
 public record FlakyConfig(String initializeExceptionMsg,
                           String createExceptionMsg,
-                          String closeExceptionMsg) {
-
-}
+                          String closeExceptionMsg) {}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/FlakyConfig.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/FlakyConfig.java
@@ -6,6 +6,45 @@
 
 package io.kroxylicious.proxy.internal.filter;
 
-public record FlakyConfig(String initializeExceptionMsg,
-                          String createExceptionMsg,
-                          String closeExceptionMsg) {}
+import java.util.function.Consumer;
+
+public final class FlakyConfig {
+    private final String initializeExceptionMsg;
+    private final String createExceptionMsg;
+    private final String closeExceptionMsg;
+
+    private final Consumer<FlakyConfig> closeOrder;
+    private final Consumer<FlakyConfig> initializeOrder;
+
+    public FlakyConfig(String initializeExceptionMsg,
+                       String createExceptionMsg,
+                       String closeExceptionMsg,
+                       Consumer<FlakyConfig> initializeOrder,
+                       Consumer<FlakyConfig> closeOrder) {
+        this.initializeExceptionMsg = initializeExceptionMsg;
+        this.createExceptionMsg = createExceptionMsg;
+        this.closeExceptionMsg = closeExceptionMsg;
+        this.initializeOrder = initializeOrder;
+        this.closeOrder = closeOrder;
+    }
+
+    public String initializeExceptionMsg() {
+        return initializeExceptionMsg;
+    }
+
+    public String createExceptionMsg() {
+        return createExceptionMsg;
+    }
+
+    public String closeExceptionMsg() {
+        return closeExceptionMsg;
+    }
+
+    public void onClose() {
+        closeOrder.accept(this);
+    }
+
+    public void onInitialize() {
+        initializeOrder.accept(this);
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/FlakyFactory.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/FlakyFactory.java
@@ -11,6 +11,7 @@ import java.util.concurrent.CompletionStage;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
+import org.junit.jupiter.api.Assertions;
 
 import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.FilterFactory;
@@ -24,6 +25,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 @Plugin(configType = FlakyConfig.class)
 public class FlakyFactory implements FilterFactory<FlakyConfig, FlakyConfig> {
 
+    public static int INITIALIZED_AND_UNCLOSED = 0;
+
     private FlakyConfig config;
 
     @Override
@@ -32,12 +35,14 @@ public class FlakyFactory implements FilterFactory<FlakyConfig, FlakyConfig> {
         if (config.initializeExceptionMsg() != null) {
             throw new RuntimeException(config.initializeExceptionMsg());
         }
+        INITIALIZED_AND_UNCLOSED += 1;
         return config;
     }
 
     @NonNull
     @Override
     public Filter createFilter(FilterFactoryContext context, FlakyConfig configuration) {
+        Assertions.assertNotNull(configuration);
         if (config.createExceptionMsg() != null) {
             throw new RuntimeException(config.createExceptionMsg());
         }
@@ -45,7 +50,9 @@ public class FlakyFactory implements FilterFactory<FlakyConfig, FlakyConfig> {
     }
 
     @Override
-    public void close() {
+    public void close(FlakyConfig configuration) {
+        Assertions.assertNotNull(configuration);
+        INITIALIZED_AND_UNCLOSED -= 1;
         if (config.closeExceptionMsg() != null) {
             throw new RuntimeException(config.closeExceptionMsg());
         }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/FlakyFactory.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/FlakyFactory.java
@@ -6,12 +6,12 @@
 
 package io.kroxylicious.proxy.internal.filter;
 
+import java.util.Objects;
 import java.util.concurrent.CompletionStage;
 
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
-import org.junit.jupiter.api.Assertions;
 
 import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.FilterFactory;
@@ -31,6 +31,8 @@ public class FlakyFactory implements FilterFactory<FlakyConfig, FlakyConfig> {
 
     @Override
     public FlakyConfig initialize(FilterFactoryContext context, FlakyConfig config) {
+        Objects.requireNonNull(context);
+        Objects.requireNonNull(config);
         this.config = config;
         if (config.initializeExceptionMsg() != null) {
             throw new RuntimeException(config.initializeExceptionMsg());
@@ -42,7 +44,7 @@ public class FlakyFactory implements FilterFactory<FlakyConfig, FlakyConfig> {
     @NonNull
     @Override
     public Filter createFilter(FilterFactoryContext context, FlakyConfig configuration) {
-        Assertions.assertNotNull(configuration);
+        Objects.requireNonNull(configuration);
         if (config.createExceptionMsg() != null) {
             throw new RuntimeException(config.createExceptionMsg());
         }
@@ -51,7 +53,7 @@ public class FlakyFactory implements FilterFactory<FlakyConfig, FlakyConfig> {
 
     @Override
     public void close(FlakyConfig configuration) {
-        Assertions.assertNotNull(configuration);
+        Objects.requireNonNull(configuration);
         INITIALIZED_AND_UNCLOSED -= 1;
         if (config.closeExceptionMsg() != null) {
             throw new RuntimeException(config.closeExceptionMsg());

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/FlakyFactory.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/FlakyFactory.java
@@ -25,8 +25,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 @Plugin(configType = FlakyConfig.class)
 public class FlakyFactory implements FilterFactory<FlakyConfig, FlakyConfig> {
 
-    public static int INITIALIZED_AND_UNCLOSED = 0;
-
     private FlakyConfig config;
 
     @Override
@@ -37,7 +35,7 @@ public class FlakyFactory implements FilterFactory<FlakyConfig, FlakyConfig> {
         if (config.initializeExceptionMsg() != null) {
             throw new RuntimeException(config.initializeExceptionMsg());
         }
-        INITIALIZED_AND_UNCLOSED += 1;
+        config.onInitialize();
         return config;
     }
 
@@ -54,7 +52,7 @@ public class FlakyFactory implements FilterFactory<FlakyConfig, FlakyConfig> {
     @Override
     public void close(FlakyConfig configuration) {
         Objects.requireNonNull(configuration);
-        INITIALIZED_AND_UNCLOSED -= 1;
+        config.onClose();
         if (config.closeExceptionMsg() != null) {
             throw new RuntimeException(config.closeExceptionMsg());
         }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/FlakyFactory.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/FlakyFactory.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.FilterFactory;
+import io.kroxylicious.proxy.filter.FilterFactoryContext;
+import io.kroxylicious.proxy.filter.RequestFilter;
+import io.kroxylicious.proxy.filter.RequestFilterResult;
+import io.kroxylicious.proxy.plugin.Plugin;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+@Plugin(configType = FlakyConfig.class)
+public class FlakyFactory implements FilterFactory<FlakyConfig, FlakyConfig> {
+
+    private FlakyConfig config;
+
+    @Override
+    public FlakyConfig initialize(FilterFactoryContext context, FlakyConfig config) {
+        this.config = config;
+        if (config.initializeExceptionMsg() != null) {
+            throw new RuntimeException(config.initializeExceptionMsg());
+        }
+        return config;
+    }
+
+    @NonNull
+    @Override
+    public Filter createFilter(FilterFactoryContext context, FlakyConfig configuration) {
+        if (config.createExceptionMsg() != null) {
+            throw new RuntimeException(config.createExceptionMsg());
+        }
+        return new Filter(context, configuration, this.getClass());
+    }
+
+    @Override
+    public void close() {
+        if (config.closeExceptionMsg() != null) {
+            throw new RuntimeException(config.closeExceptionMsg());
+        }
+    }
+
+    public static class Filter implements RequestFilter, TestFilter {
+        private final FilterFactoryContext context;
+        private final FlakyConfig exampleConfig;
+        private final Class<? extends FilterFactory> contributorClass;
+
+        public Filter(FilterFactoryContext context, FlakyConfig exampleConfig, Class<? extends FilterFactory> contributorClass) {
+            this.context = context;
+            this.exampleConfig = exampleConfig;
+            this.contributorClass = contributorClass;
+        }
+
+        @Override
+        public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage request, FilterContext context) {
+            throw new IllegalStateException("not implemented!");
+        }
+
+        public FilterFactoryContext getContext() {
+            return context;
+        }
+
+        public ExampleConfig getExampleConfig() {
+            return null;
+        }
+
+        public Class<? extends FilterFactory> getContributorClass() {
+            return contributorClass;
+        }
+
+    }
+}

--- a/kroxylicious-runtime/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
+++ b/kroxylicious-runtime/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
@@ -13,3 +13,4 @@ io.kroxylicious.proxy.internal.filter.SetterInjection
 io.kroxylicious.proxy.internal.filter.FactoryMethod
 io.kroxylicious.proxy.internal.filter.MissingPluginImplName
 io.kroxylicious.proxy.internal.filter.NestedPluginConfigFactory
+io.kroxylicious.proxy.internal.filter.FlakyFactory


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds a `close()` method to the `FilterFactory`, and ensures it's called:

* On any `initialize()`'d filters if any other configured filter throws during its own call to `initialize()` (i.e. during abortive proxy startup).
* When the proxy is shutdown.

### Additional Context

To address #1208.

