### PR TITLE
Fix #1144: make transition-staging-repository-state drop an idempotent operation

### DIFF
--- a/scripts/transition-staging-repository-state.sh
+++ b/scripts/transition-staging-repository-state.sh
@@ -59,6 +59,9 @@ if [[ ${ASSERT_NO_STAGING_REPOS} == "true" ]]; then
 elif [[ ${STATE} ]]; then
   if [[ ${NUM_REPOS} -eq 0 ]]; then
       >&2 echo "No staging repository found to apply a ${STATE} state transition."
+     if [[ ${STATE} == "drop" ]]; then
+         exit 0
+     fi
      exit 1
   elif [[ ${NUM_REPOS} -gt 1 ]]; then
       >&2 echo "Too many staging repositories found (${NUM_REPOS})."


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

why: the script is used to clean up in the event of failure, if the release process hasn't reached that far, it is legitimate that the staging-repo won't exist.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
