### PR TITLE
Add missing fireChannelReadComplete in FilterHandler

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -359,8 +359,6 @@ public class FilterHandler extends ChannelDuplexHandler {
                 LOGGER.debug("{}: Forwarding response: {}", channelDescriptor(), decodedFrame);
             }
             ctx.fireChannelRead(responseFrame);
-            // required to flush the message back to the client
-            ctx.fireChannelReadComplete();
         }
         else {
             if (decodedFrame.body() != message) {
@@ -374,6 +372,8 @@ public class FilterHandler extends ChannelDuplexHandler {
             }
             ctx.fireChannelRead(decodedFrame);
         }
+        // required to flush the message back to the client
+        ctx.fireChannelReadComplete();
     }
 
     private void forwardShortCircuitResponse(DecodedRequestFrame<?> decodedFrame, RequestFilterResult requestFilterResult) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

If `handleResponseFilterResult` is running in an async context, the `decodedFrame` is written to `inboundChannel` but not flushed. 

It works now because the future is completed and `handleResponseFilterResult` is running in sync context. `fireChannelReadComplete` is called by netty. We can not rely on this in async context.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
