### PR TITLE
Avoid filling stack traces when throwing BufferTooSmallException 

### DIFF
--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/BufferTooSmallException.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/BufferTooSmallException.java
@@ -10,4 +10,9 @@ public class BufferTooSmallException extends RuntimeException {
     public BufferTooSmallException() {
         super();
     }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return null;
+    }
 }


### PR DESCRIPTION


### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

Avoid filling stack traces when throwing BufferTooSmallException as it creates new exception in the hot path should lead to better performance

See https://stackoverflow.com/questions/1520859/overriding-fillinstacktrace-for-a-standard-jvm-exceptions

This was found while investigating 

https://github.com/kroxylicious/kroxylicious/issues/1205

### Additional Context

Improved performance

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
