### PR TITLE
Forward the initial HAProxyMessage in KafkaAuthnHandler and release HAProxyMessage when closing the channel

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -435,6 +435,9 @@ public class KafkaProxyFrontendHandler
     @Override
     public void channelInactive(ChannelHandlerContext ctx) {
         LOGGER.trace("INACTIVE on inbound {}", ctx.channel());
+        if (haProxyMessage != null) {
+            haProxyMessage.release();
+        }
         if (outboundCtx == null) {
             return;
         }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

1. Forward the initial HaProxyMessage in KafkaAuthnHandler. When both HAProxyMessageDecoder and KafkaAuthnHandler are added to the pipeline, an HAProxyMessage will be rejected by KafkaAuthnHandler with a `new IllegalStateException("Unexpected message class io.netty.handler.codec.haproxy.HAProxyMessage")`
2. Release HAProxyMessage when closing the channel. 
```txt
ERROR 2024-06-13 12:02:03.403 v1(6) ResourceLeakDetector.java:337 _ _ _ _ _ [IOUringEventLoopGroup-5-1] LEAK: HAProxyMessage.release() was not called before it's garbage-collected. See https://netty.io/wiki/reference-counted-objects.html for more information.
``` 

### Additional Context

_Why are you making this pull request?_

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [x] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
