### PR TITLE
adding collecting cluster-info when the test fails to easy finding the root cause

### DIFF
--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
@@ -33,7 +33,7 @@ public class Environment {
     private static final String SKIP_STRIMZI_INSTALL_ENV = "SKIP_STRIMZI_INSTALL";
     private static final String KAFKA_CLIENT_ENV = "KAFKA_CLIENT";
     private static final String STRIMZI_VERSION_ENV = "STRIMZI_VERSION";
-    private static final String DUMP_LOGS_ENV = "DUMP_LOGS";
+    private static final String CLUSTER_DUMP_DIR_ENV = "CLUSTER_DUMP_DIR";
 
     /**
      * The kafka version default value
@@ -76,7 +76,7 @@ public class Environment {
     private static final String VAULT_CHART_VERSION_DEFAULT = "0.27.0";
     private static final String SKIP_STRIMZI_INSTALL_DEFAULT = "false";
     private static final String KAFKA_CLIENT_DEFAULT = "strimzi_test_client";
-    private static final String DUMP_LOGS_DEFAULT = System.getProperty("java.io.tmpdir");
+    private static final String CLUSTER_DUMP_DIR_DEFAULT = System.getProperty("java.io.tmpdir");
 
     /**
      * KAFKA_VERSION env variable assignment
@@ -109,7 +109,7 @@ public class Environment {
 
     public static final String STRIMZI_VERSION = getOrDefault(STRIMZI_VERSION_ENV, STRIMZI_VERSION_DEFAULT);
 
-    public static final String DUMP_LOGS = getOrDefault(DUMP_LOGS_ENV, DUMP_LOGS_DEFAULT);
+    public static final String CLUSTER_DUMP_DIR = getOrDefault(CLUSTER_DUMP_DIR_ENV, CLUSTER_DUMP_DIR_DEFAULT);
 
     private static String getOrDefault(String varName, String defaultValue) {
         return getOrDefault(varName, String::toString, defaultValue);

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
@@ -33,6 +33,7 @@ public class Environment {
     private static final String SKIP_STRIMZI_INSTALL_ENV = "SKIP_STRIMZI_INSTALL";
     private static final String KAFKA_CLIENT_ENV = "KAFKA_CLIENT";
     private static final String STRIMZI_VERSION_ENV = "STRIMZI_VERSION";
+    private static final String DUMP_LOGS_ENV = "DUMP_LOGS";
 
     /**
      * The kafka version default value
@@ -75,6 +76,7 @@ public class Environment {
     private static final String VAULT_CHART_VERSION_DEFAULT = "0.27.0";
     private static final String SKIP_STRIMZI_INSTALL_DEFAULT = "false";
     private static final String KAFKA_CLIENT_DEFAULT = "strimzi_test_client";
+    private static final String DUMP_LOGS_DEFAULT = System.getProperty("java.io.tmpdir");
 
     /**
      * KAFKA_VERSION env variable assignment
@@ -106,6 +108,8 @@ public class Environment {
     public static final String KAFKA_CLIENT = getOrDefault(KAFKA_CLIENT_ENV, KAFKA_CLIENT_DEFAULT);
 
     public static final String STRIMZI_VERSION = getOrDefault(STRIMZI_VERSION_ENV, STRIMZI_VERSION_DEFAULT);
+
+    public static final String DUMP_LOGS = getOrDefault(DUMP_LOGS_ENV, DUMP_LOGS_DEFAULT);
 
     private static String getOrDefault(String varName, String defaultValue) {
         return getOrDefault(varName, String::toString, defaultValue);

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
@@ -12,7 +12,11 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -33,6 +37,8 @@ import io.fabric8.kubernetes.api.model.ServiceBuilder;
 
 import io.kroxylicious.systemtests.Constants;
 import io.kroxylicious.systemtests.Environment;
+import io.kroxylicious.systemtests.executor.Exec;
+import io.kroxylicious.systemtests.executor.ExecResult;
 import io.kroxylicious.systemtests.k8s.exception.KubeClusterException;
 import io.kroxylicious.systemtests.templates.kroxylicious.KroxyliciousSecretTemplates;
 
@@ -232,6 +238,31 @@ public class DeploymentUtils {
             }
             kubeClient().getClient().secrets().inNamespace(namespace).resource(secret).create();
             await().atMost(Duration.ofSeconds(10)).until(() -> kubeClient().getClient().secrets().inNamespace(namespace).resource(secret).get() != null);
+        }
+    }
+
+    /**
+     * Collect cluster info.
+     *
+     * @param namespace the namespace
+     * @param testClassName the test class name
+     * @param testMethodName the test method name
+     */
+    public static void collectClusterInfo(String namespace, String testClassName, String testMethodName) {
+        String formattedDate = DateTimeFormatter.ofPattern("yyyy_MM_dd_HH_mm_ss")
+                .withZone(ZoneId.systemDefault())
+                .format(Instant.now());
+        List<String> executableCommand = List.of(cmdKubeClient(namespace).toString(), "cluster-info", "dump",
+                "--namespaces", String.join(",", namespace, Constants.KAFKA_DEFAULT_NAMESPACE),
+                "--output-directory", "/tmp/" + testClassName.replace(".", "_") + "_" +
+                        testMethodName + "_cluster_dump_" + formattedDate);
+        ExecResult result = Exec.exec(null, executableCommand, Duration.ofSeconds(20), true, false, null);
+        if (result.isSuccess()) {
+            LOGGER.atInfo().log(result.out());
+        }
+        else {
+            throw new KubeClusterException("Unable to collect cluster info from namespaces '" + namespace + "' and '" + Constants.KAFKA_DEFAULT_NAMESPACE +
+                    "': " + result.err());
         }
     }
 

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
@@ -254,7 +254,7 @@ public class DeploymentUtils {
                 .format(Instant.now());
         List<String> executableCommand = List.of(cmdKubeClient(namespace).toString(), "cluster-info", "dump",
                 "--namespaces", String.join(",", namespace, Constants.KAFKA_DEFAULT_NAMESPACE),
-                "--output-directory", Environment.DUMP_LOGS + "/" + testClassName.replace(".", "_") + "_" +
+                "--output-directory", Environment.CLUSTER_DUMP_DIR + "/" + testClassName.replace(".", "_") + "_" +
                         testMethodName + "_cluster_dump_" + formattedDate);
         ExecResult result = Exec.exec(null, executableCommand, Duration.ofSeconds(20), true, false, null);
         if (result.isSuccess()) {

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
@@ -254,7 +254,7 @@ public class DeploymentUtils {
                 .format(Instant.now());
         List<String> executableCommand = List.of(cmdKubeClient(namespace).toString(), "cluster-info", "dump",
                 "--namespaces", String.join(",", namespace, Constants.KAFKA_DEFAULT_NAMESPACE),
-                "--output-directory", System.getProperty("java.io.tmpdir") + "/" + testClassName.replace(".", "_") + "_" +
+                "--output-directory", Environment.DUMP_LOGS + "/" + testClassName.replace(".", "_") + "_" +
                         testMethodName + "_cluster_dump_" + formattedDate);
         ExecResult result = Exec.exec(null, executableCommand, Duration.ofSeconds(20), true, false, null);
         if (result.isSuccess()) {

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
@@ -13,7 +13,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
@@ -250,7 +250,7 @@ public class DeploymentUtils {
      */
     public static void collectClusterInfo(String namespace, String testClassName, String testMethodName) {
         String formattedDate = DateTimeFormatter.ofPattern("yyyy_MM_dd_HH_mm_ss")
-                .withZone(ZoneId.systemDefault())
+                .withZone(ZoneOffset.UTC)
                 .format(Instant.now());
         List<String> executableCommand = List.of(cmdKubeClient(namespace).toString(), "cluster-info", "dump",
                 "--namespaces", String.join(",", namespace, Constants.KAFKA_DEFAULT_NAMESPACE),

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
@@ -254,7 +254,7 @@ public class DeploymentUtils {
                 .format(Instant.now());
         List<String> executableCommand = List.of(cmdKubeClient(namespace).toString(), "cluster-info", "dump",
                 "--namespaces", String.join(",", namespace, Constants.KAFKA_DEFAULT_NAMESPACE),
-                "--output-directory", System.getProperty("java.io.tmpdir") + "/" +  testClassName.replace(".", "_") + "_" +
+                "--output-directory", System.getProperty("java.io.tmpdir") + "/" + testClassName.replace(".", "_") + "_" +
                         testMethodName + "_cluster_dump_" + formattedDate);
         ExecResult result = Exec.exec(null, executableCommand, Duration.ofSeconds(20), true, false, null);
         if (result.isSuccess()) {

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
@@ -254,7 +254,7 @@ public class DeploymentUtils {
                 .format(Instant.now());
         List<String> executableCommand = List.of(cmdKubeClient(namespace).toString(), "cluster-info", "dump",
                 "--namespaces", String.join(",", namespace, Constants.KAFKA_DEFAULT_NAMESPACE),
-                "--output-directory", "/tmp/" + testClassName.replace(".", "_") + "_" +
+                "--output-directory", System.getProperty("java.io.tmpdir") + "/" +  testClassName.replace(".", "_") + "_" +
                         testMethodName + "_cluster_dump_" + formattedDate);
         ExecResult result = Exec.exec(null, executableCommand, Duration.ofSeconds(20), true, false, null);
         if (result.isSuccess()) {

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
@@ -123,7 +123,7 @@ public class KafkaUtils {
             throw new KubeClusterException.NotFound("Kafka cluster name not found!");
         }
         kubeClient().getClient().pods().inNamespace(deployNamespace).withName(podName).withGracePeriod(0).delete();
-        kubeClient().getClient().pods().inNamespace(deployNamespace).withName(podName).waitUntilCondition(Objects::isNull, 60, TimeUnit.SECONDS);
+        kubeClient().getClient().pods().inNamespace(deployNamespace).withName(podName).waitUntilCondition(Objects::isNull, 5, TimeUnit.MINUTES);
         DeploymentUtils.waitForDeploymentRunning(deployNamespace, podName, Duration.ofMinutes(5));
         return !Objects.equals(podUid, getPodUid(deployNamespace, podName));
     }

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/extensions/KroxyliciousExtension.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/extensions/KroxyliciousExtension.java
@@ -61,13 +61,14 @@ public class KroxyliciousExtension implements ParameterResolver, BeforeEachCallb
     public void afterEach(ExtensionContext extensionContext) {
         String namespace = extractK8sNamespace(extensionContext);
         try {
-        Optional<Throwable> exception = extensionContext.getExecutionException();
-        if (exception.isPresent()) {
-            DeploymentUtils.collectClusterInfo(namespace, extensionContext.getRequiredTestClass().getSimpleName(), extensionContext.getRequiredTestMethod().getName());
+            Optional<Throwable> exception = extensionContext.getExecutionException();
+            if (exception.isPresent()) {
+                DeploymentUtils.collectClusterInfo(namespace, extensionContext.getRequiredTestClass().getSimpleName(),
+                        extensionContext.getRequiredTestMethod().getName());
+            }
         }
-        } finally {
-
-        NamespaceUtils.deleteNamespaceWithWait(namespace);
+        finally {
+            NamespaceUtils.deleteNamespaceWithWait(namespace);
         }
     }
 

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/extensions/KroxyliciousExtension.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/extensions/KroxyliciousExtension.java
@@ -50,7 +50,7 @@ public class KroxyliciousExtension implements ParameterResolver, BeforeEachCallb
         Parameter parameter = parameterContext.getParameter();
         Class<?> type = parameter.getType();
         LOGGER.trace("test {}: Resolving parameter ({} {})", extensionContext.getUniqueId(), type.getSimpleName(), parameter.getName());
-        if (String.class.getTypeName().equals(type.getName()) && parameter.getName().toLowerCase().contains("namespace")) {
+        if (String.class.equals(type) && parameter.getName().toLowerCase().contains("namespace")) {
             return extractK8sNamespace(extensionContext);
         }
 

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/extensions/KroxyliciousExtension.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/extensions/KroxyliciousExtension.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.systemtests.extensions;
 
 import java.lang.reflect.Parameter;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.junit.jupiter.api.TestInfo;
@@ -49,17 +50,22 @@ public class KroxyliciousExtension implements ParameterResolver, BeforeEachCallb
         Parameter parameter = parameterContext.getParameter();
         Class<?> type = parameter.getType();
         LOGGER.trace("test {}: Resolving parameter ({} {})", extensionContext.getUniqueId(), type.getSimpleName(), parameter.getName());
-        if (String.class.getTypeName().equals(type.getName())) {
-            if (parameter.getName().toLowerCase().contains("namespace")) {
-                return extractK8sNamespace(extensionContext);
-            }
+        if (String.class.getTypeName().equals(type.getName()) && parameter.getName().toLowerCase().contains("namespace")) {
+            return extractK8sNamespace(extensionContext);
         }
+
         return extensionContext;
     }
 
     @Override
     public void afterEach(ExtensionContext extensionContext) {
-        NamespaceUtils.deleteNamespaceWithWait(extractK8sNamespace(extensionContext));
+        String namespace = extractK8sNamespace(extensionContext);
+        Optional<Throwable> exception = extensionContext.getExecutionException();
+        if (exception.isPresent()) {
+            DeploymentUtils.collectClusterInfo(namespace, extensionContext.getRequiredTestClass().getSimpleName(), extensionContext.getRequiredTestMethod().getName());
+        }
+
+        NamespaceUtils.deleteNamespaceWithWait(namespace);
     }
 
     @Override

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/extensions/KroxyliciousExtension.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/extensions/KroxyliciousExtension.java
@@ -60,12 +60,15 @@ public class KroxyliciousExtension implements ParameterResolver, BeforeEachCallb
     @Override
     public void afterEach(ExtensionContext extensionContext) {
         String namespace = extractK8sNamespace(extensionContext);
+        try {
         Optional<Throwable> exception = extensionContext.getExecutionException();
         if (exception.isPresent()) {
             DeploymentUtils.collectClusterInfo(namespace, extensionContext.getRequiredTestClass().getSimpleName(), extensionContext.getRequiredTestMethod().getName());
         }
+        } finally {
 
         NamespaceUtils.deleteNamespaceWithWait(namespace);
+        }
     }
 
     @Override


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Added `kubectl cluster-info dump` for current namespaces when any test fail so we have more info about the status of the cluster.

Fixes #1283 

### Checklist

- [x] Write tests
- [X] Make sure all tests pass
- [x] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [X] Update documentation
- [x] Reference relevant issue(s) and close them after merging
- [X] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
