### PR TITLE
Run all tests with the NettyLeak detector.

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ApiVersionsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ApiVersionsIT.java
@@ -12,6 +12,9 @@ import org.apache.kafka.common.message.ApiVersionsRequestData;
 import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
 
 import io.kroxylicious.test.Request;
 import io.kroxylicious.test.Response;
@@ -35,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * a new ApiKey that this version of Kroxylicious is unaware of)
  * TODO check if this is still sensible behaviour, potentially a RequestFilter would attempt to decode these and fail.
  */
+@ExtendWith(NettyLeakDetectorExtension.class)
 public class ApiVersionsIT {
 
     @Test

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/BaseIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/BaseIT.java
@@ -23,12 +23,15 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.TopicCollection;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
+
 import io.kroxylicious.test.tester.KroxyliciousTester;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(KafkaClusterExtension.class)
+@ExtendWith(NettyLeakDetectorExtension.class)
 public abstract class BaseIT {
 
     protected CreateTopicsResult createTopics(Admin admin, NewTopic... topics) {

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/MetricsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/MetricsIT.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
 import io.micrometer.core.instrument.Metrics;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
@@ -34,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(KafkaClusterExtension.class)
+@ExtendWith(NettyLeakDetectorExtension.class)
 class MetricsIT {
 
     @BeforeEach

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/OutOfBandRequestIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/OutOfBandRequestIT.java
@@ -18,6 +18,9 @@ import org.apache.kafka.common.message.DescribeClusterResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
 
 import io.kroxylicious.proxy.config.FilterDefinition;
 import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
@@ -47,6 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *     <li>A can not filter X or the response to X, the flow was terminated.</li>
  * </ol>
  */
+@ExtendWith(NettyLeakDetectorExtension.class)
 public class OutOfBandRequestIT {
 
     @Test

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ProxyRpcTest.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ProxyRpcTest.java
@@ -18,8 +18,11 @@ import org.apache.kafka.common.protocol.ApiMessage;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
 
 import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
 import io.kroxylicious.proxy.filter.FixedClientIdFilterFactory;
@@ -42,6 +45,7 @@ import static org.apache.kafka.common.protocol.ApiKeys.FIND_COORDINATOR;
 import static org.apache.kafka.common.protocol.ApiKeys.METADATA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(NettyLeakDetectorExtension.class)
 public class ProxyRpcTest {
     private static MockServerKroxyliciousTester mockTester;
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/SingleFilterFactoryInstanceTest.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/SingleFilterFactoryInstanceTest.java
@@ -10,6 +10,9 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
 
 import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
 import io.kroxylicious.test.tester.MockServerKroxyliciousTester;
@@ -17,6 +20,7 @@ import io.kroxylicious.test.tester.MockServerKroxyliciousTester;
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.mockKafkaKroxyliciousTester;
 
+@ExtendWith(NettyLeakDetectorExtension.class)
 public class SingleFilterFactoryInstanceTest {
     public static final String INITIALISATION_COUNTER = "configInstanceId";
     private MockServerKroxyliciousTester mockTester;


### PR DESCRIPTION
Fixes: #202

### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Run all integration tests using the NettyLeakDetector.

### Additional Context

Tested with 
```patch
Index: kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java	(revision 4cb64e473254c5fdffad40a86b5c551a075392b9)
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java	(date 1718853640689)
@@ -23,6 +23,8 @@
 import org.slf4j.LoggerFactory;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelDuplexHandler;
@@ -220,7 +222,8 @@
             LOGGER.debug("{}: Dispatching downstream {} request to filter{}: {}",
                     channelDescriptor(), decodedFrame.apiKey(), filterDescriptor(), decodedFrame);
         }
-
+        final ByteBuf buffer = ctx.alloc().buffer();
+        buffer.retain();
         var stage = invoker.onRequest(decodedFrame.apiKey(), decodedFrame.apiVersion(), decodedFrame.header(),
                 decodedFrame.body(), filterContext);
         return stage instanceof InternalCompletionStage ? ((InternalCompletionStage<RequestFilterResult>) stage).getUnderlyingCompletableFuture()
```
If the extension is not loaded the leak is logged with the extension the test fails.
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
