### PR TITLE
[#904] Introduce FilterDispatchExecutor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@ For changes that effect a public API, the [deprecation policy](./DEV_GUIDE.md#de
 Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
+* [#1322](https://github.com/kroxylicious/kroxylicious/pull/1322): Introduce FilterDispatchExecutor
 * [#1154](https://github.com/kroxylicious/kroxylicious/pull/1154): Apicurio based schema validation filter
+
+### Changes, deprecations and removals
+
+* FilterFactoryContext#eventLoop() is deprecated, replaced by FilterFactoryContext#filterDispatchExecutor().
+This returns FilterDispatchExecutor, a new interface extending ScheduledExecutorService. FilterDispatchExecutor
+has methods to enable Filters to check if the current thread is the Filter Dispatch Thread and it offers
+specialized futures, where chained async methods will also run on the Filter Dispatch Thread when no executor
+is supplied. This is intended to be a tool to make it convenient for Filters to hand off work to uncontrolled
+threads, then switch back to an execution context where mutation of Filter members is safe.
 
 ## 0.6.0
 

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterDispatchExecutor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterDispatchExecutor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Function;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * An Executor backed by the <b>Filter Dispatch Thread</b>. That is the single thread associated with the Channel for
+ * a Filter Instance. All invocations of that instance's methods are made by the Filter Dispatch Thread.
+ * <p>
+ * If all accesses/mutations of Filter Members happen on the Filter Dispatch Thread, then those interactions are
+ * serial and threadsafe. This executor enables Authors to do work in uncontrolled threads and then return to
+ * the Filter Dispatch Thread to take advantage of this convenient threading guarantee.
+ * </p>
+ * <p>
+ * Note that implementations of FilterDispatchExecutor will not honour the shut-down methods {@link #shutdown()}
+ * and {@link #shutdownNow()} and will throw a RuntimeException if those methods are called, as the client is
+ * not allowed to shut down the Filter Dispatch Thread.
+ * </p>
+ * @see io.kroxylicious.proxy.filter
+ */
+public interface FilterDispatchExecutor extends ScheduledExecutorService {
+
+    /**
+     * @return Return true if {@link Thread#currentThread()} is this Filter Dispatch Thread, false otherwise
+     */
+    boolean isInFilterDispatchThread();
+
+    /**
+     * Switches to this Filter Dispatch Thread. The CompletionStage returned is an implementation
+     * that discourages blocking work and will throw if the client attempts to call
+     * {@link CompletionStage#toCompletableFuture()}. Any async work chained onto the
+     * result CompletionStage using methods like {@link CompletionStage#thenApplyAsync(Function)}
+     * will also be executed on the Filter Dispatch Thread.
+     * @param stage input stage
+     * @return a stage completed (both exceptionally and normally) by this Filter Dispatch Thread
+     * @param <T> stage value type
+     */
+    <T> CompletionStage<T> completeOnFilterDispatchThread(@NonNull CompletionStage<T> stage);
+
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactoryContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactoryContext.java
@@ -24,8 +24,19 @@ public interface FilterFactoryContext {
      * Should be safe
      * to mutate Filter members from this executor.
      * @return executor, or null
+     * @deprecated use {@link #filterDispatchExecutor()} instead
      */
+    @Deprecated(since = "0.7.0")
     ScheduledExecutorService eventLoop();
+
+    /**
+     * An executor backed by the single Thread responsible for dispatching
+     * work to a Filter instance for a channel.
+     * It is safe to mutate Filter members from this executor.
+     * @return executor
+     * @throws IllegalStateException if the factory is not bound to a channel yet.
+     */
+    FilterDispatchExecutor filterDispatchExecutor();
 
     /**
      * Gets a plugin instance for the given plugin type and name

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/package-info.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/package-info.java
@@ -57,7 +57,7 @@
  *  <p>Filter implementations are free to rely on these guarantees to safely maintain state within fields
  *     of the Filter without employing additional synchronization.</p>
  *  <p>If a Filter needs to do some asynchronous work and mutate members of the Filter, they can access
- *  the thread for the connection via {@link io.kroxylicious.proxy.filter.FilterFactoryContext#eventLoop()},
+ *  the thread for the connection via {@link io.kroxylicious.proxy.filter.FilterFactoryContext#filterDispatchExecutor()},
  *  which is available in {@link io.kroxylicious.proxy.filter.FilterFactory#createFilter(FilterFactoryContext, java.lang.Object)}
  *  when it is creating an instance of a Filter. Ensure that any work executes quickly as this is the IO thread for potentially
  *  many connections.</p>

--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidation.java
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidation.java
@@ -78,7 +78,7 @@ public class OauthBearerValidation implements FilterFactory<OauthBearerValidatio
     @NonNull
     @Override
     public OauthBearerValidationFilter createFilter(FilterFactoryContext context, SharedOauthBearerValidationContext sharedContext) {
-        return new OauthBearerValidationFilter(context.eventLoop(), sharedContext);
+        return new OauthBearerValidationFilter(context.filterDispatchExecutor(), sharedContext);
     }
 
     @Override

--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationTest.java
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationTest.java
@@ -8,7 +8,6 @@ package io.kroxylicious.proxy.filter.oauthbearer;
 
 import java.net.URI;
 import java.util.List;
-import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler;
@@ -20,6 +19,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
+import io.kroxylicious.proxy.filter.FilterDispatchExecutor;
 import io.kroxylicious.proxy.filter.FilterFactoryContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,7 +39,7 @@ class OauthBearerValidationTest {
     private OAuthBearerValidatorCallbackHandler callbackHandler;
 
     @Mock
-    private ScheduledExecutorService executor;
+    private FilterDispatchExecutor executor;
 
     @Test
     void mustProvideDefaultValuesForConfig() throws Exception {
@@ -77,7 +77,7 @@ class OauthBearerValidationTest {
     @SuppressWarnings("java:S5838")
     void mustInitAndCreateFilterFromConfig() throws Exception {
         // given
-        when(ffc.eventLoop()).thenReturn(executor);
+        when(ffc.filterDispatchExecutor()).thenReturn(executor);
         OauthBearerValidation oauthBearerValidation = new OauthBearerValidation(callbackHandler);
         OauthBearerValidation.Config config = new OauthBearerValidation.Config(
                 new URI("https://jwks.endpoint"),
@@ -129,7 +129,7 @@ class OauthBearerValidationTest {
     void mustInitAndCreateFilter(OauthBearerValidation.Config config) {
         // given
         OauthBearerValidation oauthBearerValidation = new OauthBearerValidation(callbackHandler);
-        when(ffc.eventLoop()).thenReturn(executor);
+        when(ffc.filterDispatchExecutor()).thenReturn(executor);
 
         // when
         SharedOauthBearerValidationContext sharedContext = oauthBearerValidation.initialize(ffc, config);

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryption.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryption.java
@@ -114,7 +114,7 @@ public class RecordEncryption<K, E> implements FilterFactory<RecordEncryptionCon
     public RecordEncryptionFilter<K> createFilter(FilterFactoryContext context,
                                                   SharedEncryptionContext<K, E> sharedEncryptionContext) {
 
-        ScheduledExecutorService filterThreadExecutor = context.eventLoop();
+        ScheduledExecutorService filterThreadExecutor = context.filterDispatchExecutor();
         FilterThreadExecutor executor = new FilterThreadExecutor(filterThreadExecutor);
         var encryptionManager = new InBandEncryptionManager<>(Encryption.V2,
                 sharedEncryptionContext.dekManager().edekSerde(),

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopEncryptionTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopEncryptionTest.java
@@ -6,8 +6,6 @@
 
 package io.kroxylicious.filter.encryption;
 
-import java.util.concurrent.ScheduledExecutorService;
-
 import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.filter.encryption.config.KekSelectorService;
@@ -16,6 +14,7 @@ import io.kroxylicious.filter.encryption.config.TopicNameBasedKekSelector;
 import io.kroxylicious.kms.service.Kms;
 import io.kroxylicious.kms.service.KmsService;
 import io.kroxylicious.kms.service.Serde;
+import io.kroxylicious.proxy.filter.FilterDispatchExecutor;
 import io.kroxylicious.proxy.filter.FilterFactoryContext;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -39,7 +38,7 @@ class EnvelopEncryptionTest {
 
         doReturn(kmsService).when(fc).pluginInstance(KmsService.class, "KMS");
         doReturn(kms).when(kmsService).buildKms(any());
-        doReturn(mock(ScheduledExecutorService.class)).when(fc).eventLoop();
+        doReturn(mock(FilterDispatchExecutor.class)).when(fc).filterDispatchExecutor();
         doReturn(edekSerde).when(kms).edekSerde();
 
         doReturn(kekSelectorService).when(fc).pluginInstance(KekSelectorService.class, "SELECTOR");

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionTest.java
@@ -9,7 +9,6 @@ package io.kroxylicious.filter.encryption;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
 
 import javax.crypto.Cipher;
 
@@ -26,6 +25,7 @@ import io.kroxylicious.filter.encryption.dek.DekException;
 import io.kroxylicious.kms.service.Kms;
 import io.kroxylicious.kms.service.KmsService;
 import io.kroxylicious.kms.service.Serde;
+import io.kroxylicious.proxy.filter.FilterDispatchExecutor;
 import io.kroxylicious.proxy.filter.FilterFactoryContext;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -65,7 +65,7 @@ class RecordEncryptionTest {
 
         doReturn(kmsService).when(fc).pluginInstance(KmsService.class, "KMS");
         doReturn(kms).when(kmsService).buildKms(any());
-        doReturn(mock(ScheduledExecutorService.class)).when(fc).eventLoop();
+        doReturn(mock(FilterDispatchExecutor.class)).when(fc).filterDispatchExecutor();
         doReturn(edekSerde).when(kms).edekSerde();
 
         doReturn(kekSelectorService).when(fc).pluginInstance(KekSelectorService.class, "SELECTOR");

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/ForwardingStyle.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/ForwardingStyle.java
@@ -45,7 +45,7 @@ public enum ForwardingStyle implements Function<ForwardingContext, CompletionSta
     ASYNCHRONOUS_DELAYED_ON_EVENTlOOP {
         @Override
         public CompletionStage<ApiMessage> apply(ForwardingContext context) {
-            ScheduledExecutorService executor = context.constructionContext().eventLoop();
+            ScheduledExecutorService executor = context.constructionContext().filterDispatchExecutor();
             CompletableFuture<ApiMessage> result = new CompletableFuture<>();
             executor.schedule(() -> {
                 result.complete(context.body());

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -16,6 +16,7 @@ import io.kroxylicious.proxy.config.PluginFactory;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
 import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
+import io.kroxylicious.proxy.filter.FilterDispatchExecutor;
 import io.kroxylicious.proxy.filter.FilterFactory;
 import io.kroxylicious.proxy.filter.FilterFactoryContext;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
@@ -92,6 +93,11 @@ public class FilterChainFactory implements AutoCloseable {
                 @Override
                 public ScheduledExecutorService eventLoop() {
                     return null;
+                }
+
+                @Override
+                public FilterDispatchExecutor filterDispatchExecutor() {
+                    throw new IllegalStateException("no Filter Dispatch executor available at filter factory initialization time");
                 }
 
                 @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/NettyFilterDispatchExecutor.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/NettyFilterDispatchExecutor.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.netty.channel.EventLoop;
+
+import io.kroxylicious.proxy.filter.FilterDispatchExecutor;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class NettyFilterDispatchExecutor implements FilterDispatchExecutor {
+
+    private final EventLoop eventLoop;
+
+    private NettyFilterDispatchExecutor(@NonNull EventLoop eventLoop) {
+        Objects.requireNonNull(eventLoop, "eventLoop cannot be null");
+        this.eventLoop = eventLoop;
+    }
+
+    public static FilterDispatchExecutor eventLoopExecutor(@NonNull EventLoop loop) {
+        return new NettyFilterDispatchExecutor(loop);
+    }
+
+    @Override
+    public boolean isInFilterDispatchThread() {
+        return eventLoop.inEventLoop();
+    }
+
+    EventLoop getEventLoop() {
+        return eventLoop;
+    }
+
+    @Override
+    public <T> CompletionStage<T> completeOnFilterDispatchThread(@NonNull CompletionStage<T> completionStage) {
+        Objects.requireNonNull(completionStage, "completionStage was null");
+        CompletableFuture<T> future = new InternalCompletableFuture<>(this);
+        completionStage.whenComplete((value, throwable) -> {
+            if (isInFilterDispatchThread()) {
+                forward(value, throwable, future);
+            }
+            else {
+                execute(() -> forward(value, throwable, future));
+            }
+        });
+        return future.minimalCompletionStage();
+    }
+
+    private static <T> void forward(T value, Throwable throwable, CompletableFuture<T> future) {
+        if (throwable != null) {
+            future.completeExceptionally(throwable);
+        }
+        else {
+            future.complete(value);
+        }
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        return eventLoop.schedule(command, delay, unit);
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        return eventLoop.schedule(callable, delay, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        return eventLoop.scheduleAtFixedRate(command, initialDelay, period, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        return eventLoop.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+    }
+
+    @Override
+    public void shutdown() {
+        // no-op, eventLoop lifecycle is not owned by this executor that is made available to Filters
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        // no-op, eventLoop lifecycle is not owned by this executor that is made available to Filters
+        return List.of();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return eventLoop.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return eventLoop.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return eventLoop.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return eventLoop.submit(task);
+    }
+
+    @NonNull
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return eventLoop.submit(task, result);
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return eventLoop.submit(task);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return eventLoop.invokeAll(tasks);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+        return eventLoop.invokeAll(tasks, timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        return eventLoop.invokeAny(tasks);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return eventLoop.invokeAny(tasks, timeout, unit);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        eventLoop.execute(command);
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/NettyFilterContext.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/NettyFilterContext.java
@@ -8,25 +8,34 @@ package io.kroxylicious.proxy.internal.filter;
 
 import java.util.concurrent.ScheduledExecutorService;
 
+import io.netty.channel.EventLoop;
+
 import io.kroxylicious.proxy.config.PluginFactory;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
+import io.kroxylicious.proxy.filter.FilterDispatchExecutor;
 import io.kroxylicious.proxy.filter.FilterFactoryContext;
+import io.kroxylicious.proxy.internal.NettyFilterDispatchExecutor;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public class NettyFilterContext implements FilterFactoryContext {
-    private final ScheduledExecutorService eventLoop;
+    private final FilterDispatchExecutor dispatchExecutor;
     private final PluginFactoryRegistry pluginFactoryRegistry;
 
-    public NettyFilterContext(ScheduledExecutorService eventLoop,
+    public NettyFilterContext(EventLoop eventLoop,
                               PluginFactoryRegistry pluginFactoryRegistry) {
-        this.eventLoop = eventLoop;
+        this.dispatchExecutor = NettyFilterDispatchExecutor.eventLoopExecutor(eventLoop);
         this.pluginFactoryRegistry = pluginFactoryRegistry;
     }
 
     @Override
     public ScheduledExecutorService eventLoop() {
-        return eventLoop;
+        return filterDispatchExecutor();
+    }
+
+    @Override
+    public FilterDispatchExecutor filterDispatchExecutor() {
+        return dispatchExecutor;
     }
 
     @NonNull

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -28,6 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoop;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.ByteToMessageDecoder;
@@ -71,6 +72,9 @@ class KafkaProxyInitializerTest {
     private VirtualClusterBinding vcb;
 
     @Mock(strictness = Mock.Strictness.LENIENT)
+    private EventLoop eventLoop;
+
+    @Mock(strictness = Mock.Strictness.LENIENT)
     private ServerSocketChannel serverSocketChannel;
 
     @Captor
@@ -91,6 +95,7 @@ class KafkaProxyInitializerTest {
         final InetSocketAddress localhost = new InetSocketAddress(0);
         when(channel.pipeline()).thenReturn(channelPipeline);
         when(channel.parent()).thenReturn(serverSocketChannel);
+        when(channel.eventLoop()).thenReturn(eventLoop);
         when(channel.localAddress()).thenReturn(InetSocketAddress.createUnresolved("localhost", 9099));
 
         when(serverSocketChannel.localAddress()).thenReturn(localhost);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/NettyFilterDispatchExecutorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/NettyFilterDispatchExecutorTest.java
@@ -1,0 +1,434 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.netty.channel.DefaultEventLoop;
+import io.netty.channel.EventLoop;
+import io.netty.util.concurrent.ScheduledFuture;
+
+import io.kroxylicious.proxy.filter.FilterDispatchExecutor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatObject;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.BOOLEAN;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * These tests check that work is delegated to a netty event loop. For pragmatic reasons,
+ * to avoid re-testing that the numerous methods of the underlying executor actually execute their
+ * Runnable/Callable and honour cancellation, many of the tests use a mock event loop. We
+ * check that the parameters are delegated as expected to the mock, and that the result
+ * from the mock is forwarded, untouched, to the client.
+ */
+class NettyFilterDispatchExecutorTest {
+
+    @Test
+    void nullEventLoopNotAllowed() {
+        assertThatThrownBy(() -> NettyFilterDispatchExecutor.eventLoopExecutor(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("eventLoop cannot be null");
+    }
+
+    @Test
+    void getEventloop() {
+        EventLoop eventLoop = new DefaultEventLoop();
+        try {
+            FilterDispatchExecutor dispatchExecutor = NettyFilterDispatchExecutor.eventLoopExecutor(eventLoop);
+            assertThat(dispatchExecutor).isInstanceOfSatisfying(NettyFilterDispatchExecutor.class, ex -> {
+                assertThat(ex.getEventLoop()).isSameAs(eventLoop);
+            });
+        }
+        finally {
+            eventLoop.shutdownGracefully();
+        }
+    }
+
+    @Test
+    void notInFilterDispatchThreadWhenInTestThread() {
+        EventLoop eventLoop = new DefaultEventLoop();
+        try {
+            FilterDispatchExecutor dispatchExecutor = NettyFilterDispatchExecutor.eventLoopExecutor(eventLoop);
+            assertThat(dispatchExecutor.isInFilterDispatchThread()).isFalse();
+        }
+        finally {
+            eventLoop.shutdownGracefully();
+        }
+    }
+
+    @Test
+    void nullStageNotAllowed() {
+        EventLoop eventLoop = new DefaultEventLoop();
+        try {
+            FilterDispatchExecutor dispatchExecutor = NettyFilterDispatchExecutor.eventLoopExecutor(eventLoop);
+            assertThatThrownBy(() -> dispatchExecutor.completeOnFilterDispatchThread(null))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessage("completionStage was null");
+        }
+        finally {
+            eventLoop.shutdownGracefully();
+        }
+    }
+
+    @Test
+    void notInFilterDispatchThreadWhenInAnotherEventLoop() {
+        EventLoop eventLoop = new DefaultEventLoop();
+        EventLoop anotherEventLoop = new DefaultEventLoop();
+        try {
+            FilterDispatchExecutor dispatchExecutor = NettyFilterDispatchExecutor.eventLoopExecutor(eventLoop);
+            Future<Boolean> inDispatchThreadFuture = anotherEventLoop.submit(dispatchExecutor::isInFilterDispatchThread);
+            assertThat(inDispatchThreadFuture).succeedsWithin(5, TimeUnit.SECONDS, BOOLEAN).isEqualTo(false);
+        }
+        finally {
+            eventLoop.shutdownGracefully();
+            anotherEventLoop.shutdownGracefully();
+        }
+    }
+
+    @Test
+    void inFilterDispatchThreadWhenInEventLoop() {
+        EventLoop eventLoop = new DefaultEventLoop();
+        try {
+            FilterDispatchExecutor dispatchExecutor = NettyFilterDispatchExecutor.eventLoopExecutor(eventLoop);
+            Future<Boolean> inDispatchThreadFuture = eventLoop.submit(dispatchExecutor::isInFilterDispatchThread);
+            assertThat(inDispatchThreadFuture).succeedsWithin(5, TimeUnit.SECONDS, BOOLEAN).isEqualTo(true);
+        }
+        finally {
+            eventLoop.shutdownGracefully();
+        }
+    }
+
+    @Test
+    void inFilterDispatchThreadByDelegation() {
+        EventLoop eventLoop = new DefaultEventLoop();
+        try {
+            FilterDispatchExecutor dispatchExecutor = NettyFilterDispatchExecutor.eventLoopExecutor(eventLoop);
+            Future<Boolean> inDispatchThreadFuture = dispatchExecutor.submit(dispatchExecutor::isInFilterDispatchThread);
+            assertThat(inDispatchThreadFuture).succeedsWithin(5, TimeUnit.SECONDS, BOOLEAN).isEqualTo(true);
+        }
+        finally {
+            eventLoop.shutdownGracefully();
+        }
+    }
+
+    @Test
+    void completeOnFilterDispatchThreadWhenInEventLoop() {
+        EventLoop eventLoop = new DefaultEventLoop();
+        try {
+            FilterDispatchExecutor dispatchExecutor = NettyFilterDispatchExecutor.eventLoopExecutor(eventLoop);
+            CompletableFuture<Object> completionStage = new CompletableFuture<>();
+            CompletionStage<Boolean> inDispatchThread = dispatchExecutor.completeOnFilterDispatchThread(completionStage)
+                    .thenApply(o -> dispatchExecutor.isInFilterDispatchThread());
+            completionStage.complete("arbitrary");
+            assertThat(chainStandardCompletableFuture(inDispatchThread)).succeedsWithin(5, TimeUnit.SECONDS, BOOLEAN).isEqualTo(true);
+        }
+        finally {
+            eventLoop.shutdownGracefully();
+        }
+    }
+
+    static <T> CompletableFuture<T> chainStandardCompletableFuture(CompletionStage<T> stage) {
+        CompletableFuture<T> future = new CompletableFuture<>();
+        stage.whenComplete((o, throwable) -> {
+            if (throwable != null) {
+                future.completeExceptionally(throwable);
+            }
+            else {
+                future.complete(o);
+            }
+        });
+        return future;
+    }
+
+    @Test
+    void completeOnFilterDispatchThreadResultCannotBeConvertedToCompletableFuture() {
+        EventLoop eventLoop = new DefaultEventLoop();
+        try {
+            FilterDispatchExecutor dispatchExecutor = NettyFilterDispatchExecutor.eventLoopExecutor(eventLoop);
+            CompletableFuture<Object> completionStage = new CompletableFuture<>();
+            CompletionStage<Object> inDispatchThread = dispatchExecutor.completeOnFilterDispatchThread(completionStage);
+            assertThatThrownBy(inDispatchThread::toCompletableFuture)
+                    .isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessage("CompletableFuture usage disallowed, we don't want to block the event loop or allow unexpected completion");
+        }
+        finally {
+            eventLoop.shutdownGracefully();
+        }
+    }
+
+    @Test
+    void completeOnFilterDispatchThreadResultNotCompletableByClientByCasting() {
+        EventLoop eventLoop = new DefaultEventLoop();
+        try {
+            FilterDispatchExecutor dispatchExecutor = NettyFilterDispatchExecutor.eventLoopExecutor(eventLoop);
+            CompletableFuture<Object> completionStage = new CompletableFuture<>();
+            CompletionStage<Object> inDispatchThread = dispatchExecutor.completeOnFilterDispatchThread(completionStage);
+            assertThatObject(inDispatchThread).isNotInstanceOf(CompletableFuture.class);
+        }
+        finally {
+            eventLoop.shutdownGracefully();
+        }
+    }
+
+    @Test
+    void completeOnFilterDispatchThreadResultChainedAsyncOperationsDefaultToDispatchThread() {
+        EventLoop eventLoop = new DefaultEventLoop();
+        try {
+            FilterDispatchExecutor dispatchExecutor = NettyFilterDispatchExecutor.eventLoopExecutor(eventLoop);
+            CompletableFuture<Object> completionStage = new CompletableFuture<>();
+            CompletionStage<Object> inDispatchThread = dispatchExecutor.completeOnFilterDispatchThread(completionStage);
+            CompletionStage<Boolean> chainedAsyncStage = inDispatchThread.thenApplyAsync(o -> dispatchExecutor.isInFilterDispatchThread());
+            completionStage.complete("abc");
+            assertThat(chainStandardCompletableFuture(chainedAsyncStage)).succeedsWithin(5, TimeUnit.SECONDS, BOOLEAN).isEqualTo(true);
+        }
+        finally {
+            eventLoop.shutdownGracefully();
+        }
+    }
+
+    // sanity check, future is completed as expected when the input future is completed by the dispatcher thread
+    @Test
+    void completeOnFilterDispatchThreadWhenInDispatchThread() {
+        EventLoop eventLoop = new DefaultEventLoop();
+        try {
+            FilterDispatchExecutor dispatchExecutor = NettyFilterDispatchExecutor.eventLoopExecutor(eventLoop);
+            CompletableFuture<Object> completionStage = new CompletableFuture<>();
+            CompletionStage<Boolean> inDispatchThread = dispatchExecutor.completeOnFilterDispatchThread(completionStage)
+                    .thenApply(o -> dispatchExecutor.isInFilterDispatchThread());
+            dispatchExecutor.execute(() -> completionStage.complete("arbitrary"));
+            assertThat(chainStandardCompletableFuture(inDispatchThread)).succeedsWithin(5, TimeUnit.SECONDS, BOOLEAN).isEqualTo(true);
+        }
+        finally {
+            eventLoop.shutdownGracefully();
+        }
+    }
+
+    @Test
+    void completeOnFilterDispatchThreadWhenCompletedByAnotherEventLoop() {
+        EventLoop eventLoop = new DefaultEventLoop();
+        EventLoop anotherLoop = new DefaultEventLoop();
+        try {
+            FilterDispatchExecutor dispatchExecutor = NettyFilterDispatchExecutor.eventLoopExecutor(eventLoop);
+            CompletableFuture<Object> completionStage = new CompletableFuture<>();
+            CompletionStage<Boolean> inDispatchThread = dispatchExecutor.completeOnFilterDispatchThread(completionStage)
+                    .thenApply(o -> dispatchExecutor.isInFilterDispatchThread());
+            anotherLoop.execute(() -> completionStage.complete("arbitrary"));
+            assertThat(chainStandardCompletableFuture(inDispatchThread)).succeedsWithin(5, TimeUnit.SECONDS, BOOLEAN).isEqualTo(true);
+            // double-check we are on the expected eventloop
+            CompletableFuture<Object> completionStage2 = new CompletableFuture<>();
+            CompletionStage<Boolean> inExpectedEventLoop = dispatchExecutor.completeOnFilterDispatchThread(completionStage2)
+                    .thenApply(o -> eventLoop.inEventLoop() && !anotherLoop.inEventLoop());
+            anotherLoop.execute(() -> completionStage2.complete("arbitrary"));
+            assertThat(chainStandardCompletableFuture(inExpectedEventLoop)).succeedsWithin(5, TimeUnit.SECONDS, BOOLEAN).isEqualTo(true);
+        }
+        finally {
+            eventLoop.shutdownGracefully();
+            anotherLoop.shutdownGracefully();
+        }
+    }
+
+    @Test
+    void scheduleCallableDelegated() {
+        EventLoop mock = Mockito.mock();
+        FilterDispatchExecutor dispatch = NettyFilterDispatchExecutor.eventLoopExecutor(mock);
+        Callable<String> callable = () -> "hi";
+        ScheduledFuture<String> future = Mockito.mock();
+        when(mock.schedule(callable, 1, TimeUnit.SECONDS)).thenReturn(future);
+        Future<String> scheduled = dispatch.schedule(callable, 1, TimeUnit.SECONDS);
+        assertThat(scheduled).isSameAs(future);
+    }
+
+    @Test
+    void submitCallableDelegated() {
+        EventLoop mock = Mockito.mock();
+        FilterDispatchExecutor dispatch = NettyFilterDispatchExecutor.eventLoopExecutor(mock);
+        Callable<String> callable = () -> "hi";
+        ScheduledFuture<String> future = Mockito.mock();
+        when(mock.submit(callable)).thenReturn(future);
+        Future<String> scheduled = dispatch.submit(callable);
+        assertThat(scheduled).isSameAs(future);
+    }
+
+    @Test
+    void scheduleRunnableDelegated() {
+        EventLoop mock = Mockito.mock();
+        FilterDispatchExecutor dispatch = NettyFilterDispatchExecutor.eventLoopExecutor(mock);
+        Runnable runnable = () -> {
+        };
+        ScheduledFuture<Void> future = Mockito.mock();
+        doReturn(future).when(mock).schedule(runnable, 1, TimeUnit.SECONDS);
+        Future<?> scheduled = dispatch.schedule(runnable, 1, TimeUnit.SECONDS);
+        assertThat(scheduled).isSameAs(future);
+    }
+
+    @Test
+    void submitRunnableDelegated() {
+        EventLoop mock = Mockito.mock();
+        FilterDispatchExecutor dispatch = NettyFilterDispatchExecutor.eventLoopExecutor(mock);
+        Runnable runnable = () -> {
+        };
+        ScheduledFuture<?> future = Mockito.mock();
+        doReturn(future).when(mock).submit(runnable);
+        Future<?> scheduled = dispatch.submit(runnable);
+        assertThat(scheduled).isSameAs(future);
+    }
+
+    @Test
+    void submitRunnableResultDelegated() {
+        EventLoop mock = Mockito.mock();
+        FilterDispatchExecutor dispatch = NettyFilterDispatchExecutor.eventLoopExecutor(mock);
+        Runnable runnable = () -> {
+        };
+        ScheduledFuture<String> future = Mockito.mock();
+        doReturn(future).when(mock).submit(runnable, "result");
+        Future<String> scheduled = dispatch.submit(runnable, "result");
+        assertThat(scheduled).isSameAs(future);
+    }
+
+    @Test
+    void executeDelegated() {
+        EventLoop mock = Mockito.mock();
+        FilterDispatchExecutor dispatch = NettyFilterDispatchExecutor.eventLoopExecutor(mock);
+        Runnable runnable = () -> {
+        };
+        dispatch.execute(runnable);
+        verify(mock).execute(runnable);
+    }
+
+    @Test
+    void scheduleAtFixedRateDelegated() {
+        EventLoop mock = Mockito.mock();
+        FilterDispatchExecutor dispatch = NettyFilterDispatchExecutor.eventLoopExecutor(mock);
+        Runnable runnable = () -> {
+        };
+        ScheduledFuture<Void> future = Mockito.mock();
+        doReturn(future).when(mock).scheduleAtFixedRate(runnable, 1L, 2L, TimeUnit.SECONDS);
+        Future<?> scheduled = dispatch.scheduleAtFixedRate(runnable, 1L, 2L, TimeUnit.SECONDS);
+        assertThat(scheduled).isSameAs(future);
+    }
+
+    @Test
+    void scheduleWithFixedDelayDelegated() {
+        EventLoop mock = Mockito.mock();
+        FilterDispatchExecutor dispatch = NettyFilterDispatchExecutor.eventLoopExecutor(mock);
+        Runnable runnable = () -> {
+        };
+        ScheduledFuture<Void> future = Mockito.mock();
+        doReturn(future).when(mock).scheduleWithFixedDelay(runnable, 1L, 2L, TimeUnit.SECONDS);
+        Future<?> scheduled = dispatch.scheduleWithFixedDelay(runnable, 1L, 2L, TimeUnit.SECONDS);
+        assertThat(scheduled).isSameAs(future);
+    }
+
+    @Test
+    void isShutdownDelegated() {
+        EventLoop mock = Mockito.mock();
+        FilterDispatchExecutor dispatch = NettyFilterDispatchExecutor.eventLoopExecutor(mock);
+        when(mock.isShutdown()).thenReturn(true);
+        assertThat(dispatch.isShutdown()).isTrue();
+        when(mock.isShutdown()).thenReturn(false);
+        assertThat(dispatch.isShutdown()).isFalse();
+    }
+
+    @Test
+    void isTerminatedDelegated() {
+        EventLoop mock = Mockito.mock();
+        FilterDispatchExecutor dispatch = NettyFilterDispatchExecutor.eventLoopExecutor(mock);
+        when(mock.isTerminated()).thenReturn(true);
+        assertThat(dispatch.isTerminated()).isTrue();
+        when(mock.isTerminated()).thenReturn(false);
+        assertThat(dispatch.isTerminated()).isFalse();
+    }
+
+    @Test
+    void awaitTerminationDelegated() throws InterruptedException {
+        EventLoop mock = Mockito.mock();
+        FilterDispatchExecutor dispatch = NettyFilterDispatchExecutor.eventLoopExecutor(mock);
+        when(mock.awaitTermination(1L, TimeUnit.MINUTES)).thenReturn(true);
+        assertThat(dispatch.awaitTermination(1L, TimeUnit.MINUTES)).isTrue();
+    }
+
+    @Test
+    void shutdownIsNoOp() {
+        EventLoop mock = Mockito.mock();
+        FilterDispatchExecutor dispatch = NettyFilterDispatchExecutor.eventLoopExecutor(mock);
+        dispatch.shutdownNow();
+        verifyNoInteractions(mock);
+    }
+
+    @Test
+    void shutdownNowIsNoOp() {
+        EventLoop mock = Mockito.mock();
+        FilterDispatchExecutor dispatch = NettyFilterDispatchExecutor.eventLoopExecutor(mock);
+        dispatch.shutdownNow();
+        verifyNoInteractions(mock);
+    }
+
+    @Test
+    void invokeAll() throws InterruptedException {
+        EventLoop mock = Mockito.mock();
+        FilterDispatchExecutor dispatch = NettyFilterDispatchExecutor.eventLoopExecutor(mock);
+        Callable<String> callable = () -> "hi";
+        ScheduledFuture<String> future = Mockito.mock();
+        List<Callable<String>> callables = List.of(callable);
+        List<ScheduledFuture<String>> futures = List.of(future);
+        doReturn(futures).when(mock).invokeAll(callables);
+        List<Future<String>> results = dispatch.invokeAll(callables);
+        assertThat(results).isSameAs(futures);
+    }
+
+    @Test
+    void invokeAny() throws InterruptedException, ExecutionException {
+        EventLoop mock = Mockito.mock();
+        FilterDispatchExecutor dispatch = NettyFilterDispatchExecutor.eventLoopExecutor(mock);
+        Callable<String> callable = () -> "hi";
+        List<Callable<String>> callables = List.of(callable);
+        String result = "result";
+        doReturn(result).when(mock).invokeAny(callables);
+        String results = dispatch.invokeAny(callables);
+        assertThat(results).isEqualTo(result);
+    }
+
+    @Test
+    void invokeAnyWithTimeout() throws InterruptedException, ExecutionException, TimeoutException {
+        EventLoop mock = Mockito.mock();
+        FilterDispatchExecutor dispatch = NettyFilterDispatchExecutor.eventLoopExecutor(mock);
+        Callable<String> callable = () -> "hi";
+        List<Callable<String>> callables = List.of(callable);
+        String result = "result";
+        doReturn(result).when(mock).invokeAny(callables, 1L, TimeUnit.SECONDS);
+        String results = dispatch.invokeAny(callables, 1L, TimeUnit.SECONDS);
+        assertThat(results).isEqualTo(result);
+    }
+
+    @Test
+    void invokeAllWithTimeout() throws InterruptedException {
+        EventLoop mock = Mockito.mock();
+        FilterDispatchExecutor dispatch = NettyFilterDispatchExecutor.eventLoopExecutor(mock);
+        Callable<String> callable = () -> "hi";
+        ScheduledFuture<String> future = Mockito.mock();
+        List<Callable<String>> callables = List.of(callable);
+        List<ScheduledFuture<String>> futures = List.of(future);
+        doReturn(futures).when(mock).invokeAll(callables, 1L, TimeUnit.SECONDS);
+        List<Future<String>> results = dispatch.invokeAll(callables, 1L, TimeUnit.SECONDS);
+        assertThat(results).isSameAs(futures);
+    }
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Closes #904

* Deprecates ScheduledExecutorService FilterFactoryContext#eventLoop()
* Adds FilterDispatchExecutor FilterFactoryContext#filterDispatchExecutor()

### Additional Context

The framework guarantees that their Filter methods will be dispatched by a single thread (the event loop for the Filter instance's channel), which gives Filter Authors this nice property that they can mutate members of the Filter safely, as Filter invocation is single-threaded.
    
We also give the Filter Auther an asynchronous API using Java's CompletionStage, so it's possible to move work to arbitrary threads. If the Author needs to change Threads then they no longer have this convenient thread safety guarantee and would have to co-ordinate access to the members.
    
To fix this we added FilterFactoryContext#eventLoop() so that the Author can use the executor to switch back to the Filter Dispatch Thread and safely access members. The fact it exposes a ScheduledExecutorService is inflexible if we want to add to it and the naming is implementation specific. We would prefer to avoid the netty naming.
    
We also at some stage broke our guarantee that Filter methods would be dispatched on the Filter Dispatch Thread and have implemented a test to try and verify what thread we are on. This test obtained the name of the thread at dispatch time and passed it to the client for assertion. This is roundabout and a lot of code for checking what we want. It would be simpler if we had some way to assert the invariant that we must be in the Filter Dispatch Thread.
    
To address the naming and flexibility of eventLoop we move to the more domain-specific naming of filterDispatchExecutor() and add our own Interface that extends ScheduledExecutorService.
    
To enable Authors and our tests to detect if execution is happening on the Filter Dispatch Thread we have a boolean isInFilterDispatchThread() method. To make it convenient to switch back from an arbitrary thread we offer <T> CompletionStage<T> switchToFilterDispatchThread(CompletionStage<T> stage);

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
