### PR TITLE
[System Tests] Added restart mechanism when kaf consumer job fails

### DIFF
--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
@@ -12,7 +12,6 @@ import java.time.Duration;
  * The interface Constants.
  */
 public interface Constants {
-
     /**
      * The deployment name for kroxylicous
      */
@@ -165,12 +164,10 @@ public interface Constants {
     String PULL_IMAGE_IF_NOT_PRESENT = "IfNotPresent";
 
     /**
-     * Feature gate related constants
+     * Restart policy
      */
-    String USE_KRAFT_MODE = "+UseKRaft";
-    String DONT_USE_KRAFT_MODE = "-UseKRaft";
-    String USE_KAFKA_NODE_POOLS = "+KafkaNodePools";
-    String DONT_USE_KAFKA_NODE_POOLS = "-KafkaNodePools";
+    String RESTART_POLICY_ONFAILURE = "OnFailure";
+    String RESTART_POLICY_NEVER= "Never";
 
     /**
      * Scraper pod labels

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
@@ -167,7 +167,7 @@ public interface Constants {
      * Restart policy
      */
     String RESTART_POLICY_ONFAILURE = "OnFailure";
-    String RESTART_POLICY_NEVER= "Never";
+    String RESTART_POLICY_NEVER = "Never";
 
     /**
      * Scraper pod labels

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/testclients/TestClientsJobTemplates.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/testclients/TestClientsJobTemplates.java
@@ -57,7 +57,7 @@ public class TestClientsJobTemplates {
                 .withName(jobName)
                 .endMetadata()
                 .withNewSpec()
-                .withRestartPolicy("Never")
+                .withRestartPolicy(Constants.RESTART_POLICY_NEVER)
                 .endSpec()
                 .endTemplate()
                 .endSpec();
@@ -171,8 +171,10 @@ public class TestClientsJobTemplates {
     public static JobBuilder defaultKafkaGoConsumerJob(String jobName, List<String> args) {
         return baseClientJob(jobName)
                 .editSpec()
+                .withBackoffLimit(3)
                 .editTemplate()
                 .editSpec()
+                .withRestartPolicy(Constants.RESTART_POLICY_ONFAILURE)
                 .withContainers(new ContainerBuilder()
                         .withName("kafka-go-consumer")
                         .withImage(Constants.KAF_CLIENT_IMAGE)


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Added a restart policy in the job created to run kaf consumers in case it fails to connect. It will retry it 3 times.

### Additional Context

Fixes #1317 

I've been investigating if kaf contains some kind of configuration to allow a reconnection to the kafka broker/topic, but I didn't find anything. Please if you find something useful, please let me know.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [x] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [x] Update documentation
- [x] Reference relevant issue(s) and close them after merging
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
