### PR TITLE
Expose problem of compose send request

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/ConsumerGroupTopicMappingFilter.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/ConsumerGroupTopicMappingFilter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.OffsetCommitRequestData;
+import org.apache.kafka.common.message.OffsetCommitResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+
+public class ConsumerGroupTopicMappingFilter implements
+        OffsetCommitRequestFilter {
+
+    @Override
+    public CompletionStage<RequestFilterResult> onOffsetCommitRequest(short apiVersion, RequestHeaderData header, OffsetCommitRequestData request,
+                                                                      FilterContext context) {
+
+        var stages = new ArrayList<CompletionStage<OffsetCommitResponseData>>();
+
+        for (var i = 0; i < request.topics().size(); i++) {
+            var offsetCommitRequestTopic = request.topics().get(i).duplicate();
+            var req = request.duplicate()
+                    .setGroupId(request.groupId() + ":" + i)
+                    .setTopics(Collections.singletonList(offsetCommitRequestTopic));
+            stages.add(context.sendRequest(header, request));
+        }
+
+        return chainListOffsetsRequest(stages)
+                .thenCompose(response -> context.requestFilterResultBuilder().shortCircuitResponse(response).completed());
+    }
+
+    private CompletionStage<OffsetCommitResponseData> chainListOffsetsRequest(ArrayList<CompletionStage<OffsetCommitResponseData>> stages) {
+        // Start with an initial CompletionStage that has an empty Result
+        CompletionStage<OffsetCommitResponseData> result = CompletableFuture.completedStage(new OffsetCommitResponseData());
+
+        // Chain each CompletionStage
+        for (CompletionStage<OffsetCommitResponseData> stage : stages) {
+            result = result.thenCompose(prevResult -> stage.thenApply(currentResult -> {
+                prevResult.topics().addAll(currentResult.topics());
+                return prevResult;
+            }));
+        }
+
+        return result;
+    }
+
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/ConsumerGroupTopicMappingFilterFactory.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/ConsumerGroupTopicMappingFilterFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import io.kroxylicious.proxy.plugin.Plugin;
+import io.kroxylicious.proxy.plugin.PluginConfigurationException;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+@Plugin(configType = Void.class)
+public class ConsumerGroupTopicMappingFilterFactory implements FilterFactory<Void, Void> {
+    @Override
+    public Void initialize(FilterFactoryContext context, Void config) throws PluginConfigurationException {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public Filter createFilter(FilterFactoryContext context, Void initializationData) {
+        return new ConsumerGroupTopicMappingFilter();
+    }
+}

--- a/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
+++ b/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
@@ -4,3 +4,4 @@ io.kroxylicious.proxy.filter.RequestResponseMarkingFilterFactory
 io.kroxylicious.proxy.filter.OutOfBandSendFilterFactory
 io.kroxylicious.proxy.filter.RejectingCreateTopicFilterFactory
 io.kroxylicious.proxy.InvocationCountingFilterFactory
+io.kroxylicious.proxy.filter.ConsumerGroupTopicMappingFilterFactory


### PR DESCRIPTION
### Type of change

Display a problem

### Description

When I tried to compose `sendRequest` stages, I have an exception `Cause message java.lang.UnsupportedOperationException: CompletableFuture usage disallowed, we don't want to block the event loop or allow unexpected completion`

### Additional Context

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
