### PR TITLE
Allocate direct buffers when encrypting batches rather than heap buff…

### DIFF
--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/InBandEncryptionManager.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/InBandEncryptionManager.java
@@ -152,7 +152,7 @@ public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
                                          @NonNull MemoryRecords memoryRecords,
                                          @NonNull Dek<E>.Encryptor encryptor,
                                          @NonNull IntFunction<ByteBufferOutputStream> bufferAllocator) {
-        ByteBuffer recordBuffer = ByteBuffer.allocate(recordBufferInitialBytes);
+        ByteBuffer recordBuffer = ByteBuffer.allocateDirect(recordBufferInitialBytes);
         do {
             try {
                 return RecordStream.ofRecords(memoryRecords)


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

In looking at the flame graph for a recent perf test run I noticed we are allocating heap buffers and direct buffers during encryption and direct buffers seem a lot cheaper. This PR is to see if that actually holds true.
![Screenshot 2024-06-27 at 12 20 56 PM](https://github.com/kroxylicious/kroxylicious/assets/2833578/16a84559-4ba4-4079-ad6e-53988e889e5a)
The purple is the direct allocation and while the yellow is the heap allocaiton.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
