### PR TITLE
[System Tests] removed duplicated describe-key call when deleting/rotating a KEK and removed unused getKekKeyId method

### DIFF
--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/kms/aws/AbstractAwsKmsTestKekManager.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/kms/aws/AbstractAwsKmsTestKekManager.java
@@ -21,6 +21,7 @@ import io.kroxylicious.systemtests.k8s.exception.KubeClusterException;
 
 public abstract class AbstractAwsKmsTestKekManager implements TestKekManager {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private DescribeKeyResponse keyResponse;
 
     @Override
     public void rotateKek(String alias) {
@@ -30,14 +31,14 @@ public abstract class AbstractAwsKmsTestKekManager implements TestKekManager {
             throw new UnknownAliasException(alias);
         }
         else {
-            rotate(alias);
+            rotate(alias, keyResponse.keyMetadata().keyId());
         }
     }
 
     @Override
     public boolean exists(String alias) {
         try {
-            read(alias);
+            keyResponse = read(alias);
             return true;
         }
         catch (KubeClusterException nfe) {
@@ -51,7 +52,7 @@ public abstract class AbstractAwsKmsTestKekManager implements TestKekManager {
             throw new UnknownAliasException(alias);
         }
         else {
-            delete(alias);
+            delete(alias, keyResponse.keyMetadata().keyId());
         }
     }
 
@@ -71,9 +72,9 @@ public abstract class AbstractAwsKmsTestKekManager implements TestKekManager {
 
     abstract DescribeKeyResponse read(String alias);
 
-    abstract void rotate(String alias);
+    abstract void rotate(String alias, String keyId);
 
-    abstract void delete(String alias);
+    abstract void delete(String alias, String keyId);
 
     abstract ExecResult runAwsKmsCommand(String... command);
 

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/kms/aws/AbstractKubeAwsKmsTestKmsFacade.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/kms/aws/AbstractKubeAwsKmsTestKmsFacade.java
@@ -29,19 +29,13 @@ public abstract class AbstractKubeAwsKmsTestKmsFacade extends AbstractAwsKmsTest
     protected static final String UPDATE_ALIAS = "update-alias";
     protected static final String DELETE_ALIAS = "delete-alias";
     protected static final String DESCRIBE_KEY = "describe-key";
+    protected static final String DISABLE_KEY = "disable-key";
     protected static final String SCHEDULE_KEY_DELETION = "schedule-key-deletion";
     protected static final String PARAM_ALIAS_NAME = "--alias-name";
     protected static final String PARAM_TARGET_KEY_ID = "--target-key-id";
     protected static final String PARAM_KEY_ID = "--key-id";
     protected static final String PARAM_PENDING_WINDOW_IN_DAYS = "--pending-window-in-days";
     protected AwsKmsClient awsKmsClient;
-
-    /**
-     * Gets kek key id.
-     *
-     * @return the kek key id
-     */
-    public abstract String getKekKeyId();
 
     @Override
     public boolean isAvailable() {

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/kms/aws/KubeAwsKmsCloudTestKmsFacade.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/kms/aws/KubeAwsKmsCloudTestKmsFacade.java
@@ -28,7 +28,6 @@ import static io.kroxylicious.kms.provider.aws.kms.AwsKmsTestKmsFacade.SCHEDULE_
  */
 public class KubeAwsKmsCloudTestKmsFacade extends AbstractKubeAwsKmsTestKmsFacade {
     private final String awsCmd;
-    private String kekKeyId;
 
     /**
      * Instantiates a new Kube AWS Kms Cloud test kms facade.
@@ -37,15 +36,6 @@ public class KubeAwsKmsCloudTestKmsFacade extends AbstractKubeAwsKmsTestKmsFacad
     public KubeAwsKmsCloudTestKmsFacade() {
         this.awsKmsClient = new AwsKmsCloud();
         awsCmd = awsKmsClient.getAwsCmd();
-    }
-
-    /**
-     * Gets kek key id.
-     *
-     * @return the kek key id
-     */
-    public String getKekKeyId() {
-        return kekKeyId;
     }
 
     @Override
@@ -62,21 +52,16 @@ public class KubeAwsKmsCloudTestKmsFacade extends AbstractKubeAwsKmsTestKmsFacad
         @Override
         void create(String alias) {
             var createKeyResponse = runAwsKmsCommand(CREATE_KEY_RESPONSE_TYPE_REF, awsCmd, KMS, CREATE);
-            kekKeyId = createKeyResponse.keyMetadata().keyId();
-
-            runAwsKmsCommand(awsCmd, KMS, CREATE_ALIAS, PARAM_ALIAS_NAME, ALIAS_PREFIX + alias, PARAM_TARGET_KEY_ID, kekKeyId);
+            runAwsKmsCommand(awsCmd, KMS, CREATE_ALIAS, PARAM_ALIAS_NAME, ALIAS_PREFIX + alias, PARAM_TARGET_KEY_ID, createKeyResponse.keyMetadata().keyId());
         }
 
         @Override
-        void rotate(String alias) {
-            var key = read(alias);
-            runAwsKmsCommand(awsCmd, KMS, ROTATE, PARAM_KEY_ID, key.keyMetadata().keyId());
+        void rotate(String alias, String keyId) {
+            runAwsKmsCommand(awsCmd, KMS, ROTATE, PARAM_KEY_ID, keyId);
         }
 
         @Override
-        void delete(String alias) {
-            var key = read(alias);
-            var keyId = key.keyMetadata().keyId();
+        void delete(String alias, String keyId) {
             runAwsKmsCommand(SCHEDULE_KEY_DELETION_RESPONSE_TYPE_REF,
                     awsCmd, KMS, SCHEDULE_KEY_DELETION, PARAM_KEY_ID, keyId, PARAM_PENDING_WINDOW_IN_DAYS, "7" /* Minimum allowed */);
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement

### Description

Removed duplicated `describe-key` call when removing/rotating a KEK. Fixes #1342 

### Additional Context

Every time we deleted a KEK, the `describe-key` was called twice, once to check if the alias exists and another one to get the KeyId to be deleted. What I've tried to do is to simplify that by getting the keyId when checking if the alias exists. So we can reduce another call on AWS.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [x] Update documentation
- [x] Reference relevant issue(s) and close them after merging
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
