### PR TITLE
Cleanup message extraction.

### DIFF
--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/StrimziTestClient.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/StrimziTestClient.java
@@ -7,9 +7,9 @@
 package io.kroxylicious.systemtests.clients;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.awaitility.core.ConditionTimeoutException;
@@ -94,7 +94,7 @@ public class StrimziTestClient implements KafkaClient {
         String podName = KafkaUtils.createJob(deployNamespace, name, testClientJob);
         String log = waitForConsumer(deployNamespace, podName, timeout);
         LOGGER.atInfo().setMessage("Log: {}").addArgument(log).log();
-        List<String> logRecords = extractRecordLinesFromLog(log);
+        Stream<String> logRecords = extractRecordLinesFromLog(log);
         return getConsumerRecords(logRecords);
     }
 
@@ -103,20 +103,27 @@ public class StrimziTestClient implements KafkaClient {
         return kubeClient().logsInSpecificNamespace(namespace, podName);
     }
 
-    private List<ConsumerRecord> getConsumerRecords(List<String> logRecords) {
-        return logRecords.stream().map(x -> ConsumerRecord.parseFromJsonString(VALUE_TYPE_REF, x))
-                .filter(Objects::nonNull).map(ConsumerRecord.class::cast).toList();
+    private List<ConsumerRecord> getConsumerRecords(Stream<String> logRecords) {
+        return logRecords.filter(Predicate.not(String::isBlank))
+                .map(x -> ConsumerRecord.parseFromJsonString(VALUE_TYPE_REF, x))
+                .filter(Objects::nonNull)
+                .map(ConsumerRecord.class::cast)
+                .toList();
     }
 
-    private List<String> extractRecordLinesFromLog(String log) {
-        List<String> records = new ArrayList<>();
+    private Stream<String> extractRecordLinesFromLog(String log) {
         String stringToSeek = "Received message:";
 
-        List<String> receivedMessages = Stream.of(log.split("\n")).filter(l -> l.contains(stringToSeek)).toList();
-        for (String receivedMessage : receivedMessages) {
-            records.add(receivedMessage.split(stringToSeek)[1].trim());
-        }
-
-        return records;
+        return Stream.of(log.split("\n"))
+                .filter(l -> l.contains(stringToSeek))
+                .map(line -> {
+                    final String[] split = line.split(stringToSeek, 1);
+                    if (split.length > 1) {
+                        return split[1];
+                    }
+                    else {
+                        return "";
+                    }
+                });
     }
 }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/StrimziTestClient.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/StrimziTestClient.java
@@ -117,7 +117,7 @@ public class StrimziTestClient implements KafkaClient {
         return Stream.of(log.split("\n"))
                 .filter(l -> l.contains(stringToSeek))
                 .map(line -> {
-                    final String[] split = line.split(stringToSeek, 1);
+                    final String[] split = line.split(stringToSeek, 2); // Limit is 1 based so a limit of 2 means use the seek at most 1 times
                     if (split.length > 1) {
                         return split[1];
                     }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/StrimziTestClient.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/StrimziTestClient.java
@@ -37,6 +37,7 @@ import static org.awaitility.Awaitility.await;
  * The type Strimzi Test client (java client based CLI).
  */
 public class StrimziTestClient implements KafkaClient {
+    private static final String RECEIVED_MESSAGE_MARKER = "Received message:";
     private static final Logger LOGGER = LoggerFactory.getLogger(StrimziTestClient.class);
     private static final TypeReference<StrimziTestClientConsumerRecord> VALUE_TYPE_REF = new TypeReference<>() {
     };
@@ -112,12 +113,10 @@ public class StrimziTestClient implements KafkaClient {
     }
 
     private Stream<String> extractRecordLinesFromLog(String log) {
-        String stringToSeek = "Received message:";
-
         return Stream.of(log.split("\n"))
-                .filter(l -> l.contains(stringToSeek))
+                .filter(l -> l.contains(RECEIVED_MESSAGE_MARKER))
                 .map(line -> {
-                    final String[] split = line.split(stringToSeek, 2); // Limit is 1 based so a limit of 2 means use the seek at most 1 times
+                    final String[] split = line.split(RECEIVED_MESSAGE_MARKER, 2); // Limit is 1 based so a limit of 2 means use the seek at most 1 times
                     if (split.length > 1) {
                         return split[1];
                     }


### PR DESCRIPTION
### Type of change

This means the tests fail with an assertion error as we'd expect rather than throwing exceptions like
```java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1

   	at io.kroxylicious.systemtests.clients.StrimziTestClient.extractRecordLinesFromLog(StrimziTestClient.java:117)
   	at io.kroxylicious.systemtests.clients.StrimziTestClient.consumeMessages(StrimziTestClient.java:97)
   	at io.kroxylicious.systemtests.steps.KroxyliciousSteps.consumeMessages(KroxyliciousSteps.java:47)
   	at io.kroxylicious.systemtests.steps.KroxyliciousSteps.consumeMessageFromKafkaCluster(KroxyliciousSteps.java:65)
   	at io.kroxylicious.systemtests.RecordEncryptionST.ensureClusterHasEncryptedMessage(RecordEncryptionST.java:97)
```


- Bugfix

### Description

_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
