### PR TITLE
Make EDEK cache refresh and expiry durations configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#1354](https://github.com/kroxylicious/kroxylicious/pull/1354): Make EDEK cache refresh and expiry durations configurable
 * [#1360](https://github.com/kroxylicious/kroxylicious/pull/1360): Bump kafka.version from 3.7.0 to 3.7.1
 * [#1322](https://github.com/kroxylicious/kroxylicious/pull/1322): Introduce FilterDispatchExecutor
 * [#1154](https://github.com/kroxylicious/kroxylicious/pull/1154): Apicurio based schema validation filter
@@ -19,6 +20,9 @@ has methods to enable Filters to check if the current thread is the Filter Dispa
 specialized futures, where chained async methods will also run on the Filter Dispatch Thread when no executor
 is supplied. This is intended to be a tool to make it convenient for Filters to hand off work to uncontrolled
 threads, then switch back to an execution context where mutation of Filter members is safe.
+* Record Encryption Filter: Data Encryption Keys will now be refreshed one hour after creation by default.
+This is a bugfix for [#1139](https://github.com/kroxylicious/kroxylicious/issues/1339) to ensure we start
+using new key material after key-encryption-keys are rotated in the KMS within some controlled duration.
 
 ## 0.6.0
 

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryption.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryption.java
@@ -104,7 +104,9 @@ public class RecordEncryption<K, E> implements FilterFactory<RecordEncryptionCon
         Kms<K, E> kms = buildKms(context, configuration);
 
         DekManager<K, E> dekManager = new DekManager<>(ignored -> kms, null, 5_000_000);
-        EncryptionDekCache<K, E> encryptionDekCache = new EncryptionDekCache<>(dekManager, null, EncryptionDekCache.NO_MAX_CACHE_SIZE);
+        KmsCacheConfig cacheConfig = configuration.kmsCache();
+        EncryptionDekCache<K, E> encryptionDekCache = new EncryptionDekCache<>(dekManager, null, EncryptionDekCache.NO_MAX_CACHE_SIZE,
+                cacheConfig.encryptionDekCacheRefreshAfterWriteDuration(), cacheConfig.encryptionDekCacheExpireAfterWriteDuration());
         DecryptionDekCache<K, E> decryptionDekCache = new DecryptionDekCache<>(dekManager, null, DecryptionDekCache.NO_MAX_CACHE_SIZE);
         return new SharedEncryptionContext<>(kms, configuration, dekManager, encryptionDekCache, decryptionDekCache);
     }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/KmsCacheConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/KmsCacheConfig.java
@@ -17,7 +17,9 @@ public record KmsCacheConfig(
                              Integer resolvedAliasCacheSize,
                              Duration resolvedAliasExpireAfterWriteDuration,
                              Duration resolvedAliasRefreshAfterWriteDuration,
-                             Duration notFoundAliasExpireAfterWriteDuration) {
+                             Duration notFoundAliasExpireAfterWriteDuration,
+                             Duration encryptionDekCacheRefreshAfterWriteDuration,
+                             Duration encryptionDekCacheExpireAfterWriteDuration) {
 
     public KmsCacheConfig {
         decryptedDekCacheSize = requireNonNullElse(decryptedDekCacheSize, 1000);
@@ -26,6 +28,8 @@ public record KmsCacheConfig(
         resolvedAliasExpireAfterWriteDuration = requireNonNullElse(resolvedAliasExpireAfterWriteDuration, Duration.ofMinutes(10));
         resolvedAliasRefreshAfterWriteDuration = requireNonNullElse(resolvedAliasRefreshAfterWriteDuration, Duration.ofMinutes(8));
         notFoundAliasExpireAfterWriteDuration = requireNonNullElse(notFoundAliasExpireAfterWriteDuration, Duration.ofSeconds(30));
+        encryptionDekCacheRefreshAfterWriteDuration = requireNonNullElse(encryptionDekCacheRefreshAfterWriteDuration, Duration.ofHours(1));
+        encryptionDekCacheExpireAfterWriteDuration = requireNonNullElse(encryptionDekCacheExpireAfterWriteDuration, Duration.ofHours(2));
     }
 
     @SuppressWarnings("java:S1905") // Sonar's warning about this is incorrect, the cast is required.
@@ -34,18 +38,21 @@ public record KmsCacheConfig(
                    Integer resolvedAliasCacheSize,
                    Long resolvedAliasExpireAfterWriteSeconds,
                    Long resolvedAliasRefreshAfterWriteSeconds,
-                   Long notFoundAliasExpireAfterWriteSeconds) {
+                   Long notFoundAliasExpireAfterWriteSeconds,
+                   Long decryptedDekRefreshAfterWriteSeconds,
+                   Long decryptedDekExpireAfterWriteSeconds) {
         this(mapNotNull(decryptedDekCacheSize, Function.identity()),
                 (Duration) mapNotNull(decryptedDekExpireAfterAccessSeconds, Duration::ofSeconds),
                 mapNotNull(resolvedAliasCacheSize, Function.identity()),
                 mapNotNull(resolvedAliasExpireAfterWriteSeconds, Duration::ofSeconds),
                 mapNotNull(resolvedAliasRefreshAfterWriteSeconds, Duration::ofSeconds),
-                mapNotNull(notFoundAliasExpireAfterWriteSeconds, Duration::ofSeconds));
+                mapNotNull(notFoundAliasExpireAfterWriteSeconds, Duration::ofSeconds),
+                mapNotNull(decryptedDekRefreshAfterWriteSeconds, Duration::ofSeconds),
+                mapNotNull(decryptedDekExpireAfterWriteSeconds, Duration::ofSeconds));
     }
 
     static <T, Y> Y mapNotNull(T t, Function<T, Y> function) {
         return t == null ? null : function.apply(t);
     }
 
-    private static final KmsCacheConfig DEFAULT_CONFIG = new KmsCacheConfig(null, (Long) null, null, null, null, null);
 }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionTest.java
@@ -85,6 +85,8 @@ class RecordEncryptionTest {
         assertThat(config.resolvedAliasExpireAfterWriteDuration()).isEqualTo(Duration.ofMinutes(10));
         assertThat(config.resolvedAliasRefreshAfterWriteDuration()).isEqualTo(Duration.ofMinutes(8));
         assertThat(config.notFoundAliasExpireAfterWriteDuration()).isEqualTo(Duration.ofSeconds(30));
+        assertThat(config.encryptionDekCacheRefreshAfterWriteDuration()).isEqualTo(Duration.ofHours(1));
+        assertThat(config.encryptionDekCacheExpireAfterWriteDuration()).isEqualTo(Duration.ofHours(2));
     }
 
     @Test
@@ -96,6 +98,8 @@ class RecordEncryptionTest {
         experimental.put("resolvedAliasExpireAfterWriteSeconds", null);
         experimental.put("resolvedAliasRefreshAfterWriteSeconds", null);
         experimental.put("notFoundAliasExpireAfterWriteSeconds", null);
+        experimental.put("encryptionDekRefreshAfterWriteSeconds", null);
+        experimental.put("encryptionDekExpireAfterWriteSeconds", null);
         KmsCacheConfig config = new RecordEncryptionConfig("vault", 1L, "selector", 1L,
                 experimental).kmsCache();
         assertThat(config.decryptedDekCacheSize()).isEqualTo(1000);
@@ -104,6 +108,8 @@ class RecordEncryptionTest {
         assertThat(config.resolvedAliasExpireAfterWriteDuration()).isEqualTo(Duration.ofMinutes(10));
         assertThat(config.resolvedAliasRefreshAfterWriteDuration()).isEqualTo(Duration.ofMinutes(8));
         assertThat(config.notFoundAliasExpireAfterWriteDuration()).isEqualTo(Duration.ofSeconds(30));
+        assertThat(config.encryptionDekCacheRefreshAfterWriteDuration()).isEqualTo(Duration.ofHours(1));
+        assertThat(config.encryptionDekCacheExpireAfterWriteDuration()).isEqualTo(Duration.ofHours(2));
     }
 
     @Test
@@ -114,7 +120,9 @@ class RecordEncryptionTest {
                 3,
                 Duration.ofSeconds(4L),
                 Duration.ofSeconds(5L),
-                Duration.ofSeconds(6L));
+                Duration.ofSeconds(6L),
+                Duration.ofSeconds(7L),
+                Duration.ofSeconds(8L));
 
         HashMap<String, Object> experimental = new HashMap<>();
         experimental.put("decryptedDekCacheSize", 1);
@@ -123,6 +131,8 @@ class RecordEncryptionTest {
         experimental.put("resolvedAliasExpireAfterWriteSeconds", 4);
         experimental.put("resolvedAliasRefreshAfterWriteSeconds", 5);
         experimental.put("notFoundAliasExpireAfterWriteSeconds", 6);
+        experimental.put("encryptionDekRefreshAfterWriteSeconds", 7);
+        experimental.put("encryptionDekExpireAfterWriteSeconds", 8);
         KmsCacheConfig config = new RecordEncryptionConfig("vault", 1L, "selector", 1L, experimental).kmsCache();
         assertThat(config).isEqualTo(kmsCacheConfig);
     }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/config/RecordEncryptionConfigTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/config/RecordEncryptionConfigTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.config;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RecordEncryptionConfigTest {
+
+    static Stream<Arguments> experimentalConfig() {
+        return Stream.of(
+                Arguments.of("decryptedDekCacheSize", 2, 2, (Function<KmsCacheConfig, Integer>) KmsCacheConfig::decryptedDekCacheSize),
+                Arguments.of("decryptedDekCacheSize", "3", 3, (Function<KmsCacheConfig, Integer>) KmsCacheConfig::decryptedDekCacheSize),
+                Arguments.of("decryptedDekCacheSize", null, 1000, (Function<KmsCacheConfig, Integer>) KmsCacheConfig::decryptedDekCacheSize),
+                Arguments.of("decryptedDekExpireAfterAccessSeconds", 4L, Duration.ofSeconds(4),
+                        (Function<KmsCacheConfig, Duration>) KmsCacheConfig::decryptedDekExpireAfterAccessDuration),
+                Arguments.of("decryptedDekExpireAfterAccessSeconds", "5", Duration.ofSeconds(5),
+                        (Function<KmsCacheConfig, Duration>) KmsCacheConfig::decryptedDekExpireAfterAccessDuration),
+                Arguments.of("decryptedDekExpireAfterAccessSeconds", null, Duration.ofHours(1),
+                        (Function<KmsCacheConfig, Duration>) KmsCacheConfig::decryptedDekExpireAfterAccessDuration),
+                Arguments.of("resolvedAliasCacheSize", 2, 2, (Function<KmsCacheConfig, Integer>) KmsCacheConfig::resolvedAliasCacheSize),
+                Arguments.of("resolvedAliasCacheSize", 3, 3, (Function<KmsCacheConfig, Integer>) KmsCacheConfig::resolvedAliasCacheSize),
+                Arguments.of("resolvedAliasCacheSize", null, 1000, (Function<KmsCacheConfig, Integer>) KmsCacheConfig::resolvedAliasCacheSize),
+                Arguments.of("resolvedAliasExpireAfterWriteSeconds", 4L, Duration.ofSeconds(4),
+                        (Function<KmsCacheConfig, Duration>) KmsCacheConfig::resolvedAliasExpireAfterWriteDuration),
+                Arguments.of("resolvedAliasExpireAfterWriteSeconds", "5", Duration.ofSeconds(5),
+                        (Function<KmsCacheConfig, Duration>) KmsCacheConfig::resolvedAliasExpireAfterWriteDuration),
+                Arguments.of("resolvedAliasExpireAfterWriteSeconds", null, Duration.ofMinutes(10),
+                        (Function<KmsCacheConfig, Duration>) KmsCacheConfig::resolvedAliasExpireAfterWriteDuration),
+                Arguments.of("resolvedAliasRefreshAfterWriteSeconds", 4L, Duration.ofSeconds(4),
+                        (Function<KmsCacheConfig, Duration>) KmsCacheConfig::resolvedAliasRefreshAfterWriteDuration),
+                Arguments.of("resolvedAliasRefreshAfterWriteSeconds", "5", Duration.ofSeconds(5),
+                        (Function<KmsCacheConfig, Duration>) KmsCacheConfig::resolvedAliasRefreshAfterWriteDuration),
+                Arguments.of("resolvedAliasRefreshAfterWriteSeconds", null, Duration.ofMinutes(8),
+                        (Function<KmsCacheConfig, Duration>) KmsCacheConfig::resolvedAliasRefreshAfterWriteDuration),
+                Arguments.of("notFoundAliasExpireAfterWriteSeconds", 4L, Duration.ofSeconds(4),
+                        (Function<KmsCacheConfig, Duration>) KmsCacheConfig::notFoundAliasExpireAfterWriteDuration),
+                Arguments.of("notFoundAliasExpireAfterWriteSeconds", "5", Duration.ofSeconds(5),
+                        (Function<KmsCacheConfig, Duration>) KmsCacheConfig::notFoundAliasExpireAfterWriteDuration),
+                Arguments.of("notFoundAliasExpireAfterWriteSeconds", null, Duration.ofSeconds(30),
+                        (Function<KmsCacheConfig, Duration>) KmsCacheConfig::notFoundAliasExpireAfterWriteDuration),
+                Arguments.of("encryptionDekRefreshAfterWriteSeconds", 4L, Duration.ofSeconds(4),
+                        (Function<KmsCacheConfig, Duration>) KmsCacheConfig::encryptionDekCacheRefreshAfterWriteDuration),
+                Arguments.of("encryptionDekRefreshAfterWriteSeconds", "5", Duration.ofSeconds(5),
+                        (Function<KmsCacheConfig, Duration>) KmsCacheConfig::encryptionDekCacheRefreshAfterWriteDuration),
+                Arguments.of("encryptionDekRefreshAfterWriteSeconds", null, Duration.ofHours(1),
+                        (Function<KmsCacheConfig, Duration>) KmsCacheConfig::encryptionDekCacheRefreshAfterWriteDuration),
+                Arguments.of("encryptionDekExpireAfterWriteSeconds", 4L, Duration.ofSeconds(4),
+                        (Function<KmsCacheConfig, Duration>) KmsCacheConfig::encryptionDekCacheExpireAfterWriteDuration),
+                Arguments.of("encryptionDekExpireAfterWriteSeconds", "5", Duration.ofSeconds(5),
+                        (Function<KmsCacheConfig, Duration>) KmsCacheConfig::encryptionDekCacheExpireAfterWriteDuration),
+                Arguments.of("encryptionDekExpireAfterWriteSeconds", null, Duration.ofHours(2),
+                        (Function<KmsCacheConfig, Duration>) KmsCacheConfig::encryptionDekCacheExpireAfterWriteDuration));
+    }
+
+    @ParameterizedTest(name = "{0} - {1}")
+    @MethodSource
+    void experimentalConfig(String configKey, Object configValue, Object expectedKmsConfig, Function<KmsCacheConfig, Object> accessor) {
+        assertThat(accessor.apply(getKmsCacheConfig(configKey, configValue))).isEqualTo(expectedKmsConfig);
+    }
+
+    static Stream<Arguments> invalidExperimentalConfig() {
+        return Stream.of(
+                Arguments.of("decryptedDekCacheSize", List.of()),
+                Arguments.of("decryptedDekCacheSize", "banana"),
+                Arguments.of("decryptedDekExpireAfterAccessSeconds", List.of()),
+                Arguments.of("decryptedDekExpireAfterAccessSeconds", "banana"),
+                Arguments.of("resolvedAliasCacheSize", List.of()),
+                Arguments.of("resolvedAliasCacheSize", "banana"),
+                Arguments.of("resolvedAliasExpireAfterWriteSeconds", List.of()),
+                Arguments.of("resolvedAliasExpireAfterWriteSeconds", "banana"),
+                Arguments.of("resolvedAliasRefreshAfterWriteSeconds", List.of()),
+                Arguments.of("resolvedAliasRefreshAfterWriteSeconds", "banana"),
+                Arguments.of("notFoundAliasExpireAfterWriteSeconds", List.of()),
+                Arguments.of("notFoundAliasExpireAfterWriteSeconds", "banana"),
+                Arguments.of("encryptionDekRefreshAfterWriteSeconds", List.of()),
+                Arguments.of("encryptionDekRefreshAfterWriteSeconds", "banana"),
+                Arguments.of("encryptionDekExpireAfterWriteSeconds", List.of()),
+                Arguments.of("encryptionDekExpireAfterWriteSeconds", "banana"));
+    }
+
+    @ParameterizedTest(name = "{0} - {1}")
+    @MethodSource
+    void invalidExperimentalConfig(String configKey, Object configValue) {
+        RecordEncryptionConfig config = createConfig(Map.of(configKey, configValue));
+        assertThatThrownBy(config::kmsCache).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static @NonNull KmsCacheConfig getKmsCacheConfig(String key, Object value) {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put(key, value);
+        RecordEncryptionConfig config = createConfig(map);
+        return config.kmsCache();
+    }
+
+    private static @NonNull RecordEncryptionConfig createConfig(Map<String, Object> map) {
+        return new RecordEncryptionConfig("kms", 1L, "selector", 2L, map);
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/decrypt/InBandDecryptionManagerTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/decrypt/InBandDecryptionManagerTest.java
@@ -1030,7 +1030,7 @@ class InBandDecryptionManagerTest {
                                                                                        int maxCacheSize) {
 
         DekManager<UUID, InMemoryEdek> dekManager = new DekManager<>(ignored -> kms, null, maxEncryptionsPerDek);
-        var cache = new EncryptionDekCache<>(dekManager, directExecutor(), maxCacheSize);
+        var cache = new EncryptionDekCache<>(dekManager, directExecutor(), maxCacheSize, Duration.ofHours(1), Duration.ofHours(1));
         return new InBandEncryptionManager<>(Encryption.V2,
                 dekManager.edekSerde(),
                 recordBufferInitialBytes,

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/BytesEdek.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/BytesEdek.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.encryption;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Objects;
+
+import io.kroxylicious.kms.service.Serde;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public record BytesEdek(byte[] edek) {
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BytesEdek bytesEdek = (BytesEdek) o;
+        return Objects.deepEquals(edek, bytesEdek.edek);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(edek);
+    }
+
+    @Override
+    public String toString() {
+        return "BytesEdek{" +
+                "edek=" + Base64.getEncoder().encodeToString(edek) +
+                '}';
+    }
+
+    static Serde<BytesEdek> getSerde() {
+        return new Serde<>() {
+            @Override
+            public int sizeOf(BytesEdek object) {
+                return object.edek.length;
+            }
+
+            @Override
+            public void serialize(BytesEdek object, @NonNull ByteBuffer buffer) {
+                throw new UnsupportedOperationException("serialize not supported");
+            }
+
+            @Override
+            public BytesEdek deserialize(@NonNull ByteBuffer buffer) {
+                byte[] bytes = new byte[buffer.remaining()];
+                buffer.get(bytes);
+                return new BytesEdek(bytes);
+            }
+        };
+    }
+}


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Adds record encryption configurations:

- experimental.encryptionDekRefreshAfterWriteSeconds, which means that after that duration, when the cache is hit, it will asynchronously load a new DEK. The existing DEK will be returned while the load is in progress, but soon clients should start receiving the new DEK, once async loading has completed.

- experimental.encryptionDekExpireAfterWriteSeconds, which means that after that duration the DEK is eligible to be expired and evicted from the cache. This expiry is driven by read/write operations to the cache so it is not precise when the expiry will occur.

Why:
Currently when the KEK is rotated externally in Vault or AWS, the DEKs in use by a proxy instance continue to be used until they have been used to encrypt 5M records. This means a DEK encrypted with an old KEK could be used far beyond the time of rotation. Users will expect the new Key Material to be used for all records in a timely fashion after rotation.

This configuration gives us a mechanism to ensure that DEKs are only used for a certain duration after creation. So we can say, "after rotation, all records will carry DEKS encrypted with the new key within encryptionDekExpireAfterWriteSeconds"

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
