### PR TITLE
Changes for Kafka 3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#1356](https://github.com/kroxylicious/kroxylicious/pull/1356): Changes for Kafka 3.8.0 #1356
 * [#1354](https://github.com/kroxylicious/kroxylicious/pull/1354): Make EDEK cache refresh and expiry durations configurable
 * [#1360](https://github.com/kroxylicious/kroxylicious/pull/1360): Bump kafka.version from 3.7.0 to 3.7.1
 * [#1322](https://github.com/kroxylicious/kroxylicious/pull/1322): Introduce FilterDispatchExecutor

--- a/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/assertj/RecordBatchAssertTest.java
+++ b/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/assertj/RecordBatchAssertTest.java
@@ -10,6 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.OptionalLong;
 
+import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.RecordBatch;
@@ -173,7 +174,7 @@ class RecordBatchAssertTest {
         RecordBatch batch = RecordTestUtils.singleElementRecordBatch("KEY", "VALUE");
         RecordBatch batchSameMetadata = RecordTestUtils.singleElementRecordBatch("KEY", "VALUE",
                 new RecordHeader("HEADER", "HEADER_VALUE".getBytes(StandardCharsets.UTF_8)));
-        RecordBatch batchDifferentMetadata = singleElementRecordBatch(RecordBatch.CURRENT_MAGIC_VALUE, 1L, CompressionType.GZIP, TimestampType.CREATE_TIME, 1L, 1L,
+        RecordBatch batchDifferentMetadata = singleElementRecordBatch(RecordBatch.CURRENT_MAGIC_VALUE, 1L, Compression.gzip().build(), TimestampType.CREATE_TIME, 1L, 1L,
                 (short) 1, 1, false,
                 false, 1,
                 "KEY".getBytes(

--- a/kroxylicious-filters/kroxylicious-multitenant/src/test/resources/io/kroxylicious/proxy/filter/multitenant/ApiVersions.test.yaml
+++ b/kroxylicious-filters/kroxylicious-multitenant/src/test/resources/io/kroxylicious/proxy/filter/multitenant/ApiVersions.test.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+- apiMessageType: API_VERSIONS
+  version: 3
+  description: https://github.com/kroxylicious/kroxylicious/issues/1364
+  response:
+    payload:
+      errorCode: 0
+      throttleTimeMs: 0
+      apiKeys:
+      - apiKey: 74
+        minVersion: 0
+        maxVersion: 0
+      - apiKey: 75
+        minVersion: 0
+        maxVersion: 0
+      - apiKey: 76
+        minVersion: 0
+        maxVersion: 0
+    diff:
+      - op: remove
+        path: "/apiKeys/1"
+  disabled: false

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionFilterTest.java
@@ -21,6 +21,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.LongStream;
 
+import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.FetchResponseData.FetchableTopicResponse;
@@ -31,7 +32,6 @@ import org.apache.kafka.common.message.ProduceRequestData.TopicProduceData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
-import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MemoryRecordsBuilder;
 import org.apache.kafka.common.record.Record;
@@ -312,7 +312,7 @@ class RecordEncryptionFilterTest {
 
     @NonNull
     private static MemoryRecordsBuilder memoryRecordsBuilderForStream(ByteBufferOutputStream stream) {
-        return new MemoryRecordsBuilder(stream, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE, TimestampType.CREATE_TIME, 0,
+        return new MemoryRecordsBuilder(stream, RecordBatch.CURRENT_MAGIC_VALUE, Compression.NONE, TimestampType.CREATE_TIME, 0,
                 RecordBatch.NO_TIMESTAMP, RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, RecordBatch.NO_SEQUENCE, false, false,
                 RecordBatch.NO_PARTITION_LEADER_EPOCH, stream.remaining());
     }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/common/RecordEncryptionUtilTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/common/RecordEncryptionUtilTest.java
@@ -9,8 +9,8 @@ import java.nio.ByteBuffer;
 import java.util.function.Function;
 import java.util.stream.LongStream;
 
+import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.header.internals.RecordHeader;
-import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.record.RecordBatch;
@@ -77,7 +77,7 @@ class RecordEncryptionUtilTest {
 
     private static void newBatch(BatchAwareMemoryRecordsBuilder recordsBuilder) {
         recordsBuilder.addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
-                CompressionType.NONE,
+                Compression.NONE,
                 TimestampType.CREATE_TIME,
                 0L,
                 RecordBatch.NO_TIMESTAMP,

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/decrypt/InBandDecryptionManagerTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/decrypt/InBandDecryptionManagerTest.java
@@ -24,9 +24,9 @@ import java.util.stream.Stream;
 
 import javax.crypto.SecretKey;
 
+import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
-import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MutableRecordBatch;
 import org.apache.kafka.common.record.Record;
@@ -137,13 +137,14 @@ class InBandDecryptionManagerTest {
         EncryptionScheme<UUID> scheme = createScheme(kms);
         var encryptionManager = createEncryptionManager(kms, 500_000);
 
-        MutableRecordBatch firstBatch = RecordTestUtils.singleElementRecordBatch(RecordBatch.CURRENT_MAGIC_VALUE, 1L, CompressionType.GZIP, TimestampType.CREATE_TIME, 2L,
+        MutableRecordBatch firstBatch = RecordTestUtils.singleElementRecordBatch(RecordBatch.CURRENT_MAGIC_VALUE, 1L, Compression.gzip().build(),
+                TimestampType.CREATE_TIME, 2L,
                 3L,
                 (short) 4, 5, false, false, 1, ARBITRARY_KEY.getBytes(
                         StandardCharsets.UTF_8),
                 ARBITRARY_VALUE.getBytes(StandardCharsets.UTF_8));
 
-        MutableRecordBatch secondBatch = RecordTestUtils.singleElementRecordBatch(RecordBatch.CURRENT_MAGIC_VALUE, 2L, CompressionType.NONE,
+        MutableRecordBatch secondBatch = RecordTestUtils.singleElementRecordBatch(RecordBatch.CURRENT_MAGIC_VALUE, 2L, Compression.NONE,
                 TimestampType.LOG_APPEND_TIME, 9L, 10L,
                 (short) 11, 12, false, false, 2, ARBITRARY_KEY_2.getBytes(
                         StandardCharsets.UTF_8),
@@ -168,13 +169,14 @@ class InBandDecryptionManagerTest {
         var encryptionManager = createEncryptionManager(kms, 500_000);
         var decryptionManager = createDecryptionManager(kms);
 
-        MutableRecordBatch firstBatch = RecordTestUtils.singleElementRecordBatch(RecordBatch.CURRENT_MAGIC_VALUE, 1L, CompressionType.GZIP, TimestampType.CREATE_TIME, 2L,
+        MutableRecordBatch firstBatch = RecordTestUtils.singleElementRecordBatch(RecordBatch.CURRENT_MAGIC_VALUE, 1L, Compression.gzip().build(),
+                TimestampType.CREATE_TIME, 2L,
                 3L,
                 (short) 4, 5, false, false, 1, ARBITRARY_KEY.getBytes(
                         StandardCharsets.UTF_8),
                 ARBITRARY_VALUE.getBytes(StandardCharsets.UTF_8));
 
-        MutableRecordBatch secondBatch = RecordTestUtils.singleElementRecordBatch(RecordBatch.CURRENT_MAGIC_VALUE, 2L, CompressionType.NONE,
+        MutableRecordBatch secondBatch = RecordTestUtils.singleElementRecordBatch(RecordBatch.CURRENT_MAGIC_VALUE, 2L, Compression.NONE,
                 TimestampType.LOG_APPEND_TIME, 9L, 10L,
                 (short) 11, 12, false, false, 2, ARBITRARY_KEY_2.getBytes(
                         StandardCharsets.UTF_8),

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/proxy/filter/simpletransform/FetchResponseTransformationFilter.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/proxy/filter/simpletransform/FetchResponseTransformationFilter.java
@@ -12,13 +12,13 @@ import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.MetadataRequestData;
 import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MemoryRecordsBuilder;
 import org.apache.kafka.common.record.MutableRecordBatch;
@@ -96,7 +96,7 @@ public class FetchResponseTransformationFilter implements FetchResponseFilter {
             for (FetchResponseData.PartitionData partitionData : topicData.partitions()) {
                 var records = (MemoryRecords) partitionData.records();
                 var stream = context.createByteBufferOutputStream(records.sizeInBytes());
-                try (var newRecords = new MemoryRecordsBuilder(stream, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE, TimestampType.CREATE_TIME, 0,
+                try (var newRecords = new MemoryRecordsBuilder(stream, RecordBatch.CURRENT_MAGIC_VALUE, Compression.NONE, TimestampType.CREATE_TIME, 0,
                         System.currentTimeMillis(), RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, RecordBatch.NO_SEQUENCE, false, false,
                         RecordBatch.NO_PARTITION_LEADER_EPOCH,
                         stream.remaining())) {

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/proxy/filter/simpletransform/ProduceRequestTransformationFilter.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/proxy/filter/simpletransform/ProduceRequestTransformationFilter.java
@@ -8,10 +8,10 @@ package io.kroxylicious.proxy.filter.simpletransform;
 
 import java.util.concurrent.CompletionStage;
 
+import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MemoryRecordsBuilder;
 import org.apache.kafka.common.record.MutableRecordBatch;
@@ -53,7 +53,7 @@ public class ProduceRequestTransformationFilter implements ProduceRequestFilter 
             for (ProduceRequestData.PartitionProduceData partitionData : topicData.partitionData()) {
                 MemoryRecords records = (MemoryRecords) partitionData.records();
                 var stream = ctx.createByteBufferOutputStream(records.sizeInBytes());
-                try (var newRecords = new MemoryRecordsBuilder(stream, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE, TimestampType.CREATE_TIME, 0,
+                try (var newRecords = new MemoryRecordsBuilder(stream, RecordBatch.CURRENT_MAGIC_VALUE, Compression.NONE, TimestampType.CREATE_TIME, 0,
                         System.currentTimeMillis(), RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, RecordBatch.NO_SEQUENCE, false, false,
                         RecordBatch.NO_PARTITION_LEADER_EPOCH,
                         stream.remaining())) {

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/test/java/io/kroxylicious/proxy/filter/simpletransform/FetchResponseTransformationFilterFactoryFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/test/java/io/kroxylicious/proxy/filter/simpletransform/FetchResponseTransformationFilterFactoryFilterTest.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.FetchResponseData.FetchableTopicResponse;
 import org.apache.kafka.common.message.FetchResponseData.PartitionData;
@@ -24,7 +25,6 @@ import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
-import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MemoryRecordsBuilder;
 import org.apache.kafka.common.record.Record;
@@ -223,7 +223,7 @@ class FetchResponseTransformationFilterFactoryFilterTest {
     private static MemoryRecords buildOneRecord(String key, String value) {
         ByteBuffer buffer = ByteBuffer.allocate(1024);
         try (MemoryRecordsBuilder builder = MemoryRecords.builder(buffer, RecordBatch.CURRENT_MAGIC_VALUE,
-                CompressionType.NONE, TimestampType.CREATE_TIME, 0L, System.currentTimeMillis())) {
+                Compression.NONE, TimestampType.CREATE_TIME, 0L, System.currentTimeMillis())) {
             builder.append(0L, key.getBytes(), value.getBytes());
             return builder.build();
         }

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/test/java/io/kroxylicious/proxy/filter/simpletransform/ProduceRequestTransformationFilterFactoryFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/test/java/io/kroxylicious/proxy/filter/simpletransform/ProduceRequestTransformationFilterFactoryFilterTest.java
@@ -15,12 +15,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.ProduceRequestData.PartitionProduceData;
 import org.apache.kafka.common.message.ProduceRequestData.TopicProduceData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
-import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MemoryRecordsBuilder;
 import org.apache.kafka.common.record.Record;
@@ -157,7 +157,7 @@ class ProduceRequestTransformationFilterFactoryFilterTest {
 
     private static MemoryRecords buildOneRecord(String key, String value) {
         try (MemoryRecordsBuilder builder = MemoryRecords.builder(ByteBuffer.allocate(1024), RecordBatch.CURRENT_MAGIC_VALUE,
-                CompressionType.NONE, TimestampType.CREATE_TIME, 0L, System.currentTimeMillis())) {
+                Compression.NONE, TimestampType.CREATE_TIME, 0L, System.currentTimeMillis())) {
             builder.append(0L, key.getBytes(), value.getBytes());
             return builder.build();
         }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/ApiMessageSampleGenerator.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/ApiMessageSampleGenerator.java
@@ -24,13 +24,13 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.protocol.Message;
 import org.apache.kafka.common.protocol.types.BoundField;
 import org.apache.kafka.common.protocol.types.Schema;
 import org.apache.kafka.common.record.BaseRecords;
-import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MemoryRecordsBuilder;
 import org.apache.kafka.common.record.RecordBatch;
@@ -199,7 +199,7 @@ public class ApiMessageSampleGenerator {
         String value = "value-" + random.nextInt(RANGE_MIN, RANGE_MAX);
         long baseOffset = random.nextInt(RANGE_MIN, RANGE_MAX);
         long logAppendTime = RecordBatch.NO_TIMESTAMP;
-        try (MemoryRecordsBuilder builder = MemoryRecords.builder(ByteBuffer.allocate(1), RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE,
+        try (MemoryRecordsBuilder builder = MemoryRecords.builder(ByteBuffer.allocate(1), RecordBatch.CURRENT_MAGIC_VALUE, Compression.NONE,
                 TimestampType.CREATE_TIME, baseOffset,
                 logAppendTime,
                 RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, RecordBatch.NO_SEQUENCE, false,

--- a/kroxylicious-kafka-message-tools/src/test/java/io/kroxylicious/kafka/transform/BatchAwareMemoryRecordsBuilderTest.java
+++ b/kroxylicious-kafka-message-tools/src/test/java/io/kroxylicious/kafka/transform/BatchAwareMemoryRecordsBuilderTest.java
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.StreamSupport;
 
+import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.ControlRecordType;
@@ -68,7 +69,7 @@ class BatchAwareMemoryRecordsBuilderTest {
     void shouldBePossibleToWriteBatchAfterBuildingABatch() {
         // Given
         var builder = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(100));
-        builder.addBatch(CompressionType.NONE, TimestampType.CREATE_TIME, 0L);
+        builder.addBatch(Compression.NONE, TimestampType.CREATE_TIME, 0L);
         byte[] value1 = { 4, 5, 6 };
         builder.appendWithOffset(0L, 1L, new byte[]{ 1, 2, 3 }, value1, new Header[]{});
         byte[] value2 = { 10, 11, 12 };
@@ -106,7 +107,7 @@ class BatchAwareMemoryRecordsBuilderTest {
         builder.writeBatch(recordBatch);
 
         // When
-        builder.addBatch(CompressionType.NONE, TimestampType.CREATE_TIME, 1L);
+        builder.addBatch(Compression.NONE, TimestampType.CREATE_TIME, 1L);
         byte[] value2 = { 4, 5, 6 };
         builder.appendWithOffset(1L, 1L, new byte[]{ 1, 2, 3 }, value2, new Header[]{});
         MemoryRecords output = builder.build();
@@ -153,7 +154,7 @@ class BatchAwareMemoryRecordsBuilderTest {
         // Then
         assertThatThrownBy(() -> {
             builder.addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
-                    CompressionType.NONE,
+                    Compression.NONE,
                     TimestampType.CREATE_TIME,
                     0,
                     0,
@@ -191,7 +192,7 @@ class BatchAwareMemoryRecordsBuilderTest {
         // Given
         var builder = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(100));
         builder.addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
-                CompressionType.NONE,
+                Compression.NONE,
                 TimestampType.CREATE_TIME,
                 0,
                 0,
@@ -217,7 +218,7 @@ class BatchAwareMemoryRecordsBuilderTest {
         // Given
         var builder = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(100));
         builder.addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
-                CompressionType.NONE,
+                Compression.NONE,
                 TimestampType.CREATE_TIME,
                 0,
                 0,
@@ -246,7 +247,7 @@ class BatchAwareMemoryRecordsBuilderTest {
         // Given
         var builder = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(100));
         builder.addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
-                CompressionType.NONE,
+                Compression.NONE,
                 TimestampType.CREATE_TIME,
                 0,
                 0,
@@ -293,7 +294,7 @@ class BatchAwareMemoryRecordsBuilderTest {
         // Given
         var builder = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(100));
         builder.addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
-                CompressionType.NONE,
+                Compression.NONE,
                 TimestampType.CREATE_TIME,
                 0,
                 0,
@@ -326,7 +327,7 @@ class BatchAwareMemoryRecordsBuilderTest {
         // Given
         var builder = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(100));
         builder.addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
-                CompressionType.NONE,
+                Compression.NONE,
                 TimestampType.CREATE_TIME,
                 0,
                 0,
@@ -356,7 +357,7 @@ class BatchAwareMemoryRecordsBuilderTest {
         // Given
         var builder = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(100));
         builder.addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
-                CompressionType.NONE,
+                Compression.NONE,
                 TimestampType.CREATE_TIME,
                 0,
                 0,
@@ -385,7 +386,7 @@ class BatchAwareMemoryRecordsBuilderTest {
         // Given
         var builder = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(100));
         builder.addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
-                CompressionType.NONE,
+                Compression.NONE,
                 TimestampType.CREATE_TIME,
                 0,
                 0,
@@ -416,7 +417,7 @@ class BatchAwareMemoryRecordsBuilderTest {
         // Given
         var builder = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(initialBufferSize));
         builder.addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
-                CompressionType.NONE,
+                Compression.NONE,
                 TimestampType.CREATE_TIME,
                 0,
                 0,
@@ -429,7 +430,7 @@ class BatchAwareMemoryRecordsBuilderTest {
                 0);
         builder.append(new SimpleRecord("hello".getBytes(StandardCharsets.UTF_8)));
         builder.addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
-                CompressionType.ZSTD,
+                Compression.zstd().build(),
                 TimestampType.LOG_APPEND_TIME,
                 1, // not base off
                 0,
@@ -470,7 +471,7 @@ class BatchAwareMemoryRecordsBuilderTest {
         // Given
         var builder = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(initialBufferSize));
         builder.addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
-                CompressionType.NONE,
+                Compression.NONE,
                 TimestampType.CREATE_TIME,
                 0,
                 0,
@@ -483,7 +484,7 @@ class BatchAwareMemoryRecordsBuilderTest {
                 0);
         builder.append(new SimpleRecord("data-key".getBytes(StandardCharsets.UTF_8), "data-value".getBytes(StandardCharsets.UTF_8)));
         builder.addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
-                CompressionType.ZSTD,
+                Compression.zstd().build(),
                 TimestampType.LOG_APPEND_TIME,
                 1,
                 0,
@@ -534,7 +535,7 @@ class BatchAwareMemoryRecordsBuilderTest {
         // When
         var builder1 = new BatchAwareMemoryRecordsBuilder(buffer);
         builder1.addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
-                CompressionType.NONE,
+                Compression.NONE,
                 TimestampType.CREATE_TIME,
                 0,
                 0,
@@ -554,7 +555,7 @@ class BatchAwareMemoryRecordsBuilderTest {
 
         var builder2 = new BatchAwareMemoryRecordsBuilder(buffer);
         builder2.addBatch(RecordBatch.CURRENT_MAGIC_VALUE,
-                CompressionType.NONE,
+                Compression.NONE,
                 TimestampType.CREATE_TIME,
                 0,
                 0,

--- a/kroxylicious-kafka-message-tools/src/test/java/io/kroxylicious/kafka/transform/RecordStreamTest.java
+++ b/kroxylicious-kafka-message-tools/src/test/java/io/kroxylicious/kafka/transform/RecordStreamTest.java
@@ -10,8 +10,8 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 
+import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.header.Header;
-import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.MutableRecordBatch;
 import org.apache.kafka.common.record.Record;
@@ -43,7 +43,7 @@ class RecordStreamTest {
     @Test
     void ofRecordsToList() {
         var mrb = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(ByteBuffer.allocate(10)));
-        var mr = mrb.addBatch(CompressionType.NONE, TimestampType.LOG_APPEND_TIME, 10)
+        var mr = mrb.addBatch(Compression.NONE, TimestampType.LOG_APPEND_TIME, 10)
                 .append(new SimpleRecord(42, "hello".getBytes(StandardCharsets.UTF_8), "world".getBytes(StandardCharsets.UTF_8), new Header[0]))
                 .build();
         RecordStream<Void> rs = RecordStream.ofRecords(mr);
@@ -80,7 +80,7 @@ class RecordStreamTest {
     @Test
     void ofRecordsToSet() {
         var mrb = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(ByteBuffer.allocate(10)));
-        var mr = mrb.addBatch(CompressionType.NONE, TimestampType.LOG_APPEND_TIME, 10)
+        var mr = mrb.addBatch(Compression.NONE, TimestampType.LOG_APPEND_TIME, 10)
                 .append(new SimpleRecord(42, "hello".getBytes(StandardCharsets.UTF_8), "world".getBytes(StandardCharsets.UTF_8), new Header[0]))
                 .build();
         RecordStream<Void> rs = RecordStream.ofRecords(mr);
@@ -94,7 +94,7 @@ class RecordStreamTest {
     @Test
     void ofRecordsForEachRecord() {
         var mrb = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(ByteBuffer.allocate(10)));
-        var mr = mrb.addBatch(CompressionType.NONE, TimestampType.CREATE_TIME, 10)
+        var mr = mrb.addBatch(Compression.NONE, TimestampType.CREATE_TIME, 10)
                 .append(new SimpleRecord(42, "hello".getBytes(StandardCharsets.UTF_8), "world".getBytes(StandardCharsets.UTF_8), new Header[0]))
                 .build();
         RecordStream<Void> rs = RecordStream.ofRecords(mr);
@@ -112,7 +112,7 @@ class RecordStreamTest {
     void ofRecordsToMemoryRecords() {
         var mrb = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(ByteBuffer.allocate(10)));
         int baseOffset = 11;
-        var mr = mrb.addBatch(CompressionType.NONE, TimestampType.CREATE_TIME, baseOffset)
+        var mr = mrb.addBatch(Compression.NONE, TimestampType.CREATE_TIME, baseOffset)
                 .append(new SimpleRecord(42, "hello".getBytes(StandardCharsets.UTF_8), "world".getBytes(StandardCharsets.UTF_8), new Header[0]))
                 .build();
         RecordStream<Void> rs = RecordStream.ofRecords(mr);
@@ -133,7 +133,7 @@ class RecordStreamTest {
     void ofRecordsWithIndexToMemoryRecords() {
         var mrb = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(ByteBuffer.allocate(10)));
         int baseOffset = 10;
-        var mr = mrb.addBatch(CompressionType.NONE, TimestampType.CREATE_TIME, baseOffset)
+        var mr = mrb.addBatch(Compression.NONE, TimestampType.CREATE_TIME, baseOffset)
                 .append(new SimpleRecord(42, "hello".getBytes(StandardCharsets.UTF_8), "world".getBytes(StandardCharsets.UTF_8), new Header[0]))
                 .append(new SimpleRecord(65, "HELLO".getBytes(StandardCharsets.UTF_8), "WORLD".getBytes(StandardCharsets.UTF_8), new Header[0]))
                 .build();
@@ -162,7 +162,7 @@ class RecordStreamTest {
     void ofRecordsMapPerRecordToMemoryRecords() {
         var mrb = new BatchAwareMemoryRecordsBuilder(new ByteBufferOutputStream(ByteBuffer.allocate(10)));
         int baseOffset = 10;
-        var mr = mrb.addBatch(CompressionType.NONE, TimestampType.CREATE_TIME, baseOffset)
+        var mr = mrb.addBatch(Compression.NONE, TimestampType.CREATE_TIME, baseOffset)
                 .append(new SimpleRecord(42, "hello".getBytes(StandardCharsets.UTF_8), "world".getBytes(StandardCharsets.UTF_8), new Header[0]))
                 .append(new SimpleRecord(65, "HELLO".getBytes(StandardCharsets.UTF_8), "WORLD".getBytes(StandardCharsets.UTF_8), new Header[0]))
                 .build();

--- a/kroxylicious-krpc-plugin/src/test/resources/Kproxy/KrpcRequestFilter-expected.txt
+++ b/kroxylicious-krpc-plugin/src/test/resources/Kproxy/KrpcRequestFilter-expected.txt
@@ -41,6 +41,7 @@ import org.apache.kafka.common.message.DescribeGroupsRequestData;
 import org.apache.kafka.common.message.DescribeLogDirsRequestData;
 import org.apache.kafka.common.message.DescribeProducersRequestData;
 import org.apache.kafka.common.message.DescribeQuorumRequestData;
+import org.apache.kafka.common.message.DescribeTopicPartitionsRequestData;
 import org.apache.kafka.common.message.DescribeTransactionsRequestData;
 import org.apache.kafka.common.message.DescribeUserScramCredentialsRequestData;
 import org.apache.kafka.common.message.ElectLeadersRequestData;
@@ -234,6 +235,9 @@ public /* sealed */ interface KrpcRequestFilter extends KrpcFilter /* TODO permi
                 break;
             case DESCRIBE_QUORUM:
                 state = ((DescribeQuorumRequestFilter) this).onDescribeQuorumRequest((DescribeQuorumRequestData) decodedFrame.body(), filterContext);
+                break;
+            case DESCRIBE_TOPIC_PARTITIONS:
+                state = ((DescribeTopicPartitionsRequestFilter) this).onDescribeTopicPartitionsRequest((DescribeTopicPartitionsRequestData) decodedFrame.body(), filterContext);
                 break;
             case DESCRIBE_TRANSACTIONS:
                 state = ((DescribeTransactionsRequestFilter) this).onDescribeTransactionsRequest((DescribeTransactionsRequestData) decodedFrame.body(), filterContext);
@@ -449,6 +453,8 @@ public /* sealed */ interface KrpcRequestFilter extends KrpcFilter /* TODO permi
                 return this instanceof DescribeProducersRequestFilter;
             case DESCRIBE_QUORUM:
                 return this instanceof DescribeQuorumRequestFilter;
+            case DESCRIBE_TOPIC_PARTITIONS:
+                return this instanceof DescribeTopicPartitionsRequestFilter;
             case DESCRIBE_TRANSACTIONS:
                 return this instanceof DescribeTransactionsRequestFilter;
             case DESCRIBE_USER_SCRAM_CREDENTIALS:

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoder.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoder.java
@@ -144,7 +144,7 @@ public class KafkaRequestDecoder extends KafkaMessageDecoder {
             if (apiVersion < 9) { // Last non-flexible version
                 transactionIdLength = in.readShort();
             }
-            else if (apiVersion == 9 || apiVersion == 10) { // Flexible versions
+            else if (apiVersion <= 11) { // Flexible versions
                 transactionIdLength = ByteBufAccessorImpl.readUnsignedVarint(in);
             }
             else {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/util/MemoryRecordsHelper.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/util/MemoryRecordsHelper.java
@@ -5,43 +5,46 @@
  */
 package io.kroxylicious.proxy.internal.util;
 
-import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.record.MemoryRecordsBuilder;
 import org.apache.kafka.common.record.RecordBatch;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 
 /**
- * This is introduces additional factory builder methods then {@link org.apache.kafka.common.record.MemoryRecords#builder} ones,
- * in order to use {@link ByteBufOutputStream}<br>
+ * This introduces additional factory builder methods for {@link org.apache.kafka.common.record.MemoryRecords} that
+ * accepts {@link ByteBufOutputStream}<br>
  *
  */
 public class MemoryRecordsHelper {
 
+    private MemoryRecordsHelper() {
+    }
+
     public static MemoryRecordsBuilder builder(ByteBufferOutputStream stream,
-                                               CompressionType compressionType,
+                                               Compression compression,
                                                TimestampType timestampType,
                                                long baseOffset) {
-        return builder(stream, RecordBatch.CURRENT_MAGIC_VALUE, compressionType, timestampType, baseOffset);
+        return builder(stream, RecordBatch.CURRENT_MAGIC_VALUE, compression, timestampType, baseOffset);
     }
 
     private static MemoryRecordsBuilder builder(ByteBufferOutputStream stream,
                                                 byte magic,
-                                                CompressionType compressionType,
+                                                Compression compression,
                                                 TimestampType timestampType,
                                                 long baseOffset) {
         long logAppendTime = RecordBatch.NO_TIMESTAMP;
         if (timestampType == TimestampType.LOG_APPEND_TIME) {
             logAppendTime = System.currentTimeMillis();
         }
-        return builder(stream, magic, compressionType, timestampType, baseOffset, logAppendTime,
+        return builder(stream, magic, compression, timestampType, baseOffset, logAppendTime,
                 RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, RecordBatch.NO_SEQUENCE, false,
                 RecordBatch.NO_PARTITION_LEADER_EPOCH);
     }
 
     private static MemoryRecordsBuilder builder(ByteBufferOutputStream stream,
                                                 byte magic,
-                                                CompressionType compressionType,
+                                                Compression compression,
                                                 TimestampType timestampType,
                                                 long baseOffset,
                                                 long logAppendTime,
@@ -50,13 +53,13 @@ public class MemoryRecordsHelper {
                                                 int baseSequence,
                                                 boolean isTransactional,
                                                 int partitionLeaderEpoch) {
-        return builder(stream, magic, compressionType, timestampType, baseOffset,
+        return builder(stream, magic, compression, timestampType, baseOffset,
                 logAppendTime, producerId, producerEpoch, baseSequence, isTransactional, false, partitionLeaderEpoch);
     }
 
     private static MemoryRecordsBuilder builder(ByteBufferOutputStream stream,
                                                 byte magic,
-                                                CompressionType compressionType,
+                                                Compression compression,
                                                 TimestampType timestampType,
                                                 long baseOffset,
                                                 long logAppendTime,
@@ -66,7 +69,7 @@ public class MemoryRecordsHelper {
                                                 boolean isTransactional,
                                                 boolean isControlBatch,
                                                 int partitionLeaderEpoch) {
-        return new MemoryRecordsBuilder(stream, magic, compressionType, timestampType, baseOffset,
+        return new MemoryRecordsBuilder(stream, magic, compression, timestampType, baseOffset,
                 logAppendTime, producerId, producerEpoch, baseSequence, isTransactional, isControlBatch, partitionLeaderEpoch,
                 stream.remaining());
     }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/RequestDecoderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/RequestDecoderTest.java
@@ -9,7 +9,6 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.kafka.common.message.ApiMessageType;
@@ -66,8 +65,8 @@ public class RequestDecoderTest extends AbstractCodecTest {
     };
     public static final KafkaRequestDecoder MAX_FRAME_SIZE_10_BYTES_DECODER = getKafkaRequestDecoder(DECODE_EVERYTHING, 10);
 
-    public static List<Object[]> produceRequestApiVersions() {
-        List<Short> produceVersions = requestApiVersions(ApiMessageType.PRODUCE).collect(Collectors.toList());
+    static List<Object[]> produceRequestApiVersions() {
+        List<Short> produceVersions = requestApiVersions(ApiMessageType.PRODUCE).toList();
         List<Object[]> cartesianProduct = new ArrayList<>();
         produceVersions
                 .forEach(produceVersion -> Stream.of((short) 0, (short) 1, (short) -1).forEach(acks -> cartesianProduct.add(new Object[]{ produceVersion, acks })));

--- a/kroxylicious-sample/src/main/java/io/kroxylicious/sample/util/SampleFilterTransformer.java
+++ b/kroxylicious-sample/src/main/java/io/kroxylicious/sample/util/SampleFilterTransformer.java
@@ -9,6 +9,7 @@ package io.kroxylicious.sample.util;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
+import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.record.AbstractRecords;
@@ -87,7 +88,8 @@ public class SampleFilterTransformer {
      * functionality in io.kroxylicious.proxy.internal, but we aren't supposed to import from there.
      */
     private static MemoryRecordsBuilder createMemoryRecordsBuilder(ByteBufferOutputStream stream, RecordBatch firstBatch) {
-        return new MemoryRecordsBuilder(stream, firstBatch.magic(), firstBatch.compressionType(), firstBatch.timestampType(), firstBatch.baseOffset(),
+        return new MemoryRecordsBuilder(stream, firstBatch.magic(), Compression.of(firstBatch.compressionType()).build(), firstBatch.timestampType(),
+                firstBatch.baseOffset(),
                 firstBatch.maxTimestamp(), firstBatch.producerId(), firstBatch.producerEpoch(), firstBatch.baseSequence(), firstBatch.isTransactional(),
                 firstBatch.isControlBatch(), firstBatch.partitionLeaderEpoch(), stream.remaining());
     }

--- a/kroxylicious-sample/src/test/java/io/kroxylicious/sample/SampleFetchResponseFilterTest.java
+++ b/kroxylicious-sample/src/test/java/io/kroxylicious/sample/SampleFetchResponseFilterTest.java
@@ -12,13 +12,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.message.ApiMessageType;
 import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
-import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.MemoryRecordsBuilder;
 import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.record.RecordBatch;
@@ -160,7 +160,7 @@ class SampleFetchResponseFilterTest {
         // Build stream
         var stream = new ByteBufferOutputStream(ByteBuffer.wrap(transformValue.getBytes(StandardCharsets.UTF_8)));
         // Build records from stream
-        var recordsBuilder = new MemoryRecordsBuilder(stream, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE, TimestampType.CREATE_TIME, 0,
+        var recordsBuilder = new MemoryRecordsBuilder(stream, RecordBatch.CURRENT_MAGIC_VALUE, Compression.NONE, TimestampType.CREATE_TIME, 0,
                 RecordBatch.NO_TIMESTAMP, RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, RecordBatch.NO_SEQUENCE, false, false,
                 RecordBatch.NO_PARTITION_LEADER_EPOCH, stream.remaining());
         // Create record Headers

--- a/kroxylicious-sample/src/test/java/io/kroxylicious/sample/SampleProduceRequestFilterTest.java
+++ b/kroxylicious-sample/src/test/java/io/kroxylicious/sample/SampleProduceRequestFilterTest.java
@@ -12,13 +12,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.message.ApiMessageType;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
-import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.common.record.MemoryRecordsBuilder;
 import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.record.RecordBatch;
@@ -153,7 +153,7 @@ class SampleProduceRequestFilterTest {
         // Build stream
         var stream = new ByteBufferOutputStream(ByteBuffer.wrap(transformValue.getBytes(StandardCharsets.UTF_8)));
         // Build records from stream
-        var recordsBuilder = new MemoryRecordsBuilder(stream, RecordBatch.CURRENT_MAGIC_VALUE, CompressionType.NONE, TimestampType.CREATE_TIME, 0,
+        var recordsBuilder = new MemoryRecordsBuilder(stream, RecordBatch.CURRENT_MAGIC_VALUE, Compression.NONE, TimestampType.CREATE_TIME, 0,
                 RecordBatch.NO_TIMESTAMP, RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, RecordBatch.NO_SEQUENCE, false, false,
                 RecordBatch.NO_PARTITION_LEADER_EPOCH, stream.remaining());
         // Create record Headers

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <hamcrest.version>2.2</hamcrest.version>
         <jackson.version>2.17.2</jackson.version>
         <junit.version>5.10.3</junit.version>
-        <kafka.version>3.7.1</kafka.version>
+        <kafka.version>3.8.0</kafka.version>
         <kroxy.extension.version>0.9.0</kroxy.extension.version>
         <log4j.version>2.23.1</log4j.version>
         <caffeine.version>3.1.8</caffeine.version>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Testing Kroxylicious against Apache Kafka 3.8.0.

* Changes to reflect changes in the MemoryRecordsBuilder API (Compression)
* Changes to MultiTenantFilter to provide basic DescribeTopicParitions support.

**Note: The POM references the Apache Kafka staging repo.  Do not merge.**

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
