### PR TITLE
systemtests: pull snapshot images once per process

### DIFF
--- a/kroxylicious-systemtests/pom.xml
+++ b/kroxylicious-systemtests/pom.xml
@@ -68,6 +68,11 @@
             <artifactId>junit-jupiter-api</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- third party dependencies - runtime and compile -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
@@ -159,12 +159,13 @@ public interface Constants {
      */
     String KAFKA_ADMIN_CLIENT_LABEL = "admin-client-cli";
     /**
-     * Image pull if not present.
+     * Image pull policies
      */
     String PULL_IMAGE_IF_NOT_PRESENT = "IfNotPresent";
+    String PULL_IMAGE_ALWAYS = "Always";
 
     /**
-     * Restart policy
+     * Restart policies
      */
     String RESTART_POLICY_ONFAILURE = "OnFailure";
     String RESTART_POLICY_NEVER = "Never";

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/ContainerTemplates.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/ContainerTemplates.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.systemtests.templates;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+
+import io.kroxylicious.systemtests.Constants;
+
+public class ContainerTemplates {
+
+    private static final List<String> SNAPSHOT_STRINGS = List.of("latest", "snapshot");
+
+    private static final Set<String> snapshotImagesPulledOnce = new HashSet<>();
+
+    /**
+     * If the image contains the string 'latest' we set imagePullPolicy to Always for the first
+     * Container built and then IfNotPresent thereafter (process-scoped). This is to help ensure
+     * we have the latest image during local development.
+     *
+     * @param containerName container name
+     * @param image         image
+     * @return container builder
+     */
+    public synchronized static ContainerBuilder baseImageBuilder(String containerName, String image) {
+        var imagePullPolicy = Constants.PULL_IMAGE_IF_NOT_PRESENT;
+        String lowerCaseImage = image.toLowerCase();
+        if (SNAPSHOT_STRINGS.stream().anyMatch(lowerCaseImage::contains) && !snapshotImagesPulledOnce.contains(image)) {
+            imagePullPolicy = Constants.PULL_IMAGE_ALWAYS;
+            snapshotImagesPulledOnce.add(image);
+        }
+        return new ContainerBuilder()
+                .withName(containerName)
+                .withImage(image)
+                .withImagePullPolicy(imagePullPolicy);
+    }
+}

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/kroxylicious/KroxyliciousDeploymentTemplates.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/kroxylicious/KroxyliciousDeploymentTemplates.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
 import io.fabric8.kubernetes.api.model.LocalObjectReferenceBuilder;
@@ -19,6 +18,7 @@ import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 
 import io.kroxylicious.systemtests.Constants;
+import io.kroxylicious.systemtests.templates.ContainerTemplates;
 
 /**
  * The type Kroxylicious deployment templates.
@@ -55,10 +55,7 @@ public class KroxyliciousDeploymentTemplates {
                 .withLabels(kroxyLabelSelector)
                 .endMetadata()
                 .withNewSpec()
-                .withContainers(new ContainerBuilder()
-                        .withName("kroxylicious")
-                        .withImage(containerImage)
-                        .withImagePullPolicy("Always")
+                .withContainers(ContainerTemplates.baseImageBuilder("kroxylicious", containerImage)
                         .withArgs("--config", "/opt/kroxylicious/config/config.yaml")
                         .withPorts(getPlainContainerPortList())
                         .withVolumeMounts(getPlainVolumeMountList())

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/metrics/ScraperTemplates.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/metrics/ScraperTemplates.java
@@ -9,12 +9,12 @@ package io.kroxylicious.systemtests.templates.metrics;
 import java.util.HashMap;
 import java.util.Map;
 
-import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.LocalObjectReferenceBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 
 import io.kroxylicious.systemtests.Constants;
 import io.kroxylicious.systemtests.Environment;
+import io.kroxylicious.systemtests.templates.ContainerTemplates;
 
 public class ScraperTemplates {
 
@@ -48,12 +48,9 @@ public class ScraperTemplates {
                 .endMetadata()
                 .withNewSpec()
                 .withContainers(
-                        new ContainerBuilder()
-                                .withName(podName)
-                                .withImage(scraperImage)
+                        ContainerTemplates.baseImageBuilder(podName, scraperImage)
                                 .withCommand("sleep")
                                 .withArgs("infinity")
-                                .withImagePullPolicy("IfNotPresent")
                                 .build())
                 .withImagePullSecrets(new LocalObjectReferenceBuilder()
                         .withName("regcred")

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/testclients/TestClientsJobTemplates.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/testclients/TestClientsJobTemplates.java
@@ -10,12 +10,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 
 import io.kroxylicious.systemtests.Constants;
+import io.kroxylicious.systemtests.templates.ContainerTemplates;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
@@ -75,10 +75,7 @@ public class TestClientsJobTemplates {
                 .editSpec()
                 .editTemplate()
                 .editSpec()
-                .withContainers(new ContainerBuilder()
-                        .withName("admin")
-                        .withImage(Constants.TEST_CLIENTS_IMAGE)
-                        .withImagePullPolicy(Constants.PULL_IMAGE_IF_NOT_PRESENT)
+                .withContainers(ContainerTemplates.baseImageBuilder("admin", Constants.TEST_CLIENTS_IMAGE)
                         .withCommand("admin-client")
                         .withArgs(args)
                         .build())
@@ -111,10 +108,7 @@ public class TestClientsJobTemplates {
                 .editSpec()
                 .editTemplate()
                 .editSpec()
-                .withContainers(new ContainerBuilder()
-                        .withName(containerName)
-                        .withImage(image)
-                        .withImagePullPolicy(Constants.PULL_IMAGE_IF_NOT_PRESENT)
+                .withContainers(ContainerTemplates.baseImageBuilder(containerName, image)
                         .withEnv(envVars)
                         .build())
                 .endSpec()
@@ -150,10 +144,7 @@ public class TestClientsJobTemplates {
                 .editSpec()
                 .editTemplate()
                 .editSpec()
-                .withContainers(new ContainerBuilder()
-                        .withName("kcat")
-                        .withImage(Constants.KCAT_CLIENT_IMAGE)
-                        .withImagePullPolicy(Constants.PULL_IMAGE_IF_NOT_PRESENT)
+                .withContainers(ContainerTemplates.baseImageBuilder("kcat", Constants.KCAT_CLIENT_IMAGE)
                         .withArgs(args)
                         .build())
                 .endSpec()
@@ -175,10 +166,7 @@ public class TestClientsJobTemplates {
                 .editTemplate()
                 .editSpec()
                 .withRestartPolicy(Constants.RESTART_POLICY_ONFAILURE)
-                .withContainers(new ContainerBuilder()
-                        .withName("kafka-go-consumer")
-                        .withImage(Constants.KAF_CLIENT_IMAGE)
-                        .withImagePullPolicy(Constants.PULL_IMAGE_IF_NOT_PRESENT)
+                .withContainers(ContainerTemplates.baseImageBuilder("kafka-go-consumer", Constants.KAF_CLIENT_IMAGE)
                         .withArgs(args)
                         .build())
                 .endSpec()

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/templates/ContainerTemplatesTest.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/templates/ContainerTemplatesTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.systemtests.templates;
+
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+
+import io.kroxylicious.systemtests.Constants;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ContainerTemplatesTest {
+
+    public static final String CONTAINER_NAME = "test";
+
+    @Test
+    void baseImageBuilder() {
+        ContainerBuilder test = ContainerTemplates.baseImageBuilder(CONTAINER_NAME, "test:1.2.3");
+        assertThat(test.getName()).isEqualTo(CONTAINER_NAME);
+        assertThat(test.getImage()).isEqualTo("test:1.2.3");
+        assertThat(test.getImagePullPolicy()).isEqualTo(Constants.PULL_IMAGE_IF_NOT_PRESENT);
+    }
+
+    static Stream<String> imageContainingTagIsPulledOnce() {
+        return Stream.of("latest",
+                "LATEST",
+                "a-latest",
+                "latest-b",
+                "a-latest-b",
+                "snapshot",
+                "SNAPSHOT",
+                "a-snapshot",
+                "snapshot-b",
+                "a-snapshot-b");
+    }
+
+    private static @NonNull String randomImageWithTag(String tag) {
+        return UUID.randomUUID() + ":" + tag;
+    }
+
+    /**
+     * This is to help ensure images with latest tags are up-to-date for local testing. In CI the env will be clean.
+     */
+    @MethodSource
+    @ParameterizedTest
+    void imageContainingTagIsPulledOnce(String tag) {
+        String image = randomImageWithTag(tag);
+        ContainerBuilder test = ContainerTemplates.baseImageBuilder(CONTAINER_NAME, image);
+        assertThat(test.getName()).isEqualTo(CONTAINER_NAME);
+        assertThat(test.getImage()).isEqualTo(image);
+        assertThat(test.getImagePullPolicy()).isEqualTo(Constants.PULL_IMAGE_ALWAYS);
+
+        ContainerBuilder test2 = ContainerTemplates.baseImageBuilder(CONTAINER_NAME, image);
+        assertThat(test2.getName()).isEqualTo(CONTAINER_NAME);
+        assertThat(test2.getImage()).isEqualTo(image);
+        assertThat(test2.getImagePullPolicy()).isEqualTo(Constants.PULL_IMAGE_IF_NOT_PRESENT);
+    }
+
+}


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Set imagePullPolicy to Always the first time we create a Container with 'latest' in the image, for that image.

Why:
Currently we are using a SNAPSHOT tag that has the image changing underneath it over time for Strimzi test-clients. Locally we have had test failures because minikube had cached an older version of the tag (before the Kafka consumer was changed to emit JSON) and we have an image pull policy of IfNotPresent.

It's on the developer to remember to clean Minikube and provide a fresh env manually, so mistakes will happen, this provides another protection.

Ideally we would get back to an immutable tag for test reproducibility. Waiting on an upstream release by the look.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
