### PR TITLE
Enable local rendering of the asciidoc diagrams (such as a2s)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -757,6 +757,13 @@
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
                 <version>3.0.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctorj-diagram</artifactId>
+                        <version>2.3.1</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <id>convert-to-html</id>
@@ -764,6 +771,9 @@
                             <goal>process-asciidoc</goal>
                         </goals>
                         <configuration>
+                            <requires>
+                                <require>asciidoctor-diagram</require>
+                            </requires>
                             <outputDirectory>${project.build.directory}/html</outputDirectory>
                             <attributes>
                                 <source-highlighter>coderay</source-highlighter>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature
- Documentation

### Description

As a author of documentation for Kroxylicioius, I can use 

```
mvn org.asciidoctor:asciidoctor-maven-plugin:process-asciidoc@convert-to-html
```

to render my Asciidoc changes locally in order to conveniently view them in a browser.  However the asciiart diagrams
included in the asciidocs currently go unrendered. 

I'd like the rendering to be done.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
