### PR TITLE
Ignore SDKMan environment configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+.sdkmanrc


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Gitignores an sdkman config file

This file configures an SDKMAN JDK (and other managed SDKS like maven) to switch to when you cd to kroxylicious
in a terminal. You can also run a command to install the listed SDKs.

It could be a good addition but I'd like to try it locally and gitignore it for a while withoutadding it to the repo.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
