### PR TITLE
Update FilterInvoker javadoc

### DIFF
--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvoker.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvoker.java
@@ -75,7 +75,7 @@ public interface FilterInvoker {
     /**
      * <p>Handle deserialized request data. Implementations must tolerate being called with requests that this FilterInvoker
      * is NOT interested in handling. If any FilterInvoker in the chain should handle a response, then all invokers in the chain
-     * are eligible to have their onRequest called. Implementations should forward requests they do not wish to operator on.
+     * are eligible to have their onRequest called. Implementations should forward requests they do not wish to operate on.
      * </p><p>
      * Filters must return a {@link CompletionStage<RequestFilterResult>} object.  This object
      * encapsulates the request to be forwarded and, optionally, orders for actions such as closing the connection or
@@ -100,7 +100,7 @@ public interface FilterInvoker {
     /**
      * <p>Handle deserialized response data. Implementations must tolerate being called with responses that this FilterInvoker
      * is NOT interested in handling. If any FilterInvoker in the chain should handle a response, then all invokers in the chain
-     * are eligible to have their onResponse called. Implementations should forward responses they do not wish to operator on.
+     * are eligible to have their onResponse called. Implementations should forward responses they do not wish to operate on.
      * </p><p>
      * Filters must return a {@link CompletionStage<ResponseFilterResult>} object.  This object
      * encapsulates the response to be forwarded and, optionally, orders for actions such as closing the connection or

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvoker.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterInvoker.java
@@ -73,8 +73,9 @@ public interface FilterInvoker {
     }
 
     /**
-     * <p>Handle deserialized request data. It is implicit that the underlying filter
-     * wants to handle this data because it indicated that with {@link #shouldHandleRequest(ApiKeys, short)}
+     * <p>Handle deserialized request data. Implementations must tolerate being called with requests that this FilterInvoker
+     * is NOT interested in handling. If any FilterInvoker in the chain should handle a response, then all invokers in the chain
+     * are eligible to have their onRequest called. Implementations should forward requests they do not wish to operator on.
      * </p><p>
      * Filters must return a {@link CompletionStage<RequestFilterResult>} object.  This object
      * encapsulates the request to be forwarded and, optionally, orders for actions such as closing the connection or
@@ -97,8 +98,9 @@ public interface FilterInvoker {
     }
 
     /**
-     * <p>Handle deserialized response data. It is implicit that the underlying filter
-     * wants to handle this data because it indicated that with {@link #shouldHandleResponse(ApiKeys, short)}
+     * <p>Handle deserialized response data. Implementations must tolerate being called with responses that this FilterInvoker
+     * is NOT interested in handling. If any FilterInvoker in the chain should handle a response, then all invokers in the chain
+     * are eligible to have their onResponse called. Implementations should forward responses they do not wish to operator on.
      * </p><p>
      * Filters must return a {@link CompletionStage<ResponseFilterResult>} object.  This object
      * encapsulates the response to be forwarded and, optionally, orders for actions such as closing the connection or


### PR DESCRIPTION
### Type of change

- Documentation

### Description

When refactoring invokers we changed the logic so that if any
FilterInvoker indicates it is interested in a message (via
shouldHandle[Request|Response), then all FilterInvokers in the chain are
eligble to handle that message. The FilterInvoker is responsible for
doing a simple forward if it receives a decoded message that it isn't
interested in.

The javadoc was incorrect. Closes #322

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
