### PR TITLE
Override localstack image to 3.5.0

### DIFF
--- a/kroxylicious-systemtests/src/main/resources/helm_localstack_overrides.yaml
+++ b/kroxylicious-systemtests/src/main/resources/helm_localstack_overrides.yaml
@@ -5,6 +5,8 @@
 #
 
 # Helm Overrides File for localstack used by the system tests.
+image:
+  tag: "3.5.0"
 enableStartupScripts: true
 startupScriptContent: |
   #!/bin/bash


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The system tests are trying to assert that we are using a particular
version of localstack but the helm chart install
localstack/localstack:latest

### Additional Context

System tests are failing, see [build](https://github.com/kroxylicious/kroxylicious/pull/1383#issuecomment-2257098917)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
