### PR TITLE
fix kafka version until Strimzi is released

### DIFF
--- a/kroxylicious-systemtests/pom.xml
+++ b/kroxylicious-systemtests/pom.xml
@@ -23,6 +23,11 @@
         using Strimzi, to simulate a real scenario for end-to-end testing treating Kroxylicious as a black box.
     </description>
 
+    <properties>
+        <!-- remove it when Strimzi new version is released -->
+        <kafka.version>3.7.1</kafka.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

After releasing Kafka 3.8.0 into Kroxylicious, system tests are broken because this version is still not supported by Strimzi. So we need this temporary fix to make them work again

### Additional Context


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
