### PR TITLE
Reset semver checks on release

### DIFF
--- a/kroxylicious-api/pom.xml
+++ b/kroxylicious-api/pom.xml
@@ -23,7 +23,7 @@
 
     <properties>
         <libs.dir>libs</libs.dir>
-        <ApiCompatability.ReferenceVersion>0.5.0</ApiCompatability.ReferenceVersion>
+        <ApiCompatability.ReferenceVersion>0.6.0</ApiCompatability.ReferenceVersion>
         <ApiCompatability.EnforceForMajorVersionZero>true</ApiCompatability.EnforceForMajorVersionZero>
     </properties>
 

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -172,6 +172,13 @@ updateVersions "${RELEASE_VERSION}" "${DEVELOPMENT_VERSION}"
 ${SED} -i -e "s_##\s${RELEASE_VERSION//./\\.}_## SNAPSHOT\n## ${RELEASE_VERSION//./\\.}_g" CHANGELOG.md
 
 git add 'CHANGELOG.md'
+
+# bump the reference version in kroxylicious-api
+mvn -q -B -f kroxylicious-api/pom.xml versions:set-property -Dproperty="ApiCompatability.ReferenceVersion" -DnewVersion="${RELEASE_VERSION}" -DgenerateBackupPoms=false
+# reset kroxylicious-api to enable semver checks if they have been disabled
+mvn -q -B -f kroxylicious-api/pom.xml versions:set-property -Dproperty="ApiCompatability.EnforceForMajorVersionZero" -DnewVersion="true" -DgenerateBackupPoms=false
+git add kroxylicious-api/pom.xml
+
 git commit --message "Start next development version" --signoff
 
 if [[ "${DRY_RUN:-false}" == true ]]; then


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

- update reference version when checking semver compatibility of api to 0.6.0
- update release script to set the reference version and reset the compatibility check flag on release

I have a branch where I want to disable the semver checking so that I can make breaking changes to kroxylicious-api. The current setup causes the build to fail on a breaking change, which is a nice early warning for an inadvertent change, but I would like to disable it for 0.7.0-SNAPSHOT so that we can clean up some deprecations.

The script will put things back to rights during the release.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
