### PR TITLE
Add ability to access metrics from KroxyliciousTester

### DIFF
--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/AdminHttpClient.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/AdminHttpClient.java
@@ -6,40 +6,59 @@
 
 package io.kroxylicious.test.tester;
 
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static java.net.http.HttpResponse.BodyHandlers.ofString;
 
 /**
  * Client for interacting with the admin HTTP endpoint of a kroxylicious instance.
  */
-public class AdminHttpClient {
-
-    /**
-     * An instance of the admin http client
-     */
-    public static AdminHttpClient INSTANCE = new AdminHttpClient();
-
-    private AdminHttpClient() {
-
-    }
+public class AdminHttpClient implements Closeable {
+    private static final String METRICS = "metrics";
 
     private final HttpClient httpClient = HttpClient.newHttpClient();
+    private final URI uri;
+
+    AdminHttpClient(@NonNull URI uri) {
+        this.uri = uri;
+    }
 
     public HttpResponse<String> getFromAdminEndpoint(String endpoint) {
         try {
-            HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost:9190/" + endpoint)).GET().build();
+            HttpRequest request = HttpRequest.newBuilder(uri.resolve(endpoint)).GET().build();
             return httpClient.send(request, ofString());
         }
         catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(ie);
         }
-        catch (Exception e) {
-            throw new RuntimeException(e);
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
+    }
+
+    /**
+     * Scrapes the metrics from the admin endpoint.
+     *
+     * @return list of metrics.
+     */
+    @NonNull
+    public List<SimpleMetric> scrapeMetrics() {
+        var text = getFromAdminEndpoint(METRICS).body();
+        return SimpleMetric.parse(text);
+    }
+
+    @Override
+    public void close() {
+        // can't close httpClient until Java 21
     }
 }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousClients.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousClients.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.test.tester;
 
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -30,7 +31,7 @@ import io.kroxylicious.testing.kafka.clients.CloseableAdmin;
 import io.kroxylicious.testing.kafka.clients.CloseableConsumer;
 import io.kroxylicious.testing.kafka.clients.CloseableProducer;
 
-class KroxyliciousClients {
+class KroxyliciousClients implements Closeable {
     private final Map<String, Object> defaultClientConfiguration;
 
     private final List<Admin> admins;

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousTester.java
@@ -263,4 +263,10 @@ public interface KroxyliciousTester extends Closeable {
      * @return the bootstrap address of the named virtual cluster
      */
     String getBootstrapAddress(String clusterName);
+
+    /**
+     * @return the Admin Http Client
+     * @throws IllegalStateException admin interface not available
+     */
+    AdminHttpClient getAdminHttpClient();
 }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/SimpleMetric.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/SimpleMetric.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test.tester;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Simple representation of a Prometheus metric
+ * @param name metric name
+ * @param labels metric labels
+ * @param value metric value
+ */
+public record SimpleMetric(String name, Map<String, String> labels, double value) {
+
+    // https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md
+    // note: RE doesn't handle escaping within label values
+    @SuppressWarnings("java:S5852") //
+    private static final Pattern PROM_TEXT_EXPOSITION_PATTERN = Pattern
+            .compile("^(?<metric>[a-zA-Z_:][a-zA-Z0-9_:]*)(\\{(?<labels>.*)})?[\\t ]*(?<value>[0-9E.]*)[\\t ]*(?<timestamp>\\d+)?$");
+    private static final Pattern NAME_WITH_QUOTED_VALUE = Pattern.compile("^(?<name>[a-zA-Z_:][a-zA-Z0-9_:]*)=\"(?<value>.*)\"$");
+
+    static List<SimpleMetric> parse(String output) {
+        var all = new ArrayList<SimpleMetric>();
+        try (var reader = new BufferedReader(new StringReader(output))) {
+            var line = reader.readLine();
+            while (line != null) {
+                if (!(line.startsWith("#") || line.isEmpty())) {
+                    var matched = PROM_TEXT_EXPOSITION_PATTERN.matcher(line);
+                    if (!matched.matches()) {
+                        throw new IllegalArgumentException("Failed to parse metric %s".formatted(line));
+                    }
+
+                    all.add(parseMetric(matched, line));
+                }
+                line = reader.readLine();
+            }
+            return all;
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException("Failed to parse metrics", e);
+        }
+    }
+
+    private static SimpleMetric parseMetric(Matcher matched, String line) {
+        try {
+            var metricName = matched.group("metric");
+            var metricValue = Double.parseDouble(matched.group("value"));
+            var metricLabels = matched.group("labels");
+            var labels = labelsToMap(metricLabels);
+            return new SimpleMetric(metricName, labels, metricValue);
+        }
+        catch (IllegalArgumentException iae) {
+            throw new IllegalArgumentException("Failed to parse metric %s".formatted(line), iae);
+        }
+    }
+
+    @NonNull
+    private static Map<String, String> labelsToMap(String metricLabels) {
+        if (metricLabels == null || metricLabels.isEmpty()) {
+            return Map.of();
+        }
+        var splitLabels = metricLabels.split(",");
+        return Arrays.stream(splitLabels)
+                .map(NAME_WITH_QUOTED_VALUE::matcher)
+                .filter(Matcher::matches)
+                .collect(Collectors.toMap(nv -> nv.group("name"), nv -> nv.group("value")));
+    }
+}

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/SimpleMetricTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/SimpleMetricTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test.tester;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SimpleMetricTest {
+
+    /**
+     * Known good from <a href="https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#text-format-example">exposition_formats</a>
+     */
+    static Stream<Arguments> knownGood() {
+        return Stream.of(
+                Arguments.of("single metric with labels, value and timestamp",
+                        """
+                                http_requests_total{method="post",code="200"} 1027 1395066363000""",
+                        List.of(new SimpleMetric("http_requests_total", Map.of("method", "post", "code", "200"), 1027))),
+                Arguments.of("single metric no labels",
+                        """
+                                metric_without_timestamp_and_labels 12.47""",
+                        List.of(new SimpleMetric("metric_without_timestamp_and_labels", Map.of(), 12.47))),
+                Arguments.of("many metrics",
+                        """
+                                rpc_duration_seconds{quantile="0.01"} 3102
+                                rpc_duration_seconds{quantile="0.05"} 3272""",
+                        List.of(new SimpleMetric("rpc_duration_seconds", Map.of("quantile", "0.01"), 3102),
+                                new SimpleMetric("rpc_duration_seconds", Map.of("quantile", "0.05"), 3272))),
+                Arguments.of("with help",
+                        """
+                                # HELP rpc_duration_seconds A summary of the RPC duration in seconds.
+                                # TYPE rpc_duration_seconds summary
+                                rpc_duration_seconds{quantile="0.05"} 3272""",
+                        List.of(new SimpleMetric("rpc_duration_seconds", Map.of("quantile", "0.05"), 3272))),
+                Arguments.of("ignores empty lines",
+                        """
+                                # HELP rpc_duration_seconds A summary of the RPC duration in seconds.
+
+                                rpc_duration_seconds{quantile="0.05"} 3272""",
+                        List.of(new SimpleMetric("rpc_duration_seconds", Map.of("quantile", "0.05"), 3272))));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("knownGood")
+    void parseKnownGood(String name, String expositionString, List<SimpleMetric> expected) {
+        var actual = SimpleMetric.parse(expositionString);
+        assertThat(actual)
+                .containsExactlyElementsOf(expected);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "(bad)", "no_value", "invalid_value three" })
+    void parseError(String malformed) {
+        assertThatThrownBy(() -> SimpleMetric.parse(malformed))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Failed to parse metric");
+    }
+}

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/SimpleMetricTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/SimpleMetricTest.java
@@ -39,18 +39,30 @@ class SimpleMetricTest {
                                 rpc_duration_seconds{quantile="0.05"} 3272""",
                         List.of(new SimpleMetric("rpc_duration_seconds", Map.of("quantile", "0.01"), 3102),
                                 new SimpleMetric("rpc_duration_seconds", Map.of("quantile", "0.05"), 3272))),
-                Arguments.of("with help",
+                Arguments.of("metric with help",
                         """
                                 # HELP rpc_duration_seconds A summary of the RPC duration in seconds.
                                 # TYPE rpc_duration_seconds summary
                                 rpc_duration_seconds{quantile="0.05"} 3272""",
                         List.of(new SimpleMetric("rpc_duration_seconds", Map.of("quantile", "0.05"), 3272))),
-                Arguments.of("ignores empty lines",
+                Arguments.of("metric surrounded by empty lines",
                         """
-                                # HELP rpc_duration_seconds A summary of the RPC duration in seconds.
 
-                                rpc_duration_seconds{quantile="0.05"} 3272""",
-                        List.of(new SimpleMetric("rpc_duration_seconds", Map.of("quantile", "0.05"), 3272))));
+                                rpc_duration_seconds{quantile="0.05"} 3272
+                                """,
+                        List.of(new SimpleMetric("rpc_duration_seconds", Map.of("quantile", "0.05"), 3272))),
+                Arguments.of("no metrics - newlines only",
+                        """
+
+
+                                """,
+                        List.of()),
+                Arguments.of("no metrics - comments only",
+                        """
+                                #Mary had a little lamb
+                                #His fleece was white as snow
+                                """,
+                        List.of()));
     }
 
     @ParameterizedTest(name = "{0}")


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

In #1355, we needed the ability to make observations of the metrics emitted by Kroxylicious metrics from the IT.  That PR took an inline approach, but discussions on the PR had indicated we wished to refactor.

In this PR, we augment KroxyliciousTester's API with a method `#getAdminHttpClient`, which provides an API facilitating access to Kroxylicious's admin endpoint and the metrics.   We also introduce a convenience method `#scrapeMetric` that scrapes the metric from the endpoint and provides a response in the form of `SimpleMetric` objects.

_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
