### PR TITLE
[record encryption] Exploration - Make AES 256 GCM transformation and provider configurable

### DIFF
--- a/kroxylicious-filters/kroxylicious-record-encryption/pom.xml
+++ b/kroxylicious-filters/kroxylicious-record-encryption/pom.xml
@@ -39,7 +39,7 @@
             <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-kafka-message-tools</artifactId>
         </dependency>
-        
+
 	    <dependency>
             <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-kms</artifactId>
@@ -139,6 +139,12 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.78.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryption.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryption.java
@@ -9,7 +9,6 @@ package io.kroxylicious.filter.encryption;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/common/PersistedIdentifiable.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/common/PersistedIdentifiable.java
@@ -7,7 +7,7 @@
 package io.kroxylicious.filter.encryption.common;
 
 /**
- * <p>Abstraction for identifying specific behaviours (implementations such as {@link io.kroxylicious.filter.encryption.dek.Aes#AES_256_GCM_128}
+ * <p>Abstraction for identifying specific behaviours (implementations such as {@link io.kroxylicious.filter.encryption.dek.Aes}
  * or {@link io.kroxylicious.filter.encryption.dek.ChaChaPoly#INSTANCE})
  * from a set of possible behaviours (interfaces such as {@link io.kroxylicious.filter.encryption.dek.CipherManager}) in a way that guarantees
  * backwards compatibility between releases of the filter.</p>
@@ -21,7 +21,7 @@ package io.kroxylicious.filter.encryption.common;
  *
  * <h2>Example</h2>
  * <p>Users refer to a specific cipher via an element of the enum {@link io.kroxylicious.filter.encryption.config.CipherSpec} (this is the name).
- * When a particular {@link io.kroxylicious.filter.encryption.dek.CipherManager} implementation (such as {@link io.kroxylicious.filter.encryption.dek.Aes#AES_256_GCM_128})
+ * When a particular {@link io.kroxylicious.filter.encryption.dek.CipherManager} implementation (such as {@link io.kroxylicious.filter.encryption.dek.Aes})
  * is used to encrypt a plaintext we store it's {@link #serializedId()} in the record.
  * When we need to decrypt that a ciphertext we use the {@link #serializedId()} within the record to recover the implementation.</p>
  *

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/CipherOverrideConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/CipherOverrideConfig.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.config;
+
+import java.util.Map;
+
+public record CipherOverrideConfig(Map<CipherSpec, CipherOverrides> overridesMap) {}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/CipherOverrides.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/CipherOverrides.java
@@ -6,4 +6,4 @@
 
 package io.kroxylicious.filter.encryption.config;
 
-public record CipherOverrides(String transformation) {}
+public record CipherOverrides(String transformation, String provider) {}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/CipherOverrides.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/CipherOverrides.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.config;
+
+public record CipherOverrides(String transformation) {}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/RecordEncryptionConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/RecordEncryptionConfig.java
@@ -98,6 +98,6 @@ public record RecordEncryptionConfig(@JsonProperty(required = true) @PluginImplN
     }
 
     private @NonNull CipherOverrides getOverridesForSpec(CipherSpec spec) {
-        return new CipherOverrides(getExperimentalString(spec.name() + ".transformationOverride"));
+        return new CipherOverrides(getExperimentalString(spec.name() + ".transformationOverride"), getExperimentalString(spec.name() + ".provider"));
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/Encryption.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/Encryption.java
@@ -8,6 +8,7 @@ package io.kroxylicious.filter.encryption.crypto;
 
 import io.kroxylicious.filter.encryption.common.PersistedIdentifiable;
 import io.kroxylicious.filter.encryption.config.AadSpec;
+import io.kroxylicious.filter.encryption.config.CipherOverrideConfig;
 import io.kroxylicious.filter.encryption.config.CipherSpec;
 import io.kroxylicious.filter.encryption.config.EncryptionVersion;
 import io.kroxylicious.filter.encryption.dek.CipherSpecResolver;
@@ -24,11 +25,15 @@ import io.kroxylicious.filter.encryption.dek.CipherSpecResolver;
 public class Encryption implements PersistedIdentifiable<EncryptionVersion> {
 
     public static final Encryption V1 = new Encryption((byte) 1, EncryptionVersion.V1_UNSUPPORTED, WrapperV1.INSTANCE, ParcelV1.INSTANCE);
-    public static final Encryption V2 = new Encryption((byte) 2, EncryptionVersion.V2,
-            new WrapperV2(
-                    CipherSpecResolver.of(CipherSpec.AES_256_GCM_128),
-                    AadResolver.of(AadSpec.NONE)),
-            ParcelV1.INSTANCE);
+
+    public static Encryption v2(CipherOverrideConfig config) {
+        return new Encryption((byte) 2, EncryptionVersion.V2,
+                new WrapperV2(
+                        CipherSpecResolver.of(config, CipherSpec.AES_256_GCM_128),
+                        AadResolver.of(AadSpec.NONE)),
+                ParcelV1.INSTANCE);
+    }
+
     /***
      * take extreme care when updating the implementations, because new versions are forever once released.
      * If you're adding a new version here you will also need to add it to {@link EncryptionResolver#ALL}.

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/EncryptionResolver.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/crypto/EncryptionResolver.java
@@ -10,11 +10,14 @@ import java.util.Collection;
 import java.util.List;
 
 import io.kroxylicious.filter.encryption.common.AbstractResolver;
+import io.kroxylicious.filter.encryption.config.CipherOverrideConfig;
 import io.kroxylicious.filter.encryption.config.EncryptionVersion;
 
 public class EncryptionResolver extends AbstractResolver<EncryptionVersion, Encryption, EncryptionResolver> {
 
-    public static final EncryptionResolver ALL = new EncryptionResolver(List.of(Encryption.V1, Encryption.V2));
+    public static EncryptionResolver all(CipherOverrideConfig config) {
+        return new EncryptionResolver(List.of(Encryption.V1, Encryption.v2(config)));
+    }
 
     EncryptionResolver(Collection<Encryption> impls) {
         super(impls);

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/CipherSpecResolver.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/CipherSpecResolver.java
@@ -10,13 +10,16 @@ import java.util.Collection;
 import java.util.List;
 
 import io.kroxylicious.filter.encryption.common.AbstractResolver;
+import io.kroxylicious.filter.encryption.config.CipherOverrideConfig;
 import io.kroxylicious.filter.encryption.config.CipherSpec;
 
 public class CipherSpecResolver extends AbstractResolver<CipherSpec, CipherManager, CipherSpecResolver> {
 
-    public static final CipherSpecResolver ALL = new CipherSpecResolver(List.of(
-            Aes.AES_256_GCM_128,
-            ChaChaPoly.INSTANCE));
+    public static CipherSpecResolver all(CipherOverrideConfig cipherOverrideConfig) {
+        return new CipherSpecResolver(List.of(
+                Aes.aes256gcm128(cipherOverrideConfig),
+                ChaChaPoly.INSTANCE));
+    }
 
     public CipherSpecResolver(Collection<CipherManager> impls) {
         super(impls);
@@ -27,8 +30,8 @@ public class CipherSpecResolver extends AbstractResolver<CipherSpec, CipherManag
         return new UnknownCipherSpecException(msg);
     }
 
-    public static CipherSpecResolver of(CipherSpec... cipherSpec) {
-        return ALL.subset(cipherSpec);
+    public static CipherSpecResolver of(CipherOverrideConfig cipherOverrideConfig, CipherSpec... cipherSpec) {
+        return all(cipherOverrideConfig).subset(cipherSpec);
     }
 
     @Override

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/EncryptionDekCache.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/EncryptionDekCache.java
@@ -54,11 +54,12 @@ public class EncryptionDekCache<K, E> {
                               @Nullable Executor dekCacheExecutor,
                               int dekCacheMaxItems,
                               @NonNull Duration refreshAfterWrite,
-                              @NonNull Duration expireAfterWrite) {
+                              @NonNull Duration expireAfterWrite,
+                              CipherSpecResolver cipherSpecResolver) {
         Objects.requireNonNull(refreshAfterWrite, "refreshAfterWrite is null");
         Objects.requireNonNull(expireAfterWrite, "expireAfterWrite is null");
         this.dekManager = Objects.requireNonNull(dekManager);
-        this.cipherSpecResolver = CipherSpecResolver.ALL;
+        this.cipherSpecResolver = cipherSpecResolver;
         Caffeine<Object, Object> cache = Caffeine.newBuilder();
         if (dekCacheMaxItems != NO_MAX_CACHE_SIZE) {
             cache = cache.maximumSize(dekCacheMaxItems);

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionTest.java
@@ -180,7 +180,7 @@ class RecordEncryptionTest {
         AbstractThrowableAssert<?, ? extends Throwable> throwableAssert = assertThatThrownBy(() -> {
             RecordEncryption.checkCipherSuite(cipherSpec -> {
                 throw new DekException("Could not construct cipher for " + cipherSpec);
-            });
+            }, configuration);
         }).isInstanceOf(EncryptionConfigurationException.class);
         throwableAssert.hasMessageContaining("Cipher Suite check failed, one or more ciphers could not be loaded");
         for (CipherSpec value : CipherSpec.values()) {
@@ -190,7 +190,7 @@ class RecordEncryptionTest {
 
     @Test
     void checkCipherSuiteSuccess() {
-        assertThatCode(() -> RecordEncryption.checkCipherSuite(cipherSpec -> arbitraryCipher)).doesNotThrowAnyException();
+        assertThatCode(() -> RecordEncryption.checkCipherSuite(cipherSpec -> arbitraryCipher, configuration)).doesNotThrowAnyException();
     }
 
 }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/crypto/EncryptionTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/crypto/EncryptionTest.java
@@ -6,9 +6,12 @@
 
 package io.kroxylicious.filter.encryption.crypto;
 
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.filter.encryption.config.AadSpec;
+import io.kroxylicious.filter.encryption.config.CipherOverrideConfig;
 import io.kroxylicious.filter.encryption.config.CipherSpec;
 import io.kroxylicious.filter.encryption.dek.Aes;
 import io.kroxylicious.filter.encryption.dek.UnknownCipherSpecException;
@@ -27,21 +30,23 @@ class EncryptionTest {
     @Test
     void v2() {
         // Encryption v1 supports WrapperV2
-        assertThat(Encryption.V2.wrapper()).isExactlyInstanceOf(WrapperV2.class);
+        assertThat(Encryption.v2(new CipherOverrideConfig(Map.of())).wrapper()).isExactlyInstanceOf(WrapperV2.class);
 
         // Encryption v1 supports ParcelV1
-        assertThat(Encryption.V2.parcel()).isExactlyInstanceOf(ParcelV1.class);
+        assertThat(Encryption.v2(new CipherOverrideConfig(Map.of())).parcel()).isExactlyInstanceOf(ParcelV1.class);
 
-        var cipherSpecResolver = ((WrapperV2) Encryption.V2.wrapper()).cipherSpecResolver();
+        var cipherSpecResolver = ((WrapperV2) Encryption.v2(new CipherOverrideConfig(Map.of())).wrapper()).cipherSpecResolver();
         // Encryption v1 supports AES, does not support CHACHA
-        assertThat(cipherSpecResolver.fromName(CipherSpec.AES_256_GCM_128)).isSameAs(Aes.AES_256_GCM_128);
-        assertThat(cipherSpecResolver.fromSerializedId(Aes.AES_256_GCM_128.serializedId())).isSameAs(Aes.AES_256_GCM_128);
-        assertThat(cipherSpecResolver.toSerializedId(Aes.AES_256_GCM_128)).isEqualTo(Aes.AES_256_GCM_128.serializedId());
+        assertThat(cipherSpecResolver.fromName(CipherSpec.AES_256_GCM_128)).isEqualTo(Aes.aes256gcm128(new CipherOverrideConfig(Map.of())));
+        assertThat(cipherSpecResolver.fromSerializedId(Aes.aes256gcm128(new CipherOverrideConfig(Map.of())).serializedId())).isEqualTo(Aes.aes256gcm128(
+                new CipherOverrideConfig(Map.of())));
+        assertThat(cipherSpecResolver.toSerializedId(Aes.aes256gcm128(new CipherOverrideConfig(Map.of()))))
+                .isEqualTo(Aes.aes256gcm128(new CipherOverrideConfig(Map.of())).serializedId());
         // Encryption v1 does not support CHACHA
         assertThatThrownBy(() -> cipherSpecResolver.fromName(CipherSpec.CHACHA20_POLY1305)).isExactlyInstanceOf(UnknownCipherSpecException.class)
                 .hasMessage("Unknown CipherSpec name: CHACHA20_POLY1305");
 
-        var aadResolver = ((WrapperV2) Encryption.V2.wrapper()).aadResolver();
+        var aadResolver = ((WrapperV2) Encryption.v2(new CipherOverrideConfig(Map.of())).wrapper()).aadResolver();
         // Encryption v1 supports AAD.NONE
         assertThat(aadResolver.fromName(AadSpec.NONE)).isExactlyInstanceOf(AadNone.class);
         assertThat(aadResolver.fromSerializedId(AadNone.INSTANCE.serializedId())).isExactlyInstanceOf(AadNone.class);

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/AesTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/AesTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.dek;
+
+import java.util.Map;
+
+import javax.crypto.Cipher;
+
+import io.kroxylicious.filter.encryption.config.EncryptionConfigurationException;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.filter.encryption.config.CipherOverrideConfig;
+import io.kroxylicious.filter.encryption.config.CipherOverrides;
+import io.kroxylicious.filter.encryption.config.CipherSpec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AesTest {
+
+    @Test
+    void defaultAes256gcm128TransformationEmptyConfig() {
+        Aes aes = Aes.aes256gcm128(new CipherOverrideConfig(Map.of()));
+        Cipher cipher = aes.newCipher();
+        assertThat(cipher.getAlgorithm()).isEqualTo("AES_256/GCM/NoPadding");
+    }
+
+    @Test
+    void defaultAes256gcm128TransformationNullOverride() {
+        Aes aes = Aes.aes256gcm128(new CipherOverrideConfig(Map.of(CipherSpec.AES_256_GCM_128, new CipherOverrides(null, null))));
+        Cipher cipher = aes.newCipher();
+        assertThat(cipher.getAlgorithm()).isEqualTo("AES_256/GCM/NoPadding");
+    }
+
+    @Test
+    void overrideAes256gcm128Transformation() {
+        Aes aes = Aes.aes256gcm128(new CipherOverrideConfig(Map.of(CipherSpec.AES_256_GCM_128, new CipherOverrides("AES/GCM/NoPadding", null))));
+        Cipher cipher = aes.newCipher();
+        assertThat(cipher.getAlgorithm()).isEqualTo("AES/GCM/NoPadding");
+    }
+
+    @Test
+    void cannotOverrideAes256gcm128TransformationToArbitraryAlgorithm() {
+        CipherOverrideConfig cipherOverrideConfig = new CipherOverrideConfig(
+                Map.of(CipherSpec.AES_256_GCM_128, new CipherOverrides("ChaCha20-Poly1305/NONE/NoPadding", null)));
+        assertThatThrownBy(() -> Aes.aes256gcm128(cipherOverrideConfig)).isInstanceOf(EncryptionConfigurationException.class).hasMessage(
+                "AES_256_GCM_128 override transformation: ChaCha20-Poly1305/NONE/NoPadding is not one of the allowed values: [AES/GCM/NoPadding, AES_256/GCM/NoPadding]");
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/AesTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/AesTest.java
@@ -6,17 +6,18 @@
 
 package io.kroxylicious.filter.encryption.dek;
 
+import java.security.Security;
 import java.util.Map;
 
 import javax.crypto.Cipher;
 
-import io.kroxylicious.filter.encryption.config.EncryptionConfigurationException;
-
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.filter.encryption.config.CipherOverrideConfig;
 import io.kroxylicious.filter.encryption.config.CipherOverrides;
 import io.kroxylicious.filter.encryption.config.CipherSpec;
+import io.kroxylicious.filter.encryption.config.EncryptionConfigurationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -50,6 +51,22 @@ class AesTest {
                 Map.of(CipherSpec.AES_256_GCM_128, new CipherOverrides("ChaCha20-Poly1305/NONE/NoPadding", null)));
         assertThatThrownBy(() -> Aes.aes256gcm128(cipherOverrideConfig)).isInstanceOf(EncryptionConfigurationException.class).hasMessage(
                 "AES_256_GCM_128 override transformation: ChaCha20-Poly1305/NONE/NoPadding is not one of the allowed values: [AES/GCM/NoPadding, AES_256/GCM/NoPadding]");
+    }
+
+    @Test
+    void overrideAes256gcm128Provider() {
+        BouncyCastleProvider alternativeProvider = new BouncyCastleProvider();
+        try {
+            Security.addProvider(alternativeProvider);
+            Aes aes = Aes
+                    .aes256gcm128(new CipherOverrideConfig(Map.of(CipherSpec.AES_256_GCM_128, new CipherOverrides("AES/GCM/NoPadding", alternativeProvider.getName()))));
+            Cipher cipher = aes.newCipher();
+            assertThat(cipher.getAlgorithm()).isEqualTo("AES/GCM/NoPadding");
+            assertThat(cipher.getProvider()).isEqualTo(alternativeProvider);
+        }
+        finally {
+            Security.removeProvider(alternativeProvider.getName());
+        }
     }
 
 }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/CipherManagerTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/CipherManagerTest.java
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
@@ -20,6 +21,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import io.kroxylicious.filter.encryption.config.CipherOverrideConfig;
 import io.kroxylicious.filter.encryption.config.CipherSpec;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,15 +29,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CipherManagerTest {
 
     public static List<Arguments> allCipherManagers() {
-        return Arrays.stream(CipherSpec.values()).map(cs -> Arguments.of(CipherSpecResolver.ALL.fromName(cs))).toList();
+        return Arrays.stream(CipherSpec.values()).map(cs -> Arguments.of(CipherSpecResolver.all(new CipherOverrideConfig(Map.of())).fromName(cs))).toList();
     }
 
     @ParameterizedTest
     @MethodSource("allCipherManagers")
     void serializedParamsGoodForDecrypt(CipherManager cipherManager) throws GeneralSecurityException {
 
-        assertThat(CipherSpecResolver.ALL.fromSerializedId(
-                CipherSpecResolver.ALL.toSerializedId(cipherManager))).isSameAs(cipherManager);
+        assertThat(CipherSpecResolver.all(new CipherOverrideConfig(Map.of())).fromSerializedId(
+                CipherSpecResolver.all(new CipherOverrideConfig(Map.of())).toSerializedId(cipherManager))).isEqualTo(cipherManager);
 
         var params = cipherManager.paramSupplier().get();
 

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/CipherSpecResolverTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/CipherSpecResolverTest.java
@@ -7,10 +7,12 @@
 package io.kroxylicious.filter.encryption.dek;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
+import io.kroxylicious.filter.encryption.config.CipherOverrideConfig;
 import io.kroxylicious.filter.encryption.config.CipherSpec;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -19,12 +21,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class CipherSpecResolverTest {
     @Test
     void fromPersistentIdShouldThrowIfUnknownPersistentId() {
-        assertThatThrownBy(() -> CipherSpecResolver.ALL.fromSerializedId((byte) 123)).isExactlyInstanceOf(UnknownCipherSpecException.class);
+        assertThatThrownBy(() -> CipherSpecResolver.all(new CipherOverrideConfig(Map.of())).fromSerializedId((byte) 123))
+                .isExactlyInstanceOf(UnknownCipherSpecException.class);
     }
 
     @Test
     void persistentIdsShouldBeUnique() {
-        assertThat(Arrays.stream(CipherSpec.values()).map(CipherSpecResolver.ALL::fromName).collect(Collectors.toSet()))
+        assertThat(Arrays.stream(CipherSpec.values()).map(CipherSpecResolver.all(new CipherOverrideConfig(Map.of()))::fromName).collect(Collectors.toSet()))
                 .hasSize(CipherSpec.values().length);
     }
 }

--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -151,6 +151,13 @@
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.78.1</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- the next two are used by the Netty Leak Detection test -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/RecordEncryptionFilterIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/RecordEncryptionFilterIT.java
@@ -18,6 +18,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import io.kroxylicious.filter.encryption.config.CipherOverrideConfig;
+
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -280,7 +282,7 @@ class RecordEncryptionFilterIT {
             List<byte[]> encryptionVersions = StreamSupport.stream(kafkaRecord.headers().headers(EncryptionHeader.ENCRYPTION_HEADER_NAME).spliterator(), false)
                     .map(Header::value).toList();
             assertThat(encryptionVersions).hasSize(1).singleElement(BYTE_ARRAY).hasSize(1);
-            Encryption encryption = EncryptionResolver.ALL.fromSerializedId(encryptionVersions.getFirst()[0]);
+            Encryption encryption = EncryptionResolver.all(new CipherOverrideConfig(Map.of())).fromSerializedId(encryptionVersions.getFirst()[0]);
             return encryption.wrapper().readSpecAndEdek(ByteBuffer.wrap(kafkaRecord.value()), BytesEdek.getSerde(), (cipherManager, o) -> o);
         }).collect(Collectors.toSet());
         assertThat(edeks).hasSizeGreaterThan(1);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Closes #1401

1. Enables the user to configure the transformation for `AES_256_GCM_128` to `AES/GCM/NoPadding` (but disallow setting it to other arbitrary algorithms)
2. Enables the user to configure the provider for `AES_256_GCM_128` so they can explicitly target an alternate provider like bouncycastle and fail at configuration time if that provider was not registered.
3. Add integration tests showing that a bouncycastle configuration fails without the provider registered, and then show that the encrypt/decrypt roundtrip works if bouncycastle is registered.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
