### PR TITLE
record-encryption: document KEK rotation implications and config

### DIFF
--- a/docs/modules/record-encryption/con-record-encryption-overview.adoc
+++ b/docs/modules/record-encryption/con-record-encryption-overview.adoc
@@ -15,7 +15,7 @@ Data is encrypted with a Data Encryption Key (DEK).
 The DEK is encrypted using a Key Encryption Key (KEK).
 The KEK is stored securely in a Key Management System (KMS).
 Symmetric encryption keys::
-AES(GCM) 256 bit encryption symmetric encryption keys are used to encrypt and decrypt record data. 
+AES(GCM) 256 bit encryption symmetric encryption keys are used to encrypt and decrypt record data.
 
 The process is as follows:
 
@@ -73,7 +73,17 @@ It is recommended to use the KMS in a high availability (HA) configuration.
 Key rotation involves periodically replacing cryptographic keys with new ones and is considered a best practice in cryptography.
 
 The filter allows the rotation of Key Encryption Keys (KEKs) within the Key Management System (KMS). 
-When a KEK is rotated, the new key material is used for newly produced records. Existing records, encrypted with older KEK versions, remain decryptable as long as the previous KEK versions are still in the KMS.
+When a KEK is rotated, the new key material is eventually used for newly produced records. Existing records, encrypted with older KEK versions, remain decryptable as long as the previous KEK versions are still available in the KMS.
+
+:fn-dek-refresh: footnote:[Assuming traffic is flowing regularly through your encrypted topic. The refresh is driven by \
+records that need encryption flowing through your topic. In cases where there are very infrequent messages flowing it is \
+possible for a DEK to be used up to 2 hours (by default) after creation.]
+
+When the KEK is rotated in the external KMS, it will take up to 1 hour (by default) before all{fn-dek-refresh} records produced by the filter
+contain a DEK encrypted with the new key material. This is because existing encrypted DEKs are used for a configurable
+amount of time after creation, the Filter caches the encrypted DEK, one hour after creation they are eligible to be refreshed.
+
+If you need to rotate key material immediately, execute a rolling restart of your cluster of Kroxylicious instances.
 
 WARNING: If an old KEK version is removed from the KMS, records encrypted with that key will become unreadable, causing fetch operations to fail. 
 In such cases, the consumer offset must be advanced beyond those records.
@@ -82,7 +92,7 @@ In such cases, the consumer offset must be advanced beyond those records.
 
 The record encryption filter encrypts only the values of records, leaving record keys, headers, and timestamps untouched. 
 Null record values, which might represent deletions in compacted topics, are transmitted to the broker unencrypted. 
-This approach ensures that compacted topics function correctly. 
+This approach ensures that compacted topics function correctly.
 
 == Unencrypted topics
 

--- a/docs/modules/record-encryption/proc-configuring-record-encryption-filter.adoc
+++ b/docs/modules/record-encryption/proc-configuring-record-encryption-filter.adoc
@@ -35,6 +35,10 @@ filters:
       selector: <KEK_selector_service_name> # <3>
       selectorConfig:
         template: "KEK_${topicName}" # <4>
+      experimental:
+        encryptionDekRefreshAfterWriteSeconds: 3600 # <5>
+        encryptionDekExpireAfterWriteSeconds: 7200 # <6>
+        maxEncryptionsPerDek: 5000000 # <7>
 	 # ...
 ----
 <1> The KMS service name.
@@ -42,7 +46,14 @@ filters:
 <3> The Key Encryption Key (KEK) selector to use. The `${topicName}` is a literal understood by the proxy. 
 For example, if using the `TemplateKekSelector` with the template `KEK_$\{topicName}`, create a key for every topic that
 is to be encrypted with the key name matching the topic name, prefixed by the string `KEK_`.
-<4> The template for deriving the KEK, based on a specific topic name. 
+<4> The template for deriving the KEK, based on a specific topic name.
+<5> How long after creation of a DEK before it becomes eligible for rotation. On the **next** encryption request, the cache will asynchronously create a new DEK.  Encryption requests will continue to use the old DEK until the new DEK is ready.
+<6> How long after creation of a DEK until it is removed from the cache. This setting puts an upper bound on how long a DEK can remain cached.
+<7> The maximum number of records any DEK should be used to encrypt. After this limit is hit, that DEK will be destroyed and a new one created.
+
+NOTE: `encryptionDekRefreshAfterWriteSeconds` and `encryptionDekExpireAfterWriteSeconds` help govern the "originator usage period" of the DEK. That is the period of time the DEK will be used to encrypt records.  Keeping the period short helps reduce the blast radius in the event that DEK key material is leaked. However, there is a trade-off. The additional KMS API calls will increase produce/consume latency and may increase your KMS provider costs. +
+      +
+      `maxEncryptionsPerDek` helps prevent key exhaustion by placing an upper limit of the amount of times that a DEK may be used to encrypt records.
 
 . Verify that the encryption has been applied to the specified topics by producing messages through the proxy and then consuming directly and indirectly from the Kafka cluster.
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Contributes to #1339 

We have added controls so that users can configure how quickly they respond. Users should be aware of how the Filter caches the encrypted DEKs and the tradeoff between KMS operations and the delay until new key material is applied.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
