### PR TITLE
Fix #1348: Rework the Record Encryption documentation describing the role of the administrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#1348](https://github.com/kroxylicious/kroxylicious/issues/1348) Fix #1348: Rework the Record Encryption documentation describing the role of the administrator
 * [#1415](https://github.com/kroxylicious/kroxylicious/pull/1415) Fix #1415: Improve record validation docs #1429
 * [#1417](https://github.com/kroxylicious/kroxylicious/pull/1417): Extend JsonSchemaValidator to validate the incoming schema id matches the expected.
 * [#1401](https://github.com/kroxylicious/kroxylicious/issues/1401): Support a FIPs-certified cipher from an alternative provider

--- a/docs/modules/record-encryption/aws-kms/con-aws-kms-key-creation.adoc
+++ b/docs/modules/record-encryption/aws-kms/con-aws-kms-key-creation.adoc
@@ -5,7 +5,7 @@
 [id='con-aws-kms-key-creation-{context}']
 = Creating AWS KMS keys
 
-As the Administrator, use either the AWS Console or CLI to
+As the administrator, use either the AWS Console or CLI to
 {aws}/kms/latest/developerguide/create-keys.html#create-symmetric-cmk[create] a *Symmetric key* with *Encrypt and decrypt*
 usage.  Multi-region keys are supported.  It is not possible to make use of keys from other AWS accountsfootnote:[https://github.com/kroxylicious/kroxylicious/issues/1217].
 

--- a/docs/modules/record-encryption/aws-kms/con-aws-kms-setup.adoc
+++ b/docs/modules/record-encryption/aws-kms/con-aws-kms-setup.adoc
@@ -17,11 +17,10 @@ the instructions accordingly.
 To use the filter, an administrator (or administrative process) must create the encryption keys within AWS KMS that will be used to encrypt the records.
 The organization deploying the Record Encryption filter is responsible for managing this administrator or process.
 
-The administrator must have permissions to create keys in AWS KMS.  As a starting point, the
-built-in AWS policy `AWSKeyManagementServicePowerUser` confers sufficient key management privileges.
+The administrator must have permissions to create keys in AWS KMS.
+As a starting point, the built-in AWS policy `AWSKeyManagementServicePowerUser` confers sufficient key management privileges.
 
-To get started, use the following commands to set up an administrator with permissions
-suitable for managing encryption keys in KMS through an AWS Cloud Shell. 
+To get started, use the following commands to set up an administrator with permissions suitable for managing encryption keys in KMS through an AWS Cloud Shell.
 This example illustrates using the user name`kroxylicious-admin`, but you can choose a different name if preferred.  
 Adjust the instructions accordingly if you use a different user name.
 

--- a/docs/modules/record-encryption/aws-kms/con-aws-kms-setup.adoc
+++ b/docs/modules/record-encryption/aws-kms/con-aws-kms-setup.adoc
@@ -14,11 +14,10 @@ the instructions accordingly.
 
 == Role of the Administrator
 
-In order to use the filter, there must be an *Administrator*.  The Administrator has the responsibility
-to create encryption keys within AWS KMS which will be used to encrypt the records. It is up to the organization
-deploying Record Encryption to decide how the role of the *Administrator* maps into their organization structure.
+In order to use the filter, there must be an external entity which is responsible for creating encryption keys within AWS KMS which will be used to encrypt the records. It is up to the organization
+deploying Record Encryption to decide how this entity is managed.
 
-The *Administrator* must have permissions to log in to AWS and create keys in AWS KMS.  As a starting point, the
+The *Administrator* must have permissions to create keys in AWS KMS.  As a starting point, the
 built-in AWS policy `AWSKeyManagementServicePowerUser` confers sufficient key management privileges.
 
 To help get you started, the following commands can be used to establish an Administrator user with permissions
@@ -39,16 +38,16 @@ aws iam create-login-profile --user-name ${ADMIN} --password ${INITIAL_PASSWORD}
 echo Now log in at ${CONSOLE_URL}  with user name ${ADMIN} password ${INITIAL_PASSWORD} and change the password.
 ----
 
-== Filter IAM Identity
+== Establish an application identity for the Filter
 
 The filter needs to be able to authenticate to AWS in order to perform the operations needed for Envelope Encryption
 (generating and decrypting DEKs).  To this end, there must be an AWS IAM identity established for the filter itself with
 sufficient permissions.
 
-Use AWS IAM to create the `kroxylicious` user. Create an *Access Key* for this user. The Access Key/Secret Key pair
+Use AWS IAM to create the identity. Create an *Access Key* for this user. The Access Key/Secret Key pair
 will be used by the Filter. Do not enable the Console for this user.
 
-If using the CLI, these commands can be used to establish the Filter IAM Identity.  This example illustrates using the
+If using the CLI, these commands can be used to establish the IAM Identity for the Filter.  This example illustrates using the
 user-name `kroxylicious`. The choice of name is not significant.  If a different user-name is used, adapt the
 instructions accordingly.
 
@@ -58,7 +57,7 @@ aws iam create-user --user-name kroxylicious
 aws iam create-access-key --user-name kroxylicious
 ----
 
-== Create Alias Based Policy
+== Create Alias Based Policy for keys matching the KEK aliasing convention
 
 Create an alias based policy granting permissions to use keys aliased by the established alias naming convention.
 
@@ -93,9 +92,9 @@ EOF
 aws iam create-policy --policy-name KroxyliciousRecordEncryption --policy-document file:///tmp/policy
 ----
 
-== Apply Alias Based Policy to Filter IAM Identity
+== Apply the Alias Based Policy to the Filter's Application Identity
 
-Attach the alias policy to the Filter IAM Identity.  This will allow the Filter to invoke the
+Attach the alias policy to the Filter's Application Identity.  This will allow the filter to invoke the
 necessary key operations on all KEKs with aliases of the prescribed form.
 
 [source,shell]

--- a/docs/modules/record-encryption/aws-kms/con-aws-kms-setup.adoc
+++ b/docs/modules/record-encryption/aws-kms/con-aws-kms-setup.adoc
@@ -12,7 +12,7 @@ filter to be kept separate from any keys used by other systems. This document as
 will be to prefix the alias used by the filter with the word `KEK_`. If a different naming convention is used, adapt
 the instructions accordingly.
 
-== Role of the Administrator
+== Role of the administrator
 
 In order to use the filter, there must be an external entity which is responsible for creating encryption keys within AWS KMS which will be used to encrypt the records. It is up to the organization
 deploying Record Encryption to decide how this entity is managed.
@@ -20,10 +20,10 @@ deploying Record Encryption to decide how this entity is managed.
 The *Administrator* must have permissions to create keys in AWS KMS.  As a starting point, the
 built-in AWS policy `AWSKeyManagementServicePowerUser` confers sufficient key management privileges.
 
-To help get you started, the following commands can be used to establish an Administrator user with permissions
-suitable for managing encryption keys in KMS via an AWS Cloud Shell. This example illustrates using the user-name
-`kroxylicious-admin` but the choice of name is not significant.  If a different user-name is used, adapt the
-instructions accordingly.
+To get started, use the following commands to set up an administrator with permissions
+suitable for managing encryption keys in KMS through an AWS Cloud Shell. 
+This example illustrates using the user name`kroxylicious-admin`, but you can choose a different name if preferred.  
+Adjust the instructions accordingly if you use a different user name.
 
 [source,shell]
 ----
@@ -38,11 +38,10 @@ aws iam create-login-profile --user-name ${ADMIN} --password ${INITIAL_PASSWORD}
 echo Now log in at ${CONSOLE_URL}  with user name ${ADMIN} password ${INITIAL_PASSWORD} and change the password.
 ----
 
-== Establish an application identity for the Filter
+== Establish an application identity for the filter
 
-The filter needs to be able to authenticate to AWS in order to perform the operations needed for Envelope Encryption
-(generating and decrypting DEKs).  To this end, there must be an AWS IAM identity established for the filter itself with
-sufficient permissions.
+The filter must authenticate to AWS in order to perform envelope encryption operations, such as generating and decrypting DEKs. 
+Therefore, an AWS IAM identity with sufficient permissions must be created for the filter.
 
 Use AWS IAM to create the identity. Create an *Access Key* for this user. The Access Key/Secret Key pair
 will be used by the Filter. Do not enable the Console for this user.

--- a/docs/modules/record-encryption/aws-kms/con-aws-kms-setup.adoc
+++ b/docs/modules/record-encryption/aws-kms/con-aws-kms-setup.adoc
@@ -46,9 +46,9 @@ Use AWS IAM to create this identity and generate an *Access Key* for it.
 The Access Key/Secret Key pair is used by the filter. 
 Do not enable console access for this user.
 
-If using the CLI, these commands can be used to establish the IAM Identity for the Filter.  This example illustrates using the
-user-name `kroxylicious`. The choice of name is not significant.  If a different user-name is used, adapt the
-instructions accordingly.
+Using the CLI, the following commands create the IAM identity for the filter. 
+This example uses the user name `kroxylicious`, but you can choose a different name if needed. 
+Adjust the instructions accordingly if using a different user name.
 
 [source,shell]
 ----

--- a/docs/modules/record-encryption/aws-kms/con-aws-kms-setup.adoc
+++ b/docs/modules/record-encryption/aws-kms/con-aws-kms-setup.adoc
@@ -42,8 +42,9 @@ echo Now log in at ${CONSOLE_URL}  with user name ${ADMIN} password ${INITIAL_PA
 The filter must authenticate to AWS in order to perform envelope encryption operations, such as generating and decrypting DEKs. 
 Therefore, an AWS IAM identity with sufficient permissions must be created for the filter.
 
-Use AWS IAM to create the identity. Create an *Access Key* for this user. The Access Key/Secret Key pair
-will be used by the Filter. Do not enable the Console for this user.
+Use AWS IAM to create this identity and generate an *Access Key* for it. 
+The Access Key/Secret Key pair is used by the filter. 
+Do not enable console access for this user.
 
 If using the CLI, these commands can be used to establish the IAM Identity for the Filter.  This example illustrates using the
 user-name `kroxylicious`. The choice of name is not significant.  If a different user-name is used, adapt the

--- a/docs/modules/record-encryption/aws-kms/con-aws-kms-setup.adoc
+++ b/docs/modules/record-encryption/aws-kms/con-aws-kms-setup.adoc
@@ -7,10 +7,9 @@
 
 The filter references KEKs within AWS via an {aws}/kms/latest/developerguide/alias-about.html[AWS key alias].
 
-It is necessary to establish a naming convention for the alias names. This will allow the keys used by the
-filter to be kept separate from any keys used by other systems. This document assumes that the naming convention
-will be to prefix the alias used by the filter with the word `KEK_`. If a different naming convention is used, adapt
-the instructions accordingly.
+Establish a naming convention for key aliases to keep the filter’s keys separate from those used by other systems.
+Here, we use a prefix of KEK_ for filter aliases.
+Adjust the instructions if a different naming convention is used.
 
 == Role of the administrator
 

--- a/docs/modules/record-encryption/aws-kms/con-aws-kms-setup.adoc
+++ b/docs/modules/record-encryption/aws-kms/con-aws-kms-setup.adoc
@@ -93,8 +93,8 @@ aws iam create-policy --policy-name KroxyliciousRecordEncryption --policy-docume
 
 == Apply the alias-based policy to the filter's application identity
 
-Attach the alias policy to the Filter's Application Identity.  This will allow the filter to invoke the
-necessary key operations on all KEKs with aliases of the prescribed form.
+Attach the alias policy to the filter's application identity. 
+This will allow the filter to perform key operations on all KEKs with aliases that match the specified naming convention.
 
 [source,shell]
 ----

--- a/docs/modules/record-encryption/aws-kms/con-aws-kms-setup.adoc
+++ b/docs/modules/record-encryption/aws-kms/con-aws-kms-setup.adoc
@@ -91,7 +91,7 @@ EOF
 aws iam create-policy --policy-name KroxyliciousRecordEncryption --policy-document file:///tmp/policy
 ----
 
-== Apply the Alias Based Policy to the Filter's Application Identity
+== Apply the alias-based policy to the filter's application identity
 
 Attach the alias policy to the Filter's Application Identity.  This will allow the filter to invoke the
 necessary key operations on all KEKs with aliases of the prescribed form.

--- a/docs/modules/record-encryption/aws-kms/con-aws-kms-setup.adoc
+++ b/docs/modules/record-encryption/aws-kms/con-aws-kms-setup.adoc
@@ -12,17 +12,18 @@ filter to be kept separate from any keys used by other systems. This document as
 will be to prefix the alias used by the filter with the word `KEK_`. If a different naming convention is used, adapt
 the instructions accordingly.
 
-== Administrator Actor
+== Role of the Administrator
 
-To use the filter, there must be an administrative identity established within AWS IAM.  This user, which is likely to be a human,
-has the responsibility to manage keys and aliases within AWS KMS for use by the filter.
+In order to use the filter, there must be an *Administrator*.  The Administrator has the responsibility
+to create encryption keys within AWS KMS which will be used to encrypt the records. It is up to the organization
+deploying Record Encryption to decide how the role of the *Administrator* maps into their organization structure.
 
-Use AWS IAM to create a `kroxylicious-admin` user. Attach the policies `AWSKeyManagementServicePowerUser` and `IAMUserChangePassword`
-to the user. You may wish to attach policy `AWSCloudShellFullAccess` so the Administrator can use the AWS CloudShell to
-use CLI to manage the KEKs. Grant the user access to the Console.
+The *Administrator* must have permissions to log in to AWS and create keys in AWS KMS.  As a starting point, the
+built-in AWS policy `AWSKeyManagementServicePowerUser` confers sufficient key management privileges.
 
-If using the CLI, the following commands can be used to establish the Administrator user.  This example illustrates using the
-user-name `kroxylicious-admin`.  The choice of name is not significant.  If a different user-name is used, adapt the
+To help get you started, the following commands can be used to establish an Administrator user with permissions
+suitable for managing encryption keys in KMS via an AWS Cloud Shell. This example illustrates using the user-name
+`kroxylicious-admin` but the choice of name is not significant.  If a different user-name is used, adapt the
 instructions accordingly.
 
 [source,shell]
@@ -38,16 +39,17 @@ aws iam create-login-profile --user-name ${ADMIN} --password ${INITIAL_PASSWORD}
 echo Now log in at ${CONSOLE_URL}  with user name ${ADMIN} password ${INITIAL_PASSWORD} and change the password.
 ----
 
-== Filter Actor
+== Filter IAM Identity
 
-The Record Encryption Filter needs to be able to log in to AWS itself.  For this there needs to be service account
-identity established within AWS IAM.
+The filter needs to be able to authenticate to AWS in order to perform the operations needed for Envelope Encryption
+(generating and decrypting DEKs).  To this end, there must be an AWS IAM identity established for the filter itself with
+sufficient permissions.
 
 Use AWS IAM to create the `kroxylicious` user. Create an *Access Key* for this user. The Access Key/Secret Key pair
 will be used by the Filter. Do not enable the Console for this user.
 
-If using the CLI, these commands can be used to establish the Filter Actor.  This example illustrates using the user-name
-`kroxylicious`. The choice of name is not significant.  If a different user-name is used, adapt the
+If using the CLI, these commands can be used to establish the Filter IAM Identity.  This example illustrates using the
+user-name `kroxylicious`. The choice of name is not significant.  If a different user-name is used, adapt the
 instructions accordingly.
 
 [source,shell]
@@ -91,9 +93,9 @@ EOF
 aws iam create-policy --policy-name KroxyliciousRecordEncryption --policy-document file:///tmp/policy
 ----
 
-== Apply Alias Based Policy to Filter Actor
+== Apply Alias Based Policy to Filter IAM Identity
 
-Attach the alias policy to the Filter Actor user.  This will allow the Filter actor to invoke the
+Attach the alias policy to the Filter IAM Identity.  This will allow the Filter to invoke the
 necessary key operations on all KEKs with aliases of the prescribed form.
 
 [source,shell]

--- a/docs/modules/record-encryption/aws-kms/con-aws-kms-setup.adoc
+++ b/docs/modules/record-encryption/aws-kms/con-aws-kms-setup.adoc
@@ -56,7 +56,7 @@ aws iam create-user --user-name kroxylicious
 aws iam create-access-key --user-name kroxylicious
 ----
 
-== Create Alias Based Policy for keys matching the KEK aliasing convention
+== Create an alias-based policy for KEK aliases
 
 Create an alias based policy granting permissions to use keys aliased by the established alias naming convention.
 

--- a/docs/modules/record-encryption/aws-kms/con-aws-kms-setup.adoc
+++ b/docs/modules/record-encryption/aws-kms/con-aws-kms-setup.adoc
@@ -14,10 +14,10 @@ the instructions accordingly.
 
 == Role of the administrator
 
-In order to use the filter, there must be an external entity which is responsible for creating encryption keys within AWS KMS which will be used to encrypt the records. It is up to the organization
-deploying Record Encryption to decide how this entity is managed.
+To use the filter, an administrator (or administrative process) must create the encryption keys within AWS KMS that will be used to encrypt the records.
+The organization deploying the Record Encryption filter is responsible for managing this administrator or process.
 
-The *Administrator* must have permissions to create keys in AWS KMS.  As a starting point, the
+The administrator must have permissions to create keys in AWS KMS.  As a starting point, the
 built-in AWS policy `AWSKeyManagementServicePowerUser` confers sufficient key management privileges.
 
 To get started, use the following commands to set up an administrator with permissions

--- a/docs/modules/record-encryption/hashicorp-vault/con-vault-key-creation.adoc
+++ b/docs/modules/record-encryption/hashicorp-vault/con-vault-key-creation.adoc
@@ -5,7 +5,7 @@
 [id='con-vault-key-creation-{context}']
 = Creating HashiCorp Vault keys
 
-As the Administrator, use either the HashiCorp UI or CLI to create AES-256 symmetric keys following your
+As the administrator, use either the HashiCorp UI or CLI to create AES-256 symmetric keys following your
 key naming convention. The key type must be `aes256-gcm96`, which is Vault's default key type.
 
 TIP: It is recommended to use a key rotation policy.

--- a/docs/modules/record-encryption/hashicorp-vault/con-vault-key-creation.adoc
+++ b/docs/modules/record-encryption/hashicorp-vault/con-vault-key-creation.adoc
@@ -5,7 +5,7 @@
 [id='con-vault-key-creation-{context}']
 = Creating HashiCorp Vault keys
 
-Using the Administrator actor, use either the HashiCorp UI or CLI to create AES-256 symmetric keys following your
+As the Administrator, use either the HashiCorp UI or CLI to create AES-256 symmetric keys following your
 key naming convention. The key type must be `aes256-gcm96`, which is Vault's default key type.
 
 TIP: It is recommended to use a key rotation policy.

--- a/docs/modules/record-encryption/hashicorp-vault/con-vault-setup.adoc
+++ b/docs/modules/record-encryption/hashicorp-vault/con-vault-setup.adoc
@@ -47,10 +47,9 @@ https://myvaultinstance:8200/v1/mytransit
 
 == Establish the naming convention for keys within Vault hierarchy
 
-It is necessary to determine a naming convention for the KEKs within Vault.  This will allow the keys used by the
-filter to be kept separate from any keys used by other systems.  This document assumes that the naming convention
-will be to prefix the keys used by the filter with the word `KEK_`.  If a different naming convention is used, adapt
-the instructions accordingly.
+Establish a naming convention for keys to keep the filter’s keys separate from those used by other systems.
+Here, we use a prefix of KEK_ for filter key name.
+Adjust the instructions if a different naming convention is used.
 
 == Role of the administrator
 

--- a/docs/modules/record-encryption/hashicorp-vault/con-vault-setup.adoc
+++ b/docs/modules/record-encryption/hashicorp-vault/con-vault-setup.adoc
@@ -58,7 +58,7 @@ In order to use the filter, there must be an *Administrator*.  The Administrator
 to create encryption keys within Vault which will be used to encrypt the records. It is up to the organization
 deploying Record Encryption to decide how the role of the *Administrator* maps into their organization structure.
 
-The *Administrator* must have permissions to log in to Vault and create keys beneath `transit/keys/KEK_*` in the
+The *Administrator* must have permissions to create keys beneath `transit/keys/KEK_*` in the
 Vault hierarchy.
 
 As a guideline, the minimal Vault policy required by the *Administrator* is as follows:
@@ -70,7 +70,7 @@ capabilities = ["read", "write"]
 }
 ----
 
-== Filter Token
+== Establish an application identity for the Filter
 
 The filter needs to be able to authenticate to Vault in order to perform the operations needed for Envelope Encryption
 (generating and decrypting DEKs).  To this end, there must be a Vault identity established for the filter itself with

--- a/docs/modules/record-encryption/hashicorp-vault/con-vault-setup.adoc
+++ b/docs/modules/record-encryption/hashicorp-vault/con-vault-setup.adoc
@@ -58,10 +58,10 @@ In order to use the filter, there must be an *Administrator*.  The Administrator
 to create encryption keys within Vault which will be used to encrypt the records. It is up to the organization
 deploying Record Encryption to decide how the role of the *Administrator* maps into their organization structure.
 
-The *Administrator* must have permissions to create keys beneath `transit/keys/KEK_*` in the
+The administrator must have permissions to create keys beneath `transit/keys/KEK_*` in the
 Vault hierarchy.
 
-As a guideline, the minimal Vault policy required by the *Administrator* is as follows:
+As a guideline, the minimal Vault policy required by the administrator is as follows:
 
 [source,shell]
 ----
@@ -70,11 +70,10 @@ capabilities = ["read", "write"]
 }
 ----
 
-== Establish an application identity for the Filter
+== Establish an application identity for the filter
 
-The filter needs to be able to authenticate to Vault in order to perform the operations needed for Envelope Encryption
-(generating and decrypting DEKs).  To this end, there must be a Vault identity established for the filter itself with
-sufficient permissions.
+The filter must authenticate to Vault in order to perform envelope encryption operations, such as generating and decrypting DEKs
+Therefore, a Vault identity with sufficient permissions must be created for the filter.
 
 Create a Vault policy for the filter:
 
@@ -122,7 +121,8 @@ token_policies     [kroxylicious_encryption_filter_policy]
 ----
 
 The token must be {hashicorp-vault}/docs/concepts/tokens#token-time-to-live-periodic-tokens-and-explicit-max-ttls[renewed]
-before expiration.  It is the responsibility of the *Administrator* to do this.
+before expiration.  
+It is the responsibility of the administrator to do this.
 
 This can be done with a command like:
 

--- a/docs/modules/record-encryption/hashicorp-vault/con-vault-setup.adoc
+++ b/docs/modules/record-encryption/hashicorp-vault/con-vault-setup.adoc
@@ -54,9 +54,8 @@ the instructions accordingly.
 
 == Role of the Administrator
 
-In order to use the filter, there must be an *Administrator*.  The Administrator has the responsibility
-to create encryption keys within Vault which will be used to encrypt the records. It is up to the organization
-deploying Record Encryption to decide how the role of the *Administrator* maps into their organization structure.
+To use the filter, an administrator (or administrative process) must create the encryption keys within Vault that will be used to encrypt the records.
+The organization deploying the Record Encryption filter is responsible for managing this administrator or process.
 
 The administrator must have permissions to create keys beneath `transit/keys/KEK_*` in the
 Vault hierarchy.

--- a/docs/modules/record-encryption/hashicorp-vault/con-vault-setup.adoc
+++ b/docs/modules/record-encryption/hashicorp-vault/con-vault-setup.adoc
@@ -52,13 +52,12 @@ filter to be kept separate from any keys used by other systems.  This document a
 will be to prefix the keys used by the filter with the word `KEK_`.  If a different naming convention is used, adapt
 the instructions accordingly.
 
-== Role of the Administrator
+== Role of the administrator
 
 To use the filter, an administrator (or administrative process) must create the encryption keys within Vault that will be used to encrypt the records.
 The organization deploying the Record Encryption filter is responsible for managing this administrator or process.
 
-The administrator must have permissions to create keys beneath `transit/keys/KEK_*` in the
-Vault hierarchy.
+The administrator must have permissions to create keys beneath `transit/keys/KEK_*` in the Vault hierarchy.
 
 As a guideline, the minimal Vault policy required by the administrator is as follows:
 

--- a/docs/modules/record-encryption/hashicorp-vault/con-vault-setup.adoc
+++ b/docs/modules/record-encryption/hashicorp-vault/con-vault-setup.adoc
@@ -128,12 +128,12 @@ This can be done with a command like:
 vault token renew --accessor <token_accessor>
 ----
 
-== Testing the Kroxylicious Vault Token using the CLI
+== Testing the application identity for the filter using the CLI
 
-To test whether the Kroxylicious Vault Token and the policy are working correctly, a
+To test whether the application identity and the policy are working correctly, a
 https://raw.githubusercontent.com/kroxylicious/kroxylicious/main/scripts/validate_vault_token.sh[script] can be used.
 
-First, as an Administrator, create a KEK in the hierarchy at this path `transit/keys/KEK_testkey`.
+First, as the administrator, create a KEK in the hierarchy at this path `transit/keys/KEK_testkey`.
 
 [source,shell]
 ----

--- a/docs/modules/record-encryption/hashicorp-vault/con-vault-setup.adoc
+++ b/docs/modules/record-encryption/hashicorp-vault/con-vault-setup.adoc
@@ -52,18 +52,16 @@ filter to be kept separate from any keys used by other systems.  This document a
 will be to prefix the keys used by the filter with the word `KEK_`.  If a different naming convention is used, adapt
 the instructions accordingly.
 
-== Administrator Actor
+== Role of the Administrator
 
-To use the filter, there must be an administrative actor established.  This actor, which is likely to be a human,
-has the responsibility to create keys within Vault for use by the filter.
+In order to use the filter, there must be an *Administrator*.  The Administrator has the responsibility
+to create encryption keys within Vault which will be used to encrypt the records. It is up to the organization
+deploying Record Encryption to decide how the role of the *Administrator* maps into their organization structure.
 
-The Administrator must have permissions to log in to Vault and create keys beneath `transit/keys/KEK_*` in the
+The *Administrator* must have permissions to log in to Vault and create keys beneath `transit/keys/KEK_*` in the
 Vault hierarchy.
 
-The exact steps required to establish an administrative actor will depend on the way that Vault instance has been
-{hashicorp-vault}/tutorials/auth-methods[setup].
-
-A minimal Vault policy required by the Administrator is as follows:
+As a guideline, the minimal Vault policy required by the *Administrator* is as follows:
 
 [source,shell]
 ----
@@ -72,12 +70,13 @@ capabilities = ["read", "write"]
 }
 ----
 
-== Filter Actor
+== Filter Token
 
-To use the filter, there must be a Vault identity established for the filter itself.  This identity must have
-permissions to perform the operations needed for envelope encryption (generating and decrypting DEKs).
+The filter needs to be able to authenticate to Vault in order to perform the operations needed for Envelope Encryption
+(generating and decrypting DEKs).  To this end, there must be a Vault identity established for the filter itself with
+sufficient permissions.
 
-Create a Vault policy for the filter actor:
+Create a Vault policy for the filter:
 
 [source,shell]
 ----
@@ -101,7 +100,7 @@ configuration of the token to suit the standards required by your organization]:
 
 [source,shell]
 ----
-vault token create -display-name "kroxylicious encryption filter" \
+vault token create -display-name "kroxylicious record encryption" \
                    -policy=kroxylicious_encryption_filter_policy \
                    -period=768h \                                     <1>
                    -no-default-policy \                               <2>
@@ -123,7 +122,7 @@ token_policies     [kroxylicious_encryption_filter_policy]
 ----
 
 The token must be {hashicorp-vault}/docs/concepts/tokens#token-time-to-live-periodic-tokens-and-explicit-max-ttls[renewed]
-before expiration.  It is the responsibility of the Administrator to do this.
+before expiration.  It is the responsibility of the *Administrator* to do this.
 
 This can be done with a command like:
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix
- Documentation

### Description

The intent is to try to convey that the fact that something outside the system (an admin) needs to be responsible for creating KEKs that will be used by Record Encryption without dictating an organisational model or an account called 'kroxylicious-admin'.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [x] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
