### PR TITLE
Extend JsonSchemaValidator to validate the schema id used by the producer matches the schema id configured at the proxy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#1417](https://github.com/kroxylicious/kroxylicious/pull/1417): Extend JsonSchemaValidator to validate the incoming schema id matches the expected.
 * [#1401](https://github.com/kroxylicious/kroxylicious/issues/1401): Support a FIPs-certified cipher from an alternative provider
 * [#1416](https://github.com/kroxylicious/kroxylicious/pull/1416): Schema validation should not rely on the syntax validation
 * [#1393](https://github.com/kroxylicious/kroxylicious/pull/1393): Remove api versions service

--- a/kroxylicious-filters/kroxylicious-record-validation/pom.xml
+++ b/kroxylicious-filters/kroxylicious-record-validation/pom.xml
@@ -107,5 +107,9 @@
             <artifactId>spotbugs-annotations</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-serde-common</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSchemaBytebufValidator.java
@@ -12,31 +12,87 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.Record;
 
 import io.apicurio.registry.resolver.strategy.ArtifactReference;
+import io.apicurio.registry.serde.AbstractKafkaSerDe;
+import io.apicurio.registry.serde.DefaultIdHandler;
+import io.apicurio.registry.serde.IdHandler;
+import io.apicurio.registry.serde.headers.DefaultHeadersHandler;
+import io.apicurio.registry.serde.headers.HeadersHandler;
 import io.apicurio.schema.validation.json.JsonValidationResult;
 import io.apicurio.schema.validation.json.JsonValidator;
 
 import io.kroxylicious.proxy.filter.schema.validation.Result;
 
-public class JsonSchemaBytebufValidator implements BytebufValidator {
+import edu.umd.cs.findbugs.annotations.NonNull;
 
+public class JsonSchemaBytebufValidator implements BytebufValidator {
     private final JsonValidator jsonValidator;
+    private final Long globalId;
+    private final Map<Boolean, HeadersHandler> headerHandler;
+    private final Map<Boolean, IdHandler> idHandler;
 
     public JsonSchemaBytebufValidator(Map<String, Object> schemaResolverConfig, Long globalId) {
+        this.globalId = globalId;
         this.jsonValidator = new JsonValidator(schemaResolverConfig, Optional.of(ArtifactReference.fromGlobalId(globalId)));
+        this.headerHandler = Map.of(
+                true, buildHeaderHandler(true),
+                false, buildHeaderHandler(false));
+        this.idHandler = Map.of(
+                true, buildIdHandler(true),
+                false, buildIdHandler(false));
     }
 
     @Override
     public CompletionStage<Result> validate(ByteBuffer buffer, Record record, boolean isKey) {
         try {
-            JsonValidationResult jsonValidationResult = jsonValidator.validateByArtifactReference(buffer.clear());
+            // If the record includes a schema id, validate that it is consistent with the expected globalId.
+            Optional<Long> extractedGlobalId = extractGlobalIdFromRecord(buffer, record, isKey);
+            if (extractedGlobalId.filter(e -> !e.equals(globalId)).isPresent()) {
+                return CompletableFuture
+                        .completedStage(new Result(false, "Unexpected schema id in record (%d), expecting %d".formatted(extractedGlobalId.get(), globalId)));
+            }
+
+            JsonValidationResult jsonValidationResult = jsonValidator.validateByArtifactReference(buffer);
             return jsonValidationResult.success() ? Result.VALID_RESULT_STAGE
                     : CompletableFuture.completedFuture(new Result(false, jsonValidationResult.toString()));
         }
         catch (RuntimeException ex) {
-            return CompletableFuture.completedFuture(new Result(false, ex.getMessage()));
+            return CompletableFuture.completedStage(new Result(false, ex.getMessage()));
         }
+    }
+
+    private Optional<Long> extractGlobalIdFromRecord(ByteBuffer buffer, Record kafkaRecord, boolean isKey) {
+        if (kafkaRecord.headers().length > 0) {
+            var recordHeaders = new RecordHeaders(kafkaRecord.headers());
+            var ref = headerHandler.get(isKey).readHeaders(recordHeaders);
+
+            if (ref.getGlobalId() != null) {
+                return Optional.of(ref.getGlobalId());
+            }
+        }
+
+        var minBytes = 1 + idHandler.get(isKey).idSize();
+        if (buffer.remaining() > minBytes && buffer.get(buffer.position()) == AbstractKafkaSerDe.MAGIC_BYTE) {
+            buffer.get(); // ignore magic
+            return Optional.of(idHandler.get(isKey).readId(buffer).getGlobalId());
+        }
+        return Optional.empty();
+    }
+
+    @NonNull
+    private static DefaultHeadersHandler buildHeaderHandler(boolean isKey) {
+        var handler = new DefaultHeadersHandler();
+        handler.configure(Map.of(), isKey);
+        return handler;
+    }
+
+    @NonNull
+    private static DefaultIdHandler buildIdHandler(boolean isKey) {
+        var handler = new DefaultIdHandler();
+        handler.configure(Map.of(), isKey);
+        return handler;
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSchemaBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSchemaBytebufValidatorTest.java
@@ -37,8 +37,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JsonSchemaBytebufValidatorTest {
 
     private static final long GLOBAL_ID = 1L;
-    private static final byte[] VALID_JSON = "{\"firstName\":\"a\",\"lastName\":\"b\"}".getBytes(StandardCharsets.UTF_8);
-    private static final byte[] INVALID_JSON = "{\"firstName\":\"a\",\"lastName\":\"b\",\"age\":-3}".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] VALID_JSON = """
+            {"firstName":"a","lastName":"b"}""".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] INVALID_JSON = """
+            {"firstName":"a","lastName":"b","age":-3}""".getBytes(StandardCharsets.UTF_8);
     private static final byte[] RECORD_KEY = "a".getBytes(StandardCharsets.UTF_8);
 
     private static WireMockServer registryServer;
@@ -159,12 +161,11 @@ public class JsonSchemaBytebufValidatorTest {
         var future = validator.validate(record.value(), record, false);
         assertThat(future)
                 .succeedsWithin(Duration.ofSeconds(1))
-                .returns(false, Result::valid)
-                .returns("Unexpected schema id in record (2), expecting 1", Result::errorMessage);
+                .isEqualTo(new Result(false, "Unexpected schema id in record (2), expecting 1"));
     }
 
     @Test
-    void valueWithWrongSchemaIdInBodyRejected() {
+    void valueWithUnexpectedSchemaIdInBodyRejected() {
         var value = asSchemaIdPrefixBuf(GLOBAL_ID + 1, VALID_JSON);
         Record record = record(RECORD_KEY, value);
         BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, GLOBAL_ID);

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSchemaBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSchemaBytebufValidatorTest.java
@@ -172,14 +172,12 @@ public class JsonSchemaBytebufValidatorTest {
         var future = validator.validate(record.value(), record, false);
         assertThat(future)
                 .succeedsWithin(Duration.ofSeconds(1))
-                .returns(false, Result::valid)
-                .returns("Unexpected schema id in record (2), expecting 1", Result::errorMessage);
+                .isEqualTo(new Result(false, "Unexpected schema id in record (2), expecting 1"));
     }
 
     private byte[] toByteArray(long globalId) {
         var buf = ByteBuffer.allocate(Long.BYTES);
         buf.putLong(globalId);
-        buf.flip();
         return buf.array();
     }
 

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSchemaBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSchemaBytebufValidatorTest.java
@@ -8,25 +8,26 @@ package io.kroxylicious.proxy.filter.schema;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.record.DefaultRecord;
 import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
+
+import io.apicurio.registry.serde.AbstractKafkaSerDe;
+import io.apicurio.registry.serde.SerdeHeaders;
 
 import io.kroxylicious.proxy.filter.schema.validation.Result;
 import io.kroxylicious.proxy.filter.schema.validation.bytebuf.BytebufValidator;
@@ -35,17 +36,18 @@ import io.kroxylicious.proxy.filter.schema.validation.bytebuf.BytebufValidators;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(MockitoExtension.class)
 public class JsonSchemaBytebufValidatorTest {
 
-    @Mock(strictness = Mock.Strictness.LENIENT)
-    BytebufValidator mockValidator;
+    private static final long GLOBAL_ID = 1L;
+    private static final byte[] VALID_JSON = "{\"firstName\":\"a\",\"lastName\":\"b\"}".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] INVALID_JSON = "{\"firstName\":\"a\",\"lastName\":\"b\",\"age\":-3}".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] RECORD_KEY = "a".getBytes(StandardCharsets.UTF_8);
 
-    static WireMockServer registryServer;
+    private static WireMockServer registryServer;
+
+    private static Map<String, Object> apicurioConfig;
 
     private static final String JSON_SCHEMA = """
             {
@@ -90,6 +92,8 @@ public class JsonSchemaBytebufValidatorTest {
                         .willReturn(WireMock.aResponse()
                                 .withHeader("Content-Type", "application/json")
                                 .withBody("[]")));
+
+        apicurioConfig = Map.of("apicurio.registry.url", registryServer.baseUrl());
     }
 
     @AfterAll
@@ -98,47 +102,88 @@ public class JsonSchemaBytebufValidatorTest {
     }
 
     @Test
-    void testValueValidated() {
-        Record record = createRecord("a", "{\"firstName\":\"a\",\"lastName\":\"b\"}");
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(Map.of("apicurio.registry.url", registryServer.baseUrl()), 1L);
-        Result result = validate(record, validator);
-        assertTrue(result.valid());
-        verifyNoMoreInteractions(mockValidator);
+    void valuePassesSchemaValidation() {
+        Record record = createRecord(RECORD_KEY, VALID_JSON);
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, GLOBAL_ID);
+        var future = validator.validate(record.value(), record, false);
+
+        assertThat(future)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .returns(true, Result::valid);
     }
 
     @Test
-    void testValueInvalidAgeInvalidated() {
-        Record record = createRecord("a", "{\"firstName\":\"a\",\"lastName\":\"b\",\"age\":-3}");
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(Map.of("apicurio.registry.url", registryServer.baseUrl()), 1L);
-        Result result = validate(record, validator);
-        assertFalse(result.valid());
-        verifyNoMoreInteractions(mockValidator);
+    void jsonValueFailsSchemaValidation() {
+        Record record = createRecord(RECORD_KEY, INVALID_JSON);
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, GLOBAL_ID);
+        var future = validator.validate(record.value(), record, false);
+
+        assertThat(future)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .returns(false, Result::valid);
     }
 
     @Test
-    void testInvalidValueInValidated() {
-        Record record = createRecord("a", "123");
-        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(Map.of("apicurio.registry.url", registryServer.baseUrl()), 1L);
-        Result result = validate(record, validator);
-        assertFalse(result.valid());
-        verifyNoMoreInteractions(mockValidator);
+    void nonJsonValueFailsValidation() {
+        Record record = createRecord(RECORD_KEY, "123".getBytes(StandardCharsets.UTF_8));
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, GLOBAL_ID);
+        var future = validator.validate(record.value(), record, false);
+        assertThat(future)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .returns(false, Result::valid);
     }
 
-    private static Result validate(Record record, BytebufValidator validator) {
-        try {
-            return validator.validate(record.value(), record, false).toCompletableFuture().get(5, TimeUnit.SECONDS);
-        }
-        catch (ExecutionException | InterruptedException | TimeoutException e) {
-            throw new RuntimeException(e);
-        }
+    @Test
+    void valueWithCorrectSchemaIdInHeaderPassesValidation() {
+        Record record = createRecord(RECORD_KEY, VALID_JSON, new RecordHeader(SerdeHeaders.HEADER_VALUE_GLOBAL_ID, toByteArray(GLOBAL_ID)));
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, GLOBAL_ID);
+        var future = validator.validate(record.value(), record, false);
+        assertThat(future)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .returns(true, Result::valid);
     }
 
-    private Record createRecord(String key, String value) {
+    @Test
+    void valueWithCorrectSchemaIdInBodyPassesValidation() {
+        var value = asSchemaIdPrefixBuf(GLOBAL_ID, VALID_JSON);
+        Record record = createRecord(RECORD_KEY, value);
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, GLOBAL_ID);
+        var future = validator.validate(record.value(), record, false);
+        assertThat(future)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .returns(true, Result::valid);
+    }
+
+    @Test
+    void valueWithWrongSchemaIdInHeaderRejected() {
+        Record record = createRecord(RECORD_KEY, VALID_JSON, new RecordHeader(SerdeHeaders.HEADER_VALUE_GLOBAL_ID, toByteArray(GLOBAL_ID + 1)));
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, GLOBAL_ID);
+        var future = validator.validate(record.value(), record, false);
+        assertThat(future)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .returns(false, Result::valid)
+                .returns("Unexpected schema id in record (2), expecting 1", Result::errorMessage);
+    }
+
+    @Test
+    void valueWithWrongSchemaIdInBodyRejected() {
+        var value = asSchemaIdPrefixBuf(GLOBAL_ID + 1, VALID_JSON);
+        Record record = createRecord(RECORD_KEY, value);
+        BytebufValidator validator = BytebufValidators.jsonSchemaValidator(apicurioConfig, GLOBAL_ID);
+        var future = validator.validate(record.value(), record, false);
+        assertThat(future)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .returns(false, Result::valid)
+                .returns("Unexpected schema id in record (2), expecting 1", Result::errorMessage);
+    }
+
+    private Record createRecord(byte[] key, byte[] value, Header... headers) {
         ByteBuffer keyBuf = toBufNullable(key);
         ByteBuffer valueBuf = toBufNullable(value);
 
-        try (ByteBufferOutputStream bufferOutputStream = new ByteBufferOutputStream(1000); DataOutputStream dataOutputStream = new DataOutputStream(bufferOutputStream)) {
-            DefaultRecord.writeTo(dataOutputStream, 0, 0, keyBuf, valueBuf, Record.EMPTY_HEADERS);
+        try (ByteBufferOutputStream bufferOutputStream = new ByteBufferOutputStream(1000);
+                DataOutputStream dataOutputStream = new DataOutputStream(bufferOutputStream)) {
+            DefaultRecord.writeTo(dataOutputStream, 0, 0, keyBuf, valueBuf, headers);
             dataOutputStream.flush();
             bufferOutputStream.flush();
             ByteBuffer buffer = bufferOutputStream.buffer();
@@ -146,15 +191,30 @@ public class JsonSchemaBytebufValidatorTest {
             return DefaultRecord.readFrom(buffer, 0, 0, 0, 0L);
         }
         catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(e);
         }
     }
 
-    private static ByteBuffer toBufNullable(String key) {
-        if (key == null) {
+    private static ByteBuffer toBufNullable(byte[] buf) {
+        if (buf == null) {
             return null;
         }
-        byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
-        return ByteBuffer.wrap(keyBytes);
+        return ByteBuffer.wrap(buf);
+    }
+
+    private byte[] toByteArray(long globalId) {
+        var buf = ByteBuffer.allocate(Long.BYTES);
+        buf.putLong(globalId);
+        buf.flip();
+        return buf.array();
+    }
+
+    private byte[] asSchemaIdPrefixBuf(long globalId, byte[] content) {
+        ByteBuffer buf = ByteBuffer.allocate(1 /* magic */ + Long.BYTES /* global id */ + content.length);
+        buf.put(AbstractKafkaSerDe.MAGIC_BYTE);
+        buf.putLong(globalId);
+        buf.put(content);
+
+        return buf.array();
     }
 }

--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -127,6 +127,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
             <scope>test</scope>
@@ -209,6 +214,21 @@
         <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-serde-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-schema-resolver</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-serdes-jsonschema-serde</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSchemaValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSchemaValidationIT.java
@@ -91,11 +91,11 @@ class JsonSchemaValidationIT extends SchemaValidationBaseIT {
     private static final String APICURIO_REGISTRY_HOST = "http://localhost";
     private static final Integer APICURIO_REGISTRY_PORT = 8081;
     private static final String APICURIO_REGISTRY_URL = APICURIO_REGISTRY_HOST + ":" + APICURIO_REGISTRY_PORT;
-    public static final String FIRST_ARTIFACT_ID = UUID.randomUUID().toString();
-    public static final String SECOND_ARTIFACT_ID = UUID.randomUUID().toString();
-    public static long FIRST_GLOBAL_ID;
-    public static long SECOND_GLOBAL_ID;
-    private final static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String FIRST_ARTIFACT_ID = UUID.randomUUID().toString();
+    private static final String SECOND_ARTIFACT_ID = UUID.randomUUID().toString();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    public static long firstGlobalId;
+    public static long secondGlobalId;
 
     private static GenericContainer registryContainer;
 
@@ -120,8 +120,8 @@ class JsonSchemaValidationIT extends SchemaValidationBaseIT {
 
         // Preparation: In this test class, a schema already registered in Apicurio Registry with globalId one is expected, so we register it upfront.
         try (var client = RegistryClientFactory.create(APICURIO_REGISTRY_URL)) {
-            FIRST_GLOBAL_ID = client.createArtifact(null, FIRST_ARTIFACT_ID, IoUtil.toStream(JSON_SCHEMA_TOPIC_1)).getGlobalId();
-            SECOND_GLOBAL_ID = client.createArtifact(null, SECOND_ARTIFACT_ID, IoUtil.toStream(JSON_SCHEMA_TOPIC_1)).getGlobalId();
+            firstGlobalId = client.createArtifact(null, FIRST_ARTIFACT_ID, IoUtil.toStream(JSON_SCHEMA_TOPIC_1)).getGlobalId();
+            secondGlobalId = client.createArtifact(null, SECOND_ARTIFACT_ID, IoUtil.toStream(JSON_SCHEMA_TOPIC_1)).getGlobalId();
         }
     }
 
@@ -130,7 +130,7 @@ class JsonSchemaValidationIT extends SchemaValidationBaseIT {
         var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder(ProduceValidationFilterFactory.class.getName()).withConfig("rules",
                         List.of(Map.of("topicNames", List.of(topic1.name()), "valueRule",
-                                Map.of("schemaValidationConfig", Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "apicurioGlobalId", FIRST_GLOBAL_ID)))))
+                                Map.of("schemaValidationConfig", Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "apicurioGlobalId", firstGlobalId)))))
                         .build());
 
         try (var tester = kroxyliciousTester(config);
@@ -152,7 +152,7 @@ class JsonSchemaValidationIT extends SchemaValidationBaseIT {
         var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder(ProduceValidationFilterFactory.class.getName()).withConfig("rules",
                         List.of(Map.of("topicNames", List.of(topic2.name()), "valueRule",
-                                Map.of("schemaValidationConfig", Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "apicurioGlobalId", FIRST_GLOBAL_ID)))))
+                                Map.of("schemaValidationConfig", Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "apicurioGlobalId", firstGlobalId)))))
                         .build());
 
         try (var tester = kroxyliciousTester(config);
@@ -193,7 +193,7 @@ class JsonSchemaValidationIT extends SchemaValidationBaseIT {
         public ArtifactReference artifactReference(Record data, ParsedSchema parsedSchema) {
             return ArtifactReference.builder()
                     .artifactId(FIRST_ARTIFACT_ID)
-                    .globalId(FIRST_GLOBAL_ID)
+                    .globalId(firstGlobalId)
                     .build();
         }
 
@@ -212,7 +212,7 @@ class JsonSchemaValidationIT extends SchemaValidationBaseIT {
         var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder(ProduceValidationFilterFactory.class.getName()).withConfig("rules",
                         List.of(Map.of("topicNames", List.of(topic1.name()), "valueRule",
-                                Map.of("schemaValidationConfig", Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "apicurioGlobalId", FIRST_GLOBAL_ID)))))
+                                Map.of("schemaValidationConfig", Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "apicurioGlobalId", firstGlobalId)))))
                         .build());
 
         var keySerde = new Serdes.StringSerde();
@@ -254,7 +254,7 @@ class JsonSchemaValidationIT extends SchemaValidationBaseIT {
         var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder(ProduceValidationFilterFactory.class.getName()).withConfig("rules",
                         List.of(Map.of("topicNames", List.of(topic1.name()), "valueRule",
-                                Map.of("schemaValidationConfig", Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "apicurioGlobalId", SECOND_GLOBAL_ID)))))
+                                Map.of("schemaValidationConfig", Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "apicurioGlobalId", secondGlobalId)))))
                         .build());
 
         var keySerde = new Serdes.StringSerde();

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSchemaValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSchemaValidationIT.java
@@ -126,7 +126,7 @@ class JsonSchemaValidationIT extends SchemaValidationBaseIT {
     }
 
     @Test
-    void validJsonProduceAccepted(KafkaCluster cluster, Topic topic1) throws Exception {
+    void shouldAcceptValidJsonInProduceRequest(KafkaCluster cluster, Topic topic1) throws Exception {
         var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder(ProduceValidationFilterFactory.class.getName()).withConfig("rules",
                         List.of(Map.of("topicNames", List.of(topic1.name()), "valueRule",

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSchemaValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSchemaValidationIT.java
@@ -15,22 +15,35 @@ import java.util.concurrent.Future;
 import java.util.function.Consumer;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.serialization.Serdes;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.PortBinding;
 import com.github.dockerjava.api.model.Ports;
 
+import io.apicurio.registry.resolver.ParsedSchema;
+import io.apicurio.registry.resolver.data.Record;
+import io.apicurio.registry.resolver.strategy.ArtifactReference;
+import io.apicurio.registry.resolver.strategy.ArtifactReferenceResolverStrategy;
 import io.apicurio.registry.rest.client.RegistryClientFactory;
+import io.apicurio.registry.serde.SerdeConfig;
+import io.apicurio.registry.serde.jsonschema.JsonSchemaSerde;
 import io.apicurio.rest.client.util.IoUtil;
 
 import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
@@ -41,9 +54,12 @@ import io.kroxylicious.testing.kafka.junit5ext.Topic;
 
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(KafkaClusterExtension.class)
+@EnabledIf(value = "isDockerAvailable", disabledReason = "docker unavailable")
 class JsonSchemaValidationIT extends SchemaValidationBaseIT {
 
     private static final String JSON_SCHEMA_TOPIC_1 = """
@@ -75,6 +91,11 @@ class JsonSchemaValidationIT extends SchemaValidationBaseIT {
     private static final String APICURIO_REGISTRY_HOST = "http://localhost";
     private static final Integer APICURIO_REGISTRY_PORT = 8081;
     private static final String APICURIO_REGISTRY_URL = APICURIO_REGISTRY_HOST + ":" + APICURIO_REGISTRY_PORT;
+    public static final String FIRST_ARTIFACT_ID = UUID.randomUUID().toString();
+    public static final String SECOND_ARTIFACT_ID = UUID.randomUUID().toString();
+    public static long FIRST_GLOBAL_ID;
+    public static long SECOND_GLOBAL_ID;
+    private final static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private static GenericContainer registryContainer;
 
@@ -99,16 +120,17 @@ class JsonSchemaValidationIT extends SchemaValidationBaseIT {
 
         // Preparation: In this test class, a schema already registered in Apicurio Registry with globalId one is expected, so we register it upfront.
         try (var client = RegistryClientFactory.create(APICURIO_REGISTRY_URL)) {
-            client.createArtifact(null, UUID.randomUUID().toString(), IoUtil.toStream(JSON_SCHEMA_TOPIC_1));
+            FIRST_GLOBAL_ID = client.createArtifact(null, FIRST_ARTIFACT_ID, IoUtil.toStream(JSON_SCHEMA_TOPIC_1)).getGlobalId();
+            SECOND_GLOBAL_ID = client.createArtifact(null, SECOND_ARTIFACT_ID, IoUtil.toStream(JSON_SCHEMA_TOPIC_1)).getGlobalId();
         }
     }
 
     @Test
-    void testValidJsonProduceAccepted(KafkaCluster cluster, Topic topic1) throws Exception {
+    void validJsonProduceAccepted(KafkaCluster cluster, Topic topic1) throws Exception {
         var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder(ProduceValidationFilterFactory.class.getName()).withConfig("rules",
                         List.of(Map.of("topicNames", List.of(topic1.name()), "valueRule",
-                                Map.of("schemaValidationConfig", Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "apicurioGlobalId", 1L)))))
+                                Map.of("schemaValidationConfig", Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "apicurioGlobalId", FIRST_GLOBAL_ID)))))
                         .build());
 
         try (var tester = kroxyliciousTester(config);
@@ -125,12 +147,12 @@ class JsonSchemaValidationIT extends SchemaValidationBaseIT {
     }
 
     @Test
-    void testInvalidAgeProduceRejectedUsingTopicNames(KafkaCluster cluster, Topic topic1, Topic topic2) throws Exception {
+    void invalidAgeProduceRejectedUsingTopicNames(KafkaCluster cluster, Topic topic1, Topic topic2) throws Exception {
         // Topic 2 has schema validation, invalid data cannot be sent.
         var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder(ProduceValidationFilterFactory.class.getName()).withConfig("rules",
                         List.of(Map.of("topicNames", List.of(topic2.name()), "valueRule",
-                                Map.of("schemaValidationConfig", Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "apicurioGlobalId", 1L)))))
+                                Map.of("schemaValidationConfig", Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "apicurioGlobalId", FIRST_GLOBAL_ID)))))
                         .build());
 
         try (var tester = kroxyliciousTester(config);
@@ -144,23 +166,111 @@ class JsonSchemaValidationIT extends SchemaValidationBaseIT {
             producer.send(new ProducerRecord<>(topic1.name(), "my-key", INVALID_AGE_MESSAGE)).get();
             consumer.subscribe(Set.of(topic1.name()));
             var records = consumer.poll(Duration.ofSeconds(10));
-            assertThat(records.count()).isOne();
-            assertThat(records.iterator().next().value()).isEqualTo(INVALID_AGE_MESSAGE);
+            assertThat(records.records(topic1.name()))
+                    .hasSize(1)
+                    .map(ConsumerRecord::value)
+                    .containsExactly(INVALID_AGE_MESSAGE);
         }
     }
 
     @Test
-    void testNonExistentSchema(KafkaCluster cluster, Topic topic1) throws Exception {
+    void nonExistentSchema(KafkaCluster cluster, Topic topic) {
         var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder(ProduceValidationFilterFactory.class.getName()).withConfig("rules",
-                        List.of(Map.of("topicNames", List.of(topic1.name()), "valueRule",
+                        List.of(Map.of("topicNames", List.of(topic.name()), "valueRule",
                                 Map.of("schemaValidationConfig", Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "apicurioGlobalId", 3L)))))
                         .build());
 
         try (var tester = kroxyliciousTester(config);
                 var producer = getProducer(tester, 0, 16384)) {
-            Future<RecordMetadata> invalid = producer.send(new ProducerRecord<>(topic1.name(), "my-key", JSON_MESSAGE));
+            Future<RecordMetadata> invalid = producer.send(new ProducerRecord<>(topic.name(), "my-key", JSON_MESSAGE));
             assertInvalidRecordExceptionThrown(invalid, "No artifact with ID '3' in group 'null' was found");
+        }
+    }
+
+    public static class FixedArtifactReferenceResolver implements ArtifactReferenceResolverStrategy {
+        @Override
+        public ArtifactReference artifactReference(Record data, ParsedSchema parsedSchema) {
+            return ArtifactReference.builder()
+                    .artifactId(FIRST_ARTIFACT_ID)
+                    .globalId(FIRST_GLOBAL_ID)
+                    .build();
+        }
+
+        @Override
+        public boolean loadSchema() {
+            return false;
+        }
+
+    }
+
+    public record PersonBean(String firstName, String lastName, int age) {}
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void clientSideUsesSchemasToo(boolean schemaIdInHeader, KafkaCluster cluster, Topic topic1) throws Exception {
+        var config = proxy(cluster)
+                .addToFilters(new FilterDefinitionBuilder(ProduceValidationFilterFactory.class.getName()).withConfig("rules",
+                        List.of(Map.of("topicNames", List.of(topic1.name()), "valueRule",
+                                Map.of("schemaValidationConfig", Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "apicurioGlobalId", FIRST_GLOBAL_ID)))))
+                        .build());
+
+        var keySerde = new Serdes.StringSerde();
+        var producerValueSerde = new JsonSchemaSerde<PersonBean>();
+        producerValueSerde.configure(Map.of(
+                SerdeConfig.REGISTRY_URL, APICURIO_REGISTRY_URL,
+                SerdeConfig.ARTIFACT_RESOLVER_STRATEGY, FixedArtifactReferenceResolver.class.getName(),
+                SerdeConfig.ENABLE_HEADERS, schemaIdInHeader), false);
+
+        var consumerValueSerde = new JsonSchemaSerde<>();
+        consumerValueSerde.configure(Map.of(
+                SerdeConfig.REGISTRY_URL, APICURIO_REGISTRY_URL), false);
+
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer(keySerde, producerValueSerde, Map.of(
+                        ProducerConfig.LINGER_MS_CONFIG, 0,
+                        ProducerConfig.BATCH_SIZE_CONFIG, 16384));
+                var consumer = tester.consumer(keySerde, consumerValueSerde, Map.of(
+                        GROUP_ID_CONFIG, "my-group-id",
+                        AUTO_OFFSET_RESET_CONFIG, "earliest"))) {
+            var bean = new PersonBean("john", "smith", 23);
+            producer.send(new ProducerRecord<>(topic1.name(), "my-key", bean)).get();
+            consumer.subscribe(Set.of(topic1.name()));
+
+            // note that when the schemaid is in the value, there's no type information so the deserializer will give a JsonNode.
+            Object expected = schemaIdInHeader ? bean : OBJECT_MAPPER.valueToTree(bean);
+            var records = consumer.poll(Duration.ofSeconds(10));
+
+            assertThat(records.records(topic1.name()))
+                    .hasSize(1)
+                    .map(ConsumerRecord::value)
+                    .containsExactly(expected);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void detectsClientProducingWithWrongSchema(boolean schemaIdInHeader, KafkaCluster cluster, Topic topic1) {
+        var config = proxy(cluster)
+                .addToFilters(new FilterDefinitionBuilder(ProduceValidationFilterFactory.class.getName()).withConfig("rules",
+                        List.of(Map.of("topicNames", List.of(topic1.name()), "valueRule",
+                                Map.of("schemaValidationConfig", Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "apicurioGlobalId", SECOND_GLOBAL_ID)))))
+                        .build());
+
+        var keySerde = new Serdes.StringSerde();
+        var valuSerde = new JsonSchemaSerde<PersonBean>();
+        valuSerde.configure(Map.of(
+                SerdeConfig.REGISTRY_URL, APICURIO_REGISTRY_URL,
+                SerdeConfig.ARTIFACT_RESOLVER_STRATEGY, FixedArtifactReferenceResolver.class.getName(),
+                SerdeConfig.ENABLE_HEADERS, schemaIdInHeader), false);
+
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer(keySerde, valuSerde, Map.of(
+                        ProducerConfig.LINGER_MS_CONFIG, 0,
+                        ProducerConfig.BATCH_SIZE_CONFIG, 16384))) {
+            var bean = new PersonBean("john", "smith", 23);
+            var invalid = producer.send(new ProducerRecord<>(topic1.name(), "my-key", bean));
+            assertInvalidRecordExceptionThrown(invalid, "Unexpected schema id in record (1), expecting 2");
         }
     }
 
@@ -169,5 +279,9 @@ class JsonSchemaValidationIT extends SchemaValidationBaseIT {
         if (registryContainer != null && registryContainer.isRunning()) {
             registryContainer.stop();
         }
+    }
+
+    static boolean isDockerAvailable() {
+        return DockerClientFactory.instance().isDockerAvailable();
     }
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSchemaValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSchemaValidationIT.java
@@ -250,7 +250,7 @@ class JsonSchemaValidationIT extends SchemaValidationBaseIT {
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
-    void detectsClientProducingWithWrongSchema(boolean schemaIdInHeader, KafkaCluster cluster, Topic topic1) {
+    void detectsClientProducingWithWrongSchemaId(boolean schemaIdInHeader, KafkaCluster cluster, Topic topic1) {
         var config = proxy(cluster)
                 .addToFilters(new FilterDefinitionBuilder(ProduceValidationFilterFactory.class.getName()).withConfig("rules",
                         List.of(Map.of("topicNames", List.of(topic1.name()), "valueRule",
@@ -258,14 +258,14 @@ class JsonSchemaValidationIT extends SchemaValidationBaseIT {
                         .build());
 
         var keySerde = new Serdes.StringSerde();
-        var valuSerde = new JsonSchemaSerde<PersonBean>();
-        valuSerde.configure(Map.of(
+        var valueSerde = new JsonSchemaSerde<PersonBean>();
+        valueSerde.configure(Map.of(
                 SerdeConfig.REGISTRY_URL, APICURIO_REGISTRY_URL,
                 SerdeConfig.ARTIFACT_RESOLVER_STRATEGY, FixedArtifactReferenceResolver.class.getName(),
                 SerdeConfig.ENABLE_HEADERS, schemaIdInHeader), false);
 
         try (var tester = kroxyliciousTester(config);
-                var producer = tester.producer(keySerde, valuSerde, Map.of(
+                var producer = tester.producer(keySerde, valueSerde, Map.of(
                         ProducerConfig.LINGER_MS_CONFIG, 0,
                         ProducerConfig.BATCH_SIZE_CONFIG, 16384))) {
             var bean = new PersonBean("john", "smith", 23);

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSchemaValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSchemaValidationIT.java
@@ -204,7 +204,7 @@ class JsonSchemaValidationIT extends SchemaValidationBaseIT {
 
     }
 
-    public record PersonBean(String firstName, String lastName, int age) {}
+    record PersonBean(String firstName, String lastName, int age) {}
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSchemaValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/schema/validation/JsonSchemaValidationIT.java
@@ -86,8 +86,10 @@ class JsonSchemaValidationIT extends SchemaValidationBaseIT {
             }
             """;
 
-    private static final String JSON_MESSAGE = "{\"firstName\":\"json1\",\"lastName\":\"json2\"}";
-    private static final String INVALID_AGE_MESSAGE = "{\"firstName\":\"json1\",\"lastName\":\"json2\",\"age\":-3}";
+    private static final String JSON_MESSAGE = """
+            {"firstName":"json1","lastName":"json2"}""";
+    private static final String INVALID_AGE_MESSAGE = """
+            {"firstName":"json1","lastName":"json2","age":-3}""";
     private static final String APICURIO_REGISTRY_HOST = "http://localhost";
     private static final Integer APICURIO_REGISTRY_PORT = 8081;
     private static final String APICURIO_REGISTRY_URL = APICURIO_REGISTRY_HOST + ":" + APICURIO_REGISTRY_PORT;

--- a/pom.xml
+++ b/pom.xml
@@ -302,7 +302,16 @@
                 <artifactId>apicurio-registry-schema-validation-jsonschema</artifactId>
                 <version>${apicurio-schema-validation.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>io.apicurio</groupId>
+                <artifactId>apicurio-registry-serdes-jsonschema-serde</artifactId>
+                <version>${apicurio-registry.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.apicurio</groupId>
+                <artifactId>apicurio-registry-serde-common</artifactId>
+                <version>${apicurio-registry.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.bitbucket.b_c</groupId>
                 <artifactId>jose4j</artifactId>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

_This was prompted by writing the [use-case](https://github.com/kroxylicious/kroxylicious.github.io/pull/63) for the feature.  It occured to me that using this feature with clients that are using schemas would be the norm._

`JsonSchemaValidator` now validates the schema id used by the producer (passed either in the header or as preamble bytes on the key/value) matches the schema id configured at the proxy.  If there is a mismatch, the record is rejected and validation error is returned to the producer.

If the producer isn't using schemas, then the proxy just validates the content against the schema (previous behaviour).

why: if an organisation has adopted adopting, schemas will generally be employed at the client.  You want to fail early if the producer and proxy are configured to use different globalIds.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [x] Reference relevant issue(s) and close them after merging
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
