### PR TITLE
record-encryption: log details about Cipher origin

### DIFF
--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryption.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryption.java
@@ -6,9 +6,11 @@
 
 package io.kroxylicious.filter.encryption;
 
+import java.security.Provider;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
@@ -82,7 +84,9 @@ public class RecordEncryption<K, E> implements FilterFactory<RecordEncryptionCon
     /* exposed for testing */ static void checkCipherSuite(Function<CipherManager, Cipher> cipherFunc) {
         List<CipherSpec> failures = Arrays.stream(CipherSpec.values()).flatMap(cipherSpec -> {
             try {
-                cipherFunc.apply(CipherSpecResolver.ALL.fromName(cipherSpec));
+                Cipher cipher = cipherFunc.apply(CipherSpecResolver.ALL.fromName(cipherSpec));
+                String provider = Optional.ofNullable(cipher.getProvider()).map(Provider::getName).orElse("(no provider)");
+                LOGGER.info("Loaded Cipher {} from provider {} for CipherSpec {}", cipher, provider, cipherSpec);
                 return Stream.empty();
             }
             catch (Exception e) {


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

during the one-time check that the Ciphers are available, we log details about the algorithm and provider.

Contributes to #1401

### Additional Context

Users may wish to plug in alternate providers for Cipher algorithms, for example to use a fips-certified bouncycastle implementation instead of a platform implementation. This can be achieved by configuring the environment so that the alternative provider is preferred but we want to expose where the algorithms are loaded from to give users confidence that they have configured their environment correctly.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
