### PR TITLE
Fix #1422: Remove BytebufValidator#validate length formal parameter

### DIFF
--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/Result.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/Result.java
@@ -16,8 +16,6 @@ import java.util.concurrent.CompletionStage;
  */
 public record Result(boolean valid, String errorMessage) {
 
-    /**
-     * valid result
-     */
-    public static CompletionStage<Result> VALID = CompletableFuture.completedFuture(new Result(true, null));
+    public static final Result VALID_RESULT = new Result(true, null);
+    public static CompletionStage<Result> VALID_RESULT_STAGE = CompletableFuture.completedFuture(VALID_RESULT);
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/AllValidBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/AllValidBytebufValidator.java
@@ -16,7 +16,7 @@ import io.kroxylicious.proxy.filter.schema.validation.Result;
 class AllValidBytebufValidator implements BytebufValidator {
 
     @Override
-    public CompletionStage<Result> validate(ByteBuffer buffer, int length, Record record, boolean isKey) {
-        return Result.VALID;
+    public CompletionStage<Result> validate(ByteBuffer buffer, Record record, boolean isKey) {
+        return Result.VALID_RESULT_STAGE;
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/BytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/BytebufValidator.java
@@ -27,10 +27,9 @@ public interface BytebufValidator {
      * </p>
      *
      * @param buffer the buffer containing data
-     * @param length the length of the value in the buffer (buffer may contain more data after the value)
      * @param record the record the buffer was extracted from
      * @param isKey true if the buffer is the key of the record, false if it is the value of the record
      * @return a valid result if the buffer is valid
      */
-    CompletionStage<Result> validate(ByteBuffer buffer, int length, Record record, boolean isKey);
+    CompletionStage<Result> validate(ByteBuffer buffer, Record record, boolean isKey);
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/ChainingByteBufferValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/ChainingByteBufferValidator.java
@@ -30,13 +30,13 @@ class ChainingByteBufferValidator implements BytebufValidator {
     }
 
     @Override
-    public CompletionStage<Result> validate(ByteBuffer buffer, int length, Record kafkaRecord, boolean isKey) {
-        var future = Result.VALID;
+    public CompletionStage<Result> validate(ByteBuffer buffer, Record kafkaRecord, boolean isKey) {
+        var future = Result.VALID_RESULT_STAGE;
 
         for (BytebufValidator bv : elements) {
             future = future.thenCompose(x -> {
                 if (x.valid()) {
-                    return bv.validate(buffer.asReadOnlyBuffer(), length, kafkaRecord, isKey);
+                    return bv.validate(buffer.asReadOnlyBuffer(), kafkaRecord, isKey);
                 }
                 else {
                     return CompletableFuture.completedStage(x);

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSchemaBytebufValidator.java
@@ -29,10 +29,10 @@ public class JsonSchemaBytebufValidator implements BytebufValidator {
     }
 
     @Override
-    public CompletionStage<Result> validate(ByteBuffer buffer, int length, Record record, boolean isKey) {
+    public CompletionStage<Result> validate(ByteBuffer buffer, Record record, boolean isKey) {
         try {
             JsonValidationResult jsonValidationResult = jsonValidator.validateByArtifactReference(buffer.clear());
-            return jsonValidationResult.success() ? Result.VALID
+            return jsonValidationResult.success() ? Result.VALID_RESULT_STAGE
                     : CompletableFuture.completedFuture(new Result(false, jsonValidationResult.toString()));
         }
         catch (RuntimeException ex) {

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSyntaxBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/JsonSyntaxBytebufValidator.java
@@ -8,6 +8,7 @@ package io.kroxylicious.proxy.filter.schema.validation.bytebuf;
 
 import java.io.InputStream;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -35,13 +36,15 @@ class JsonSyntaxBytebufValidator implements BytebufValidator {
     }
 
     @Override
-    public CompletionStage<Result> validate(ByteBuffer buffer, int size, Record record, boolean isKey) {
+    public CompletionStage<Result> validate(ByteBuffer buffer, Record record, boolean isKey) {
+        Objects.requireNonNull(record);
         if (buffer == null) {
             throw new IllegalArgumentException("buffer is null");
         }
-        if (size < 1) {
+        if (buffer.remaining() < 1) {
             throw new IllegalArgumentException("size is less than 1");
         }
+
         try (InputStream inputStream = new ByteBufferInputStream(buffer);
                 JsonParser parser = mapper.getFactory().createParser(inputStream)) {
             if (validateObjectKeysUnique) {
@@ -50,7 +53,7 @@ class JsonSyntaxBytebufValidator implements BytebufValidator {
             while (parser.nextToken() != null) {
             }
 
-            return Result.VALID;
+            return Result.VALID_RESULT_STAGE;
         }
         catch (Exception e) {
             String message = "value was not syntactically correct JSON" + (e.getMessage() != null ? ": " + e.getMessage() : "");

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/record/KeyAndValueRecordValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/schema/validation/record/KeyAndValueRecordValidator.java
@@ -36,7 +36,7 @@ public class KeyAndValueRecordValidator implements RecordValidator {
 
     @Override
     public CompletionStage<Result> validate(Record record) {
-        CompletionStage<Result> keyValid = keyValidator.validate(record.key(), record.keySize(), record, true);
+        CompletionStage<Result> keyValid = keyValidator.validate(record.key(), record, true);
         return keyValid.thenCompose(result -> {
             if (!result.valid()) {
                 return CompletableFuture.completedFuture(new Result(false, "Key was invalid: " + result.errorMessage()));
@@ -48,13 +48,13 @@ public class KeyAndValueRecordValidator implements RecordValidator {
     }
 
     private CompletionStage<Result> validateValue(Record record) {
-        CompletionStage<Result> valueValid = valueValidator.validate(record.value(), record.valueSize(), record, false);
+        CompletionStage<Result> valueValid = valueValidator.validate(record.value(), record, false);
         return valueValid.thenCompose(result1 -> {
             if (!result1.valid()) {
                 return CompletableFuture.completedFuture(new Result(false, "Value was invalid: " + result1.errorMessage()));
             }
             else {
-                return Result.VALID;
+                return Result.VALID_RESULT_STAGE;
             }
         });
     }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSchemaBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSchemaBytebufValidatorTest.java
@@ -126,7 +126,7 @@ public class JsonSchemaBytebufValidatorTest {
 
     private static Result validate(Record record, BytebufValidator validator) {
         try {
-            return validator.validate(record.value(), record.valueSize(), record, false).toCompletableFuture().get(5, TimeUnit.SECONDS);
+            return validator.validate(record.value(), record, false).toCompletableFuture().get(5, TimeUnit.SECONDS);
         }
         catch (ExecutionException | InterruptedException | TimeoutException e) {
             throw new RuntimeException(e);

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSyntaxBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/JsonSyntaxBytebufValidatorTest.java
@@ -177,7 +177,7 @@ class JsonSyntaxBytebufValidatorTest {
     void testKeyValidated() throws ExecutionException, InterruptedException, TimeoutException {
         Record record = createRecord("\"abc\"", "123");
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(true);
-        Result result = validator.validate(record.key(), record.keySize(), record, true).toCompletableFuture().get(5, TimeUnit.SECONDS);
+        Result result = validator.validate(record.key(), record, true).toCompletableFuture().get(5, TimeUnit.SECONDS);
         assertTrue(result.valid());
     }
 
@@ -194,14 +194,12 @@ class JsonSyntaxBytebufValidatorTest {
     void testNullValueThrows() {
         Record record = createRecord("a", null);
         BytebufValidator validator = BytebufValidators.jsonSyntaxValidator(false);
-        assertThrows(IllegalArgumentException.class, () -> {
-            validate(record, validator);
-        });
+        assertThrows(IllegalArgumentException.class, () -> validate(record, validator));
     }
 
     private static Result validate(Record record, BytebufValidator validator) {
         try {
-            return validator.validate(record.value(), record.valueSize(), record, false).toCompletableFuture().get(5, TimeUnit.SECONDS);
+            return validator.validate(record.value(), record, false).toCompletableFuture().get(5, TimeUnit.SECONDS);
         }
         catch (ExecutionException | InterruptedException | TimeoutException e) {
             throw new RuntimeException(e);

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/NullEmptyBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/bytebuf/NullEmptyBytebufValidatorTest.java
@@ -7,90 +7,157 @@
 package io.kroxylicious.proxy.filter.schema.validation.bytebuf;
 
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.common.record.Record;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.kroxylicious.proxy.filter.schema.validation.Result;
 
 import static io.kroxylicious.proxy.filter.schema.validation.bytebuf.BytebufValidators.nullEmptyValidator;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class NullEmptyBytebufValidatorTest {
 
-    private final Record record = mock(Record.class);
+    @Mock
+    BytebufValidator mockValidator;
 
     @Test
-    void testNullValid() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
+    void nullKeyValid() {
         boolean nullValid = true;
+
+        var record = createMockRecord(null, true);
         BytebufValidator validator = nullEmptyValidator(nullValid, true, mockValidator);
-        Result validate = validate(validator, null, 0, true);
-        assertTrue(validate.valid());
+        var result = validator.validate(record.key(), record, true);
+
+        assertThat(result)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .returns(true, Result::valid);
+
         verifyNoInteractions(mockValidator);
     }
 
     @Test
-    void testNullInvalid() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
+    void nullKeyInvalid() {
         boolean nullValid = false;
         BytebufValidator validator = nullEmptyValidator(nullValid, true, mockValidator);
-        Result validate = validate(validator, null, 0, true);
-        assertFalse(validate.valid());
+
+        var record = createMockRecord(null, true);
+        var result = validator.validate(record.key(), record, true);
+
+        assertThat(result)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .returns(false, Result::valid);
+
         verifyNoInteractions(mockValidator);
     }
 
     @Test
-    void testEmptyValid() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
+    void emptyKeyValid() {
         boolean emptyValid = true;
+
+        var record = createMockRecord(null, true);
         BytebufValidator validator = nullEmptyValidator(true, emptyValid, mockValidator);
-        Result validate = validate(validator, ByteBuffer.wrap(new byte[0]), 0, true);
-        assertTrue(validate.valid());
+        var result = validator.validate(record.key(), record, true);
+
+        assertThat(result)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .returns(true, Result::valid);
+
         verifyNoInteractions(mockValidator);
     }
 
     @Test
-    void testEmptyInvalid() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
+    void emptyKeyInvalid() {
         boolean emptyValid = false;
+        var record = createMockRecord(new byte[0], true);
         BytebufValidator validator = nullEmptyValidator(true, emptyValid, mockValidator);
-        Result validate = validate(validator, ByteBuffer.wrap(new byte[0]), 0, true);
-        assertFalse(validate.valid());
+        var result = validator.validate(record.key(), record, true);
+
+        assertThat(result)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .returns(false, Result::valid);
+
         verifyNoInteractions(mockValidator);
     }
 
     @Test
-    void testDelegation() {
-        BytebufValidator mockValidator = mock(BytebufValidator.class);
-        when(mockValidator.validate(any(), anyInt(), any(), anyBoolean())).thenReturn(CompletableFuture.completedFuture(new Result(false, "FAIL")));
+    void nullValueValid() {
+        boolean nullValid = true;
+
+        var record = createMockRecord(null, false);
+        BytebufValidator validator = nullEmptyValidator(nullValid, true, mockValidator);
+        var result = validator.validate(record.value(), record, false);
+
+        assertThat(result)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .returns(true, Result::valid);
+
+        verifyNoInteractions(mockValidator);
+    }
+
+    @Test
+    void delegateValid() {
+        when(mockValidator.validate(any(), any(), anyBoolean())).thenReturn(Result.VALID_RESULT_STAGE);
+
+        var record = createMockRecord(new byte[1], true);
+
         BytebufValidator validator = nullEmptyValidator(true, true, mockValidator);
-        ByteBuffer buffer = ByteBuffer.wrap(new byte[1]);
-        int length = 1;
-        Result validate = validate(validator, buffer, length, true);
-        assertFalse(validate.valid());
-        assertEquals("FAIL", validate.errorMessage());
-        verify(mockValidator).validate(buffer, length, record, true);
+
+        var result = validator.validate(record.key(), record, true);
+
+        assertThat(result)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .returns(true, Result::valid);
+
+        verify(mockValidator, times(1)).validate(any(ByteBuffer.class), any(Record.class), anyBoolean());
     }
 
-    private Result validate(BytebufValidator validator, ByteBuffer buffer, int length, boolean isKey) {
-        try {
-            return validator.validate(buffer, length, record, isKey).toCompletableFuture().get(5, TimeUnit.SECONDS);
-        }
-        catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    @Test
+    void delegateInvalid() {
+        when(mockValidator.validate(any(), any(), anyBoolean())).thenReturn(CompletableFuture.completedFuture(new Result(false, "FAIL")));
+
+        var record = createMockRecord(new byte[1], true);
+
+        BytebufValidator validator = nullEmptyValidator(true, true, mockValidator);
+
+        var result = validator.validate(record.key(), record, true);
+
+        assertThat(result)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .returns(false, Result::valid)
+                .returns("FAIL", Result::errorMessage);
+
+        verify(mockValidator, times(1)).validate(any(ByteBuffer.class), any(Record.class), anyBoolean());
     }
 
+    private Record createMockRecord(byte[] o, boolean isKey) {
+        var mock = mock(Record.class);
+        var hasField = o != null;
+        var fieldSize = o == null ? -1 : o.length;
+        var fieldBuf = o == null ? null : ByteBuffer.wrap(o);
+        if (isKey) {
+            when(mock.hasKey()).thenReturn(hasField);
+            when(mock.keySize()).thenReturn(fieldSize);
+            when(mock.key()).thenReturn(fieldBuf);
+        }
+        else {
+            when(mock.hasValue()).thenReturn(hasField);
+            when(mock.valueSize()).thenReturn(fieldSize);
+            when(mock.value()).thenReturn(fieldBuf);
+        }
+        return mock;
+    }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/record/KeyAndValueRecordValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/record/KeyAndValueRecordValidatorTest.java
@@ -24,8 +24,8 @@ import static org.mockito.Mockito.mock;
 class KeyAndValueRecordValidatorTest {
 
     public static final String FAIL_MESSAGE = "fail";
-    public static final BytebufValidator INVALID = (buffer, length, record, isKey) -> CompletableFuture.completedFuture(new Result(false, FAIL_MESSAGE));
-    public static final BytebufValidator VALID = (buffer, length, record, isKey) -> Result.VALID;
+    public static final BytebufValidator INVALID = (buffer, record, isKey) -> CompletableFuture.completedFuture(new Result(false, FAIL_MESSAGE));
+    public static final BytebufValidator VALID = (buffer, record, isKey) -> Result.VALID_RESULT_STAGE;
 
     @Test
     void testInvalidKey() {

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/topic/PerRecordTopicValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/schema/validation/topic/PerRecordTopicValidatorTest.java
@@ -42,7 +42,7 @@ class PerRecordTopicValidatorTest {
         var tpd = createTopicProduceDataWithOnePartition(RecordTestUtils.record("good"));
         var topicValidator = new PerRecordTopicValidator(validator);
 
-        when(validator.validate(any(Record.class))).thenReturn(Result.VALID);
+        when(validator.validate(any(Record.class))).thenReturn(Result.VALID_RESULT_STAGE);
         var result = topicValidator.validateTopicData(tpd);
         assertThat(result)
                 .succeedsWithin(Duration.ofSeconds(1))
@@ -84,7 +84,7 @@ class PerRecordTopicValidatorTest {
         var tpd = createTopicProduceDataWithOnePartition(good, bad);
         var topicValidator = new PerRecordTopicValidator(validator);
 
-        when(validator.validate(good)).thenReturn(Result.VALID);
+        when(validator.validate(good)).thenReturn(Result.VALID_RESULT_STAGE);
         when(validator.validate(bad)).thenReturn(CompletableFuture.completedStage(new Result(false, "my bad record")));
         var result = topicValidator.validateTopicData(tpd);
 
@@ -110,7 +110,7 @@ class PerRecordTopicValidatorTest {
 
         var topicValidator = new PerRecordTopicValidator(validator);
 
-        when(validator.validate(good)).thenReturn(Result.VALID);
+        when(validator.validate(good)).thenReturn(Result.VALID_RESULT_STAGE);
         when(validator.validate(bad)).thenReturn(CompletableFuture.completedStage(new Result(false, "my bad record")));
         when(validator.validate(ugly)).thenReturn(CompletableFuture.completedStage(new Result(false, "my ugly record")));
 
@@ -141,7 +141,7 @@ class PerRecordTopicValidatorTest {
 
         var topicValidator = new PerRecordTopicValidator(validator);
 
-        when(validator.validate(good)).thenReturn(Result.VALID);
+        when(validator.validate(good)).thenReturn(Result.VALID_RESULT_STAGE);
         when(validator.validate(bad)).thenReturn(CompletableFuture.completedStage(new Result(false, "my bad record")));
         when(validator.validate(ugly)).thenReturn(CompletableFuture.completedStage(new Result(false, "my ugly record")));
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

Remove BytebufValidator#validate length formal parameter.

why: The parameter is superfluous as the buffer is right sized so implementations can consume all of it.

### Additional Context

There's no public API affected by this change.  The ByteBufferValidator API is internal to the filter, and it is not a pluggable API.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [x] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
