### PR TITLE
Document global id validation

### DIFF
--- a/docs/_assets/attributes.adoc
+++ b/docs/_assets/attributes.adoc
@@ -39,3 +39,6 @@
 
 //AWS links
 :aws:  https://docs.aws.amazon.com/
+
+// Apicurio links
+:apicurio-docs: https://www.apicur.io/registry/docs/apicurio-registry/2.6.x/

--- a/docs/_assets/attributes.adoc
+++ b/docs/_assets/attributes.adoc
@@ -16,6 +16,7 @@
 //Latest version
 :ProductVersion: 0.6
 :tag: v0.6.0
+:ApicurioVersion: 2.6.x
 
 //Proxy links
 :github: https://github.com/kroxylicious/kroxylicious
@@ -41,4 +42,4 @@
 :aws:  https://docs.aws.amazon.com/
 
 // Apicurio links
-:apicurio-docs: https://www.apicur.io/registry/docs/apicurio-registry/2.6.x/
+:apicurio-docs: https://www.apicur.io/registry/docs/apicurio-registry/{ApicurioVersion}/

--- a/docs/modules/record-validation/proc-record-validation.adoc
+++ b/docs/modules/record-validation/proc-record-validation.adoc
@@ -54,7 +54,14 @@ Replace the token `<rule definition>`  in the YAML configuration with either a S
 
 .Example Schema Validation Rule Definition
 
-The Schema Validation rule validates that the key or value matches the identified schema.
+The Schema Validation rule validates that the key or value matches a schema identified by its global ID within an Apicurio Schema Registry.
+
+If the key or value does not adhere to the schema, the record will be rejected.  
+
+Additionally, if the kafka producer has embedded a global ID within the record, using either Apicurio `globalId` record header or serialized at the start the content itself
+it will be validated against the global ID defined by the rule.  If they do not match, the record will be rejected.  See the 
+(https://www.apicur.io/registry/docs/apicurio-registry/2.6.x/getting-started/assembly-using-kafka-client-serdes.html#_consumer_schema_configuration)[Apicurio documentation) for details
+of how the global ID is embedded into the record.
 
 [source,yaml]
 ----

--- a/docs/modules/record-validation/proc-record-validation.adoc
+++ b/docs/modules/record-validation/proc-record-validation.adoc
@@ -60,7 +60,8 @@ If the key or value does not adhere to the schema, the record will be rejected.
 
 Additionally, if the kafka producer has embedded a global ID within the record it will be validated against the global ID defined by the rule. If they do not match, the record will be rejected.  See the 
 ({apicurio-docs}/getting-started/assembly-using-kafka-client-serdes.html#_consumer_schema_configuration)[Apicurio documentation) for details
-of how the global ID could be embedded into the record. The filter supports extracting ID's from either Apicurio `globalId` record header or serialized at the start the content itself (Confluent avro style)
+on how the global ID could be embedded into the record. 
+The filter supports extracting ID's from either the Apicurio `globalId` record header or from the serialized content itself (Confluent Avro style).
 
 [source,yaml]
 ----

--- a/docs/modules/record-validation/proc-record-validation.adoc
+++ b/docs/modules/record-validation/proc-record-validation.adoc
@@ -59,7 +59,7 @@ The Schema Validation rule validates that the key or value matches a schema iden
 If the key or value does not adhere to the schema, the record will be rejected.  
 
 Additionally, if the kafka producer has embedded a global ID within the record it will be validated against the global ID defined by the rule. If they do not match, the record will be rejected.  See the 
-({apicurio-docs}/getting-started/assembly-using-kafka-client-serdes.html#_consumer_schema_configuration)[Apicurio documentation) for details
+{apicurio-docs}/getting-started/assembly-using-kafka-client-serdes.html#_consumer_schema_configuration[Apicurio documentation^] for details
 on how the global ID could be embedded into the record. 
 The filter supports extracting ID's from either the Apicurio `globalId` record header or from the serialized content itself (Confluent Avro style).
 

--- a/docs/modules/record-validation/proc-record-validation.adoc
+++ b/docs/modules/record-validation/proc-record-validation.adoc
@@ -61,7 +61,7 @@ If the key or value does not adhere to the schema, the record will be rejected.
 Additionally, if the kafka producer has embedded a global ID within the record it will be validated against the global ID defined by the rule. If they do not match, the record will be rejected.  See the 
 {apicurio-docs}/getting-started/assembly-using-kafka-client-serdes.html#_consumer_schema_configuration[Apicurio documentation^] for details
 on how the global ID could be embedded into the record. 
-The filter supports extracting ID's from either the Apicurio `globalId` record header or from the serialized content itself (Confluent Avro style).
+The filter supports extracting ID's from either the Apicurio `globalId` record header or from the initial bytes of the serialized content itself.
 
 [source,yaml]
 ----

--- a/docs/modules/record-validation/proc-record-validation.adoc
+++ b/docs/modules/record-validation/proc-record-validation.adoc
@@ -58,7 +58,7 @@ The Schema Validation rule validates that the key or value matches a schema iden
 
 If the key or value does not adhere to the schema, the record will be rejected.  
 
-Additionally, if the kafka producer has embedded a global ID within the record it will be validated against the global ID defined by the rule.  If they do not match, the record will be rejected.  See the 
+Additionally, if the kafka producer has embedded a global ID within the record it will be validated against the global ID defined by the rule. If they do not match, the record will be rejected.  See the 
 ({apicurio-docs}/getting-started/assembly-using-kafka-client-serdes.html#_consumer_schema_configuration)[Apicurio documentation) for details
 of how the global ID could be embedded into the record. The filter supports extracting ID's from either Apicurio `globalId` record header or serialized at the start the content itself (Confluent avro style)
 

--- a/docs/modules/record-validation/proc-record-validation.adoc
+++ b/docs/modules/record-validation/proc-record-validation.adoc
@@ -58,10 +58,9 @@ The Schema Validation rule validates that the key or value matches a schema iden
 
 If the key or value does not adhere to the schema, the record will be rejected.  
 
-Additionally, if the kafka producer has embedded a global ID within the record, using either Apicurio `globalId` record header or serialized at the start the content itself
-it will be validated against the global ID defined by the rule.  If they do not match, the record will be rejected.  See the 
+Additionally, if the kafka producer has embedded a global ID within the record it will be validated against the global ID defined by the rule.  If they do not match, the record will be rejected.  See the 
 ({apicurio-docs}/getting-started/assembly-using-kafka-client-serdes.html#_consumer_schema_configuration)[Apicurio documentation) for details
-of how the global ID is embedded into the record.
+of how the global ID could be embedded into the record. The filter supports extracting ID's from either Apicurio `globalId` record header or serialized at the start the content itself (Confluent avro style)
 
 [source,yaml]
 ----

--- a/docs/modules/record-validation/proc-record-validation.adoc
+++ b/docs/modules/record-validation/proc-record-validation.adoc
@@ -60,7 +60,7 @@ If the key or value does not adhere to the schema, the record will be rejected.
 
 Additionally, if the kafka producer has embedded a global ID within the record, using either Apicurio `globalId` record header or serialized at the start the content itself
 it will be validated against the global ID defined by the rule.  If they do not match, the record will be rejected.  See the 
-(https://www.apicur.io/registry/docs/apicurio-registry/2.6.x/getting-started/assembly-using-kafka-client-serdes.html#_consumer_schema_configuration)[Apicurio documentation) for details
+({apicurio-docs}/getting-started/assembly-using-kafka-client-serdes.html#_consumer_schema_configuration)[Apicurio documentation) for details
 of how the global ID is embedded into the record.
 
 [source,yaml]


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

This is documentation to go with #1417.   That PR changed JsonSchemaValidator so that it is capable of validating that the schema id sent by the producer matches the schema id configured at the proxy.  The schema id may be passed as a header or as initial bytes in the content. 

If the producer doesn't send a schema id, there's no change in behaviour.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [x] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
