### PR TITLE
Fix ##1440 : Address sporadically failing CacheKmsTests

### DIFF
--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/kms/CachingKms.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/kms/CachingKms.java
@@ -24,6 +24,7 @@ import io.kroxylicious.kms.service.DekPair;
 import io.kroxylicious.kms.service.Kms;
 import io.kroxylicious.kms.service.Serde;
 import io.kroxylicious.kms.service.UnknownAliasException;
+import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -114,4 +115,20 @@ public class CachingKms<K, E> implements Kms<K, E> {
         });
         return resolved;
     }
+
+    @VisibleForTesting
+    void decryptDekCacheCleanUp() {
+        decryptDekCache.synchronous().cleanUp();
+    }
+
+    @VisibleForTesting
+    void resolveAliasCacheCleanUp() {
+        resolveAliasCache.synchronous().cleanUp();
+    }
+
+    @VisibleForTesting
+    void notFoundAliasCacheCleanUp() {
+        notFoundAliasCache.cleanUp();
+    }
+
 }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Caffeine performs cleanup work in small amounts, after r/w operations, or in the background.  This means that it is not generally predictable when the cache will remove/evict entries.  This is leading to the unit test instability as the test assumes deterministic behaviour.

Solution is inspired by: https://github.com/ben-manes/caffeine/wiki/Cleanup

This is a test only issue - no change in production behaviour.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
