### PR TITLE
Replace versions in doc book when releasing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ fabric.properties
 
 docs/*.html
 .sdkmanrc
+.releaseNotes

--- a/docs/_assets/attributes.adoc
+++ b/docs/_assets/attributes.adoc
@@ -20,7 +20,7 @@
 
 //Proxy links
 :github: https://github.com/kroxylicious/kroxylicious
-:github-releases: https://github.com/kroxylicious/kroxylicious/releases/tag/{gitRef}
+:github-releases: https://github.com/kroxylicious/kroxylicious/{gitRef}
 :github-issues: https://github.com/kroxylicious/kroxylicious/issues[Kroxylicious issues^]
 :api-javadoc: https://javadoc.io/doc/io.kroxylicious/kroxylicious-api/{ProductVersion}
 :kms-api-javadoc: https://javadoc.io/doc/io.kroxylicious/kroxylicious-kms/{ProductVersion}

--- a/docs/_assets/attributes.adoc
+++ b/docs/_assets/attributes.adoc
@@ -15,18 +15,17 @@
 
 //Latest version
 :ProductVersion: 0.6
-:tag: v0.6.0
+:gitRef: v0.6.0
 :ApicurioVersion: 2.6.x
 
 //Proxy links
 :github: https://github.com/kroxylicious/kroxylicious
-:github-releases: https://github.com/kroxylicious/kroxylicious/releases/tag/{tag}
+:github-releases: https://github.com/kroxylicious/kroxylicious/releases/tag/{gitRef}
 :github-issues: https://github.com/kroxylicious/kroxylicious/issues[Kroxylicious issues^]
 :api-javadoc: https://javadoc.io/doc/io.kroxylicious/kroxylicious-api/{ProductVersion}
 :kms-api-javadoc: https://javadoc.io/doc/io.kroxylicious/kroxylicious-kms/{ProductVersion}
 :encryption-api-javadoc: https://javadoc.io/doc/io.kroxylicious/kroxylicious-encryption/{ProductVersion}
-:design-doc: https://github.com/kroxylicious/kroxylicious/blob/{tag}/kroxylicious-filters/kroxylicious-encryption/doc/design.adoc
-:start-script: https://github.com/kroxylicious/kroxylicious/blob/{tag}/kroxylicious-app/src/assembly/kroxylicious-start.sh
+:start-script: https://github.com/kroxylicious/kroxylicious/blob/{gitRef}/kroxylicious-app/src/assembly/kroxylicious-start.sh
 
 //Kafka links
 :ApacheKafkaSite: https://kafka.apache.org[Apache Kafka website^]

--- a/docs/modules/con-operating.adoc
+++ b/docs/modules/con-operating.adoc
@@ -12,7 +12,7 @@ Configure common tags and standard binders for JVM and system metrics to ensure 
 
 == Logging
 
-The Kroxylicious {github-releases}[binary distributions^] ship with https://logging.apache.org/log4j/2.x[log4j2] as a logging backend. To customize the logging configuration:
+The Kroxylicious {github-releases}[binary distribution^] bundles https://logging.apache.org/log4j/2.x[log4j2] as a logging backend. To customize the logging configuration users can:
 
 === Use an Alternative Log4j configuration file
 

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -143,6 +143,8 @@ echo "Versioning Kroxylicious as ${RELEASE_VERSION}"
 updateVersions "${INITIAL_VERSION}" "${RELEASE_VERSION}"
 #Set the release version in the Changelog
 ${SED} -i -e "s_##\sSNAPSHOT_## ${RELEASE_VERSION//./\\.}_g" CHANGELOG.md
+${SED} -i -e "s_:ProductVersion:.*_:ProductVersion: ${RELEASE_VERSION%.*}_g" docs/_assets/attributes.adoc
+${SED} -i -e "s_:tag:.*_:tag: v${RELEASE_VERSION//./\\.}_g" docs/_assets/attributes.adoc
 git add 'CHANGELOG.md'
 
 echo "Validating things still build"

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -210,7 +210,11 @@ gh repo set-default "$(git remote get-url "${REPOSITORY}")"
 echo "Creating draft release notes."
 API_COMPATABILITY_REPORT=kroxylicious-api/target/japicmp/"${RELEASE_VERSION}"-compatability.html
 cp kroxylicious-api/target/japicmp/japicmp.html "${API_COMPATABILITY_REPORT}"
-gh release create --title "${RELEASE_TAG}" --notes-file "CHANGELOG.md" --draft "${RELEASE_TAG}" ./kroxylicious-*/target/kroxylicious-*-bin.* "${API_COMPATABILITY_REPORT}"
+RELEASE_NOTES_DIR=releaseNotes
+mkdir -p ${RELEASE_NOTES_DIR}
+csplit -f "${RELEASE_NOTES_DIR}/release-notes_" CHANGELOG.md "/^## /" '{*}'
+# csplit will create a file for every version as we use ## to denote versions. We also use # CHANGELOG as a header so the current release is actually in the 01 file (zero based)
+gh release create --title "${RELEASE_TAG}" --notes-file "${RELEASE_NOTES_DIR}/release-notes_01" --draft "${RELEASE_TAG}" ./kroxylicious-*/target/kroxylicious-*-bin.* "${API_COMPATABILITY_REPORT}"
 
 
 BODY="Release version ${RELEASE_VERSION}"

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -210,7 +210,7 @@ gh repo set-default "$(git remote get-url "${REPOSITORY}")"
 echo "Creating draft release notes."
 API_COMPATABILITY_REPORT=kroxylicious-api/target/japicmp/"${RELEASE_VERSION}"-compatability.html
 cp kroxylicious-api/target/japicmp/japicmp.html "${API_COMPATABILITY_REPORT}"
-RELEASE_NOTES_DIR=releaseNotes
+RELEASE_NOTES_DIR=.releaseNotes
 mkdir -p ${RELEASE_NOTES_DIR}
 csplit -f "${RELEASE_NOTES_DIR}/release-notes_" CHANGELOG.md "/^## /" '{*}'
 # csplit will create a file for every version as we use ## to denote versions. We also use # CHANGELOG as a header so the current release is actually in the 01 file (zero based)

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -143,9 +143,11 @@ echo "Versioning Kroxylicious as ${RELEASE_VERSION}"
 updateVersions "${INITIAL_VERSION}" "${RELEASE_VERSION}"
 #Set the release version in the Changelog
 ${SED} -i -e "s_##\sSNAPSHOT_## ${RELEASE_VERSION//./\\.}_g" CHANGELOG.md
+git add 'CHANGELOG.md'
+
 ${SED} -i -e "s_:ProductVersion:.*_:ProductVersion: ${RELEASE_VERSION%.*}_g" docs/_assets/attributes.adoc
 ${SED} -i -e "s_:tag:.*_:tag: v${RELEASE_VERSION//./\\.}_g" docs/_assets/attributes.adoc
-git add 'CHANGELOG.md'
+git add 'docs/_assets/attributes.adoc'
 
 echo "Validating things still build"
 mvn -q -B clean install -Pquick

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -152,7 +152,7 @@ updateVersions "${INITIAL_VERSION}" "${RELEASE_VERSION}"
 replaceInFile "s_##\sSNAPSHOT_## ${RELEASE_VERSION//./\\.}_g" CHANGELOG.md
 
 replaceInFile "s_:ProductVersion:.*_:ProductVersion: ${RELEASE_VERSION%.*}_g" docs/_assets/attributes.adoc
-replaceInFile "s_:tag:.*_:tag: v${RELEASE_VERSION//./\\.}_g" docs/_assets/attributes.adoc
+replaceInFile "s_:gitRef:.*_:gitRef: v${RELEASE_VERSION//./\\.}_g" docs/_assets/attributes.adoc
 
 echo "Validating things still build"
 mvn -q -B clean install -Pquick
@@ -182,7 +182,7 @@ replaceInFile "s_##\s${RELEASE_VERSION//./\\.}_## SNAPSHOT\n## ${RELEASE_VERSION
 
 # bump the docs for the development version
 replaceInFile "s_:ProductVersion:.*_:ProductVersion: ${DEVELOPMENT_VERSION%.*}_g" docs/_assets/attributes.adoc
-replaceInFile "s_:tag:.*_:tag: v${DEVELOPMENT_VERSION//./\\.}_g" docs/_assets/attributes.adoc # this doesn't make a lot sense...
+replaceInFile "s_:gitRef:.*_:gitRef: v${DEVELOPMENT_VERSION//./\\.}_g" docs/_assets/attributes.adoc # this doesn't make a lot sense...
 
 # bump the reference version in kroxylicious-api
 mvn -q -B -f kroxylicious-api/pom.xml versions:set-property -Dproperty="ApiCompatability.ReferenceVersion" -DnewVersion="${RELEASE_VERSION}" -DgenerateBackupPoms=false

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -152,7 +152,7 @@ updateVersions "${INITIAL_VERSION}" "${RELEASE_VERSION}"
 replaceInFile "s_##\sSNAPSHOT_## ${RELEASE_VERSION//./\\.}_g" CHANGELOG.md
 
 replaceInFile "s_:ProductVersion:.*_:ProductVersion: ${RELEASE_VERSION%.*}_g" docs/_assets/attributes.adoc
-replaceInFile "s_:gitRef:.*_:gitRef: v${RELEASE_VERSION//./\\.}_g" docs/_assets/attributes.adoc
+replaceInFile "s_:gitRef:.*_:gitRef: releases/tag/v${RELEASE_VERSION//./\\.}_g" docs/_assets/attributes.adoc
 
 echo "Validating things still build"
 mvn -q -B clean install -Pquick
@@ -182,7 +182,7 @@ replaceInFile "s_##\s${RELEASE_VERSION//./\\.}_## SNAPSHOT\n## ${RELEASE_VERSION
 
 # bump the docs for the development version
 replaceInFile "s_:ProductVersion:.*_:ProductVersion: ${DEVELOPMENT_VERSION%.*}_g" docs/_assets/attributes.adoc
-replaceInFile "s_:gitRef:.*_:gitRef: v${DEVELOPMENT_VERSION//./\\.}_g" docs/_assets/attributes.adoc # this doesn't make a lot sense...
+replaceInFile "s_:gitRef:.*_:gitRef: tree/main_g" docs/_assets/attributes.adoc # this doesn't make a lot sense...
 
 # bump the reference version in kroxylicious-api
 mvn -q -B -f kroxylicious-api/pom.xml versions:set-property -Dproperty="ApiCompatability.ReferenceVersion" -DnewVersion="${RELEASE_VERSION}" -DgenerateBackupPoms=false


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Ensure the docbook gets updated when releasing a new version.

### Additional Context

git diff after running the changes.

```
diff --git a/docs/_assets/attributes.adoc b/docs/_assets/attributes.adoc
index 8284a847c..d71ca8bf8 100644
--- a/docs/_assets/attributes.adoc
+++ b/docs/_assets/attributes.adoc
@@ -14,8 +14,8 @@
 :icons: font
 
 //Latest version
-:ProductVersion: 0.6
-:tag: v0.6.0
+:ProductVersion: 0.7
+:tag: v0.7.0
 
 //Proxy links
 :github: https://github.com/kroxylicious/kroxylicious
 ```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
