### PR TITLE
Exclude transitive dependency on lombok

### DIFF
--- a/kroxylicious-filters/kroxylicious-record-validation/pom.xml
+++ b/kroxylicious-filters/kroxylicious-record-validation/pom.xml
@@ -55,6 +55,12 @@
         <dependency>
             <groupId>io.apicurio</groupId>
             <artifactId>apicurio-registry-schema-resolver</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.projectlombok</groupId>
+                    <artifactId>lombok</artifactId>
+                </exclusion>
+            </exclusions> 
         </dependency>
         <dependency>
             <groupId>io.apicurio</groupId>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

From the Lombok docs https://projectlombok.org/setup/maven:
> To set up lombok with any build tool, you have to specify that the lombok dependency
is required to compile your source code, but does not need to be present when
running/testing/jarring/otherwise deploying your code. Generally this is called
a 'provided' dependency.

We can remove this, less jars to worry about on the classpath

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
