### PR TITLE
Validate yaml snippets in ascii docs

### DIFF
--- a/docs/modules/con-custom-filters.adoc
+++ b/docs/modules/con-custom-filters.adoc
@@ -212,7 +212,7 @@ Filter result builders allow you to:
 The builder lets you combine legal behaviours together.  For instance, to close the connection after forwarding
 a response to a client, a response filter could use:
 
-[source,yaml]
+[source,java]
 ----
 return context.responseFilterResultBuilder()
         .forward(header, response)

--- a/docs/modules/record-encryption/proc-configuring-record-encryption-filter.adoc
+++ b/docs/modules/record-encryption/proc-configuring-record-encryption-filter.adoc
@@ -39,7 +39,6 @@ filters:
         encryptionDekRefreshAfterWriteSeconds: 3600 # <5>
         encryptionDekExpireAfterWriteSeconds: 7200 # <6>
         maxEncryptionsPerDek: 5000000 # <7>
-	 # ...
 ----
 <1> The KMS service name.
 <2> Configuration specific to the KMS provider.

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,8 @@
         <jose4j.version>0.9.6</jose4j.version>
 
         <!-- Test dependencies -->
-        <strimzi.version>0.45.0</strimzi.version>  <!-- when bumping strimzi, be sure to comment out the kafka.version override in the systemtest module's pom -->
+        <strimzi.version>0.45.0
+        </strimzi.version>  <!-- when bumping strimzi, be sure to comment out the kafka.version override in the systemtest module's pom -->
         <kubernetes-client.version>6.13.4</kubernetes-client.version>
         <enforcer.api.version>3.5.0</enforcer.api.version>
         <maven.core.version>3.9.9</maven.core.version>
@@ -79,6 +80,7 @@
         <wiremock.version>3.10.0</wiremock.version>
         <docker-java.version>3.4.1</docker-java.version>
         <junit-pioneer.version>2.3.0</junit-pioneer.version>
+        <skip-validate-yaml-snippets>true</skip-validate-yaml-snippets>
     </properties>
 
     <name>Parent POM</name>
@@ -405,7 +407,7 @@
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-core</artifactId>
                 <version>${maven.core.version}</version>
-             </dependency>
+            </dependency>
             <dependency>
                 <groupId>org.awaitility</groupId>
                 <artifactId>awaitility</artifactId>
@@ -784,6 +786,11 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.5.0</version>
+            </plugin>
+            <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
                 <version>3.1.1</version>
@@ -923,20 +930,25 @@
                                     <failOnWarning>true</failOnWarning>
                                     <ignoreUnusedRuntime>true</ignoreUnusedRuntime>
                                     <ignoredUsedUndeclaredDependencies>
-                                        <ignoredUsedUndeclaredDependency>com.google.code.findbugs:jsr305</ignoredUsedUndeclaredDependency>
+                                        <ignoredUsedUndeclaredDependency>com.google.code.findbugs:jsr305
+                                        </ignoredUsedUndeclaredDependency>
                                     </ignoredUsedUndeclaredDependencies>
                                     <ignoredUnusedDeclaredDependencies>
                                         <!-- several modules have a test dependency on log4j-slf4j2-impl to enable test logging -->
-                                        <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j2-impl</ignoredUnusedDeclaredDependency>
+                                        <ignoredUnusedDeclaredDependency>org.apache.logging.log4j:log4j-slf4j2-impl
+                                        </ignoredUnusedDeclaredDependency>
                                         <!-- for some reason, the analyzer fails to detect netty-transport-native-unix-common use -->
-                                        <ignoredUnusedDeclaredDependency>io.netty:netty-transport-native-unix-common</ignoredUnusedDeclaredDependency>
+                                        <ignoredUnusedDeclaredDependency>io.netty:netty-transport-native-unix-common
+                                        </ignoredUnusedDeclaredDependency>
                                         <!-- dependency analyzer seems not to grok that a dependency on a
                                         @Retention(RetentionPolicy.SOURCE) annotation is still a dependency -->
-                                        <ignoredUnusedDeclaredDependency>io.kroxylicious:kroxylicious-annotations</ignoredUnusedDeclaredDependency>
+                                        <ignoredUnusedDeclaredDependency>io.kroxylicious:kroxylicious-annotations
+                                        </ignoredUnusedDeclaredDependency>
                                     </ignoredUnusedDeclaredDependencies>
                                     <ignoredDependencies>
                                         <!-- Kroxylicious junit extension requires this to be on the classpath -->
-                                        <ignoredUnusedDeclaredDependency>org.apache.kafka:kafka_2.13</ignoredUnusedDeclaredDependency>
+                                        <ignoredUnusedDeclaredDependency>org.apache.kafka:kafka_2.13
+                                        </ignoredUnusedDeclaredDependency>
                                     </ignoredDependencies>
                                 </configuration>
                             </execution>
@@ -1078,6 +1090,7 @@
                 <sonar.organization>kroxylicious</sonar.organization>
                 <sonar.host.url>https://sonarcloud.io</sonar.host.url>
                 <impsort-maven-plugin.goal>check</impsort-maven-plugin.goal>
+                <skip-validate-yaml-snippets>false</skip-validate-yaml-snippets>
             </properties>
             <build>
                 <plugins>
@@ -1160,6 +1173,24 @@
                                     <formats>
                                         <format>XML</format>
                                     </formats>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>docs-validate-yaml-snippets</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${skip-validate-yaml-snippets}</skip>
+                                    <!--suppress MavenModelInspection -->
+                                    <executable>${rootdir}/scripts/extract-yaml-fencedcodeblocks.sh</executable>
                                 </configuration>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,7 @@
         <jose4j.version>0.9.6</jose4j.version>
 
         <!-- Test dependencies -->
-        <strimzi.version>0.45.0
-        </strimzi.version>  <!-- when bumping strimzi, be sure to comment out the kafka.version override in the systemtest module's pom -->
+        <strimzi.version>0.45.0</strimzi.version>  <!-- when bumping strimzi, be sure to comment out the kafka.version override in the systemtest module's pom -->
         <kubernetes-client.version>6.13.4</kubernetes-client.version>
         <enforcer.api.version>3.5.0</enforcer.api.version>
         <maven.core.version>3.9.9</maven.core.version>

--- a/scripts/extract-codeblock.awk
+++ b/scripts/extract-codeblock.awk
@@ -3,7 +3,7 @@
 #
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
-BEGIN {CODEBLOCK = 0; SNIPPET = 0; RED = "\\033[0;31m"; NO_COLOUR = "\\033[0m"; }
+BEGIN {CODEBLOCK = 0; SNIPPET = 0}
 BEGINFILE {
     if (ERRNO != "") {
         print "couldn't open " FILENAME " skipping"
@@ -14,12 +14,12 @@ BEGINFILE {
 SNIPPET && !CODEBLOCK && /[-]{4}/            { CODEBLOCK = 1; COUNTER = COUNTER++ ; next} # code block found
 CODEBLOCK && /[-]{4}/                        {
     yq_cmd = ("echo '" buf "' | yq 'true' > /dev/null")
-    ext = system(yq_cmd);
+    ext = system(yq_cmd)
     if (ext != 0) {
         printf "Invalid %s snippet between lines %s and %s of %s \n", BLOCKTYPE, SNIPPET, FNR, FILENAME
     }
-    CODEBLOCK = 0;
-    SNIPPET = 0;
+    CODEBLOCK = 0
+    SNIPPET = 0
     buf = ""
 } # code block terminated
 CODEBLOCK                                    { buf = buf $0 ORS }

--- a/scripts/extract-codeblock.awk
+++ b/scripts/extract-codeblock.awk
@@ -1,0 +1,24 @@
+BEGIN {CODEBLOCK = 0; SNIPPET = 0; RED = "\\033[0;31m"; NO_COLOUR = "\\033[0m"; }
+BEGINFILE {
+    if (ERRNO != "") {
+        print "couldn't open " FILENAME " skipping"
+        nextfile
+    }
+}
+/^\[source,yaml\]/                           { SNIPPET = 1; next} # code block follows between `----`
+SNIPPET && !CODEBLOCK && /[-]{4}/            { CODEBLOCK = 1; COUNTER = COUNTER++ ; next} # code block found
+CODEBLOCK && /[-]{4}/                        {
+    CODEBLOCK = 0;
+    SNIPPET = 0;
+    yq_cmd = ("echo '" buf "' | yq 'true' > /dev/null")
+    ext = system(yq_cmd);
+    if (ext != 0) {
+        print "Invalid YAML snippet at " FNR " of " FILENAME
+    }
+    SNIPPET = 0
+    buf = ""
+} # code block terminated
+CODEBLOCK                                    { buf = buf $0 ORS }
+ENDFILE {
+#    print "validated YAML in "  FILENAME
+}

--- a/scripts/extract-codeblock.awk
+++ b/scripts/extract-codeblock.awk
@@ -1,3 +1,8 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
 BEGIN {CODEBLOCK = 0; SNIPPET = 0; RED = "\\033[0;31m"; NO_COLOUR = "\\033[0m"; }
 BEGINFILE {
     if (ERRNO != "") {

--- a/scripts/extract-codeblock.awk
+++ b/scripts/extract-codeblock.awk
@@ -3,7 +3,7 @@
 #
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
-BEGIN {CODEBLOCK = 0; SNIPPET = 0}
+BEGIN {CODEBLOCK = 0; SNIPPET = 0; EXIT_CODE = 0}
 BEGINFILE {
     if (ERRNO != "") {
         print "couldn't open " FILENAME " skipping"
@@ -16,7 +16,8 @@ CODEBLOCK && /[-]{4}/                        {
     yq_cmd = ("echo '" buf "' | yq 'true' > /dev/null")
     ext = system(yq_cmd)
     if (ext != 0) {
-        printf "Invalid %s snippet between lines %s and %s of %s \n", BLOCKTYPE, SNIPPET, FNR, FILENAME
+        printf ( "Invalid %s snippet between lines %s and %s of %s \n", BLOCKTYPE, SNIPPET, FNR, FILENAME)
+        EXIT_CODE = 1
     }
     CODEBLOCK = 0
     SNIPPET = 0
@@ -24,5 +25,6 @@ CODEBLOCK && /[-]{4}/                        {
 } # code block terminated
 CODEBLOCK                                    { buf = buf $0 ORS }
 ENDFILE {
-#    print "validated YAML in "  FILENAME
+    #    print "validated YAML in "  FILENAME
 }
+END {exit EXIT_CODE}

--- a/scripts/extract-codeblock.awk
+++ b/scripts/extract-codeblock.awk
@@ -5,17 +5,16 @@ BEGINFILE {
         nextfile
     }
 }
-/^\[source,yaml\]/                           { SNIPPET = 1; next} # code block follows between `----`
+/^\[source,yaml\]/                           { SNIPPET = FNR; next} # code block follows between `----`
 SNIPPET && !CODEBLOCK && /[-]{4}/            { CODEBLOCK = 1; COUNTER = COUNTER++ ; next} # code block found
 CODEBLOCK && /[-]{4}/                        {
-    CODEBLOCK = 0;
-    SNIPPET = 0;
     yq_cmd = ("echo '" buf "' | yq 'true' > /dev/null")
     ext = system(yq_cmd);
     if (ext != 0) {
-        print "Invalid YAML snippet at " FNR " of " FILENAME
+        printf "Invalid %s snippet between lines %s and %s of %s \n", BLOCKTYPE, SNIPPET, FNR, FILENAME
     }
-    SNIPPET = 0
+    CODEBLOCK = 0;
+    SNIPPET = 0;
     buf = ""
 } # code block terminated
 CODEBLOCK                                    { buf = buf $0 ORS }

--- a/scripts/extract-yaml-fencedcodeblocks.sh
+++ b/scripts/extract-yaml-fencedcodeblocks.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# Extracts fenced code blocks from the given markdown supplied on stdin, emitting them to stdout.
+# If the fenced code block has an attribute `adjunct` its contents are emitted too, before the codeblock to which it is
+# applied.
+#
+# Supports only codeblocks delimited by backticks.
+
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. "${SCRIPT_DIR}/common.sh"
+
+BLOCKTYPE=${BLOCKTYPE:-yaml}
+DOCS_DIR=${DOCS_DIR:-${SCRIPT_DIR}/../docs}
+
+#Find the files and then pass them to GAWK as args so it knows the file names
+find "${DOCS_DIR}" -type f -name "*.adoc" -exec "${GAWK}" -f "${SCRIPT_DIR}/extract-codeblock.awk" -vBLOCKTYPE="${BLOCKTYPE}" {} ";"

--- a/scripts/extract-yaml-fencedcodeblocks.sh
+++ b/scripts/extract-yaml-fencedcodeblocks.sh
@@ -20,4 +20,4 @@ BLOCKTYPE=${BLOCKTYPE:-yaml}
 DOCS_DIR=${DOCS_DIR:-${SCRIPT_DIR}/../docs}
 
 #Find the files and then pass them to GAWK as args so it knows the file names
-find "${DOCS_DIR}" -type f -name "*.adoc" -exec "${GAWK}" -f "${SCRIPT_DIR}/extract-codeblock.awk" -vBLOCKTYPE="${BLOCKTYPE}" {} ";"
+find "${DOCS_DIR}" -type f -name "*.adoc" -print0 | xargs -0 -n1 "${GAWK}" -f "${SCRIPT_DIR}/extract-codeblock.awk" -vBLOCKTYPE="${BLOCKTYPE}" "${0}"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

A script to extract the snippets of YAML from the ascii docs and check that they are valid.

### Additional Context

After publishing the 0.7.0 Docs we noticed that some of the yaml snippets were being rendered with red boxes in them as they were not valid (white space errors). This script is a step in catching that and preventing that. 

I haven't figured out how to integrate it into the dev or release flows yet but wanted to get this script up for review.

Errors currently reported as:
```
❯ scripts/extract-yaml-fencedcodeblocks.sh
Error: bad file '-': yaml: line 15: found character that cannot start any token
Invalid yaml snippet between lines 26 and 43 of /Users/sbarker/src/kroxy/kroxylicious/scripts/../docs/modules/record-encryption/proc-configuring-record-encryption-filter.adoc
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
