### PR TITLE
Using assertThat(future) provides cleaner error handling and better us…

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/BaseIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/BaseIT.java
@@ -35,19 +35,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 public abstract class BaseIT {
 
     protected CreateTopicsResult createTopics(Admin admin, NewTopic... topics) {
-        try {
-            List<NewTopic> topicsList = List.of(topics);
-            var created = admin.createTopics(topicsList);
-            assertThat(created.values()).hasSizeGreaterThanOrEqualTo(topicsList.size());
-            created.all().get(10, TimeUnit.SECONDS);
-            return created;
-        }
-        catch (ExecutionException e) {
-            throw new RuntimeException(e.getCause());
-        }
-        catch (InterruptedException | TimeoutException e) {
-            throw new RuntimeException(e);
-        }
+        List<NewTopic> topicsList = List.of(topics);
+        var created = admin.createTopics(topicsList);
+        assertThat(created.values()).hasSizeGreaterThanOrEqualTo(topicsList.size());
+        assertThat(created.all()).succeedsWithin(10, TimeUnit.SECONDS);
+        return created;
     }
 
     protected CreateTopicsResult createTopic(Admin admin, String topic, int numPartitions) {
@@ -55,17 +47,9 @@ public abstract class BaseIT {
     }
 
     protected DeleteTopicsResult deleteTopics(Admin admin, TopicCollection topics) {
-        try {
-            var deleted = admin.deleteTopics(topics);
-            deleted.all().get(10, TimeUnit.SECONDS);
-            return deleted;
-        }
-        catch (ExecutionException e) {
-            throw new RuntimeException(e.getCause());
-        }
-        catch (InterruptedException | TimeoutException e) {
-            throw new RuntimeException(e);
-        }
+        var deleted = admin.deleteTopics(topics);
+        assertThat(deleted.all()).succeedsWithin(10, TimeUnit.SECONDS);
+        return deleted;
     }
 
     protected Map<String, Object> buildClientConfig(Map<String, Object>... configs) {


### PR DESCRIPTION
…er experience than sneaky throwing checked exceptions.

### Type of change

- Enhancement / new feature

### Description

Provides a better experience when there are issues with interacting with Kafka

### Additional Context

The Netty 4.2 experiment is having issue and high lights a mixture of test failures. Compare

```
java.lang.AssertionError: 
Expecting
  <KafkaFutureImpl[Incomplete]>
to be completed within 10S.

exception caught while trying to get the future result: java.util.concurrent.TimeoutException
	at java.base/java.util.concurrent.CompletableFuture.timedGet(CompletableFuture.java:1960)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2095)
```
with
```
024-08-26 13:50:26 WARN  org.apache.kafka.clients.NetworkClient:693 - [NodeToControllerChannelManager id=0 name=registration] Attempting to close NetworkClient that has already been closed.

java.lang.RuntimeException: java.util.concurrent.TimeoutException

	at io.kroxylicious.proxy.BaseIT.createTopics(BaseIT.java:49)
	at io.kroxylicious.proxy.BaseIT.createTopic(BaseIT.java:54)
	at io.kroxylicious.proxy.TlsIT.upstreamUsesSelfSignedTls_TrustStore(TlsIT.java:116)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
Caused by: java.util.concurrent.TimeoutException
	at java.base/java.util.concurrent.CompletableFuture.timedGet(CompletableFuture.java:1960)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2095)
	at org.apache.kafka.common.internals.KafkaFutureImpl.get(KafkaFutureImpl.java:180)
	at io.kroxylicious.proxy.BaseIT.createTopics(BaseIT.java:42)
	... 5 more
```
I think its much clearer what has gone wrong in the former case than in the later.
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
