### PR TITLE
Upstream Kafka TLS hostname verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ For changes that effect a public API, the [deprecation policy](./DEV_GUIDE.md#de
 Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
+
+* [#1414](https://github.com/kroxylicious/kroxylicious/issues/1474) Enable hostname verification when connecting to upstream clusters using TLS 
+
 ## 0.7.0
 
 * [#1414](https://github.com/kroxylicious/kroxylicious/issues/1414) Address record validation filter name inconsistency

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/PlatformTrustProvider.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/PlatformTrustProvider.java
@@ -6,7 +6,13 @@
 
 package io.kroxylicious.proxy.config.tls;
 
+@SuppressWarnings("java:S6548")
 public class PlatformTrustProvider implements TrustProvider {
+
+    public static final PlatformTrustProvider INSTANCE = new PlatformTrustProvider();
+
+    private PlatformTrustProvider() {
+    }
 
     @Override
     public <T> T accept(TrustProviderVisitor<T> visitor) {

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/PlatformTrustProvider.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/PlatformTrustProvider.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config.tls;
+
+public class PlatformTrustProvider implements TrustProvider {
+
+    @Override
+    public <T> T accept(TrustProviderVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/TrustProvider.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/TrustProvider.java
@@ -27,5 +27,4 @@ public interface TrustProvider {
      * @param visitor visitor.
      */
     <T> T accept(TrustProviderVisitor<T> visitor);
-
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/TrustProviderVisitor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/TrustProviderVisitor.java
@@ -16,4 +16,6 @@ public interface TrustProviderVisitor<T> {
 
     T visit(InsecureTls insecureTls);
 
+    T visit(PlatformTrustProvider platformTrustProviderTls);
+
 }

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/config/tls/InsecureTlsTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/config/tls/InsecureTlsTest.java
@@ -18,13 +18,19 @@ class InsecureTlsTest {
         InsecureTls result = trustProvider.accept(new TrustProviderVisitor<>() {
             @Override
             public InsecureTls visit(TrustStore trustStore) {
-                throw new RuntimeException("should not be called");
+                throw new RuntimeException("unexpected call to visit(TrustStore)");
             }
 
             @Override
             public InsecureTls visit(InsecureTls insecureTls) {
                 return insecureTls;
             }
+
+            @Override
+            public InsecureTls visit(PlatformTrustProvider platformTrustProviderTls) {
+                throw new RuntimeException("unexpected call to visit(PlatformTrustProvider)");
+            }
+
         });
         assertThat(result).isSameAs(trustProvider);
     }

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/config/tls/PlatformTrustProviderTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/config/tls/PlatformTrustProviderTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class PlatformTrustProviderTest {
     @Test
     void testAccept() {
-        TrustProvider trustProvider = new PlatformTrustProvider();
+        TrustProvider trustProvider = PlatformTrustProvider.INSTANCE;
         Void result = trustProvider.accept(new TrustProviderVisitor<>() {
             @Override
             public Void visit(TrustStore trustStore) {

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/config/tls/PlatformTrustProviderTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/config/tls/PlatformTrustProviderTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config.tls;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PlatformTrustProviderTest {
+    @Test
+    void testAccept() {
+        TrustProvider trustProvider = new PlatformTrustProvider();
+        Void result = trustProvider.accept(new TrustProviderVisitor<>() {
+            @Override
+            public Void visit(TrustStore trustStore) {
+                throw new RuntimeException("unexpected call to visit(TrustStore)");
+            }
+
+            @Override
+            public Void visit(InsecureTls insecureTls) {
+                throw new RuntimeException("unexpected call to visit(InsecureTls)");
+            }
+
+            @Override
+            public Void visit(PlatformTrustProvider platformTrustProviderTls) {
+                return null;
+            }
+
+        });
+        assertThat(result).isNull();
+    }
+}

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/config/tls/TrustStoreTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/config/tls/TrustStoreTest.java
@@ -49,6 +49,11 @@ class TrustStoreTest {
             public TrustStore visit(InsecureTls insecureTls) {
                 throw new RuntimeException("unexpected call to visit(InsecureTls)");
             }
+
+            @Override
+            public TrustStore visit(PlatformTrustProvider platformTrustProviderTls) {
+                throw new RuntimeException("unexpected call to visit(PlatformTrustProvider)");
+            }
         });
         assertThat(result).isSameAs(trustProvider);
     }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/TlsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/TlsIT.java
@@ -132,6 +132,7 @@ class TlsIT extends BaseIT {
                 .addToVirtualClusters("demo", new VirtualClusterBuilder()
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers.replace("localhost", "127.0.0.1"))
+                        // 127.0.0.1 is not included as Subject Alternate Name (SAN) so hostname validation will fail.
                         .withNewTls()
                         .withNewTrustStoreTrust()
                         .withStoreFile(brokerTruststore)

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/TlsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/TlsIT.java
@@ -185,7 +185,7 @@ class TlsIT extends BaseIT {
 
         var brokerCert = new KeytoolCertificateGenerator();
         var clientCert = new KeytoolCertificateGenerator();
-        clientCert.generateSelfSignedCertificateEntry("clientTest@kroxylicious.io", "client", "Dev", "Kroxylicious.ip", null, null, "US");
+        clientCert.generateSelfSignedCertificateEntry("clientTest@kroxylicious.io", "client", "Dev", "Kroxylicious.io", null, null, "US");
 
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .brokerKeytoolCertificateGenerator(brokerCert)

--- a/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/config/JdkTls.java
+++ b/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/config/JdkTls.java
@@ -27,6 +27,7 @@ import io.kroxylicious.proxy.config.tls.InsecureTls;
 import io.kroxylicious.proxy.config.tls.KeyPair;
 import io.kroxylicious.proxy.config.tls.KeyProvider;
 import io.kroxylicious.proxy.config.tls.KeyProviderVisitor;
+import io.kroxylicious.proxy.config.tls.PlatformTrustProvider;
 import io.kroxylicious.proxy.config.tls.Tls;
 import io.kroxylicious.proxy.config.tls.TrustProvider;
 import io.kroxylicious.proxy.config.tls.TrustProviderVisitor;
@@ -180,6 +181,11 @@ public record JdkTls(Tls tls) {
                 else {
                     return getDefaultTrustManagers();
                 }
+            }
+
+            @Override
+            public TrustManager[] visit(PlatformTrustProvider platformTrustProviderTls) {
+                return new TrustManager[0];
             }
 
             private static TrustManager[] getDefaultTrustManagers() {

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/config/JdkTls.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/config/JdkTls.java
@@ -27,6 +27,7 @@ import io.kroxylicious.proxy.config.tls.InsecureTls;
 import io.kroxylicious.proxy.config.tls.KeyPair;
 import io.kroxylicious.proxy.config.tls.KeyProvider;
 import io.kroxylicious.proxy.config.tls.KeyProviderVisitor;
+import io.kroxylicious.proxy.config.tls.PlatformTrustProvider;
 import io.kroxylicious.proxy.config.tls.Tls;
 import io.kroxylicious.proxy.config.tls.TrustProvider;
 import io.kroxylicious.proxy.config.tls.TrustProviderVisitor;
@@ -180,6 +181,11 @@ public record JdkTls(Tls tls) {
                 else {
                     return getDefaultTrustManagers();
                 }
+            }
+
+            @Override
+            public TrustManager[] visit(PlatformTrustProvider platformTrustProviderTls) {
+                return getDefaultTrustManagers();
             }
 
             private static TrustManager[] getDefaultTrustManagers() {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -311,7 +311,7 @@ public class KafkaProxyFrontendHandler
             pipeline.addFirst("networkLogger", new LoggingHandler("io.kroxylicious.proxy.internal.UpstreamNetworkLogger"));
         }
 
-        virtualCluster.getUpstreamSslContext().ifPresent(c -> pipeline.addFirst("ssl", c.newHandler(outboundChannel.alloc())));
+        virtualCluster.getUpstreamSslContext().ifPresent(c -> pipeline.addFirst("ssl", c.newHandler(outboundChannel.alloc(), remote.host(), remote.port())));
 
         connectFuture.addListener(future -> {
             if (future.isSuccess()) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
@@ -176,9 +176,9 @@ public class VirtualCluster implements ClusterNetworkAddressConfigProvider {
     }
 
     private Optional<SslContext> buildDownstreamSslContext() {
-        return tls.map(tls -> {
+        return tls.map(tlsConfiguration -> {
             try {
-                return Optional.of(tls.key()).map(NettyKeyProvider::new).map(NettyKeyProvider::forServer).orElseThrow().build();
+                return Optional.of(tlsConfiguration.key()).map(NettyKeyProvider::new).map(NettyKeyProvider::forServer).orElseThrow().build();
             }
             catch (SSLException e) {
                 throw new UncheckedIOException(e);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
@@ -194,7 +194,7 @@ public class VirtualCluster implements ClusterNetworkAddressConfigProvider {
                 var sslContextBuilder = Optional.ofNullable(targetClusterTls.key()).map(NettyKeyProvider::new).map(NettyKeyProvider::forClient)
                         .orElse(SslContextBuilder.forClient());
 
-                final TrustProvider trustProvider = Optional.ofNullable(targetClusterTls.trust()).orElse(new PlatformTrustProvider());
+                final TrustProvider trustProvider = Optional.ofNullable(targetClusterTls.trust()).orElse(PlatformTrustProvider.INSTANCE);
                 var withTrust = new NettyTrustProvider(trustProvider).apply(sslContextBuilder);
 
                 return withTrust.build();

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
@@ -187,11 +187,13 @@ public class VirtualCluster implements ClusterNetworkAddressConfigProvider {
     }
 
     private Optional<SslContext> buildUpstreamSslContext() {
-        return targetCluster.tls().map(tls -> {
+        return targetCluster.tls().map(targetClusterTls -> {
             try {
-                var sslContextBuilder = Optional.ofNullable(tls.key()).map(NettyKeyProvider::new).map(NettyKeyProvider::forClient).orElse(SslContextBuilder.forClient());
-                var withTrust = Optional.ofNullable(tls.trust()).map(NettyTrustProvider::new).map(tp -> tp.apply(sslContextBuilder))
+                var sslContextBuilder = Optional.ofNullable(targetClusterTls.key()).map(NettyKeyProvider::new).map(NettyKeyProvider::forClient)
+                        .orElse(SslContextBuilder.forClient());
+                var withTrust = Optional.ofNullable(targetClusterTls.trust()).map(NettyTrustProvider::new).map(tp -> tp.apply(sslContextBuilder))
                         .orElse(sslContextBuilder);
+                withTrust.endpointIdentificationAlgorithm("HTTPS");
                 return withTrust.build();
             }
             catch (SSLException e) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/NettyTrustProviderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/NettyTrustProviderTest.java
@@ -84,4 +84,16 @@ class NettyTrustProviderTest {
         // Then
         assertThat(sslContextBuilder).extracting("endpointIdentificationAlgorithm").isEqualTo("HTTPS");
     }
+
+    @Test
+    void shouldEnableHostnameVerificationForPlatformTrust() {
+        // Given
+        var trustStore = new NettyTrustProvider(PlatformTrustProvider.INSTANCE);
+
+        // When
+        trustStore.apply(sslContextBuilder);
+
+        // Then
+        assertThat(sslContextBuilder).extracting("endpointIdentificationAlgorithm").isEqualTo("HTTPS");
+    }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/NettyTrustProviderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/NettyTrustProviderTest.java
@@ -42,6 +42,7 @@ class NettyTrustProviderTest {
         var sslContext = sslContextBuilder.build();
         assertThat(sslContext).isNotNull();
         assertThat(sslContext.isClient()).isTrue();
+        assertThat(sslContextBuilder).extracting("endpointIdentificationAlgorithm").isEqualTo("HTTPS");
     }
 
     @Test
@@ -60,4 +61,27 @@ class NettyTrustProviderTest {
                 .hasRootCauseInstanceOf(FileNotFoundException.class);
     }
 
+    @Test
+    void shouldDisableHostnameVerification() {
+        // Given
+        var trustStore = new NettyTrustProvider(new InsecureTls(true));
+
+        // When
+        trustStore.apply(sslContextBuilder);
+
+        // Then
+        assertThat(sslContextBuilder).extracting("endpointIdentificationAlgorithm").isNull();
+    }
+
+    @Test
+    void shouldEnableHostnameVerification() {
+        // Given
+        var trustStore = new NettyTrustProvider(new InsecureTls(false));
+
+        // When
+        trustStore.apply(sslContextBuilder);
+
+        // Then
+        assertThat(sslContextBuilder).extracting("endpointIdentificationAlgorithm").isEqualTo("HTTPS");
+    }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.model;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.config.TargetCluster;
+import io.kroxylicious.proxy.config.tls.InsecureTls;
+import io.kroxylicious.proxy.config.tls.KeyPair;
+import io.kroxylicious.proxy.config.tls.Tls;
+import io.kroxylicious.proxy.config.tls.TlsTestConstants;
+import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.PortPerBrokerClusterNetworkAddressConfigProvider;
+
+import static io.kroxylicious.proxy.service.HostPort.parse;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VirtualClusterTest {
+
+    @Test
+    void shouldBuildSslContext() {
+        // Given
+        final KeyPair keyPair = new KeyPair(TlsTestConstants.getResourceLocationOnFilesystem("server.key"),
+                TlsTestConstants.getResourceLocationOnFilesystem("server.crt"),
+                null);
+        final Optional<Tls> tls = Optional.of(new Tls(keyPair,
+                new InsecureTls(false)));
+        final PortPerBrokerClusterNetworkAddressConfigProvider.PortPerBrokerClusterNetworkAddressConfigProviderConfig clusterNetworkAddressConfigProviderConfig = new PortPerBrokerClusterNetworkAddressConfigProvider.PortPerBrokerClusterNetworkAddressConfigProviderConfig(
+                parse("localhost:1235"),
+                "localhost", 19092, 0, 1);
+        final PortPerBrokerClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider = new PortPerBrokerClusterNetworkAddressConfigProvider(
+                clusterNetworkAddressConfigProviderConfig);
+
+        // When
+
+        final VirtualCluster virtualCluster = new VirtualCluster("wibble", new TargetCluster("bootstrap:9092", tls), clusterNetworkAddressConfigProvider, tls, false,
+                false);
+
+        // Then
+        assertThat(virtualCluster).isNotNull().extracting("upstreamSslContext").isNotNull();
+    }
+}


### PR DESCRIPTION
### Type of change


- Enhancement / new feature

### Description

Enable SSL hostname verification.

### Additional Context

Netty 4.2 enables HTTPS style hostname validation by default as its more secure (see https://github.com/netty/netty/pull/14127).  However, the APIs exist in the 4.1, so we can enable them earlier. This PR is to start the discussion if we want to apply this independent of what or when we decide to use netty 4.2

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
