### PR TITLE
[test refactoring] simplify the way the IT test tells the kafka client to retrieve schema

### DIFF
--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -223,11 +223,6 @@
         </dependency>
         <dependency>
             <groupId>io.apicurio</groupId>
-            <artifactId>apicurio-registry-schema-resolver</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.apicurio</groupId>
             <artifactId>apicurio-registry-serdes-jsonschema-serde</artifactId>
             <scope>test</scope>
         </dependency>

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/validation/JsonSchemaRecordValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/validation/JsonSchemaRecordValidationIT.java
@@ -40,10 +40,6 @@ import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.PortBinding;
 import com.github.dockerjava.api.model.Ports;
 
-import io.apicurio.registry.resolver.ParsedSchema;
-import io.apicurio.registry.resolver.data.Record;
-import io.apicurio.registry.resolver.strategy.ArtifactReference;
-import io.apicurio.registry.resolver.strategy.ArtifactReferenceResolverStrategy;
 import io.apicurio.registry.rest.client.RegistryClientFactory;
 import io.apicurio.registry.serde.SerdeConfig;
 import io.apicurio.registry.serde.jsonschema.JsonSchemaSerde;
@@ -181,22 +177,6 @@ class JsonSchemaRecordValidationIT extends RecordValidationBaseIT {
         }
     }
 
-    public static class FixedArtifactReferenceResolver implements ArtifactReferenceResolverStrategy {
-        @Override
-        public ArtifactReference artifactReference(Record data, ParsedSchema parsedSchema) {
-            return ArtifactReference.builder()
-                    .artifactId(FIRST_ARTIFACT_ID)
-                    .globalId(firstGlobalId)
-                    .build();
-        }
-
-        @Override
-        public boolean loadSchema() {
-            return false;
-        }
-
-    }
-
     record PersonBean(String firstName, String lastName, int age) {}
 
     @ParameterizedTest
@@ -294,7 +274,7 @@ class JsonSchemaRecordValidationIT extends RecordValidationBaseIT {
         var producerKeySerde = new JsonSchemaSerde<PersonBean>();
         producerKeySerde.configure(Map.of(
                 SerdeConfig.REGISTRY_URL, APICURIO_REGISTRY_URL,
-                SerdeConfig.ARTIFACT_RESOLVER_STRATEGY, FixedArtifactReferenceResolver.class.getName(),
+                SerdeConfig.EXPLICIT_ARTIFACT_ID, FIRST_ARTIFACT_ID,
                 SerdeConfig.ENABLE_HEADERS, schemaIdInHeader), isKey);
         return producerKeySerde;
     }


### PR DESCRIPTION


### Type of change

_Select the type of your PR_

- Refactoring

### Description

[test refactoring] simplify the way we tell the kafka client to retrieve schema
(avoids the need for the `ArtifactReferenceResolverStrategy` implementation)

### Additional Context

I'd reached out to the Apicurio team on this in a different channel.  @carlesarnal came back with the advice to use the `EXPLICIT_ARTIFACT_ID`.

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
