### PR TITLE
Give KmsService lifecycle methods (init and close) following pattern established by FilterFactory

### DIFF
--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryption.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryption.java
@@ -110,7 +110,7 @@ public class RecordEncryption<K, E> implements FilterFactory<RecordEncryptionCon
         Kms<K, E> kms = buildKms(configuration, kmsPlugin, kmsInitData);
 
         var dekConfig = configuration.dekManager();
-        DekManager<K, E> dekManager = new DekManager<>(ignored -> kms, null, dekConfig.maxEncryptionsPerDek());
+        DekManager<K, E> dekManager = new DekManager<>(kms, dekConfig.maxEncryptionsPerDek());
 
         KmsCacheConfig cacheConfig = configuration.kmsCache();
         EncryptionDekCache<K, E> encryptionDekCache = new EncryptionDekCache<>(dekManager, null, EncryptionDekCache.NO_MAX_CACHE_SIZE,

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/SharedEncryptionContext.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/SharedEncryptionContext.java
@@ -24,24 +24,28 @@ public class SharedEncryptionContext<K, E> {
     private final DekManager<K, E> dekManager;
     private final EncryptionDekCache<K, E> encryptionDekCache;
     private final DecryptionDekCache<K, E> decryptionDekCache;
+    private final Runnable kmsCloser;
 
     /**
      * @param kms
      * @param configuration
      * @param dekManager
      * @param encryptionDekCache
+     * @param kmsCloser kms closer
      */
     SharedEncryptionContext(
                             Kms<K, E> kms,
                             RecordEncryptionConfig configuration,
                             DekManager<K, E> dekManager,
                             EncryptionDekCache<K, E> encryptionDekCache,
-                            DecryptionDekCache<K, E> decryptionDekCache) {
+                            DecryptionDekCache<K, E> decryptionDekCache,
+                            Runnable kmsCloser) {
         this.kms = kms;
         this.configuration = configuration;
         this.dekManager = dekManager;
         this.encryptionDekCache = encryptionDekCache;
         this.decryptionDekCache = decryptionDekCache;
+        this.kmsCloser = kmsCloser;
     }
 
     public Kms<K, E> kms() {
@@ -62,5 +66,9 @@ public class SharedEncryptionContext<K, E> {
 
     public DecryptionDekCache<K, E> decryptionDekCache() {
         return decryptionDekCache;
+    }
+
+    public Runnable kmsCloser() {
+        return kmsCloser;
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/SharedEncryptionContext.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/SharedEncryptionContext.java
@@ -15,60 +15,20 @@ import io.kroxylicious.kms.service.Kms;
 /**
  * Things which are shared between instances of the filter.
  * Because they're shared between filter instances, the things shared here must be thread-safe.
+ *
+ * @param kms KMS
+ * @param kmsServiceCloser KMS closer
+ * @param configuration configuration
+ * @param dekManager DEK manager
+ * @param encryptionDekCache Encryption DEK Cache
+ * @param decryptionDekCache Decryption DEK Cache
+ *
  * @param <K> The type of KEK id.
  * @param <E> The type of the encrypted DEK.
  */
-public class SharedEncryptionContext<K, E> {
-    private final Kms<K, E> kms;
-    private final RecordEncryptionConfig configuration;
-    private final DekManager<K, E> dekManager;
-    private final EncryptionDekCache<K, E> encryptionDekCache;
-    private final DecryptionDekCache<K, E> decryptionDekCache;
-    private final Runnable kmsCloser;
-
-    /**
-     * @param kms
-     * @param configuration
-     * @param dekManager
-     * @param encryptionDekCache
-     * @param kmsCloser kms closer
-     */
-    SharedEncryptionContext(
-                            Kms<K, E> kms,
-                            RecordEncryptionConfig configuration,
-                            DekManager<K, E> dekManager,
-                            EncryptionDekCache<K, E> encryptionDekCache,
-                            DecryptionDekCache<K, E> decryptionDekCache,
-                            Runnable kmsCloser) {
-        this.kms = kms;
-        this.configuration = configuration;
-        this.dekManager = dekManager;
-        this.encryptionDekCache = encryptionDekCache;
-        this.decryptionDekCache = decryptionDekCache;
-        this.kmsCloser = kmsCloser;
-    }
-
-    public Kms<K, E> kms() {
-        return kms;
-    }
-
-    public RecordEncryptionConfig configuration() {
-        return configuration;
-    }
-
-    public DekManager<K, E> dekManager() {
-        return dekManager;
-    }
-
-    public EncryptionDekCache<K, E> encryptionDekCache() {
-        return encryptionDekCache;
-    }
-
-    public DecryptionDekCache<K, E> decryptionDekCache() {
-        return decryptionDekCache;
-    }
-
-    public Runnable kmsCloser() {
-        return kmsCloser;
-    }
-}
+record SharedEncryptionContext<K, E>(Kms<K, E> kms,
+                                     Runnable kmsServiceCloser,
+                                     RecordEncryptionConfig configuration,
+                                     DekManager<K, E> dekManager,
+                                     EncryptionDekCache<K, E> encryptionDekCache,
+                                     DecryptionDekCache<K, E> decryptionDekCache) {}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DekManager.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DekManager.java
@@ -32,7 +32,7 @@ public class DekManager<K, E> {
     private final Kms<K, E> kms;
     private final long maxEncryptionsPerDek;
 
-    public <C> DekManager(KmsService<C, K, E> kmsService, C config, long maxEncryptionsPerDek) {
+    public <C> DekManager(KmsService<C, C, K, E> kmsService, C config, long maxEncryptionsPerDek) {
         this.kms = kmsService.buildKms(config);
         this.maxEncryptionsPerDek = maxEncryptionsPerDek;
     }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DekManager.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DekManager.java
@@ -14,7 +14,6 @@ import javax.annotation.concurrent.ThreadSafe;
 import io.kroxylicious.filter.encryption.config.EncryptionConfigurationException;
 import io.kroxylicious.kms.service.DestroyableRawSecretKey;
 import io.kroxylicious.kms.service.Kms;
-import io.kroxylicious.kms.service.KmsService;
 import io.kroxylicious.kms.service.Serde;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -32,8 +31,8 @@ public class DekManager<K, E> {
     private final Kms<K, E> kms;
     private final long maxEncryptionsPerDek;
 
-    public <C> DekManager(KmsService<C, C, K, E> kmsService, C config, long maxEncryptionsPerDek) {
-        this.kms = kmsService.buildKms(config);
+    public DekManager(Kms<K, E> kms, long maxEncryptionsPerDek) {
+        this.kms = kms;
         this.maxEncryptionsPerDek = maxEncryptionsPerDek;
     }
 

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/FixedDekKmsService.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/FixedDekKmsService.java
@@ -22,7 +22,7 @@ import io.kroxylicious.kms.service.Serde;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-public class FixedDekKmsService implements KmsService<FixedDekKmsService.Config, ByteBuffer, ByteBuffer> {
+public class FixedDekKmsService implements KmsService<FixedDekKmsService.Config, FixedDekKmsService.Config, ByteBuffer, ByteBuffer> {
 
     private final SecretKey dek;
     private final ByteBuffer edek;
@@ -43,7 +43,7 @@ public class FixedDekKmsService implements KmsService<FixedDekKmsService.Config,
 
     @NonNull
     @Override
-    public Kms<ByteBuffer, ByteBuffer> buildKms(Config options) {
+    public Kms<ByteBuffer, ByteBuffer> buildKms(Config initializationData) {
         return fixedEdekKms;
     }
 

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionTest.java
@@ -35,10 +35,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 class RecordEncryptionTest {
 
@@ -55,9 +55,12 @@ class RecordEncryptionTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     void shouldInitAndCreateFilter() {
-        RecordEncryptionConfig config = new RecordEncryptionConfig("KMS", null, "SELECTOR", null, null);
-        var ee = new RecordEncryption<>();
+        var kmsConfig = new Object();
+        var kmsInitData = new Object();
+        var config = new RecordEncryptionConfig("KMS", kmsConfig, "SELECTOR", null, null);
+        var recordEncryption = new RecordEncryption<>();
         var fc = mock(FilterFactoryContext.class);
         var kmsService = mock(KmsService.class);
         var kms = mock(Kms.class);
@@ -66,16 +69,39 @@ class RecordEncryptionTest {
         var edekSerde = mock(Serde.class);
 
         doReturn(kmsService).when(fc).pluginInstance(KmsService.class, "KMS");
-        doReturn(kms).when(kmsService).buildKms(any());
+        doReturn(kmsInitData).when(kmsService).initialize(kmsConfig);
+        doReturn(kms).when(kmsService).buildKms(kmsInitData);
         doReturn(mock(FilterDispatchExecutor.class)).when(fc).filterDispatchExecutor();
         doReturn(edekSerde).when(kms).edekSerde();
 
         doReturn(kekSelectorService).when(fc).pluginInstance(KekSelectorService.class, "SELECTOR");
         doReturn(kekSelector).when(kekSelectorService).buildSelector(any(), any());
 
-        var sec = ee.initialize(fc, config);
-        var filter = ee.createFilter(fc, sec);
-        assertNotNull(filter);
+        var sec = recordEncryption.initialize(fc, config);
+        var filter = recordEncryption.createFilter(fc, sec);
+        assertThat(filter).isNotNull();
+        recordEncryption.close(sec);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void closePropagatedToKmsService() {
+        var kmsConfig = new Object();
+        var kmsInitData = new Object();
+        var config = new RecordEncryptionConfig("KMS", kmsConfig, "SELECTOR", null, null);
+        var recordEncryption = new RecordEncryption<>();
+        var fc = mock(FilterFactoryContext.class);
+        var kmsService = mock(KmsService.class);
+        var kms = mock(Kms.class);
+
+        doReturn(kmsService).when(fc).pluginInstance(KmsService.class, "KMS");
+        doReturn(kmsInitData).when(kmsService).initialize(kmsConfig);
+        doReturn(kms).when(kmsService).buildKms(kmsInitData);
+
+        var sec = recordEncryption.initialize(fc, config);
+        recordEncryption.close(sec);
+
+        verify(kmsService).close(kmsInitData);
     }
 
     @Test

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/crypto/SerializedFormTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/crypto/SerializedFormTest.java
@@ -184,7 +184,7 @@ class SerializedFormTest {
         doReturn(new ByteArraySerde()).when(kms).edekSerde();
         KmsService<Object, Object, byte[], byte[]> kmsService = Mockito.mock(KmsService.class);
         doReturn(kms).when(kmsService).buildKms(null);
-        var dm = new DekManager<>(kmsService, null, 1);
+        var dm = new DekManager<>(kms, 1);
 
         var dek = dm.generateDek(kekId, cm).toCompletableFuture().join();
         byte[] edek = dek.edek();

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/crypto/SerializedFormTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/crypto/SerializedFormTest.java
@@ -182,7 +182,7 @@ class SerializedFormTest {
         DekPair dekPair = new DekPair(HexFormat.of().parseHex(edekHex), DestroyableRawSecretKey.takeOwnershipOf(HexFormat.of().parseHex("0dec"), "foo"));
         doReturn(CompletableFuture.completedFuture(dekPair)).when(kms).generateDekPair(kekId);
         doReturn(new ByteArraySerde()).when(kms).edekSerde();
-        KmsService<Object, byte[], byte[]> kmsService = Mockito.mock(KmsService.class);
+        KmsService<Object, Object, byte[], byte[]> kmsService = Mockito.mock(KmsService.class);
         doReturn(kms).when(kmsService).buildKms(null);
         var dm = new DekManager<>(kmsService, null, 1);
 

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/decrypt/InBandDecryptionManagerTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/decrypt/InBandDecryptionManagerTest.java
@@ -1007,7 +1007,7 @@ class InBandDecryptionManagerTest {
     @NonNull
     private static InBandDecryptionManager<UUID, InMemoryEdek> createDecryptionManager(InMemoryKms kms) {
 
-        DekManager<UUID, InMemoryEdek> dekManager = new DekManager<>(ignored -> kms, null, 1);
+        DekManager<UUID, InMemoryEdek> dekManager = new DekManager<>(kms, 1);
         var dekCache = new DecryptionDekCache<>(dekManager, directExecutor(), DecryptionDekCache.NO_MAX_CACHE_SIZE);
         return new InBandDecryptionManager<>(EncryptionResolver.ALL,
                 dekManager,
@@ -1031,7 +1031,7 @@ class InBandDecryptionManagerTest {
                                                                                        int recordBufferMaxBytes,
                                                                                        int maxCacheSize) {
 
-        DekManager<UUID, InMemoryEdek> dekManager = new DekManager<>(ignored -> kms, null, maxEncryptionsPerDek);
+        DekManager<UUID, InMemoryEdek> dekManager = new DekManager<>(kms, maxEncryptionsPerDek);
         var cache = new EncryptionDekCache<>(dekManager, directExecutor(), maxCacheSize, Duration.ofHours(1), Duration.ofHours(1));
         return new InBandEncryptionManager<>(Encryption.V2,
                 dekManager.edekSerde(),

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/decrypt/InBandDecryptionManagerTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/decrypt/InBandDecryptionManagerTest.java
@@ -1063,7 +1063,8 @@ class InBandDecryptionManagerTest {
     @NonNull
     private static InMemoryKms getInMemoryKms() {
         var kmsService = UnitTestingKmsService.newInstance();
-        return kmsService.buildKms(new UnitTestingKmsService.Config());
+        var init = kmsService.initialize(new UnitTestingKmsService.Config());
+        return kmsService.buildKms(init);
     }
 
     @NonNull

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/DekManagerTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/DekManagerTest.java
@@ -36,7 +36,7 @@ class DekManagerTest {
         var kms = unitTestingKmsService.buildKms(options);
         var kekId = kms.generateKey();
         kms.createAlias(kekId, "foo");
-        var dm = new DekManager<>(unitTestingKmsService, options, 1);
+        var dm = new DekManager<>(kms, 1);
 
         // When
         var resolvedKekId = dm.resolveAlias("foo").toCompletableFuture().join();
@@ -54,7 +54,7 @@ class DekManagerTest {
         var kms = unitTestingKmsService.buildKms(options);
         var kekId = kms.generateKey();
         kms.createAlias(kekId, "foo");
-        var dm = new DekManager<>(unitTestingKmsService, options, 1);
+        var dm = new DekManager<>(kms, 1);
 
         // When
         var dek = dm.generateDek(kekId, cipherManager).toCompletableFuture().join();
@@ -72,7 +72,7 @@ class DekManagerTest {
         var kms = unitTestingKmsService.buildKms(options);
         var kekId = kms.generateKey();
         kms.createAlias(kekId, "foo");
-        var dm = new DekManager<>(unitTestingKmsService, options, 1_000);
+        var dm = new DekManager<>(kms, 1_000);
 
         // Generate a DEK anduse it to encrypt
         var dek = dm.generateDek(kekId, cipherManager).toCompletableFuture().join();
@@ -106,7 +106,8 @@ class DekManagerTest {
     @Test
     void aes256KeyMustBe256bits() {
         var fixedDekKmsService = new FixedDekKmsService(128);
-        DekManager<ByteBuffer, ByteBuffer> manager = new DekManager<>(fixedDekKmsService, new FixedDekKmsService.Config(), 10000);
+        var kms = fixedDekKmsService.buildKms(null);
+        DekManager<ByteBuffer, ByteBuffer> manager = new DekManager<>(kms, 10000);
         CompletionStage<Dek<ByteBuffer>> dekCompletionStage = manager.generateDek(fixedDekKmsService.getKekId(), Aes.AES_256_GCM_128);
         assertThat(dekCompletionStage).failsWithin(10, TimeUnit.SECONDS)
                 .withThrowableOfType(ExecutionException.class)

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/DekManagerTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/DekManagerTest.java
@@ -31,9 +31,10 @@ class DekManagerTest {
     @Test
     void testResolveAlias() {
         // Given
-        UnitTestingKmsService unitTestingKmsService = UnitTestingKmsService.newInstance();
-        UnitTestingKmsService.Config options = new UnitTestingKmsService.Config(12, 96, List.of());
-        var kms = unitTestingKmsService.buildKms(options);
+        var unitTestingKmsService = UnitTestingKmsService.newInstance();
+        var config = new UnitTestingKmsService.Config(12, 96, List.of());
+        var init = unitTestingKmsService.initialize(config);
+        var kms = unitTestingKmsService.buildKms(init);
         var kekId = kms.generateKey();
         kms.createAlias(kekId, "foo");
         var dm = new DekManager<>(kms, 1);
@@ -49,9 +50,10 @@ class DekManagerTest {
     @MethodSource("io.kroxylicious.filter.encryption.dek.CipherManagerTest#allCipherManagers")
     void testLimitsNumbersOfEncryptors(CipherManager cipherManager) {
         // Given
-        UnitTestingKmsService unitTestingKmsService = UnitTestingKmsService.newInstance();
-        UnitTestingKmsService.Config options = new UnitTestingKmsService.Config(12, 96, List.of());
-        var kms = unitTestingKmsService.buildKms(options);
+        var unitTestingKmsService = UnitTestingKmsService.newInstance();
+        var config = new UnitTestingKmsService.Config(12, 96, List.of());
+        var init = unitTestingKmsService.initialize(config);
+        var kms = unitTestingKmsService.buildKms(init);
         var kekId = kms.generateKey();
         kms.createAlias(kekId, "foo");
         var dm = new DekManager<>(kms, 1);
@@ -67,9 +69,10 @@ class DekManagerTest {
     @MethodSource("io.kroxylicious.filter.encryption.dek.CipherManagerTest#allCipherManagers")
     void testDecryptedEdekIsGoodForDecryptingData(CipherManager cipherManager) {
         // Given
-        UnitTestingKmsService unitTestingKmsService = UnitTestingKmsService.newInstance();
-        UnitTestingKmsService.Config options = new UnitTestingKmsService.Config(12, 96, List.of());
-        var kms = unitTestingKmsService.buildKms(options);
+        var unitTestingKmsService = UnitTestingKmsService.newInstance();
+        var config = new UnitTestingKmsService.Config(12, 96, List.of());
+        var init = unitTestingKmsService.initialize(config);
+        var kms = unitTestingKmsService.buildKms(init);
         var kekId = kms.generateKey();
         kms.createAlias(kekId, "foo");
         var dm = new DekManager<>(kms, 1_000);
@@ -106,7 +109,8 @@ class DekManagerTest {
     @Test
     void aes256KeyMustBe256bits() {
         var fixedDekKmsService = new FixedDekKmsService(128);
-        var kms = fixedDekKmsService.buildKms(null);
+        var init = fixedDekKmsService.initialize(null);
+        var kms = fixedDekKmsService.buildKms(init);
         DekManager<ByteBuffer, ByteBuffer> manager = new DekManager<>(kms, 10000);
         CompletionStage<Dek<ByteBuffer>> dekCompletionStage = manager.generateDek(fixedDekKmsService.getKekId(), Aes.AES_256_GCM_128);
         assertThat(dekCompletionStage).failsWithin(10, TimeUnit.SECONDS)

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/encrypt/RecordEncryptorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/encrypt/RecordEncryptorTest.java
@@ -65,7 +65,8 @@ class RecordEncryptorTest {
     static TestComponents setup(int keysize) {
         try {
             fixedDekKmsService = new FixedDekKmsService(keysize);
-            DekManager<ByteBuffer, ByteBuffer> manager = new DekManager<>(fixedDekKmsService, new FixedDekKmsService.Config(), 10000);
+            var kms = fixedDekKmsService.buildKms(null);
+            DekManager<ByteBuffer, ByteBuffer> manager = new DekManager<>(kms, 10000);
             CompletionStage<Dek<ByteBuffer>> dekCompletionStage = manager.generateDek(fixedDekKmsService.getKekId(), Aes.AES_256_GCM_128);
             Dek<ByteBuffer> dek = dekCompletionStage.toCompletableFuture().get(0, TimeUnit.SECONDS);
             var encryptor = dek.encryptor(1000);

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/encrypt/TemplateKekSelectorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/encrypt/TemplateKekSelectorTest.java
@@ -42,7 +42,9 @@ class TemplateKekSelectorTest {
 
     @Test
     void shouldResolveWhenAliasExists() {
-        var kms = UnitTestingKmsService.newInstance().buildKms(new UnitTestingKmsService.Config());
+        var kmsService = UnitTestingKmsService.newInstance();
+        var init = kmsService.initialize(new UnitTestingKmsService.Config());
+        var kms = kmsService.buildKms(init);
         var selector = getSelector(kms, "topic-${topicName}");
 
         var kek = kms.generateKey();
@@ -55,7 +57,9 @@ class TemplateKekSelectorTest {
 
     @Test
     void shouldNotThrowWhenAliasDoesNotExist() {
-        var kms = UnitTestingKmsService.newInstance().buildKms(new UnitTestingKmsService.Config());
+        var kmsService = UnitTestingKmsService.newInstance();
+        var init = kmsService.initialize(new UnitTestingKmsService.Config());
+        var kms = kmsService.buildKms(init);
         var selector = getSelector(kms, "topic-${topicName}");
 
         var map = selector.selectKek(Set.of("my-topic")).toCompletableFuture().join();

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/kms/service/KmsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/kms/service/KmsIT.java
@@ -35,7 +35,7 @@ class KmsIT<C, K, E> {
     @BeforeEach
     @SuppressWarnings("unchecked")
     void beforeEach(TestKmsFacade<?, ?, ?> facade) throws Exception {
-        var service = (KmsService<C, K, E>) facade.getKmsServiceClass().getDeclaredConstructor(new Class[]{}).newInstance();
+        var service = (KmsService<C, C, K, E>) facade.getKmsServiceClass().getDeclaredConstructor(new Class[]{}).newInstance();
         kms = service.buildKms((C) facade.getKmsServiceConfig());
         manager = facade.getTestKekManager();
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/EnvelopeEncryptionFilterIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/EnvelopeEncryptionFilterIT.java
@@ -38,7 +38,7 @@ class EnvelopeEncryptionFilterIT {
     private static final String HELLO_WORLD = "hello world";
 
     @TestTemplate
-    void roundTripSingleRecord(KafkaCluster cluster, Topic topic, TestKmsFacade<?, ?, ?> testKmsFacade) throws Exception {
+    void roundTripSingleRecord(KafkaCluster cluster, Topic topic, TestKmsFacade<?, ?, ?, ?> testKmsFacade) throws Exception {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
 
@@ -63,7 +63,7 @@ class EnvelopeEncryptionFilterIT {
     }
 
     @SuppressWarnings("removal")
-    private FilterDefinition buildEncryptionFilterDefinition(TestKmsFacade<?, ?, ?> testKmsFacade) {
+    private FilterDefinition buildEncryptionFilterDefinition(TestKmsFacade<?, ?, ?, ?> testKmsFacade) {
         return new FilterDefinitionBuilder(EnvelopeEncryption.class.getSimpleName())
                 .withConfig("kms", testKmsFacade.getKmsServiceClass().getSimpleName())
                 .withConfig("kmsConfig", testKmsFacade.getKmsServiceConfig())

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/RecordEncryptionFilterIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/RecordEncryptionFilterIT.java
@@ -70,7 +70,7 @@ class RecordEncryptionFilterIT {
     private static final String HELLO_SECRET = "hello secret";
 
     @TestTemplate
-    void roundTripSingleRecord(KafkaCluster cluster, Topic topic, TestKmsFacade<?, ?, ?> testKmsFacade) throws Exception {
+    void roundTripSingleRecord(KafkaCluster cluster, Topic topic, TestKmsFacade<?, ?, ?, ?> testKmsFacade) throws Exception {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
 
@@ -95,7 +95,7 @@ class RecordEncryptionFilterIT {
     }
 
     @TestTemplate
-    void roundTripTransactional(KafkaCluster cluster, Topic topic, TestKmsFacade<?, ?, ?> testKmsFacade) {
+    void roundTripTransactional(KafkaCluster cluster, Topic topic, TestKmsFacade<?, ?, ?, ?> testKmsFacade) {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
 
@@ -124,7 +124,7 @@ class RecordEncryptionFilterIT {
 
     // check that records from aborted transaction are not exposed to read_committed clients
     @TestTemplate
-    void roundTripTransactionalAbort(KafkaCluster cluster, Topic topic, TestKmsFacade<?, ?, ?> testKmsFacade) {
+    void roundTripTransactionalAbort(KafkaCluster cluster, Topic topic, TestKmsFacade<?, ?, ?, ?> testKmsFacade) {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
 
@@ -160,7 +160,7 @@ class RecordEncryptionFilterIT {
 
     // check that records from uncommitted transaction are not exposed to read_committed clients
     @TestTemplate
-    void roundTripTransactionalIsolation(KafkaCluster cluster, Topic topic, TestKmsFacade<?, ?, ?> testKmsFacade) {
+    void roundTripTransactionalIsolation(KafkaCluster cluster, Topic topic, TestKmsFacade<?, ?, ?, ?> testKmsFacade) {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
 
@@ -198,7 +198,7 @@ class RecordEncryptionFilterIT {
     }
 
     @TestTemplate
-    void roundTripManyRecordsFromDifferentProducers(KafkaCluster cluster, Topic topic, TestKmsFacade<?, ?, ?> testKmsFacade) throws Exception {
+    void roundTripManyRecordsFromDifferentProducers(KafkaCluster cluster, Topic topic, TestKmsFacade<?, ?, ?, ?> testKmsFacade) throws Exception {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
 
@@ -230,7 +230,7 @@ class RecordEncryptionFilterIT {
     // EDEKs can be configured with a time-based expiry. This gives us the nice property that after a KEK is rotated
     // in the external KMS a new EDEK will be generated using the new key.
     @TestTemplate
-    void edekExpiry(KafkaCluster cluster, Topic topic, TestKmsFacade<?, ?, ?> testKmsFacade,
+    void edekExpiry(KafkaCluster cluster, Topic topic, TestKmsFacade<?, ?, ?, ?> testKmsFacade,
                     @ClientConfig(name = ConsumerConfig.GROUP_ID_CONFIG, value = "rotation-test") @ClientConfig(name = ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, value = "earliest") KafkaConsumer<byte[], byte[]> directConsumer)
             throws Exception {
         var testKekManager = testKmsFacade.getTestKekManager();
@@ -288,7 +288,7 @@ class RecordEncryptionFilterIT {
 
     // This ensures the decrypt-ability guarantee, post kek rotation
     @TestTemplate
-    void decryptionAfterKekRotation(KafkaCluster cluster, Topic topic, TestKmsFacade<?, ?, ?> testKmsFacade) throws Exception {
+    void decryptionAfterKekRotation(KafkaCluster cluster, Topic topic, TestKmsFacade<?, ?, ?, ?> testKmsFacade) throws Exception {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
 
@@ -318,7 +318,7 @@ class RecordEncryptionFilterIT {
     }
 
     @TestTemplate
-    void topicRecordsAreUnreadableOnServer(KafkaCluster cluster, Topic topic, KafkaConsumer<String, String> directConsumer, TestKmsFacade<?, ?, ?> testKmsFacade)
+    void topicRecordsAreUnreadableOnServer(KafkaCluster cluster, Topic topic, KafkaConsumer<String, String> directConsumer, TestKmsFacade<?, ?, ?, ?> testKmsFacade)
             throws Exception {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
@@ -345,7 +345,7 @@ class RecordEncryptionFilterIT {
     }
 
     @TestTemplate
-    void unencryptedRecordsConsumable(KafkaCluster cluster, KafkaProducer<String, String> directProducer, Topic topic, TestKmsFacade<?, ?, ?> testKmsFacade)
+    void unencryptedRecordsConsumable(KafkaCluster cluster, KafkaProducer<String, String> directProducer, Topic topic, TestKmsFacade<?, ?, ?, ?> testKmsFacade)
             throws Exception {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
@@ -375,7 +375,7 @@ class RecordEncryptionFilterIT {
     @TestTemplate
     void nullValueRecordProducedAndConsumedSuccessfully(KafkaCluster cluster,
                                                         @ClientConfig(name = ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, value = "earliest") @ClientConfig(name = ConsumerConfig.GROUP_ID_CONFIG, value = "test") Consumer<String, String> directConsumer,
-                                                        Topic topic, TestKmsFacade<?, ?, ?> testKmsFacade)
+                                                        Topic topic, TestKmsFacade<?, ?, ?, ?> testKmsFacade)
             throws Exception {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
@@ -407,7 +407,7 @@ class RecordEncryptionFilterIT {
     }
 
     @TestTemplate
-    void produceAndConsumeEncryptedAndPlainTopicsAtSameTime(KafkaCluster cluster, Topic encryptedTopic, Topic plainTopic, TestKmsFacade<?, ?, ?> testKmsFacade)
+    void produceAndConsumeEncryptedAndPlainTopicsAtSameTime(KafkaCluster cluster, Topic encryptedTopic, Topic plainTopic, TestKmsFacade<?, ?, ?, ?> testKmsFacade)
             throws Exception {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(encryptedTopic.name());
@@ -445,7 +445,7 @@ class RecordEncryptionFilterIT {
     void offsetFidelity(@BrokerConfig(name = "log.cleaner.backoff.ms", value = "50") KafkaCluster cluster,
                         @TopicConfig(name = "segment.ms", value = "125") @TopicConfig(name = "cleanup.policy", value = "compact") Topic compactedTopic,
                         Consumer<String, String> directConsumer,
-                        TestKmsFacade<?, ?, ?> testKmsFacade)
+                        TestKmsFacade<?, ?, ?, ?> testKmsFacade)
             throws Exception {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(compactedTopic.name());
@@ -506,7 +506,7 @@ class RecordEncryptionFilterIT {
 
     // TODO express this test as a unit test and consider doing away with the test as the IT level.
     @TestTemplate
-    void shouldGenerateOneDek(KafkaCluster cluster, Topic topic, TestKmsFacade<?, ?, ?> testKmsFacade) throws Exception {
+    void shouldGenerateOneDek(KafkaCluster cluster, Topic topic, TestKmsFacade<?, ?, ?, ?> testKmsFacade) throws Exception {
         assumeThatCode(testKmsFacade::getKms).doesNotThrowAnyException();
         assertThat(testKmsFacade.getKms()).isInstanceOf(InMemoryKms.class);
 
@@ -549,7 +549,7 @@ class RecordEncryptionFilterIT {
 
     }
 
-    private FilterDefinition buildEncryptionFilterDefinition(TestKmsFacade<?, ?, ?> testKmsFacade) {
+    private FilterDefinition buildEncryptionFilterDefinition(TestKmsFacade<?, ?, ?, ?> testKmsFacade) {
         return new FilterDefinitionBuilder(RecordEncryption.class.getSimpleName())
                 .withConfig("kms", testKmsFacade.getKmsServiceClass().getSimpleName())
                 .withConfig("kmsConfig", testKmsFacade.getKmsServiceConfig())

--- a/kroxylicious-kms-provider-aws-kms-test-support/src/main/java/io/kroxylicious/kms/provider/aws/kms/AbstractAwsKmsTestKmsFacade.java
+++ b/kroxylicious-kms-provider-aws-kms-test-support/src/main/java/io/kroxylicious/kms/provider/aws/kms/AbstractAwsKmsTestKmsFacade.java
@@ -41,7 +41,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-public abstract class AbstractAwsKmsTestKmsFacade implements TestKmsFacade<Config, String, AwsKmsEdek> {
+public abstract class AbstractAwsKmsTestKmsFacade implements TestKmsFacade<Config, Config, String, AwsKmsEdek> {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final int MINIMUM_ALLOWED_EXPIRY_DAYS = 7;
     private static final TypeReference<CreateKeyResponse> CREATE_KEY_RESPONSE_TYPE_REF = new TypeReference<>() {

--- a/kroxylicious-kms-provider-aws-kms-test-support/src/main/java/io/kroxylicious/kms/provider/aws/kms/AbstractAwsKmsTestKmsFacadeFactory.java
+++ b/kroxylicious-kms-provider-aws-kms-test-support/src/main/java/io/kroxylicious/kms/provider/aws/kms/AbstractAwsKmsTestKmsFacadeFactory.java
@@ -9,7 +9,7 @@ package io.kroxylicious.kms.provider.aws.kms;
 import io.kroxylicious.kms.provider.aws.kms.config.Config;
 import io.kroxylicious.kms.service.TestKmsFacadeFactory;
 
-public abstract class AbstractAwsKmsTestKmsFacadeFactory implements TestKmsFacadeFactory<Config, String, AwsKmsEdek> {
+public abstract class AbstractAwsKmsTestKmsFacadeFactory implements TestKmsFacadeFactory<Config, Config, String, AwsKmsEdek> {
     @Override
     public abstract AbstractAwsKmsTestKmsFacade build();
 }

--- a/kroxylicious-kms-provider-aws-kms-test-support/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsTestKmsFacadeFactory.java
+++ b/kroxylicious-kms-provider-aws-kms-test-support/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsTestKmsFacadeFactory.java
@@ -12,7 +12,7 @@ import io.kroxylicious.kms.service.TestKmsFacadeFactory;
 /**
  * Factory for {@link AwsKmsTestKmsFacade}s.
  */
-public class AwsKmsTestKmsFacadeFactory extends AbstractAwsKmsTestKmsFacadeFactory implements TestKmsFacadeFactory<Config, String, AwsKmsEdek> {
+public class AwsKmsTestKmsFacadeFactory extends AbstractAwsKmsTestKmsFacadeFactory implements TestKmsFacadeFactory<Config, Config, String, AwsKmsEdek> {
     /**
      * {@inheritDoc}
      */

--- a/kroxylicious-kms-provider-aws-kms-test-support/src/test/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsTestKmsFacadeTest.java
+++ b/kroxylicious-kms-provider-aws-kms-test-support/src/test/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsTestKmsFacadeTest.java
@@ -16,7 +16,7 @@ import io.kroxylicious.kms.service.AbstractTestKmsFacadeTest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
-class AwsKmsTestKmsFacadeTest extends AbstractTestKmsFacadeTest<Config, String, AwsKmsEdek> {
+class AwsKmsTestKmsFacadeTest extends AbstractTestKmsFacadeTest<Config, Config, String, AwsKmsEdek> {
 
     AwsKmsTestKmsFacadeTest() {
         super(new AwsKmsTestKmsFacadeFactory());

--- a/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsService.java
+++ b/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsService.java
@@ -18,16 +18,16 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * An implementation of the {@link KmsService} interface backed by a remote instance of AWS KMS.
  */
 @Plugin(configType = Config.class)
-public class AwsKmsService implements KmsService<Config, String, AwsKmsEdek> {
+public class AwsKmsService implements KmsService<Config, Config, String, AwsKmsEdek> {
 
     @NonNull
     @Override
-    public AwsKms buildKms(Config options) {
-        return new AwsKms(options.endpointUrl(),
-                options.accessKey().getProvidedPassword(),
-                options.secretKey().getProvidedPassword(),
-                options.region(),
-                Duration.ofSeconds(20), options.sslContext());
+    public AwsKms buildKms(Config initializationData) {
+        return new AwsKms(initializationData.endpointUrl(),
+                initializationData.accessKey().getProvidedPassword(),
+                initializationData.secretKey().getProvidedPassword(),
+                initializationData.region(),
+                Duration.ofSeconds(20), initializationData.sslContext());
     }
 
 }

--- a/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsTest.java
+++ b/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsTest.java
@@ -150,7 +150,9 @@ class AwsKmsTest {
             var address = httpServer.getAddress();
             var awsAddress = "http://127.0.0.1:" + address.getPort();
             var config = new Config(URI.create(awsAddress), new InlinePassword("access"), new InlinePassword("secret"), "us-west-2", null);
-            var service = new AwsKmsService().buildKms(config);
+            var awsKmsService = new AwsKmsService();
+            var initData = awsKmsService.initialize(config);
+            var service = awsKmsService.buildKms(initData);
             consumer.accept(service);
         }
         finally {

--- a/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/AbstractVaultTestKmsFacade.java
+++ b/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/AbstractVaultTestKmsFacade.java
@@ -32,7 +32,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import static java.net.URLEncoder.encode;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-public abstract class AbstractVaultTestKmsFacade implements TestKmsFacade<Config, String, VaultEdek> {
+public abstract class AbstractVaultTestKmsFacade implements TestKmsFacade<Config, Config, String, VaultEdek> {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final TypeReference<VaultResponse<VaultResponse.ReadKeyData>> VAULT_RESPONSE_READ_KEY_DATA_TYPEREF = new TypeReference<>() {
     };

--- a/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/AbstractVaultTestKmsFacadeFactory.java
+++ b/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/AbstractVaultTestKmsFacadeFactory.java
@@ -9,7 +9,7 @@ package io.kroxylicious.kms.provider.hashicorp.vault;
 import io.kroxylicious.kms.provider.hashicorp.vault.config.Config;
 import io.kroxylicious.kms.service.TestKmsFacadeFactory;
 
-public abstract class AbstractVaultTestKmsFacadeFactory implements TestKmsFacadeFactory<Config, String, VaultEdek> {
+public abstract class AbstractVaultTestKmsFacadeFactory implements TestKmsFacadeFactory<Config, Config, String, VaultEdek> {
     @Override
     public abstract AbstractVaultTestKmsFacade build();
 }

--- a/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultTestKmsFacadeFactory.java
+++ b/kroxylicious-kms-provider-hashicorp-vault-test-support/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultTestKmsFacadeFactory.java
@@ -12,7 +12,7 @@ import io.kroxylicious.kms.service.TestKmsFacadeFactory;
 /**
  * Factory for {@link VaultTestKmsFacade}s.
  */
-public class VaultTestKmsFacadeFactory extends AbstractVaultTestKmsFacadeFactory implements TestKmsFacadeFactory<Config, String, VaultEdek> {
+public class VaultTestKmsFacadeFactory extends AbstractVaultTestKmsFacadeFactory implements TestKmsFacadeFactory<Config, Config, String, VaultEdek> {
     /**
      * {@inheritDoc}
      */

--- a/kroxylicious-kms-provider-hashicorp-vault-test-support/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultTestKmsFacadeTest.java
+++ b/kroxylicious-kms-provider-hashicorp-vault-test-support/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultTestKmsFacadeTest.java
@@ -16,7 +16,7 @@ import io.kroxylicious.kms.service.AbstractTestKmsFacadeTest;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
-class VaultTestKmsFacadeTest extends AbstractTestKmsFacadeTest<Config, String, VaultEdek> {
+class VaultTestKmsFacadeTest extends AbstractTestKmsFacadeTest<Config, Config, String, VaultEdek> {
 
     VaultTestKmsFacadeTest() {
         super(new VaultTestKmsFacadeFactory());

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsService.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsService.java
@@ -18,12 +18,13 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * An implementation of the {@link KmsService} interface backed by a remote instance of HashiCorp Vault.
  */
 @Plugin(configType = Config.class)
-public class VaultKmsService implements KmsService<Config, String, VaultEdek> {
+public class VaultKmsService implements KmsService<Config, Config, String, VaultEdek> {
 
     @NonNull
     @Override
-    public VaultKms buildKms(Config options) {
-        return new VaultKms(options.vaultTransitEngineUrl(), options.vaultToken().getProvidedPassword(), Duration.ofSeconds(20), options.sslContext());
+    public VaultKms buildKms(Config initializationData) {
+        return new VaultKms(initializationData.vaultTransitEngineUrl(), initializationData.vaultToken().getProvidedPassword(), Duration.ofSeconds(20),
+                initializationData.sslContext());
     }
 
 }

--- a/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsTest.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsTest.java
@@ -203,7 +203,9 @@ class VaultKmsTest {
             InetSocketAddress address = httpServer.getAddress();
             String vaultAddress = "http://127.0.0.1:" + address.getPort() + "/v1/transit";
             var config = new Config(URI.create(vaultAddress), new InlinePassword("token"), null);
-            VaultKms service = new VaultKmsService().buildKms(config);
+            var vaultKmsService = new VaultKmsService();
+            var initData = vaultKmsService.initialize(config);
+            var service = vaultKmsService.buildKms(initData);
             consumer.accept(service);
         }
         finally {

--- a/kroxylicious-kms-provider-kroxylicious-inmemory-test-support/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryTestKmsFacade.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory-test-support/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryTestKmsFacade.java
@@ -11,18 +11,23 @@ import java.util.UUID;
 import java.util.concurrent.CompletionException;
 
 import io.kroxylicious.kms.provider.kroxylicious.inmemory.IntegrationTestingKmsService.Config;
+import io.kroxylicious.kms.provider.kroxylicious.inmemory.IntegrationTestingKmsService.Init;
 import io.kroxylicious.kms.service.TestKekManager;
 import io.kroxylicious.kms.service.TestKmsFacade;
 import io.kroxylicious.kms.service.UnknownAliasException;
 
-public class InMemoryTestKmsFacade implements TestKmsFacade<Config, UUID, InMemoryEdek> {
+public class InMemoryTestKmsFacade implements TestKmsFacade<Config, Init, UUID, InMemoryEdek> {
 
     private final UUID kmsId = UUID.randomUUID();
     private InMemoryKms kms;
 
     @Override
     public void start() {
-        kms = IntegrationTestingKmsService.newInstance().buildKms(new Config(kmsId.toString()));
+        var config = new Config(kmsId.toString());
+
+        var service = IntegrationTestingKmsService.newInstance();
+        var initData = service.initialize(config);
+        kms = service.buildKms(initData);
     }
 
     @Override

--- a/kroxylicious-kms-provider-kroxylicious-inmemory-test-support/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryTestKmsFacadeFactory.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory-test-support/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryTestKmsFacadeFactory.java
@@ -9,12 +9,13 @@ package io.kroxylicious.kms.provider.kroxylicious.inmemory;
 import java.util.UUID;
 
 import io.kroxylicious.kms.provider.kroxylicious.inmemory.IntegrationTestingKmsService.Config;
+import io.kroxylicious.kms.provider.kroxylicious.inmemory.IntegrationTestingKmsService.Init;
 import io.kroxylicious.kms.service.TestKmsFacadeFactory;
 
 /**
  * Factory for {@link InMemoryTestKmsFacade}s.
  */
-public class InMemoryTestKmsFacadeFactory implements TestKmsFacadeFactory<Config, UUID, InMemoryEdek> {
+public class InMemoryTestKmsFacadeFactory implements TestKmsFacadeFactory<Config, Init, UUID, InMemoryEdek> {
     /**
      * {@inheritDoc}
      */

--- a/kroxylicious-kms-provider-kroxylicious-inmemory-test-support/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryTestKmsFacadeTest.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory-test-support/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryTestKmsFacadeTest.java
@@ -11,11 +11,12 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.kms.provider.kroxylicious.inmemory.IntegrationTestingKmsService.Config;
+import io.kroxylicious.kms.provider.kroxylicious.inmemory.IntegrationTestingKmsService.Init;
 import io.kroxylicious.kms.service.AbstractTestKmsFacadeTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class InMemoryTestKmsFacadeTest extends AbstractTestKmsFacadeTest<Config, UUID, InMemoryEdek> {
+class InMemoryTestKmsFacadeTest extends AbstractTestKmsFacadeTest<Config, Init, UUID, InMemoryEdek> {
 
     InMemoryTestKmsFacadeTest() {
         super(new InMemoryTestKmsFacadeFactory());

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/IntegrationTestingKmsService.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/IntegrationTestingKmsService.java
@@ -37,7 +37,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * @see UnitTestingKmsService
  */
 @Plugin(configType = IntegrationTestingKmsService.Config.class)
-public class IntegrationTestingKmsService implements KmsService<IntegrationTestingKmsService.Config, UUID, InMemoryEdek> {
+public class IntegrationTestingKmsService implements KmsService<IntegrationTestingKmsService.Config, IntegrationTestingKmsService.Config, UUID, InMemoryEdek> {
 
     public static IntegrationTestingKmsService newInstance() {
         return (IntegrationTestingKmsService) ServiceLoader.load(KmsService.class).stream()
@@ -60,8 +60,8 @@ public class IntegrationTestingKmsService implements KmsService<IntegrationTesti
 
     @NonNull
     @Override
-    public InMemoryKms buildKms(Config options) {
-        return KMSES.computeIfAbsent(options.name(), ignored -> new InMemoryKms(12, 128, Map.of(), Map.of()));
+    public InMemoryKms buildKms(Config initializationData) {
+        return KMSES.computeIfAbsent(initializationData.name(), ignored -> new InMemoryKms(12, 128, Map.of(), Map.of()));
     }
 
     public static void delete(String name) {

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/IntegrationTestingKmsService.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/IntegrationTestingKmsService.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.kms.provider.kroxylicious.inmemory;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -37,7 +38,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * @see UnitTestingKmsService
  */
 @Plugin(configType = IntegrationTestingKmsService.Config.class)
-public class IntegrationTestingKmsService implements KmsService<IntegrationTestingKmsService.Config, IntegrationTestingKmsService.Config, UUID, InMemoryEdek> {
+public class IntegrationTestingKmsService implements KmsService<IntegrationTestingKmsService.Config, IntegrationTestingKmsService.Init, UUID, InMemoryEdek> {
 
     public static IntegrationTestingKmsService newInstance() {
         return (IntegrationTestingKmsService) ServiceLoader.load(KmsService.class).stream()
@@ -56,12 +57,24 @@ public class IntegrationTestingKmsService implements KmsService<IntegrationTesti
         }
     }
 
+    public record Init(
+                       Config config) {
+        public Init {
+            Objects.requireNonNull(config);
+        }
+    }
+
     private static final Map<String, InMemoryKms> KMSES = new ConcurrentHashMap<>();
+
+    @Override
+    public Init initialize(Config config) {
+        return new Init(config);
+    }
 
     @NonNull
     @Override
-    public InMemoryKms buildKms(Config initializationData) {
-        return KMSES.computeIfAbsent(initializationData.name(), ignored -> new InMemoryKms(12, 128, Map.of(), Map.of()));
+    public InMemoryKms buildKms(Init initializationData) {
+        return KMSES.computeIfAbsent(initializationData.config().name(), ignored -> new InMemoryKms(12, 128, Map.of(), Map.of()));
     }
 
     public static void delete(String name) {

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/UnitTestingKmsService.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/UnitTestingKmsService.java
@@ -36,7 +36,7 @@ import static java.util.stream.Collectors.toMap;
  * @see IntegrationTestingKmsService
  */
 @Plugin(configType = UnitTestingKmsService.Config.class)
-public class UnitTestingKmsService implements KmsService<UnitTestingKmsService.Config, UUID, InMemoryEdek> {
+public class UnitTestingKmsService implements KmsService<UnitTestingKmsService.Config, UnitTestingKmsService.Config, UUID, InMemoryEdek> {
     private Map<Config, InMemoryKms> kmsMap = new ConcurrentHashMap<>();
 
     public static UnitTestingKmsService newInstance() {
@@ -79,14 +79,14 @@ public class UnitTestingKmsService implements KmsService<UnitTestingKmsService.C
 
     @NonNull
     @Override
-    public InMemoryKms buildKms(Config options) {
-        return kmsMap.computeIfAbsent(options, config -> {
-            List<Kek> kekDefs = options.existingKeks();
+    public InMemoryKms buildKms(Config initializationData) {
+        return kmsMap.computeIfAbsent(initializationData, config -> {
+            List<Kek> kekDefs = initializationData.existingKeks();
             Map<UUID, DestroyableRawSecretKey> keys = kekDefs.stream()
                     .collect(toMap(k -> UUID.fromString(k.uuid), k -> DestroyableRawSecretKey.takeCopyOf(k.key, k.algorithm)));
             Map<String, UUID> aliases = kekDefs.stream().collect(toMap(k -> k.alias, k -> UUID.fromString(k.uuid)));
-            return new InMemoryKms(options.numIvBytes(),
-                    options.numAuthBits(),
+            return new InMemoryKms(initializationData.numIvBytes(),
+                    initializationData.numAuthBits(),
                     keys, aliases);
         });
     }

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/IntegrationTestingKmsServiceTest.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/IntegrationTestingKmsServiceTest.java
@@ -54,13 +54,17 @@ class IntegrationTestingKmsServiceTest {
     void shouldWorkAcrossServiceInstances() {
         // given
         var kmsId = UUID.randomUUID().toString();
-        var kms = service.buildKms(new IntegrationTestingKmsService.Config(kmsId));
+        var init = service.initialize(new IntegrationTestingKmsService.Config(kmsId));
+        var kms = service.buildKms(init);
         var kek = kms.generateKey();
         assertNotNull(kek);
         kms.createAlias(kek, "myAlias");
 
+        var service2 = IntegrationTestingKmsService.newInstance();
+        var init2 = service2.initialize(new IntegrationTestingKmsService.Config(kmsId));
+
         // when
-        var theSameKms = IntegrationTestingKmsService.newInstance().buildKms(new IntegrationTestingKmsService.Config(kmsId));
+        var theSameKms = service2.buildKms(init2);
 
         // then
         assertEquals(kek, theSameKms.resolveAlias("myAlias").join());
@@ -72,9 +76,13 @@ class IntegrationTestingKmsServiceTest {
     void shouldGenerateDeks() {
         // given
         var kms1Id = UUID.randomUUID().toString();
-        var kms1 = service.buildKms(new IntegrationTestingKmsService.Config(kms1Id));
+        var init1 = service.initialize(new IntegrationTestingKmsService.Config(kms1Id));
+        var kms1 = service.buildKms(init1);
+
         var kms2Id = UUID.randomUUID().toString();
-        var kms2 = IntegrationTestingKmsService.newInstance().buildKms(new IntegrationTestingKmsService.Config(kms2Id));
+        var service2 = IntegrationTestingKmsService.newInstance();
+        var init2 = service.initialize(new IntegrationTestingKmsService.Config(kms2Id));
+        var kms2 = service2.buildKms(init2);
         var key1 = kms1.generateKey();
         assertNotNull(key1);
         var key2 = kms2.generateKey();
@@ -96,9 +104,12 @@ class IntegrationTestingKmsServiceTest {
     void shouldRejectsAnotherKmsesKeks() {
         // given
         var kms1Id = UUID.randomUUID().toString();
-        var kms1 = service.buildKms(new IntegrationTestingKmsService.Config(kms1Id));
+        var init1 = service.initialize(new IntegrationTestingKmsService.Config(kms1Id));
+        var kms1 = service.buildKms(init1);
         var kms2Id = UUID.randomUUID().toString();
-        var kms2 = IntegrationTestingKmsService.newInstance().buildKms(new IntegrationTestingKmsService.Config(kms2Id));
+        var service2 = IntegrationTestingKmsService.newInstance();
+        var init2 = service.initialize(new IntegrationTestingKmsService.Config(kms2Id));
+        var kms2 = service2.buildKms(init2);
         var key1 = kms1.generateKey();
         assertNotNull(key1);
         var key2 = kms2.generateKey();
@@ -127,7 +138,8 @@ class IntegrationTestingKmsServiceTest {
     void shouldDecryptDeks() {
         // given
         var kmsId = UUID.randomUUID().toString();
-        var kms = service.buildKms(new IntegrationTestingKmsService.Config(kmsId));
+        var init = service.initialize(new IntegrationTestingKmsService.Config(kmsId));
+        var kms = service.buildKms(init);
         var kek = kms.generateKey();
         assertNotNull(kek);
         var pair = kms.generateDekPair(kek).join();
@@ -148,7 +160,8 @@ class IntegrationTestingKmsServiceTest {
     @Test
     void shouldSerializeAndDeserializeEdeks() {
         var kmsId = UUID.randomUUID().toString();
-        var kms = service.buildKms(new IntegrationTestingKmsService.Config(kmsId));
+        var init = service.initialize(new IntegrationTestingKmsService.Config(kmsId));
+        var kms = service.buildKms(init);
         var kek = kms.generateKey();
 
         var edek = kms.generateDekPair(kek).join().edek();
@@ -169,7 +182,8 @@ class IntegrationTestingKmsServiceTest {
     @Test
     void shouldLookupByAlias() {
         var kmsId = UUID.randomUUID().toString();
-        var kms = service.buildKms(new IntegrationTestingKmsService.Config(kmsId));
+        var init = service.initialize(new IntegrationTestingKmsService.Config(kmsId));
+        var kms = service.buildKms(init);
         var kek = kms.generateKey();
 
         var lookup = kms.resolveAlias("bob");
@@ -195,7 +209,8 @@ class IntegrationTestingKmsServiceTest {
     @Test
     void deleteAliasFailsWithUnknownAlias() {
         var kmsId = UUID.randomUUID().toString();
-        var kms = service.buildKms(new IntegrationTestingKmsService.Config(kmsId));
+        var init = service.initialize(new IntegrationTestingKmsService.Config(kmsId));
+        var kms = service.buildKms(init);
 
         assertThatThrownBy(() -> kms.deleteAlias("bob"))
                 .isInstanceOf(UnknownAliasException.class);
@@ -206,7 +221,8 @@ class IntegrationTestingKmsServiceTest {
     @Test
     void deleteKey() {
         var kmsId = UUID.randomUUID().toString();
-        var kms = service.buildKms(new IntegrationTestingKmsService.Config(kmsId));
+        var init = service.initialize(new IntegrationTestingKmsService.Config(kmsId));
+        var kms = service.buildKms(init);
         var kek = kms.generateKey();
 
         kms.deleteKey(kek);
@@ -219,7 +235,8 @@ class IntegrationTestingKmsServiceTest {
     @Test
     void deleteKeyFailsIfAliasPresent() {
         var kmsId = UUID.randomUUID().toString();
-        var kms = service.buildKms(new IntegrationTestingKmsService.Config(kmsId));
+        var init = service.initialize(new IntegrationTestingKmsService.Config(kmsId));
+        var kms = service.buildKms(init);
         var kek = kms.generateKey();
         kms.createAlias(kek, "bob");
 

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/UnitTestingKmsServiceTest.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/UnitTestingKmsServiceTest.java
@@ -9,79 +9,77 @@ package io.kroxylicious.kms.provider.kroxylicious.inmemory;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.kroxylicious.kms.service.DekPair;
 import io.kroxylicious.kms.service.DestroyableRawSecretKey;
 import io.kroxylicious.kms.service.SecretKeyUtils;
 import io.kroxylicious.kms.service.UnknownAliasException;
 import io.kroxylicious.kms.service.UnknownKeyException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class UnitTestingKmsServiceTest {
 
     UnitTestingKmsService service;
+    UnitTestingKmsService.Init serviceInitData;
 
     @BeforeEach
     public void before() {
         service = UnitTestingKmsService.newInstance();
+        serviceInitData = service.initialize(new UnitTestingKmsService.Config());
     }
 
     @Test
     void shouldRejectOutOfBoundIvBytes() {
         // given
         List<UnitTestingKmsService.Kek> existingKeks = List.of();
-        assertThrows(IllegalArgumentException.class, () -> new UnitTestingKmsService.Config(0, 128, existingKeks));
+        assertThatThrownBy(() -> new UnitTestingKmsService.Config(0, 128, existingKeks))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void shouldRejectOutOfBoundAuthBits() {
         List<UnitTestingKmsService.Kek> existingKeks = List.of();
-        assertThrows(IllegalArgumentException.class, () -> new UnitTestingKmsService.Config(12, 0, existingKeks));
+        assertThatThrownBy(() -> new UnitTestingKmsService.Config(12, 0, existingKeks))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void shouldGenerateDeks() {
         // given
-        var kms1 = service.buildKms(new UnitTestingKmsService.Config());
-        var kms2 = UnitTestingKmsService.newInstance().buildKms(new UnitTestingKmsService.Config());
+        var kms1 = service.buildKms(serviceInitData);
+
         var key1 = kms1.generateKey();
-        assertNotNull(key1);
-        var key2 = kms2.generateKey();
-        assertNotNull(key2);
+        assertThat(key1).isNotNull();
 
         // when
-        CompletableFuture<DekPair<InMemoryEdek>> gen1 = kms1.generateDekPair(key1);
-        CompletableFuture<DekPair<InMemoryEdek>> gen2 = kms2.generateDekPair(key2);
+        var gen1 = kms1.generateDekPair(key1);
 
         // then
         assertThat(gen1).isCompleted();
-        assertThat(gen2).isCompleted();
     }
 
     @Test
     void shouldRejectsAnotherKmsesKeks() {
         // given
-        var kms1 = service.buildKms(new UnitTestingKmsService.Config());
-        var kms2 = UnitTestingKmsService.newInstance().buildKms(new UnitTestingKmsService.Config());
+        var kms1 = service.buildKms(serviceInitData);
+        var service2 = UnitTestingKmsService.newInstance();
+        var service2InitData = service2.initialize(new UnitTestingKmsService.Config());
+        var kms2 = service2.buildKms(service2InitData);
+
         var key1 = kms1.generateKey();
-        assertNotNull(key1);
+        assertThat(key1).isNotNull();
         var key2 = kms2.generateKey();
-        assertNotNull(key2);
+        assertThat(key1).isNotNull();
 
         // when
-        CompletableFuture<DekPair<InMemoryEdek>> gen1 = kms1.generateDekPair(key2);
-        CompletableFuture<DekPair<InMemoryEdek>> gen2 = kms2.generateDekPair(key1);
+        var gen1 = kms1.generateDekPair(key2);
+        var gen2 = kms2.generateDekPair(key1);
 
         // then
         assertThat(gen1).failsWithin(Duration.ZERO)
@@ -98,25 +96,27 @@ class UnitTestingKmsServiceTest {
     @Test
     void shouldDecryptDeks() {
         // given
-        var kms = service.buildKms(new UnitTestingKmsService.Config());
+        var kms = service.buildKms(serviceInitData);
         var kek = kms.generateKey();
-        assertNotNull(kek);
+        assertThat(kek).isNotNull();
         var pair = kms.generateDekPair(kek).join();
-        assertNotNull(pair);
-        assertNotNull(pair.edek());
-        assertNotNull(pair.dek());
+        assertThat(pair).isNotNull();
+        assertThat(pair.edek()).isNotNull();
+        assertThat(pair.dek()).isNotNull();
 
         // when
         var decryptedDek = kms.decryptEdek(pair.edek()).join();
 
         // then
-        assertTrue(SecretKeyUtils.same((DestroyableRawSecretKey) pair.dek(), (DestroyableRawSecretKey) decryptedDek),
-                "Expect the decrypted DEK to equal the originally generated DEK");
+        var expected = (DestroyableRawSecretKey) pair.dek();
+        assertThat(decryptedDek)
+                .asInstanceOf(InstanceOfAssertFactories.type(DestroyableRawSecretKey.class))
+                .matches(x -> SecretKeyUtils.same(x, expected));
     }
 
     @Test
     void shouldSerializeAndDeserializeEdeks() {
-        var kms = service.buildKms(new UnitTestingKmsService.Config());
+        var kms = service.buildKms(serviceInitData);
         var kek = kms.generateKey();
 
         var edek = kms.generateDekPair(kek).join().edek();
@@ -124,17 +124,17 @@ class UnitTestingKmsServiceTest {
         var serde = kms.edekSerde();
         var buffer = ByteBuffer.allocate(serde.sizeOf(edek));
         serde.serialize(edek, buffer);
-        assertFalse(buffer.hasRemaining());
+        assertThat(buffer.hasRemaining()).isFalse();
         buffer.flip();
 
         var deserialized = serde.deserialize(buffer);
 
-        assertEquals(edek, deserialized);
+        assertThat(edek).isEqualTo(deserialized);
     }
 
     @Test
     void shouldLookupByAlias() {
-        var kms = service.buildKms(new UnitTestingKmsService.Config());
+        var kms = service.buildKms(serviceInitData);
         var kek = kms.generateKey();
 
         var lookup = kms.resolveAlias("bob");
@@ -144,8 +144,9 @@ class UnitTestingKmsServiceTest {
                 .withMessage("io.kroxylicious.kms.service.UnknownAliasException: bob");
 
         kms.createAlias(kek, "bob");
-        var gotFromAlias = kms.resolveAlias("bob").join();
-        assertEquals(kek, gotFromAlias);
+        assertThat(kms.resolveAlias("bob"))
+                .succeedsWithin(Duration.ZERO)
+                .isEqualTo(kek);
 
         kms.deleteAlias("bob");
         lookup = kms.resolveAlias("bob");

--- a/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/AbstractTestKmsFacadeTest.java
+++ b/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/AbstractTestKmsFacadeTest.java
@@ -22,12 +22,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * @param <E> The type of encrypted DEK
  */
 @SuppressWarnings("java:S5960") // this is test code, it exists in the main module to facilitate its use by concrete test cases
-public abstract class AbstractTestKmsFacadeTest<C, K, E> {
+public abstract class AbstractTestKmsFacadeTest<C, I, K, E> {
 
     private static final String ALIAS = "myalias";
-    protected final TestKmsFacadeFactory<C, K, E> factory;
+    protected final TestKmsFacadeFactory<C, I, K, E> factory;
 
-    protected AbstractTestKmsFacadeTest(TestKmsFacadeFactory<C, K, E> factory) {
+    protected AbstractTestKmsFacadeTest(TestKmsFacadeFactory<C, I, K, E> factory) {
         Objects.requireNonNull(factory);
         this.factory = factory;
     }

--- a/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKmsFacade.java
+++ b/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKmsFacade.java
@@ -9,10 +9,11 @@ package io.kroxylicious.kms.service;
 /**
  * Represents the Kms itself, exposed for test purpose.
  * @param <C> The config type
+ * @param <I> The init type
  * @param <K> The key reference
  * @param <E> The type of encrypted DEK
  */
-public interface TestKmsFacade<C, K, E> extends AutoCloseable {
+public interface TestKmsFacade<C, I, K, E> extends AutoCloseable {
 
     /**
      * Returns true of this facade is available, or false otherwise.
@@ -43,7 +44,7 @@ public interface TestKmsFacade<C, K, E> extends AutoCloseable {
      *
      * @return service class
      */
-    Class<? extends KmsService<C, C, K, E>> getKmsServiceClass();
+    Class<? extends KmsService<C, I, K, E>> getKmsServiceClass();
 
     /**
      * Gets the configuration Kroxylicious will need to use to connect to the underlying KMS.

--- a/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKmsFacade.java
+++ b/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKmsFacade.java
@@ -43,7 +43,7 @@ public interface TestKmsFacade<C, K, E> extends AutoCloseable {
      *
      * @return service class
      */
-    Class<? extends KmsService<C, K, E>> getKmsServiceClass();
+    Class<? extends KmsService<C, C, K, E>> getKmsServiceClass();
 
     /**
      * Gets the configuration Kroxylicious will need to use to connect to the underlying KMS.

--- a/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKmsFacadeFactory.java
+++ b/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKmsFacadeFactory.java
@@ -15,21 +15,22 @@ import java.util.stream.Stream;
  * @param <K> The key reference
  * @param <E> The type of encrypted DEK
  */
-public interface TestKmsFacadeFactory<C, K, E> {
+public interface TestKmsFacadeFactory<C, I, K, E> {
 
     /**
      * Creates a TestKmsFacade instance
      *
      * @return instance
      */
-    TestKmsFacade<C, K, E> build();
+    TestKmsFacade<C, I, K, E> build();
 
     /**
      * Discovers the available {@link TestKmsFacadeFactory}.
+     *
      * @return factories
      */
     @SuppressWarnings("unchecked")
-    static <C, K, E> Stream<TestKmsFacadeFactory<C, K, E>> getTestKmsFacadeFactories() {
+    static <C, I, K, E> Stream<TestKmsFacadeFactory<C, I, K, E>> getTestKmsFacadeFactories() {
         return ServiceLoader.load(TestKmsFacadeFactory.class).stream()
                 .map(ServiceLoader.Provider::get);
     }

--- a/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKmsFacadeInvocationContextProvider.java
+++ b/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKmsFacadeInvocationContextProvider.java
@@ -34,7 +34,7 @@ public class TestKmsFacadeInvocationContextProvider implements TestTemplateInvoc
                 .map(TemplateInvocationContext::new);
     }
 
-    private record TemplateInvocationContext(TestKmsFacade<?, ?, ?> kmsFacade) implements TestTemplateInvocationContext {
+    private record TemplateInvocationContext(TestKmsFacade<?, ?, ?, ?> kmsFacade) implements TestTemplateInvocationContext {
 
         @Override
         public String getDisplayName(int invocationIndex) {
@@ -51,9 +51,9 @@ public class TestKmsFacadeInvocationContextProvider implements TestTemplateInvoc
 
             return List.of(
                     (BeforeEachCallback) extensionContext -> kmsFacade.start(),
-                    new TypeBasedParameterResolver<TestKmsFacade<?, ?, ?>>() {
+                    new TypeBasedParameterResolver<TestKmsFacade<?, ?, ?, ?>>() {
                         @Override
-                        public TestKmsFacade<?, ?, ?> resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+                        public TestKmsFacade<?, ?, ?, ?> resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
                             return kmsFacade;
                         }
                     },

--- a/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/KmsService.java
+++ b/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/KmsService.java
@@ -17,13 +17,33 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public interface KmsService<C, I, K, E> {
 
+    /**
+     * Initialises the service.  This method must be invoked exactly once
+     * before {@link #buildKms(Object)} is called.
+     *
+     * @param config configuration
+     * @return initializationData
+     */
     default I initialize(C config) {
         return (I) config;
     }
 
+    /**
+     * Builds the KMS service.
+     *
+     * @param initializationData initialization data
+     * @return the KMS.
+     */
     @NonNull
     Kms<K, E> buildKms(I initializationData);
 
+    /**
+     * Closes the service.  The caller must pass the {@code initializationData}
+     * returned by the call to {@link #initialize(Object)}.  Implementations
+     * of this method must be idempotent.
+     *
+     * @param initializationData initialization data
+     */
     default void close(I initializationData) {
     }
 }

--- a/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/KmsService.java
+++ b/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/KmsService.java
@@ -11,11 +11,19 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 /**
  * Service interface for KMSs
  * @param <C> The config type
+ * @param <I> The initialization type
  * @param <K> The key reference
  * @param <E> The type of encrypted DEK
  */
-public interface KmsService<C, K, E> {
-    @NonNull
-    Kms<K, E> buildKms(C options);
+public interface KmsService<C, I, K, E> {
 
+    default I initialize(C config) {
+        return (I) config;
+    }
+
+    @NonNull
+    Kms<K, E> buildKms(I initializationData);
+
+    default void close(I initializationData) {
+    }
 }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/Kroxylicious.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/Kroxylicious.java
@@ -49,7 +49,7 @@ public class Kroxylicious {
         resourceManager.createResourceWithWait(KroxyliciousConfigMapTemplates.defaultKroxyliciousConfig(clusterName, deploymentNamespace).build());
     }
 
-    private void createRecordEncryptionFilterConfigMap(String clusterName, TestKmsFacade<?, ?, ?> testKmsFacade, ExperimentalKmsConfig experimentalKmsConfig) {
+    private void createRecordEncryptionFilterConfigMap(String clusterName, TestKmsFacade<?, ?, ?, ?> testKmsFacade, ExperimentalKmsConfig experimentalKmsConfig) {
         LOGGER.info("Deploy Kroxylicious config Map with record encryption filter in {} namespace", deploymentNamespace);
         resourceManager
                 .createResourceWithWait(
@@ -80,7 +80,7 @@ public class Kroxylicious {
      * @param replicas the replicas
      * @param testKmsFacade the test kms facade
      */
-    public void deployPortPerBrokerPlainWithRecordEncryptionFilter(String clusterName, int replicas, TestKmsFacade<?, ?, ?> testKmsFacade) {
+    public void deployPortPerBrokerPlainWithRecordEncryptionFilter(String clusterName, int replicas, TestKmsFacade<?, ?, ?, ?> testKmsFacade) {
         deployPortPerBrokerPlainWithRecordEncryptionFilter(clusterName, replicas, testKmsFacade, null);
     }
 
@@ -91,7 +91,7 @@ public class Kroxylicious {
      * @param replicas the replicas
      * @param testKmsFacade the test kms facade
      */
-    public void deployPortPerBrokerPlainWithRecordEncryptionFilter(String clusterName, int replicas, TestKmsFacade<?, ?, ?> testKmsFacade,
+    public void deployPortPerBrokerPlainWithRecordEncryptionFilter(String clusterName, int replicas, TestKmsFacade<?, ?, ?, ?> testKmsFacade,
                                                                    ExperimentalKmsConfig experimentalKmsConfig) {
         createRecordEncryptionFilterConfigMap(clusterName, testKmsFacade, experimentalKmsConfig);
         deployPortPerBrokerPlain(replicas);

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/kroxylicious/KroxyliciousConfigMapTemplates.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/kroxylicious/KroxyliciousConfigMapTemplates.java
@@ -61,13 +61,13 @@ public final class KroxyliciousConfigMapTemplates {
      * @param testKmsFacade the test kms facade
      * @return the config map builder
      */
-    public static ConfigMapBuilder kroxyliciousRecordEncryptionConfig(String clusterName, String namespaceName, TestKmsFacade<?, ?, ?> testKmsFacade,
+    public static ConfigMapBuilder kroxyliciousRecordEncryptionConfig(String clusterName, String namespaceName, TestKmsFacade<?, ?, ?, ?> testKmsFacade,
                                                                       ExperimentalKmsConfig experimentalKmsConfig) {
         return baseKroxyliciousConfig(namespaceName)
                 .addToData("config.yaml", getRecordEncryptionConfigMap(clusterName, testKmsFacade, experimentalKmsConfig));
     }
 
-    private static String buildEncryptionFilter(TestKmsFacade<?, ?, ?> testKmsFacade, ExperimentalKmsConfig experimentalKmsConfig) {
+    private static String buildEncryptionFilter(TestKmsFacade<?, ?, ?, ?> testKmsFacade, ExperimentalKmsConfig experimentalKmsConfig) {
         return """
                 - type: RecordEncryption
                   config:
@@ -96,7 +96,7 @@ public final class KroxyliciousConfigMapTemplates {
         return configYaml;
     }
 
-    private static String getRecordEncryptionConfigMap(String clusterName, TestKmsFacade<?, ?, ?> testKmsFacade, ExperimentalKmsConfig experimentalKmsConfig) {
+    private static String getRecordEncryptionConfigMap(String clusterName, TestKmsFacade<?, ?, ?, ?> testKmsFacade, ExperimentalKmsConfig experimentalKmsConfig) {
         String configYaml = buildEncryptionFilter(testKmsFacade, experimentalKmsConfig);
 
         return """

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/RecordEncryptionST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/RecordEncryptionST.java
@@ -91,7 +91,7 @@ class RecordEncryptionST extends AbstractST {
     }
 
     @TestTemplate
-    void ensureClusterHasEncryptedMessage(String namespace, TestKmsFacade<?, ?, ?> testKmsFacade) {
+    void ensureClusterHasEncryptedMessage(String namespace, TestKmsFacade<?, ?, ?, ?> testKmsFacade) {
         testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek("KEK_" + topicName);
         int numberOfMessages = 1;
@@ -123,7 +123,7 @@ class RecordEncryptionST extends AbstractST {
     }
 
     @TestTemplate
-    void produceAndConsumeMessage(String namespace, TestKmsFacade<?, ?, ?> testKmsFacade) {
+    void produceAndConsumeMessage(String namespace, TestKmsFacade<?, ?, ?, ?> testKmsFacade) {
         testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek("KEK_" + topicName);
         int numberOfMessages = 1;
@@ -152,7 +152,7 @@ class RecordEncryptionST extends AbstractST {
 
     @SuppressWarnings("java:S2925")
     @TestTemplate
-    void ensureClusterHasEncryptedMessageWithRotatedKEK(String namespace, TestKmsFacade<?, ?, ?> testKmsFacade) {
+    void ensureClusterHasEncryptedMessageWithRotatedKEK(String namespace, TestKmsFacade<?, ?, ?, ?> testKmsFacade) {
         // Skip AWS test execution because the ciphertext blob metadata to read the version of the KEK is not available anywhere
         assumeThat(testKmsFacade.getKmsServiceClass().getSimpleName().toLowerCase().contains("vault")).isTrue();
         testKekManager = testKmsFacade.getTestKekManager();
@@ -218,7 +218,7 @@ class RecordEncryptionST extends AbstractST {
 
     @SuppressWarnings("java:S2925")
     @TestTemplate
-    void produceAndConsumeMessageWithRotatedKEK(String namespace, TestKmsFacade<?, ?, ?> testKmsFacade) {
+    void produceAndConsumeMessageWithRotatedKEK(String namespace, TestKmsFacade<?, ?, ?, ?> testKmsFacade) {
         testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek("KEK_" + topicName);
         int numberOfMessages = 1;

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/extensions/TestKubeKmsFacadeInvocationContextProvider.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/extensions/TestKubeKmsFacadeInvocationContextProvider.java
@@ -38,7 +38,7 @@ public class TestKubeKmsFacadeInvocationContextProvider implements TestTemplateI
                 .map(TestKubeKmsFacadeInvocationContextProvider.TemplateInvocationContext::new);
     }
 
-    private record TemplateInvocationContext(TestKmsFacade<?, ?, ?> kmsFacade) implements TestTemplateInvocationContext {
+    private record TemplateInvocationContext(TestKmsFacade<?, ?, ?, ?> kmsFacade) implements TestTemplateInvocationContext {
 
         @Override
         public String getDisplayName(int invocationIndex) {
@@ -55,9 +55,9 @@ public class TestKubeKmsFacadeInvocationContextProvider implements TestTemplateI
 
             return List.of(
                     (BeforeEachCallback) extensionContext -> kmsFacade.start(),
-                    new TypeBasedParameterResolver<TestKmsFacade<?, ?, ?>>() {
+                    new TypeBasedParameterResolver<TestKmsFacade<?, ?, ?, ?>>() {
                         @Override
-                        public TestKmsFacade<?, ?, ?> resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+                        public TestKmsFacade<?, ?, ?, ?> resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
                             return kmsFacade;
                         }
                     },


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

why: sometimes KMS's need to make use of long lived resources that need to be closed once the KMS service is no longer required. #1442 is an example.  There the KMS (well, the `CredentialsProviders`) needs to use a thread-pool to do its work.  I'd like to start the threadpool in the `init` and shut it down in the `close`.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
