### PR TITLE
Exclude TLS interfaces from binary compat checks for 0.7.1

### DIFF
--- a/kroxylicious-api/pom.xml
+++ b/kroxylicious-api/pom.xml
@@ -158,6 +158,8 @@
                         <breakBuildBasedOnSemanticVersioningForMajorVersionZero>${ApiCompatability.EnforceForMajorVersionZero}</breakBuildBasedOnSemanticVersioningForMajorVersionZero>
                         <excludes>
                             <exclude>io.kroxylicious.proxy.config.secret.FilePasswordFilePath</exclude>  <!-- used purely in config files and the name still exists (as a JSON alias) -->
+                            <exclude>io.kroxylicious.proxy.config.tls.PlatformTrustProvider</exclude>  <!-- only used from kroxylicious-runtime, temporary exclusion for 0.7.1 -->
+                            <exclude>io.kroxylicious.proxy.config.tls.TrustProviderVisitor</exclude>  <!-- new method only used from kroxylicious-runtime, temporary exclusion for 0.7.1 -->
                         </excludes>
                         <!-- see documentation -->
                     </parameter>


### PR DESCRIPTION
### Type of change

- Kludge

### Description

Currently releasing 0.7.1 is blocked because we've added an interface and method to kroxylicious-api.

They aren't surfaced in user configuration, don't affect user filter APIs, and are only used by the runtime. We don't want to release an 0.8.0 just for this fix.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
