### PR TITLE
Ensure the state machine transitions to failed when closing in response to an exception

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -483,8 +483,7 @@ public class KafkaProxyFrontendHandler
                             LOGGER.warn("Netty caught exception from the frontend: {}", cause.getMessage(), cause);
                             buildErrorResponseFrame().ifPresentOrElse(
                                     resp -> closeWith(ctx.channel(), resp),
-                                    () -> closeNoResponse(ctx.channel())
-                            );
+                                    () -> closeNoResponse(ctx.channel()));
                         });
 
     }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Ensure the connection state machine is updated appropriately when closing the inbound channel with an exception.

### Additional Context

As part of #1475 @tombentley and I noticed that there was no transition in exceptionCaught. We also noticed that the `FrameOversizedException` handling was following a very similar pattern to the `SSLHandlerException` and needing to unwrap decoder exceptions. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
