### PR TITLE
Remove the instance methods from KafkaProxyExceptionMapper

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaAuthnHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaAuthnHandler.java
@@ -180,21 +180,17 @@ public class KafkaAuthnHandler extends ChannelInboundHandlerAdapter {
 
     @VisibleForTesting
     State lastSeen;
-    private final KafkaProxyExceptionMapper exceptionHandler;
 
     public KafkaAuthnHandler(Channel ch,
-                             Map<SaslMechanism, AuthenticateCallbackHandler> mechanismHandlers,
-                             KafkaProxyExceptionMapper exceptionHandler) {
-        this(ch, State.START, mechanismHandlers, exceptionHandler);
+                             Map<SaslMechanism, AuthenticateCallbackHandler> mechanismHandlers) {
+        this(ch, State.START, mechanismHandlers);
     }
 
     @VisibleForTesting
     KafkaAuthnHandler(Channel ch,
                       State init,
-                      Map<SaslMechanism, AuthenticateCallbackHandler> mechanismHandlers,
-                      KafkaProxyExceptionMapper exceptionHandler) {
+                      Map<SaslMechanism, AuthenticateCallbackHandler> mechanismHandlers) {
         this.lastSeen = init;
-        this.exceptionHandler = exceptionHandler;
         LOG.debug("{}: Initial state {}", ch, lastSeen);
         this.mechanismHandlers = mechanismHandlers.entrySet().stream().collect(Collectors.toMap(
                 e -> e.getKey().mechanismName(), Map.Entry::getValue));
@@ -287,7 +283,7 @@ public class KafkaAuthnHandler extends ChannelInboundHandlerAdapter {
                     ctx.fireChannelRead(frame);
                 }
                 else {
-                    writeFramedResponse(ctx, frame, exceptionHandler.errorResponseMessage(frame, NOT_AUTHENTICATED_EXCEPTION));
+                    writeFramedResponse(ctx, frame, KafkaProxyExceptionMapper.errorResponseMessage(frame, NOT_AUTHENTICATED_EXCEPTION));
                 }
         }
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -55,9 +55,13 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
     private final PluginFactoryRegistry pfr;
     private final FilterChainFactory filterChainFactory;
 
-    public KafkaProxyInitializer(FilterChainFactory filterChainFactory, PluginFactoryRegistry pfr, boolean tls,
-                                 VirtualClusterBindingResolver virtualClusterBindingResolver, EndpointReconciler endpointReconciler,
-                                 boolean haproxyProtocol, Map<KafkaAuthnHandler.SaslMechanism, AuthenticateCallbackHandler> authnMechanismHandlers) {
+    public KafkaProxyInitializer(FilterChainFactory filterChainFactory,
+                                 PluginFactoryRegistry pfr,
+                                 boolean tls,
+                                 VirtualClusterBindingResolver virtualClusterBindingResolver,
+                                 EndpointReconciler endpointReconciler,
+                                 boolean haproxyProtocol,
+                                 Map<KafkaAuthnHandler.SaslMechanism, AuthenticateCallbackHandler> authnMechanismHandlers) {
         this.pfr = pfr;
         this.endpointReconciler = endpointReconciler;
         this.haproxyProtocol = haproxyProtocol;
@@ -159,7 +163,6 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
     void addHandlers(SocketChannel ch, VirtualClusterBinding binding) {
         var virtualCluster = binding.virtualCluster();
         ChannelPipeline pipeline = ch.pipeline();
-        final KafkaProxyExceptionMapper exceptionHandler = new KafkaProxyExceptionMapper();
         if (virtualCluster.isLogNetwork()) {
             pipeline.addLast("networkLogger", new LoggingHandler("io.kroxylicious.proxy.internal.DownstreamNetworkLogger", LogLevel.INFO));
         }
@@ -184,12 +187,12 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
 
         if (!authnHandlers.isEmpty()) {
             LOGGER.debug("Adding authn handler for handlers {}", authnHandlers);
-            pipeline.addLast(new KafkaAuthnHandler(ch, authnHandlers, exceptionHandler));
+            pipeline.addLast(new KafkaAuthnHandler(ch, authnHandlers));
         }
 
         ApiVersionsServiceImpl apiVersionService = new ApiVersionsServiceImpl();
         final NetFilter netFilter = new InitalizerNetFilter(dp, apiVersionService, ch, binding, pfr, filterChainFactory, endpointReconciler);
-        var frontendHandler = new KafkaProxyFrontendHandler(netFilter, dp, virtualCluster, exceptionHandler);
+        var frontendHandler = new KafkaProxyFrontendHandler(netFilter, dp, virtualCluster);
 
         pipeline.addLast("netHandler", frontendHandler);
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
@@ -81,7 +81,7 @@ public class KafkaAuthnHandlerTest {
     private void buildChannel(Map<SaslMechanism, AuthenticateCallbackHandler> mechanismHandlers) {
         channel = new EmbeddedChannel();
         kafkaAuthnHandler = new KafkaAuthnHandler(channel,
-                KafkaAuthnHandler.State.START, mechanismHandlers, new KafkaProxyExceptionMapper());
+                KafkaAuthnHandler.State.START, mechanismHandlers);
         channel.pipeline().addLast(kafkaAuthnHandler);
         userEventCollector = new UserEventCollector();
         channel.pipeline().addLast(userEventCollector);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyExceptionMapperTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyExceptionMapperTest.java
@@ -6,7 +6,6 @@
 
 package io.kroxylicious.proxy.internal;
 
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import javax.net.ssl.SSLHandshakeException;
@@ -17,113 +16,27 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AbstractResponse;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Named;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import io.netty.buffer.Unpooled;
-import io.netty.handler.codec.DecoderException;
-import io.netty.handler.ssl.SslHandshakeTimeoutException;
-
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
-import io.kroxylicious.proxy.frame.OpaqueResponseFrame;
-import io.kroxylicious.proxy.frame.ResponseFrame;
 import io.kroxylicious.test.RequestFactory;
 
 import static io.kroxylicious.test.assertj.ResponseAssert.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Named.named;
 
 class KafkaProxyExceptionMapperTest {
 
     private static final SSLHandshakeException HANDSHAKE_EXCEPTION = new SSLHandshakeException("it went wrong");
 
-    private KafkaProxyExceptionMapper kafkaProxyExceptionMapper;
-    private OpaqueResponseFrame resp;
-
-    @BeforeEach
-    void setUp() {
-        kafkaProxyExceptionMapper = new KafkaProxyExceptionMapper();
-        resp = new OpaqueResponseFrame(Unpooled.EMPTY_BUFFER, 42, 0);
-    }
-
-    @Test
-    void shouldCloseWithForRegisteredException() {
-        // Given
-        kafkaProxyExceptionMapper.registerExceptionResponse(SSLHandshakeException.class, throwable -> Optional.of(resp));
-
-        // When
-        final Optional<ResponseFrame> result = kafkaProxyExceptionMapper.mapException(HANDSHAKE_EXCEPTION);
-
-        // Then
-        assertThat(result).hasValue(resp);
-    }
-
-    @Test
-    void shouldUnwrapCauseToFindForRegisteredException() {
-        // Given
-        kafkaProxyExceptionMapper.registerExceptionResponse(SSLHandshakeException.class, throwable -> Optional.of(resp));
-
-        // When
-        final Optional<ResponseFrame> result = kafkaProxyExceptionMapper.mapException(new DecoderException(HANDSHAKE_EXCEPTION));
-
-        // Then
-        assertThat(result).hasValue(resp);
-    }
-
-    @Test
-    void shouldMapSubclassesOfRegisteredException() {
-        // Given
-        kafkaProxyExceptionMapper.registerExceptionResponse(SSLHandshakeException.class, throwable -> Optional.of(resp));
-
-        // When
-        final Optional<ResponseFrame> result = kafkaProxyExceptionMapper.mapException(new DecoderException(new SslHandshakeTimeoutException("It took to long, guv!")));
-
-        // Then
-        assertThat(result).hasValue(resp);
-    }
-
-    @Test
-    void shouldCompleteWithCircularCauseChainDoesnotMatch() {
-        // Given
-        kafkaProxyExceptionMapper.registerExceptionResponse(RuntimeException.class, throwable -> Optional.of(resp));
-        Exception e1 = new Exception("1");
-        Exception e2 = new Exception("2", e1);
-        Exception e3 = new Exception("3", e2);
-        e1.initCause(e3);
-
-        // When
-        final Optional<?> result = kafkaProxyExceptionMapper.mapException(e1);
-
-        // Then
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    void shouldCompleteWithCircularCauseChainMatches() {
-        // Given
-        kafkaProxyExceptionMapper.registerExceptionResponse(RuntimeException.class, throwable -> Optional.of(resp));
-        Exception e1 = new Exception("1");
-        Exception e2 = new RuntimeException("2", e1);
-        Exception e3 = new Exception("3", e2);
-        e1.initCause(e3);
-
-        // When
-        final Optional<ResponseFrame> result = kafkaProxyExceptionMapper.mapException(e1);
-
-        // Then
-        assertThat(result).hasValue(resp);
-    }
-
     @ParameterizedTest
     @MethodSource({ "decodedFrameSourceLatestVersion", "decodedFrameSourceOldestVersion" })
     void shouldGenerateErrorResponseApiKey(DecodedRequestFrame<?> request) {
         // Given
         // When
-        final AbstractResponse response = kafkaProxyExceptionMapper.errorResponse(request, new BrokerNotAvailableException("handshake failure", HANDSHAKE_EXCEPTION));
+        final AbstractResponse response = KafkaProxyExceptionMapper.errorResponse(request, new BrokerNotAvailableException("handshake failure", HANDSHAKE_EXCEPTION));
 
         // Then
         assertThat(response)


### PR DESCRIPTION
### Type of change

- Refactoring


### Description

Further to #1475, it's not ideal that the ExceptionMapper is instantiated per-connection but always handles errors in the same way. This is really telling us that either :
1. the ExceptionMapper could be instantiated once for a proxy process, or
2. that the error handling doesn't need to be pluggable and could just be handled via normal code, rather than the extra indirection of `Function`. 

This PR basically explores route 2. 

The main drawback of this approach seems to be that it makes the tests a little harder to write.. On the other hand it makes the exception handling easier to read and follow.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
