### PR TITLE
Give KmsService lifecycle methods (initialize and close) (Take 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#1498](https://github.com/kroxylicious/kroxylicious/pull/1498) Give KmsService lifecycle methods
 * [#1514](https://github.com/kroxylicious/kroxylicious/pull/1514) Bump io.netty:netty-bom from 4.1.112.Final to 4.1.113.Final
 * [#1517](https://github.com/kroxylicious/kroxylicious/pull/1517) Bump apicurio-registry.version from 2.6.2.Final to 2.6.3.Final
 * [#1515](https://github.com/kroxylicious/kroxylicious/pull/1515) Bump io.micrometer:micrometer-bom from 1.13.2 to 1.13.4

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/SharedEncryptionContext.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/SharedEncryptionContext.java
@@ -15,52 +15,20 @@ import io.kroxylicious.kms.service.Kms;
 /**
  * Things which are shared between instances of the filter.
  * Because they're shared between filter instances, the things shared here must be thread-safe.
+ *
+ * @param kms KMS
+ * @param kmsServiceCloser KMS closer
+ * @param configuration configuration
+ * @param dekManager DEK manager
+ * @param encryptionDekCache Encryption DEK Cache
+ * @param decryptionDekCache Decryption DEK Cache
+ *
  * @param <K> The type of KEK id.
  * @param <E> The type of the encrypted DEK.
  */
-public class SharedEncryptionContext<K, E> {
-    private final Kms<K, E> kms;
-    private final RecordEncryptionConfig configuration;
-    private final DekManager<K, E> dekManager;
-    private final EncryptionDekCache<K, E> encryptionDekCache;
-    private final DecryptionDekCache<K, E> decryptionDekCache;
-
-    /**
-     * @param kms
-     * @param configuration
-     * @param dekManager
-     * @param encryptionDekCache
-     */
-    SharedEncryptionContext(
-                            Kms<K, E> kms,
-                            RecordEncryptionConfig configuration,
-                            DekManager<K, E> dekManager,
-                            EncryptionDekCache<K, E> encryptionDekCache,
-                            DecryptionDekCache<K, E> decryptionDekCache) {
-        this.kms = kms;
-        this.configuration = configuration;
-        this.dekManager = dekManager;
-        this.encryptionDekCache = encryptionDekCache;
-        this.decryptionDekCache = decryptionDekCache;
-    }
-
-    public Kms<K, E> kms() {
-        return kms;
-    }
-
-    public RecordEncryptionConfig configuration() {
-        return configuration;
-    }
-
-    public DekManager<K, E> dekManager() {
-        return dekManager;
-    }
-
-    public EncryptionDekCache<K, E> encryptionDekCache() {
-        return encryptionDekCache;
-    }
-
-    public DecryptionDekCache<K, E> decryptionDekCache() {
-        return decryptionDekCache;
-    }
-}
+record SharedEncryptionContext<K, E>(Kms<K, E> kms,
+                                     Runnable kmsServiceCloser,
+                                     RecordEncryptionConfig configuration,
+                                     DekManager<K, E> dekManager,
+                                     EncryptionDekCache<K, E> encryptionDekCache,
+                                     DecryptionDekCache<K, E> decryptionDekCache) {}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DekManager.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/DekManager.java
@@ -14,7 +14,6 @@ import javax.annotation.concurrent.ThreadSafe;
 import io.kroxylicious.filter.encryption.config.EncryptionConfigurationException;
 import io.kroxylicious.kms.service.DestroyableRawSecretKey;
 import io.kroxylicious.kms.service.Kms;
-import io.kroxylicious.kms.service.KmsService;
 import io.kroxylicious.kms.service.Serde;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -32,8 +31,8 @@ public class DekManager<K, E> {
     private final Kms<K, E> kms;
     private final long maxEncryptionsPerDek;
 
-    public <C> DekManager(KmsService<C, K, E> kmsService, C config, long maxEncryptionsPerDek) {
-        this.kms = kmsService.buildKms(config);
+    public DekManager(Kms<K, E> kms, long maxEncryptionsPerDek) {
+        this.kms = kms;
         this.maxEncryptionsPerDek = maxEncryptionsPerDek;
     }
 

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopEncryptionTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/EnvelopEncryptionTest.java
@@ -37,7 +37,7 @@ class EnvelopEncryptionTest {
         var edekSerde = mock(Serde.class);
 
         doReturn(kmsService).when(fc).pluginInstance(KmsService.class, "KMS");
-        doReturn(kms).when(kmsService).buildKms(any());
+        doReturn(kms).when(kmsService).buildKms();
         doReturn(mock(FilterDispatchExecutor.class)).when(fc).filterDispatchExecutor();
         doReturn(edekSerde).when(kms).edekSerde();
 

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/FixedDekKmsService.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/FixedDekKmsService.java
@@ -22,11 +22,11 @@ import io.kroxylicious.kms.service.Serde;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-public class FixedDekKmsService implements KmsService<FixedDekKmsService.Config, ByteBuffer, ByteBuffer> {
+public class FixedDekKmsService implements KmsService<Void, ByteBuffer, ByteBuffer> {
 
+    private static final ByteBuffer KEK_ID = ByteBuffer.wrap(new byte[]{ 1, 2, 3 });
     private final SecretKey dek;
     private final ByteBuffer edek;
-    private static final ByteBuffer KEK_ID = ByteBuffer.wrap(new byte[]{ 1, 2, 3 });
     private final FixedEdekKms fixedEdekKms = new FixedEdekKms();
 
     public FixedDekKmsService(int keysize) {
@@ -41,9 +41,14 @@ public class FixedDekKmsService implements KmsService<FixedDekKmsService.Config,
         }
     }
 
+    @Override
+    public void initialize(@NonNull Void config) {
+        // this KMS requires no config
+    }
+
     @NonNull
     @Override
-    public Kms<ByteBuffer, ByteBuffer> buildKms(Config options) {
+    public Kms<ByteBuffer, ByteBuffer> buildKms() {
         return fixedEdekKms;
     }
 
@@ -54,8 +59,6 @@ public class FixedDekKmsService implements KmsService<FixedDekKmsService.Config,
     public Serde<ByteBuffer> edekSerde() {
         return fixedEdekKms.edekSerde();
     }
-
-    public record Config() {}
 
     private class FixedEdekKms implements Kms<ByteBuffer, ByteBuffer> {
 

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/crypto/SerializedFormTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/crypto/SerializedFormTest.java
@@ -183,8 +183,8 @@ class SerializedFormTest {
         doReturn(CompletableFuture.completedFuture(dekPair)).when(kms).generateDekPair(kekId);
         doReturn(new ByteArraySerde()).when(kms).edekSerde();
         KmsService<Object, byte[], byte[]> kmsService = Mockito.mock(KmsService.class);
-        doReturn(kms).when(kmsService).buildKms(null);
-        var dm = new DekManager<>(kmsService, null, 1);
+        doReturn(kms).when(kmsService).buildKms();
+        var dm = new DekManager<>(kms, 1);
 
         var dek = dm.generateDek(kekId, cm).toCompletableFuture().join();
         byte[] edek = dek.edek();

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/encrypt/RecordEncryptorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/encrypt/RecordEncryptorTest.java
@@ -65,7 +65,8 @@ class RecordEncryptorTest {
     static TestComponents setup(int keysize) {
         try {
             fixedDekKmsService = new FixedDekKmsService(keysize);
-            DekManager<ByteBuffer, ByteBuffer> manager = new DekManager<>(fixedDekKmsService, new FixedDekKmsService.Config(), 10000);
+            var kms = fixedDekKmsService.buildKms();
+            DekManager<ByteBuffer, ByteBuffer> manager = new DekManager<>(kms, 10000);
             CompletionStage<Dek<ByteBuffer>> dekCompletionStage = manager.generateDek(fixedDekKmsService.getKekId(), Aes.AES_256_GCM_128);
             Dek<ByteBuffer> dek = dekCompletionStage.toCompletableFuture().get(0, TimeUnit.SECONDS);
             var encryptor = dek.encryptor(1000);

--- a/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsService.java
+++ b/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsService.java
@@ -21,24 +21,19 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 @Plugin(configType = Config.class)
 public class AwsKmsService implements KmsService<Config, String, AwsKmsEdek> {
 
-    @SuppressWarnings("java:S3077") // Config is an immutable object
+    @SuppressWarnings("java:S3077") // KMS services are thread safe. As Config is immutable, volatile is sufficient to ensure its safe publication between threads.
     private volatile Config config;
 
     @Override
     public void initialize(@NonNull Config config) {
         Objects.requireNonNull(config);
-        if (this.config != null) {
-            throw new IllegalStateException("KMS service is already initialized");
-        }
         this.config = config;
     }
 
     @NonNull
     @Override
     public AwsKms buildKms() {
-        if (config == null) {
-            throw new IllegalStateException("KMS service not initialized");
-        }
+        Objects.requireNonNull(config, "KMS service not initialized");
         return new AwsKms(config.endpointUrl(),
                 config.accessKey().getProvidedPassword(),
                 config.secretKey().getProvidedPassword(),

--- a/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsService.java
+++ b/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsService.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.kms.provider.aws.kms;
 
 import java.time.Duration;
+import java.util.Objects;
 
 import io.kroxylicious.kms.provider.aws.kms.config.Config;
 import io.kroxylicious.kms.service.KmsService;
@@ -20,14 +21,28 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 @Plugin(configType = Config.class)
 public class AwsKmsService implements KmsService<Config, String, AwsKmsEdek> {
 
-    @NonNull
+    @SuppressWarnings("java:S3077") // Config is an immutable object
+    private volatile Config config;
+
     @Override
-    public AwsKms buildKms(Config options) {
-        return new AwsKms(options.endpointUrl(),
-                options.accessKey().getProvidedPassword(),
-                options.secretKey().getProvidedPassword(),
-                options.region(),
-                Duration.ofSeconds(20), options.sslContext());
+    public void initialize(@NonNull Config config) {
+        Objects.requireNonNull(config);
+        if (this.config != null) {
+            throw new IllegalStateException("KMS service is already initialized");
+        }
+        this.config = config;
     }
 
+    @NonNull
+    @Override
+    public AwsKms buildKms() {
+        if (config == null) {
+            throw new IllegalStateException("KMS service not initialized");
+        }
+        return new AwsKms(config.endpointUrl(),
+                config.accessKey().getProvidedPassword(),
+                config.secretKey().getProvidedPassword(),
+                config.region(),
+                Duration.ofSeconds(20), config.sslContext());
+    }
 }

--- a/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsServiceTest.java
+++ b/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsServiceTest.java
@@ -6,15 +6,11 @@
 
 package io.kroxylicious.kms.provider.aws.kms;
 
-import java.net.URI;
 import java.util.Optional;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import io.kroxylicious.kms.provider.aws.kms.config.Config;
-import io.kroxylicious.proxy.config.secret.InlinePassword;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -34,14 +30,6 @@ class AwsKmsServiceTest {
     @Test
     void detectsMissingInitialization() {
         assertThatThrownBy(() -> awsKmsService.buildKms())
-                .isInstanceOf(IllegalStateException.class);
-    }
-
-    @Test
-    void detectsRepeatedInitialization() {
-        var config = new Config(URI.create("https:://invalid"), new InlinePassword("accessKey"), new InlinePassword("secretKey"), "us-east-1", null);
-        awsKmsService.initialize(config);
-        assertThatThrownBy(() -> awsKmsService.initialize(config))
-                .isInstanceOf(IllegalStateException.class);
+                .isInstanceOf(NullPointerException.class);
     }
 }

--- a/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsServiceTest.java
+++ b/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsServiceTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kms.provider.aws.kms;
+
+import java.net.URI;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.kms.provider.aws.kms.config.Config;
+import io.kroxylicious.proxy.config.secret.InlinePassword;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AwsKmsServiceTest {
+    private AwsKmsService awsKmsService;
+
+    @BeforeEach
+    void beforeEach() {
+        awsKmsService = new AwsKmsService();
+    }
+
+    @AfterEach
+    void afterEach() {
+        Optional.ofNullable(awsKmsService).ifPresent(AwsKmsService::close);
+    }
+
+    @Test
+    void detectsMissingInitialization() {
+        assertThatThrownBy(() -> awsKmsService.buildKms())
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void detectsRepeatedInitialization() {
+        var config = new Config(URI.create("https:://invalid"), new InlinePassword("accessKey"), new InlinePassword("secretKey"), "us-east-1", null);
+        awsKmsService.initialize(config);
+        assertThatThrownBy(() -> awsKmsService.initialize(config))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsTest.java
+++ b/kroxylicious-kms-provider-aws-kms/src/test/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsTest.java
@@ -150,7 +150,10 @@ class AwsKmsTest {
             var address = httpServer.getAddress();
             var awsAddress = "http://127.0.0.1:" + address.getPort();
             var config = new Config(URI.create(awsAddress), new InlinePassword("access"), new InlinePassword("secret"), "us-west-2", null);
-            var service = new AwsKmsService().buildKms(config);
+            @SuppressWarnings("resource")
+            var awsKmsService = new AwsKmsService();
+            awsKmsService.initialize(config);
+            var service = awsKmsService.buildKms();
             consumer.accept(service);
         }
         finally {

--- a/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsService.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/main/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsService.java
@@ -21,24 +21,19 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 @Plugin(configType = Config.class)
 public class VaultKmsService implements KmsService<Config, String, VaultEdek> {
 
-    @SuppressWarnings("java:S3077") // Config is an immutable object
+    @SuppressWarnings("java:S3077") // KMS services are thread safe. As Config is immutable, volatile is sufficient to ensure its safe publication between threads.
     private volatile Config config;
 
     @Override
     public void initialize(@NonNull Config config) {
         Objects.requireNonNull(config);
-        if (this.config != null) {
-            throw new IllegalStateException("KMS service is already initialized");
-        }
         this.config = config;
     }
 
     @NonNull
     @Override
     public VaultKms buildKms() {
-        if (config == null) {
-            throw new IllegalStateException("KMS service not initialized");
-        }
+        Objects.requireNonNull(config, "KMS service not initialized");
         return new VaultKms(config.vaultTransitEngineUrl(), config.vaultToken().getProvidedPassword(), Duration.ofSeconds(20),
                 config.sslContext());
     }

--- a/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsServiceTest.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsServiceTest.java
@@ -6,15 +6,11 @@
 
 package io.kroxylicious.kms.provider.hashicorp.vault;
 
-import java.net.URI;
 import java.util.Optional;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import io.kroxylicious.kms.provider.hashicorp.vault.config.Config;
-import io.kroxylicious.proxy.config.secret.InlinePassword;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -34,14 +30,6 @@ class VaultKmsServiceTest {
     @Test
     void detectsMissingInitialization() {
         assertThatThrownBy(() -> vaultKmsService.buildKms())
-                .isInstanceOf(IllegalStateException.class);
-    }
-
-    @Test
-    void detectsRepeatedInitialization() {
-        var config = new Config(URI.create("https:://invalid"), new InlinePassword("pass"), null);
-        vaultKmsService.initialize(config);
-        assertThatThrownBy(() -> vaultKmsService.initialize(config))
-                .isInstanceOf(IllegalStateException.class);
+                .isInstanceOf(NullPointerException.class);
     }
 }

--- a/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsServiceTest.java
+++ b/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/VaultKmsServiceTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kms.provider.hashicorp.vault;
+
+import java.net.URI;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.kms.provider.hashicorp.vault.config.Config;
+import io.kroxylicious.proxy.config.secret.InlinePassword;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class VaultKmsServiceTest {
+    private VaultKmsService vaultKmsService;
+
+    @BeforeEach
+    void beforeEach() {
+        vaultKmsService = new VaultKmsService();
+    }
+
+    @AfterEach
+    void afterEach() {
+        Optional.ofNullable(vaultKmsService).ifPresent(VaultKmsService::close);
+    }
+
+    @Test
+    void detectsMissingInitialization() {
+        assertThatThrownBy(() -> vaultKmsService.buildKms())
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void detectsRepeatedInitialization() {
+        var config = new Config(URI.create("https:://invalid"), new InlinePassword("pass"), null);
+        vaultKmsService.initialize(config);
+        assertThatThrownBy(() -> vaultKmsService.initialize(config))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/kroxylicious-kms-provider-kroxylicious-inmemory-test-support/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryTestKmsFacade.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory-test-support/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryTestKmsFacade.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.kms.provider.kroxylicious.inmemory;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletionException;
 
@@ -19,14 +20,20 @@ public class InMemoryTestKmsFacade implements TestKmsFacade<Config, UUID, InMemo
 
     private final UUID kmsId = UUID.randomUUID();
     private InMemoryKms kms;
+    private IntegrationTestingKmsService service;
 
     @Override
     public void start() {
-        kms = IntegrationTestingKmsService.newInstance().buildKms(new Config(kmsId.toString()));
+        var config = new Config(kmsId.toString());
+
+        service = IntegrationTestingKmsService.newInstance();
+        service.initialize(config);
+        kms = service.buildKms();
     }
 
     @Override
     public void stop() {
+        Optional.ofNullable(service).ifPresent(IntegrationTestingKmsService::close);
         IntegrationTestingKmsService.delete(kmsId.toString());
     }
 

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/IntegrationTestingKmsService.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/IntegrationTestingKmsService.java
@@ -65,19 +65,13 @@ public class IntegrationTestingKmsService implements KmsService<IntegrationTesti
     @Override
     public void initialize(@NonNull Config config) {
         Objects.requireNonNull(config);
-        if (this.config != null) {
-            throw new IllegalStateException("KMS service is already initialized");
-        }
         this.config = config;
     }
 
     @NonNull
     @Override
     public InMemoryKms buildKms() {
-        if (config == null) {
-            throw new IllegalStateException("KMS service not initialized");
-        }
-
+        Objects.requireNonNull(config, "KMS service not initialized");
         return KMSES.computeIfAbsent(config.name(), ignored -> new InMemoryKms(12, 128, Map.of(), Map.of()));
     }
 

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/UnitTestingKmsService.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/UnitTestingKmsService.java
@@ -78,18 +78,13 @@ public class UnitTestingKmsService implements KmsService<UnitTestingKmsService.C
     @Override
     public void initialize(@NonNull Config config) {
         Objects.requireNonNull(config);
-        if (this.config != null) {
-            throw new IllegalStateException("KMS service is already initialized");
-        }
         this.config = config;
     }
 
     @NonNull
     @Override
     public InMemoryKms buildKms() {
-        if (config == null) {
-            throw new IllegalStateException("KMS service not initialized");
-        }
+        Objects.requireNonNull(config, "KMS service not initialized");
 
         return kmsMap.computeIfAbsent(config, c -> {
             List<Kek> kekDefs = c.existingKeks();

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/UnitTestingKmsService.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/UnitTestingKmsService.java
@@ -8,6 +8,7 @@ package io.kroxylicious.kms.provider.kroxylicious.inmemory;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -37,7 +38,9 @@ import static java.util.stream.Collectors.toMap;
  */
 @Plugin(configType = UnitTestingKmsService.Config.class)
 public class UnitTestingKmsService implements KmsService<UnitTestingKmsService.Config, UUID, InMemoryEdek> {
-    private Map<Config, InMemoryKms> kmsMap = new ConcurrentHashMap<>();
+    private final Map<Config, InMemoryKms> kmsMap = new ConcurrentHashMap<>();
+    @SuppressWarnings("java:S3077") // Config is an immutable object
+    private volatile Config config;
 
     public static UnitTestingKmsService newInstance() {
         return (UnitTestingKmsService) ServiceLoader.load(KmsService.class).stream()
@@ -70,23 +73,31 @@ public class UnitTestingKmsService implements KmsService<UnitTestingKmsService.C
         public Config() {
             this(12, 128, List.of());
         }
+    }
 
-        @Override
-        public List<Kek> existingKeks() {
-            return existingKeks == null ? List.of() : existingKeks;
+    @Override
+    public void initialize(@NonNull Config config) {
+        Objects.requireNonNull(config);
+        if (this.config != null) {
+            throw new IllegalStateException("KMS service is already initialized");
         }
+        this.config = config;
     }
 
     @NonNull
     @Override
-    public InMemoryKms buildKms(Config options) {
-        return kmsMap.computeIfAbsent(options, config -> {
-            List<Kek> kekDefs = options.existingKeks();
+    public InMemoryKms buildKms() {
+        if (config == null) {
+            throw new IllegalStateException("KMS service not initialized");
+        }
+
+        return kmsMap.computeIfAbsent(config, c -> {
+            List<Kek> kekDefs = c.existingKeks();
             Map<UUID, DestroyableRawSecretKey> keys = kekDefs.stream()
                     .collect(toMap(k -> UUID.fromString(k.uuid), k -> DestroyableRawSecretKey.takeCopyOf(k.key, k.algorithm)));
             Map<String, UUID> aliases = kekDefs.stream().collect(toMap(k -> k.alias, k -> UUID.fromString(k.uuid)));
-            return new InMemoryKms(options.numIvBytes(),
-                    options.numAuthBits(),
+            return new InMemoryKms(c.numIvBytes(),
+                    c.numAuthBits(),
                     keys, aliases);
         });
     }

--- a/kroxylicious-kms-provider-kroxylicious-inmemory/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/UnitTestingKmsServiceTest.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory/src/test/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/UnitTestingKmsServiceTest.java
@@ -9,79 +9,83 @@ package io.kroxylicious.kms.provider.kroxylicious.inmemory;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.kroxylicious.kms.service.DekPair;
 import io.kroxylicious.kms.service.DestroyableRawSecretKey;
 import io.kroxylicious.kms.service.SecretKeyUtils;
 import io.kroxylicious.kms.service.UnknownAliasException;
 import io.kroxylicious.kms.service.UnknownKeyException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class UnitTestingKmsServiceTest {
 
-    UnitTestingKmsService service;
+    private UnitTestingKmsService service;
 
     @BeforeEach
-    public void before() {
+    public void beforeEach() {
         service = UnitTestingKmsService.newInstance();
+        service.initialize(new UnitTestingKmsService.Config());
+    }
+
+    @AfterEach
+    public void afterEach() {
+        Optional.ofNullable(service).ifPresent(UnitTestingKmsService::close);
     }
 
     @Test
     void shouldRejectOutOfBoundIvBytes() {
         // given
         List<UnitTestingKmsService.Kek> existingKeks = List.of();
-        assertThrows(IllegalArgumentException.class, () -> new UnitTestingKmsService.Config(0, 128, existingKeks));
+        assertThatThrownBy(() -> new UnitTestingKmsService.Config(0, 128, existingKeks))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void shouldRejectOutOfBoundAuthBits() {
         List<UnitTestingKmsService.Kek> existingKeks = List.of();
-        assertThrows(IllegalArgumentException.class, () -> new UnitTestingKmsService.Config(12, 0, existingKeks));
+        assertThatThrownBy(() -> new UnitTestingKmsService.Config(12, 0, existingKeks))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void shouldGenerateDeks() {
         // given
-        var kms1 = service.buildKms(new UnitTestingKmsService.Config());
-        var kms2 = UnitTestingKmsService.newInstance().buildKms(new UnitTestingKmsService.Config());
+        var kms1 = service.buildKms();
+
         var key1 = kms1.generateKey();
-        assertNotNull(key1);
-        var key2 = kms2.generateKey();
-        assertNotNull(key2);
+        assertThat(key1).isNotNull();
 
         // when
-        CompletableFuture<DekPair<InMemoryEdek>> gen1 = kms1.generateDekPair(key1);
-        CompletableFuture<DekPair<InMemoryEdek>> gen2 = kms2.generateDekPair(key2);
+        var gen1 = kms1.generateDekPair(key1);
 
         // then
         assertThat(gen1).isCompleted();
-        assertThat(gen2).isCompleted();
     }
 
     @Test
     void shouldRejectsAnotherKmsesKeks() {
         // given
-        var kms1 = service.buildKms(new UnitTestingKmsService.Config());
-        var kms2 = UnitTestingKmsService.newInstance().buildKms(new UnitTestingKmsService.Config());
+        var kms1 = service.buildKms();
+        var service2 = UnitTestingKmsService.newInstance();
+        service2.initialize(new UnitTestingKmsService.Config());
+        var kms2 = service2.buildKms();
+
         var key1 = kms1.generateKey();
-        assertNotNull(key1);
+        assertThat(key1).isNotNull();
         var key2 = kms2.generateKey();
-        assertNotNull(key2);
+        assertThat(key1).isNotNull();
 
         // when
-        CompletableFuture<DekPair<InMemoryEdek>> gen1 = kms1.generateDekPair(key2);
-        CompletableFuture<DekPair<InMemoryEdek>> gen2 = kms2.generateDekPair(key1);
+        var gen1 = kms1.generateDekPair(key2);
+        var gen2 = kms2.generateDekPair(key1);
 
         // then
         assertThat(gen1).failsWithin(Duration.ZERO)
@@ -93,30 +97,33 @@ class UnitTestingKmsServiceTest {
                 .withThrowableOfType(ExecutionException.class)
                 .withCauseInstanceOf(UnknownKeyException.class)
                 .withMessage("io.kroxylicious.kms.service.UnknownKeyException");
+        service2.close();
     }
 
     @Test
     void shouldDecryptDeks() {
         // given
-        var kms = service.buildKms(new UnitTestingKmsService.Config());
+        var kms = service.buildKms();
         var kek = kms.generateKey();
-        assertNotNull(kek);
+        assertThat(kek).isNotNull();
         var pair = kms.generateDekPair(kek).join();
-        assertNotNull(pair);
-        assertNotNull(pair.edek());
-        assertNotNull(pair.dek());
+        assertThat(pair).isNotNull();
+        assertThat(pair.edek()).isNotNull();
+        assertThat(pair.dek()).isNotNull();
 
         // when
         var decryptedDek = kms.decryptEdek(pair.edek()).join();
 
         // then
-        assertTrue(SecretKeyUtils.same((DestroyableRawSecretKey) pair.dek(), (DestroyableRawSecretKey) decryptedDek),
-                "Expect the decrypted DEK to equal the originally generated DEK");
+        var expected = (DestroyableRawSecretKey) pair.dek();
+        assertThat(decryptedDek)
+                .asInstanceOf(InstanceOfAssertFactories.type(DestroyableRawSecretKey.class))
+                .matches(x -> SecretKeyUtils.same(x, expected));
     }
 
     @Test
     void shouldSerializeAndDeserializeEdeks() {
-        var kms = service.buildKms(new UnitTestingKmsService.Config());
+        var kms = service.buildKms();
         var kek = kms.generateKey();
 
         var edek = kms.generateDekPair(kek).join().edek();
@@ -124,17 +131,17 @@ class UnitTestingKmsServiceTest {
         var serde = kms.edekSerde();
         var buffer = ByteBuffer.allocate(serde.sizeOf(edek));
         serde.serialize(edek, buffer);
-        assertFalse(buffer.hasRemaining());
+        assertThat(buffer.hasRemaining()).isFalse();
         buffer.flip();
 
         var deserialized = serde.deserialize(buffer);
 
-        assertEquals(edek, deserialized);
+        assertThat(edek).isEqualTo(deserialized);
     }
 
     @Test
     void shouldLookupByAlias() {
-        var kms = service.buildKms(new UnitTestingKmsService.Config());
+        var kms = service.buildKms();
         var kek = kms.generateKey();
 
         var lookup = kms.resolveAlias("bob");
@@ -144,8 +151,9 @@ class UnitTestingKmsServiceTest {
                 .withMessage("io.kroxylicious.kms.service.UnknownAliasException: bob");
 
         kms.createAlias(kek, "bob");
-        var gotFromAlias = kms.resolveAlias("bob").join();
-        assertEquals(kek, gotFromAlias);
+        assertThat(kms.resolveAlias("bob"))
+                .succeedsWithin(Duration.ZERO)
+                .isEqualTo(kek);
 
         kms.deleteAlias("bob");
         lookup = kms.resolveAlias("bob");

--- a/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKmsFacadeFactory.java
+++ b/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKmsFacadeFactory.java
@@ -26,6 +26,7 @@ public interface TestKmsFacadeFactory<C, K, E> {
 
     /**
      * Discovers the available {@link TestKmsFacadeFactory}.
+     *
      * @return factories
      */
     @SuppressWarnings("unchecked")

--- a/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/KmsService.java
+++ b/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/KmsService.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.kms.service;
 
+import javax.annotation.concurrent.ThreadSafe;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -14,8 +16,38 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * @param <K> The key reference
  * @param <E> The type of encrypted DEK
  */
-public interface KmsService<C, K, E> {
-    @NonNull
-    Kms<K, E> buildKms(C options);
+@ThreadSafe
+public interface KmsService<C, K, E> extends AutoCloseable {
 
+    /**
+     * Initialises the service.  This method must be invoked exactly once
+     * before {@link #buildKms()} is called.
+     *
+     * @param config KMS service configuration
+     * @throws IllegalStateException if the KMS Service has already been initialised or the KMS service is closed.
+     */
+    void initialize(C config);
+
+    /**
+     * Builds a KMS service.
+     * {@link #initialize(C)} must have been called before this method is invoked.
+     *
+     * @return the KMS.
+     * @throws IllegalStateException if the KMS Service has not been initialised or the KMS service is closed.
+     */
+    @NonNull
+    Kms<K, E> buildKms() throws IllegalStateException;
+
+    /**
+     * Closes the service. Once the service is closed, the building of new {@link Kms} or the
+     * continued use of previously built {@link Kms}s is not allowed. The affect using a {@link Kms}
+     * after the service that created it is closed is undefined.
+     * <br/>
+     * Implementations of this method must be idempotent.
+     * <br/>
+     * Close implementations must tolerate the closing of service that has not been initialized or
+     * one for which initialization did not fully complete without further exception.
+     */
+    default void close() {
+    }
 }

--- a/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/KmsService.java
+++ b/kroxylicious-kms/src/main/java/io/kroxylicious/kms/service/KmsService.java
@@ -24,7 +24,6 @@ public interface KmsService<C, K, E> extends AutoCloseable {
      * before {@link #buildKms()} is called.
      *
      * @param config KMS service configuration
-     * @throws IllegalStateException if the KMS Service has already been initialised or the KMS service is closed.
      */
     void initialize(C config);
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

why: sometimes KMS's need to make use of long lived resources that need to be closed once the KMS service is no longer required.

This is an alternative to #1478 and uses a simpler KmsService API.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
