### PR TITLE
Fix #819: Release process should automate the 'release' stage of the release process down to a single manual step

### DIFF
--- a/.github/workflows/deploy_release.yaml
+++ b/.github/workflows/deploy_release.yaml
@@ -56,6 +56,21 @@ jobs:
           fetch-tags: true
           fetch-depth: 0
 
+      - name: 'Check team membership'
+        if: ${{ github.repository == 'kroxylicious/kroxylicious' }}
+        uses: tspascoal/get-user-teams-membership@v2
+        id: team-membership
+        with:
+          username: ${{ github.actor }}
+          team: release-engineers
+          GITHUB_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
+
+      - name: 'Stop workflow if user is not a release-engineer'
+        if: ${{ github.repository == 'kroxylicious/kroxylicious' && steps.team-membership.outputs.isTeamMember == 'false' }}
+        run: |
+          gh issue comment  ${{ github.event.issue.number }} --body "${{ github.actor }} is not a member of https://github.com/orgs/kroxylicious/teams/release-engineers)"
+          exit -1
+
       - name: 'Get the branch name associated with the PR'
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}

--- a/.github/workflows/deploy_release.yaml
+++ b/.github/workflows/deploy_release.yaml
@@ -19,7 +19,6 @@ name: Deploy Release
 # This workflow is intended to be run after successfully validation of the release
 # staged by stage_release.  It will release (or drop) the staging repository.
 #
-#
 # It requires the following:
 # variables:
 # KROXYLICIOUS_SONATYPE_TOKEN_USERNAME - Sonatype Access User Token Username
@@ -29,19 +28,21 @@ name: Deploy Release
 #
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
-      release-version:
-        description: 'The release version, e.g. 0.7.0'
+      release-pr-issue-number:
+        description: 'PR number that is performing the release'
+        type: number
         required: true
       next-state:
         description: 'Desired next state for this release'
         required: true
-        type: choice
-        default: drop
-        options:
-          - drop
-          - release
+        type: string
+    secrets:
+      KROXYLICIOUS_SONATYPE_TOKEN_PASSWORD:
+        required: true
+      KROXYLICIOUS_RELEASE_TOKEN:
+        required: true
 
 jobs:
   build:
@@ -51,8 +52,21 @@ jobs:
       - name: 'Check out repository'
         uses: actions/checkout@v4
         with:
-          ref: v${{ github.event.inputs.release-version }}
           token: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
+          fetch-tags: true
+          fetch-depth: 0
+
+      - name: 'Get the branch associated with the PR'
+        env:
+          GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
+        run: |
+            echo "PR_HEAD=$(gh pr view ${{ inputs.release-pr-issue-number}} --json headRefName | jq -r .headRefName)" >> $GITHUB_ENV
+
+      - name: 'Get release tag from the branch of PR'
+        env:
+          GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
+        run: |
+          echo "RELEASE_VERSION=$(git name-rev --no-undefined --tags --name-only  origin/${PR_HEAD}^ | sed -e 's/^v//')" >> $GITHUB_ENV
 
       - name: 'Cache Maven packages'
         uses: actions/cache@v4
@@ -75,10 +89,26 @@ jobs:
         env:
           SONATYPE_TOKEN_USERNAME: ${{ vars.KROXYLICIOUS_SONATYPE_TOKEN_USERNAME }}
           SONATYPE_TOKEN_PASSWORD: ${{ secrets.KROXYLICIOUS_SONATYPE_TOKEN_PASSWORD }}
-        run: ./scripts/transition-staging-repository-state.sh -s ${{ github.event.inputs.next-state }}
+        run: ./scripts/transition-staging-repository-state.sh -s ${{ inputs.next-state }}
 
       - name: 'Transition release notes to desired state'
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }} # For the gh cmd line tool used by transition-github-release-note-state.sh
-        run: ./scripts/transition-github-release-note-state.sh -s  ${{ github.event.inputs.next-state }} -v ${{ github.event.inputs.release-version }}
+        run: ./scripts/transition-github-release-note-state.sh -s  ${{ inputs.next-state }} -v ${{ env.RELEASE_VERSION }}
 
+      - name: 'Merge PR'
+        if: inputs.next-state == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
+        run: |
+          # TODO: verify that main hasn't moved
+          echo gh pr merge --delete-branch --rebase ${{ inputs.release-pr-issue-number }}
+
+      - name: 'Drop PR'
+        if: always() && inputs.next-state == 'drop'
+        env:
+          GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
+        run: |
+          gh pr close --comment "Release dropped" --delete-branch ${{ inputs.release-pr-issue-number }} 
+
+# Merge the PR or Close the PR

--- a/.github/workflows/deploy_release.yaml
+++ b/.github/workflows/deploy_release.yaml
@@ -105,7 +105,7 @@ jobs:
           echo gh pr merge --delete-branch --rebase ${{ inputs.release-pr-issue-number }}
 
       - name: 'Drop PR'
-        if: always() && inputs.next-state == 'drop'
+        if: inputs.next-state == 'drop'
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
         run: |

--- a/.github/workflows/deploy_release.yaml
+++ b/.github/workflows/deploy_release.yaml
@@ -56,17 +56,36 @@ jobs:
           fetch-tags: true
           fetch-depth: 0
 
-      - name: 'Get the branch associated with the PR'
+      - name: 'Get the branch name associated with the PR'
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
         run: |
-            echo "PR_HEAD=$(gh pr view ${{ inputs.release-pr-issue-number}} --json headRefName | jq -r .headRefName)" >> $GITHUB_ENV
+            echo "PR_BRANCH=$(gh pr view ${{ inputs.release-pr-issue-number}} --json headRefName | jq -r .headRefName)" >> $GITHUB_ENV
 
-      - name: 'Get release tag from the branch of PR'
+      - name: 'Get release version from the branch of PR'
+        run: |
+          # This knows the commit that precedes PR_BRANCH will carry the tag.
+          TAG=$(git name-rev --no-undefined --tags --name-only  origin/${PR_BRANCH}^)
+          echo "RELEASE_VERSION=$(echo ${TAG} | sed -e 's/^v//')" >> $GITHUB_ENV
+
+      - name: 'Get heads'
+        run: |
+          # Get main's current head
+          echo "MAIN_HEAD=$(git rev-list -n 1 main)" >> $GITHUB_ENV
+
+          # Get PR's view of where main ought to be.  This is two commits behind PR's head.
+          echo "PR_MAIN_REF=$(git rev-list -n 1 ${PR_BRANCH}^^)" >> $GITHUB_ENV
+
+      - name: 'Check for PR/main divergence'
+        if: inputs.next-state == 'release'
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
         run: |
-          echo "RELEASE_VERSION=$(git name-rev --no-undefined --tags --name-only  origin/${PR_HEAD}^ | sed -e 's/^v//')" >> $GITHUB_ENV
+          if [[ "${MAIN_HEAD}" != "${PR_MAIN_REF}" ]];
+          then
+            gh pr comment --body "Release PR (expects main ${PR_MAIN_REF}) has diverged from main (${MAIN_HEAD}). You must drop this release and restage the release." ${{ inputs.release-pr-issue-number }}
+            exit 1
+          fi
 
       - name: 'Cache Maven packages'
         uses: actions/cache@v4
@@ -101,8 +120,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
         run: |
-          # TODO: verify that main hasn't moved
-          echo gh pr merge --delete-branch --rebase ${{ inputs.release-pr-issue-number }}
+          gh pr merge --delete-branch --rebase ${{ inputs.release-pr-issue-number }}
 
       - name: 'Drop PR'
         if: inputs.next-state == 'drop'
@@ -111,4 +129,3 @@ jobs:
         run: |
           gh pr close --comment "Release dropped" --delete-branch ${{ inputs.release-pr-issue-number }} 
 
-# Merge the PR or Close the PR

--- a/.github/workflows/promote_release.yaml
+++ b/.github/workflows/promote_release.yaml
@@ -126,11 +126,24 @@ jobs:
           server-password: SONATYPE_TOKEN_PASSWORD # env variable for Sonatype password
           overwrite-settings: true
 
-      - name: 'Transition snapshot repository to desired state'
+      - name: 'Transition staging repository to desired state'
         env:
           SONATYPE_TOKEN_USERNAME: ${{ vars.KROXYLICIOUS_SONATYPE_TOKEN_USERNAME }}
           SONATYPE_TOKEN_PASSWORD: ${{ secrets.KROXYLICIOUS_SONATYPE_TOKEN_PASSWORD }}
         run: ./scripts/transition-staging-repository-state.sh -s ${{ inputs.command == 'promote-release' && 'release' || 'drop' }}
+
+      - name: 'Unblock the merge'
+        if: inputs.command == 'promote-release'
+        env:
+          GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
+        run: |
+          gh api --method POST \
+                 -H "Accept: application/vnd.github+json" \
+                 -H "X-GitHub-Api-Version: 2022-11-28" \
+                 /repos/${{ github.repository }}/statuses/${PR_MAIN_REF} \
+                 -f "state=success" \
+                 -f "description=Sonatype Release Is Done" \
+                 -f "context=sonatype"
 
       - name: 'Transition release notes to desired state'
         env:

--- a/.github/workflows/promote_release.yaml
+++ b/.github/workflows/promote_release.yaml
@@ -84,6 +84,15 @@ jobs:
         run: |
             echo "PR_BRANCH=$(gh pr view ${{ inputs.release-pr-issue-number}} --json headRefName | jq -r .headRefName)" >> $GITHUB_ENV
 
+      - name: 'Branch name matches naming conventions'
+        env:
+          GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
+        run: |
+          if [[ ! "${PR_BRANCH}" =~ ^release-work- ]]; then
+            gh issue comment  ${{ github.event.issue.number }} --body "This PR's branch name (${PR_BRANCH}) is not in the expected form."
+            exit -1
+          fi
+
       - name: 'Get release version from the branch of PR'
         run: |
           # This knows the commit that precedes PR_BRANCH will carry the tag.

--- a/.github/workflows/promote_release.yaml
+++ b/.github/workflows/promote_release.yaml
@@ -14,14 +14,21 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-name: Deploy Release
+name: Promote Release
 
-# This workflow is intended to be run after successfully validation of the release
-# staged by stage_release.  It will release (or drop) the staging repository.
+# This workflow is dispatched by robot-command-dispatcher in response to a promote-release
+# (or drop-release command).
+#
+# It will release the staged maven artefacts, and merge the release PR.
 #
 # It requires the following:
+# inputs:
+# release-pr-issue-number - the issue number of release PR
+# command - promote-release or drop-release
+#
 # variables:
 # KROXYLICIOUS_SONATYPE_TOKEN_USERNAME - Sonatype Access User Token Username
+#
 # secrets:
 # KROXYLICIOUS_SONATYPE_TOKEN_PASSWORD - Sonatype Access User Token Password
 # KROXYLICIOUS_RELEASE_TOKEN             - GitHub PAT wih content/createPullRequest permission for Kroxylicious repo.
@@ -34,8 +41,8 @@ on:
         description: 'PR number that is performing the release'
         type: number
         required: true
-      next-state:
-        description: 'Desired next state for this release'
+      command:
+        description: 'Dispatched command'
         required: true
         type: string
     secrets:
@@ -92,7 +99,7 @@ jobs:
           echo "PR_MAIN_REF=$(git rev-list -n 1 ${PR_BRANCH}^^)" >> $GITHUB_ENV
 
       - name: 'Check for PR/main divergence'
-        if: inputs.next-state == 'release'
+        if: inputs.command == 'release'
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
         run: |
@@ -123,22 +130,22 @@ jobs:
         env:
           SONATYPE_TOKEN_USERNAME: ${{ vars.KROXYLICIOUS_SONATYPE_TOKEN_USERNAME }}
           SONATYPE_TOKEN_PASSWORD: ${{ secrets.KROXYLICIOUS_SONATYPE_TOKEN_PASSWORD }}
-        run: ./scripts/transition-staging-repository-state.sh -s ${{ inputs.next-state }}
+        run: ./scripts/transition-staging-repository-state.sh -s ${{ inputs.command == 'promote-release' && 'release' || 'drop' }}
 
       - name: 'Transition release notes to desired state'
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }} # For the gh cmd line tool used by transition-github-release-note-state.sh
-        run: ./scripts/transition-github-release-note-state.sh -s  ${{ inputs.next-state }} -v ${{ env.RELEASE_VERSION }}
+        run: ./scripts/transition-github-release-note-state.sh -s  ${{ inputs.command == 'promote-release' && 'release' || 'drop' }} -v ${{ env.RELEASE_VERSION }}
 
       - name: 'Merge PR'
-        if: inputs.next-state == 'release'
+        if: inputs.command == 'promote-release'
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
         run: |
           gh pr merge --delete-branch --rebase ${{ inputs.release-pr-issue-number }}
 
       - name: 'Drop PR'
-        if: inputs.next-state == 'drop'
+        if: inputs.command == 'promote-drop'
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
         run: |

--- a/.github/workflows/promote_release.yaml
+++ b/.github/workflows/promote_release.yaml
@@ -167,8 +167,8 @@ jobs:
                  -H "X-GitHub-Api-Version: 2022-11-28" \
                  /repos/${{ github.repository }}/statuses/${PR_MAIN_REF} \
                  -f "state=success" \
-                 -f "description=Sonatype Release Is Done" \
-                 -f "context=sonatype"
+                 -f "description=Release to Maven Central is complete" \
+                 -f "context=maven-central"
 
       - name: 'Transition release notes to desired state'
         env:

--- a/.github/workflows/promote_release.yaml
+++ b/.github/workflows/promote_release.yaml
@@ -97,6 +97,10 @@ jobs:
         run: |
           # This knows the commit that precedes PR_BRANCH will carry the tag.
           TAG=$(git name-rev --no-undefined --tags --name-only  origin/${PR_BRANCH}^)
+          if [[ ! "${TAG}" =~ ^v ]]; then
+            gh issue comment  ${{ github.event.issue.number }} --body "The release tag '${TAG}' is not in the expected form."
+            exit -1
+          fi
           echo "RELEASE_VERSION=$(echo ${TAG} | sed -e 's/^v//')" >> $GITHUB_ENV
 
       - name: 'Get heads'

--- a/.github/workflows/promote_release.yaml
+++ b/.github/workflows/promote_release.yaml
@@ -99,13 +99,29 @@ jobs:
           echo "PR_MAIN_REF=$(git rev-list -n 1 ${PR_BRANCH}^^)" >> $GITHUB_ENV
 
       - name: 'Check for PR/main divergence'
-        if: inputs.command == 'release'
+        if: ${{ inputs.command == 'promote-release' }}
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
         run: |
           if [[ "${MAIN_HEAD}" != "${PR_MAIN_REF}" ]];
           then
             gh pr comment --body "Release PR (expects main ${PR_MAIN_REF}) has diverged from main (${MAIN_HEAD}). You must drop this release and restage the release." ${{ inputs.release-pr-issue-number }}
+            exit 1
+          fi
+
+      - name: 'Check build workflow has completed successfully'
+        if: ${{ inputs.command == 'promote-release' }}
+        env:
+          GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
+        run: |
+          STATUS=$(gh api --method POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              /repos/${{ github.repository }}/commits/${PR_MAIN_REF}/check-runs \
+              | jq --exit-status -r '.check_runs[] | select(.name=="build") | .status + "/" + .conclusion')
+
+          if [[ ${STATUS} != "completed/success" ]]; then
+            gh pr comment --body "Build workflow has not completed successfully (${STATUS}). Ask me again later." ${{ inputs.release-pr-issue-number }}
             exit 1
           fi
 
@@ -133,7 +149,7 @@ jobs:
         run: ./scripts/transition-staging-repository-state.sh -s ${{ inputs.command == 'promote-release' && 'release' || 'drop' }}
 
       - name: 'Unblock the merge'
-        if: inputs.command == 'promote-release'
+        if: ${{ inputs.command == 'promote-release' }}
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
         run: |
@@ -151,14 +167,14 @@ jobs:
         run: ./scripts/transition-github-release-note-state.sh -s  ${{ inputs.command == 'promote-release' && 'release' || 'drop' }} -v ${{ env.RELEASE_VERSION }}
 
       - name: 'Merge PR'
-        if: inputs.command == 'promote-release'
+        if: ${{ inputs.command == 'promote-release' }}
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
         run: |
           gh pr merge --delete-branch --rebase ${{ inputs.release-pr-issue-number }}
 
       - name: 'Drop PR'
-        if: inputs.command == 'promote-drop'
+        if: ${{ inputs.command == 'drop-release' }}
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
         run: |

--- a/.github/workflows/robot-command-dispatcher.yaml
+++ b/.github/workflows/robot-command-dispatcher.yaml
@@ -37,7 +37,7 @@ jobs:
         id: team-membership
         with:
           username: ${{ github.actor }}
-          team: Developers
+          team: release-engineers
           GITHUB_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
 
       - name: 'Stop workflow if user is not a team member'

--- a/.github/workflows/robot-command-dispatcher.yaml
+++ b/.github/workflows/robot-command-dispatcher.yaml
@@ -1,0 +1,56 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+name: Kroxylicious Robot Command Dispatcher
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  process-command:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request }} && contains(github.event.comment.body, '@kroxylicious-robot')
+    steps:
+      - name: 'Check team membership'
+        if: ${{ github.repository == 'kroxylicious/kroxylicious' }}
+        uses: tspascoal/get-user-teams-membership@v2
+        id: team-membership
+        with:
+          username: ${{ github.actor }}
+          team: admins
+          GITHUB_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
+      - name: 'Stop workflow if user is not a team member'
+        if: ${{ github.repository == 'kroxylicious/kroxylicious' && steps.team-membership.outputs.isTeamMember == 'false' }}
+        run: |
+          gh issue comment  ${{ github.event.issue.number }} --body "${{ github.actor }} is not entitled to use @kroxylicious-robot"
+          exit -1
+      - name: 'Extract command'
+        run: |
+          echo "COMMAND=$(echo "${{ github.event.comment.body }}" | awk '/^@kroxylicious-robot/ {print $2}')" >> $GITHUB_ENV
+          echo "Command is ${COMMAND}"
+    outputs:
+      command: ${{ env.COMMAND }}
+  dispatch-release-or-drop:
+    needs: process-command
+    if: needs.process-command.outputs.command == 'drop' || needs.process-command.outputs.command == 'release'
+    uses: ./.github/workflows/deploy_release.yaml
+    with:
+      next-state: ${{ needs.process-command.outputs.command }}
+      release-pr-issue-number: ${{ github.event.issue.number }}
+    secrets: inherit
+
+

--- a/.github/workflows/robot-command-dispatcher.yaml
+++ b/.github/workflows/robot-command-dispatcher.yaml
@@ -53,7 +53,7 @@ jobs:
           COMMAND=$(echo "${{ github.event.comment.body }}" | awk '/^@kroxylicious-robot/ {print $2}')
           echo "COMMAND=${COMMAND}" >> $GITHUB_ENV
           case "${COMMAND}" in
-            release | drop)
+            promote-release | drop-release)
               ;;
             *)
               echo "UNRECOGNIZED=true" >> $GITHUB_ENV
@@ -66,10 +66,10 @@ jobs:
 
   dispatch-release-or-drop:
     needs: process-command
-    if: ${{ needs.process-command.outputs.command == 'drop' || needs.process-command.outputs.command == 'release' }}
-    uses: ./.github/workflows/deploy_release.yaml
+    if: ${{ needs.process-command.outputs.command == 'drop-release' || needs.process-command.outputs.command == 'promote-release' }}
+    uses: ./.github/workflows/promote_release.yaml
     with:
-      next-state: ${{ needs.process-command.outputs.command }}
+      command: ${{ needs.process-command.outputs.command }}
       release-pr-issue-number: ${{ github.event.issue.number }}
     secrets: inherit
 

--- a/.github/workflows/robot-command-dispatcher.yaml
+++ b/.github/workflows/robot-command-dispatcher.yaml
@@ -31,12 +31,13 @@ jobs:
         id: team-membership
         with:
           username: ${{ github.actor }}
-          team: admins
+          team: Developers
           GITHUB_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
+
       - name: 'Stop workflow if user is not a team member'
         if: ${{ github.repository == 'kroxylicious/kroxylicious' && steps.team-membership.outputs.isTeamMember == 'false' }}
         run: |
-          gh issue comment  ${{ github.event.issue.number }} --body "${{ github.actor }} is not entitled to use @kroxylicious-robot"
+          gh issue comment  ${{ github.event.issue.number }} --body "${{ github.actor }} is not entitled to use @kroxylicious-robot. The user must be a member of https://github.com/orgs/kroxylicious/teams/Developer)"
           exit -1
       - name: 'Extract command'
         run: |

--- a/.github/workflows/robot-command-dispatcher.yaml
+++ b/.github/workflows/robot-command-dispatcher.yaml
@@ -21,10 +21,16 @@ on:
     types: [created]
 
 jobs:
+
   process-command:
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue.pull_request }} && contains(github.event.comment.body, '@kroxylicious-robot')
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '@kroxylicious-robot') }}
     steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
+
       - name: 'Check team membership'
         if: ${{ github.repository == 'kroxylicious/kroxylicious' }}
         uses: tspascoal/get-user-teams-membership@v2
@@ -36,22 +42,51 @@ jobs:
 
       - name: 'Stop workflow if user is not a team member'
         if: ${{ github.repository == 'kroxylicious/kroxylicious' && steps.team-membership.outputs.isTeamMember == 'false' }}
+        env:
+          GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
         run: |
           gh issue comment  ${{ github.event.issue.number }} --body "${{ github.actor }} is not entitled to use @kroxylicious-robot. The user must be a member of https://github.com/orgs/kroxylicious/teams/Developer)"
           exit -1
+
       - name: 'Extract command'
         run: |
-          echo "COMMAND=$(echo "${{ github.event.comment.body }}" | awk '/^@kroxylicious-robot/ {print $2}')" >> $GITHUB_ENV
-          echo "Command is ${COMMAND}"
+          COMMAND=$(echo "${{ github.event.comment.body }}" | awk '/^@kroxylicious-robot/ {print $2}')
+          echo "COMMAND=${COMMAND}" >> $GITHUB_ENV
+          case "${COMMAND}" in
+            release | drop)
+              ;;
+            *)
+              echo "UNRECOGNIZED=true" >> $GITHUB_ENV
+              ;;
+          esac
+
     outputs:
       command: ${{ env.COMMAND }}
+      unrecognized: ${{ env.UNRECOGNIZED }}
+
   dispatch-release-or-drop:
     needs: process-command
-    if: needs.process-command.outputs.command == 'drop' || needs.process-command.outputs.command == 'release'
+    if: ${{ needs.process-command.outputs.command == 'drop' || needs.process-command.outputs.command == 'release' }}
     uses: ./.github/workflows/deploy_release.yaml
     with:
       next-state: ${{ needs.process-command.outputs.command }}
       release-pr-issue-number: ${{ github.event.issue.number }}
     secrets: inherit
+
+  dispatch-help:
+    runs-on: ubuntu-latest
+    needs: process-command
+    if: ${{ needs.process-command.outputs.unrecognized == 'true' }}
+    steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
+
+      - name: 'Send help'
+        env:
+          GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
+        run: |
+          gh issue comment  ${{ github.event.issue.number }} --body "Sorry, I don't understand the command '${{ needs.process-command.outputs.command }}'."
 
 

--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -108,6 +108,10 @@ jobs:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }} # For the gh cmd line tool used by transition-github-release-note-state.sh
         run: ./scripts/transition-github-release-note-state.sh -v ${{ github.event.inputs.release-version }} -a
 
+      - name: 'Create git work branch name'
+        run: |
+          echo "WORK_BRANCH=release-work-${{ github.event.inputs.release-version }}-$(openssl rand -hex 12)" >> $GITHUB_ENV
+
       - name: 'Stage Release'
         run: |
           SIGNING_KEY_SHORT_NAME=$(gpg --list-public-keys --keyid-format short --with-colons | awk -F: '/^pub:/ {print $5}' | head -n 1)
@@ -115,6 +119,7 @@ jobs:
                                      -v ${{ github.event.inputs.release-version }} \
                                      -n ${{ github.event.inputs.development-version }} \
                                      -b ${{ github.event.inputs.branch }} \
+                                     -w ${{ env.WORK_BRANCH }} \
                                      ${{ github.event.inputs.dry-run == 'true' && '-d' || '' }} \
                                      ${{ github.event.inputs.skip-tests == 'true' && '-s' || '' }}
         env:
@@ -145,3 +150,26 @@ jobs:
           SONATYPE_TOKEN_USERNAME: ${{ vars.KROXYLICIOUS_SONATYPE_TOKEN_USERNAME }}
           SONATYPE_TOKEN_PASSWORD: ${{ secrets.KROXYLICIOUS_SONATYPE_TOKEN_PASSWORD }}
         run: ./scripts/transition-staging-repository-state.sh -s close
+
+      - name: 'Comment on PR to prompt next phase of the release'
+        if: ${{ github.event.inputs.dry-run == 'false' }}
+        env:
+          GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }} # For the gh cmd line tool used by stage-release.sh
+        run: |
+          gh pr comment ${{ env.WORK_BRANCH }} --body-file - << 'EOF'
+          Hey, that's the ${{ github.event.inputs.release-version }} release prepared and its artefacts successfully staged to Sonatype. This PR contains a commit for ${{ github.event.inputs.release-version }} and a commit for ${{ github.event.inputs.development-version }}
+          which will reopen main for new work.
+          
+          There are a couple of steps to do before the release is completed.
+          
+          * [ ] Let the CI workflow on this PR complete.
+          * [ ] [Kick the tyres](https://github.com/kroxylicious/kroxylicious-junit5-extension/blob/main/RELEASING.md#making-the-release-public)
+            on the Maven artefacts.
+          
+          Once done, comment <code>&commat;kroxylicious-robot release</code> on this PR. This will release the artefacts to Maven Central and merge this PR to main.
+          
+          If things don't look good, abort the release by saying <code>&commat;kroxylicious-robot drop</code>.
+          
+          Thank you,
+          Your friendly Kroxylicious Github Robot.
+          EOF

--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -151,6 +151,20 @@ jobs:
           SONATYPE_TOKEN_PASSWORD: ${{ secrets.KROXYLICIOUS_SONATYPE_TOKEN_PASSWORD }}
         run: ./scripts/transition-staging-repository-state.sh -s close
 
+      - name: 'Add pending status to block the merge'
+        if: ${{ github.event.inputs.dry-run == 'false' }}
+        env:
+          GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
+        run: |
+          WORK_SHA=$(git rev-list -n 1 origin/${WORK_BRANCH})
+          gh api --method POST \
+                 -H "Accept: application/vnd.github+json" \
+                 -H "X-GitHub-Api-Version: 2022-11-28" \
+                 /repos/${{ github.repository }}/statuses/${WORK_SHA} \
+                 -f "state=pending" \
+                 -f "description=Blocked until Sonatype staging repository is released." \
+                 -f "context=sonatype"
+
       - name: 'Comment on PR to prompt next phase of the release'
         if: ${{ github.event.inputs.dry-run == 'false' }}
         env:

--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -177,8 +177,8 @@ jobs:
                  -H "X-GitHub-Api-Version: 2022-11-28" \
                  /repos/${{ github.repository }}/statuses/${WORK_SHA} \
                  -f "state=pending" \
-                 -f "description=Blocked until Sonatype staging repository is released." \
-                 -f "context=sonatype"
+                 -f "description=Blocked until staging repository is released to Maven Central." \
+                 -f "context=maven-central"
 
       - name: 'Comment on PR to prompt next phase of the release'
         if: ${{ github.event.inputs.dry-run == 'false' }}

--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -163,6 +163,7 @@ jobs:
           There are a couple of steps to do before the release is completed.
           
           * [ ] Let the CI workflow on this PR complete.
+          * [ ] Review the "[Sonatype] iokroxylicious-nnnn repository report" email for unexpected threats.
           * [ ] [Kick the tyres](https://github.com/kroxylicious/kroxylicious-junit5-extension/blob/main/RELEASING.md#making-the-release-public)
             on the Maven artefacts.
           

--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -157,19 +157,17 @@ jobs:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }} # For the gh cmd line tool used by stage-release.sh
         run: |
           gh pr comment ${{ env.WORK_BRANCH }} --body-file - << 'EOF'
-          Hey, that's the ${{ github.event.inputs.release-version }} release prepared and its artefacts successfully staged to Sonatype. This PR contains a commit for ${{ github.event.inputs.release-version }} and a commit for ${{ github.event.inputs.development-version }}
-          which will reopen main for new work.
+          Hey, that's the ${{ github.event.inputs.release-version }} release prepared and its artefacts successfully staged to Sonatype. This PR contains a commit for ${{ github.event.inputs.release-version }} and a commit for ${{ github.event.inputs.development-version }} which will reopen main for new work.
           
           There are a couple of steps to do before the release is completed.
           
           * [ ] Let the CI workflow on this PR complete.
           * [ ] Review the "[Sonatype] iokroxylicious-nnnn repository report" email for unexpected threats.
-          * [ ] [Kick the tyres](https://github.com/kroxylicious/kroxylicious-junit5-extension/blob/main/RELEASING.md#making-the-release-public)
-            on the Maven artefacts.
+          * [ ] [Kick the tyres](https://github.com/kroxylicious/kroxylicious-junit5-extension/blob/main/RELEASING.md#making-the-release-public) on the Maven artefacts.
           
-          Once done, comment <code>&commat;kroxylicious-robot release</code> on this PR. This will release the artefacts to Maven Central and merge this PR to main.
+          Once done, comment <code>&commat;kroxylicious-robot promote-release</code> on this PR. This will release the artefacts to Maven Central and merge this PR to main.
           
-          If things don't look good, abort the release by saying <code>&commat;kroxylicious-robot drop</code>.
+          If things don't look good, abort the release by saying <code>&commat;kroxylicious-robot drop-release</code>.
           
           Thank you,
           Your friendly Kroxylicious Github Robot.

--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -72,6 +72,21 @@ jobs:
           ref: ${{ github.event.inputs.branch }}
           token: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
 
+      - name: 'Check team membership'
+        if: ${{ github.repository == 'kroxylicious/kroxylicious' }}
+        uses: tspascoal/get-user-teams-membership@v2
+        id: team-membership
+        with:
+          username: ${{ github.actor }}
+          team: release-engineers
+          GITHUB_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
+
+      - name: 'Stop workflow if user is not a release-engineer'
+        if: ${{ github.repository == 'kroxylicious/kroxylicious' && steps.team-membership.outputs.isTeamMember == 'false' }}
+        run: |
+          echo "${{ github.actor }} is not a member of https://github.com/orgs/kroxylicious/teams/release-engineers)"
+          exit -1
+
       - name: 'Configure Git username/email'
         run: |
           git config --global user.name "${GITHUB_ACTOR}"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,7 +15,7 @@ At a high level, the process is as follows:
 
 ## Pre-Requisites
 
-You must be a member of the Kroxylicious organization and have access to [create 
+You must be a member of the Kroxylicious [release-engineers](https://github.com/orgs/kroxylicious/teams/release-engineers) and have access to [create 
 secrets](https://github.com/kroxylicious/kroxylicious/settings/secrets/actions) within the kroxylicious repository.
 
 You will need a GPG key, follow this [guide](https://help.ubuntu.com/community/GnuPrivacyGuardHowto#Generating_an_OpenPGP_Key).
@@ -88,9 +88,7 @@ The local changes made to `T`'s POM can be reverted.
 
 ### Making the release public
 
-1. Run [deploy_workflow](https://github.com/kroxylicious/kroxylicious/actions/workflows/deploy_release.yaml)
-   setting the `next-state` to `release` to publish the artefact and publish the release notes.
-1. Merge release PR (use Rebase and Merge strategy) and delete the branch after.
+1. Comment on the PR `@kroxylcious-robot promote-release`.
 1. Let [Kroxylicious Team Developers](https://kroxylicious.slack.com/archives/C04V1K6EAKZ) know the release is finished.
 1. [Publish](https://github.com/kroxylicious/kroxylicious.github.io/blob/main/docs/README.md) the documentation for the release
 1. Merge the blog post PR
@@ -100,9 +98,8 @@ If anything goes wrong, follow the steps in [Failed Releases](#failed-releases)
 
 ### Failed Releases
 
-If the release fails verification, use the [deploy_workflow](https://github.com/kroxylicious/kroxylicious/actions/workflows/deploy_release.yaml) with  the `drop` argument.
-This will drop the snapshot repository and delete the release notes. Manually close the PR
-and delete the associated branch.
+If the release fails verification, comment on the PR `@kroxylcious-robot drop-release`.
+This will drop the snapshot repository, delete the release notes and close PR.
 
 ### Remove your private key/passphrase
 

--- a/scripts/transition-github-release-note-state.sh
+++ b/scripts/transition-github-release-note-state.sh
@@ -57,6 +57,11 @@ if [[ ${ASSERT_NO_RELEASE_NOTES_EXIST} == "true" ]]; then
   exit 0
 elif [[ ${STATE} ]]; then
   NUM_EXIST_DRAFT_RELEASE_NOTES=$(curl "${CURL_ARGS[@]}" | jq --arg tag "${TAG}" '[.[] | select ( .tag_name == $tag and .draft == true )] | length')
+  if [[ ${NUM_EXIST_DRAFT_RELEASE_NOTES} == 0 && ${STATE} == "drop" ]]; then
+    >&2 echo "No draft release notes for tag ${TAG}."
+    exit 0
+  fi
+
   if [[ ${NUM_EXIST_DRAFT_RELEASE_NOTES} != 1 ]]; then
       >&2 echo "Unexpected number of draft release notes for tag ${TAG} found (${NUM_EXIST_DRAFT_RELEASE_NOTES})"
    exit 11


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Step towards #819.  

Second stage of the release is now performed by commenting on the release PR.  This will release the staged artifacts to Maven Central and then merge the release PR in the correct manner.      If you want to drop the release there's the robot understand a drop command too.

`@kroxylicious-robot (promote-release|drop-release)`

There are a couple of checks built in to stop anyone using the robot.  Only **Developers** may interact with the robot.  If you are not in the Developer team you'll get an error message posted back.  Only **release-engineers** may actually promote and drop the release.  

Promote has a couple of other safety checks:

* that the branch actually looks like a release branch.
* that PR and main haven't diverged.
* the PR workflow for the the maven run actually finished successfully

I've also used a https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28 to mean that merge button will be disabled on the PR until to the artefacts are released.

### Additional Context

I used lots of features of Github Actions that I haven't used before, so there could well be a better way to do it.

I've tested the drop path pretty well on my fork.  There's some paths that I can't test until it gets merged to main (the permissions check and the actual merge of the PR itself.


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
