### PR TITLE
Fix docs automation

### DIFF
--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -47,7 +47,7 @@ on:
         required: false
         default: 'main'
       website-repository:
-        description: 'The URL of the website repository, starting with everything after the @, e.g. github.com/kroxylicious/kroxylicious.github.io.git'
+        description: 'The URI of the website repository, starting with everything after the @, e.g. github.com/kroxylicious/kroxylicious.github.io.git'
         required: false
         default: 'github.com/kroxylicious/kroxylicious.github.io.git'
       skip-tests:
@@ -127,7 +127,7 @@ jobs:
         if: ${{ success() }}
         run: |
           ./scripts/stage-docs.sh -v ${{ github.event.inputs.release-version }} \
-                                  -u ${{ github.event.inputs.website-repository }} \
+                                  -u "https://user:${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}@${{ github.event.inputs.website-repository }}" \
                                   ${{ github.event.inputs.dry-run == 'true' && '-d' || '' }}
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }} # For the gh cmd line tool used by stage-docs.sh

--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -47,9 +47,9 @@ on:
         required: false
         default: 'main'
       website-repository:
-        description: 'The URL of the website repository, e.g. git@github.com:kroxylicious/kroxylicious.github.io.git'
+        description: 'The URL of the website repository, starting with everything after the @, e.g. github.com/kroxylicious/kroxylicious.github.io.git'
         required: false
-        default: 'git@github.com:kroxylicious/kroxylicious.github.io.git'
+        default: 'github.com/kroxylicious/kroxylicious.github.io.git'
       skip-tests:
         description: 'Whether to skip the tests before pushing the tag'
         type: boolean

--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -74,8 +74,8 @@ jobs:
 
       - name: 'Configure Git username/email'
         run: |
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
+          git config --global user.name "${GITHUB_ACTOR}"
+          git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
 
       - name: 'Cache Maven packages'
         uses: actions/cache@v4
@@ -125,10 +125,10 @@ jobs:
 
       - name: 'Stage release docs'
         if: ${{ success() }}
-        run: ./scripts/stage-docs.sh -v ${{ github.event.inputs.release-version }} \
-          -u ${{ github.event.inputs.website-repository }} \
-          -b ${{ github.event.inputs.branch }} \
-          ${{ github.event.inputs.dry-run == 'true' && '-d' || '' }}
+        run: |
+          ./scripts/stage-docs.sh -v ${{ github.event.inputs.release-version }} \
+                                  -u ${{ github.event.inputs.website-repository }} \
+                                  ${{ github.event.inputs.dry-run == 'true' && '-d' || '' }}
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }} # For the gh cmd line tool used by stage-docs.sh
 

--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -126,9 +126,9 @@ jobs:
       - name: 'Stage release docs'
         if: ${{ success() }}
         run: ./scripts/stage-docs.sh -v ${{ github.event.inputs.release-version }} \
-                                     -u ${{ github.event.inputs.website-repository }} \
-                                     -b ${{ github.event.inputs.branch }} \
-                                     ${{ github.event.inputs.dry-run == 'true' && '-d' || '' }}
+          -u ${{ github.event.inputs.website-repository }} \
+          -b ${{ github.event.inputs.branch }} \
+          ${{ github.event.inputs.dry-run == 'true' && '-d' || '' }}
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }} # For the gh cmd line tool used by stage-docs.sh
 

--- a/scripts/stage-docs.sh
+++ b/scripts/stage-docs.sh
@@ -15,13 +15,11 @@ REPOSITORY="origin"
 BRANCH_FROM="main"
 DRY_RUN="false"
 ORIGINAL_GH_DEFAULT_REPO=""
-while getopts ":v:u:b:dh" opt; do
+while getopts ":v:u:dh" opt; do
   case $opt in
     v) RELEASE_VERSION="${OPTARG}"
     ;;
     u) WEBSITE_REPO_URL="${OPTARG}"
-    ;;
-    b) BRANCH_FROM="${OPTARG}"
     ;;
     d) DRY_RUN="true"
     ;;
@@ -30,7 +28,6 @@ while getopts ":v:u:b:dh" opt; do
 usage: $0 -v version -u url [-b branch] [-r repository] [-d] [-h]
  -v version number e.g. 0.3.0
  -u url of the website repository e.g. git@github.com:kroxylicious/kroxylicious.github.io.git
- -b branch to release from (defaults to 'main')
  -d dry-run mode
  -h this help message
 EOF
@@ -96,7 +93,7 @@ WEBSITE_TMP=$(mktemp -d)
 
 # Use a `/.` at the end of the source path to avoid the source path being appended to the destination path if the `.../_files/` folder already exists
 KROXYLICIOUS_DOCS_LOCATION="${ORIGINAL_WORKING_DIR}/docs/."
-WEBSITE_DOCS_LOCATION="${WEBSITE_TMP}/kroxylicious.github.io/docs/${RELEASE_TAG}"
+WEBSITE_DOCS_LOCATION="${WEBSITE_TMP}/docs/${RELEASE_TAG}"
 
 if [[ "${DRY_RUN:-false}" == true ]]; then
     #Disable the shell check as the colour codes only work with interpolation.
@@ -105,14 +102,15 @@ if [[ "${DRY_RUN:-false}" == true ]]; then
     GIT_DRYRUN="--dry-run"
 fi
 
+git config -l | grep 'http\..*\.extraheader' | cut -d= -f1 | xargs -L1 git config --unset-all
+
 echo "Checking out tags/${RELEASE_TAG} in  in $(git remote get-url "${REPOSITORY}")"
 git checkout "tags/${RELEASE_TAG}"
 
 # Move to temp directory so we don't end up with website files in the main repository
 cd "${WEBSITE_TMP}"
 echo "In '$(pwd)', cloning website repository at ${WEBSITE_URL}"
-git clone "${WEBSITE_URL}"
-cd kroxylicious.github.io/
+git clone "${WEBSITE_URL}" "${WEBSITE_TMP}"
 
 # config so we can actually push to the website repo without it blowing up
 git config --unset-all http.https://github.com/.extraheader

--- a/scripts/stage-docs.sh
+++ b/scripts/stage-docs.sh
@@ -53,8 +53,6 @@ fi
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-WEBSITE_URL="https://user:${GH_TOKEN}@${WEBSITE_REPO_URL}"
-
 ORIGINAL_WORKING_BRANCH=$(git branch --show-current)
 ORIGINAL_WORKING_DIR=$(pwd)
 
@@ -102,6 +100,9 @@ if [[ "${DRY_RUN:-false}" == true ]]; then
     GIT_DRYRUN="--dry-run"
 fi
 
+# GitHub sets at least one http...extraheader config option in Git which prevents using the Actions' SSH Key for other repos
+# We have to find these settings and disable them here in the Kroxylicious repo before we can do anything with the website repo
+# Otherwise commits and pushes wil fail
 git config -l | grep 'http\..*\.extraheader' | cut -d= -f1 | xargs -L1 git config --unset-all
 
 echo "Checking out tags/${RELEASE_TAG} in  in $(git remote get-url "${REPOSITORY}")"
@@ -109,8 +110,8 @@ git checkout "tags/${RELEASE_TAG}"
 
 # Move to temp directory so we don't end up with website files in the main repository
 cd "${WEBSITE_TMP}"
-echo "In '$(pwd)', cloning website repository at ${WEBSITE_URL}"
-git clone "${WEBSITE_URL}" "${WEBSITE_TMP}"
+echo "In '$(pwd)', cloning website repository at ${WEBSITE_REPO_URL}"
+git clone "${WEBSITE_REPO_URL}" "${WEBSITE_TMP}"
 
 ORIGINAL_WEBSITE_WORKING_BRANCH=$(git branch --show-current)
 

--- a/scripts/stage-docs.sh
+++ b/scripts/stage-docs.sh
@@ -112,11 +112,6 @@ cd "${WEBSITE_TMP}"
 echo "In '$(pwd)', cloning website repository at ${WEBSITE_URL}"
 git clone "${WEBSITE_URL}" "${WEBSITE_TMP}"
 
-# config so we can actually push to the website repo without it blowing up
-git config --unset-all http.https://github.com/.extraheader
-git config user.name "GitHub Actions Bot"
-git config user.email "<>"
-
 ORIGINAL_WEBSITE_WORKING_BRANCH=$(git branch --show-current)
 
 echo "Creating branch ${RELEASE_DOCS_BRANCH} from ${BRANCH_FROM} in $(git remote get-url "${REPOSITORY}")"

--- a/scripts/stage-docs.sh
+++ b/scripts/stage-docs.sh
@@ -56,6 +56,8 @@ fi
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+WEBSITE_URL="https://user:${GH_TOKEN}@${WEBSITE_REPO_URL}"
+
 ORIGINAL_WORKING_BRANCH=$(git branch --show-current)
 ORIGINAL_WORKING_DIR=$(pwd)
 
@@ -108,9 +110,14 @@ git checkout "tags/${RELEASE_TAG}"
 
 # Move to temp directory so we don't end up with website files in the main repository
 cd "${WEBSITE_TMP}"
-echo "In '$(pwd)', cloning website repository at ${WEBSITE_REPO_URL}"
-git clone "${WEBSITE_REPO_URL}"
+echo "In '$(pwd)', cloning website repository at ${WEBSITE_URL}"
+git clone "${WEBSITE_URL}"
 cd kroxylicious.github.io/
+
+# config so we can actually push to the website repo without it blowing up
+git config --unset-all http.https://github.com/.extraheader
+git config user.name "GitHub Actions Bot"
+git config user.email "<>"
 
 ORIGINAL_WEBSITE_WORKING_BRANCH=$(git branch --show-current)
 

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -92,10 +92,6 @@ cleanup() {
       gh repo set-default ${ORIGINAL_GH_DEFAULT_REPO}
     fi
 
-    if [[ ${RELEASE_TAG} ]]; then
-      git tag --delete "${RELEASE_TAG}" || true
-    fi
-
     # Note that git branch -D echos the sha of the deleted branch to
     # stdout.  This is great for debugging the release process as it
     # lets the developer restore to the state of the tree.


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Fixes issues in release docs automation introduced in #1491 (discussed in Kroxylicious slack [here](https://kroxylicious.slack.com/archives/C04V1K6EAKZ/p1726142878163919)).

### Additional Context

I've tested this fix on my own fork and it works fine, even to the point of raising the PR against the website repo ([see here](https://github.com/gracegrimwood/kroxylicious.github.io/pull/2)). I had some issues testing this branch when `dry-run` was `false`, which was due to missing the requisite Sonatype tokens. I commented out the parts of the workflow that require those tokens and ran with `dry-run` off, and it worked just fine.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
