### PR TITLE
docs: add missing steps to kubernetes example prerequisites

### DIFF
--- a/kubernetes-examples/README.md
+++ b/kubernetes-examples/README.md
@@ -30,7 +30,12 @@ The instructions for running the examples are given below.
 * [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/)
 * [helm](https://helm.sh/docs/helm/helm_install/)
 * [kaf](https://github.com/birdayz/kaf)
-* macOS users must have [`gsed`](https://formulae.brew.sh/formula/gnu-sed)
+* macOS users must have [`gsed`](https://formulae.brew.sh/formula/gnu-sed) and [`gawk`](https://formulae.brew.sh/formula/gawk)
+
+On top of these prerequisites, you will need to generate the maven wrapper `mvnw` by running in the root directory:
+```shell
+mvn wrapper:wrapper
+```
 
 If you want build your own kroxylicious images you'll additionally need: 
 

--- a/kubernetes-examples/README.md
+++ b/kubernetes-examples/README.md
@@ -32,11 +32,6 @@ The instructions for running the examples are given below.
 * [kaf](https://github.com/birdayz/kaf)
 * macOS users must have [`gsed`](https://formulae.brew.sh/formula/gnu-sed) and [`gawk`](https://formulae.brew.sh/formula/gawk)
 
-On top of these prerequisites, you will need to generate the maven wrapper `mvnw` by running in the root directory:
-```shell
-mvn wrapper:wrapper
-```
-
 If you want build your own kroxylicious images you'll additionally need: 
 
 * [Docker engine](https://docs.docker.com/engine/install) or [podman](https://podman.io/docs/installation) 

--- a/scripts/run-example.sh
+++ b/scripts/run-example.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 DEFAULT_KROXYLICIOUS_IMAGE='quay.io/kroxylicious/kroxylicious'
 KROXYLICIOUS_IMAGE=${KROXYLICIOUS_IMAGE:-${DEFAULT_KROXYLICIOUS_IMAGE}}
-STRIMZI_VERSION=$(./mvnw org.apache.maven.plugins:maven-help-plugin:3.4.0:evaluate -Dexpression=strimzi.version -q -DforceStdout)
+STRIMZI_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.4.0:evaluate -Dexpression=strimzi.version -q -DforceStdout)
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 . "${SCRIPT_DIR}/common.sh"
@@ -128,4 +128,3 @@ if [[ -f "${SAMPLE_DIR}"/postinstall.sh ]]; then
 fi
 
 echo  -e  "${GREEN}Example installed successfully, to continue refer to ${SAMPLE_DIR}/README.md.${NOCOLOR}"
-


### PR DESCRIPTION
### Type of change

- Documentation

### Description

While trying to run the kubernetes example on MacOS, I found a couple steps/prerequisites that were missing. This PR adds those. Specifically:
1. The script uses `mvnw` but there is no `mvnw` in the repo, so I added a step to generate the maven wrapper
2. On MacOS you need to install `gawk`

### Additional Context

The Kubernetes Example script does not run on MacOS without these steps

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
