### PR TITLE
[System Tests] Fixed sporadic error in RestartKafkaBroker test

### DIFF
--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
@@ -238,7 +238,7 @@ public class DeploymentUtils {
     }
 
     private static boolean isPendingPhase(String p) {
-        LOGGER.atInfo().setMessage("Pod Status: {}").addArgument(p).log();
+        LOGGER.atDebug().setMessage("Pod Status: {}").addArgument(p).log();
         return "pending".equalsIgnoreCase(p);
     }
 

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
@@ -159,22 +159,6 @@ public class DeploymentUtils {
     }
 
     /**
-     * Wait for deployment to be restarted.
-     *
-     * @param namespaceName the namespace name
-     * @param podName the pod name
-     * @param timeout the timeout
-     */
-    public static void waitForDeploymentToBeRestarted(String namespaceName, String podName, Duration timeout) {
-        await().alias("await pod to be deleted or in non-running phase")
-                .atMost(timeout)
-                .pollInterval(Duration.ofMillis(500))
-                .until(() -> kubeClient().getPod(namespaceName, podName) == null
-                        || !kubeClient().isDeploymentRunning(namespaceName, podName));
-        DeploymentUtils.waitForDeploymentRunning(namespaceName, podName, timeout);
-    }
-
-    /**
      * Wait for deployment running.
      *
      * @param namespaceName the namespace name

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
@@ -159,6 +159,22 @@ public class DeploymentUtils {
     }
 
     /**
+     * Wait for deployment to be restarted.
+     *
+     * @param namespaceName the namespace name
+     * @param podName the pod name
+     * @param timeout the timeout
+     */
+    public static void waitForDeploymentToBeRestarted(String namespaceName, String podName, Duration timeout) {
+        await().alias("await pod to be deleted or in non-running phase")
+                .atMost(timeout)
+                .pollInterval(Duration.ofMillis(500))
+                .until(() -> kubeClient().getPod(namespaceName, podName) == null
+                        || !kubeClient().isDeploymentRunning(namespaceName, podName));
+        DeploymentUtils.waitForDeploymentRunning(namespaceName, podName, timeout);
+    }
+
+    /**
      * Wait for deployment running.
      *
      * @param namespaceName the namespace name
@@ -222,7 +238,7 @@ public class DeploymentUtils {
     }
 
     private static boolean isPendingPhase(String p) {
-        LOGGER.atDebug().setMessage("Pod Status: {}").addArgument(p).log();
+        LOGGER.atInfo().setMessage("Pod Status: {}").addArgument(p).log();
         return "pending".equalsIgnoreCase(p);
     }
 

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
@@ -222,6 +222,7 @@ public class DeploymentUtils {
     }
 
     private static boolean isPendingPhase(String p) {
+        LOGGER.atDebug().setMessage("Pod Status: {}").addArgument(p).log();
         return "pending".equalsIgnoreCase(p);
     }
 

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
@@ -9,7 +9,6 @@ package io.kroxylicious.systemtests.utils;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -123,7 +122,6 @@ public class KafkaUtils {
             throw new KubeClusterException.NotFound("Kafka cluster name not found!");
         }
         kubeClient().getClient().pods().inNamespace(deployNamespace).withName(podName).withGracePeriod(0).delete();
-        kubeClient().getClient().pods().inNamespace(deployNamespace).withName(podName).waitUntilCondition(Objects::isNull, 5, TimeUnit.MINUTES);
         DeploymentUtils.waitForDeploymentRunning(deployNamespace, podName, Duration.ofMinutes(5));
         return !Objects.equals(podUid, getPodUid(deployNamespace, podName));
     }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
@@ -122,7 +122,7 @@ public class KafkaUtils {
             throw new KubeClusterException.NotFound("Kafka cluster name not found!");
         }
         kubeClient().getClient().pods().inNamespace(deployNamespace).withName(podName).withGracePeriod(0).delete();
-        DeploymentUtils.waitForDeploymentToBeRestarted(deployNamespace, podName, Duration.ofMinutes(5));
+        DeploymentUtils.waitForDeploymentRunning(deployNamespace, podName, Duration.ofMinutes(5));
         return !Objects.equals(podUid, getPodUid(deployNamespace, podName));
     }
 

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/KafkaUtils.java
@@ -122,7 +122,7 @@ public class KafkaUtils {
             throw new KubeClusterException.NotFound("Kafka cluster name not found!");
         }
         kubeClient().getClient().pods().inNamespace(deployNamespace).withName(podName).withGracePeriod(0).delete();
-        DeploymentUtils.waitForDeploymentRunning(deployNamespace, podName, Duration.ofMinutes(5));
+        DeploymentUtils.waitForDeploymentToBeRestarted(deployNamespace, podName, Duration.ofMinutes(5));
         return !Objects.equals(podUid, getPodUid(deployNamespace, podName));
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The null checking has been replaced to avoid sporadic errors due to a race condition (sometimes null object is not detected because is faster than the code).

### Additional Context

Fixes #1520 

### Checklist

- [x] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [x] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [x] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [x] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
