### PR TITLE
Fix #1539: Rename TestKekManager#unwrapRuntimeException to better name and tighten parameters

### DIFF
--- a/kroxylicious-kms-provider-kroxylicious-inmemory-test-support/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryTestKmsFacade.java
+++ b/kroxylicious-kms-provider-kroxylicious-inmemory-test-support/src/main/java/io/kroxylicious/kms/provider/kroxylicious/inmemory/InMemoryTestKmsFacade.java
@@ -80,7 +80,7 @@ public class InMemoryTestKmsFacade implements TestKmsFacade<Config, UUID, InMemo
                     kms.createAlias(kekId, alias);
                 }
                 else {
-                    throw unwrapRuntimeException(e);
+                    throw toRuntimeException(e);
                 }
             }
         }
@@ -94,7 +94,7 @@ public class InMemoryTestKmsFacade implements TestKmsFacade<Config, UUID, InMemo
                 kms.deleteKey(kekRef);
             }
             catch (CompletionException e) {
-                throw unwrapRuntimeException(e);
+                throw toRuntimeException(e);
             }
         }
 
@@ -108,7 +108,7 @@ public class InMemoryTestKmsFacade implements TestKmsFacade<Config, UUID, InMemo
                 kms.createAlias(kekId, alias);
             }
             catch (CompletionException e) {
-                throw unwrapRuntimeException(e);
+                throw toRuntimeException(e);
             }
         }
     }

--- a/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKekManager.java
+++ b/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKekManager.java
@@ -8,6 +8,8 @@ package io.kroxylicious.kms.service;
 
 import java.util.concurrent.CompletionException;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 /**
  * Exposes the ability to manage the KEKs on a KMS implementation.
  */
@@ -54,7 +56,7 @@ public interface TestKekManager {
             if (e.getCause() instanceof UnknownAliasException) {
                 return false;
             }
-            throw unwrapRuntimeException(e);
+            throw toRuntimeException(e);
         }
     }
 
@@ -72,7 +74,8 @@ public interface TestKekManager {
         }
     }
 
-    default RuntimeException unwrapRuntimeException(Exception e) {
-        return e.getCause() instanceof RuntimeException re ? re : new RuntimeException(e.getCause());
+    default RuntimeException toRuntimeException(@NonNull CompletionException e) {
+        var cause = e.getCause();
+        return cause instanceof RuntimeException re ? re : new RuntimeException(cause);
     }
 }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

why: previous method signature was misleading.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
