### PR TITLE
adapt Vault installation to Openshift

### DIFF
--- a/kroxylicious-systemtests/pom.xml
+++ b/kroxylicious-systemtests/pom.xml
@@ -61,6 +61,10 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>openshift-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-httpclient-jdk</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/kroxylicious-systemtests/pom.xml
+++ b/kroxylicious-systemtests/pom.xml
@@ -61,7 +61,15 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>openshift-client</artifactId>
+            <artifactId>openshift-client-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>openshift-model</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>openshift-model-operator</artifactId>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kms/vault/Vault.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kms/vault/Vault.java
@@ -110,14 +110,18 @@ public class Vault {
                 Optional.of(Map.of("server.dev.devRootToken", vaultRootToken,
                         "global.openshift", String.valueOf(openshiftCluster),
                         "server.route.enabled", String.valueOf(openshiftCluster),
-                        "server.route.host", VAULT_SERVICE_NAME + "." + getIngressDomain(),
+                        "server.route.host", VAULT_SERVICE_NAME + "." + getIngressDomain(openshiftCluster),
                         "server.route.tls", "null")));
     }
 
-    private String getIngressDomain() {
-        OpenShiftClient openshiftClient = kubeClient().getClient().adapt(OpenShiftClient.class);
-        IngressControllerList pods = openshiftClient.operator().ingressControllers().inNamespace("openshift-ingress-operator").list();
-        return pods.getItems().stream().map(x -> x.getStatus().getDomain()).findFirst().orElse("local");
+    private String getIngressDomain(boolean openshiftCluster) {
+        String defaultDomain = "local";
+        if (openshiftCluster) {
+            OpenShiftClient openshiftClient = kubeClient().getClient().adapt(OpenShiftClient.class);
+            IngressControllerList pods = openshiftClient.operator().ingressControllers().inNamespace("openshift-ingress-operator").list();
+            return pods.getItems().stream().map(x -> x.getStatus().getDomain()).findFirst().orElse(defaultDomain);
+        }
+        return defaultDomain;
     }
 
     /**

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kms/vault/Vault.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kms/vault/Vault.java
@@ -16,6 +16,9 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.fabric8.openshift.api.model.operator.v1.IngressControllerList;
+import io.fabric8.openshift.client.OpenShiftClient;
+
 import io.kroxylicious.systemtests.Environment;
 import io.kroxylicious.systemtests.executor.ExecResult;
 import io.kroxylicious.systemtests.k8s.exception.KubeClusterException;
@@ -105,7 +108,16 @@ public class Vault {
                 Optional.of(Environment.VAULT_CHART_VERSION),
                 Optional.of(Path.of(TestUtils.getResourcesURI("helm_vault_overrides.yaml"))),
                 Optional.of(Map.of("server.dev.devRootToken", vaultRootToken,
-                        "global.openshift", String.valueOf(openshiftCluster))));
+                        "global.openshift", String.valueOf(openshiftCluster),
+                        "server.route.enabled", String.valueOf(openshiftCluster),
+                        "server.route.host", VAULT_SERVICE_NAME + "." + getIngressDomain(),
+                        "server.route.tls", "null")));
+    }
+
+    private String getIngressDomain() {
+        OpenShiftClient openshiftClient = kubeClient().getClient().adapt(OpenShiftClient.class);
+        IngressControllerList pods = openshiftClient.operator().ingressControllers().inNamespace("openshift-ingress-operator").list();
+        return pods.getItems().stream().map(x -> x.getStatus().getDomain()).findFirst().orElse("local");
     }
 
     /**
@@ -124,6 +136,11 @@ public class Vault {
      * @return the vault url.
      */
     public URI getVaultUrl() {
-        return URI.create("http://" + DeploymentUtils.getNodePortServiceAddress(deploymentNamespace, VAULT_SERVICE_NAME));
+        if (getInstance().isOpenshift()) {
+            return URI.create("http://" + DeploymentUtils.getOpenshiftRouteServiceAddress(deploymentNamespace, VAULT_SERVICE_NAME));
+        }
+        else {
+            return URI.create("http://" + DeploymentUtils.getNodePortServiceAddress(deploymentNamespace, VAULT_SERVICE_NAME));
+        }
     }
 }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
@@ -38,6 +38,9 @@ import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.api.model.RouteList;
+import io.fabric8.openshift.client.OpenShiftClient;
 
 import io.kroxylicious.systemtests.Constants;
 import io.kroxylicious.systemtests.Environment;
@@ -304,6 +307,25 @@ public class DeploymentUtils {
                 .orElseThrow(() -> new KubeClusterException("Unable to get the service port of " + serviceName));
         String address = nodeIP + ":" + port;
         LOGGER.debug("Deduced nodeport address for service: {} as: {}", serviceName, address);
+        return address;
+    }
+
+    /**
+     * Gets openshift route service address.
+     *
+     * @param deploymentNamespace the deployment namespace
+     * @param serviceName the service name
+     * @return the openshift route service address
+     */
+    public static String getOpenshiftRouteServiceAddress(String deploymentNamespace, String serviceName) {
+        OpenShiftClient openshiftClient = kubeClient().getClient().adapt(OpenShiftClient.class);
+        RouteList routes = openshiftClient.routes().inNamespace(deploymentNamespace).list();
+        Route route2 = openshiftClient.routes().inNamespace(deploymentNamespace).withName(serviceName).get();
+        Route route = routes.getItems().stream().filter(x -> x.getMetadata().getName().equals(serviceName)).findFirst().orElse(null);
+        // if present
+        assert route != null;
+        String address = route.getSpec().getHost();
+        LOGGER.debug("Deduced route address for service: {} as: {}", serviceName, address);
         return address;
     }
 }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
@@ -39,7 +39,6 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.openshift.api.model.Route;
-import io.fabric8.openshift.api.model.RouteList;
 import io.fabric8.openshift.client.OpenShiftClient;
 
 import io.kroxylicious.systemtests.Constants;
@@ -319,11 +318,11 @@ public class DeploymentUtils {
      */
     public static String getOpenshiftRouteServiceAddress(String deploymentNamespace, String serviceName) {
         OpenShiftClient openshiftClient = kubeClient().getClient().adapt(OpenShiftClient.class);
-        RouteList routes = openshiftClient.routes().inNamespace(deploymentNamespace).list();
-        Route route2 = openshiftClient.routes().inNamespace(deploymentNamespace).withName(serviceName).get();
-        Route route = routes.getItems().stream().filter(x -> x.getMetadata().getName().equals(serviceName)).findFirst().orElse(null);
-        // if present
-        assert route != null;
+        Route route = openshiftClient.routes().inNamespace(deploymentNamespace).withName(serviceName).get();
+        if (route == null) {
+            throw new KubeClusterException.NotFound("Openshift Route in namespace" + deploymentNamespace + " with name " + serviceName + " not found!"
+                    + "Unable to get the service address");
+        }
         String address = route.getSpec().getHost();
         LOGGER.debug("Deduced route address for service: {} as: {}", serviceName, address);
         return address;

--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,12 @@
             </dependency>
 
             <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>openshift-client</artifactId>
+                <version>${kubernetes-client.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.flipkart.zjsonpatch</groupId>
                 <artifactId>zjsonpatch</artifactId>
                 <version>${zjsonpatch.version}</version>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Since latest changes to use REST API instead of Vault CLI, we need to create a Route in Openshift to be able to communicate to Vault from outside the cluster.

### Additional Context

Fixes #1541 

### Checklist

- [x] Write tests
- [x] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [x] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [x] Ensure the PR references relevant issue(s) so they are closed on merging.
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
