### PR TITLE
Remove site plugin declaration and version enforcement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -665,11 +665,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>3.20.0</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.5.1</version>
                     <configuration>
@@ -1017,7 +1012,8 @@
                                             <banLatest>true</banLatest>
                                             <banRelease>true</banRelease>
                                             <banSnapshots>false</banSnapshots>
-                                            <phases>clean,deploy,site</phases>
+                                            <phases>clean,deploy</phases>
+                                            <unCheckedPluginList>org.apache.maven.plugins:maven-site-plugin</unCheckedPluginList>
                                         </requirePluginVersions>
                                     </rules>
                                 </configuration>


### PR DESCRIPTION
We don't use the site plugin but the enforcer plugin detects it and wants us to put a version on it.

Saves following up on dependa maintenance for this plugin we don't use.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
