### PR TITLE
Dockerfile for operator + Kube manifests

### DIFF
--- a/kroxylicious-app/src/assembly/kroxylicious-start.sh
+++ b/kroxylicious-app/src/assembly/kroxylicious-start.sh
@@ -5,15 +5,20 @@
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
+# Disable warnings about `local` variables
+# shellcheck disable=SC3043
 script_dir() {
   # Default is current directory
-  local dir=$(dirname "$0")
-  local full_dir=$(cd "${dir}" && pwd)
+  local dir
+  dir=$(dirname "$0")
+  local full_dir
+  full_dir=$(cd "${dir}" && pwd)
   echo ${full_dir}
 }
 
 classpath() {
-  local class_path="$(script_dir)/../libs/*"
+  local class_path
+  class_path="$(script_dir)/../libs/*"
   if [ -n "${KROXYLICIOUS_CLASSPATH:-}" ]; then
     class_path="$class_path:${KROXYLICIOUS_CLASSPATH}"
   fi
@@ -24,7 +29,8 @@ if [ "${KROXYLICIOUS_LOGGING_OPTIONS+set}" != set ]; then
   KROXYLICIOUS_LOGGING_OPTIONS="-Dlog4j2.configurationFile=$(script_dir)/../config/log4j2.yaml"
 fi
 export JAVA_OPTIONS="${KROXYLICIOUS_LOGGING_OPTIONS} ${JAVA_OPTIONS:-}"
-export JAVA_CLASSPATH="$(classpath)"
+JAVA_CLASSPATH="$(classpath)"
+export JAVA_CLASSPATH
 export JAVA_MAIN_CLASS=io.kroxylicious.app.Kroxylicious
-exec $(script_dir)/run-java.sh "$@"
+exec "$(script_dir)"/run-java.sh "$@"
 

--- a/kroxylicious-operator/DEV_GUIDE.md
+++ b/kroxylicious-operator/DEV_GUIDE.md
@@ -1,0 +1,82 @@
+This is the Kroxylicious operator for Kubernetes.
+
+# Hacking and Debugging
+
+If you want to iterate quickly on the operator the simplest way is to run it as a process on your host (i.e. *not* running it within a Kubernetes cluster).
+
+Note: The Integration Tests will only run if your kubectl context is pointing at a cluster. For development, we recommend using  `minikube`, for example:
+
+```bash
+minikube start --kubernetes-version=latest --driver=podman 
+````
+
+You should now be able to run the tests using `mvn`.
+
+If you want to run the `OperatorMain` (e.g. from your IDE, maybe for dubugging) then you'll need to install the CRD:
+
+```bash
+kubectl install -f src/main/resources/META-INF/fabric8
+```
+
+You should now be able to play around with `KafkaProxy` CRs; read the "Creating a `KafkaProxy`" section.
+
+Alternatively you can build the operator properly and run it within Kube...
+
+# Building & installing the operator
+
+## Building
+
+Note: The Integration Tests will only run if your kubectl context is pointing at a cluster. For development, we recommend using  `minikube`, for example:
+
+```bash
+minikube start --kubernetes-version=latest --driver=podman 
+````
+
+Building the operator distribution
+
+```bash
+mvn package
+````
+
+should produce a `target/kroxylicious-operator-0.9.0-SNAPSHOT-bin` directory.
+
+Build the operator image. For development purposes you can use the minikube registry directly using `minikube image build`, which will be faster than alternatives like pushing to quay.io from your host only for kube to pull the same image right back when you deploy the operator.
+
+```bash
+minikube image build . -t quay.io/kroxylicious/operator:latest --build-opt=build-arg=KROXYLICIOUS_VERSION=0.9.0-SNAPSHOT
+```
+
+## Installing the operator
+
+```
+kubectl apply -f install 
+```
+
+You can check that worked with something like
+
+```
+kubectl logs -n kroxylicious-operator pods/kroxylicious-operator-7cd88454c8-fjcxm operator
+```
+
+(your pod hash suffix will differ)
+
+# Creating a `KafkaProxy`
+
+```
+kubectl apply -f examples/simple/
+```
+
+You can check that worked with something like
+
+```
+kubectl logs -n my-proxy pods/simple-647d99d9b5-hkwt2 proxy 
+```
+
+(your pod hash suffix will differ)
+
+Note that on its own the proxy won't try to connect to the Kafka cluster.
+
+
+# Testing
+
+To test things properly you'll need to point your virtual clusters at a running Kafka and also run a Kafka client so the proxy is handling some load.

--- a/kroxylicious-operator/DEV_GUIDE.md
+++ b/kroxylicious-operator/DEV_GUIDE.md
@@ -15,7 +15,7 @@ You should now be able to run the tests using `mvn`.
 If you want to run the `OperatorMain` (e.g. from your IDE, maybe for dubugging) then you'll need to install the CRD:
 
 ```bash
-kubectl install -f src/main/resources/META-INF/fabric8
+kubectl apply -f src/main/resources/META-INF/fabric8
 ```
 
 You should now be able to play around with `KafkaProxy` CRs; read the "Creating a `KafkaProxy`" section.

--- a/kroxylicious-operator/Dockerfile
+++ b/kroxylicious-operator/Dockerfile
@@ -1,0 +1,53 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+
+ARG JAVA_VERSION=17
+ARG TARGETOS
+ARG TARGETARCH
+ARG KROXYLICIOUS_VERSION
+ARG CURRENT_USER
+ARG CURRENT_USER_UID
+
+RUN microdnf -y update \
+    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
+    && microdnf clean all
+
+ENV JAVA_HOME /usr/lib/jvm/jre-17
+
+#####
+# Add Tini
+#####
+ENV TINI_VERSION v0.19.0
+ENV TINI_SHA256_AMD64=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c
+ENV TINI_SHA256_ARM64=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81
+ENV TINI_SHA256_PPC64LE=3f658420974768e40810001a038c29d003728c5fe86da211cff5059e48cfdfde
+ENV TINI_SHA256_S390X=931b70a182af879ca249ae9de87ef68423121b38d235c78997fafc680ceab32d
+RUN set -ex; \
+    if [[ "${TARGETOS}/${TARGETARCH}" = "linux/ppc64le" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-ppc64le -o /usr/bin/tini; \
+        echo "${TINI_SHA256_PPC64LE} */usr/bin/tini" | sha256sum -c; \
+        chmod +x /usr/bin/tini; \
+    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/arm64" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 -o /usr/bin/tini; \
+        echo "${TINI_SHA256_ARM64} */usr/bin/tini" | sha256sum -c; \
+        chmod +x /usr/bin/tini; \
+    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/s390x" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x -o /usr/bin/tini; \
+        echo "${TINI_SHA256_S390X} */usr/bin/tini" | sha256sum -c; \
+        chmod +x /usr/bin/tini; \
+    else \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o /usr/bin/tini; \
+        echo "${TINI_SHA256_AMD64} */usr/bin/tini" | sha256sum -c; \
+        chmod +x /usr/bin/tini; \
+    fi
+
+COPY target/kroxylicious-operator-${KROXYLICIOUS_VERSION}-bin/kroxylicious-operator-${KROXYLICIOUS_VERSION} /opt/kroxylicious-operator
+
+RUN if [[ -n "${CURRENT_USER}" && "${CURRENT_USER}" != "root" ]] ; then groupadd -r -g "${CURRENT_USER_UID}" "${CURRENT_USER}" && useradd -m -r -u "${CURRENT_USER_UID}" -g "${CURRENT_USER}" "${CURRENT_USER}"; fi
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/opt/kroxylicious-operator/bin/operator-start.sh" ]

--- a/kroxylicious-operator/examples/simple/00.Namespace.my-proxy.yaml
+++ b/kroxylicious-operator/examples/simple/00.Namespace.my-proxy.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+# A Namespace for a single KafkaProxy instance
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-proxy
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: proxy

--- a/kroxylicious-operator/examples/simple/01.KafkaProxy.simple.yaml
+++ b/kroxylicious-operator/examples/simple/01.KafkaProxy.simple.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: simple
+  namespace: my-proxy
+spec:
+  clusters:
+    - name: "my-cluster"
+      upstream:
+        bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092

--- a/kroxylicious-operator/install/00.Namespace.kroxylicious-operator.yaml
+++ b/kroxylicious-operator/install/00.Namespace.kroxylicious-operator.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+# A Namespace for the operator
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kroxylicious-operator
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: operator

--- a/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-dependent.yaml
+++ b/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-dependent.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+# The access rules for the resources the Kroxylicious Operator produces
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kroxylicious-operator-dependent
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+      - delete
+  - apiGroups:
+      - "apps"
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+      - delete

--- a/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-watched.yaml
+++ b/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-watched.yaml
@@ -1,0 +1,35 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+# The access rules for the resources the Kroxylicious Operator consumes
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kroxylicious-operator-watched
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: operator
+rules:
+  - apiGroups:
+      - "kroxylicious.io"
+    resources:
+      - kafka-proxies
+    verbs:
+      - get
+      - list
+      - watch
+      # - create
+      # - patch
+      # - update
+  - apiGroups:
+      - "kroxylicious.io"
+    resources:
+      - kafka-proxies/status
+    verbs:
+      - get
+      - patch
+      - update

--- a/kroxylicious-operator/install/01.ServiceAccount.kroxylicious-operator.yaml
+++ b/kroxylicious-operator/install/01.ServiceAccount.kroxylicious-operator.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+# The ServiceAccount used by the Kroxylicious Operator
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kroxylicious-operator
+  namespace: kroxylicious-operator
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: operator

--- a/kroxylicious-operator/install/02.ClusterRoleBinding.kroxylicious-operator-dependent.yaml
+++ b/kroxylicious-operator/install/02.ClusterRoleBinding.kroxylicious-operator-dependent.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+# Binds the access rules for the resources the Kroxylicious Operator produces
+# to the operator's service account
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kroxylicious-operator-dependent
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: operator
+subjects:
+  - kind: ServiceAccount
+    name: kroxylicious-operator
+    namespace: kroxylicious-operator
+roleRef:
+  kind: ClusterRole
+  name: kroxylicious-operator-dependent
+  apiGroup: rbac.authorization.k8s.io

--- a/kroxylicious-operator/install/02.ClusterRoleBinding.kroxylicious-operator-watched.yaml
+++ b/kroxylicious-operator/install/02.ClusterRoleBinding.kroxylicious-operator-watched.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+# Binds the access rules for the resources the Kroxylicious Operator consumes
+# to the operator's service account
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kroxylicious-operator-watched
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: operator
+subjects:
+  - kind: ServiceAccount
+    name: kroxylicious-operator
+    namespace: kroxylicious-operator
+roleRef:
+  kind: ClusterRole
+  name: kroxylicious-operator-watched
+  apiGroup: rbac.authorization.k8s.io

--- a/kroxylicious-operator/install/03.Deployment.kroxylicious-operator.yaml
+++ b/kroxylicious-operator/install/03.Deployment.kroxylicious-operator.yaml
@@ -1,0 +1,39 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+# The Deployment for the operator
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kroxylicious-operator
+  namespace: kroxylicious-operator
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kroxylicious
+  template:
+    metadata:
+      labels:
+        app: kroxylicious
+    spec:
+      serviceAccountName: kroxylicious-operator
+      containers:
+        - name: operator
+          image: quay.io/kroxylicious/operator:latest
+          imagePullPolicy: IfNotPresent
+          args: [ ]
+          resources:
+            limits:
+              memory: 300M
+              cpu: 1
+            requests:
+              memory: 300M
+              cpu: 1

--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -181,6 +181,28 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/assembly/binary-distribution.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id> <!-- this is used for inheritance merges -->
+                        <phase>package</phase> <!-- bind to the packaging phase -->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>

--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -198,10 +198,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>io.fabric8</groupId>
-                <artifactId>docker-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/kroxylicious-operator/src/assembly/binary-distribution.xml
+++ b/kroxylicious-operator/src/assembly/binary-distribution.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright Kroxylicious Authors.
-  ~
-  ~ Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
-  -->
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
 <assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 https://maven.apache.org/xsd/assembly-2.2.0.xsd">

--- a/kroxylicious-operator/src/assembly/binary-distribution.xml
+++ b/kroxylicious-operator/src/assembly/binary-distribution.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Kroxylicious Authors.
+  ~
+  ~ Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+  -->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 https://maven.apache.org/xsd/assembly-2.2.0.xsd">
+    <id>bin</id>
+    <formats>
+        <format>tar.gz</format>
+        <format>zip</format>
+        <format>dir</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}/src/assembly</directory>
+            <outputDirectory>/bin/</outputDirectory>
+            <includes>
+                <include>run-java.sh</include>
+                <include>operator-start.sh</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/..</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>LICENSE</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/src/main/resources/</directory>
+            <outputDirectory>/config/</outputDirectory>
+            <includes>
+                <include>log4j2.yaml</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/libs/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>false</unpack>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/kroxylicious-operator/src/assembly/operator-start.sh
+++ b/kroxylicious-operator/src/assembly/operator-start.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# Disable warnings about `local` variables
+# shellcheck disable=SC3043
+script_dir() {
+  # Default is current directory
+  local dir
+  dir=$(dirname "$0")
+  local full_dir
+  full_dir=$(cd "${dir}" && pwd)
+  echo ${full_dir}
+}
+
+classpath() {
+  local class_path
+  class_path="$(script_dir)/../libs/*"
+  if [ -n "${KROXYLICIOUS_CLASSPATH:-}" ]; then
+    class_path="$class_path:${KROXYLICIOUS_CLASSPATH}"
+  fi
+  echo "${class_path}"
+}
+
+if [ "${KROXYLICIOUS_LOGGING_OPTIONS+set}" != set ]; then
+  KROXYLICIOUS_LOGGING_OPTIONS="-Dlog4j2.configurationFile=$(script_dir)/../config/log4j2.yaml"
+fi
+export JAVA_OPTIONS="${KROXYLICIOUS_LOGGING_OPTIONS} ${JAVA_OPTIONS:-}"
+JAVA_CLASSPATH="$(classpath)"
+export JAVA_CLASSPATH
+export JAVA_MAIN_CLASS=io.kroxylicious.kubernetes.operator.OperatorMain
+exec "$(script_dir)"/run-java.sh "$@"
+

--- a/kroxylicious-operator/src/assembly/run-java.sh
+++ b/kroxylicious-operator/src/assembly/run-java.sh
@@ -1,0 +1,619 @@
+#!/bin/bash
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# shellcheck disable=SC2039,SC2002
+# Disable SC2039 something is undefined in posix script wide as we run in
+# Disable SC2002 useless use of cat.
+
+# ===================================================================================
+# Generic startup script for running arbitrary Java applications with
+# being optimized for running in containers
+#
+# Usage:
+#    # Execute a Java app:
+#    ./run-java.sh <args given to Java code>
+#
+#    # Get options which can be used for invoking Java apps like Maven or Tomcat
+#    ./run-java.sh options [....]
+#
+#
+# This script will pick up either a 'fat' jar which can be run with "-jar"
+# or you can specify a JAVA_MAIN_CLASS.
+#
+# Source and Documentation can be found
+# at https://github.com/fabric8io-images/run-java-sh
+#
+# Env-variables evaluated in this script:
+#
+# JAVA_OPTIONS: Checked for already set options
+# JAVA_MAX_MEM_RATIO: Ratio use to calculate a default maximum Memory, in percent.
+#                     E.g. the "50" value implies that 50% of the Memory
+#                     given to the container is used as the maximum heap memory with
+#                     '-Xmx'.
+#                     It defaults to "25" when the maximum amount of memory available
+#                     to the container is below 300M, otherwise defaults to "50".
+#                     It is a heuristic and should be better backed up with real
+#                     experiments and measurements.
+#                     For a good overviews what tuning options are available -->
+#                             https://youtu.be/Vt4G-pHXfs4
+#                             https://www.youtube.com/watch?v=w1rZOY5gbvk
+#                             https://vimeo.com/album/4133413/video/181900266
+# Also note that heap is only a small portion of the memory used by a JVM. There are lot
+# of other memory areas (metadata, thread, code cache, ...) which adds to the overall
+# size. When your container gets killed because of an OOM, then you should tune
+# the absolute values.
+# JAVA_INIT_MEM_RATIO: Ratio use to calculate a default initial heap memory, in percent.
+#                      By default this value is not set.
+#
+# The following variables are exposed to your Java application:
+#
+# CONTAINER_MAX_MEMORY: Max memory for the container (if running within a container)
+# MAX_CORE_LIMIT: Number of cores available for the container (if running within a container)
+
+
+# ==========================================================
+
+# Fail on a single failed command in a pipeline (if supported)
+(set -o | grep -q pipefail) && set -o pipefail
+
+# Fail on error and undefined vars
+set -eu
+
+# Save global script args
+ARGS="$@"
+
+# ksh is different for defining local vars
+if [ -n "${KSH_VERSION:-}" ]; then
+  alias local=typeset
+fi
+
+# Error is indicated with a prefix in the return value
+check_error() {
+  local error_msg="$1"
+  if echo "${error_msg}" | grep -q "^ERROR:"; then
+    echo "${error_msg}"
+    exit 1
+  fi
+}
+
+# The full qualified directory where this script is located in
+script_dir() {
+  # Default is current directory
+  local dir full_dir
+  dir=$(dirname "$0")
+  full_dir=$(cd "${dir}" && pwd)
+  echo "${full_dir}"
+}
+
+# Try hard to find a sane default jar-file
+auto_detect_jar_file() {
+  local dir="$1"
+
+  # Filter out temporary jars from the shade plugin which start with 'original-'
+  local old_dir
+  old_dir="$(pwd)"
+  if cd "${dir}"; then
+    # NB: Find both (single) JAR *or* WAR <https://github.com/fabric8io-images/run-java-sh/issues/79>
+    local nr_jars
+    nr_jars="$(ls 2>/dev/null | grep -e '.*\.jar$' -e '.*\.war$' | grep -c -v '^original-' | awk '{print $1}')"
+    if [ "${nr_jars}" = 1 ]; then
+      ls 2>/dev/null | grep -e '.*\.jar$' -e '.*\.war$' | grep -v '^original-'
+      exit 0
+    fi
+    cd "${old_dir}"
+    echo "ERROR: Neither JAVA_MAIN_CLASS nor JAVA_APP_JAR is set and ${nr_jars} found in ${dir} (1 expected)"
+  else
+    echo "ERROR: No directory ${dir} found for auto detection"
+  fi
+}
+
+# Check directories (arg 2...n) for a jar file (arg 1)
+find_jar_file() {
+  local jar="$1"
+  shift;
+
+  # Absolute path check if jar specifies an absolute path
+  if [ "${jar}" != ${jar#/} ]; then
+    if [ -f "${jar}" ]; then
+      echo "${jar}"
+    else
+      echo "ERROR: No such file ${jar}"
+    fi
+  else
+    for dir in $*; do
+      if [ -f "${dir}/$jar" ]; then
+        echo "${dir}/$jar"
+        return
+      fi
+    done
+    echo "ERROR: No ${jar} found in $*"
+  fi
+}
+
+# Generic formula evaluation based on awk
+calc() {
+  local formula="$1"
+  shift
+  echo "$@" | awk '
+    function ceil(x) {
+      return x % 1 ? int(x) + 1 : x
+    }
+    function log2(x) {
+      return log(x)/log(2)
+    }
+    function max2(x, y) {
+      return x > y ? x : y
+    }
+    function round(x) {
+      return int(x + 0.5)
+    }
+    {print '"int(${formula})"'}
+  '
+}
+
+# kroxy customization: use code from https://github.com/fabric8io-images/run-java-sh/pull/113 to support cgroups v2 locations
+# Based on the cgroup limits, figure out the max number of core we should utilize
+core_limit() {
+  if [ -r "/sys/fs/cgroup/cgroup.controllers" ]; then
+    # cgroup v2
+    local cpu_file="/sys/fs/cgroup/cpu.max"
+    if [ -r "${cpu_file}" ]; then
+      local cpu_quota cpu_period
+      cpu_quota="$(cat ${cpu_file} | awk '{ print $1 }')"
+      cpu_period="$(cat ${cpu_file} | awk '{ print $2 }')"
+
+      # cfs_quota_us == max --> no restrictions
+      if [ "${cpu_quota:-0}" != "max" ]; then
+        calc 'ceil($1/$2)' "${cpu_quota}" "${cpu_period}"
+      fi
+    fi
+  else
+    # cgroup v1
+    local cpu_period_file="/sys/fs/cgroup/cpu/cpu.cfs_period_us"
+    local cpu_quota_file="/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+    if [ -r "${cpu_period_file}" ]; then
+      local cpu_period
+      cpu_period="$(cat ${cpu_period_file})"
+
+      if [ -r "${cpu_quota_file}" ]; then
+        local cpu_quota
+        cpu_quota="$(cat ${cpu_quota_file})"
+        # cfs_quota_us == -1 --> no restrictions
+        if [ ${cpu_quota:-0} -ne -1 ]; then
+          calc 'ceil($1/$2)' "${cpu_quota}" "${cpu_period}"
+        fi
+      fi
+    fi
+  fi
+}
+
+# kroxy customization: use code from https://github.com/fabric8io-images/run-java-sh/pull/113 to support cgroups v2 locations
+max_memory() {
+  # High number which is the max limit until which memory is supposed to be
+  # unbounded.
+
+  local mem_file=""
+  if [ -r "/sys/fs/cgroup/cgroup.controllers" ]; then
+    # cgroup v2
+    mem_file="/sys/fs/cgroup/memory.max"
+  else
+    # cgroup v1
+    mem_file="/sys/fs/cgroup/memory/memory.limit_in_bytes"
+  fi
+
+  if [ -r "${mem_file}" ]; then
+    local max_mem_cgroup max_mem_meminfo_kb max_mem_meminfo
+    max_mem_cgroup="$(cat ${mem_file})"
+    max_mem_meminfo_kb="$(cat /proc/meminfo | awk '/MemTotal/ {print $2}')"
+    max_mem_meminfo="$((max_mem_meminfo_kb * 1024))"
+    if [ ${max_mem_cgroup:-0} != -1 ] && [ "${max_mem_cgroup:-max}" != "max" ] && [ ${max_mem_cgroup:-0} -lt ${max_mem_meminfo:-0} ]
+    then
+      echo "${max_mem_cgroup}"
+    fi
+  fi
+}
+
+init_limit_env_vars() {
+  # Read in container limits and export the as environment variables
+  local core_limit mem_limit
+  core_limit="$(core_limit)"
+  if [ -n "${core_limit}" ]; then
+    export CONTAINER_CORE_LIMIT="${core_limit}"
+  fi
+
+  mem_limit="$(max_memory)"
+  if [ -n "${mem_limit}" ]; then
+    export CONTAINER_MAX_MEMORY="${mem_limit}"
+  fi
+}
+
+load_env() {
+  local script_dir="$1"
+
+  # Configuration stuff is read from this file
+  local run_env_sh="run-env.sh"
+
+  # Load default default config
+  if [ -f "${script_dir}/${run_env_sh}" ]; then
+    . "${script_dir}/${run_env_sh}"
+  fi
+
+  # Check also $JAVA_APP_DIR. Overrides other defaults
+  # It's valid to set the app dir in the default script
+  JAVA_APP_DIR="${JAVA_APP_DIR:-${script_dir}}"
+  if [ -f "${JAVA_APP_DIR}/${run_env_sh}" ]; then
+    . "${JAVA_APP_DIR}/${run_env_sh}"
+  fi
+  export JAVA_APP_DIR
+
+  # JAVA_LIB_DIR defaults to JAVA_APP_DIR/lib
+  export JAVA_LIB_DIR="${JAVA_LIB_DIR:-${JAVA_APP_DIR}}"
+  if [ -z "${JAVA_MAIN_CLASS:-}" ] && [ -z "${JAVA_APP_JAR:-}" ]; then
+    JAVA_APP_JAR="$(auto_detect_jar_file ${JAVA_APP_DIR})"
+    check_error "${JAVA_APP_JAR}"
+  fi
+
+  if [ -n "${JAVA_APP_JAR:-}" ]; then
+    local jar
+    jar="$(find_jar_file ${JAVA_APP_JAR} ${JAVA_APP_DIR} ${JAVA_LIB_DIR})"
+    check_error "${jar}"
+    export JAVA_APP_JAR="${jar}"
+  else
+    export JAVA_MAIN_CLASS
+  fi
+}
+
+# Check for standard /opt/run-java-options first, fallback to run-java-options in the path if not existing
+run_java_options() {
+  if [ -f "/opt/run-java-options" ]; then
+    . /opt/run-java-options
+  else
+    if which run-java-options >/dev/null 2>&1; then
+      run-java-options
+    fi
+  fi
+}
+
+debug_options() {
+  if [ -n "${JAVA_ENABLE_DEBUG:-}" ] || [ -n "${JAVA_DEBUG_ENABLE:-}" ] ||  [ -n "${JAVA_DEBUG:-}" ]; then
+	  local debug_port="${JAVA_DEBUG_PORT:-5005}"
+    local suspend_mode="n"
+    if [ -n "${JAVA_DEBUG_SUSPEND:-}" ]; then
+      if ! echo "${JAVA_DEBUG_SUSPEND}" | grep -q -e '^\(false\|n\|no\|0\)$'; then
+        suspend_mode="y"
+      fi
+    fi
+
+	  echo "-agentlib:jdwp=transport=dt_socket,server=y,suspend=${suspend_mode},address=*:${debug_port}"
+  fi
+}
+
+# Read in a classpath either from a file with a single line, colon separated
+# or given line-by-line in separate lines
+# Arg 1: path to classpath (must exist), optional arg2: application jar, which is stripped from the classpath in
+# multi line arrangements
+format_classpath() {
+  local cp_file="$1"
+  local app_jar="${2:-}"
+
+  local wc_out
+  if wc_out=$(wc -l "${cp_file}" 2>&1); then
+    echo "Cannot read lines in ${cp_file}: $wc_out"
+    exit 1
+  fi
+
+  local nr_lines
+  nr_lines=$(echo $wc_out | awk '{ print $1 }')
+  if [ ${nr_lines} -gt 1 ]; then
+    local sep=""
+    local classpath=""
+    while read file; do
+      local full_path="${JAVA_LIB_DIR}/${file}"
+      # Don't include app jar if include in list
+      if [ "${app_jar}" != "${full_path}" ]; then
+        classpath="${classpath}${sep}${full_path}"
+      fi
+      sep=":"
+    done < "${cp_file}"
+    echo "${classpath}"
+  else
+    # Supposed to be a single line, colon separated classpath file
+    cat "${cp_file}"
+  fi
+}
+
+# ==========================================================================
+
+memory_options() {
+  echo "$(calc_init_memory) $(calc_max_memory)"
+  return
+}
+
+# Check for memory options and set max heap size if needed
+calc_max_memory() {
+  # Check whether -Xmx is already given in JAVA_OPTIONS
+  if echo "${JAVA_OPTIONS:-}" | grep -q -- "-Xmx"; then
+    return
+  fi
+
+  if [ -z "${CONTAINER_MAX_MEMORY:-}" ]; then
+    return
+  fi
+
+  # Check for the 'real memory size' and calculate Xmx from the ratio
+  if [ -n "${JAVA_MAX_MEM_RATIO:-}" ]; then
+    if [ "${JAVA_MAX_MEM_RATIO}" -eq 0 ]; then
+      # Explicitly switched off
+      return
+    fi
+    calc_mem_opt "${CONTAINER_MAX_MEMORY}" "${JAVA_MAX_MEM_RATIO}" "mx"
+  fi
+}
+
+# Check for memory options and set initial heap size if requested
+calc_init_memory() {
+  # Check whether -Xms is already given in JAVA_OPTIONS.
+  if echo "${JAVA_OPTIONS:-}" | grep -q -- "-Xms"; then
+    return
+  fi
+
+  # Check if value set
+  if [ -z "${JAVA_INIT_MEM_RATIO:-}" ] || [ -z "${CONTAINER_MAX_MEMORY:-}" ] || [ "${JAVA_INIT_MEM_RATIO}" -eq 0 ]; then
+    return
+  fi
+
+  # Calculate Xms from the ratio given
+  calc_mem_opt "${CONTAINER_MAX_MEMORY}" "${JAVA_INIT_MEM_RATIO}" "ms"
+}
+
+calc_mem_opt() {
+  local max_mem="$1"
+  local fraction="$2"
+  local mem_opt="$3"
+
+  local val
+  val=$(calc 'round($1*$2/100/1048576)' "${max_mem}" "${fraction}")
+  echo "-X${mem_opt}${val}m"
+}
+
+c2_disabled() {
+  if [ -n "${CONTAINER_MAX_MEMORY:-}" ]; then
+    # Disable C2 compiler when container memory <=300MB
+    if [ "${CONTAINER_MAX_MEMORY}" -le 314572800 ]; then
+      echo true
+      return
+    fi
+  fi
+  echo false
+}
+
+# Switch on diagnostics except when switched off
+diagnostics_options() {
+  if [ -n "${JAVA_DIAGNOSTICS:-}" ]; then
+    echo "-XX:NativeMemoryTracking=summary -Xlog:gc*:stdout:time -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints"
+  fi
+}
+
+# Replicate thread ergonomics for tiered compilation.
+# This could ideally be skipped when tiered compilation is disabled.
+# The algorithm is taken from:
+# OpenJDK / jdk8u / jdk8u / hotspot
+# src/share/vm/runtime/advancedThresholdPolicy.cpp
+ci_compiler_count() {
+  local core_limit="$1"
+  local log_cpu loglog_cpu count c1_count c2_count
+  log_cpu=$(calc 'log2($1)' "$core_limit")
+  loglog_cpu=$(calc 'log2(max2($1,1))' "$log_cpu")
+  count=$(calc 'max2($1*$2,1)*3/2' "$log_cpu" "$loglog_cpu")
+  c1_count=$(calc 'max2($1/3,1)' "$count")
+  c2_count=$(calc 'max2($1-$2,1)' "$count" "$c1_count")
+  [ $(c2_disabled) = true ] && echo "$c1_count" || calc '$1+$2' "$c1_count" "$c2_count"
+}
+
+#-XX:MinHeapFreeRatio=20  These parameters tell the heap to shrink aggressively and to grow conservatively.
+#-XX:MaxHeapFreeRatio=40  Thereby optimizing the amount of memory available to the operating system.
+heap_ratio() {
+  echo "-XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40"
+}
+
+# These parameters are necessary when running parallel GC if you want to use the Min and Max Heap Free ratios.
+# Skip setting gc_options if any other GC is set in JAVA_OPTIONS.
+# -XX:GCTimeRatio=4
+# -XX:AdaptiveSizePolicyWeight=90
+gc_options() {
+  if echo "${JAVA_OPTIONS:-}" | grep -q -- "-XX:.*Use.*GC"; then
+    return
+  fi
+  echo " -XX:+ExitOnOutOfMemoryError"
+}
+
+java_default_options() {
+  # Echo options, trimming trailing and multiple spaces
+  echo "$(memory_options) $(diagnostics_options) $(gc_options)" | awk '$1=$1'
+
+}
+
+# ==============================================================================
+
+# parse the URL
+parse_url() {
+  #[scheme://][user[:password]@]host[:port][/path][?params]
+  # shellcheck disable=SC2001
+  # This is not a simple search and replace of a single value. The usage of sed is justified
+  echo "$1" | sed -e "s+^\(\([^:]*\)://\)\?\(\([^:@]*\)\(:\([^@]*\)\)\?@\)\?\([^:/?]*\)\(:\([^/?]*\)\)\?.*$+ local scheme='\2' username='\4' password='\6' hostname='\7' port='\9'+"
+}
+
+java_proxy_options() {
+  local url="$1"
+  local transport="$2"
+  local ret=""
+
+  if [ -n "$url" ] ; then
+    eval $(parse_url "$url")
+    if [ -n "$hostname" ] ; then
+      ret="-D${transport}.proxyHost=${hostname}"
+    fi
+    if [ -n "$port" ] ; then
+      ret="$ret -D${transport}.proxyPort=${port}"
+    fi
+    if [ -n "$username" ] || [ -n "$password" ] ; then
+      echo "WARNING: Proxy URL for ${transport} contains authentication credentials, these are not supported by java" >&2
+    fi
+  fi
+  echo "$ret"
+}
+
+# Check for proxy options and echo if enabled.
+proxy_options() {
+  local ret=""
+  ret="$(java_proxy_options "${https_proxy:-${HTTPS_PROXY:-}}" https)"
+  ret="$ret $(java_proxy_options "${http_proxy:-${HTTP_PROXY:-}}" http)"
+
+  local noProxy="${no_proxy:-${NO_PROXY:-}}"
+  if [ -n "$noProxy" ] ; then
+    ret="$ret -Dhttp.nonProxyHosts=$(echo "|$noProxy" | sed -e 's/,[[:space:]]*/|/g' | sed -e 's/[[:space:]]//g' | sed -e 's/|\./|\*\./g' | cut -c 2-)"
+  fi
+  echo "$ret"
+}
+
+# ==============================================================================
+
+# Set process name if possible
+exec_args() {
+  if [ -n "${JAVA_APP_NAME:-}" ]; then
+    # Not all shells support the 'exec -a newname' syntax..
+    # shellcheck disable=SC2046
+    # disable SC2046 as there is no word splitting to happen
+    if eval $(exec -a test true 2>/dev/null); then
+      echo "-a '${JAVA_APP_NAME}'"
+    fi
+  fi
+}
+
+# Combine all java options
+java_options() {
+  # Normalize spaces with awk (i.e. trim and eliminate double spaces)
+  # See e.g. https://www.physicsforums.com/threads/awk-1-1-1-file-txt.658865/ for an explanation
+  # of this awk idiom
+  echo "${JAVA_OPTIONS:-} $(run_java_options) $(debug_options) $(proxy_options) $(java_default_options)" | awk '$1=$1'
+}
+
+# Fetch classpath from env or from a local "run-classpath" file
+classpath() {
+  local cp_path="."
+  if [ "${JAVA_LIB_DIR}" != "${JAVA_APP_DIR}" ]; then
+    cp_path="${cp_path}:${JAVA_LIB_DIR}"
+  fi
+  if [ -z "${JAVA_CLASSPATH:-}" ] && [ -n "${JAVA_MAIN_CLASS:-}" ]; then
+    if [ -n "${JAVA_APP_JAR:-}" ]; then
+      cp_path="${cp_path}:${JAVA_APP_JAR}"
+    fi
+    if [ -f "${JAVA_LIB_DIR}/classpath" ]; then
+      # Classpath is pre-created and stored in a 'run-classpath' file
+      cp_path="${cp_path}:$(format_classpath ${JAVA_LIB_DIR}/classpath ${JAVA_APP_JAR:-})"
+    else
+      # No order implied
+      cp_path="${cp_path}:${JAVA_APP_DIR}/*"
+    fi
+  elif [ -n "${JAVA_CLASSPATH:-}" ]; then
+    # Given from the outside
+    cp_path="${JAVA_CLASSPATH}"
+  fi
+  echo "${cp_path}"
+}
+
+# Checks if a flag is present in the arguments.
+hasflag() {
+    local filters="$@"
+    for var in $ARGS; do
+        for filter in $filters; do
+          if [ "$var" = "$filter" ]; then
+              echo 'true'
+              return
+          fi
+        done
+    done
+}
+
+# ==============================================================================
+
+options() {
+    if [ -z ${1:-} ]; then
+      java_options
+      return
+    fi
+
+    local ret=""
+    if [ $(hasflag --debug) ]; then
+      ret="$ret $(debug_options)"
+    fi
+    if [ $(hasflag --proxy) ]; then
+      ret="$ret $(proxy_options)"
+    fi
+    if [ $(hasflag --java-default) ]; then
+      ret="$ret $(java_default_options)"
+    fi
+    if [ $(hasflag --memory) ]; then
+      ret="$ret $(memory_options)"
+    fi
+    if [ $(hasflag --diagnostics) ]; then
+      ret="$ret $(diagnostics_options)"
+    fi
+    if [ $(hasflag --gc) ]; then
+      ret="$ret $(gc_options)"
+    fi
+
+    echo $ret | awk '$1=$1'
+}
+
+# Start JVM
+run() {
+  # Initialize environment
+  load_env $(script_dir)
+
+  local args
+  pushd ${JAVA_APP_DIR}
+  if [ -n "${JAVA_MAIN_CLASS:-}" ] ; then
+     args="${JAVA_MAIN_CLASS}"
+  elif [ -n "${JAVA_APP_JAR:-}" ]; then
+     args="-jar ${JAVA_APP_JAR}"
+  else
+     echo "Either JAVA_MAIN_CLASS or JAVA_APP_JAR needs to be given"
+     exit 1
+  fi
+
+  if [ "${HIDE_CMD_LINE:-}" != 1 ] && [ "${HIDE_CMD_LINE:-}" != true ]; then
+    echo exec $(exec_args) java $(java_options) -cp "$(classpath)" ${args} "$@"
+  fi
+
+  # Don't put ${args} in quotes, otherwise it would be interpreted as a single arg.
+  # However it could be two args (see above). zsh doesn't like this btw, but zsh is not
+  # supported anyway.
+
+  # kroxy customization: return to user dir so configuration path can be relative
+  popd
+  exec $(exec_args) java $(java_options) -cp "$(classpath)" ${args} "$@"
+}
+
+# =============================================================================
+# Fire up
+
+# Set env vars reflecting limits
+init_limit_env_vars
+
+first_arg=${1:-}
+if [ "${first_arg}" = "options" ]; then
+  # Print out options only
+  shift
+  options "$@"
+  exit 0
+elif [ "${first_arg}" = "run" ]; then
+  # Run is the default command, but can be given to allow "options"
+  # as first argument to your
+  shift
+fi
+run "$@"

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
@@ -5,6 +5,8 @@
  */
 package io.kroxylicious.kubernetes.operator;
 
+import java.time.Duration;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,8 +21,15 @@ public class OperatorMain {
 
     public static void main(String[] args) {
         Operator operator = new Operator();
+        operator.installShutdownHook(Duration.ofSeconds(10));
         operator.register(new ProxyReconciler());
-        operator.start();
-        LOGGER.info("Operator started.");
+        try {
+            operator.start();
+            LOGGER.info("Operator started.");
+        }
+        catch (Exception e) {
+            LOGGER.error("Operator has thrown exception '{}' during startup. Will now exit.", e.toString());
+            System.exit(1);
+        }
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds a `Dockerfile` for building the operator, plus some YAMLs for standing up the operator in kubernetes.

I've made no attempt to integrate the operator image build with the rest of the build/CI in this PR. So it makes a start on #1570, but not enough to consider it fixed.

Fixes #1571
Fixes #1576

