### PR TITLE
Dependabot/maven/com.fasterxml.jackson jackson bom 2.18.1

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/ConfigParser.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/ConfigParser.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.KeyDeserializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
 import com.fasterxml.jackson.databind.cfg.HandlerInstantiator;
 import com.fasterxml.jackson.databind.cfg.MapperConfig;
@@ -91,9 +92,10 @@ public class ConfigParser implements PluginFactoryRegistry {
                 .setVisibility(PropertyAccessor.FIELD, Visibility.ANY)
                 .setVisibility(PropertyAccessor.CREATOR, Visibility.ANY)
                 .setConstructorDetector(ConstructorDetector.USE_PROPERTIES_BASED)
-                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                .configure(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY, false)
-                .configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true)
+                .enable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .disable(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY)
+                .enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION)
                 .setSerializationInclusion(JsonInclude.Include.NON_DEFAULT)
                 .registerModule(new PluginModule())
                 .setHandlerInstantiator(new PluginHandlerInstantiator());

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/FilterDefinition.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/FilterDefinition.java
@@ -15,7 +15,7 @@ import io.kroxylicious.proxy.plugin.PluginImplConfig;
 import io.kroxylicious.proxy.plugin.PluginImplName;
 
 public record FilterDefinition(
-                               @PluginImplName(FilterFactory.class) @JsonProperty(required = true, defaultValue = "") String type,
+                               @PluginImplName(FilterFactory.class) @JsonProperty(required = true) String type,
                                @PluginImplConfig(implNameProperty = "type") Object config) {
 
     @JsonCreator

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/FilterDefinition.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/FilterDefinition.java
@@ -15,7 +15,7 @@ import io.kroxylicious.proxy.plugin.PluginImplConfig;
 import io.kroxylicious.proxy.plugin.PluginImplName;
 
 public record FilterDefinition(
-                               @PluginImplName(FilterFactory.class) @JsonProperty(required = true) String type,
+                               @PluginImplName(FilterFactory.class) @JsonProperty(required = true, defaultValue = "") String type,
                                @PluginImplConfig(implNameProperty = "type") Object config) {
 
     @JsonCreator

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/service/HostPort.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/service/HostPort.java
@@ -86,7 +86,7 @@ public final class HostPort {
      * @param address stringified form of the host port, separated by colon (:).
      * @return a {@link HostPort}
      */
-    @JsonCreator
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     @SuppressWarnings("java:S2583") // java:S2583 warns that the address null check can never fail. This is untrue as the NonNull constraint is advisory.
     public static HostPort parse(@NonNull String address) {
         var exceptionText = ("unexpected address formation '%s'." +

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -403,7 +403,7 @@ class ConfigParserTest {
             fail("generated YAML:\n %s", yaml);
         })
                 .isInstanceOf(IllegalArgumentException.class)
-                .withFailMessage("Failed to encode configuration as YAML");
+                .hasMessage("Failed to encode configuration as YAML");
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -400,7 +400,7 @@ class ConfigParserTest {
 
     @Test
     void shouldThrowWhenSerializingUnserializableObject() {
-        var config = new Configuration(null, null, List.of(new FilterDefinition("", new UnseriasliseableConfig(""))), null, false);
+        var config = new Configuration(null, null, List.of(new FilterDefinition("", new NonSerializableConfig(""))), null, false);
 
         ConfigParser cp = new ConfigParser();
         assertThatThrownBy(() -> {
@@ -461,9 +461,10 @@ class ConfigParserTest {
                 .extracting(KeyStore::storePasswordProvider)
                 .extracting(PasswordProvider::getProvidedPassword)
                 .isEqualTo(password);
+
     }
 
-    private record UnseriasliseableConfig(String id) {
+    private record NonSerializableConfig(String id) {
         @Override
         @JsonGetter
         public String id() {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -58,8 +58,8 @@ class ConfigParserTest {
 
     public static Stream<Arguments> yamlDeserializeSerializeFidelity() {
         return Stream.of(Arguments.of("Top level flags", """
-                        useIoUring: true
-                        """),
+                useIoUring: true
+                """),
                 Arguments.of("Virtual cluster (PortPerBroker)", """
                         virtualClusters:
                           demo1:
@@ -259,30 +259,30 @@ class ConfigParserTest {
     void shouldDetectDuplicateClusterNodeNames() {
         // Given
         assertThatThrownBy(() ->
-                // When
-                configParser.parseConfiguration("""
-                        virtualClusters:
-                          demo1:
-                            targetCluster:
-                              bootstrap_servers: kafka.example:1234
-                            clusterNetworkAddressConfigProvider:
-                              type: PortPerBrokerClusterNetworkAddressConfigProvider
-                              config:
-                                bootstrapAddress: cluster1:9192
-                                numberOfBrokerPorts: 1
-                                brokerAddressPattern: localhost
-                                brokerStartPort: 9193
-                          demo1:
-                            targetCluster:
-                              bootstrap_servers: magic-kafka.example:1234
-                            clusterNetworkAddressConfigProvider:
-                              type: PortPerBrokerClusterNetworkAddressConfigProvider
-                              config:
-                                bootstrapAddress: cluster2:9193
-                                numberOfBrokerPorts: 1
-                                brokerAddressPattern: localhost
-                                brokerStartPort: 10193
-                        """))
+        // When
+        configParser.parseConfiguration("""
+                virtualClusters:
+                  demo1:
+                    targetCluster:
+                      bootstrap_servers: kafka.example:1234
+                    clusterNetworkAddressConfigProvider:
+                      type: PortPerBrokerClusterNetworkAddressConfigProvider
+                      config:
+                        bootstrapAddress: cluster1:9192
+                        numberOfBrokerPorts: 1
+                        brokerAddressPattern: localhost
+                        brokerStartPort: 9193
+                  demo1:
+                    targetCluster:
+                      bootstrap_servers: magic-kafka.example:1234
+                    clusterNetworkAddressConfigProvider:
+                      type: PortPerBrokerClusterNetworkAddressConfigProvider
+                      config:
+                        bootstrapAddress: cluster2:9193
+                        numberOfBrokerPorts: 1
+                        brokerAddressPattern: localhost
+                        brokerStartPort: 10193
+                """))
                 // Then
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasCauseInstanceOf(JsonMappingException.class) // Debatable to enforce the wrapped JsonMappingException
@@ -322,15 +322,15 @@ class ConfigParserTest {
                 - type: NestedPluginConfigFactory
                   config:
                     examplePlugin: NotAKnownPlugin
-                
+
                 """));
         var vie = assertInstanceOf(ValueInstantiationException.class, iae.getCause());
         var upie = assertInstanceOf(UnknownPluginInstanceException.class, vie.getCause());
         assertEquals("Unknown io.kroxylicious.proxy.internal.filter.ExamplePluginFactory plugin instance for "
-                        + "name 'NotAKnownPlugin'. "
-                        + "Known plugin instances are [ExamplePluginInstance, io.kroxylicious.proxy.internal.filter.ExamplePluginInstance]. "
-                        + "Plugins must be loadable by java.util.ServiceLoader and annotated with "
-                        + "@Plugin.",
+                + "name 'NotAKnownPlugin'. "
+                + "Known plugin instances are [ExamplePluginInstance, io.kroxylicious.proxy.internal.filter.ExamplePluginInstance]. "
+                + "Plugins must be loadable by java.util.ServiceLoader and annotated with "
+                + "@Plugin.",
                 upie.getMessage());
     }
 
@@ -357,13 +357,13 @@ class ConfigParserTest {
 
     public static Stream<Arguments> shouldWorkWithDifferentConfigCreators() {
         return Stream.of(Arguments.of("constructor injection",
-                        """
-                                filters:
-                                - type: ConstructorInjection
-                                  config:
-                                    str: hello, world
-                                """,
-                        ConstructorInjectionConfig.class),
+                """
+                        filters:
+                        - type: ConstructorInjection
+                          config:
+                            str: hello, world
+                        """,
+                ConstructorInjectionConfig.class),
                 Arguments.of("factory method",
                         """
                                 filters:

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <freemarker.version>2.3.33</freemarker.version>
         <guava.version>33.3.1-jre</guava.version>
         <hamcrest.version>3.0</hamcrest.version>
-        <jackson.version>2.17.2</jackson.version>
+        <jackson.version>2.18.1</jackson.version>
         <junit.version>5.11.3</junit.version>
         <kafka.version>3.8.0</kafka.version>
         <kroxy.extension.version>0.9.1</kroxy.extension.version>


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Bump to jackson 2.18

### Additional Context

Jackson 2.18 was more than just a simple dependency bump.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
