### PR TITLE
operator: enable users to supply labels to Kroxylicious podTemplate

### DIFF
--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -240,6 +240,11 @@
                     -->
                     <source>src/main/resources/META-INF/fabric8</source>
                     <extraAnnotations>true</extraAnnotations>
+                    <existingJavaTypes>
+                        <io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyspec.PodTemplate>
+                            io.fabric8.kubernetes.api.model.PodTemplateSpec
+                        </io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyspec.PodTemplate>
+                    </existingJavaTypes>
                     <packageOverrides>
                         <!-- the default package name ($apiGroup.$apiVersion) doesn't work for us -->
                         <io.kroxylicious.v1alpha1>io.kroxylicious.kubernetes.api.v1alpha1</io.kroxylicious.v1alpha1>

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeployment.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeployment.java
@@ -6,9 +6,11 @@
 package io.kroxylicious.kubernetes.operator;
 
 import java.util.Map;
+import java.util.Optional;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.PodTemplateSpecBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
@@ -77,11 +79,14 @@ public class ProxyDeployment
 
     private PodTemplateSpec podTemplate(KafkaProxy primary,
                                         Context<KafkaProxy> context) {
-        PodTemplateSpec podTemplate = primary.getSpec().getPodTemplate();
-        PodTemplateSpecBuilder builder = podTemplate != null ? podTemplate.edit() : new PodTemplateSpecBuilder();
+        Map<String, String> labelsFromSpec = Optional.ofNullable(primary.getSpec().getPodTemplate())
+                .map(PodTemplateSpec::getMetadata)
+                .map(ObjectMeta::getLabels)
+                .orElse(Map.of());
         // @formatter:off
-        return builder
+        return new PodTemplateSpecBuilder()
                 .editOrNewMetadata()
+                    .addToLabels(labelsFromSpec)
                     .addToLabels(podLabels())
                 .endMetadata()
                 .editOrNewSpec()

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeployment.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeployment.java
@@ -77,10 +77,12 @@ public class ProxyDeployment
 
     private PodTemplateSpec podTemplate(KafkaProxy primary,
                                         Context<KafkaProxy> context) {
+        PodTemplateSpec podTemplate = primary.getSpec().getPodTemplate();
+        PodTemplateSpecBuilder builder = podTemplate != null ? podTemplate.edit() : new PodTemplateSpecBuilder();
         // @formatter:off
-        return new PodTemplateSpecBuilder()
+        return builder
                 .editOrNewMetadata()
-                    .withLabels(podLabels())
+                    .addToLabels(podLabels())
                 .endMetadata()
                 .editOrNewSpec()
                     .withContainers(proxyContainer(primary, context))

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
@@ -81,7 +81,16 @@ spec:
                               type: string
                             name:
                               type: string
-
+                podTemplate:
+                  type: object
+                  properties:
+                    metadata:
+                      properties:
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
             status:
               type: object
               properties:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/in-KafkaProxy.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/in-KafkaProxy.yaml
@@ -9,6 +9,7 @@ kind: KafkaProxy
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
   name: use-pod-template-spec
+  namespace: proxy-ns
 spec:
   clusters:
   - name: "one"
@@ -17,4 +18,4 @@ spec:
   podTemplate:
     metadata:
       labels:
-        environment: "production"
+        environment: "production-from-podTemplate"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/in-KafkaProxy.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/in-KafkaProxy.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: use-pod-template-spec
+spec:
+  clusters:
+  - name: "one"
+    upstream:
+      bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+  podTemplate:
+    metadata:
+      labels:
+        environment: "production"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Deployment-use-pod-template-spec.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Deployment-use-pod-template-spec.yaml
@@ -16,6 +16,7 @@ metadata:
     app.kubernetes.io/instance: "use-pod-template-spec"
     app.kubernetes.io/component: "proxy"
   name: "use-pod-template-spec"
+  namespace: proxy-ns
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"
@@ -28,7 +29,7 @@ spec:
   template:
     metadata:
       labels:
-        environment: "production"
+        environment: "production-from-podTemplate"
         app: "kroxylicious"
     spec:
       containers:
@@ -36,7 +37,7 @@ spec:
           image: "quay.io/kroxylicious/kroxylicious:0.9.0-SNAPSHOT"
           args:
             - "--config"
-            - "/opt/kroxylicious/config/config.yaml"
+            - "/opt/kroxylicious/config/proxy-config.yaml"
           ports:
             - containerPort: 9190
               name: "metrics"
@@ -45,9 +46,9 @@ spec:
             - containerPort: 9294
             - containerPort: 9295
           volumeMounts:
-            - mountPath: "/opt/kroxylicious/config/config.yaml"
+            - mountPath: "/opt/kroxylicious/config/proxy-config.yaml"
               name: "config-volume"
-              subPath: "config.yaml"
+              subPath: "proxy-config.yaml"
       volumes:
         - name: "config-volume"
           secret:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Deployment-use-pod-template-spec.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Deployment-use-pod-template-spec.yaml
@@ -1,0 +1,54 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  labels:
+    app: "kroxylicious"
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/instance: "use-pod-template-spec"
+    app.kubernetes.io/component: "proxy"
+  name: "use-pod-template-spec"
+  ownerReferences:
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxy"
+      name: "use-pod-template-spec"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: "kroxylicious"
+  template:
+    metadata:
+      labels:
+        environment: "production"
+        app: "kroxylicious"
+    spec:
+      containers:
+        - name: "proxy"
+          image: "quay.io/kroxylicious/kroxylicious:0.9.0-SNAPSHOT"
+          args:
+            - "--config"
+            - "/opt/kroxylicious/config/config.yaml"
+          ports:
+            - containerPort: 9190
+              name: "metrics"
+            - containerPort: 9292
+            - containerPort: 9293
+            - containerPort: 9294
+            - containerPort: 9295
+          volumeMounts:
+            - mountPath: "/opt/kroxylicious/config/config.yaml"
+              name: "config-volume"
+              subPath: "config.yaml"
+      volumes:
+        - name: "config-volume"
+          secret:
+            secretName: "use-pod-template-spec"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Secret-use-pod-template-spec.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Secret-use-pod-template-spec.yaml
@@ -15,12 +15,13 @@ metadata:
     app.kubernetes.io/instance: "use-pod-template-spec"
     app.kubernetes.io/component: "proxy"
   name: "use-pod-template-spec"
+  namespace: proxy-ns
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"
       name: "use-pod-template-spec"
 stringData:
-  config.yaml: | 
+  proxy-config.yaml: | 
     ---
     adminHttp:
       host: "0.0.0.0"
@@ -35,6 +36,6 @@ stringData:
           type: "PortPerBrokerClusterNetworkAddressConfigProvider"
           config:
             bootstrapAddress: "localhost:9292"
-            brokerAddressPattern: "one"
+            brokerAddressPattern: "one.proxy-ns.svc.cluster.local"
             brokerStartPort: 9293
             numberOfBrokerPorts: 3

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Secret-use-pod-template-spec.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Secret-use-pod-template-spec.yaml
@@ -1,0 +1,40 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: "v1"
+kind: "Secret"
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/instance: "use-pod-template-spec"
+    app.kubernetes.io/component: "proxy"
+  name: "use-pod-template-spec"
+  ownerReferences:
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxy"
+      name: "use-pod-template-spec"
+stringData:
+  config.yaml: | 
+    ---
+    adminHttp:
+      host: "0.0.0.0"
+      port: 9190
+      endpoints:
+        prometheus: {}
+    virtualClusters:
+      one:
+        targetCluster:
+          bootstrap_servers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
+        clusterNetworkAddressConfigProvider:
+          type: "PortPerBrokerClusterNetworkAddressConfigProvider"
+          config:
+            bootstrapAddress: "localhost:9292"
+            brokerAddressPattern: "one"
+            brokerStartPort: 9293
+            numberOfBrokerPorts: 3

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Service-one.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Service-one.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/instance: "use-pod-template-spec"
     app.kubernetes.io/component: "proxy"
   name: "one"
+  namespace: proxy-ns
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Service-one.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Service-one.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/instance: "use-pod-template-spec"
+    app.kubernetes.io/component: "proxy"
+  name: "one"
+  ownerReferences:
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxy"
+      name: "use-pod-template-spec"
+spec:
+  ports:
+    - name: "one-9292"
+      port: 9292
+      protocol: "TCP"
+      targetPort: 9292
+    - name: "one-9293"
+      port: 9293
+      protocol: "TCP"
+      targetPort: 9293
+    - name: "one-9294"
+      port: 9294
+      protocol: "TCP"
+      targetPort: 9294
+    - name: "one-9295"
+      port: 9295
+      protocol: "TCP"
+      targetPort: 9295
+  selector:
+    app: "kroxylicious"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Closes #1610

This adds a `podTemplate` property to `KafkaProxy` that is mapped to a `io.fabric8.kubernetes.api.model.PodTemplateSpec`. This spec is used as the basis for the Deployment podTemplate.

By mapping it to the kubernetes API we benefit from an API users will be familiar with for configuring pods.

We want to be careful about which properties we enable users to work with as, once released, we will be on the hook for compatibility. So for a start we only tolerate users supplying metadata.labels in their CR. In future we will like add further elements of the PodTemplateSpec like resource limits/requests.

### Rejected Alternative - Embedded Resource

We wondered if we could use [x-kubernetes-embedded-resource](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#rawextension) to declare that we are embedding a Pod. The hope was that the k8s API could validate that the user is embedding a valid Pod in their CR, plus we could use CEL to restrict which fields the user can supply in the spec/metadata to limit which parts we allow to be user-configured. This doesn't appear to be the case.

With:
```yaml
podTemplate:
  type: object
  x-kubernetes-embedded-resource: true
  x-kubernetes-preserve-unknown-fields: true
```
the k8s api server requires the user to supply an `apiVersion` and `kind` field like:
```yaml
  podTemplate:
    apiVersion: "v1"
    kind: "Pod"
```
and it will validate that `metadata` is a valid `ObjectMeta`, for example:
```yaml
  podTemplate:
    apiVersion: "v1"
    kind: "Pod"
    metadata:
      labels:
        a: b
      banana: "apple"
```
is rejected because `banana` is an unknown metadata field.

However, it does not appear to go any further than that. I can supply a `spec` that is invalid for a `Pod`. Or I can refer to a non-existing kind, and it is accepted by the api server.

Also I cannot use CEL to validate anything about the spec. See the [CEL docs](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/2876-crd-validation-expression-language/README.md#type-system-integration)
> 'object' with x-kubernetes-embedded-type	object / "message type", 'apiVersion', 'kind', 'metadata.name' and 'metadata.generateName' are implicitly included in schema
> 'object' with x-kubernetes-preserve-unknown-fields	object / "message type", unknown fields are NOT accessible in CEL expression

So I can use CEL to restrict the kind to Pod and the apiVersion to v1, but can't disallow fields in the spec.

`x-kubernetes-embedded-resource` just appears to be a shorthand for adding `apiVersion`, `kind` and `metadata` fields to the schema, rather than enabling some deeper validation.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
