### PR TITLE
operator: Use absolute service host for brokerAddressPattern

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ClusterService.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ClusterService.java
@@ -49,6 +49,13 @@ public class ClusterService
     }
 
     /**
+     * @return the fully qualified service hostname
+     */
+    static String absoluteServiceHost(KafkaProxy primary, Clusters cluster) {
+        return serviceName(cluster) + "." + primary.getMetadata().getNamespace() + ".svc.cluster.local";
+    }
+
+    /**
      * The inverse of {@link #serviceName(Clusters)}
      * @param service A service
      * @return  The name of the cluster corresponding to the given Service

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigSecret.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigSecret.java
@@ -200,7 +200,7 @@ public class ProxyConfigSecret
                         "PortPerBrokerClusterNetworkAddressConfigProvider",
                         new PortPerBrokerClusterNetworkAddressConfigProvider.PortPerBrokerClusterNetworkAddressConfigProviderConfig(
                                 new HostPort("localhost", 9292 + (100 * clusterNum)),
-                                ClusterService.serviceName(cluster),
+                                ClusterService.absoluteServiceHost(primary, cluster),
                                 null,
                                 null,
                                 null)),

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-api-not-declared/in-KafkaProxy.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-api-not-declared/in-KafkaProxy.yaml
@@ -9,6 +9,7 @@ kind: KafkaProxy
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
   name: example
+  namespace: proxy-ns
 spec:
   clusters:
   - name: "foo"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-api-not-declared/in-One-filter-one.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-api-not-declared/in-One-filter-one.yaml
@@ -9,5 +9,6 @@ kind: One
 apiVersion: org.example.one/v1
 metadata:
   name: filter-one
+  namespace: proxy-ns
 spec:
   filterOneConfig: true

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-api-not-declared/in-Two-filter-two.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-api-not-declared/in-Two-filter-two.yaml
@@ -9,5 +9,6 @@ kind: Two
 apiVersion: com.example.two/v1beta42
 metadata:
   name: filter-two
+  namespace: proxy-ns
 spec:
   filterTwoConfig: 42

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-api-not-declared/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-api-not-declared/out-Deployment-example.yaml
@@ -16,6 +16,7 @@ metadata:
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example"
+  namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-api-not-declared/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-api-not-declared/out-Secret-example.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example"
+  namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"
@@ -35,7 +36,7 @@ stringData:
           type: "PortPerBrokerClusterNetworkAddressConfigProvider"
           config:
             bootstrapAddress: "localhost:9392"
-            brokerAddressPattern: "bar"
+            brokerAddressPattern: "bar.proxy-ns.svc.cluster.local"
             brokerStartPort: 9393
             numberOfBrokerPorts: 3
     filters:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-api-not-declared/out-Service-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-api-not-declared/out-Service-bar.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "bar"
+  namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-KafkaProxy.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-KafkaProxy.yaml
@@ -9,6 +9,7 @@ kind: KafkaProxy
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
   name: example
+  namespace: proxy-ns
 spec:
   clusters:
     - name: "foo"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-One-filter-one.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-One-filter-one.yaml
@@ -9,5 +9,6 @@ kind: One
 apiVersion: org.example.one/v1
 metadata:
   name: filter-one
+  namespace: proxy-ns
 spec:
   filterOneConfig: true

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-Two-filter-two.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-Two-filter-two.yaml
@@ -9,5 +9,6 @@ kind: Two
 apiVersion: com.example.two/v1beta42
 metadata:
   name: filter-two
+  namespace: proxy-ns
 spec:
   filterTwoConfig: 42

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Deployment-example.yaml
@@ -16,6 +16,7 @@ metadata:
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example"
+  namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Secret-example.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example"
+  namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"
@@ -35,7 +36,7 @@ stringData:
           type: "PortPerBrokerClusterNetworkAddressConfigProvider"
           config:
             bootstrapAddress: "localhost:9392"
-            brokerAddressPattern: "bar"
+            brokerAddressPattern: "bar.proxy-ns.svc.cluster.local"
             brokerStartPort: 9393
             numberOfBrokerPorts: 3
     filters:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Service-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Service-bar.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "bar"
+  namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/in-KafkaProxy.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/in-KafkaProxy.yaml
@@ -9,6 +9,7 @@ kind: KafkaProxy
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
   name: minimal
+  namespace: proxy-ns
 spec:
   clusters:
   - name: "one"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Deployment-minimal.yaml
@@ -16,6 +16,7 @@ metadata:
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal"
+  namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Secret-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Secret-minimal.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal"
+  namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"
@@ -35,6 +36,6 @@ stringData:
           type: "PortPerBrokerClusterNetworkAddressConfigProvider"
           config:
             bootstrapAddress: "localhost:9292"
-            brokerAddressPattern: "one"
+            brokerAddressPattern: "one.proxy-ns.svc.cluster.local"
             brokerStartPort: 9293
             numberOfBrokerPorts: 3

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Service-one.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Service-one.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one"
+  namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/in-KafkaProxy.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/in-KafkaProxy.yaml
@@ -9,6 +9,7 @@ kind: KafkaProxy
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
   name: twocluster
+  namespace: proxy-ns
 spec:
   clusters:
     - name: foo

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Deployment-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Deployment-twocluster.yaml
@@ -16,6 +16,7 @@ metadata:
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "twocluster"
+  namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Secret-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Secret-twocluster.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "twocluster"
+  namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"
@@ -35,7 +36,7 @@ stringData:
           type: "PortPerBrokerClusterNetworkAddressConfigProvider"
           config:
             bootstrapAddress: "localhost:9292"
-            brokerAddressPattern: "foo"
+            brokerAddressPattern: "foo.proxy-ns.svc.cluster.local"
             brokerStartPort: 9293
             numberOfBrokerPorts: 3
       bar:
@@ -45,6 +46,6 @@ stringData:
           type: "PortPerBrokerClusterNetworkAddressConfigProvider"
           config:
             bootstrapAddress: "localhost:9392"
-            brokerAddressPattern: "bar"
+            brokerAddressPattern: "bar.proxy-ns.svc.cluster.local"
             brokerStartPort: 9393
             numberOfBrokerPorts: 3

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Service-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Service-bar.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "bar"
+  namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Service-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Service-foo.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "foo"
+  namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/in-KafkaProxy.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/in-KafkaProxy.yaml
@@ -9,6 +9,7 @@ kind: KafkaProxy
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
   name: example
+  namespace: proxy-ns
 spec:
   clusters:
   - name: "foo"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/in-One-filter-one.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/in-One-filter-one.yaml
@@ -9,5 +9,6 @@ kind: One
 apiVersion: org.example.one/v1
 metadata:
   name: filter-one
+  namespace: proxy-ns
 spec:
   filterOneConfig: true

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/in-Two-filter-two.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/in-Two-filter-two.yaml
@@ -9,5 +9,6 @@ kind: Two
 apiVersion: com.example.two/v1beta42
 metadata:
   name: filter-two
+  namespace: proxy-ns
 spec:
   filterTwoConfig: 42

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Deployment-example.yaml
@@ -16,6 +16,7 @@ metadata:
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example"
+  namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Secret-example.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example"
+  namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"
@@ -35,7 +36,7 @@ stringData:
           type: "PortPerBrokerClusterNetworkAddressConfigProvider"
           config:
             bootstrapAddress: "localhost:9292"
-            brokerAddressPattern: "foo"
+            brokerAddressPattern: "foo.proxy-ns.svc.cluster.local"
             brokerStartPort: 9293
             numberOfBrokerPorts: 3
     filters:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Service-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Service-foo.yaml
@@ -15,6 +15,7 @@ metadata:
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "foo"
+  namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Enables client pods in arbitrary namespaces to connect to the proxy via the service created by the operator.

The brokerAddressPattern was previously the service name, which is resolved relative to the client pod namespace. So after clients retrieved cluster metadata via the proxy they could not connect to the brokers as they attempted to resolve the broker relative to their own namespace.

ie bootstrapping with `my-cluster.my-proxy.svc.cluster.local:9292` returned node addresses like `my-cluster:${brokerPort}` and the resolution failed in the client.

Closes #1606

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
