### PR TITLE
Add local testing script for operator

### DIFF
--- a/kroxylicious-operator/DEV_GUIDE.md
+++ b/kroxylicious-operator/DEV_GUIDE.md
@@ -24,6 +24,15 @@ Alternatively you can build the operator properly and run it within Kube...
 
 # Building & installing the operator
 
+There is a convenience script to clean build the operator and install it into minikube. The script will attempt to clean out any installed operator resources and CRDs
+while preserving expensive resources like a Strimzi kafka cluster.
+
+```
+../scripts/run-operator.sh
+```
+
+If you need more control, the following steps explain how to manually build and install.
+
 ## Building
 
 Note: The Integration Tests will only run if your kubectl context is pointing at a cluster. For development, we recommend using  `minikube`, for example:

--- a/scripts/run-operator.sh
+++ b/scripts/run-operator.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# simple script to build and run the operator
+cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" || exit
+cd ..
+echo "building operator maven project"
+mvn package --projects :kroxylicious-operator --also-make -DskipTests
+cd kroxylicious-operator || exit
+
+if ! minikube status
+then
+  echo "starting minikube"
+  minikube start
+fi
+
+echo "building operator image in minikube"
+minikube image build . -t quay.io/kroxylicious/operator:latest --build-opt=build-arg=KROXYLICIOUS_VERSION=0.9.0-SNAPSHOT
+
+echo "installing kafka (no-op if already installed)"
+kubectl create namespace kafka
+kubectl create -n kafka -f 'https://strimzi.io/install/latest?namespace=kafka'
+kubectl wait -n kafka deployment/strimzi-cluster-operator --for=condition=Available=True --timeout=300s
+kubectl apply -n kafka -f https://strimzi.io/examples/latest/kafka/kraft/kafka-single-node.yaml
+kubectl wait -n kafka kafka/my-cluster --for=condition=Ready --timeout=300s
+
+echo "deleting example"
+kubectl delete -f examples/simple/ --ignore-not-found=true --timeout=30s --grace-period=1
+
+echo "deleting kroxylicious-operator installation"
+kubectl delete -n kroxylicious-operator all --all --timeout=30s --grace-period=1
+kubectl delete -f install --ignore-not-found=true --timeout=30s --grace-period=1
+
+echo "deleting all kroxylicious.io resources and crds"
+for crd in $(kubectl get crds -oname | grep kroxylicious.io | awk -F / '{ print $2 }');
+  do
+  export crd
+  echo "deleting resources for crd: $crd"
+  kubectl delete -A --all "$(kubectl get crd "${crd}" -o=jsonpath='{.spec.names.singular}')" --timeout=30s --grace-period=1
+  echo "deleting crd: ${crd}"
+  kubectl delete crd "${crd}"
+done
+
+echo "installing crds"
+kubectl apply -f src/main/resources/META-INF/fabric8
+echo "installing kroxylicious-operator"
+kubectl apply -f install
+echo "installing simple proxy"
+kubectl apply -f examples/simple/
+
+if kubectl wait -n my-proxy kafkaproxy/simple --for=condition=Ready=True --timeout=300s
+then
+  echo "simple proxy should now be available in-cluster at my-cluster.my-proxy.svc.cluster.local:9292"
+else
+  echo "something went wrong!"
+  exit 1
+fi


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Firing up the operator on minikube requires walking through a bunch of
steps in the DEV_GUIDE, this automates it.

1. builds operator with mvn
2. if minikube isn't in a good state, the script starts it
3. installs a strimzi cluster (no-op if a cluster is installed)
4. removes the kroxylicious operator and attempts to clean out
   kroxylicious resources and CRDs that could be left by other branches
5. creates the kroxylicious operator and a simple proxy

The aim is to try and make it quicker to get to a relatively clean state with the latest
operator code, the CRDs from the branch installed and no proxy or filter resources installed.
All while skipping the most time consuming steps of re-initialising minikube and standing up
a strimzi kafka cluster.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
