### PR TITLE
Fix throwable cause in RecordEncryptionFilter WARN-level logging when log level is set to DEBUG

### DIFF
--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryptionFilter.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryptionFilter.java
@@ -102,7 +102,7 @@ public class RecordEncryptionFilter<K>
                 }).exceptionallyCompose(throwable -> {
                     log.atWarn().setMessage("failed to encrypt records, cause message: {}")
                             .addArgument(throwable.getMessage())
-                            .setCause(log.isDebugEnabled() ? throwable : null)
+                            .setCause(log.isDebugEnabled() ? throwable.getCause() : null)
                             .log();
                     return CompletableFuture.failedStage(throwable);
                 });
@@ -115,7 +115,7 @@ public class RecordEncryptionFilter<K>
                 .exceptionallyCompose(throwable -> {
                     log.atWarn().setMessage("failed to decrypt records, cause message: {}")
                             .addArgument(throwable.getMessage())
-                            .setCause(log.isDebugEnabled() ? throwable : null)
+                            .setCause(log.isDebugEnabled() ? throwable.getCause() : null)
                             .log();
                     return CompletableFuture.failedStage(throwable);
                 });


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Pass `throwable.getCause()` to `LoggingEventBuilder#setCause` in `RecordEncryptionFilter.java` instead of just passing `throwable`.

### Additional Context

When log level is set to `DEBUG` or `ALL`, the `WARN`-level logs in `RecordEncryptionFilter.java` don't print. This seems to be because a value (a `Throwable`) is only passed to `setCause` when `DEBUG` logging is enabled, and whatever that value is seems to silently break something in the logger *somewhere* and so no log is printed.

I found this while looking at the `RequestNotSatisfiable` issue on OpenShift, where the warning I was looking for appeared in the logs when logging level was set to default values, but disappeared from the logs (even though the same behaviour was occurring) when I turned the logging levels up to `DEBUG` or `ALL` via the `KROXYLICIOUS_ROOT_LOG_LEVEL` environment variable. The change in this PR from `throwable` to `throwable.getCause()` fixed this for me.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
