### PR TITLE
Fix #1611: ApiVersions bidirectional compatibility

### DIFF
--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/ByteBufAccessor.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/ByteBufAccessor.java
@@ -7,12 +7,13 @@ package io.kroxylicious.test.codec;
 
 import java.nio.ByteBuffer;
 
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.protocol.Writable;
 
 /**
  * Provides write access to byte buffer for serializing frames.
  */
-public interface ByteBufAccessor extends Writable {
+public interface ByteBufAccessor extends Writable, Readable {
 
     @Override
     void writeByte(byte val);
@@ -55,5 +56,9 @@ public interface ByteBufAccessor extends Writable {
      * @return writerIndex of underlying buffer
      */
     int writerIndex();
+
+    int readerIndex();
+
+    void readerIndex(int readerIndex);
 
 }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/ByteBufAccessorImpl.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/ByteBufAccessorImpl.java
@@ -19,7 +19,7 @@ import io.netty.buffer.ByteBufUtil;
  * {@code *ResponseData} classes as-is.
  * This isn't completely ideal because the Kafka APIs for decoding of Records
  * depends on NIO ByteBuffer, so copying between ByteBuffer and ByteBuf cannot
- * always be avoided.
+ * always be avoided.ø
  */
 public class ByteBufAccessorImpl implements ByteBufAccessor, Readable {
 
@@ -178,6 +178,16 @@ public class ByteBufAccessorImpl implements ByteBufAccessor, Readable {
     @Override
     public int remaining() {
         return buf.writerIndex() - buf.readerIndex();
+    }
+
+    @Override
+    public int readerIndex() {
+        return buf.readerIndex();
+    }
+
+    @Override
+    public void readerIndex(int readerIndex) {
+        buf.readerIndex(readerIndex);
     }
 
     @Override

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/DecodedFrame.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/DecodedFrame.java
@@ -134,6 +134,7 @@ public abstract class DecodedFrame<H extends ApiMessage, B extends ApiMessage>
         final ObjectSerializationCache cache = serializationCache;
         header.write(out, cache, headerVersion());
         body.write(out, cache, apiVersion());
+
         assert (out.writerIndex() - initialIndex) == encodedSize;
     }
 

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/DecodedRequestFrame.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/DecodedRequestFrame.java
@@ -42,6 +42,11 @@ public class DecodedRequestFrame<B extends ApiMessage>
         return apiKey().messageType.requestHeaderVersion(apiVersion);
     }
 
+    @Override
+    public short apiVersion() {
+        return header.requestApiVersion();
+    }
+
     public CompletableFuture<SequencedResponse> getResponseFuture() {
         return responseFuture;
     }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/Action.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/Action.java
@@ -22,10 +22,11 @@ interface Action {
         };
     }
 
-    static Action respond(ApiMessage message) {
+    static Action respond(short apiVersion, ApiMessage response) {
         return (ctx, frame) -> {
-            DecodedResponseFrame<?> responseFrame = new DecodedResponseFrame<>(frame.apiVersion(),
-                    frame.correlationId(), new ResponseHeaderData().setCorrelationId(frame.correlationId()), message);
+
+            DecodedResponseFrame<?> responseFrame = new DecodedResponseFrame<>(apiVersion,
+                    frame.correlationId(), new ResponseHeaderData().setCorrelationId(frame.correlationId()), response);
             ctx.write(responseFrame);
         };
     }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/MockHandler.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/MockHandler.java
@@ -51,11 +51,13 @@ public class MockHandler extends ChannelInboundHandlerAdapter {
 
     /**
      * Create mockhandler with initial message to serve
+     *
      * @param message message to respond with, nullable
+     * @param apiVersion
      */
-    public MockHandler(ApiMessage message) {
+    public MockHandler(ApiMessage message, short apiVersion) {
         if (message != null) {
-            setMockResponseForApiKey(ApiKeys.forId(message.apiKey()), message);
+            setMockResponseForApiKey(ApiKeys.forId(message.apiKey()), message, apiVersion);
         }
     }
 
@@ -86,9 +88,11 @@ public class MockHandler extends ChannelInboundHandlerAdapter {
 
     /**
      * Set the response
+     *
      * @param response response
+     * @param apiVersion apiVersion of the response
      */
-    public void setMockResponseForApiKey(ApiKeys keys, ApiMessage response) {
+    public void setMockResponseForApiKey(ApiKeys keys, ApiMessage response, short apiVersion) {
         addMockResponse(new TypeSafeMatcher<>() {
             @Override
             protected boolean matchesSafely(Request request) {
@@ -99,7 +103,7 @@ public class MockHandler extends ChannelInboundHandlerAdapter {
             public void describeTo(Description description) {
                 description.appendText("has key " + keys);
             }
-        }, Action.respond(response));
+        }, Action.respond(apiVersion, response));
     }
 
     public void addMockResponse(Matcher<Request> matcher, Action action) {

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/MockServer.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/MockServer.java
@@ -8,6 +8,7 @@ package io.kroxylicious.test.server;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.hamcrest.Matcher;
 
@@ -50,7 +51,7 @@ public final class MockServer implements AutoCloseable {
      */
     public void addMockResponseForApiKey(ResponsePayload response) {
         Objects.requireNonNull(response);
-        serverHandler.setMockResponseForApiKey(response.apiKeys(), response.message());
+        serverHandler.setMockResponseForApiKey(response.apiKeys(), response.message(), response.apiVersion());
     }
 
     /**
@@ -60,7 +61,7 @@ public final class MockServer implements AutoCloseable {
     public void addMockResponse(Matcher<Request> requestMatcher, ResponsePayload response) {
         Objects.requireNonNull(response);
         Objects.requireNonNull(requestMatcher);
-        serverHandler.addMockResponse(requestMatcher, Action.respond(response.message()));
+        serverHandler.addMockResponse(requestMatcher, Action.respond(response.apiVersion(), response.message()));
     }
 
     public void dropWhen(Matcher<Request> requestMatcher) {
@@ -109,7 +110,7 @@ public final class MockServer implements AutoCloseable {
         final EventGroupConfig eventGroupConfig = EventGroupConfig.create();
         bossGroup = eventGroupConfig.newBossGroup();
         workerGroup = eventGroupConfig.newWorkerGroup();
-        serverHandler = new MockHandler(response == null ? null : response.message());
+        serverHandler = Optional.ofNullable(response).map(r -> new MockHandler(r.message(), r.apiVersion())).orElse(new MockHandler(null, (short) 0));
         ServerBootstrap b = new ServerBootstrap();
         b.group(bossGroup, workerGroup)
                 .channel(eventGroupConfig.serverChannelClass())

--- a/kroxylicious-integration-test-support/src/main/templates/BodyDecoder.ftl
+++ b/kroxylicious-integration-test-support/src/main/templates/BodyDecoder.ftl
@@ -28,7 +28,6 @@ import org.apache.kafka.common.message.${messageSpec.name}Data;
 </#list>
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
-import org.apache.kafka.common.protocol.Readable;
 
 /**
 * Decodes Kafka Readable into an ApiMessage
@@ -50,17 +49,16 @@ public class BodyDecoder {
     * @return the ApiMessage
     * @throws IllegalArgumentException if an unhandled ApiKey is encountered
     */
-    static ApiMessage decodeRequest(ApiKeys apiKey, short apiVersion, Readable accessor) {
-        switch (apiKey) {
+    static ApiMessage decodeRequest(ApiKeys apiKey, short apiVersion, ByteBufAccessor accessor) {
+        return switch (apiKey) {
 <#list messageSpecs as messageSpec>
     <#if messageSpec.type?lower_case == 'request'>
-            case ${retrieveApiKey(messageSpec)}:
-                return new ${messageSpec.name}Data(accessor, apiVersion);
+            case ${retrieveApiKey(messageSpec)} ->
+                new ${messageSpec.name}Data(accessor, apiVersion);
     </#if>
 </#list>
-            default:
-                throw new IllegalArgumentException("Unsupported RPC " + apiKey);
-        }
+            default -> throw new IllegalArgumentException("Unsupported RPC " + apiKey);
+        };
     }
 
     /**
@@ -71,17 +69,35 @@ public class BodyDecoder {
     * @return the ApiMessage
     * @throws IllegalArgumentException if an unhandled ApiKey is encountered
     */
-    static ApiMessage decodeResponse(ApiKeys apiKey, short apiVersion, Readable accessor) {
-        switch (apiKey) {
+    static ApiMessage decodeResponse(ApiKeys apiKey, short apiVersion, ByteBufAccessor accessor) {
+        return switch (apiKey) {
 <#list messageSpecs as messageSpec>
     <#if messageSpec.type?lower_case == 'response'>
-            case ${retrieveApiKey(messageSpec)}:
-                return new ${messageSpec.name}Data(accessor, apiVersion);
+        <#if messageSpec.name == 'ApiVersionsResponse'>
+            case ${retrieveApiKey(messageSpec)} -> {
+                // KIP-511 when the client receives an unsupported version for the ApiVersionResponse, it fails back to version 0
+                // Use the same algorithm as https://github.com/apache/kafka/blob/a41c10fd49841381b5207c184a385622094ed440/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java#L90-L106
+                int prev = accessor.readerIndex();
+                try {
+                    yield new ${messageSpec.name}Data(accessor, apiVersion);
+                }
+                catch (RuntimeException e) {
+                    accessor.readerIndex(prev);
+                    if (apiVersion != 0) {
+                        yield new ${messageSpec.name}Data(accessor, (short) 0);
+                    }
+                    else {
+                        throw e;
+                    }
+                }
+            }
+        <#else>
+            case ${retrieveApiKey(messageSpec)} -> new ${messageSpec.name}Data(accessor, apiVersion);
+        </#if>
     </#if>
 </#list>
-            default:
-                throw new IllegalArgumentException("Unsupported RPC " + apiKey);
-        }
+            default -> throw new IllegalArgumentException("Unsupported RPC " + apiKey);
+        };
     }
 
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/DecodedRequestFrame.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/DecodedRequestFrame.java
@@ -30,6 +30,11 @@ public class DecodedRequestFrame<B extends ApiMessage>
     }
 
     @Override
+    public short apiVersion() {
+        return header.requestApiVersion();
+    }
+
+    @Override
     public short headerVersion() {
         return apiKey().messageType.requestHeaderVersion(apiVersion);
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -32,6 +32,7 @@ import io.kroxylicious.proxy.filter.FilterAndInvoker;
 import io.kroxylicious.proxy.filter.NetFilter;
 import io.kroxylicious.proxy.internal.codec.KafkaRequestDecoder;
 import io.kroxylicious.proxy.internal.codec.KafkaResponseEncoder;
+import io.kroxylicious.proxy.internal.filter.ApiVersionsFilter;
 import io.kroxylicious.proxy.internal.filter.ApiVersionsIntersectFilter;
 import io.kroxylicious.proxy.internal.filter.BrokerAddressFilter;
 import io.kroxylicious.proxy.internal.filter.EagerMetadataLearner;
@@ -230,6 +231,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
 
             NettyFilterContext filterContext = new NettyFilterContext(ch.eventLoop(), pfr);
             List<FilterAndInvoker> customProtocolFilters = filterChainFactory.createFilters(filterContext);
+            List<FilterAndInvoker> apiVersionsFilters = FilterAndInvoker.build(new ApiVersionsFilter());
             List<FilterAndInvoker> brokerAddressFilters = FilterAndInvoker.build(new BrokerAddressFilter(virtualCluster, endpointReconciler));
             var filters = new ArrayList<>(apiVersionFilters);
             filters.addAll(customProtocolFilters);
@@ -237,6 +239,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
                 filters.addAll(FilterAndInvoker.build(new EagerMetadataLearner()));
             }
             filters.addAll(brokerAddressFilters);
+            filters.addAll(apiVersionsFilters);
 
             var target = binding.upstreamTarget();
             if (target == null) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseDecoder.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseDecoder.java
@@ -5,9 +5,11 @@
  */
 package io.kroxylicious.proxy.internal.codec;
 
+import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.Readable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,6 +70,11 @@ public class KafkaResponseDecoder extends KafkaMessageDecoder {
             ResponseHeaderData header = readHeader(headerVersion, accessor);
             log().trace("{}: Header: {}", ctx, header);
             ApiMessage body = BodyDecoder.decodeResponse(apiKey, apiVersion, accessor);
+            if (body instanceof ApiVersionsResponseData apiBody && apiBody.errorCode() == Errors.UNSUPPORTED_VERSION.code()) {
+                // Supports KIP-511.  Ensure we behave like the Broker does when it signals that it
+                // can't support version of the ApiVersion RPC.
+                apiVersion = 0;
+            }
             log().trace("{}: Body: {}", ctx, body);
             Filter recipient = correlation.recipient();
             Metrics.payloadSizeBytesDownstreamSummary(apiKey, apiVersion).record(length);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseDecoder.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaResponseDecoder.java
@@ -70,8 +70,10 @@ public class KafkaResponseDecoder extends KafkaMessageDecoder {
             ResponseHeaderData header = readHeader(headerVersion, accessor);
             log().trace("{}: Header: {}", ctx, header);
             ApiMessage body = BodyDecoder.decodeResponse(apiKey, apiVersion, accessor);
+            // TODO: ugly - think it would be better if decodeResponse returned the actual apiVersion
+            // used to decode the response
             if (body instanceof ApiVersionsResponseData apiBody && apiBody.errorCode() == Errors.UNSUPPORTED_VERSION.code()) {
-                // Supports KIP-511.  Ensure we behave like the Broker does when it signals that it
+                // Supports KIP-511. Ensure we behave like the Broker does when it signals that it
                 // can't support version of the ApiVersion RPC.
                 apiVersion = 0;
             }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/ApiVersionsFilter.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/ApiVersionsFilter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.internal.filter;
+
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+
+import io.kroxylicious.proxy.filter.ApiVersionsRequestFilter;
+import io.kroxylicious.proxy.filter.ApiVersionsResponseFilter;
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.RequestFilterResult;
+import io.kroxylicious.proxy.filter.ResponseFilterResult;
+
+import org.apache.kafka.common.protocol.Errors;
+
+/**
+ * TODO
+ */
+public class ApiVersionsFilter implements ApiVersionsRequestFilter, ApiVersionsResponseFilter {
+
+    boolean unsupportedResponseRequired = false;
+
+    @Override
+    public CompletionStage<RequestFilterResult> onApiVersionsRequest(short apiVersion, RequestHeaderData header, ApiVersionsRequestData request, FilterContext context) {
+        // if client is using a codec that doesn't support a ApiVersions version known to
+        // us, clamp it to the highest/lowest we can do.
+        clampRequestApiVersionIfNecessary(header);
+        return context.forwardRequest(header, request);
+    }
+
+    @Override
+    public CompletionStage<ResponseFilterResult> onApiVersionsResponse(short apiVersion, ResponseHeaderData header, ApiVersionsResponseData response,
+                                                                       FilterContext context) {
+        if (unsupportedResponseRequired) {
+            // if the proxy was unable to support the ApiVersion requested by the client,
+            // send an UNSUPPORTED_VERSION response.  That will cause the client to negotiate.
+            response.setErrorCode(Errors.UNSUPPORTED_VERSION.code());
+        }
+        return context.forwardResponse(header, response);
+    }
+
+    private void clampRequestApiVersionIfNecessary(RequestHeaderData header) {
+        var apiVersions = ApiKeys.API_VERSIONS;
+        if (header.requestApiVersion() > apiVersions.latestVersion()) {
+            unsupportedResponseRequired = true;
+            header.setRequestApiVersion(apiVersions.latestVersion());
+        }
+        if (header.requestApiVersion() < apiVersions.oldestVersion()) {
+            unsupportedResponseRequired = true;
+            header.setRequestApiVersion(apiVersions.oldestVersion());
+        }
+    }
+}


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Bugfix

### Description

Kroxylicious should uphold Kafka's bidirectional compatibility.   As shown by #1611, it currently doesn't do that in the case that there is a different in the `ApiVersion` version.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
