### PR TITLE
Draft: POC support clients initiating with an ApiVersions request version higher than the proxy is aware of

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/ApiVersionsIntersectFilter.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/ApiVersionsIntersectFilter.java
@@ -5,9 +5,17 @@
  */
 package io.kroxylicious.proxy.internal.filter;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
+import io.kroxylicious.proxy.filter.ApiVersionsRequestFilter;
+
+import io.kroxylicious.proxy.filter.RequestFilterResult;
+
+import org.apache.kafka.common.message.ApiVersionsRequestData;
 import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 
 import io.kroxylicious.proxy.filter.ApiVersionsResponseFilter;
@@ -15,21 +23,45 @@ import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
 import io.kroxylicious.proxy.internal.ApiVersionsServiceImpl;
 
+import org.apache.kafka.common.protocol.Errors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static io.kroxylicious.proxy.internal.codec.KafkaRequestDecoder.UNSUPPORTED_VERSION_REMOVE_BEFORE_FORWARD;
+
 /**
  * Changes an API_VERSIONS response so that a client sees the intersection of supported version ranges for each
  * API key. This is an intrinsic part of correctly acting as a proxy.
  */
-public class ApiVersionsIntersectFilter implements ApiVersionsResponseFilter {
+public class ApiVersionsIntersectFilter implements ApiVersionsRequestFilter, ApiVersionsResponseFilter {
     private final ApiVersionsServiceImpl apiVersionsService;
+    private final Set<Integer> unsupportedApiVersionsRequest = new HashSet<>();
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApiVersionsIntersectFilter.class);
 
     public ApiVersionsIntersectFilter(ApiVersionsServiceImpl service) {
         this.apiVersionsService = service;
     }
 
+
     @Override
     public CompletionStage<ResponseFilterResult> onApiVersionsResponse(short apiVersion, ResponseHeaderData header, ApiVersionsResponseData data,
                                                                        FilterContext context) {
+        if(unsupportedApiVersionsRequest.contains(header.correlationId())) {
+            LOGGER.info("setting unsupported error response version for {}", header.correlationId());
+            data.setErrorCode(Errors.UNSUPPORTED_VERSION.code());
+            unsupportedApiVersionsRequest.remove(header.correlationId());
+        }
         apiVersionsService.updateVersions(context.channelDescriptor(), data);
         return context.forwardResponse(header, data);
+    }
+
+    @Override
+    public CompletionStage<RequestFilterResult> onApiVersionsRequest(short apiVersion, RequestHeaderData header, ApiVersionsRequestData request, FilterContext context) {
+        if(UNSUPPORTED_VERSION_REMOVE_BEFORE_FORWARD.equals(request.clientSoftwareName())) {
+            LOGGER.info("marking {} as an unsupported request", header.correlationId());
+            unsupportedApiVersionsRequest.add(header.correlationId());
+            request.setClientSoftwareName("");
+        }
+        return context.forwardRequest(header, request);
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

If we receive an ApiVersion request at a version higher than the proxy supports we want to tell the client that it is unsupported along with the highest ApiVersions version that is supported by broker and proxy.

To do this the proxy intercepts the ApiVersions request, substituting it's own v0 request to the broker to obtain the broker supported versions. Then when the proxy intercepts the response it sets the UNSUPPORTED_VERSION error on the response to tell the client to try again with the highest supported ApiVersions version.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
