### PR TITLE
Draft: Handle client apiversions ahead of proxy

### DIFF
--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/ResponsePayload.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/ResponsePayload.java
@@ -11,4 +11,17 @@ import org.apache.kafka.common.protocol.ApiMessage;
 
 public record ResponsePayload(ApiKeys apiKeys,
                               short apiVersion,
-                              ApiMessage message) {}
+                              ApiMessage message,
+                              short responseApiVersion) {
+
+    public ResponsePayload(ApiKeys apiKeys, short apiVersion, ApiMessage message) {
+        this(apiKeys, apiVersion, message, apiVersion);
+    }
+
+    public ResponsePayload(ApiKeys apiKeys, short apiVersion, ApiMessage message, short responseApiVersion) {
+        this.apiKeys = apiKeys;
+        this.apiVersion = apiVersion;
+        this.message = message;
+        this.responseApiVersion = responseApiVersion;
+    }
+}

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/KafkaClientHandler.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/KafkaClientHandler.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 
-import io.kroxylicious.test.codec.DecodedRequestFrame;
+import io.kroxylicious.test.codec.RequestFrame;
 
 /**
  * Simple kafka handle capable of sending one or more requests to a server side.
@@ -23,7 +23,7 @@ import io.kroxylicious.test.codec.DecodedRequestFrame;
 public class KafkaClientHandler extends ChannelInboundHandlerAdapter {
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaClientHandler.class);
 
-    private final Deque<DecodedRequestFrame<?>> queue = new ConcurrentLinkedDeque<>();
+    private final Deque<RequestFrame> queue = new ConcurrentLinkedDeque<>();
     private ChannelHandlerContext ctx;
 
     // Read/Mutated by the Netty thread only.
@@ -63,7 +63,7 @@ public class KafkaClientHandler extends ChannelInboundHandlerAdapter {
      * @param decodedRequestFrame request frame to send
      * @return future that will yield the response along with a sequenceNumber indicating the order it was received by the client.
      */
-    public CompletableFuture<SequencedResponse> sendRequest(DecodedRequestFrame<?> decodedRequestFrame) {
+    public CompletableFuture<SequencedResponse> sendRequest(RequestFrame decodedRequestFrame) {
         queue.addLast(decodedRequestFrame);
         processPendingWrites();
         return decodedRequestFrame.getResponseFuture();

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/ByteBufAccessor.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/ByteBufAccessor.java
@@ -7,12 +7,13 @@ package io.kroxylicious.test.codec;
 
 import java.nio.ByteBuffer;
 
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.protocol.Writable;
 
 /**
  * Provides write access to byte buffer for serializing frames.
  */
-public interface ByteBufAccessor extends Writable {
+public interface ByteBufAccessor extends Writable, Readable {
 
     @Override
     void writeByte(byte val);
@@ -56,4 +57,14 @@ public interface ByteBufAccessor extends Writable {
      */
     int writerIndex();
 
+    /**
+     * Get reader index
+     * @return readerIndex of underlying buffer
+     */
+    int readerIndex();
+
+    /**
+     * set reader index of underlying buffer
+     */
+    void readerIndex(int index);
 }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/ByteBufAccessorImpl.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/ByteBufAccessorImpl.java
@@ -7,8 +7,6 @@ package io.kroxylicious.test.codec;
 
 import java.nio.ByteBuffer;
 
-import org.apache.kafka.common.protocol.Readable;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 
@@ -21,7 +19,7 @@ import io.netty.buffer.ByteBufUtil;
  * depends on NIO ByteBuffer, so copying between ByteBuffer and ByteBuf cannot
  * always be avoided.
  */
-public class ByteBufAccessorImpl implements ByteBufAccessor, Readable {
+public class ByteBufAccessorImpl implements ByteBufAccessor {
 
     private final ByteBuf buf;
 
@@ -240,6 +238,16 @@ public class ByteBufAccessorImpl implements ByteBufAccessor, Readable {
     @Override
     public int writerIndex() {
         return buf.writerIndex();
+    }
+
+    @Override
+    public int readerIndex() {
+        return buf.readerIndex();
+    }
+
+    @Override
+    public void readerIndex(int index) {
+        buf.readerIndex(index);
     }
 
 }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/DecodedRequestFrame.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/DecodedRequestFrame.java
@@ -19,7 +19,7 @@ import io.kroxylicious.test.client.SequencedResponse;
  */
 public class DecodedRequestFrame<B extends ApiMessage>
         extends DecodedFrame<RequestHeaderData, B>
-        implements Frame {
+        implements RequestFrame {
 
     private final CompletableFuture<SequencedResponse> responseFuture = new CompletableFuture<>();
 

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/KafkaRequestDecoder.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/KafkaRequestDecoder.java
@@ -51,7 +51,6 @@ public class KafkaRequestDecoder extends KafkaMessageDecoder {
         LOGGER.debug("{}: {} downstream correlation id: {}", ctx, apiKey, correlationId);
 
         RequestHeaderData header;
-        final ByteBufAccessorImpl accessor;
         var decodeRequest = true;
         LOGGER.debug("Decode {}/v{} request? {}", apiKey, apiVersion, decodeRequest);
         boolean decodeResponse = true;
@@ -61,13 +60,13 @@ public class KafkaRequestDecoder extends KafkaMessageDecoder {
             log().trace("{}: headerVersion {}", ctx, headerVersion);
         }
         in.readerIndex(sof);
-        accessor = new ByteBufAccessorImpl(in);
-        header = readHeader(headerVersion, accessor);
+        ByteBufAccessorImpl acc = new ByteBufAccessorImpl(in);
+        header = readHeader(headerVersion, acc);
         if (log().isTraceEnabled()) {
             log().trace("{}: header: {}", ctx, header);
         }
         final Frame frame;
-        ApiMessage body = BodyDecoder.decodeRequest(apiKey, apiVersion, accessor);
+        ApiMessage body = BodyDecoder.decodeRequest(apiKey, apiVersion, acc);
         if (log().isTraceEnabled()) {
             log().trace("{}: body {}", ctx, body);
         }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/KafkaRequestEncoder.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/KafkaRequestEncoder.java
@@ -16,7 +16,7 @@ import io.kroxylicious.test.client.CorrelationManager;
 /**
  * Kafka Request Encoder
  */
-public class KafkaRequestEncoder extends KafkaMessageEncoder<DecodedRequestFrame<?>> {
+public class KafkaRequestEncoder extends KafkaMessageEncoder<RequestFrame> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaRequestEncoder.class);
 
@@ -36,7 +36,7 @@ public class KafkaRequestEncoder extends KafkaMessageEncoder<DecodedRequestFrame
     }
 
     @Override
-    protected void encode(ChannelHandlerContext ctx, DecodedRequestFrame frame, ByteBuf out) throws Exception {
+    protected void encode(ChannelHandlerContext ctx, RequestFrame frame, ByteBuf out) throws Exception {
         super.encode(ctx, frame, out);
         if (frame.hasResponse()) {
             correlationManager.putBrokerRequest(frame.apiKey().id, frame.apiVersion(), frame.correlationId(), frame.getResponseFuture());

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/OpaqueRequestFrame.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/OpaqueRequestFrame.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test.codec;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.buffer.ByteBuf;
+
+import io.kroxylicious.test.client.SequencedResponse;
+
+/**
+ * A frame in the Kafka protocol which has not been decoded.
+ * The wrapped buffer <strong>does not</strong> include the frame size prefix.
+ */
+public class OpaqueRequestFrame implements RequestFrame {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(io.kroxylicious.proxy.frame.OpaqueFrame.class);
+
+    /**
+     * Number of bytes required for storing the frame length.
+     */
+    private static final int FRAME_SIZE_LENGTH = Integer.BYTES;
+
+    protected final int length;
+    protected final int correlationId;
+    /** The message buffer excluding the frame size, including the header and body. */
+    protected final ByteBuf buf;
+    private final boolean hasResponse;
+    private final CompletableFuture<SequencedResponse> responseFuture = new CompletableFuture<>();
+    private final ApiKeys apiKey;
+    private final short apiVersion;
+
+    /**
+     * @param buf The message buffer (excluding the frame size)
+     * @param correlationId The correlation id
+     * @param length The length of the frame within {@code buf}.
+     * @param hasResponse do we expect a response
+     */
+    public OpaqueRequestFrame(ByteBuf buf, int correlationId, int length, boolean hasResponse, ApiKeys apiKey, short apiVersion) {
+        this.length = length;
+        this.correlationId = correlationId;
+        this.buf = buf.asReadOnly();
+        this.apiKey = apiKey;
+        this.apiVersion = apiVersion;
+        if (buf.readableBytes() != length) {
+            throw new AssertionError("readable: " + buf.readableBytes() + " length: " + length);
+        }
+        this.hasResponse = hasResponse;
+    }
+
+    @Override
+    public int correlationId() {
+        return correlationId;
+    }
+
+    @Override
+    public int estimateEncodedSize() {
+        return FRAME_SIZE_LENGTH + length;
+    }
+
+    @Override
+    public void encode(ByteBufAccessor out) {
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace("Writing {} with 4 byte length ({}) plus {} bytes from buffer {} to {}",
+                    getClass().getSimpleName(), length, buf.readableBytes(), buf, out);
+        }
+        out.ensureWritable(estimateEncodedSize());
+        out.writeInt(length);
+        byte[] bytes = new byte[length];
+        buf.readBytes(bytes);
+        out.writeByteArray(bytes);
+        buf.release();
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(" +
+                "length=" + length +
+                ", buf=" + buf +
+                ')';
+    }
+
+    @Override
+    public CompletableFuture<SequencedResponse> getResponseFuture() {
+        return responseFuture;
+    }
+
+    @Override
+    public boolean hasResponse() {
+        return hasResponse;
+    }
+
+    @Override
+    public ApiKeys apiKey() {
+        return apiKey;
+    }
+
+    @Override
+    public short apiVersion() {
+        return apiVersion;
+    }
+}

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/RequestFrame.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/RequestFrame.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test.codec;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+
+import io.kroxylicious.test.client.SequencedResponse;
+
+public interface RequestFrame extends Frame {
+
+    CompletableFuture<SequencedResponse> getResponseFuture();
+
+    /**
+     * Whether the Kafka Client expects a response to this request
+     * @return Whether the Kafka Client expects a response to this request
+     */
+    default boolean hasResponse() {
+        return true;
+    }
+
+    /**
+     * Get apiKey of body
+     * @return apiKey
+     */
+    ApiKeys apiKey();
+
+    /**
+     * Get apiVersion of frame
+     * @return apiKey
+     */
+    short apiVersion();
+
+}

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/Action.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/Action.java
@@ -24,9 +24,20 @@ interface Action {
 
     static Action respond(ApiMessage message) {
         return (ctx, frame) -> {
-            DecodedResponseFrame<?> responseFrame = new DecodedResponseFrame<>(frame.apiVersion(),
-                    frame.correlationId(), new ResponseHeaderData().setCorrelationId(frame.correlationId()), message);
-            ctx.write(responseFrame);
+            writeResponse(message, ctx, frame, frame.apiVersion());
         };
     }
+
+    static Action respond(ApiMessage message, short apiVersion) {
+        return (ctx, frame) -> {
+            writeResponse(message, ctx, frame, apiVersion);
+        };
+    }
+
+    private static void writeResponse(ApiMessage message, ChannelHandlerContext ctx, DecodedRequestFrame<?> frame, short apiVersion) {
+        DecodedResponseFrame<?> responseFrame = new DecodedResponseFrame<>(apiVersion,
+                frame.correlationId(), new ResponseHeaderData().setCorrelationId(frame.correlationId()), message);
+        ctx.write(responseFrame);
+    }
+
 }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/MockHandler.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/MockHandler.java
@@ -86,6 +86,7 @@ public class MockHandler extends ChannelInboundHandlerAdapter {
 
     /**
      * Set the response
+     *
      * @param response response
      */
     public void setMockResponseForApiKey(ApiKeys keys, ApiMessage response) {
@@ -100,6 +101,26 @@ public class MockHandler extends ChannelInboundHandlerAdapter {
                 description.appendText("has key " + keys);
             }
         }, Action.respond(response));
+    }
+
+    /**
+     * Set the response
+     *
+     * @param response response
+     * @param responseApiVersion apiVersion used to encode mock response
+     */
+    public void setMockResponseForApiKey(ApiKeys keys, ApiMessage response, short responseApiVersion) {
+        addMockResponse(new TypeSafeMatcher<>() {
+            @Override
+            protected boolean matchesSafely(Request request) {
+                return request.apiKeys() == keys;
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("has key " + keys);
+            }
+        }, Action.respond(response, responseApiVersion));
     }
 
     public void addMockResponse(Matcher<Request> matcher, Action action) {

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/MockServer.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/MockServer.java
@@ -50,7 +50,7 @@ public final class MockServer implements AutoCloseable {
      */
     public void addMockResponseForApiKey(ResponsePayload response) {
         Objects.requireNonNull(response);
-        serverHandler.setMockResponseForApiKey(response.apiKeys(), response.message());
+        serverHandler.setMockResponseForApiKey(response.apiKeys(), response.message(), response.responseApiVersion());
     }
 
     /**
@@ -60,7 +60,7 @@ public final class MockServer implements AutoCloseable {
     public void addMockResponse(Matcher<Request> requestMatcher, ResponsePayload response) {
         Objects.requireNonNull(response);
         Objects.requireNonNull(requestMatcher);
-        serverHandler.addMockResponse(requestMatcher, Action.respond(response.message()));
+        serverHandler.addMockResponse(requestMatcher, Action.respond(response.message(), response.responseApiVersion()));
     }
 
     public void dropWhen(Matcher<Request> requestMatcher) {

--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -142,6 +142,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <scope>test</scope>

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ApiVersionsDowngradeIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ApiVersionsDowngradeIT.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.ObjectSerializationCache;
+import org.junit.jupiter.api.Test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+import io.kroxylicious.test.Request;
+import io.kroxylicious.test.Response;
+import io.kroxylicious.test.ResponsePayload;
+import io.kroxylicious.test.codec.ByteBufAccessorImpl;
+import io.kroxylicious.test.codec.OpaqueRequestFrame;
+import io.kroxylicious.test.tester.KroxyliciousConfigUtils;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.common.SaslMechanism;
+
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
+import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
+import static io.kroxylicious.test.tester.KroxyliciousTesters.mockKafkaKroxyliciousTester;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * <p>
+ * In addition to the behaviour tested by {@link ApiVersionsIT} we also need to handle the client
+ * sending ApiVersions requests at an apiVersion higher than the proxy understands. With no proxy
+ * involved, the behaviour is the broker will respond with a v0 apiversions response and the error
+ * code is set to UNSUPPORTED_VERSION, so that the client can retry.
+ * </p>
+ * <br>
+ * In this case the proxy will:
+ * <ol>
+ *     <li>detect that it does not know the apiVersion in the frame</li>
+ *     <li>create and forward an ApiVersions request at the highest api version the proxy is aware of</li>
+ *     <li>correlate the response and ensure we respond with UNSUPPORTED_VERSION error and a v0 response.</li>
+ * </ol>
+ * <p>
+ * Step 3 has two flavours, if the broker responds with UNSUPPORTED_VERSION we assume the response is
+ * v0 and pass it through. If the broker responds successfully to our request, we downgrade it to a
+ * v0 response and set the error code in the proxy.
+ * </p>
+ */
+public class ApiVersionsDowngradeIT extends BaseIT {
+
+    @Test
+    void withRealBrokerAtSameVersionAsProxyClientAhead(KafkaCluster cluster) {
+        try (var tester = kroxyliciousTester(proxy(cluster));
+                var client = tester.simpleTestClient()) {
+            ApiVersionsResponseData mockResponse = new ApiVersionsResponseData();
+            ApiVersionsResponseData.ApiVersion version = new ApiVersionsResponseData.ApiVersion();
+            version.setApiKey(ApiKeys.METADATA.id).setMinVersion(ApiKeys.METADATA.oldestVersion()).setMaxVersion((short) (ApiKeys.METADATA.latestVersion() + 1));
+            mockResponse.apiKeys().add(version);
+            short apiKey = ApiKeys.API_VERSIONS.id;
+            int correlationId = 100;
+            RequestHeaderData requestHeaderData = new RequestHeaderData();
+            short unsupportedVersion = (short) (ApiKeys.API_VERSIONS.latestVersion(true) + 1);
+            requestHeaderData.setRequestApiKey(apiKey);
+            requestHeaderData.setClientId("THANG");
+            requestHeaderData.setRequestApiVersion(unsupportedVersion);
+            requestHeaderData.setCorrelationId(correlationId);
+            ObjectSerializationCache cache = new ObjectSerializationCache();
+            short requestHeaderVersion = ApiKeys.API_VERSIONS.requestHeaderVersion(unsupportedVersion);
+            int headerSize = requestHeaderData.size(cache, requestHeaderVersion);
+            int messageSize = headerSize + 4;
+            ByteBuf buffer = Unpooled.buffer(messageSize, messageSize);
+            int arbitraryBodyData = Integer.MAX_VALUE;
+            ByteBufAccessorImpl accessor = new ByteBufAccessorImpl(buffer);
+            requestHeaderData.write(accessor, cache, requestHeaderVersion);
+            accessor.writeInt(arbitraryBodyData);
+
+            CompletableFuture<Response> responseCompletableFuture = client.get(
+                    new OpaqueRequestFrame(buffer, correlationId, messageSize, true, ApiKeys.API_VERSIONS, unsupportedVersion));
+            assertThat(responseCompletableFuture).succeedsWithin(5, TimeUnit.SECONDS).satisfies(response1 -> {
+                assertThat(response1.payload().apiKeys()).isEqualTo(ApiKeys.API_VERSIONS);
+                assertThat(response1.payload().message()).isInstanceOfSatisfying(ApiVersionsResponseData.class, (data) -> {
+                    assertThat(data.errorCode()).isEqualTo(Errors.UNSUPPORTED_VERSION.code());
+                    ApiVersionsResponseData.ApiVersion expected = new ApiVersionsResponseData.ApiVersion();
+                    expected.setApiKey(ApiKeys.API_VERSIONS.id).setMinVersion(ApiKeys.API_VERSIONS.oldestVersion()).setMaxVersion(ApiKeys.API_VERSIONS.latestVersion());
+                    ApiVersionsResponseData.ApiVersionCollection collection = new ApiVersionsResponseData.ApiVersionCollection();
+                    collection.add(expected);
+                    assertThat(data.apiKeys()).isEqualTo(collection);
+                });
+            });
+            // simulate follow-up request to check the broker tolerates the client retrying
+            ApiVersionsRequestData message = new ApiVersionsRequestData();
+            message.setClientSoftwareName("testclient");
+            message.setClientSoftwareVersion("v1");
+            CompletableFuture<Response> responseCompletableFuture1 = client.get(
+                    new Request(ApiKeys.API_VERSIONS, ApiKeys.API_VERSIONS.latestVersion(), "client", message));
+            assertThat(responseCompletableFuture1).succeedsWithin(5, TimeUnit.SECONDS).satisfies(response1 -> {
+                assertThat(response1.payload().apiKeys()).isEqualTo(ApiKeys.API_VERSIONS);
+                assertThat(response1.payload().message()).isInstanceOfSatisfying(ApiVersionsResponseData.class, (data) -> {
+                    assertThat(data.errorCode()).isEqualTo((short) 0);
+                    // calculating the exact APIs coming back from the broker is a bit tricky, it will evolve over time
+                    // maybe we could hit the broker directly and figure out our expected output from that
+                    assertThat(data.apiKeys()).hasSizeGreaterThan(1);
+                });
+            });
+        }
+    }
+
+    @Test
+    void withRealSaslBrokerAtSameVersionAsProxyClientAhead(@SaslMechanism(principals = {
+            @SaslMechanism.Principal(user = "user", password = "pass") }) KafkaCluster cluster) {
+        try (var tester = kroxyliciousTester(proxy(cluster));
+                var client = tester.simpleTestClient()) {
+            ApiVersionsResponseData mockResponse = new ApiVersionsResponseData();
+            ApiVersionsResponseData.ApiVersion version = new ApiVersionsResponseData.ApiVersion();
+            version.setApiKey(ApiKeys.METADATA.id).setMinVersion(ApiKeys.METADATA.oldestVersion()).setMaxVersion((short) (ApiKeys.METADATA.latestVersion() + 1));
+            mockResponse.apiKeys().add(version);
+            short apiKey = ApiKeys.API_VERSIONS.id;
+            int correlationId = 100;
+            RequestHeaderData requestHeaderData = new RequestHeaderData();
+            short unsupportedVersion = (short) (ApiKeys.API_VERSIONS.latestVersion(true) + 1);
+            requestHeaderData.setRequestApiKey(apiKey);
+            requestHeaderData.setClientId("THANG");
+            requestHeaderData.setRequestApiVersion(unsupportedVersion);
+            requestHeaderData.setCorrelationId(correlationId);
+            ObjectSerializationCache cache = new ObjectSerializationCache();
+            short requestHeaderVersion = ApiKeys.API_VERSIONS.requestHeaderVersion(unsupportedVersion);
+            int headerSize = requestHeaderData.size(cache, requestHeaderVersion);
+            int messageSize = headerSize + 4;
+            ByteBuf buffer = Unpooled.buffer(messageSize, messageSize);
+            int arbitraryBodyData = Integer.MAX_VALUE;
+            ByteBufAccessorImpl accessor = new ByteBufAccessorImpl(buffer);
+            requestHeaderData.write(accessor, cache, requestHeaderVersion);
+            accessor.writeInt(arbitraryBodyData);
+
+            CompletableFuture<Response> responseCompletableFuture = client.get(
+                    new OpaqueRequestFrame(buffer, correlationId, messageSize, true, ApiKeys.API_VERSIONS, unsupportedVersion));
+            assertThat(responseCompletableFuture).succeedsWithin(5, TimeUnit.SECONDS).satisfies(response1 -> {
+                assertThat(response1.payload().apiKeys()).isEqualTo(ApiKeys.API_VERSIONS);
+                assertThat(response1.payload().message()).isInstanceOfSatisfying(ApiVersionsResponseData.class, (data) -> {
+                    assertThat(data.errorCode()).isEqualTo(Errors.UNSUPPORTED_VERSION.code());
+                    ApiVersionsResponseData.ApiVersion expected = new ApiVersionsResponseData.ApiVersion();
+                    expected.setApiKey(ApiKeys.API_VERSIONS.id).setMinVersion(ApiKeys.API_VERSIONS.oldestVersion()).setMaxVersion(ApiKeys.API_VERSIONS.latestVersion());
+                    ApiVersionsResponseData.ApiVersionCollection collection = new ApiVersionsResponseData.ApiVersionCollection();
+                    collection.add(expected);
+                    assertThat(data.apiKeys()).isEqualTo(collection);
+                });
+            });
+            // simulate follow-up request to check the broker tolerates the client retrying
+            ApiVersionsRequestData message = new ApiVersionsRequestData();
+            message.setClientSoftwareName("testclient");
+            message.setClientSoftwareVersion("v1");
+            CompletableFuture<Response> responseCompletableFuture1 = client.get(
+                    new Request(ApiKeys.API_VERSIONS, ApiKeys.API_VERSIONS.latestVersion(), "client", message));
+            // currently failing because the broker SASL state machine doesn't tolerate receiving a second valid ApiVersionsRequest
+            assertThat(responseCompletableFuture1).succeedsWithin(5, TimeUnit.SECONDS).satisfies(response1 -> {
+                assertThat(response1.payload().apiKeys()).isEqualTo(ApiKeys.API_VERSIONS);
+                assertThat(response1.payload().message()).isInstanceOfSatisfying(ApiVersionsResponseData.class, (data) -> {
+                    assertThat(data.errorCode()).isEqualTo((short) 0);
+                    // calculating the exact APIs coming back from the broker is a bit tricky, it will evolve over time
+                    // maybe we could hit the broker directly and figure out our expected output from that
+                    assertThat(data.apiKeys()).hasSizeGreaterThan(1);
+                });
+            });
+        }
+    }
+
+    @Test
+    void clientAheadOfProxy_BrokerUnderstandsLatestProxyVersion() {
+        try (var tester = mockKafkaKroxyliciousTester(KroxyliciousConfigUtils::proxy);
+                var client = tester.simpleTestClient()) {
+            ApiVersionsResponseData mockResponse = new ApiVersionsResponseData();
+            ApiVersionsResponseData.ApiVersion version = new ApiVersionsResponseData.ApiVersion();
+            version.setApiKey(ApiKeys.API_VERSIONS.id).setMinVersion(ApiKeys.API_VERSIONS.oldestVersion())
+                    .setMaxVersion((short) (ApiKeys.API_VERSIONS.latestVersion() + 1));
+            mockResponse.apiKeys().add(version);
+            tester.addMockResponseForApiKey(new ResponsePayload(ApiKeys.API_VERSIONS, (short) 0, mockResponse));
+
+            short apiKey = ApiKeys.API_VERSIONS.id;
+            int correlationId = 100;
+            RequestHeaderData requestHeaderData = new RequestHeaderData();
+            short unsupportedVersion = (short) (ApiKeys.API_VERSIONS.latestVersion(true) + 1);
+            requestHeaderData.setRequestApiKey(apiKey);
+            requestHeaderData.setRequestApiVersion(unsupportedVersion);
+            requestHeaderData.setCorrelationId(correlationId);
+            ObjectSerializationCache cache = new ObjectSerializationCache();
+            short requestHeaderVersion = ApiKeys.API_VERSIONS.requestHeaderVersion(unsupportedVersion);
+            int headerSize = requestHeaderData.size(cache, requestHeaderVersion);
+            int messageSize = headerSize + 4;
+            ByteBuf buffer = Unpooled.buffer(messageSize, messageSize);
+            int arbitraryBodyData = Integer.MAX_VALUE;
+            ByteBufAccessorImpl accessor = new ByteBufAccessorImpl(buffer);
+            requestHeaderData.write(accessor, cache, requestHeaderVersion);
+            accessor.writeInt(arbitraryBodyData);
+
+            CompletableFuture<Response> responseCompletableFuture = client.get(
+                    new OpaqueRequestFrame(buffer, correlationId, messageSize, true, ApiKeys.API_VERSIONS, unsupportedVersion));
+            assertThat(responseCompletableFuture).succeedsWithin(5, TimeUnit.SECONDS).satisfies(response1 -> {
+                assertThat(response1.payload().apiKeys()).isEqualTo(ApiKeys.API_VERSIONS);
+                assertThat(response1.payload().message()).isInstanceOfSatisfying(ApiVersionsResponseData.class, (data) -> {
+                    assertThat(data.errorCode()).isEqualTo(Errors.UNSUPPORTED_VERSION.code());
+                    ApiVersionsResponseData.ApiVersion expected = new ApiVersionsResponseData.ApiVersion();
+                    expected.setApiKey(ApiKeys.API_VERSIONS.id).setMinVersion(ApiKeys.API_VERSIONS.oldestVersion()).setMaxVersion(ApiKeys.API_VERSIONS.latestVersion());
+                    ApiVersionsResponseData.ApiVersionCollection collection = new ApiVersionsResponseData.ApiVersionCollection();
+                    collection.add(expected);
+                    assertThat(data.apiKeys()).isEqualTo(collection);
+                });
+            });
+        }
+    }
+
+    @Test
+    void clientAheadOfProxy_BrokerDoesNotUnderstandProxyVersion() {
+        try (var tester = mockKafkaKroxyliciousTester(KroxyliciousConfigUtils::proxy);
+                var client = tester.simpleTestClient()) {
+            ApiVersionsResponseData mockResponse = new ApiVersionsResponseData();
+            mockResponse.setErrorCode(Errors.UNSUPPORTED_VERSION.code());
+            ApiVersionsResponseData.ApiVersion version = new ApiVersionsResponseData.ApiVersion();
+            version.setApiKey(ApiKeys.METADATA.id).setMinVersion(ApiKeys.METADATA.oldestVersion()).setMaxVersion((short) (ApiKeys.METADATA.latestVersion() + 1));
+            mockResponse.apiKeys().add(version);
+            tester.addMockResponseForApiKey(new ResponsePayload(ApiKeys.API_VERSIONS, ApiKeys.API_VERSIONS.latestVersion(true), mockResponse, (short) 0));
+            short apiKey = ApiKeys.API_VERSIONS.id;
+            int correlationId = 100;
+            RequestHeaderData requestHeaderData = new RequestHeaderData();
+            short unsupportedVersion = (short) (ApiKeys.API_VERSIONS.latestVersion(true) + 1);
+            requestHeaderData.setRequestApiKey(apiKey);
+            requestHeaderData.setRequestApiVersion(unsupportedVersion);
+            requestHeaderData.setCorrelationId(correlationId);
+            ObjectSerializationCache cache = new ObjectSerializationCache();
+            short requestHeaderVersion = ApiKeys.API_VERSIONS.requestHeaderVersion(unsupportedVersion);
+            int headerSize = requestHeaderData.size(cache, requestHeaderVersion);
+            int messageSize = headerSize + 4;
+            ByteBuf buffer = Unpooled.buffer(messageSize, messageSize);
+            int arbitraryBodyData = Integer.MAX_VALUE;
+            ByteBufAccessorImpl accessor = new ByteBufAccessorImpl(buffer);
+            requestHeaderData.write(accessor, cache, requestHeaderVersion);
+            accessor.writeInt(arbitraryBodyData);
+
+            CompletableFuture<Response> responseCompletableFuture = client.get(
+                    new OpaqueRequestFrame(buffer, correlationId, messageSize, true, ApiKeys.API_VERSIONS, unsupportedVersion));
+            assertThat(responseCompletableFuture).succeedsWithin(5, TimeUnit.SECONDS).satisfies(response1 -> {
+                assertThat(response1.payload().apiKeys()).isEqualTo(ApiKeys.API_VERSIONS);
+                assertThat(response1.payload().message()).isInstanceOfSatisfying(ApiVersionsResponseData.class, (data) -> {
+                    assertThat(data.errorCode()).isEqualTo(Errors.UNSUPPORTED_VERSION.code());
+                    ApiVersionsResponseData.ApiVersion expected = new ApiVersionsResponseData.ApiVersion();
+                    expected.setApiKey(ApiKeys.METADATA.id).setMinVersion(ApiKeys.METADATA.oldestVersion()).setMaxVersion(ApiKeys.METADATA.latestVersion());
+                    ApiVersionsResponseData.ApiVersionCollection collection = new ApiVersionsResponseData.ApiVersionCollection();
+                    collection.add(expected);
+                    assertThat(data.apiKeys()).isEqualTo(collection);
+                });
+            });
+        }
+    }
+
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/BareSaslRequest.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/BareSaslRequest.java
@@ -5,6 +5,8 @@
  */
 package io.kroxylicious.proxy.frame;
 
+import static io.kroxylicious.proxy.frame.LazyRequestResponseState.lazyRequestResponseState;
+
 /**
  * Ancient versions of Kafka implemented SASL/GSSAPI by sending the token
  * on the wire as length prefixed bytes (no Kafka protocol header).
@@ -16,6 +18,7 @@ public class BareSaslRequest implements RequestFrame {
 
     private final byte[] bytes;
     private final boolean decodeResponse;
+    private final RequestResponseState requestResponseState = lazyRequestResponseState();
 
     public BareSaslRequest(byte[] bytes, boolean decodeResponse) {
         this.bytes = bytes;
@@ -35,6 +38,11 @@ public class BareSaslRequest implements RequestFrame {
     @Override
     public int correlationId() {
         return 0;
+    }
+
+    @Override
+    public RequestResponseState requestResponseState() {
+        return requestResponseState;
     }
 
     @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/BareSaslResponse.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/BareSaslResponse.java
@@ -5,6 +5,8 @@
  */
 package io.kroxylicious.proxy.frame;
 
+import static io.kroxylicious.proxy.frame.LazyRequestResponseState.lazyRequestResponseState;
+
 /**
  * Ancient versions of Kafka implemented SASL/GSSAPI by sending the response
  * on the wire as length prefixed bytes (no Kafka protocol header).
@@ -13,6 +15,7 @@ package io.kroxylicious.proxy.frame;
 public class BareSaslResponse implements ResponseFrame {
 
     private final byte[] bytes;
+    private final RequestResponseState requestResponseState = lazyRequestResponseState();
 
     public BareSaslResponse(byte[] bytes) {
         this.bytes = bytes;
@@ -31,6 +34,11 @@ public class BareSaslResponse implements ResponseFrame {
     @Override
     public int correlationId() {
         return 0;
+    }
+
+    @Override
+    public RequestResponseState requestResponseState() {
+        return requestResponseState;
     }
 
     public byte[] bytes() {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/DecodedRequestFrame.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/DecodedRequestFrame.java
@@ -9,6 +9,7 @@ import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
 
+import static io.kroxylicious.proxy.frame.LazyRequestResponseState.lazyRequestResponseState;
 import static org.apache.kafka.common.protocol.ApiKeys.PRODUCE;
 
 /**
@@ -19,6 +20,7 @@ public class DecodedRequestFrame<B extends ApiMessage>
         implements RequestFrame {
 
     private final boolean decodeResponse;
+    private final RequestResponseState requestResponseState = lazyRequestResponseState();
 
     public DecodedRequestFrame(short apiVersion,
                                int correlationId,
@@ -48,4 +50,8 @@ public class DecodedRequestFrame<B extends ApiMessage>
         return apiKey() == PRODUCE && ((ProduceRequestData) body).acks() == 0;
     }
 
+    @Override
+    public RequestResponseState requestResponseState() {
+        return requestResponseState;
+    }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/DecodedResponseFrame.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/DecodedResponseFrame.java
@@ -15,11 +15,19 @@ public class DecodedResponseFrame<B extends ApiMessage>
         extends DecodedFrame<ResponseHeaderData, B>
         implements ResponseFrame {
 
-    public DecodedResponseFrame(short apiVersion, int correlationId, ResponseHeaderData header, B body) {
+    private final RequestResponseState requestResponseState;
+
+    public DecodedResponseFrame(short apiVersion, int correlationId, ResponseHeaderData header, B body, RequestResponseState requestResponseState) {
         super(apiVersion, correlationId, header, body);
+        this.requestResponseState = requestResponseState;
     }
 
     public short headerVersion() {
         return apiKey().messageType.responseHeaderVersion(apiVersion);
+    }
+
+    @Override
+    public RequestResponseState requestResponseState() {
+        return requestResponseState;
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/Frame.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/Frame.java
@@ -28,4 +28,10 @@ public interface Frame {
      */
     int correlationId();
 
+    /**
+     * State for the request-response pair this frame is a part of
+     * @return the state
+     */
+    RequestResponseState requestResponseState();
+
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/LazyRequestResponseState.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/LazyRequestResponseState.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.frame;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LazyRequestResponseState implements RequestResponseState {
+
+    Map<Object, Object> state = null;
+
+    private LazyRequestResponseState() {
+    }
+
+    @Override
+    public <K, V> void putState(K key, V value) {
+        if (state == null) {
+            state = new HashMap<>();
+        }
+        state.put(key, value);
+    }
+
+    @Override
+    public <K, V> V getStateOrDefault(K key, V defaultValue) {
+        if (state == null) {
+            return defaultValue;
+        }
+        else {
+            Object o = state.get(key);
+            if (o == null) {
+                return defaultValue;
+            }
+            if (!defaultValue.getClass().isAssignableFrom(o.getClass())) {
+                throw new IllegalStateException(
+                        "value class " + defaultValue.getClass() + " is not assignable from " + o.getClass() + " unexpected type in the state map");
+            }
+            // noinspection unchecked
+            return (V) defaultValue.getClass().cast(o);
+        }
+    }
+
+    public static RequestResponseState lazyRequestResponseState() {
+        return new LazyRequestResponseState();
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/OpaqueRequestFrame.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/OpaqueRequestFrame.java
@@ -9,10 +9,13 @@ import org.apache.kafka.common.protocol.ApiKeys;
 
 import io.netty.buffer.ByteBuf;
 
+import static io.kroxylicious.proxy.frame.LazyRequestResponseState.lazyRequestResponseState;
+
 public class OpaqueRequestFrame extends OpaqueFrame implements RequestFrame {
 
     private final boolean decodeResponse;
     private boolean hasResponse;
+    private final RequestResponseState requestResponseState = lazyRequestResponseState();
 
     /**
      * @param buf The message buffer (excluding the frame size)
@@ -59,5 +62,10 @@ public class OpaqueRequestFrame extends OpaqueFrame implements RequestFrame {
         finally {
             buf.readerIndex(index);
         }
+    }
+
+    @Override
+    public RequestResponseState requestResponseState() {
+        return requestResponseState;
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/OpaqueResponseFrame.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/OpaqueResponseFrame.java
@@ -8,8 +8,12 @@ package io.kroxylicious.proxy.frame;
 import io.netty.buffer.ByteBuf;
 
 public class OpaqueResponseFrame extends OpaqueFrame implements ResponseFrame {
-    public OpaqueResponseFrame(ByteBuf buf, int correlationId, int length) {
+
+    private final RequestResponseState requestResponseState;
+
+    public OpaqueResponseFrame(ByteBuf buf, int correlationId, int length, RequestResponseState requestResponseState) {
         super(buf, correlationId, length);
+        this.requestResponseState = requestResponseState;
     }
 
     @Override
@@ -26,5 +30,10 @@ public class OpaqueResponseFrame extends OpaqueFrame implements ResponseFrame {
         finally {
             buf.readerIndex(index);
         }
+    }
+
+    @Override
+    public RequestResponseState requestResponseState() {
+        return requestResponseState;
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/RequestResponseState.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/RequestResponseState.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.frame;
+
+/**
+ * Represents additional state associated with a single request-response pair.
+ * This is to enable the Runtime, and perhaps later Filters, to attach state to
+ * a Request-Response pair.
+ */
+public interface RequestResponseState {
+
+    <K, V> void putState(K key, V value);
+
+    <K, V> V getStateOrDefault(K key, V defaultValue);
+
+    static RequestResponseState empty() {
+        return new RequestResponseState() {
+            @Override
+            public <K, V> void putState(K key, V value) {
+                throw new UnsupportedOperationException("empty request response state is immutable");
+            }
+
+            @Override
+            public <K, V> V getStateOrDefault(K key, V defaultValue) {
+                return defaultValue;
+            }
+        };
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ApiVersionsDowngrader.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ApiVersionsDowngrader.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+
+import io.kroxylicious.proxy.frame.DecodedFrame;
+import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.frame.Frame;
+
+import static io.kroxylicious.proxy.internal.codec.KafkaRequestDecoder.CLIENT_AHEAD_OF_PROXY;
+
+public class ApiVersionsDowngrader extends ChannelOutboundHandlerAdapter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApiVersionsDowngrader.class);
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        if (msg instanceof Frame responseFrame && responseFrame.requestResponseState().getStateOrDefault(CLIENT_AHEAD_OF_PROXY, false)) {
+            if (responseFrame instanceof DecodedFrame<?, ?> decodedFrame) {
+                if (decodedFrame.body() instanceof ApiVersionsResponseData data) {
+                    if (data.errorCode() == Errors.UNSUPPORTED_VERSION.code()) {
+                        // broker already doesn't support, forward intersected versions to client
+                        LOGGER.info("{}: forwarding error response on, proxy max version ahead of broker", ctx);
+                        ctx.write(msg, promise);
+                    }
+                    else {
+                        // broker does support max proxy version, downgrade to v0 and set error code
+                        downgradeToV0Response(ctx, promise, responseFrame, decodedFrame, data);
+                    }
+                }
+                else {
+                    ctx.fireExceptionCaught(new IllegalStateException("expect to only intercept ApiVersionsResponseData"));
+                }
+            }
+            else {
+                ctx.fireExceptionCaught(new IllegalStateException("expect ApiVersions to be decoded"));
+            }
+        }
+        else {
+            ctx.write(msg, promise);
+        }
+    }
+
+    private static void downgradeToV0Response(ChannelHandlerContext ctx, ChannelPromise promise, Frame responseFrame, DecodedFrame<?, ?> decodedFrame,
+                                              ApiVersionsResponseData data) {
+        LOGGER.info("{}: respond with v0 unsupported version response", ctx);
+        ResponseHeaderData header = new ResponseHeaderData();
+        header.setCorrelationId(decodedFrame.correlationId());
+        ApiVersionsResponseData apiVersionsResponseData = new ApiVersionsResponseData();
+        apiVersionsResponseData.setErrorCode(Errors.UNSUPPORTED_VERSION.code());
+        ApiVersionsResponseData.ApiVersionCollection collection = new ApiVersionsResponseData.ApiVersionCollection();
+        ApiVersionsResponseData.ApiVersion version = data.apiKeys().find(ApiKeys.API_VERSIONS.id);
+        if (version != null) {
+            // copy, because min and max being set on the version prevents the version being added to the collection
+            ApiVersionsResponseData.ApiVersion version1 = new ApiVersionsResponseData.ApiVersion();
+            version1.setApiKey(version.apiKey());
+            version1.setMinVersion(version.minVersion());
+            version1.setMaxVersion(version.maxVersion());
+            collection.add(version1);
+        }
+        apiVersionsResponseData.setApiKeys(collection);
+        DecodedResponseFrame<ApiMessage> downgraded = new DecodedResponseFrame<>((short) 0, decodedFrame.correlationId(), header, apiVersionsResponseData,
+                responseFrame.requestResponseState());
+        ctx.write(downgraded, promise);
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -348,7 +348,7 @@ public class FilterHandler extends ChannelDuplexHandler {
                         "Attempt to respond with ApiMessage of type " + ApiKeys.forId(message.apiKey()) + " but request is of type " + decodedFrame.apiKey());
             }
             DecodedResponseFrame<?> responseFrame = new DecodedResponseFrame<>(decodedFrame.apiVersion(), decodedFrame.correlationId(),
-                    header, message);
+                    header, message, decodedFrame.requestResponseState());
             decodedFrame.transferBuffersTo(responseFrame);
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("{}: Forwarding response: {}", channelDescriptor(), decodedFrame);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/InternalResponseFrame.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/InternalResponseFrame.java
@@ -13,6 +13,7 @@ import org.apache.kafka.common.protocol.ApiMessage;
 
 import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.frame.RequestResponseState;
 
 public class InternalResponseFrame<B extends ApiMessage> extends DecodedResponseFrame<B> {
 
@@ -20,8 +21,9 @@ public class InternalResponseFrame<B extends ApiMessage> extends DecodedResponse
 
     private final CompletableFuture<?> future;
 
-    public InternalResponseFrame(Filter recipient, short apiVersion, int correlationId, ResponseHeaderData header, B body, CompletableFuture<?> future) {
-        super(apiVersion, correlationId, header, body);
+    public InternalResponseFrame(Filter recipient, short apiVersion, int correlationId, ResponseHeaderData header, B body, CompletableFuture<?> future,
+                                 RequestResponseState requestResponseState) {
+        super(apiVersion, correlationId, header, body, requestResponseState);
         this.recipient = Objects.requireNonNull(recipient);
         this.future = future;
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaAuthnHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaAuthnHandler.java
@@ -373,7 +373,7 @@ public class KafkaAuthnHandler extends ChannelInboundHandlerAdapter {
                         data.apiVersion(),
                         data.correlationId(),
                         new ResponseHeaderData().setCorrelationId(data.correlationId()),
-                        body));
+                        body, data.requestResponseState()));
     }
 
     private byte[] doEvaluateResponse(ChannelHandlerContext ctx,

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -285,7 +285,7 @@ public class KafkaProxyFrontendHandler
                 .setCorrelationId(correlationId);
         LOGGER.debug("{}: Writing ApiVersions response", ctx.channel());
         ctx.writeAndFlush(new DecodedResponseFrame<>(
-                apiVersion, correlationId, header, API_VERSIONS_RESPONSE));
+                apiVersion, correlationId, header, API_VERSIONS_RESPONSE, frame.requestResponseState()));
     }
 
     /**
@@ -638,7 +638,7 @@ public class KafkaProxyFrontendHandler
         var responseData = KafkaProxyExceptionMapper.errorResponseMessage(triggerFrame, error);
         final ResponseHeaderData responseHeaderData = new ResponseHeaderData();
         responseHeaderData.setCorrelationId(triggerFrame.correlationId());
-        return new DecodedResponseFrame<>(triggerFrame.apiVersion(), triggerFrame.correlationId(), responseHeaderData, responseData);
+        return new DecodedResponseFrame<>(triggerFrame.apiVersion(), triggerFrame.correlationId(), responseHeaderData, responseData, triggerFrame.requestResponseState());
     }
 
     /**

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -181,6 +181,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
         pipeline.addLast("requestDecoder", decoder);
         pipeline.addLast("responseEncoder", new KafkaResponseEncoder());
         pipeline.addLast("responseOrderer", new ResponseOrderer());
+        pipeline.addLast("apiVersionsDowngrader", new ApiVersionsDowngrader());
         if (virtualCluster.isLogFrames()) {
             pipeline.addLast("frameLogger", new LoggingHandler("io.kroxylicious.proxy.internal.DownstreamFrameLogger", LogLevel.INFO));
         }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestEncoder.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestEncoder.java
@@ -51,7 +51,9 @@ public class KafkaRequestEncoder extends KafkaMessageEncoder<RequestFrame> {
                 downstreamCorrelationId,
                 hasResponse,
                 frame instanceof InternalRequestFrame ? ((InternalRequestFrame<?>) frame).recipient() : null,
-                frame instanceof InternalRequestFrame ? ((InternalRequestFrame<?>) frame).promise() : null, decodeResponse);
+                frame instanceof InternalRequestFrame ? ((InternalRequestFrame<?>) frame).promise() : null,
+                decodeResponse,
+                frame.requestResponseState());
         out.writerIndex(LENGTH + API_KEY + API_VERSION);
         out.writeInt(upstreamCorrelationId);
         if (LOGGER.isDebugEnabled()) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
@@ -36,6 +36,7 @@ import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 import io.kroxylicious.proxy.frame.OpaqueRequestFrame;
 import io.kroxylicious.proxy.frame.OpaqueResponseFrame;
+import io.kroxylicious.proxy.frame.RequestResponseState;
 import io.kroxylicious.proxy.model.VirtualCluster;
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
 import io.kroxylicious.proxy.service.HostPort;
@@ -132,7 +133,7 @@ public abstract class FilterHarness {
      * @return the opaque frame written to the channel
      */
     protected OpaqueResponseFrame writeArbitraryOpaqueResponse() {
-        OpaqueResponseFrame frame = new OpaqueResponseFrame(Unpooled.buffer(), 55, 0);
+        OpaqueResponseFrame frame = new OpaqueResponseFrame(Unpooled.buffer(), 55, 0, RequestResponseState.empty());
         channel.writeOneInbound(frame);
         return frame;
     }
@@ -148,7 +149,7 @@ public abstract class FilterHarness {
         var header = new ResponseHeaderData();
         int correlationId = 42;
         header.setCorrelationId(correlationId);
-        var frame = new DecodedResponseFrame<>(apiKey.latestVersion(), correlationId, header, data);
+        var frame = new DecodedResponseFrame<>(apiKey.latestVersion(), correlationId, header, data, RequestResponseState.empty());
         channel.writeInbound(frame);
         return frame;
     }
@@ -171,7 +172,8 @@ public abstract class FilterHarness {
         if (correlation == null) {
             throw new IllegalStateException("No corresponding internal request known " + requestCorrelationId);
         }
-        var frame = new InternalResponseFrame<>(correlation.recipient(), apiKey.latestVersion(), requestCorrelationId, header, data, correlation.promise());
+        var frame = new InternalResponseFrame<>(correlation.recipient(), apiKey.latestVersion(), requestCorrelationId, header, data, correlation.promise(),
+                RequestResponseState.empty());
         channel.writeInbound(frame);
         return frame;
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaAuthnHandlerTest.java
@@ -57,6 +57,7 @@ import io.kroxylicious.proxy.frame.ByteBufAccessor;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 import io.kroxylicious.proxy.frame.RequestFrame;
+import io.kroxylicious.proxy.frame.RequestResponseState;
 import io.kroxylicious.proxy.internal.KafkaAuthnHandler.SaslMechanism;
 import io.kroxylicious.proxy.internal.codec.CorrelationManager;
 
@@ -216,7 +217,7 @@ public class KafkaAuthnHandlerTest {
 
                 return null;
             }
-        }, new CompletableFuture<>(), true);
+        }, new CompletableFuture<>(), true, RequestResponseState.empty());
 
         channel.writeInbound(new DecodedRequestFrame<>(apiVersion, corrId, true, header, body));
     }
@@ -576,6 +577,11 @@ public class KafkaAuthnHandlerTest {
 
         @Override
         public void encode(ByteBufAccessor out) {
+        }
+
+        @Override
+        public RequestResponseState requestResponseState() {
+            return RequestResponseState.empty();
         }
 
         @Override

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
@@ -45,6 +45,7 @@ import io.kroxylicious.proxy.filter.FilterAndInvoker;
 import io.kroxylicious.proxy.filter.NetFilter;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.frame.RequestResponseState;
 import io.kroxylicious.proxy.internal.ProxyChannelState.ApiVersions;
 import io.kroxylicious.proxy.internal.ProxyChannelState.SelectingServer;
 import io.kroxylicious.proxy.internal.codec.FrameOversizedException;
@@ -693,6 +694,6 @@ class ProxyChannelStateMachineTest {
                 MetadataRequestData.HIGHEST_SUPPORTED_VERSION,
                 0,
                 new ResponseHeaderData(),
-                new MetadataResponseData());
+                new MetadataResponseData(), RequestResponseState.empty());
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ResponseOrdererTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ResponseOrdererTest.java
@@ -14,6 +14,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.kroxylicious.proxy.frame.ByteBufAccessor;
 import io.kroxylicious.proxy.frame.Frame;
 import io.kroxylicious.proxy.frame.RequestFrame;
+import io.kroxylicious.proxy.frame.RequestResponseState;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,6 +40,11 @@ class ResponseOrdererTest {
             return correlationId;
         }
 
+        @Override
+        public RequestResponseState requestResponseState() {
+            return RequestResponseState.empty();
+        }
+
     }
 
     record TestRequestFrame(int correlationId, boolean hasResponse) implements RequestFrame {
@@ -56,6 +62,11 @@ class ResponseOrdererTest {
         @Override
         public int correlationId() {
             return correlationId;
+        }
+
+        @Override
+        public RequestResponseState requestResponseState() {
+            return RequestResponseState.empty();
         }
 
         @Override

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/CorrelationManagerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/CorrelationManagerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.codec;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.frame.RequestResponseState;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CorrelationManagerTest {
+
+    private final short apiKey = (short) 1;
+    private final short apiVersion = (short) 2;
+    private final int downstreamCorrelationId = 3;
+    private final Filter recipient = Mockito.mock(Filter.class);
+    private final CompletableFuture<Object> promise = new CompletableFuture<>();
+    private final RequestResponseState state = Mockito.mock(RequestResponseState.class);
+    private final boolean decodeResponse = true;
+
+    @Test
+    public void hasResponse() {
+        CorrelationManager correlationManager = new CorrelationManager();
+        int upstreamCorrelationId = correlationManager.putBrokerRequest(apiKey, apiVersion, downstreamCorrelationId, true, recipient, promise, decodeResponse, state);
+        CorrelationManager.Correlation correlation = correlationManager.getBrokerCorrelation(upstreamCorrelationId);
+        assertThat(correlation).isNotNull();
+        assertThat(correlation.apiKey()).isEqualTo(apiKey);
+        assertThat(correlation.apiVersion()).isEqualTo(apiVersion);
+        assertThat(correlation.downstreamCorrelationId()).isEqualTo(downstreamCorrelationId);
+        assertThat(correlation.recipient()).isSameAs(recipient);
+        assertThat(correlation.promise()).isSameAs(promise);
+        assertThat(correlation.state()).isSameAs(state);
+    }
+
+    @Test
+    public void correlationRemovedOnGet() {
+        CorrelationManager correlationManager = new CorrelationManager();
+        int upstreamCorrelationId = correlationManager.putBrokerRequest(apiKey, apiVersion, downstreamCorrelationId, true, recipient, promise, decodeResponse, state);
+        // removes correlation
+        correlationManager.getBrokerCorrelation(upstreamCorrelationId);
+
+        CorrelationManager.Correlation correlation = correlationManager.getBrokerCorrelation(upstreamCorrelationId);
+        assertThat(correlation).isNull();
+    }
+
+    @Test
+    public void hasNoResponse() {
+        CorrelationManager correlationManager = new CorrelationManager();
+        int upstreamCorrelationId = correlationManager.putBrokerRequest(apiKey, apiVersion, downstreamCorrelationId, false, recipient, promise, decodeResponse, state);
+        CorrelationManager.Correlation correlation = correlationManager.getBrokerCorrelation(upstreamCorrelationId);
+        assertThat(correlation).isNull();
+    }
+
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/ResponseDecoderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/ResponseDecoderTest.java
@@ -22,6 +22,7 @@ import io.netty.buffer.Unpooled;
 
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 import io.kroxylicious.proxy.frame.OpaqueResponseFrame;
+import io.kroxylicious.proxy.frame.RequestResponseState;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -46,7 +47,7 @@ class ResponseDecoderTest extends AbstractCodecTest {
     @ParameterizedTest
     @MethodSource("requestApiVersions")
     void testApiVersionsExactlyOneFrame_decoded(short apiVersion) {
-        mgr.putBrokerRequest(ApiKeys.API_VERSIONS.id, apiVersion, 52, true, null, null, true);
+        mgr.putBrokerRequest(ApiKeys.API_VERSIONS.id, apiVersion, 52, true, null, null, true, RequestResponseState.empty());
         assertEquals(52, exactlyOneFrame_decoded(apiVersion,
                 ApiKeys.API_VERSIONS::responseHeaderVersion,
                 v -> AbstractCodecTest.exampleResponseHeader(),
@@ -62,7 +63,7 @@ class ResponseDecoderTest extends AbstractCodecTest {
     @ParameterizedTest
     @MethodSource("requestApiVersions")
     void testApiVersionsExactlyOneFrame_opaque(short apiVersion) throws Exception {
-        mgr.putBrokerRequest(ApiKeys.API_VERSIONS.id, apiVersion, 52, true, null, null, false);
+        mgr.putBrokerRequest(ApiKeys.API_VERSIONS.id, apiVersion, 52, true, null, null, false, RequestResponseState.empty());
         assertEquals(52, exactlyOneFrame_encoded(apiVersion,
                 ApiKeys.API_VERSIONS::responseHeaderVersion,
                 v -> AbstractCodecTest.exampleResponseHeader(),
@@ -132,7 +133,7 @@ class ResponseDecoderTest extends AbstractCodecTest {
 
     @Test
     void supportsFallbackToApiResponseV0() {
-        mgr.putBrokerRequest(ApiKeys.API_VERSIONS.id, (short) 3, 52, true, null, null, true);
+        mgr.putBrokerRequest(ApiKeys.API_VERSIONS.id, (short) 3, 52, true, null, null, true, RequestResponseState.empty());
 
         // given
         ByteBuf buffer = Unpooled.wrappedBuffer(serializeUsingKafkaApis((short) 0,

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/ResponseEncoderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/ResponseEncoderTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.frame.RequestResponseState;
 
 class ResponseEncoderTest extends AbstractCodecTest {
     @ParameterizedTest
@@ -23,6 +24,7 @@ class ResponseEncoderTest extends AbstractCodecTest {
         ApiVersionsResponseData exampleBody = exampleApiVersionsResponse();
         short headerVersion = ApiKeys.API_VERSIONS.responseHeaderVersion(apiVersion);
         ByteBuffer expected = serializeUsingKafkaApis(headerVersion, exampleHeader, apiVersion, exampleBody);
-        testEncode(expected, new DecodedResponseFrame<>(apiVersion, exampleHeader.correlationId(), exampleHeader, exampleBody), new KafkaResponseEncoder());
+        testEncode(expected, new DecodedResponseFrame<>(apiVersion, exampleHeader.correlationId(), exampleHeader, exampleBody, RequestResponseState.empty()),
+                new KafkaResponseEncoder());
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

It is risky to allow the unsupported version to enter our system, as we have seen in the original issue the unsupported version is parsed and allowed to flow into our filters and other internal code. It can have unexpected consequences when internal code expects to be able to use that version to size messages or encode them. Perhaps we are better off catching it at the edge and preventing the unknown version ever being presented to anything beyond the MessageDecoder at the edge.

Instead, as soon as we detect an unsupported version of ApiVersions we do not decode it, we instead create an ApiVersionsRequest message at the highest level supported by the proxy and forward that on. We mark the Frame as downgraded so that we can correlate the response in another Handler, this handler is responsible for downgrading the version.

To enable us to mark the Frame I've introduced a new concept of `RequestResponseState`, which is state that is associated with a single request-response lifecycle. This state is correlated so that any state attached to the RequestFrame is available on the ResponseFrame. This, in future, could potentially be exposed via the Filter API to enable Filters to attach some data to requests and be able to retrieve it from the response, meaning filters wouldn't have to implement their own correlation maps and they could take advantage of the CorellationManager which already implements it (and is aware of the zero-ack special case).

We also handle detecting broker responses that have been downgraded to apiVersion 0 to ensure we forward those responses correctly to the client.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
