### PR TITLE
Improve Encryption DEK co-ordination across threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ For changes that effect a public API, the [deprecation policy](./DEV_GUIDE.md#de
 Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
+
+* [#1643](https://github.com/kroxylicious/kroxylicious/pull/1643) Improve Encryption DEK co-ordination across threads
+
 ## 0.9.0
 
 * [#1668](https://github.com/kroxylicious/kroxylicious/pull/1668) Bump apicurio-registry.version from 2.6.5.Final to 2.6.6.Final

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/Dek.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/Dek.java
@@ -108,13 +108,16 @@ public final class Dek<E> {
         if (numEncryptions <= 0) {
             throw new IllegalArgumentException();
         }
+        if (!outstandingCryptors.acquireEncryptorUsage()) {
+            throw new DestroyedDekException();
+        }
         if (remainingEncryptions.addAndGet(-numEncryptions) >= 0) {
-            if (!outstandingCryptors.acquireEncryptorUsage()) {
-                throw new DestroyedDekException();
-            }
             return new Encryptor(cipherManager, atomicKey.get(), numEncryptions);
         }
-        throw new ExhaustedDekException("This DEK does not have " + numEncryptions + " encryptions available");
+        else {
+            outstandingCryptors.releaseEncryptorUsage();
+            throw new ExhaustedDekException("This DEK does not have " + numEncryptions + " encryptions available");
+        }
     }
 
     /**

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/InBandEncryptionManager.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/InBandEncryptionManager.java
@@ -12,6 +12,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.IntFunction;
 
+import io.kroxylicious.filter.encryption.dek.DestroyedDekException;
+
 import org.apache.kafka.common.errors.NetworkException;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
@@ -128,7 +130,7 @@ public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
                             bufferAllocator);
                     return CompletableFuture.completedFuture(encryptedMemoryRecords);
                 }
-                catch (ExhaustedDekException e) {
+                catch (DestroyedDekException | ExhaustedDekException e) {
                     rotateKeyContext(encryptionScheme, dek);
                     // fall through to recursive call below...
                 }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/InBandEncryptionManager.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/InBandEncryptionManager.java
@@ -35,7 +35,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
 
     private static final int MAX_ATTEMPTS = 3;
-
     /**
     * The encryption version used on the produce path.
     * Note that the encryption version used on the fetch path is read from the
@@ -182,6 +181,6 @@ public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
     private void rotateKeyContext(@NonNull EncryptionScheme<K> encryptionScheme,
                                   @NonNull Dek<E> dek) {
         dek.destroyForEncrypt();
-        dekCache.invalidate(encryptionScheme);
+        dekCache.invalidate(encryptionScheme, dek);
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/InBandEncryptionManager.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/InBandEncryptionManager.java
@@ -34,7 +34,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
 
-    private static final int MAX_ATTEMPTS = 3;
+    private static final int MAX_ATTEMPTS = 100;
     /**
     * The encryption version used on the produce path.
     * Note that the encryption version used on the fetch path is read from the

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/DekManagerTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/DekManagerTest.java
@@ -111,7 +111,7 @@ class DekManagerTest {
         var decrypted = dm.decryptEdek(inMemoryEdekSerde.deserialize(edekBuffer), cipherManager).toCompletableFuture().join();
 
         // Then
-        assertThatThrownBy(() -> decrypted.encryptor(1)).isExactlyInstanceOf(ExhaustedDekException.class);
+        assertThatThrownBy(() -> decrypted.encryptor(1)).isExactlyInstanceOf(DestroyedDekException.class);
         var decodedPlaintext = ByteBuffer.allocate(plaintext.capacity());
         decrypted.decryptor().decrypt(ciphertext[0], aad, params[0], decodedPlaintext);
         assertThat(new String(decodedPlaintext.array(), StandardCharsets.UTF_8)).isEqualTo("hello, world");

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/DekTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/dek/DekTest.java
@@ -47,11 +47,11 @@ class DekTest {
 
     @ParameterizedTest
     @MethodSource("io.kroxylicious.filter.encryption.dek.CipherManagerTest#allCipherManagers")
-    void encryptorThrowsExhaustedDekExceptionOnDekWithZeroEncryptions(CipherManager cipherManager) {
+    void encryptorThrowsDestroyedDekExceptionOnDekWithZeroEncryptions(CipherManager cipherManager) {
         var key = makeKey();
         var dek = new Dek<>("edek", key, cipherManager, 0);
         assertThatThrownBy(() -> dek.encryptor(1))
-                .isExactlyInstanceOf(ExhaustedDekException.class);
+                .isExactlyInstanceOf(DestroyedDekException.class);
     }
 
     @NonNull
@@ -486,7 +486,7 @@ class DekTest {
 
         assertThatThrownBy(() -> dek.encryptor(1))
                 .describedAs("Expect to not be able to get another encoder")
-                .isExactlyInstanceOf(ExhaustedDekException.class);
+                .isExactlyInstanceOf(DestroyedDekException.class);
 
         // Note, we use a common buffer backing both the plaintext and the ciphertext so that we're testing that
         // encrypt() is copy-safe.

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/encrypt/AsyncKms.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/encrypt/AsyncKms.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.encrypt;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+
+import javax.crypto.SecretKey;
+
+import io.kroxylicious.kms.service.DekPair;
+import io.kroxylicious.kms.service.Kms;
+import io.kroxylicious.kms.service.Serde;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+class AsyncKms<K, E> implements Kms<K, E> {
+    private final Kms<K, E> delegate;
+    private final Executor executor;
+
+    AsyncKms(Kms<K, E> delegate, Executor executor) {
+        this.delegate = delegate;
+        this.executor = executor;
+    }
+
+    @NonNull
+    @Override
+    public CompletionStage<DekPair<E>> generateDekPair(@NonNull K kekRef) {
+        return completingOnExecutor(delegate.generateDekPair(kekRef));
+    }
+
+    @NonNull
+    @Override
+    public CompletionStage<SecretKey> decryptEdek(@NonNull E edek) {
+        return completingOnExecutor(delegate.decryptEdek(edek));
+    }
+
+    @NonNull
+    @Override
+    public Serde<E> edekSerde() {
+        return delegate.edekSerde();
+    }
+
+    @NonNull
+    @Override
+    public CompletionStage<K> resolveAlias(@NonNull String alias) {
+        return completingOnExecutor(delegate.resolveAlias(alias));
+    }
+
+    private <T> @NonNull CompletionStage<T> completingOnExecutor(@NonNull CompletionStage<T> stage) {
+        return stage.whenCompleteAsync((t, throwable) -> {
+        }, executor);
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/encrypt/InBandEncryptionManagerTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/encrypt/InBandEncryptionManagerTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.encrypt;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.Record;
+import org.apache.kafka.common.utils.ByteBufferOutputStream;
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.filter.encryption.common.FilterThreadExecutor;
+import io.kroxylicious.filter.encryption.config.RecordField;
+import io.kroxylicious.filter.encryption.crypto.Encryption;
+import io.kroxylicious.filter.encryption.dek.DekManager;
+import io.kroxylicious.kms.provider.kroxylicious.inmemory.InMemoryEdek;
+import io.kroxylicious.kms.provider.kroxylicious.inmemory.InMemoryKms;
+import io.kroxylicious.kms.provider.kroxylicious.inmemory.UnitTestingKmsService;
+import io.kroxylicious.test.record.RecordTestUtils;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InBandEncryptionManagerTest {
+
+    // this test covers a bug fix where multiple encrypting threads would invalidate the cache key with
+    // undefined results. We only need to invalidate each cached DEK once
+    @Test
+    void testMultipleThreadsCooperateToMinimiseDekCreations() {
+        InMemoryKms kms = getInMemoryKms();
+        // we are testing a race condition and want high parallelism to prompt parallel usages of exhausted DEKs
+        ScheduledExecutorService executor = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors() * 2);
+        final DekManager<UUID, InMemoryEdek> dekManager = new DekManager<>(new AsyncKms<>(kms, executor), 1);
+        EncryptionDekCache<UUID, InMemoryEdek> cache = new EncryptionDekCache<>(dekManager, executor, EncryptionDekCache.NO_MAX_CACHE_SIZE, Duration.ofHours(1),
+                Duration.ofHours(1));
+        var encryptionManager = createEncryptionManager(dekManager, cache, executor);
+        var kekId = kms.generateKey();
+
+        var value = new byte[]{ 1, 2, 3 };
+        Record record = RecordTestUtils.record(value);
+
+        List<Record> initial = List.of(record);
+
+        int numEncryptionOperations = 50;
+        List<CompletableFuture<Void>> encrypts = IntStream.range(0, numEncryptionOperations)
+                .mapToObj(x -> doEncrypt(encryptionManager, "topic", 1, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)), initial,
+                        new ArrayList<>()).toCompletableFuture())
+                .toList();
+
+        CompletableFuture<?>[] array = encrypts.toArray(CompletableFuture[]::new);
+        CompletableFuture<Void> all = CompletableFuture.allOf(array);
+        assertThat(all).succeedsWithin(10, TimeUnit.SECONDS);
+        assertThat(cache.invalidationCount()).isEqualTo(numEncryptionOperations - 1);
+    }
+
+    @NonNull
+    private static InMemoryKms getInMemoryKms() {
+        var kmsService = UnitTestingKmsService.newInstance();
+        kmsService.initialize(new UnitTestingKmsService.Config());
+        return kmsService.buildKms();
+    }
+
+    @NonNull
+    private static CompletionStage<Void> doEncrypt(
+                                                   InBandEncryptionManager<UUID, InMemoryEdek> encryptionManager,
+                                                   String topic,
+                                                   int partition,
+                                                   EncryptionScheme<UUID> scheme,
+                                                   List<Record> initial,
+                                                   List<Record> encrypted) {
+        MemoryRecords records = RecordTestUtils.memoryRecords(initial);
+        return encryptionManager.encrypt(topic, partition, scheme, records, ByteBufferOutputStream::new)
+                .thenApply(memoryRecords -> {
+                    memoryRecords.records().forEach(encrypted::add);
+                    return null;
+                });
+    }
+
+    @NonNull
+    private static InBandEncryptionManager<UUID, InMemoryEdek> createEncryptionManager(DekManager<UUID, InMemoryEdek> dekManager,
+                                                                                       EncryptionDekCache<UUID, InMemoryEdek> cache,
+                                                                                       ScheduledExecutorService executor) {
+
+        return new InBandEncryptionManager<>(Encryption.V2,
+                dekManager.edekSerde(),
+                1024 * 1024,
+                8 * 1024 * 1024,
+                cache,
+                new FilterThreadExecutor(executor));
+    }
+
+}


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

1. Invalidate each DEK only once. Uses computeIfPresent to only invalidate each DEK once.
2. Increases the maximum retries. This is more of a testing enabler, it allows large numbers of competing threads to re attempt a lot more frequently. In practise retries should not be so frequent since a DEK should offer a large number of encryptions and the new rotation future will prevent threads from repeatedly trying to use a DEK that's mid destruction.
3. Added a catch for DekDestroyedException to attemptEncrypt after encountering it in testing. Multiple threads can enter Dek#encryptor and some may find the Dek has been destroyed by another thread. This falls through to wait for rotation and retry.
4. Fixed a race condition in Dek#encryptor where the Dek could be destroyed for encryption after a thread had obtained enough remainingEncryptions. The result of this was that the Dek would not be used for that encryption operation, throwing a DestroyedDekException. This means that a DEK that is both exhausted and destroyed for encryption now throws a DestroyedDekException rather than an ExhaustedDekException.
5. Only destroy the DEK for encryption after invalidating it out of the cache. This prevents threads from spinning in tight loops obtaining the destroyed DEK before it is invalidated. The cost is more threads will enter the invalidation computeIfPresent logic, which acts as a co-ordinator.

Contributes to fixing #1526

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
