### PR TITLE
Old broker test

### DIFF
--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/ResponsePayload.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/ResponsePayload.java
@@ -11,4 +11,11 @@ import org.apache.kafka.common.protocol.ApiMessage;
 
 public record ResponsePayload(ApiKeys apiKeys,
                               short apiVersion,
-                              ApiMessage message) {}
+                              ApiMessage message,
+                              short responseApiVersion) {
+
+    public ResponsePayload(ApiKeys apiKeys, short apiVersion, ApiMessage message) {
+        this(apiKeys, apiVersion, message, apiVersion);
+    }
+
+}

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/KafkaClientHandler.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/KafkaClientHandler.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 
-import io.kroxylicious.test.codec.DecodedRequestFrame;
+import io.kroxylicious.test.codec.RequestFrame;
 
 /**
  * Simple kafka handle capable of sending one or more requests to a server side.
@@ -23,7 +23,7 @@ import io.kroxylicious.test.codec.DecodedRequestFrame;
 public class KafkaClientHandler extends ChannelInboundHandlerAdapter {
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaClientHandler.class);
 
-    private final Deque<DecodedRequestFrame<?>> queue = new ConcurrentLinkedDeque<>();
+    private final Deque<RequestFrame> queue = new ConcurrentLinkedDeque<>();
     private ChannelHandlerContext ctx;
 
     // Read/Mutated by the Netty thread only.
@@ -63,7 +63,7 @@ public class KafkaClientHandler extends ChannelInboundHandlerAdapter {
      * @param decodedRequestFrame request frame to send
      * @return future that will yield the response along with a sequenceNumber indicating the order it was received by the client.
      */
-    public CompletableFuture<SequencedResponse> sendRequest(DecodedRequestFrame<?> decodedRequestFrame) {
+    public CompletableFuture<SequencedResponse> sendRequest(RequestFrame decodedRequestFrame) {
         queue.addLast(decodedRequestFrame);
         processPendingWrites();
         return decodedRequestFrame.getResponseFuture();

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/ByteBufAccessor.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/ByteBufAccessor.java
@@ -7,12 +7,13 @@ package io.kroxylicious.test.codec;
 
 import java.nio.ByteBuffer;
 
+import org.apache.kafka.common.protocol.Readable;
 import org.apache.kafka.common.protocol.Writable;
 
 /**
  * Provides write access to byte buffer for serializing frames.
  */
-public interface ByteBufAccessor extends Writable {
+public interface ByteBufAccessor extends Writable, Readable {
 
     @Override
     void writeByte(byte val);
@@ -56,4 +57,14 @@ public interface ByteBufAccessor extends Writable {
      */
     int writerIndex();
 
+    /**
+     * Get reader index
+     * @return readerIndex of underlying buffer
+     */
+    int readerIndex();
+
+    /**
+     * set reader index of underlying buffer
+     */
+    void readerIndex(int index);
 }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/ByteBufAccessorImpl.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/ByteBufAccessorImpl.java
@@ -7,8 +7,6 @@ package io.kroxylicious.test.codec;
 
 import java.nio.ByteBuffer;
 
-import org.apache.kafka.common.protocol.Readable;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 
@@ -21,7 +19,7 @@ import io.netty.buffer.ByteBufUtil;
  * depends on NIO ByteBuffer, so copying between ByteBuffer and ByteBuf cannot
  * always be avoided.
  */
-public class ByteBufAccessorImpl implements ByteBufAccessor, Readable {
+public class ByteBufAccessorImpl implements ByteBufAccessor {
 
     private final ByteBuf buf;
 
@@ -240,6 +238,16 @@ public class ByteBufAccessorImpl implements ByteBufAccessor, Readable {
     @Override
     public int writerIndex() {
         return buf.writerIndex();
+    }
+
+    @Override
+    public int readerIndex() {
+        return buf.readerIndex();
+    }
+
+    @Override
+    public void readerIndex(int index) {
+        buf.readerIndex(index);
     }
 
 }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/DecodedRequestFrame.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/DecodedRequestFrame.java
@@ -19,7 +19,7 @@ import io.kroxylicious.test.client.SequencedResponse;
  */
 public class DecodedRequestFrame<B extends ApiMessage>
         extends DecodedFrame<RequestHeaderData, B>
-        implements Frame {
+        implements RequestFrame {
 
     private final CompletableFuture<SequencedResponse> responseFuture = new CompletableFuture<>();
 
@@ -50,6 +50,7 @@ public class DecodedRequestFrame<B extends ApiMessage>
      * Whether the Kafka Client expects a response to this request
      * @return Whether the Kafka Client expects a response to this request
      */
+    @Override
     public boolean hasResponse() {
         return !(body instanceof ProduceRequest pr && pr.acks() == 0);
     }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/KafkaRequestDecoder.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/KafkaRequestDecoder.java
@@ -51,7 +51,6 @@ public class KafkaRequestDecoder extends KafkaMessageDecoder {
         LOGGER.debug("{}: {} downstream correlation id: {}", ctx, apiKey, correlationId);
 
         RequestHeaderData header;
-        final ByteBufAccessorImpl accessor;
         var decodeRequest = true;
         LOGGER.debug("Decode {}/v{} request? {}", apiKey, apiVersion, decodeRequest);
         boolean decodeResponse = true;
@@ -61,13 +60,13 @@ public class KafkaRequestDecoder extends KafkaMessageDecoder {
             log().trace("{}: headerVersion {}", ctx, headerVersion);
         }
         in.readerIndex(sof);
-        accessor = new ByteBufAccessorImpl(in);
-        header = readHeader(headerVersion, accessor);
+        ByteBufAccessorImpl acc = new ByteBufAccessorImpl(in);
+        header = readHeader(headerVersion, acc);
         if (log().isTraceEnabled()) {
             log().trace("{}: header: {}", ctx, header);
         }
         final Frame frame;
-        ApiMessage body = BodyDecoder.decodeRequest(apiKey, apiVersion, accessor);
+        ApiMessage body = BodyDecoder.decodeRequest(apiKey, apiVersion, acc);
         if (log().isTraceEnabled()) {
             log().trace("{}: body {}", ctx, body);
         }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/KafkaRequestEncoder.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/KafkaRequestEncoder.java
@@ -16,7 +16,7 @@ import io.kroxylicious.test.client.CorrelationManager;
 /**
  * Kafka Request Encoder
  */
-public class KafkaRequestEncoder extends KafkaMessageEncoder<DecodedRequestFrame<?>> {
+public class KafkaRequestEncoder extends KafkaMessageEncoder<RequestFrame> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaRequestEncoder.class);
 
@@ -36,7 +36,7 @@ public class KafkaRequestEncoder extends KafkaMessageEncoder<DecodedRequestFrame
     }
 
     @Override
-    protected void encode(ChannelHandlerContext ctx, DecodedRequestFrame frame, ByteBuf out) throws Exception {
+    protected void encode(ChannelHandlerContext ctx, RequestFrame frame, ByteBuf out) throws Exception {
         super.encode(ctx, frame, out);
         if (frame.hasResponse()) {
             correlationManager.putBrokerRequest(frame.apiKey().id, frame.apiVersion(), frame.correlationId(), frame.getResponseFuture());

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/OpaqueRequestFrame.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/OpaqueRequestFrame.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test.codec;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.buffer.ByteBuf;
+
+import io.kroxylicious.test.client.SequencedResponse;
+
+/**
+ * A frame in the Kafka protocol which has not been decoded.
+ * The wrapped buffer <strong>does not</strong> include the frame size prefix.
+ */
+public class OpaqueRequestFrame implements RequestFrame {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpaqueRequestFrame.class);
+
+    /**
+     * Number of bytes required for storing the frame length.
+     */
+    private static final int FRAME_SIZE_LENGTH = Integer.BYTES;
+
+    protected final int length;
+    protected final int correlationId;
+    /** The message buffer excluding the frame size, including the header and body. */
+    protected final ByteBuf buf;
+    private final boolean hasResponse;
+    private final CompletableFuture<SequencedResponse> responseFuture = new CompletableFuture<>();
+    private final ApiKeys apiKey;
+    private final short apiVersion;
+
+    /**
+     * @param buf The message buffer (excluding the frame size)
+     * @param correlationId The correlation id
+     * @param length The length of the frame within {@code buf}.
+     * @param hasResponse do we expect a response
+     */
+    public OpaqueRequestFrame(ByteBuf buf, int correlationId, int length, boolean hasResponse, ApiKeys apiKey, short apiVersion) {
+        this.length = length;
+        this.correlationId = correlationId;
+        this.buf = buf.asReadOnly();
+        this.apiKey = apiKey;
+        this.apiVersion = apiVersion;
+        if (buf.readableBytes() != length) {
+            throw new AssertionError("readable: " + buf.readableBytes() + " length: " + length);
+        }
+        this.hasResponse = hasResponse;
+    }
+
+    @Override
+    public int correlationId() {
+        return correlationId;
+    }
+
+    @Override
+    public int estimateEncodedSize() {
+        return FRAME_SIZE_LENGTH + length;
+    }
+
+    @Override
+    public void encode(ByteBufAccessor out) {
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace("Writing {} with 4 byte length ({}) plus {} bytes from buffer {} to {}",
+                    getClass().getSimpleName(), length, buf.readableBytes(), buf, out);
+        }
+        out.ensureWritable(estimateEncodedSize());
+        out.writeInt(length);
+        byte[] bytes = new byte[length];
+        buf.readBytes(bytes);
+        out.writeByteArray(bytes);
+        buf.release();
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(" +
+                "length=" + length +
+                ", buf=" + buf +
+                ')';
+    }
+
+    @Override
+    public CompletableFuture<SequencedResponse> getResponseFuture() {
+        return responseFuture;
+    }
+
+    @Override
+    public boolean hasResponse() {
+        return hasResponse;
+    }
+
+    @Override
+    public ApiKeys apiKey() {
+        return apiKey;
+    }
+
+    @Override
+    public short apiVersion() {
+        return apiVersion;
+    }
+}

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/RequestFrame.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/RequestFrame.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test.codec;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.kafka.common.protocol.ApiKeys;
+
+import io.kroxylicious.test.client.SequencedResponse;
+
+public interface RequestFrame extends Frame {
+
+    CompletableFuture<SequencedResponse> getResponseFuture();
+
+    /**
+     * Whether the Kafka Client expects a response to this request
+     * @return Whether the Kafka Client expects a response to this request
+     */
+    default boolean hasResponse() {
+        return true;
+    }
+
+    /**
+     * Get apiKey of body
+     * @return apiKey
+     */
+    ApiKeys apiKey();
+
+    /**
+     * Get apiVersion of frame
+     * @return apiKey
+     */
+    short apiVersion();
+
+}

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/Action.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/Action.java
@@ -23,10 +23,17 @@ interface Action {
     }
 
     static Action respond(ApiMessage message) {
-        return (ctx, frame) -> {
-            DecodedResponseFrame<?> responseFrame = new DecodedResponseFrame<>(frame.apiVersion(),
-                    frame.correlationId(), new ResponseHeaderData().setCorrelationId(frame.correlationId()), message);
-            ctx.write(responseFrame);
-        };
+        return (ctx, frame) -> writeResponse(message, ctx, frame, frame.apiVersion());
     }
+
+    static Action respond(ApiMessage message, short apiVersion) {
+        return (ctx, frame) -> writeResponse(message, ctx, frame, apiVersion);
+    }
+
+    private static void writeResponse(ApiMessage message, ChannelHandlerContext ctx, DecodedRequestFrame<?> frame, short apiVersion) {
+        DecodedResponseFrame<?> responseFrame = new DecodedResponseFrame<>(apiVersion,
+                frame.correlationId(), new ResponseHeaderData().setCorrelationId(frame.correlationId()), message);
+        ctx.write(responseFrame);
+    }
+
 }

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/MockHandler.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/MockHandler.java
@@ -86,6 +86,7 @@ public class MockHandler extends ChannelInboundHandlerAdapter {
 
     /**
      * Set the response
+     *
      * @param response response
      */
     public void setMockResponseForApiKey(ApiKeys keys, ApiMessage response) {
@@ -100,6 +101,26 @@ public class MockHandler extends ChannelInboundHandlerAdapter {
                 description.appendText("has key " + keys);
             }
         }, Action.respond(response));
+    }
+
+    /**
+     * Set the response
+     *
+     * @param response response
+     * @param responseApiVersion apiVersion used to encode mock response
+     */
+    public void setMockResponseForApiKey(ApiKeys keys, ApiMessage response, short responseApiVersion) {
+        addMockResponse(new TypeSafeMatcher<>() {
+            @Override
+            protected boolean matchesSafely(Request request) {
+                return request.apiKeys() == keys;
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("has key " + keys);
+            }
+        }, Action.respond(response, responseApiVersion));
     }
 
     public void addMockResponse(Matcher<Request> matcher, Action action) {

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/MockServer.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/server/MockServer.java
@@ -50,7 +50,7 @@ public final class MockServer implements AutoCloseable {
      */
     public void addMockResponseForApiKey(ResponsePayload response) {
         Objects.requireNonNull(response);
-        serverHandler.setMockResponseForApiKey(response.apiKeys(), response.message());
+        serverHandler.setMockResponseForApiKey(response.apiKeys(), response.message(), response.responseApiVersion());
     }
 
     /**
@@ -60,7 +60,7 @@ public final class MockServer implements AutoCloseable {
     public void addMockResponse(Matcher<Request> requestMatcher, ResponsePayload response) {
         Objects.requireNonNull(response);
         Objects.requireNonNull(requestMatcher);
-        serverHandler.addMockResponse(requestMatcher, Action.respond(response.message()));
+        serverHandler.addMockResponse(requestMatcher, Action.respond(response.message(), response.responseApiVersion()));
     }
 
     public void dropWhen(Matcher<Request> requestMatcher) {

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/MockServerKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/MockServerKroxyliciousTester.java
@@ -139,4 +139,8 @@ public class MockServerKroxyliciousTester extends DefaultKroxyliciousTester {
             }
         };
     }
+
+    public int getReceivedRequestCount() {
+        return mockServer.getReceivedRequests().size();
+    }
 }

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/client/KafkaClientTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/client/KafkaClientTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test.client;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.ApiVersionsRequest;
+import org.apache.kafka.common.requests.RequestHeader;
+import org.junit.jupiter.api.Test;
+
+import io.netty.buffer.Unpooled;
+
+import io.kroxylicious.test.Request;
+import io.kroxylicious.test.Response;
+import io.kroxylicious.test.ResponsePayload;
+import io.kroxylicious.test.codec.OpaqueRequestFrame;
+import io.kroxylicious.test.server.MockServer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KafkaClientTest {
+    @Test
+    void testClientCanSendOpaqueFrame() {
+        ApiVersionsResponseData message = new ApiVersionsResponseData();
+        message.setErrorCode(Errors.UNSUPPORTED_VERSION.code());
+        try (var mockServer = MockServer.startOnRandomPort(new ResponsePayload(ApiKeys.API_VERSIONS, (short) 0, message));
+                var kafkaClient = new KafkaClient("127.0.0.1", mockServer.port())) {
+            ApiVersionsRequest request = new ApiVersionsRequest(new ApiVersionsRequestData(), (short) 0);
+            int correlationId = 5;
+            ByteBuffer byteBuffer = request.serializeWithHeader(new RequestHeader(ApiKeys.API_VERSIONS, (short) 0, "client", correlationId));
+            int length = byteBuffer.remaining();
+            OpaqueRequestFrame frame = new OpaqueRequestFrame(Unpooled.copiedBuffer(byteBuffer), correlationId, length, true, ApiKeys.API_VERSIONS, (short) 0);
+            CompletableFuture<Response> future = kafkaClient.get(frame);
+            assertThat(future).succeedsWithin(10, TimeUnit.SECONDS).satisfies(response -> {
+                assertThat(response.payload().message()).isInstanceOfSatisfying(ApiVersionsResponseData.class, apiVersionsRequestData -> {
+                    assertThat(apiVersionsRequestData.errorCode()).isEqualTo(Errors.UNSUPPORTED_VERSION.code());
+                });
+            });
+        }
+    }
+
+    // brokers can respond with a v0 response if they do not support the ApiVersions request version, see KIP-511
+    @Test
+    void testClientCanTolerateV0ApiVersionsResponseToHigherRequestVersion() {
+        ApiVersionsResponseData message = new ApiVersionsResponseData();
+        message.setErrorCode(Errors.UNSUPPORTED_VERSION.code());
+        ResponsePayload v0Payload = new ResponsePayload(ApiKeys.API_VERSIONS, (short) 0, message);
+        try (var mockServer = MockServer.startOnRandomPort(v0Payload);
+                var kafkaClient = new KafkaClient("127.0.0.1", mockServer.port())) {
+            CompletableFuture<Response> future = kafkaClient.get(new Request(ApiKeys.API_VERSIONS, (short) 0, "client", new ApiVersionsRequestData()));
+            assertThat(future).succeedsWithin(10, TimeUnit.SECONDS).satisfies(response -> {
+                assertThat(response.payload().message()).isInstanceOfSatisfying(ApiVersionsResponseData.class, apiVersionsRequestData -> {
+                    assertThat(apiVersionsRequestData.errorCode()).isEqualTo(Errors.UNSUPPORTED_VERSION.code());
+                });
+            });
+        }
+    }
+}

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
@@ -257,6 +257,13 @@ class KroxyliciousTestersTest {
     }
 
     @Test
+    void testMockRequestInitialRequestCount() {
+        try (var tester = mockKafkaKroxyliciousTester(KroxyliciousConfigUtils::proxy)) {
+            assertThat(tester.getReceivedRequestCount()).isZero();
+        }
+    }
+
+    @Test
     void testSimpleTestClientReportsConnectionState() {
         try (var tester = mockKafkaKroxyliciousTester(KroxyliciousConfigUtils::proxy);
                 var kafkaClient = tester.simpleTestClient()) {
@@ -334,6 +341,7 @@ class KroxyliciousTestersTest {
             assertThat(response1Message).isEqualTo(mockResponse1);
             assertThat(tester.getOnlyRequestForApiKey(ApiKeys.DESCRIBE_ACLS)).isEqualTo(describeAcls);
             assertThat(tester.getRequestsForApiKey(ApiKeys.DESCRIBE_ACLS)).containsOnly(describeAcls);
+            assertThat(tester.getReceivedRequestCount()).isEqualTo(1);
 
             Request listTransactions = new Request(ApiKeys.LIST_TRANSACTIONS, ApiKeys.LIST_TRANSACTIONS.latestVersion(), "client", new ListTransactionsRequestData());
             var response2 = kafkaClient.getSync(listTransactions);
@@ -343,6 +351,7 @@ class KroxyliciousTestersTest {
             assertThat(response2Message).isEqualTo(mockResponse2);
             assertThat(tester.getOnlyRequestForApiKey(ApiKeys.LIST_TRANSACTIONS)).isEqualTo(listTransactions);
             assertThat(tester.getRequestsForApiKey(ApiKeys.LIST_TRANSACTIONS)).containsOnly(listTransactions);
+            assertThat(tester.getReceivedRequestCount()).isEqualTo(2);
         }
     }
 

--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -142,6 +142,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <scope>test</scope>

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ApiVersionsDowngradeIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ApiVersionsDowngradeIT.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.NodeApiVersions;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.ObjectSerializationCache;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.security.plain.PlainLoginModule;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+import io.kroxylicious.test.Response;
+import io.kroxylicious.test.codec.ByteBufAccessorImpl;
+import io.kroxylicious.test.codec.OpaqueRequestFrame;
+import io.kroxylicious.test.tester.KroxyliciousConfigUtils;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.common.SaslMechanism;
+import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
+import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
+import static io.kroxylicious.test.tester.KroxyliciousTesters.mockKafkaKroxyliciousTester;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * <p>
+ * In addition to the behaviour tested by {@link ApiVersionsIT} we also need to handle the client
+ * sending ApiVersions requests at an apiVersion higher than the proxy understands. With no proxy
+ * involved, the behaviour is the broker will respond with a v0 apiversions response and the error
+ * code is set to UNSUPPORTED_VERSION and the api_versions array populated with the supported versions
+ * for ApiVersions, so that the client can retry with the highest supported ApiVersions version.
+ * </p>
+ * <br>
+ * In this case the proxy will respond with it's own v0 response populated with the proxies supported
+ * ApiVersions versions. It may be that on the following request the upstream broker will be behind
+ * the proxy and respond with it's own UNSUPPORTED_VERSION response. So the clients must be able to
+ * tolerate 2 UNSUPPORTED_VERSION responses in a row.
+ * </p>
+ */
+@ExtendWith(NettyLeakDetectorExtension.class)
+@ExtendWith(KafkaClusterExtension.class)
+public class ApiVersionsDowngradeIT {
+
+    public static final int CORRELATION_ID = 100;
+    public static final short API_VERSIONS_ID = ApiKeys.API_VERSIONS.id;
+    public static final String SASL_USER = "alice";
+    public static final String SASL_PASSWORD = "foo";
+
+    @Test
+    void clientAheadOfProxy() {
+        try (var tester = mockKafkaKroxyliciousTester(KroxyliciousConfigUtils::proxy);
+                var client = tester.simpleTestClient()) {
+            OpaqueRequestFrame frame = createHypotheticalFutureRequest();
+            CompletableFuture<Response> responseCompletableFuture = client.get(
+                    frame);
+            assertThat(responseCompletableFuture).succeedsWithin(5, TimeUnit.SECONDS).satisfies(response -> {
+                assertThat(response.payload().apiKeys()).isEqualTo(ApiKeys.API_VERSIONS);
+                assertThat(response.payload().message()).isInstanceOfSatisfying(ApiVersionsResponseData.class, data -> {
+                    assertThat(data.errorCode()).isEqualTo(Errors.UNSUPPORTED_VERSION.code());
+                    ApiVersionsResponseData.ApiVersion expected = new ApiVersionsResponseData.ApiVersion();
+                    expected.setApiKey(ApiKeys.API_VERSIONS.id).setMinVersion(ApiKeys.API_VERSIONS.oldestVersion())
+                            .setMaxVersion(ApiKeys.API_VERSIONS.latestVersion(true));
+                    ApiVersionsResponseData.ApiVersionCollection collection = new ApiVersionsResponseData.ApiVersionCollection();
+                    collection.add(expected);
+                    assertThat(data.apiKeys()).isEqualTo(collection);
+                });
+            });
+            assertThat(tester.getReceivedRequestCount()).isZero();
+        }
+    }
+
+    @Test
+    void proxyRestrictedToOlderApiVersion(KafkaCluster cluster) {
+        doProxyRestrictedToOlderApiVersion(cluster, Map.of());
+    }
+
+    @Test
+    void proxyRestrictedToOlderApiVersionWithSasl(@SaslMechanism(principals = {
+            @SaslMechanism.Principal(user = SASL_USER, password = SASL_PASSWORD) }) KafkaCluster cluster) {
+        var clientSecurityProtocolConfig = new HashMap<String, Object>();
+        clientSecurityProtocolConfig.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SASL_PLAINTEXT.name);
+        clientSecurityProtocolConfig.put(SaslConfigs.SASL_JAAS_CONFIG,
+                String.format("""
+                        %s required username="%s" password="%s";""",
+                        PlainLoginModule.class.getName(), SASL_USER, SASL_PASSWORD));
+        clientSecurityProtocolConfig.put(SaslConfigs.SASL_MECHANISM, "PLAIN");
+
+        doProxyRestrictedToOlderApiVersion(cluster, clientSecurityProtocolConfig);
+    }
+
+    private void doProxyRestrictedToOlderApiVersion(KafkaCluster cluster, Map<String, Object> clientSecurityProtocolConfig) {
+        var apiVersion = (short) (ApiKeys.API_VERSIONS.latestVersion() - 1);
+        var proxy = proxy(cluster)
+                .withExperimental(Map.of("apiKeyIdMaxVersionOverride", Map.of(ApiKeys.API_VERSIONS.name(), apiVersion)));
+        try (var tester = kroxyliciousTester(proxy);
+                var admin = tester.admin(clientSecurityProtocolConfig)) {
+            // We've got no way to observe the actual version of the API versions request that is used during _negotiation_
+            // so we make do with asserting the connection is usable.
+            final var result = admin.describeCluster().clusterId();
+            assertThat(result).as("Unable to get the clusterId from the Kafka cluster").succeedsWithin(Duration.ofSeconds(10));
+            // check that the client is actually using the correct version.
+            assertThat(admin)
+                    .extracting("instance")
+                    .extracting("client")
+                    .extracting("apiVersions")
+                    .extracting("nodeApiVersions", InstanceOfAssertFactories.map(String.class, NodeApiVersions.class))
+                    .hasEntrySatisfying("0", nav -> {
+                        assertThat(nav.apiVersion(ApiKeys.API_VERSIONS).maxVersion())
+                                .isEqualTo(apiVersion);
+                    });
+        }
+    }
+
+    private static @NonNull OpaqueRequestFrame createHypotheticalFutureRequest() {
+        short unsupportedVersion = (short) (ApiKeys.API_VERSIONS.latestVersion(true) + 1);
+        RequestHeaderData requestHeaderData = getRequestHeaderData(API_VERSIONS_ID, unsupportedVersion, CORRELATION_ID);
+        short requestHeaderVersion = ApiKeys.API_VERSIONS.requestHeaderVersion(unsupportedVersion);
+        ObjectSerializationCache cache = new ObjectSerializationCache();
+        int headerSize = requestHeaderData.size(cache, requestHeaderVersion);
+        // the proxy can assume that it is safe to read the latest header version from the message, but any
+        // bytes after than cannot be read because the future message may be using a new header version with
+        // additional fields. So the bytes after the latest known header bytes are arbitrary as far as the proxy
+        // is concerned.
+        byte[] arbitraryBodyData = new byte[]{ 1, 2, 3, 4 };
+        int bodySize = arbitraryBodyData.length;
+        int messageSize = headerSize + bodySize;
+        ByteBuf buffer = Unpooled.buffer(messageSize, messageSize);
+        ByteBufAccessorImpl accessor = new ByteBufAccessorImpl(buffer);
+        requestHeaderData.write(accessor, cache, requestHeaderVersion);
+        accessor.writeByteArray(arbitraryBodyData);
+        return new OpaqueRequestFrame(buffer, CORRELATION_ID, messageSize, true, ApiKeys.API_VERSIONS, unsupportedVersion);
+    }
+
+    private static @NonNull RequestHeaderData getRequestHeaderData(short apiKey, short unsupportedVersion, int correlationId) {
+        RequestHeaderData requestHeaderData = new RequestHeaderData();
+        requestHeaderData.setRequestApiKey(apiKey);
+        requestHeaderData.setRequestApiVersion(unsupportedVersion);
+        requestHeaderData.setCorrelationId(correlationId);
+        return requestHeaderData;
+    }
+
+}

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigSecret.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigSecret.java
@@ -129,7 +129,7 @@ public class ProxyConfigSecret
                 virtualClusters,
                 filterDefinitions,
                 List.of(),
-                false);
+                false, null);
 
         return toYaml(configuration);
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -12,7 +12,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
+import org.apache.kafka.common.protocol.ApiKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +41,7 @@ import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.MicrometerDefinition;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
 import io.kroxylicious.proxy.config.admin.AdminHttpConfiguration;
+import io.kroxylicious.proxy.internal.ApiVersionsServiceImpl;
 import io.kroxylicious.proxy.internal.KafkaProxyInitializer;
 import io.kroxylicious.proxy.internal.MeterRegistries;
 import io.kroxylicious.proxy.internal.PortConflictDetector;
@@ -111,11 +114,13 @@ public final class KafkaProxy implements AutoCloseable {
 
             maybeStartMetricsListener(adminEventGroup, meterRegistries);
 
+            var overrideMap = getApiKeyMaxVersionOverride(config);
+            ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl(overrideMap);
             this.filterChainFactory = new FilterChainFactory(pfr, config.filters());
             var tlsServerBootstrap = buildServerBootstrap(serverEventGroup,
-                    new KafkaProxyInitializer(filterChainFactory, pfr, true, endpointRegistry, endpointRegistry, false, Map.of()));
+                    new KafkaProxyInitializer(filterChainFactory, pfr, true, endpointRegistry, endpointRegistry, false, Map.of(), apiVersionsService));
             var plainServerBootstrap = buildServerBootstrap(serverEventGroup,
-                    new KafkaProxyInitializer(filterChainFactory, pfr, false, endpointRegistry, endpointRegistry, false, Map.of()));
+                    new KafkaProxyInitializer(filterChainFactory, pfr, false, endpointRegistry, endpointRegistry, false, Map.of(), apiVersionsService));
 
             bindingOperationProcessor.start(plainServerBootstrap, tlsServerBootstrap);
 
@@ -134,6 +139,19 @@ public final class KafkaProxy implements AutoCloseable {
             shutdown();
             throw e;
         }
+    }
+
+    private Map<ApiKeys, Short> getApiKeyMaxVersionOverride(Configuration config) {
+        Map<String, Number> apiKeyIdMaxVersion = config.experimental()
+                .map(m -> m.get("apiKeyIdMaxVersionOverride"))
+                .filter(Map.class::isInstance)
+                .map(Map.class::cast)
+                .orElse(Map.of());
+
+        return apiKeyIdMaxVersion.entrySet()
+                .stream()
+                .collect(Collectors.toMap(e -> ApiKeys.valueOf(e.getKey()),
+                        e -> e.getValue().shortValue()));
     }
 
     private ServerBootstrap buildServerBootstrap(EventGroupConfig virtualHostEventGroup, KafkaProxyInitializer kafkaProxyInitializer) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -7,6 +7,7 @@ package io.kroxylicious.proxy.config;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import io.kroxylicious.proxy.config.admin.AdminHttpConfiguration;
 
@@ -17,7 +18,8 @@ public record Configuration(@Nullable AdminHttpConfiguration adminHttp,
                             Map<String, VirtualCluster> virtualClusters,
                             List<FilterDefinition> filters,
                             List<MicrometerDefinition> micrometer,
-                            boolean useIoUring) {
+                            boolean useIoUring,
+                            @Nullable Optional<Map<String, Object>> experimental) {
     public @Nullable AdminHttpConfiguration adminHttpConfig() {
         return adminHttp();
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ApiVersionsServiceImpl.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ApiVersionsServiceImpl.java
@@ -7,7 +7,15 @@
 package io.kroxylicious.proxy.internal;
 
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.kafka.common.message.ApiVersionsResponseData;
 import org.apache.kafka.common.message.ApiVersionsResponseData.ApiVersion;
@@ -15,21 +23,59 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 public class ApiVersionsServiceImpl {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ApiVersionsServiceImpl.class);
+    private final Function<ApiKeys, Short> apiKeysShortFunction;
 
-    public void updateVersions(String channel, ApiVersionsResponseData apiVersionsResponse) {
-        intersectApiVersions(channel, apiVersionsResponse);
+    public ApiVersionsServiceImpl() {
+        this(Map.of());
     }
 
-    private static void intersectApiVersions(String channel, ApiVersionsResponseData resp) {
+    public ApiVersionsServiceImpl(Map<ApiKeys, Short> overrideMap) {
+        this(apiKeys -> getMaxApiVersionFor(apiKeys, overrideMap));
+        sanityCheckOverrides(overrideMap);
+    }
+
+    private void sanityCheckOverrides(Map<ApiKeys, Short> overrideMap) {
+        List<String> invalidEntries = overrideMap.entrySet().stream().flatMap(e -> validate(e.getKey(), e.getValue())).toList();
+        if (!invalidEntries.isEmpty()) {
+            Collector<CharSequence, ?, String> validationMessages = Collectors.joining(",", "[", "]");
+            throw new IllegalArgumentException("api versions override map contained invalid entries: " + invalidEntries.stream().collect(validationMessages));
+        }
+    }
+
+    private Stream<String> validate(ApiKeys key, Short overrideLatestVersion) {
+        short oldestVersion = key.oldestVersion();
+        if (overrideLatestVersion < oldestVersion) {
+            return Stream.of(key.name() + " specified max version " + overrideLatestVersion + " less than oldest supported version " + key.oldestVersion());
+        }
+        return Stream.of();
+    }
+
+    private ApiVersionsServiceImpl(@NonNull Function<ApiKeys, Short> apiKeysShortFunction) {
+        Objects.requireNonNull(apiKeysShortFunction);
+        this.apiKeysShortFunction = apiKeysShortFunction;
+    }
+
+    private static short getMaxApiVersionFor(ApiKeys apiKey, Map<ApiKeys, Short> overrideMap) {
+        short latest = apiKey.latestVersion(true);
+        return Optional.ofNullable(overrideMap.get(apiKey)).map(m -> ((Integer) Math.min(latest, m.intValue())).shortValue()).orElse(latest);
+    }
+
+    public void updateVersions(String channel, ApiVersionsResponseData apiVersionsResponse) {
+        intersectApiVersions(channel, apiVersionsResponse, apiKeysShortFunction);
+    }
+
+    private static void intersectApiVersions(String channel, ApiVersionsResponseData resp, Function<ApiKeys, Short> apiKeysShortFunction) {
         Set<ApiVersion> unknownApis = new HashSet<>();
         for (var key : resp.apiKeys()) {
             short apiId = key.apiKey();
             if (ApiKeys.hasId(apiId)) {
                 ApiKeys apiKey = ApiKeys.forId(apiId);
-                intersectApiVersion(channel, key, apiKey);
+                intersectApiVersion(channel, key, apiKey, apiKeysShortFunction);
             }
             else {
                 unknownApis.add(key);
@@ -41,11 +87,13 @@ public class ApiVersionsServiceImpl {
     /**
      * Update the given {@code key}'s max and min versions so that the client uses APIs versions mutually
      * understood by both the proxy and the broker.
+     *
      * @param channel The channel.
      * @param key The key data from an upstream API_VERSIONS response.
      * @param apiKey The proxy's API key for this API.
+     * @param apiKeysShortFunction
      */
-    private static void intersectApiVersion(String channel, ApiVersionsResponseData.ApiVersion key, ApiKeys apiKey) {
+    private static void intersectApiVersion(String channel, ApiVersion key, ApiKeys apiKey, Function<ApiKeys, Short> apiKeysShortFunction) {
         short mutualMin = (short) Math.max(
                 key.minVersion(),
                 apiKey.messageType.lowestSupportedVersion());
@@ -59,7 +107,7 @@ public class ApiVersionsServiceImpl {
 
         short mutualMax = (short) Math.min(
                 key.maxVersion(),
-                apiKey.messageType.highestSupportedVersion(true));
+                apiKeysShortFunction.apply(apiKey));
         if (mutualMax != key.maxVersion()) {
             LOGGER.trace("{}: {} max version changed to {} (was: {})", channel, apiKey, mutualMin, key.maxVersion());
             key.setMaxVersion(mutualMax);
@@ -69,4 +117,7 @@ public class ApiVersionsServiceImpl {
         }
     }
 
+    public short latestVersion(ApiKeys apiKey) {
+        return apiKeysShortFunction.apply(apiKey);
+    }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/ApiVersionsDowngradeFilter.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/ApiVersionsDowngradeFilter.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.ObjectSerializationCache;
+import org.apache.kafka.common.protocol.Writable;
+
+import io.kroxylicious.proxy.filter.ApiVersionsRequestFilter;
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.RequestFilterResult;
+import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.internal.ApiVersionsServiceImpl;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class ApiVersionsDowngradeFilter implements ApiVersionsRequestFilter {
+
+    private final ApiVersionsServiceImpl apiVersionsService;
+
+    public ApiVersionsDowngradeFilter(@NonNull ApiVersionsServiceImpl apiVersionsService) {
+        this.apiVersionsService = Objects.requireNonNull(apiVersionsService);
+    }
+
+    /**
+     * This subclass is used when we receive an ApiVersions request at an api version higher
+     * than the proxy supports. It should be handled internally with a short-circuit response
+     * and not forwarded to any broker. Only the ApiVersionsDowngradeFilter should be exposed to
+     * this type.
+     */
+    private static class DowngradeApiVersionsRequestData extends ApiVersionsRequestData {
+
+        private DowngradeApiVersionsRequestData() {
+            super();
+        }
+
+        @Override
+        public void write(Writable writable, ObjectSerializationCache cache, short version) {
+            throw new UnsupportedOperationException("DowngradeApiVersionsRequestData is read-only");
+        }
+
+        @Override
+        public int size(ObjectSerializationCache cache, short version) {
+            throw new UnsupportedOperationException("DowngradeApiVersionsRequestData is read-only");
+        }
+    }
+
+    /**
+     * This subclass is used when we receive an ApiVersions request at an api version higher
+     * than the proxy supports. It should be handled internally with a short-circuit response
+     * and not forwarded further to any broker. Only the ApiVersionsDowngradeFilter should be exposed to
+     * this type.
+     */
+    private static class DowngradeRequestHeaderData extends RequestHeaderData {
+
+        private DowngradeRequestHeaderData() {
+            super();
+        }
+
+        @Override
+        public void write(Writable writable, ObjectSerializationCache cache, short version) {
+            throw new UnsupportedOperationException("DowngradeRequestHeaderData is read-only");
+        }
+
+        @Override
+        public int size(ObjectSerializationCache cache, short version) {
+            throw new UnsupportedOperationException("DowngradeRequestHeaderData is read-only");
+        }
+    }
+
+    private static RequestHeaderData apiVersionsRequestDowngradeHeader(int correlationId) {
+        return new DowngradeRequestHeaderData()
+                .setCorrelationId(correlationId)
+                .setRequestApiKey(ApiKeys.API_VERSIONS.id)
+                .setRequestApiVersion((short) 0);
+    }
+
+    public static DecodedRequestFrame<ApiVersionsRequestData> downgradeApiVersionsFrame(int correlationId) {
+        RequestHeaderData requestHeaderData = apiVersionsRequestDowngradeHeader(correlationId);
+        return new DecodedRequestFrame<>(
+                requestHeaderData.requestApiVersion(), correlationId, true, requestHeaderData, new DowngradeApiVersionsRequestData());
+    }
+
+    @Override
+    public CompletionStage<RequestFilterResult> onApiVersionsRequest(short apiVersion, RequestHeaderData header, ApiVersionsRequestData request, FilterContext context) {
+        if (request instanceof DowngradeApiVersionsRequestData) {
+            ApiVersionsResponseData.ApiVersionCollection collection = new ApiVersionsResponseData.ApiVersionCollection();
+            ApiKeys apiVersions = ApiKeys.API_VERSIONS;
+            ApiVersionsResponseData.ApiVersion version = new ApiVersionsResponseData.ApiVersion()
+                    .setApiKey(apiVersions.id)
+                    .setMinVersion(apiVersions.oldestVersion())
+                    .setMaxVersion(apiVersionsService.latestVersion(apiVersions));
+            collection.add(version);
+            ApiVersionsResponseData message = new ApiVersionsResponseData()
+                    .setApiKeys(collection)
+                    .setErrorCode(Errors.UNSUPPORTED_VERSION.code());
+            return context.requestFilterResultBuilder().shortCircuitResponse(message).completed();
+        }
+        return context.forwardRequest(header, request);
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -400,7 +400,7 @@ class ConfigParserTest {
 
     @Test
     void shouldThrowWhenSerializingUnserializableObject() {
-        var config = new Configuration(null, null, List.of(new FilterDefinition("", new NonSerializableConfig(""))), null, false);
+        var config = new Configuration(null, null, List.of(new FilterDefinition("", new NonSerializableConfig(""))), null, false, null);
 
         ConfigParser cp = new ConfigParser();
         assertThatThrownBy(() -> {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -494,7 +494,7 @@ class KafkaProxyFrontendHandlerTest {
         while ((outboundMessage = outboundChannel.readOutbound()) != null) {
             assertThat(outboundMessage).isNotNull();
             ArrayList<Object> objects = new ArrayList<>();
-            new KafkaRequestDecoder(RequestDecoderTest.DECODE_EVERYTHING, DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES).decode(
+            new KafkaRequestDecoder(RequestDecoderTest.DECODE_EVERYTHING, DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES, new ApiVersionsServiceImpl()).decode(
                     outboundChannel.pipeline().firstContext(),
                     outboundMessage, objects);
             assertThat(objects).hasSize(1);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -494,7 +494,8 @@ class KafkaProxyFrontendHandlerTest {
         while ((outboundMessage = outboundChannel.readOutbound()) != null) {
             assertThat(outboundMessage).isNotNull();
             ArrayList<Object> objects = new ArrayList<>();
-            new KafkaRequestDecoder(RequestDecoderTest.DECODE_EVERYTHING, DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES).decode(outboundChannel.pipeline().firstContext(),
+            new KafkaRequestDecoder(RequestDecoderTest.DECODE_EVERYTHING, DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES).decode(
+                    outboundChannel.pipeline().firstContext(),
                     outboundMessage, objects);
             assertThat(objects).hasSize(1);
             if (objects.get(0) instanceof DecodedRequestFrame<?> f) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -42,6 +42,7 @@ import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.config.tls.Tls;
 import io.kroxylicious.proxy.filter.FilterFactoryContext;
 import io.kroxylicious.proxy.filter.NetFilter;
+import io.kroxylicious.proxy.internal.filter.ApiVersionsDowngradeFilter;
 import io.kroxylicious.proxy.internal.filter.ApiVersionsIntersectFilter;
 import io.kroxylicious.proxy.internal.net.Endpoint;
 import io.kroxylicious.proxy.internal.net.VirtualClusterBinding;
@@ -297,7 +298,7 @@ class KafkaProxyInitializerTest {
         ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl();
         final KafkaProxyInitializer.InitalizerNetFilter initalizerNetFilter = new KafkaProxyInitializer.InitalizerNetFilter(mock(SaslDecodePredicate.class),
                 channel, vcb, pfr, fcf, (virtualCluster1, upstreamNodes) -> null,
-                new ApiVersionsIntersectFilter(apiVersionsService));
+                new ApiVersionsIntersectFilter(apiVersionsService), new ApiVersionsDowngradeFilter(apiVersionsService));
         final NetFilter.NetFilterContext netFilterContext = mock(NetFilter.NetFilterContext.class);
 
         // When

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -42,6 +42,7 @@ import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.config.tls.Tls;
 import io.kroxylicious.proxy.filter.FilterFactoryContext;
 import io.kroxylicious.proxy.filter.NetFilter;
+import io.kroxylicious.proxy.internal.filter.ApiVersionsIntersectFilter;
 import io.kroxylicious.proxy.internal.net.Endpoint;
 import io.kroxylicious.proxy.internal.net.VirtualClusterBinding;
 import io.kroxylicious.proxy.internal.net.VirtualClusterBindingResolver;
@@ -121,7 +122,7 @@ class KafkaProxyInitializerTest {
                 (endpoint, sniHostname) -> bindingStage,
                 (virtualCluster, upstreamNodes) -> null,
                 false,
-                Map.of());
+                Map.of(), new ApiVersionsServiceImpl());
         // When
         kafkaProxyInitializer.initChannel(channel);
 
@@ -141,7 +142,7 @@ class KafkaProxyInitializerTest {
                 virtualClusterBindingResolver,
                 (virtualCluster, upstreamNodes) -> null,
                 false,
-                Map.of());
+                Map.of(), new ApiVersionsServiceImpl());
         when(channelPipeline.addLast(plainChannelResolverCaptor.capture())).thenReturn(channelPipeline);
 
         kafkaProxyInitializer.initChannel(channel);
@@ -165,7 +166,7 @@ class KafkaProxyInitializerTest {
                 virtualClusterBindingResolver,
                 (virtualCluster, upstreamNodes) -> null,
                 false,
-                Map.of());
+                Map.of(), new ApiVersionsServiceImpl());
         when(channelPipeline.addLast(plainChannelResolverCaptor.capture())).thenReturn(channelPipeline);
 
         kafkaProxyInitializer.initChannel(channel);
@@ -190,7 +191,7 @@ class KafkaProxyInitializerTest {
                 (endpoint, sniHostname) -> bindingStage,
                 (virtualCluster, upstreamNodes) -> null,
                 false,
-                Map.of());
+                Map.of(), new ApiVersionsServiceImpl());
 
         // When
         kafkaProxyInitializer.addHandlers(channel, vcb);
@@ -215,7 +216,7 @@ class KafkaProxyInitializerTest {
                 (endpoint, sniHostname) -> bindingStage,
                 (virtualCluster, upstreamNodes) -> null,
                 false,
-                Map.of());
+                Map.of(), new ApiVersionsServiceImpl());
 
         // When
         kafkaProxyInitializer.addHandlers(channel, vcb);
@@ -236,7 +237,7 @@ class KafkaProxyInitializerTest {
                 (endpoint, sniHostname) -> bindingStage,
                 (virtualCluster, upstreamNodes) -> null,
                 false,
-                Map.of());
+                Map.of(), new ApiVersionsServiceImpl());
 
         // When
         kafkaProxyInitializer.addHandlers(channel, vcb);
@@ -258,7 +259,7 @@ class KafkaProxyInitializerTest {
                 (endpoint, sniHostname) -> bindingStage,
                 (virtualCluster, upstreamNodes) -> null,
                 false,
-                Map.of(KafkaAuthnHandler.SaslMechanism.PLAIN, plainHandler));
+                Map.of(KafkaAuthnHandler.SaslMechanism.PLAIN, plainHandler), new ApiVersionsServiceImpl());
 
         // When
         kafkaProxyInitializer.addHandlers(channel, vcb);
@@ -279,7 +280,7 @@ class KafkaProxyInitializerTest {
                 (endpoint, sniHostname) -> bindingStage,
                 (virtualCluster, upstreamNodes) -> null,
                 false,
-                Map.of());
+                Map.of(), new ApiVersionsServiceImpl());
 
         // When
         kafkaProxyInitializer.addHandlers(channel, vcb);
@@ -293,8 +294,10 @@ class KafkaProxyInitializerTest {
         // Given
         final FilterChainFactory fcf = mock(FilterChainFactory.class);
         when(vcb.upstreamTarget()).thenReturn(new HostPort("upstream.broker.kafka", 9090));
+        ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl();
         final KafkaProxyInitializer.InitalizerNetFilter initalizerNetFilter = new KafkaProxyInitializer.InitalizerNetFilter(mock(SaslDecodePredicate.class),
-                mock(ApiVersionsServiceImpl.class), channel, vcb, pfr, fcf, (virtualCluster1, upstreamNodes) -> null);
+                channel, vcb, pfr, fcf, (virtualCluster1, upstreamNodes) -> null,
+                new ApiVersionsIntersectFilter(apiVersionsService));
         final NetFilter.NetFilterContext netFilterContext = mock(NetFilter.NetFilterContext.class);
 
         // When
@@ -313,7 +316,7 @@ class KafkaProxyInitializerTest {
                 (endpoint, sniHostname) -> bindingStage,
                 (virtualCluster, upstreamNodes) -> null,
                 false,
-                Map.of());
+                Map.of(), new ApiVersionsServiceImpl());
 
         // When
         kafkaProxyInitializer.initChannel(channel);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoderTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.codec;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.ObjectSerializationCache;
+import org.apache.kafka.common.protocol.types.RawTaggedField;
+import org.junit.jupiter.api.Test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.DecoderException;
+
+import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.internal.ApiVersionsServiceImpl;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class KafkaRequestDecoderTest {
+
+    @Test
+    void decodeUnknownApiVersionsRespectsOverridenLatestVersion() {
+        short latestSupportedApiVersionsOverride = (short) 2;
+        ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl(Map.of(ApiKeys.API_VERSIONS, latestSupportedApiVersionsOverride));
+        EmbeddedChannel embeddedChannel = new EmbeddedChannel(new KafkaRequestDecoder(RequestDecoderTest.DECODE_EVERYTHING, 1024, apiVersionsService));
+        RequestHeaderData header = latestVersionHeaderWithAllFields(ApiKeys.API_VERSIONS, (short) (latestSupportedApiVersionsOverride + 1));
+        byte[] arbitraryBodyBytes = new byte[]{ 1, 2, 3, 4 };
+        ObjectSerializationCache cache = new ObjectSerializationCache();
+        short latestApiVersion = ApiKeys.API_VERSIONS.latestVersion(true);
+        short requestHeaderVersion = ApiKeys.API_VERSIONS.requestHeaderVersion(latestApiVersion);
+        int headerSize = header.size(cache, requestHeaderVersion);
+        int messageSize = headerSize + arbitraryBodyBytes.length;
+        ByteBuf buffer = Unpooled.buffer();
+        ByteBufAccessorImpl accessor = new ByteBufAccessorImpl(buffer);
+        accessor.writeInt(messageSize);
+        header.write(accessor, cache, requestHeaderVersion);
+        accessor.writeByteArray(arbitraryBodyBytes);
+        embeddedChannel.writeInbound(buffer);
+        Object inboundMessage = embeddedChannel.readInbound();
+        assertThat(inboundMessage).isInstanceOfSatisfying(DecodedRequestFrame.class, decodedRequestFrame -> {
+            assertThat(decodedRequestFrame.correlationId()).isEqualTo(2);
+            assertThat(decodedRequestFrame.apiKey()).isEqualTo(ApiKeys.API_VERSIONS);
+            assertThat(decodedRequestFrame.apiVersion()).isEqualTo((short) 0);
+            assertThat(decodedRequestFrame.decodeResponse()).isTrue();
+            assertThat(decodedRequestFrame.hasResponse()).isTrue();
+            assertThat(decodedRequestFrame.header()).isInstanceOfSatisfying(RequestHeaderData.class, requestHeaderData -> {
+                assertThat(requestHeaderData.correlationId()).isEqualTo(2);
+                assertThat(requestHeaderData.requestApiKey()).isEqualTo(ApiKeys.API_VERSIONS.id);
+                assertThat(requestHeaderData.requestApiVersion()).isEqualTo((short) 0);
+                assertThat(requestHeaderData.clientId()).isEmpty();
+                assertThat(requestHeaderData.unknownTaggedFields()).isEmpty();
+                short version = ApiKeys.API_VERSIONS.requestHeaderVersion((short) 0);
+                assertUnwritable(requestHeaderData, cache, version);
+            });
+            assertThat(decodedRequestFrame.body()).isInstanceOfSatisfying(ApiVersionsRequestData.class, apiVersionsRequestData -> {
+                assertUnwritable(apiVersionsRequestData, cache, (short) 0);
+            });
+        });
+    }
+
+    @Test
+    void decodeUnknownApiVersions() {
+        EmbeddedChannel embeddedChannel = new EmbeddedChannel(new KafkaRequestDecoder(RequestDecoderTest.DECODE_EVERYTHING, 1024, new ApiVersionsServiceImpl()));
+        RequestHeaderData header = latestVersionHeaderWithAllFields(ApiKeys.API_VERSIONS, Short.MAX_VALUE);
+        byte[] arbitraryBodyBytes = new byte[]{ 1, 2, 3, 4 };
+        ObjectSerializationCache cache = new ObjectSerializationCache();
+        short latestApiVersion = ApiKeys.API_VERSIONS.latestVersion(true);
+        short requestHeaderVersion = ApiKeys.API_VERSIONS.requestHeaderVersion(latestApiVersion);
+        int headerSize = header.size(cache, requestHeaderVersion);
+        int messageSize = headerSize + arbitraryBodyBytes.length;
+        ByteBuf buffer = Unpooled.buffer();
+        ByteBufAccessorImpl accessor = new ByteBufAccessorImpl(buffer);
+        accessor.writeInt(messageSize);
+        header.write(accessor, cache, requestHeaderVersion);
+        accessor.writeByteArray(arbitraryBodyBytes);
+        embeddedChannel.writeInbound(buffer);
+        Object inboundMessage = embeddedChannel.readInbound();
+        assertThat(inboundMessage).isInstanceOfSatisfying(DecodedRequestFrame.class, decodedRequestFrame -> {
+            assertThat(decodedRequestFrame.correlationId()).isEqualTo(2);
+            assertThat(decodedRequestFrame.apiKey()).isEqualTo(ApiKeys.API_VERSIONS);
+            assertThat(decodedRequestFrame.apiVersion()).isEqualTo((short) 0);
+            assertThat(decodedRequestFrame.decodeResponse()).isTrue();
+            assertThat(decodedRequestFrame.hasResponse()).isTrue();
+            assertThat(decodedRequestFrame.header()).isInstanceOfSatisfying(RequestHeaderData.class, requestHeaderData -> {
+                assertThat(requestHeaderData.correlationId()).isEqualTo(2);
+                assertThat(requestHeaderData.requestApiKey()).isEqualTo(ApiKeys.API_VERSIONS.id);
+                assertThat(requestHeaderData.requestApiVersion()).isEqualTo((short) 0);
+                assertThat(requestHeaderData.clientId()).isEmpty();
+                assertThat(requestHeaderData.unknownTaggedFields()).isEmpty();
+                short version = ApiKeys.API_VERSIONS.requestHeaderVersion((short) 0);
+                assertUnwritable(requestHeaderData, cache, version);
+            });
+            assertThat(decodedRequestFrame.body()).isInstanceOfSatisfying(ApiVersionsRequestData.class, apiVersionsRequestData -> {
+                assertUnwritable(apiVersionsRequestData, cache, (short) 0);
+            });
+        });
+    }
+
+    // after ApiVersions negotiation we should never encounter a request from the client for an api version unknown to the proxy
+    @Test
+    void throwsOnUnsupportedVersionOfNonApiVersionsRequests() {
+        EmbeddedChannel embeddedChannel = new EmbeddedChannel(new KafkaRequestDecoder(RequestDecoderTest.DECODE_EVERYTHING, 1024, new ApiVersionsServiceImpl()));
+        short maxSupportedVersion = ApiKeys.METADATA.latestVersion(true);
+        short unsupportedVersion = (short) (maxSupportedVersion + 1);
+        RequestHeaderData header = latestVersionHeaderWithAllFields(ApiKeys.METADATA, unsupportedVersion);
+        byte[] arbitraryBodyBytes = new byte[]{ 1, 2, 3, 4 };
+        ObjectSerializationCache cache = new ObjectSerializationCache();
+        short requestHeaderVersion = ApiKeys.METADATA.requestHeaderVersion(maxSupportedVersion);
+        int headerSize = header.size(cache, requestHeaderVersion);
+        int messageSize = headerSize + arbitraryBodyBytes.length;
+        ByteBuf buffer = Unpooled.buffer();
+        ByteBufAccessorImpl accessor = new ByteBufAccessorImpl(buffer);
+        accessor.writeInt(messageSize);
+        header.write(accessor, cache, requestHeaderVersion);
+        accessor.writeByteArray(arbitraryBodyBytes);
+        assertThatThrownBy(() -> {
+            embeddedChannel.writeInbound(buffer);
+        }).isInstanceOf(DecoderException.class).cause().isInstanceOf(IllegalStateException.class)
+                .hasMessage("client apiVersion %d ahead of proxy maximum %d for api key: METADATA", unsupportedVersion, maxSupportedVersion);
+    }
+
+    private static @NonNull RequestHeaderData latestVersionHeaderWithAllFields(ApiKeys requestApiKey, short requestApiVersion) {
+        RequestHeaderData header = new RequestHeaderData();
+        header.setRequestApiKey(requestApiKey.id);
+        header.setRequestApiVersion(requestApiVersion);
+        header.setCorrelationId(2);
+        header.setClientId("clientId");
+        header.unknownTaggedFields().add(new RawTaggedField(5, "arbitrary".getBytes(StandardCharsets.UTF_8)));
+        return header;
+    }
+
+    private static void assertUnwritable(ApiMessage requestHeaderData, ObjectSerializationCache cache, short version) {
+        assertThatThrownBy(() -> requestHeaderData.size(cache, version)).isInstanceOf(UnsupportedOperationException.class);
+        ByteBufAccessorImpl byteBufAccessor = new ByteBufAccessorImpl(Unpooled.buffer());
+        assertThatThrownBy(() -> requestHeaderData.write(byteBufAccessor, cache, version)).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/RequestDecoderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/RequestDecoderTest.java
@@ -306,7 +306,7 @@ public class RequestDecoderTest extends AbstractCodecTest {
         assertEquals(45,
                 exactlyOneFrame_encoded(produceVersion,
                         ApiKeys.PRODUCE::requestHeaderVersion,
-                        (x) -> header,
+                        x -> header,
                         () -> body,
                         getKafkaRequestDecoder(DECODE_NOTHING, DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES),
                         OpaqueRequestFrame.class,

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/RequestDecoderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/RequestDecoderTest.java
@@ -31,6 +31,7 @@ import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.OpaqueRequestFrame;
+import io.kroxylicious.proxy.internal.ApiVersionsServiceImpl;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -92,7 +93,7 @@ public class RequestDecoderTest extends AbstractCodecTest {
                                         .forFilters(FilterAndInvoker.build(
                                                 (ApiVersionsRequestFilter) (version, header, request, context) -> context.requestFilterResultBuilder()
                                                         .forward(header, request).completed())),
-                                DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES),
+                                DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES, new ApiVersionsServiceImpl()),
                         DecodedRequestFrame.class,
                         (RequestHeaderData header) -> header, true),
                 "Unexpected correlation id");
@@ -173,7 +174,7 @@ public class RequestDecoderTest extends AbstractCodecTest {
                                                                                                      FilterContext context) {
                                         return context.requestFilterResultBuilder().forward(header, request).completed();
                                     }
-                                })), DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES),
+                                })), DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES, new ApiVersionsServiceImpl()),
                         OpaqueRequestFrame.class, true),
                 "Unexpected correlation id");
     }
@@ -195,7 +196,7 @@ public class RequestDecoderTest extends AbstractCodecTest {
                         FilterAndInvoker.build((ApiVersionsRequestFilter) (version, header, request, context) -> {
                             return context.requestFilterResultBuilder().forward(header, request).completed();
                         })),
-                DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES)
+                DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES, new ApiVersionsServiceImpl())
                 .decode(null, byteBuf, messages);
 
         assertEquals(List.of(), messageClasses(messages));
@@ -227,7 +228,7 @@ public class RequestDecoderTest extends AbstractCodecTest {
     private static KafkaRequestDecoder getKafkaRequestDecoder(DecodePredicate predicate, int socketFrameMaxSizeBytes) {
         return new KafkaRequestDecoder(
                 predicate,
-                socketFrameMaxSizeBytes);
+                socketFrameMaxSizeBytes, new ApiVersionsServiceImpl());
     }
 
     @ParameterizedTest
@@ -269,7 +270,7 @@ public class RequestDecoderTest extends AbstractCodecTest {
                         FilterAndInvoker
                                 .build((ApiVersionsRequestFilter) (version, head, request, context) -> context.requestFilterResultBuilder().forward(header, request)
                                         .completed())),
-                DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES)
+                DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES, new ApiVersionsServiceImpl())
                 .decode(null, byteBuf, messages);
 
         assertEquals(List.of(DecodedRequestFrame.class, DecodedRequestFrame.class), messageClasses(messages));

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/ApiVersionsDowngradeFilterTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/ApiVersionsDowngradeFilterTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ByteBufferAccessor;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.protocol.ObjectSerializationCache;
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.internal.ApiVersionsServiceImpl;
+import io.kroxylicious.proxy.internal.FilterHarness;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ApiVersionsDowngradeFilterTest extends FilterHarness {
+
+    public static final ObjectSerializationCache CACHE = new ObjectSerializationCache();
+
+    @Test
+    void shortCircuitDowngradeApiVersionsRequests() {
+        buildChannel(new ApiVersionsDowngradeFilter(new ApiVersionsServiceImpl()));
+        writeRequest(ApiVersionsDowngradeFilter.downgradeApiVersionsFrame(5));
+        DecodedResponseFrame<ApiVersionsResponseData> response = channel.readInbound();
+        assertThat(response.body()).isInstanceOfSatisfying(ApiVersionsResponseData.class, apiVersionsResponseData -> {
+            assertThat(apiVersionsResponseData.errorCode()).isEqualTo(Errors.UNSUPPORTED_VERSION.code());
+            ApiVersionsResponseData.ApiVersion apiVersion = new ApiVersionsResponseData.ApiVersion();
+            apiVersion.setApiKey(ApiKeys.API_VERSIONS.id);
+            apiVersion.setMinVersion(ApiKeys.API_VERSIONS.oldestVersion());
+            apiVersion.setMaxVersion(ApiKeys.API_VERSIONS.latestVersion(true));
+            assertThat(apiVersionsResponseData.apiKeys()).containsExactly(apiVersion);
+        });
+    }
+
+    @Test
+    void shortCircuitDowngradeApiVersionsRequestsConsidersLatestVersionOverride() {
+        buildChannel(new ApiVersionsDowngradeFilter(new ApiVersionsServiceImpl(Map.of(ApiKeys.API_VERSIONS, (short) 2))));
+        writeRequest(ApiVersionsDowngradeFilter.downgradeApiVersionsFrame(5));
+        DecodedResponseFrame<ApiVersionsResponseData> response = channel.readInbound();
+        assertThat(response.body()).isInstanceOfSatisfying(ApiVersionsResponseData.class, apiVersionsResponseData -> {
+            assertThat(apiVersionsResponseData.errorCode()).isEqualTo(Errors.UNSUPPORTED_VERSION.code());
+            ApiVersionsResponseData.ApiVersion apiVersion = new ApiVersionsResponseData.ApiVersion();
+            apiVersion.setApiKey(ApiKeys.API_VERSIONS.id);
+            apiVersion.setMinVersion(ApiKeys.API_VERSIONS.oldestVersion());
+            apiVersion.setMaxVersion((short) 2);
+            assertThat(apiVersionsResponseData.apiKeys()).containsExactly(apiVersion);
+        });
+    }
+
+    @Test
+    void passThroughAnythingElse() {
+        buildChannel(new ApiVersionsDowngradeFilter(new ApiVersionsServiceImpl()));
+        DecodedRequestFrame<ApiVersionsRequestData> request = writeRequest(new ApiVersionsRequestData());
+        var propagated = channel.readOutbound();
+        assertThat(propagated).isEqualTo(request);
+    }
+
+    @Test
+    void downgradeFrameHeaderNotWritable() {
+        DecodedRequestFrame<ApiVersionsRequestData> frame = ApiVersionsDowngradeFilter.downgradeApiVersionsFrame(5);
+        RequestHeaderData header = frame.header();
+        assertThatThrownBy(() -> header.size(CACHE, (short) 1)).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> header.write(new ByteBufferAccessor(ByteBuffer.allocate(1)), CACHE, (short) 1)).isInstanceOf(
+                UnsupportedOperationException.class);
+    }
+
+    @Test
+    void downgradeFrameBodyNotWritable() {
+        DecodedRequestFrame<ApiVersionsRequestData> frame = ApiVersionsDowngradeFilter.downgradeApiVersionsFrame(5);
+        ApiVersionsRequestData body = frame.body();
+        assertThatThrownBy(() -> body.size(CACHE, (short) 1)).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> body.write(new ByteBufferAccessor(ByteBuffer.allocate(1)), CACHE, (short) 1)).isInstanceOf(
+                UnsupportedOperationException.class);
+    }
+}


### PR DESCRIPTION
End to end test verifying a two stage downgrade actually works.

uses an old broker (redpanda) with supports api-versions 0..2.

