### PR TITLE
Add opt-in test-only configuration to Proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#1648](https://github.com/kroxylicious/kroxylicious/pull/1648) Add test-only feature mechanism to Proxy configuration
 * [#1379](https://github.com/kroxylicious/kroxylicious/issues/1379) Remove Deprecated EnvelopeEncryption
 * [#1561](https://github.com/kroxylicious/kroxylicious/pull/1631) Allow Trust and ClientAuth to be set for Downstream TLS
 * [#1550](https://github.com/kroxylicious/kroxylicious/pull/1550) Upgrade Apache Kafka from 3.8.0 to 3.9.0 #1550

--- a/kroxylicious-app/src/test/java/io/kroxylicious/app/KroxyliciousIT.java
+++ b/kroxylicious-app/src/test/java/io/kroxylicious/app/KroxyliciousIT.java
@@ -6,18 +6,24 @@
 package io.kroxylicious.app;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.jupiter.api.Test;
@@ -26,12 +32,15 @@ import org.junit.jupiter.api.io.TempDir;
 
 import io.kroxylicious.proxy.config.ConfigParser;
 import io.kroxylicious.proxy.config.Configuration;
-import io.kroxylicious.proxy.service.HostPort;
+import io.kroxylicious.proxy.internal.config.Feature;
+import io.kroxylicious.proxy.internal.config.Features;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
+import static io.kroxylicious.test.tester.KroxyliciousTesters.newBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -45,9 +54,73 @@ class KroxyliciousIT {
     private static final String PLAINTEXT = "Hello, world!";
 
     @Test
-    void shouldProxyWhenRunAsStandaloneProcess(KafkaCluster cluster, Admin admin, @TempDir Path tempDir) throws Exception {
-        var proxyAddress = HostPort.parse("localhost:9192");
+    void shouldFailToStartWithTestConfigurationsByDefault(@TempDir Path tempDir) throws IOException {
+        SubprocessKroxyliciousFactory kroxyliciousFactory = new SubprocessKroxyliciousFactory(tempDir, (features, processBuilder) -> {
+            // no-op so that io is not inherited
+        }, List.of());
+        var tester = kroxyliciousTester(proxy("fake:9092").withDevelopment(Map.of("a", "b")), kroxyliciousFactory);
+        Process lastProcess = kroxyliciousFactory.lastProcess;
+        assertThat(lastProcess).isNotNull();
+        assertThat(lastProcess.onExit()).succeedsWithin(5, TimeUnit.SECONDS);
+        byte[] bytes = lastProcess.getInputStream().readAllBytes();
+        String output = new String(bytes, StandardCharsets.UTF_8);
+        assertThat(output).contains("test-only configuration for proxy present, but loading test-only configuration not enabled");
+        tester.close();
+    }
 
+    @Test
+    void shouldFailToStartWithTestConfigurationAndLoadTestConfigurationExplicitlyDisabled(@TempDir Path tempDir) throws IOException {
+        SubprocessKroxyliciousFactory kroxyliciousFactory = new SubprocessKroxyliciousFactory(tempDir, (features, processBuilder) -> {
+            processBuilder.environment().put(prefixUnlockPropertyName(Feature.TEST_ONLY_CONFIGURATION), "false");
+        }, List.of());
+        var tester = kroxyliciousTester(proxy("fake:9092").withDevelopment(Map.of("a", "b")), kroxyliciousFactory);
+        Process lastProcess = kroxyliciousFactory.lastProcess;
+        assertThat(lastProcess).isNotNull();
+        assertThat(lastProcess.onExit()).succeedsWithin(5, TimeUnit.SECONDS);
+        byte[] bytes = lastProcess.getInputStream().readAllBytes();
+        String output = new String(bytes, StandardCharsets.UTF_8);
+        assertThat(output).contains("test-only configuration for proxy present, but loading test-only configuration not enabled");
+        tester.close();
+    }
+
+    @Test
+    void shouldStartWithTestConfigurationsFeatureEnabledByEnvironmentVariable(KafkaCluster cluster, Admin admin, @TempDir Path tempDir) throws Exception {
+        admin.createTopics(List.of(
+                new NewTopic(TOPIC_1, 1, (short) 1),
+                new NewTopic(TOPIC_2, 1, (short) 1))).all().get();
+
+        try (var tester = newBuilder(proxy(cluster).withDevelopment(Map.of("a", "b")))
+                .setKroxyliciousFactory(new SubprocessKroxyliciousFactory(tempDir))
+                .setFeatures(Features.builder().enable(Feature.TEST_ONLY_CONFIGURATION).build())
+                .createDefaultKroxyliciousTester();
+                var producer = tester.producer(Map.of(
+                        ProducerConfig.CLIENT_ID_CONFIG, "shouldModifyProduceMessage",
+                        ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000));
+                var consumer = tester.consumer()) {
+            assertProxies(producer, consumer);
+        }
+    }
+
+    @Test
+    void shouldStartWithTestConfigurationsFeatureEnabledBySystemProperty(KafkaCluster cluster, Admin admin, @TempDir Path tempDir) throws Exception {
+        admin.createTopics(List.of(
+                new NewTopic(TOPIC_1, 1, (short) 1),
+                new NewTopic(TOPIC_2, 1, (short) 1))).all().get();
+
+        try (var tester = newBuilder(proxy(cluster).withDevelopment(Map.of("a", "b")))
+                .setKroxyliciousFactory(new SubprocessKroxyliciousFactory(tempDir, (features, processBuilder) -> processBuilder.inheritIO(),
+                        List.of("-D" + prefixUnlockPropertyName(Feature.TEST_ONLY_CONFIGURATION) + "=true")))
+                .createDefaultKroxyliciousTester();
+                var producer = tester.producer(Map.of(
+                        ProducerConfig.CLIENT_ID_CONFIG, "shouldModifyProduceMessage",
+                        ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000));
+                var consumer = tester.consumer()) {
+            assertProxies(producer, consumer);
+        }
+    }
+
+    @Test
+    void shouldProxyWhenRunAsStandaloneProcess(KafkaCluster cluster, Admin admin, @TempDir Path tempDir) throws Exception {
         admin.createTopics(List.of(
                 new NewTopic(TOPIC_1, 1, (short) 1),
                 new NewTopic(TOPIC_2, 1, (short) 1))).all().get();
@@ -57,36 +130,70 @@ class KroxyliciousIT {
                         ProducerConfig.CLIENT_ID_CONFIG, "shouldModifyProduceMessage",
                         ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000));
                 var consumer = tester.consumer()) {
-            producer.send(new ProducerRecord<>(TOPIC_1, "my-key", PLAINTEXT)).get();
-            producer.send(new ProducerRecord<>(TOPIC_2, "my-key", PLAINTEXT)).get();
-            producer.flush();
-
-            consumer.subscribe(Set.of(TOPIC_1));
-            ConsumerRecords<String, String> records1 = consumer.poll(Duration.ofSeconds(10));
-            consumer.subscribe(Set.of(TOPIC_2));
-            ConsumerRecords<String, String> records2 = consumer.poll(Duration.ofSeconds(10));
-
-            assertEquals(1, records1.count());
-            assertEquals(PLAINTEXT, records1.iterator().next().value());
-            assertEquals(1, records2.count());
-            assertEquals(PLAINTEXT, records2.iterator().next().value());
+            assertProxies(producer, consumer);
         }
     }
 
-    private record SubprocessKroxyliciousFactory(Path tempDir) implements Function<Configuration, AutoCloseable> {
+    private static void assertProxies(Producer<String, String> producer, Consumer<String, String> consumer)
+            throws InterruptedException, ExecutionException {
+        producer.send(new ProducerRecord<>(KroxyliciousIT.TOPIC_1, "my-key", KroxyliciousIT.PLAINTEXT)).get();
+        producer.send(new ProducerRecord<>(KroxyliciousIT.TOPIC_2, "my-key", KroxyliciousIT.PLAINTEXT)).get();
+        producer.flush();
+
+        consumer.subscribe(Set.of(KroxyliciousIT.TOPIC_1));
+        ConsumerRecords<String, String> records1 = consumer.poll(Duration.ofSeconds(10));
+        consumer.subscribe(Set.of(KroxyliciousIT.TOPIC_2));
+        ConsumerRecords<String, String> records2 = consumer.poll(Duration.ofSeconds(10));
+
+        assertEquals(1, records1.count());
+        assertEquals(KroxyliciousIT.PLAINTEXT, records1.iterator().next().value());
+        assertEquals(1, records2.count());
+        assertEquals(KroxyliciousIT.PLAINTEXT, records2.iterator().next().value());
+    }
+
+    private static String prefixUnlockPropertyName(Feature feature) {
+        return "KROXYLICIOUS_UNLOCK_" + feature.name();
+    }
+
+    private static class SubprocessKroxyliciousFactory implements BiFunction<Configuration, Features, AutoCloseable> {
+
+        private final Path tempDir;
+        private final java.util.function.BiConsumer<Features, ProcessBuilder> processBuilderModifier;
+        private final List<String> jvmArgs;
+        private Process lastProcess;
+
+        SubprocessKroxyliciousFactory(Path tempDir) {
+            this(tempDir, (features, processBuilder) -> {
+                processBuilder.inheritIO();
+                if (features.isEnabled(Feature.TEST_ONLY_CONFIGURATION)) {
+                    processBuilder.environment().put(prefixUnlockPropertyName(Feature.TEST_ONLY_CONFIGURATION), "true");
+                }
+            }, List.of());
+        }
+
+        SubprocessKroxyliciousFactory(Path tempDir, java.util.function.BiConsumer<Features, ProcessBuilder> processBuilderModifier, List<String> jvmArgs) {
+            this.tempDir = tempDir;
+            this.processBuilderModifier = processBuilderModifier;
+            this.jvmArgs = jvmArgs;
+        }
 
         @Override
-        public AutoCloseable apply(Configuration config) {
+        public AutoCloseable apply(Configuration config, Features features) {
             try {
                 Path configPath = tempDir.resolve("config.yaml");
                 Files.writeString(configPath, new ConfigParser().toYaml(config));
                 String java = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
                 String classpath = System.getProperty("java.class.path");
-                var processBuilder = new ProcessBuilder(java, "-cp", classpath, "io.kroxylicious.app.Kroxylicious", "-c", configPath.toString()).inheritIO();
-                Process start = processBuilder.start();
+                List<String> command = new ArrayList<>();
+                command.add(java);
+                command.addAll(jvmArgs);
+                command.addAll(List.of("-cp", classpath, "io.kroxylicious.app.Kroxylicious", "-c", configPath.toString()));
+                var processBuilder = new ProcessBuilder(command);
+                processBuilderModifier.accept(features, processBuilder);
+                lastProcess = processBuilder.start();
                 return () -> {
-                    start.destroy();
-                    start.onExit().get(10, TimeUnit.SECONDS);
+                    lastProcess.destroy();
+                    lastProcess.onExit().get(10, TimeUnit.SECONDS);
                 };
             }
             catch (Exception e) {

--- a/kroxylicious-app/src/test/java/io/kroxylicious/app/KroxyliciousTest.java
+++ b/kroxylicious-app/src/test/java/io/kroxylicious/app/KroxyliciousTest.java
@@ -12,6 +12,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -23,6 +24,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.kroxylicious.proxy.KafkaProxy;
+import io.kroxylicious.proxy.internal.config.Features;
 
 import picocli.CommandLine;
 
@@ -41,10 +43,16 @@ class KroxyliciousTest {
     private CommandLine cmd;
     private StringWriter soutWriter;
     private StringWriter serrWriter;
+    private AtomicReference<Features> features = new AtomicReference<>(null);
 
     @BeforeEach
     public void setup() {
-        Kroxylicious app = new Kroxylicious((ffm, configuration) -> mockProxy);
+        Kroxylicious app = new Kroxylicious((ffm, configuration, features) -> {
+            if (!this.features.compareAndSet(null, features)) {
+                throw new IllegalStateException("env already set");
+            }
+            return mockProxy;
+        });
         soutWriter = new StringWriter();
         serrWriter = new StringWriter();
         cmd = new CommandLine(app);
@@ -85,6 +93,15 @@ class KroxyliciousTest {
         when(mockProxy.startup()).thenReturn(mockProxy);
         doNothing().when(mockProxy).block();
         assertEquals(0, cmd.execute("-c", file.toString()));
+    }
+
+    @Test
+    void testDefaultFeatures(@TempDir Path dir) throws Exception {
+        Path file = copyClasspathResourceToTempFileInDir("proxy-config.yaml", dir);
+        when(mockProxy.startup()).thenReturn(mockProxy);
+        doNothing().when(mockProxy).block();
+        assertEquals(0, cmd.execute("-c", file.toString()));
+        assertThat(features).hasValue(Features.defaultFeatures());
     }
 
     @Test

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
@@ -40,6 +40,7 @@ import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.ServiceBasedPluginFactoryRegistry;
 import io.kroxylicious.proxy.config.VirtualCluster;
 import io.kroxylicious.proxy.config.tls.Tls;
+import io.kroxylicious.proxy.internal.config.Features;
 import io.kroxylicious.test.client.KafkaClient;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -220,7 +221,7 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     public void restartProxy() {
         try {
             proxy.close();
-            proxy = spawnProxy(kroxyliciousConfig);
+            proxy = spawnProxy(kroxyliciousConfig, Features.defaultFeatures());
         }
         catch (Exception e) {
             throw new IllegalStateException(e);
@@ -257,8 +258,8 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
         }
     }
 
-    static KafkaProxy spawnProxy(Configuration config) {
-        KafkaProxy kafkaProxy = new KafkaProxy(new ServiceBasedPluginFactoryRegistry(), config);
+    static KafkaProxy spawnProxy(Configuration config, Features features) {
+        KafkaProxy kafkaProxy = new KafkaProxy(new ServiceBasedPluginFactoryRegistry(), config, features);
         try {
             kafkaProxy.startup();
         }

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/DefaultKroxyliciousTesterTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/DefaultKroxyliciousTesterTest.java
@@ -565,7 +565,9 @@ class DefaultKroxyliciousTesterTest {
         return new KroxyliciousTesterBuilder().setConfigurationBuilder(configurationBuilder)
                 .setTrustStoreLocation(keytoolCertificateGenerator.getTrustStoreLocation())
                 .setTrustStorePassword(keytoolCertificateGenerator.getPassword())
-                .setKroxyliciousFactory(DefaultKroxyliciousTester::spawnProxy).setClientFactory(clientFactory).createDefaultKroxyliciousTester();
+                .setKroxyliciousFactory(DefaultKroxyliciousTester::spawnProxy)
+                .setClientFactory(clientFactory)
+                .createDefaultKroxyliciousTester();
     }
 
     private static void generateSecurityCert(KeytoolCertificateGenerator keytoolCertificateGenerator) {
@@ -580,7 +582,8 @@ class DefaultKroxyliciousTesterTest {
     private KroxyliciousTester buildTester() {
         return new KroxyliciousTesterBuilder()
                 .setConfigurationBuilder(proxy(backingCluster, VIRTUAL_CLUSTER_A, VIRTUAL_CLUSTER_B, VIRTUAL_CLUSTER_C))
-                .setKroxyliciousFactory(DefaultKroxyliciousTester::spawnProxy).setClientFactory(clientFactory).createDefaultKroxyliciousTester();
+                .setKroxyliciousFactory(DefaultKroxyliciousTester::spawnProxy).setClientFactory(clientFactory)
+                .createDefaultKroxyliciousTester();
     }
 
     public static <T> T argThat(Consumer<T> assertions) {

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigSecret.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigSecret.java
@@ -129,7 +129,8 @@ public class ProxyConfigSecret
                 virtualClusters,
                 filterDefinitions,
                 List.of(),
-                false);
+                false,
+                Optional.empty());
 
         return toYaml(configuration);
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -7,6 +7,8 @@ package io.kroxylicious.proxy.config;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 import io.kroxylicious.proxy.config.admin.AdminHttpConfiguration;
 
@@ -17,7 +19,12 @@ public record Configuration(@Nullable AdminHttpConfiguration adminHttp,
                             Map<String, VirtualCluster> virtualClusters,
                             List<FilterDefinition> filters,
                             List<MicrometerDefinition> micrometer,
-                            boolean useIoUring) {
+                            boolean useIoUring,
+                            @NonNull Optional<Map<String, Object>> development) {
+    public Configuration {
+        Objects.requireNonNull(development);
+    }
+
     public @Nullable AdminHttpConfiguration adminHttpConfig() {
         return adminHttp();
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/IllegalConfigurationException.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/IllegalConfigurationException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config;
+
+/**
+ * Signals that the configuration is syntactically/semantically correct but illegal
+ * by some policy. For example if a configuration switches on a test-only feature
+ * but the proxy does not have test-only configuration loading enabled.
+ */
+public class IllegalConfigurationException extends RuntimeException {
+    public IllegalConfigurationException(String message) {
+        super(message);
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/config/Feature.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/config/Feature.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.config;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import io.kroxylicious.proxy.config.Configuration;
+
+/**
+ * Configuration Features related to how we load configuration.
+ */
+public enum Feature {
+
+    /**
+     * Enables loading specific nodes in the configuration file which configure test-only features. These are unsupported
+     * for production usages and there are no compatibility guarantees for their configuration model.
+     */
+    TEST_ONLY_CONFIGURATION {
+        @Override
+        public Optional<String> maybeWarning(boolean enabled) {
+            if (enabled) {
+                return Optional.of(
+                        "test-only configuration for proxy will be loaded. these configurations are unsupported and have no compatibility guarantees, they could be removed or changed at any time");
+            }
+            else {
+                return Optional.empty();
+            }
+        }
+
+        @Override
+        public Stream<String> supports(Configuration configuration, boolean enabled) {
+            Optional<Map<String, Object>> development = configuration.development();
+            if (development.isPresent() && !development.get().isEmpty() && !enabled) {
+                return Stream.of("test-only configuration for proxy present, but loading test-only configuration not enabled");
+            }
+            return Stream.empty();
+        }
+    };
+
+    /**
+     * Check if a configuration is supported by this feature
+     * @param configuration proxy configuration
+     * @param enabled true if this feature is enabled
+     * @return a stream of error messages, a non-empty stream indicates the configuration is unsupported
+     */
+    public abstract Stream<String> supports(Configuration configuration, boolean enabled);
+
+    public boolean enabledByDefault() {
+        return false;
+    }
+
+    /**
+     * At proxy initialisation time, this method will be invoked to give the feature an opportunity to log
+     * any disclaimers.
+     * @param enabled true if this feature is enabled
+     */
+    public abstract Optional<String> maybeWarning(boolean enabled);
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/config/Features.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/config/Features.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.config;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import io.kroxylicious.proxy.config.Configuration;
+
+import static java.util.Arrays.stream;
+
+/**
+ * Represents the entire set of proxy features.
+ */
+public class Features {
+
+    private static final Features DEFAULT_FEATURES = new Features(Map.of());
+    private final Map<Feature, Boolean> featureToEnabled;
+
+    private Features(Map<Feature, Boolean> featureToEnabled) {
+        this.featureToEnabled = featureToEnabled;
+    }
+
+    /**
+     * Check whether this configuration is supported by the proxy's features
+     * @param configuration configuration
+     * @return if not supported, returns a list of errors, else an empty list
+     */
+    public List<String> supports(Configuration configuration) {
+        return stream(Feature.values())
+                .flatMap(feature -> feature.supports(configuration, isEnabled(feature)))
+                .toList();
+    }
+
+    /**
+     *
+     * @param feature feature to test
+     * @return true if feature enabled, else false
+     */
+    public boolean isEnabled(Feature feature) {
+        return featureToEnabled.getOrDefault(feature, feature.enabledByDefault());
+    }
+
+    public static Features defaultFeatures() {
+        return DEFAULT_FEATURES;
+    }
+
+    /**
+     * If any sensitive or unsupported features are enabled, they may return a warning to be logged
+     * @return list of warnings, empty if no warnings
+     */
+    public List<String> warnings() {
+        return stream(Feature.values()).flatMap(feature -> feature.maybeWarning(isEnabled(feature)).stream()).toList();
+    }
+
+    public static FeaturesBuilder builder() {
+        return new FeaturesBuilder();
+    }
+
+    public static class FeaturesBuilder {
+        private final Map<Feature, Boolean> features = new EnumMap<>(Feature.class);
+
+        public FeaturesBuilder enable(Feature feature) {
+            features.put(feature, true);
+            return this;
+        }
+
+        public Features build() {
+            if (features.isEmpty()) {
+                return Features.defaultFeatures();
+            }
+            return new Features(Collections.unmodifiableMap(features));
+        }
+
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Features features1 = (Features) o;
+        return Objects.equals(featureToEnabled, features1.featureToEnabled);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(featureToEnabled);
+    }
+
+    @Override
+    public String toString() {
+        return stream(Feature.values()).map(f -> f.name() + ": " + (isEnabled(f) ? "enabled" : "disabled")).collect(Collectors.joining(",", "[", "]"));
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
@@ -6,16 +6,25 @@
 
 package io.kroxylicious.proxy;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
 
 import io.kroxylicious.proxy.config.ConfigParser;
 import io.kroxylicious.proxy.config.Configuration;
+import io.kroxylicious.proxy.config.IllegalConfigurationException;
+import io.kroxylicious.proxy.config.PluginFactoryRegistry;
+import io.kroxylicious.proxy.internal.config.Features;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -40,7 +49,7 @@ class KafkaProxyTest {
                    - type: RequiresConfigFactory
                 """;
         var configParser = new ConfigParser();
-        try (var kafkaProxy = new KafkaProxy(configParser, configParser.parseConfiguration(config))) {
+        try (var kafkaProxy = new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures())) {
             assertThatThrownBy(kafkaProxy::startup).isInstanceOf(PluginConfigurationException.class)
                     .hasMessage(
                             "Exception initializing filter factory RequiresConfigFactory with config null: RequiresConfigFactory requires configuration, but config object is null");
@@ -94,7 +103,7 @@ class KafkaProxyTest {
     @MethodSource
     void detectsConflictingPorts(String name, String config, String expectedMessage) throws Exception {
         ConfigParser configParser = new ConfigParser();
-        try (var kafkaProxy = new KafkaProxy(configParser, configParser.parseConfiguration(config))) {
+        try (var kafkaProxy = new KafkaProxy(configParser, configParser.parseConfiguration(config), Features.defaultFeatures())) {
             var illegalStateException = assertThrows(IllegalStateException.class, kafkaProxy::startup);
             assertThat(illegalStateException).hasStackTraceContaining(expectedMessage);
         }
@@ -121,10 +130,36 @@ class KafkaProxyTest {
         ConfigParser configParser = new ConfigParser();
         final Configuration parsedConfiguration = configParser.parseConfiguration(config);
         var illegalStateException = assertThrows(IllegalStateException.class, () -> {
-            try (var ignored = new KafkaProxy(configParser, parsedConfiguration)) {
+            try (var ignored = new KafkaProxy(configParser, parsedConfiguration, Features.defaultFeatures())) {
                 fail("The proxy started, but a failure was expected.");
             }
         });
         assertThat(illegalStateException).hasStackTraceContaining(expectedMessage);
     }
+
+    public static Stream<Arguments> parametersNonNullable() {
+        return Stream.of(Arguments.of(null, Mockito.mock(Configuration.class), Features.defaultFeatures()),
+                Arguments.of(Mockito.mock(PluginFactoryRegistry.class), null, Features.defaultFeatures()),
+                Arguments.of(Mockito.mock(PluginFactoryRegistry.class), Mockito.mock(Configuration.class), null));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void parametersNonNullable(@NonNull PluginFactoryRegistry pfr, @NonNull Configuration config, @NonNull Features features) {
+        assertThatThrownBy(() -> {
+            new KafkaProxy(pfr, config, features);
+        }).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void invalidConfigurationForFeatures() {
+        Optional<Map<String, Object>> a = Optional.of(Map.of("a", "b"));
+        Configuration configuration = new Configuration(null, null, List.of(), null, false, a);
+        Features features = Features.defaultFeatures();
+        assertThatThrownBy(() -> {
+            KafkaProxy.validate(configuration, features);
+        }).isInstanceOf(IllegalConfigurationException.class)
+                .hasMessage("invalid configuration: test-only configuration for proxy present, but loading test-only configuration not enabled");
+    }
+
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -400,7 +400,7 @@ class ConfigParserTest {
 
     @Test
     void shouldThrowWhenSerializingUnserializableObject() {
-        var config = new Configuration(null, null, List.of(new FilterDefinition("", new NonSerializableConfig(""))), null, false);
+        var config = new Configuration(null, null, List.of(new FilterDefinition("", new NonSerializableConfig(""))), null, false, Optional.empty());
 
         ConfigParser cp = new ConfigParser();
         assertThatThrownBy(() -> {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/config/FeaturesTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/config/FeaturesTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.kroxylicious.proxy.config.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FeaturesTest {
+
+    public static List<Arguments> enabledByDefault() {
+        return List.of(Arguments.of(Feature.TEST_ONLY_CONFIGURATION, false));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void enabledByDefault(Feature feature, boolean enabledByDefault) {
+        Features features = Features.defaultFeatures();
+        assertThat(features.isEnabled(feature)).isEqualTo(enabledByDefault);
+    }
+
+    @ParameterizedTest
+    @EnumSource(Feature.class)
+    void explicitlyEnable(Feature feature) {
+        Features features = Features.builder().enable(feature).build();
+        assertThat(features.isEnabled(feature)).isTrue();
+    }
+
+    @ParameterizedTest
+    @MethodSource("enabledByDefault")
+    void enabledByDefaultViaBuilder(Feature feature, boolean enabledByDefault) {
+        Features features = Features.builder().build();
+        assertThat(features.isEnabled(feature)).isEqualTo(enabledByDefault);
+    }
+
+    static List<Arguments> supportsValidTestConfiguration() {
+        List<Arguments> cases = new ArrayList<>();
+        Features testConfigEnabled = Features.builder().enable(Feature.TEST_ONLY_CONFIGURATION).build();
+        cases.add(Arguments.of(testConfigEnabled, Map.of()));
+        cases.add(Arguments.of(testConfigEnabled, null));
+        cases.add(Arguments.of(testConfigEnabled, Map.of("a", "b")));
+        cases.add(Arguments.of(Features.defaultFeatures(), Map.of()));
+        cases.add(Arguments.of(Features.defaultFeatures(), null));
+        return cases;
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void supportsValidTestConfiguration(Features features, Map<String, Object> config) {
+        Configuration configuration = new Configuration(null, null, List.of(), null, false, Optional.ofNullable(config));
+        List<String> errorMessages = features.supports(configuration);
+        assertThat(errorMessages).isEmpty();
+    }
+
+    @Test
+    void supportsReturnsErrorOnTestConfigurationPresentWithFeatureDisabled() {
+        Optional<Map<String, Object>> a = Optional.of(Map.of("a", "b"));
+        Configuration configuration = new Configuration(null, null, List.of(), null, false, a);
+        List<String> errors = Features.defaultFeatures().supports(configuration);
+        assertThat(errors).containsExactly("test-only configuration for proxy present, but loading test-only configuration not enabled");
+    }
+
+    @Test
+    void warningsEmptyByDefault() {
+        List<String> warnings = Features.defaultFeatures().warnings();
+        assertThat(warnings).isEmpty();
+    }
+
+    @Test
+    void testOnlyConfigurationWarning() {
+        Features features = Features.builder().enable(Feature.TEST_ONLY_CONFIGURATION).build();
+        List<String> warnings = features.warnings();
+        assertThat(warnings).containsExactly(
+                "test-only configuration for proxy will be loaded. "
+                        + "these configurations are unsupported and have no compatibility guarantees, "
+                        + "they could be removed or changed at any time");
+    }
+
+    public static List<Arguments> equalsHashcode() {
+        List<Arguments> arguments = new ArrayList<>();
+        arguments.add(Arguments.of(Features.defaultFeatures(), Features.defaultFeatures(), true));
+        arguments.add(Arguments.of(Features.defaultFeatures(), Features.builder().build(), true));
+        arguments.add(Arguments.of(Features.defaultFeatures(), Features.builder().enable(Feature.TEST_ONLY_CONFIGURATION).build(), false));
+        arguments.add(Arguments.of(Features.builder().enable(Feature.TEST_ONLY_CONFIGURATION).build(), Features.builder().enable(Feature.TEST_ONLY_CONFIGURATION).build(),
+                true));
+        arguments.add(Arguments.of(Features.defaultFeatures(), "abc", false));
+        arguments.add(Arguments.of(Features.defaultFeatures(), null, false));
+        return arguments;
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void equalsHashcode(Object a, Object b, boolean equals) {
+        assertThat(a.equals(b)).isEqualTo(equals);
+        if (equals) {
+            assertThat(a.hashCode()).isEqualTo(b.hashCode());
+        }
+    }
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

1. Adds a `development` configuration map to the top level of the proxy configuration
2. Adds the concept of features, requiring the user to set `KROXYLICIOUS_UNLOCK_TEST_ONLY_CONFIGURATION=true` by env var or system prop to use the development features. It initially disallows any configuration to be provided. The proxy will not start if the `development` object is non-empty and the proxy does not have this feature enabled (the default)

### Additional Context

Split out of #1635

To enable integration testing the ApiVersions downgrade response with a real client we have an issue. The proxy may be on the latest kafka-clients version, so it's hard to test this case where the client is ahead. To test this we want to add a development only configuration to enable us to control the maximum version per ApiKey supported at the proxy, to masquerade as a proxy that only understands up to a certain version of ApiVersions.

We want to make sure it's clearly not a production feature and force users to jump through some opt-in hoops to enable the functionality.

This PR adds the foundation for this, introducing unlockable features around config loading.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
