### PR TITLE
Fix incorrect integration test comment

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ApiVersionsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ApiVersionsIT.java
@@ -29,14 +29,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * For the kafka RPCs that Kroxylicious can intercept, Kroxylicious should only offer API versions
- * that it can encode/decode using it's version of the kafka-clients lib. It should also only offer API versions
+ * that it can encode/decode using its version of the kafka-clients lib. It should also only offer API versions
  * that the Cluster can understand. So we use a Filter to intercept the ApiVersions response from the
  * Cluster and intersect those versions with the versions supported by the proxy. We offer the highest
  * minimum version for each api key supported by the Cluster and proxy. We offer the lowest maximum version
  * for each api key supported by the Cluster and proxy.
- * Any versions for ApiKeys unknown to the proxy are forwarded to the client untouched. (ie the broker supports
- * a new ApiKey that this version of Kroxylicious is unaware of)
- * TODO check if this is still sensible behaviour, potentially a RequestFilter would attempt to decode these and fail.
+ * Any versions for ApiKeys unknown to the proxy are removed from the response. (ie the broker supports
+ * a new ApiKey that this version of Kroxylicious is unaware of).
  */
 @ExtendWith(NettyLeakDetectorExtension.class)
 public class ApiVersionsIT {


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Since PR #485 we have dropped unknown ApiKeys from the response.
This supports our intent to only accept messages that the proxy
can decode.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
