### PR TITLE
Fix #1436 : remove forwardPartialRequests feature of record validation filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#1657](https://github.com/kroxylicious/kroxylicious/pull/1657) Remove forwardPartialRequests feature of record validation filter
 * [#1635](https://github.com/kroxylicious/kroxylicious/pull/1635) Handle ApiVersions unsupported version downgrade
 * [#1648](https://github.com/kroxylicious/kroxylicious/pull/1648) Add test-only feature mechanism to Proxy configuration
 * [#1379](https://github.com/kroxylicious/kroxylicious/issues/1379) Remove Deprecated EnvelopeEncryption
@@ -22,7 +23,8 @@ Format `<github issue/pr number>: <short description>`.
 
 ### Changes, deprecations and removals
 
-* The deprecated EnvelopeEncryption filter is now removed.  Use RecordEncryption instead. 
+* The deprecated EnvelopeEncryption filter is now removed.  Use RecordEncryption instead.
+* The deprecated forwardPartialRequests option has been removed from the Record Validation Filter.
 
 ## 0.8.0
 

--- a/docs/modules/record-validation/proc-record-validation.adoc
+++ b/docs/modules/record-validation/proc-record-validation.adoc
@@ -37,18 +37,11 @@ filters:
             <rule definition>                                          # <2>
           valueRule:
             <rule definition>                                          # <3>
-        forwardPartialRequests: false                                  # <5>
 ----
 <1> List of topic names to which the validation rules will be applied.
 <2> Validation rules that are applied to the record's key.
 <3> Validation rules that are applied to the record's value.
 <4> (Optional) Default rule that is applied to any topics for which there is no explict rule defined.
-<5> If `false`, any record failing validation will cause the entire produce request to be rejected.
-    If `true`, only partitions within the request where all records validated successfully will be forwarded to the
-    broker. The response the client will receive will be a mixed response with response returned from the broker
-    for the partitions whose records passed validation and error responses for the partitions that failed validation.
-    If the client is using transactions, this setting is *ignored*. Any failing record validation will
-    cause the entire produce request to be rejected.
 
 Replace the token `<rule definition>`  in the YAML configuration with either a Schema Validation rule or a JSON Syntax Validation rule depending on your requirements.
 

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/ProduceRequestValidatorBuilder.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/ProduceRequestValidatorBuilder.java
@@ -38,8 +38,8 @@ class ProduceRequestValidatorBuilder {
      */
     static ProduceRequestValidator build(ValidationConfig config) {
         RoutingProduceRequestValidator.RoutingProduceRequestValidatorBuilder builder = RoutingProduceRequestValidator.builder();
-        config.getRules().forEach(rule -> builder.appendValidatorForTopicPattern(rule.getTopicNames(), toValidatorWithNullHandling(rule)));
-        RecordValidationRule defaultRule = config.getDefaultRule();
+        config.rules().forEach(rule -> builder.appendValidatorForTopicPattern(rule.getTopicNames(), toValidatorWithNullHandling(rule)));
+        RecordValidationRule defaultRule = config.defaultRule();
         TopicValidator defaultValidator = defaultRule == null ? TopicValidators.allValid() : toValidatorWithNullHandling(defaultRule);
         builder.setDefaultValidator(defaultValidator);
         return builder.build();

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/RecordValidation.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/RecordValidation.java
@@ -24,7 +24,7 @@ public class RecordValidation implements FilterFactory<ValidationConfig, Validat
     @Override
     public RecordValidationFilter createFilter(FilterFactoryContext context, ValidationConfig configuration) {
         ProduceRequestValidator validator = ProduceRequestValidatorBuilder.build(configuration);
-        return new RecordValidationFilter(configuration.isForwardPartialRequests(), validator);
+        return new RecordValidationFilter(validator);
     }
 
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/RecordValidationFilter.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/RecordValidationFilter.java
@@ -68,7 +68,7 @@ public class RecordValidationFilter implements ProduceRequestFilter, ProduceResp
         CompletionStage<ProduceRequestValidationResult> validationStage = validator.validateRequest(request);
         return validationStage.thenCompose(result -> {
             if (result.isAnyTopicPartitionInvalid()) {
-                return handleInvalidTopicPartitions(header, request, context, result);
+                return handleInvalidTopicPartitions(request, context, result);
             }
             else {
                 return context.forwardRequest(header, request);
@@ -76,7 +76,7 @@ public class RecordValidationFilter implements ProduceRequestFilter, ProduceResp
         });
     }
 
-    private CompletionStage<RequestFilterResult> handleInvalidTopicPartitions(RequestHeaderData header, ProduceRequestData request, FilterContext context,
+    private CompletionStage<RequestFilterResult> handleInvalidTopicPartitions(ProduceRequestData request, FilterContext context,
                                                                               ProduceRequestValidationResult result) {
         if (result.isAllTopicPartitionsInvalid()) {
             LOGGER.debug("all topic-partitions for request contained invalid data: {}", result);

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/config/ValidationConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/config/ValidationConfig.java
@@ -7,7 +7,6 @@
 package io.kroxylicious.proxy.filter.validation.config;
 
 import java.util.List;
-import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -16,30 +15,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Configuration for Produce Request validation. Contains a description of the rules for validating
  * the data for all topic-partitions with a ProduceRequest and how to handle partial failures (where
  * some topic-partitions are valid and others are invalid within a single ProduceRequest)
+ *
+ * @param rules describes a list of rules, associating topics with some validation to be applied to produce data for that topic
+ * @param defaultRule the default validation rule to be applied when no rule is matched for a topic within a ProduceRequest
  */
-public class ValidationConfig {
+public record ValidationConfig(List<TopicMatchingRecordValidationRule> rules, RecordValidationRule defaultRule) {
 
-    /**
-     * If this is enabled then the proxy will (for non-transactional requests):
-     * 1. filter out invalid topic-partitions from the ProduceRequest
-     * 2. forward the filtered request up the chain
-     * 3. intercept the produce response and augment in failure details for the invalid topic-partitions
-     */
-    private final boolean forwardPartialRequests;
-    private final List<TopicMatchingRecordValidationRule> rules;
-    private final RecordValidationRule defaultRule;
-
-    /**
-     * Construct a new ValidationConfig
-     * @param forwardPartialRequests describes whether partial ProduceRequest data should be forwarded to the broker (for non-transactional requests)
-     * @param rules describes a list of rules, associating topics with some validation to be applied to produce data for that topic
-     * @param defaultRule the default validation rule to be applied when no rule is matched for a topic within a ProduceRequest
-     */
     @JsonCreator
-    public ValidationConfig(@JsonProperty(value = "forwardPartialRequests", defaultValue = "false") Boolean forwardPartialRequests,
-                            @JsonProperty("rules") List<TopicMatchingRecordValidationRule> rules,
+    public ValidationConfig(@JsonProperty("rules") List<TopicMatchingRecordValidationRule> rules,
                             @JsonProperty("defaultRule") RecordValidationRule defaultRule) {
-        this.forwardPartialRequests = forwardPartialRequests != null && forwardPartialRequests;
         this.rules = rules;
         this.defaultRule = defaultRule;
     }
@@ -48,48 +32,23 @@ public class ValidationConfig {
      * Get the rules
      * @return rules
      */
-    public List<TopicMatchingRecordValidationRule> getRules() {
+    @Override
+    public List<TopicMatchingRecordValidationRule> rules() {
         return rules;
-    }
-
-    /**
-     * is forwarding partial requests enabled?
-     * @return true if forwarding partial requests enabled
-     */
-    public boolean isForwardPartialRequests() {
-        return forwardPartialRequests;
     }
 
     /**
      * get default rule
      * @return default rule (not null)
      */
-    public RecordValidationRule getDefaultRule() {
+    @Override
+    public RecordValidationRule defaultRule() {
         return defaultRule;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ValidationConfig that = (ValidationConfig) o;
-        return forwardPartialRequests == that.forwardPartialRequests && Objects.equals(rules, that.rules) && Objects.equals(defaultRule,
-                that.defaultRule);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(forwardPartialRequests, rules, defaultRule);
     }
 
     @Override
     public String toString() {
         return "ValidationConfig{" +
-                "forwardPartialRequests=" + forwardPartialRequests +
                 ", rules=" + rules +
                 ", defaultRule=" + defaultRule +
                 '}';

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/config/ValidationConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/config/ValidationConfig.java
@@ -8,7 +8,6 @@ package io.kroxylicious.proxy.filter.validation.config;
 
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -19,32 +18,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * @param rules describes a list of rules, associating topics with some validation to be applied to produce data for that topic
  * @param defaultRule the default validation rule to be applied when no rule is matched for a topic within a ProduceRequest
  */
-public record ValidationConfig(List<TopicMatchingRecordValidationRule> rules, RecordValidationRule defaultRule) {
-
-    @JsonCreator
-    public ValidationConfig(@JsonProperty("rules") List<TopicMatchingRecordValidationRule> rules,
-                            @JsonProperty("defaultRule") RecordValidationRule defaultRule) {
-        this.rules = rules;
-        this.defaultRule = defaultRule;
-    }
-
-    /**
-     * Get the rules
-     * @return rules
-     */
-    @Override
-    public List<TopicMatchingRecordValidationRule> rules() {
-        return rules;
-    }
-
-    /**
-     * get default rule
-     * @return default rule (not null)
-     */
-    @Override
-    public RecordValidationRule defaultRule() {
-        return defaultRule;
-    }
+public record ValidationConfig(@JsonProperty("rules") List<TopicMatchingRecordValidationRule> rules,
+                               @JsonProperty("defaultRule") RecordValidationRule defaultRule) {
 
     @Override
     public String toString() {

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/config/ValidationConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/config/ValidationConfig.java
@@ -12,8 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Configuration for Produce Request validation. Contains a description of the rules for validating
- * the data for all topic-partitions with a ProduceRequest and how to handle partial failures (where
- * some topic-partitions are valid and others are invalid within a single ProduceRequest)
+ * the data for all topic-partitions within a ProduceRequest.
  *
  * @param rules describes a list of rules, associating topics with some validation to be applied to produce data for that topic
  * @param defaultRule the default validation rule to be applied when no rule is matched for a topic within a ProduceRequest
@@ -24,7 +23,7 @@ public record ValidationConfig(@JsonProperty("rules") List<TopicMatchingRecordVa
     @Override
     public String toString() {
         return "ValidationConfig{" +
-                ", rules=" + rules +
+                "rules=" + rules +
                 ", defaultRule=" + defaultRule +
                 '}';
     }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/validators/request/ProduceRequestValidationResult.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/validators/request/ProduceRequestValidationResult.java
@@ -9,7 +9,6 @@ package io.kroxylicious.proxy.filter.validation.validators.request;
 import java.util.Map;
 import java.util.stream.Stream;
 
-import io.kroxylicious.proxy.filter.validation.validators.topic.PartitionValidationResult;
 import io.kroxylicious.proxy.filter.validation.validators.topic.TopicValidationResult;
 
 /**
@@ -25,49 +24,6 @@ public record ProduceRequestValidationResult(Map<String, TopicValidationResult> 
      */
     public boolean isAnyTopicPartitionInvalid() {
         return topicValidationResults.values().stream().anyMatch(TopicValidationResult::isAnyPartitionInvalid);
-    }
-
-    /**
-     * Are all topic partitions invalid
-     * @return true if all topic-partitions were invalid
-     */
-    public boolean isAllTopicPartitionsInvalid() {
-        return topicValidationResults.values().stream().allMatch(TopicValidationResult::isAllPartitionsInvalid);
-    }
-
-    /**
-     * Are all topic partitions invalid for a topic
-     * @param topicName topic name
-     * @return true if all partitions for topicName are invalid
-     */
-    public boolean isAllPartitionsInvalid(String topicName) {
-        TopicValidationResult topicValidationResult = topicValidationResults.get(topicName);
-        if (topicValidationResult == null) {
-            return false;
-        }
-        else {
-            return topicValidationResult.isAllPartitionsInvalid();
-        }
-    }
-
-    /**
-     * Is a topic-partition valid
-     * @param topicName name of the topic
-     * @param partitionIndex index of the partition
-     * @return true if the topic-partition is valid
-     * @throws IllegalStateException if the topicName or partitionIndex has no recorded result, we should have some outcome for every topic-partition
-     */
-    public boolean isPartitionValid(String topicName, int partitionIndex) {
-        TopicValidationResult topicValidationResult = topicValidationResults.get(topicName);
-        if (topicValidationResult == null) {
-            throw new IllegalStateException("topicValidationResults should contain a result for all topics in the request, failed topic: " + topicName);
-        }
-        PartitionValidationResult partitionValidationResult = topicValidationResult.getPartitionResult(partitionIndex);
-        if (partitionValidationResult == null) {
-            throw new IllegalStateException(
-                    "partitionValidationResult should contain a result for all topics in the request, failed topic: " + topicName + ", partition" + partitionIndex);
-        }
-        return partitionValidationResult.allRecordsValid();
     }
 
     /**

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/validators/topic/AllValidTopicValidationResult.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/validators/topic/AllValidTopicValidationResult.java
@@ -17,11 +17,6 @@ record AllValidTopicValidationResult(String topicName) implements TopicValidatio
     }
 
     @Override
-    public boolean isAllPartitionsInvalid() {
-        return false;
-    }
-
-    @Override
     public Stream<PartitionValidationResult> invalidPartitions() {
         return Stream.empty();
     }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/validators/topic/PerPartitionTopicValidationResult.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/validators/topic/PerPartitionTopicValidationResult.java
@@ -17,14 +17,6 @@ record PerPartitionTopicValidationResult(String topicName, Map<Integer, Partitio
     }
 
     @Override
-    public boolean isAllPartitionsInvalid() {
-        if (partitionValidationResults.isEmpty()) {
-            return false;
-        }
-        return partitionValidationResults.values().stream().noneMatch(PartitionValidationResult::allRecordsValid);
-    }
-
-    @Override
     public Stream<PartitionValidationResult> invalidPartitions() {
         return partitionValidationResults.values().stream().filter(partitionValidationResult -> !partitionValidationResult.allRecordsValid());
     }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/validators/topic/TopicValidationResult.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/validators/topic/TopicValidationResult.java
@@ -20,12 +20,6 @@ public interface TopicValidationResult {
     boolean isAnyPartitionInvalid();
 
     /**
-     * are all partitions invalid
-     * @return true if all partitions invalid
-     */
-    boolean isAllPartitionsInvalid();
-
-    /**
      * get invalid partitions
      * @return stream of invalid partitions
      */

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/validation/RecordValidationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/validation/RecordValidationFilterTest.java
@@ -128,7 +128,6 @@ class RecordValidationFilterTest {
         var validator = new RecordValidationFilter(produceRequestValidator);
 
         when(topicValidationResult.isAnyPartitionInvalid()).thenReturn(true);
-        when(topicValidationResult.isAllPartitionsInvalid()).thenReturn(true);
         when(topicValidationResult.getPartitionResult(0)).thenReturn(new PartitionValidationResult(0, List.of(new RecordValidationFailure(0, "record error"))));
 
         var header = new RequestHeaderData();
@@ -167,7 +166,6 @@ class RecordValidationFilterTest {
         var validator = new RecordValidationFilter(produceRequestValidator);
 
         when(topicValidationResult.isAnyPartitionInvalid()).thenReturn(true);
-        when(topicValidationResult.isAllPartitionsInvalid()).thenReturn(false);
         when(topicValidationResult.getPartitionResult(0)).thenReturn(new PartitionValidationResult(0, List.of(new RecordValidationFailure(0, "record error"))));
         when(topicValidationResult.getPartitionResult(1)).thenReturn(new PartitionValidationResult(1, List.of()));
 
@@ -217,7 +215,6 @@ class RecordValidationFilterTest {
         var validator = new RecordValidationFilter(produceRequestValidator);
 
         when(topicValidationResult.isAnyPartitionInvalid()).thenReturn(true);
-        when(topicValidationResult.isAllPartitionsInvalid()).thenReturn(true);
         when(topicValidationResult.getPartitionResult(0)).thenReturn(new PartitionValidationResult(0, List.of(new RecordValidationFailure(0, "record error"))));
 
         var header = new RequestHeaderData();
@@ -256,7 +253,6 @@ class RecordValidationFilterTest {
         var validator = new RecordValidationFilter(produceRequestValidator);
 
         when(topicValidationResult.isAnyPartitionInvalid()).thenReturn(true);
-        when(topicValidationResult.isAllPartitionsInvalid()).thenReturn(false);
         when(topicValidationResult.getPartitionResult(0)).thenReturn(new PartitionValidationResult(0, List.of(new RecordValidationFailure(0, "record error"))));
 
         var header = new RequestHeaderData();

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/validation/RecordValidationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/validation/RecordValidationFilterTest.java
@@ -91,14 +91,14 @@ class RecordValidationFilterTest {
     @SuppressWarnings("DataFlowIssue")
     @Test
     void rejectsNullValidator() {
-        assertThatThrownBy(() -> new RecordValidationFilter(false, null))
+        assertThatThrownBy(() -> new RecordValidationFilter(null))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void requestThatPassesValidationIsForwarded() {
         // Given
-        var validator = new RecordValidationFilter(false, produceRequestValidator);
+        var validator = new RecordValidationFilter(produceRequestValidator);
 
         when(topicValidationResult.isAnyPartitionInvalid()).thenReturn(false);
 
@@ -125,7 +125,7 @@ class RecordValidationFilterTest {
     @Test
     void requestWithAllPartitionsFailedIsRejectedWithShortCircuitResponse() {
         // Given
-        var validator = new RecordValidationFilter(false, produceRequestValidator);
+        var validator = new RecordValidationFilter(produceRequestValidator);
 
         when(topicValidationResult.isAnyPartitionInvalid()).thenReturn(true);
         when(topicValidationResult.isAllPartitionsInvalid()).thenReturn(true);
@@ -162,56 +162,9 @@ class RecordValidationFilterTest {
     }
 
     @Test
-    void requestWithSomePartitionsFailedIsIsForwarded() {
-        // Given
-        var validator = new RecordValidationFilter(true, produceRequestValidator);
-
-        when(topicValidationResult.isAnyPartitionInvalid()).thenReturn(true);
-        when(topicValidationResult.isAllPartitionsInvalid()).thenReturn(false);
-        when(topicValidationResult.getPartitionResult(0)).thenReturn(new PartitionValidationResult(0, List.of(new RecordValidationFailure(0, "record error"))));
-        when(topicValidationResult.getPartitionResult(1)).thenReturn(new PartitionValidationResult(1, List.of()));
-
-        var header = new RequestHeaderData();
-        final ProduceRequestData.PartitionProduceData partition1 = new ProduceRequestData.PartitionProduceData();
-        final ProduceRequestData.PartitionProduceData partition2 = new ProduceRequestData.PartitionProduceData();
-        partition2.setIndex(1);
-        var request = buildProduceRequestData(new ProduceRequestData.TopicProduceData()
-                .setName(MY_TOPIC)
-                .setPartitionData(
-                        new ArrayList<>(List.of(
-                                partition1,
-                                partition2))));
-        when(produceRequestValidator.validateRequest(request)).thenReturn(
-                CompletableFuture.completedStage(new ProduceRequestValidationResult(Map.of(MY_TOPIC, topicValidationResult))));
-
-        // When
-        var result = validator.onProduceRequest(HIGHEST_SUPPORTED_VERSION, header, request, context);
-
-        // Then
-        assertThat(result)
-                .succeedsWithin(Duration.ofSeconds(1))
-                .satisfies(rfr -> {
-                    assertThat(rfr.shortCircuitResponse()).isFalse();
-                    assertThat(rfr.message())
-                            .isInstanceOf(ProduceRequestData.class);
-
-                    var prd = (ProduceRequestData) rfr.message();
-                    assertThat(prd.topicData())
-                            .singleElement()
-                            .satisfies(tpr -> {
-                                assertThat(tpr.name()).isEqualTo(MY_TOPIC);
-                                assertThat(tpr.partitionData())
-                                        .singleElement()
-                                        .extracting(ProduceRequestData.PartitionProduceData::index)
-                                        .isEqualTo(1);
-                            });
-                });
-    }
-
-    @Test
     void requestWithSomePartitionsFailedIsRejected() {
         // Given
-        var validator = new RecordValidationFilter(false, produceRequestValidator);
+        var validator = new RecordValidationFilter(produceRequestValidator);
 
         when(topicValidationResult.isAnyPartitionInvalid()).thenReturn(true);
         when(topicValidationResult.isAllPartitionsInvalid()).thenReturn(false);
@@ -261,7 +214,7 @@ class RecordValidationFilterTest {
     @Test
     void requestWithAllPartitionsFailedIsRejectedWithShortCircuitResponseInTransaction() {
         // Given
-        var validator = new RecordValidationFilter(true, produceRequestValidator);
+        var validator = new RecordValidationFilter(produceRequestValidator);
 
         when(topicValidationResult.isAnyPartitionInvalid()).thenReturn(true);
         when(topicValidationResult.isAllPartitionsInvalid()).thenReturn(true);
@@ -300,7 +253,7 @@ class RecordValidationFilterTest {
     @Test
     void requestWithSomePartitionsFailedIsRejectedWithShortCircuitResponseInTransaction() {
         // Given
-        var validator = new RecordValidationFilter(true, produceRequestValidator);
+        var validator = new RecordValidationFilter(produceRequestValidator);
 
         when(topicValidationResult.isAnyPartitionInvalid()).thenReturn(true);
         when(topicValidationResult.isAllPartitionsInvalid()).thenReturn(false);

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/validation/RecordValidationTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/validation/RecordValidationTest.java
@@ -30,7 +30,7 @@ class RecordValidationTest {
     @Test
     void shouldInitAndCreateFilter() {
         RecordValidation factory = new RecordValidation();
-        var config = factory.initialize(null, new ValidationConfig(true, List.of(), new RecordValidationRule(null, null)));
+        var config = factory.initialize(null, new ValidationConfig(List.of(), new RecordValidationRule(null, null)));
         Filter filter = factory.createFilter(null, config);
         assertThat(filter).isNotNull().isInstanceOf(RecordValidationFilter.class);
     }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/validation/config/ValidationConfigTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/validation/config/ValidationConfigTest.java
@@ -40,7 +40,7 @@ class ValidationConfigTest {
         TopicMatchingRecordValidationRule ruleOne = new TopicMatchingRecordValidationRule(Set.of("one"), null,
                 new BytebufValidation(new SyntacticallyCorrectJsonConfig(false), null, true, false));
         TopicMatchingRecordValidationRule ruleTwo = new TopicMatchingRecordValidationRule(Set.of("two"), new BytebufValidation(null, null, true, false), null);
-        ValidationConfig expected = new ValidationConfig(false, List.of(ruleOne, ruleTwo),
+        ValidationConfig expected = new ValidationConfig(List.of(ruleOne, ruleTwo),
                 new RecordValidationRule(null, new BytebufValidation(null, null, true, false)));
         assertEquals(expected, deserialised);
     }
@@ -49,7 +49,6 @@ class ValidationConfigTest {
     void testDecodeNonDefaultValues() throws JsonProcessingException {
         ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
         ValidationConfig deserialised = yamlMapper.readerFor(ValidationConfig.class).readValue("""
-                forwardPartialRequests: true
                 defaultRule:
                   valueRule:
                     allowNulls: false
@@ -72,7 +71,7 @@ class ValidationConfigTest {
         TopicMatchingRecordValidationRule ruleOne = new TopicMatchingRecordValidationRule(Set.of("one"), null,
                 new BytebufValidation(new SyntacticallyCorrectJsonConfig(true), null, false, true));
         TopicMatchingRecordValidationRule ruleTwo = new TopicMatchingRecordValidationRule(Set.of("two"), new BytebufValidation(null, null, false, true), null);
-        ValidationConfig expected = new ValidationConfig(true, List.of(ruleOne, ruleTwo), new RecordValidationRule(null, new BytebufValidation(null, null, false, true)));
+        ValidationConfig expected = new ValidationConfig(List.of(ruleOne, ruleTwo), new RecordValidationRule(null, new BytebufValidation(null, null, false, true)));
         assertEquals(expected, deserialised);
     }
 
@@ -95,7 +94,7 @@ class ValidationConfigTest {
         TopicMatchingRecordValidationRule ruleOne = new TopicMatchingRecordValidationRule(Set.of("one"), null,
                 new BytebufValidation(new SyntacticallyCorrectJsonConfig(false), null, true, false));
         TopicMatchingRecordValidationRule ruleTwo = new TopicMatchingRecordValidationRule(Set.of("two"), new BytebufValidation(null, null, true, false), null);
-        ValidationConfig expected = new ValidationConfig(false, List.of(ruleOne, ruleTwo),
+        ValidationConfig expected = new ValidationConfig(List.of(ruleOne, ruleTwo),
                 new RecordValidationRule(null, new BytebufValidation(null, null, true, false)));
         assertEquals(expected, deserialised);
     }
@@ -104,7 +103,6 @@ class ValidationConfigTest {
     void testDecodeNonDefaultValuesSchemaValidation() throws JsonProcessingException, MalformedURLException {
         ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
         ValidationConfig deserialised = yamlMapper.readerFor(ValidationConfig.class).readValue("""
-                forwardPartialRequests: true
                 defaultRule:
                   valueRule:
                     allowNulls: false
@@ -131,7 +129,7 @@ class ValidationConfigTest {
                 new BytebufValidation(new SyntacticallyCorrectJsonConfig(true), new SchemaValidationConfig(URI.create("http://localhost:8080").toURL(), 1L), false,
                         true));
         TopicMatchingRecordValidationRule ruleTwo = new TopicMatchingRecordValidationRule(Set.of("two"), new BytebufValidation(null, null, false, true), null);
-        ValidationConfig expected = new ValidationConfig(true, List.of(ruleOne, ruleTwo), new RecordValidationRule(null, new BytebufValidation(null, null, false, true)));
+        ValidationConfig expected = new ValidationConfig(List.of(ruleOne, ruleTwo), new RecordValidationRule(null, new BytebufValidation(null, null, false, true)));
         assertEquals(expected, deserialised);
     }
 
@@ -139,7 +137,6 @@ class ValidationConfigTest {
     void testDecodeInvalidValuesSchemaValidation() throws JsonProcessingException {
         ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
         ValidationConfig deserialised = yamlMapper.readerFor(ValidationConfig.class).readValue("""
-                forwardPartialRequests: true
                 defaultRule:
                   valueRule:
                     allowNulls: false
@@ -162,7 +159,7 @@ class ValidationConfigTest {
         TopicMatchingRecordValidationRule ruleOne = new TopicMatchingRecordValidationRule(Set.of("one"), null,
                 new BytebufValidation(new SyntacticallyCorrectJsonConfig(true), null, false, true));
         TopicMatchingRecordValidationRule ruleTwo = new TopicMatchingRecordValidationRule(Set.of("two"), new BytebufValidation(null, null, false, true), null);
-        ValidationConfig expected = new ValidationConfig(true, List.of(ruleOne, ruleTwo), new RecordValidationRule(null, new BytebufValidation(null, null, false, true)));
+        ValidationConfig expected = new ValidationConfig(List.of(ruleOne, ruleTwo), new RecordValidationRule(null, new BytebufValidation(null, null, false, true)));
         assertEquals(expected, deserialised);
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/validation/validators/topic/PerPartitionTopicValidationResultTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/validation/validators/topic/PerPartitionTopicValidationResultTest.java
@@ -23,7 +23,6 @@ class PerPartitionTopicValidationResultTest {
         var result = new PerPartitionTopicValidationResult("foo", Map.of());
 
         assertThat(result)
-                .returns(false, PerPartitionTopicValidationResult::isAllPartitionsInvalid)
                 .returns(false, PerPartitionTopicValidationResult::isAnyPartitionInvalid);
         assertThat(result)
                 .extracting(PerPartitionTopicValidationResult::invalidPartitions, STREAM)
@@ -36,8 +35,7 @@ class PerPartitionTopicValidationResultTest {
                 Map.of(1, new PartitionValidationResult(2, List.of(INVALID))));
 
         assertThat(result)
-                .returns(true, PerPartitionTopicValidationResult::isAnyPartitionInvalid)
-                .returns(true, PerPartitionTopicValidationResult::isAllPartitionsInvalid);
+                .returns(true, PerPartitionTopicValidationResult::isAnyPartitionInvalid);
     }
 
     @Test
@@ -47,8 +45,7 @@ class PerPartitionTopicValidationResultTest {
                         1, new PartitionValidationResult(1, List.of(INVALID))));
 
         assertThat(result)
-                .returns(true, PerPartitionTopicValidationResult::isAnyPartitionInvalid)
-                .returns(false, PerPartitionTopicValidationResult::isAllPartitionsInvalid);
+                .returns(true, PerPartitionTopicValidationResult::isAnyPartitionInvalid);
     }
 
     @Test

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/validation/validators/topic/PerRecordTopicValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/proxy/filter/validation/validators/topic/PerRecordTopicValidatorTest.java
@@ -46,7 +46,6 @@ class PerRecordTopicValidatorTest {
         var result = topicValidator.validateTopicData(tpd);
         assertThat(result)
                 .succeedsWithin(Duration.ofSeconds(1))
-                .returns(false, TopicValidationResult::isAllPartitionsInvalid)
                 .returns(false, TopicValidationResult::isAnyPartitionInvalid)
                 .extracting(TopicValidationResult::invalidPartitions, stream(PartitionValidationResult.class))
                 .isEmpty();
@@ -63,7 +62,6 @@ class PerRecordTopicValidatorTest {
         var result = topicValidator.validateTopicData(tpd);
         assertThat(result)
                 .succeedsWithin(Duration.ofSeconds(1))
-                .returns(true, TopicValidationResult::isAllPartitionsInvalid)
                 .returns(true, TopicValidationResult::isAnyPartitionInvalid);
 
         var invalidPartitions = result.toCompletableFuture().join().invalidPartitions();
@@ -118,7 +116,6 @@ class PerRecordTopicValidatorTest {
 
         assertThat(result)
                 .succeedsWithin(Duration.ofSeconds(1))
-                .returns(false, TopicValidationResult::isAllPartitionsInvalid)
                 .returns(true, TopicValidationResult::isAnyPartitionInvalid);
 
         var invalidPartitions = result.toCompletableFuture().join().invalidPartitions();
@@ -149,7 +146,6 @@ class PerRecordTopicValidatorTest {
 
         assertThat(result)
                 .succeedsWithin(Duration.ofSeconds(1))
-                .returns(true, TopicValidationResult::isAllPartitionsInvalid)
                 .returns(true, TopicValidationResult::isAnyPartitionInvalid);
 
         var invalidPartitions = result.toCompletableFuture().join().invalidPartitions().toList();


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Bugfix

### Description

Why: in the commentary of #1436 it was concluded that the inclusion of `forwardPartialRequests` option in the RecordValidation filter was an error. The problem being that if a client is sending incorrect data, then stopping immediately is the safe course of action.   Accepting some data and rejecting other is likely to lead to more harm than good.

We said we wanted to drop the feature (without deprecation).


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Update documentation
- [ ] Make sure all unit/integration tests pass
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
