### PR TITLE
Support Configuration for Cipher Suits and Protocols used by Upstream and Downstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## 0.9.0
 
+* [#1006](https://github.com/kroxylicious/kroxylicious/pull/1660) Allow CipherSuites and TLS Protocols to be passed via Configuration
 * [#1668](https://github.com/kroxylicious/kroxylicious/pull/1668) Bump apicurio-registry.version from 2.6.5.Final to 2.6.6.Final
 * [#1667](https://github.com/kroxylicious/kroxylicious/pull/1667) Bump io.micrometer:micrometer-bom from 1.14.1 to 1.14.2
 * [#1666](https://github.com/kroxylicious/kroxylicious/pull/1666) Bump org.apache.logging.log4j:log4j-bom from 2.24.2 to 2.24.3 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#1006](https://github.com/kroxylicious/kroxylicious/pull/1660) Allow CipherSuites and TLS Protocols to be passed via Configuration
 * [#1715](https://github.com/kroxylicious/kroxylicious/issues/1715) Deprecate `bootstrap_servers`, replacing it with `bootstrapServers` 
 * [#1698](https://github.com/kroxylicious/kroxylicious/pull/1698) Bump netty.io_uring.version from 0.0.25.Final to 0.0.26.Final #1698
 * [#1672](https://github.com/kroxylicious/kroxylicious/pull/1672) Limited Fortanix DSM backed KMS integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ Format `<github issue/pr number>: <short description>`.
 
 ## 0.9.0
 
-* [#1006](https://github.com/kroxylicious/kroxylicious/pull/1660) Allow CipherSuites and TLS Protocols to be passed via Configuration
 * [#1668](https://github.com/kroxylicious/kroxylicious/pull/1668) Bump apicurio-registry.version from 2.6.5.Final to 2.6.6.Final
 * [#1667](https://github.com/kroxylicious/kroxylicious/pull/1667) Bump io.micrometer:micrometer-bom from 1.14.1 to 1.14.2
 * [#1666](https://github.com/kroxylicious/kroxylicious/pull/1666) Bump org.apache.logging.log4j:log4j-bom from 2.24.2 to 2.24.3 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,3 +7,4 @@
 - Anthony Callaert(https://github.com/callaertanthony)
 - Zhenyu Luo(https://github.com/luozhenyu)
 - Carles Arnal(https://github.com/carlesarnal)
+- Alan Robinson(https://github.com/alanrobinson-dwp)

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/AllowDeny.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/AllowDeny.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config.tls;
+
+import java.util.List;
+import java.util.Set;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Class to keep track of allow and deny lists meant for use when building context for SSLEngine.
+ *
+ * @param allowed specifies a list of allowed objects ordered by preference.
+ * @param denied specifies a set of denied objects.
+ */
+public record AllowDeny<T>(@Nullable List<T> allowed, @Nullable Set<T> denied) {}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/Tls.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/Tls.java
@@ -14,9 +14,37 @@ import java.util.Locale;
  *
  * @param key specifies a key provider that provides the certificate/key used to identify this peer.
  * @param trust specifies a trust provider used by this peer to determine whether to trust the peer. If omitted platform trust is used instead.
+ * @param cipherSuites specifies a custom object which contains details of allowed and denied cipher suites
+ * @param protocols specifies a custom object which contains details of allowed and denied tls protocols
  */
 public record Tls(KeyProvider key,
-                  TrustProvider trust) {
+                  TrustProvider trust,
+                  AllowDeny<String> cipherSuites,
+                  AllowDeny<String> protocols) {
+
+    // Sundrio seems to need constructor order to matter, or it won't generate the with* methods for integration tests
+    // This can be removed once the old constructor is deprecated as unnecessary when the record will be generating it
+    public Tls(KeyProvider key, TrustProvider trust, AllowDeny<String> cipherSuites, AllowDeny<String> protocols) {
+        this.key = key;
+        this.trust = trust;
+        this.cipherSuites = cipherSuites;
+        this.protocols = protocols;
+    }
+
+    /**
+     * @deprecated use the all args constructor
+     * {@see io.kroxylicious.proxy.config.tls.Tls#Tls(
+     *      io.kroxylicious.proxy.config.tls.KeyProvider,
+     *      io.kroxylicious.proxy.config.tls.TrustProvider,
+     *      io.kroxylicious.proxy.config.tls.AllowDeny<String>,
+     *      io.kroxylicious.proxy.config.tls.AllowDeny<String>)
+     * }
+     */
+    // This is required for API backwards compatability
+    @Deprecated(forRemoval = true, since = "0.10.0")
+    public Tls(KeyProvider key, TrustProvider trust) {
+        this(key, trust, null, null);
+    }
 
     public static final String PEM = "PEM";
 

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/config/tls/TlsParseTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/config/tls/TlsParseTest.java
@@ -7,6 +7,8 @@
 package io.kroxylicious.proxy.config.tls;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Set;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -31,6 +33,8 @@ class TlsParseTest {
         Tls tls = readTls(json);
         assertThat(tls.trust()).isNull();
         assertThat(tls.key()).isNull();
+        assertThat(tls.cipherSuites()).isNull();
+        assertThat(tls.protocols()).isNull();
     }
 
     @Test
@@ -43,7 +47,7 @@ class TlsParseTest {
                 }
                 """;
         Tls tls = readTls(json);
-        assertThat(tls).isEqualTo(new Tls(null, new InsecureTls(true)));
+        assertThat(tls).isEqualTo(new Tls(null, new InsecureTls(true), null, null));
     }
 
     @Test
@@ -90,7 +94,7 @@ class TlsParseTest {
                 }
                 """;
         Tls tls = readTls(json);
-        assertThat(tls).isEqualTo(new Tls(null, new TrustStore("/tmp/file", null, null)));
+        assertThat(tls).isEqualTo(new Tls(null, new TrustStore("/tmp/file", null, null), null, null));
     }
 
     @Test
@@ -103,7 +107,7 @@ class TlsParseTest {
                 }
                 """;
         Tls tls = readTls(json);
-        assertThat(tls).isEqualTo(new Tls(null, new TrustStore("/tmp/file", null, null)));
+        assertThat(tls).isEqualTo(new Tls(null, new TrustStore("/tmp/file", null, null), null, null));
     }
 
     @Test
@@ -136,7 +140,7 @@ class TlsParseTest {
                 }
                 """;
         Tls tls = readTls(json);
-        assertThat(tls).isEqualTo(new Tls(null, new TrustStore("/tmp/file", new InlinePassword("changeit"), null)));
+        assertThat(tls).isEqualTo(new Tls(null, new TrustStore("/tmp/file", new InlinePassword("changeit"), null), null, null));
     }
 
     @Test
@@ -186,7 +190,7 @@ class TlsParseTest {
                 }
                 """;
         Tls tls = readTls(json);
-        assertThat(tls).isEqualTo(new Tls(null, new TrustStore("/tmp/file", new FilePassword("/tmp/pass"), null)));
+        assertThat(tls).isEqualTo(new Tls(null, new TrustStore("/tmp/file", new FilePassword("/tmp/pass"), null), null, null));
     }
 
     @Test
@@ -202,7 +206,7 @@ class TlsParseTest {
                 }
                 """;
         Tls tls = readTls(json);
-        assertThat(tls).isEqualTo(new Tls(null, new TrustStore("/tmp/file", new FilePassword("/tmp/pass"), null)));
+        assertThat(tls).isEqualTo(new Tls(null, new TrustStore("/tmp/file", new FilePassword("/tmp/pass"), null), null, null));
     }
 
     @Test
@@ -221,7 +225,7 @@ class TlsParseTest {
                 }
                 """;
         Tls tls = readTls(json);
-        assertThat(tls).isEqualTo(new Tls(null, new TrustStore("/tmp/file", new FilePassword("/tmp/pass"), null, new ServerOptions(TlsClientAuth.REQUIRED))));
+        assertThat(tls).isEqualTo(new Tls(null, new TrustStore("/tmp/file", new FilePassword("/tmp/pass"), null, new ServerOptions(TlsClientAuth.REQUIRED)), null, null));
     }
 
     @Test
@@ -238,7 +242,7 @@ class TlsParseTest {
                 }
                 """;
         Tls tls = readTls(json);
-        assertThat(tls).isEqualTo(new Tls(null, new TrustStore("/tmp/file", new FilePassword("/tmp/pass"), "PKCS12")));
+        assertThat(tls).isEqualTo(new Tls(null, new TrustStore("/tmp/file", new FilePassword("/tmp/pass"), "PKCS12"), null, null));
     }
 
     @Test
@@ -252,7 +256,7 @@ class TlsParseTest {
                 }
                 """;
         Tls tls = readTls(json);
-        assertThat(tls).isEqualTo(new Tls(new KeyPair("/tmp/key", "/tmp/cert", null), null));
+        assertThat(tls).isEqualTo(new Tls(new KeyPair("/tmp/key", "/tmp/cert", null), null, null, null));
     }
 
     @Test
@@ -328,7 +332,7 @@ class TlsParseTest {
                 }
                 """;
         Tls tls = readTls(json);
-        assertThat(tls).isEqualTo(new Tls(new KeyPair("/tmp/key", "/tmp/cert", new InlinePassword("changeit")), null));
+        assertThat(tls).isEqualTo(new Tls(new KeyPair("/tmp/key", "/tmp/cert", new InlinePassword("changeit")), null, null, null));
     }
 
     @Test
@@ -345,7 +349,7 @@ class TlsParseTest {
                 }
                 """;
         Tls tls = readTls(json);
-        assertThat(tls).isEqualTo(new Tls(new KeyPair("/tmp/key", "/tmp/cert", new FilePassword("/tmp/pass")), null));
+        assertThat(tls).isEqualTo(new Tls(new KeyPair("/tmp/key", "/tmp/cert", new FilePassword("/tmp/pass")), null, null, null));
     }
 
     @Test
@@ -358,7 +362,7 @@ class TlsParseTest {
                 }
                 """;
         Tls tls = readTls(json);
-        assertThat(tls).isEqualTo(new Tls(new KeyStore("/tmp/store", null, null, null), null));
+        assertThat(tls).isEqualTo(new Tls(new KeyStore("/tmp/store", null, null, null), null, null, null));
     }
 
     @Test
@@ -374,7 +378,7 @@ class TlsParseTest {
                 }
                 """;
         Tls tls = readTls(json);
-        assertThat(tls).isEqualTo(new Tls(new KeyStore("/tmp/store", new InlinePassword("changeit"), null, null), null));
+        assertThat(tls).isEqualTo(new Tls(new KeyStore("/tmp/store", new InlinePassword("changeit"), null, null), null, null, null));
     }
 
     @Test
@@ -390,7 +394,7 @@ class TlsParseTest {
                 }
                 """;
         Tls tls = readTls(json);
-        assertThat(tls).isEqualTo(new Tls(new KeyStore("/tmp/store", null, new InlinePassword("changeit"), null), null));
+        assertThat(tls).isEqualTo(new Tls(new KeyStore("/tmp/store", null, new InlinePassword("changeit"), null), null, null, null));
     }
 
     @Test
@@ -406,7 +410,7 @@ class TlsParseTest {
                 }
                 """;
         Tls tls = readTls(json);
-        assertThat(tls).isEqualTo(new Tls(new KeyStore("/tmp/store", null, new FilePassword("/tmp/pass"), null), null));
+        assertThat(tls).isEqualTo(new Tls(new KeyStore("/tmp/store", null, new FilePassword("/tmp/pass"), null), null, null, null));
     }
 
     @Test
@@ -439,7 +443,60 @@ class TlsParseTest {
                 }
                 """;
         Tls tls = readTls(json);
-        assertThat(tls).isEqualTo(new Tls(new KeyStore("/tmp/store", new FilePassword("/tmp/pass"), null, null), null));
+        assertThat(tls).isEqualTo(new Tls(new KeyStore("/tmp/store", new FilePassword("/tmp/pass"), null, null), null, null, null));
+    }
+
+    @Test
+    void testCipherSuitesProvider() throws IOException {
+        String json = """
+                {
+                    "cipherSuites": {
+                        "allowed": [
+                            "ALLOWED_CIPHER_SUITE_1",
+                            "ALLOWED_CIPHER_SUITE_2",
+                            "ALLOWED_CIPHER_SUITE_3"
+                        ],
+                        "denied": [
+                            "DENIED_CIPHER_SUITE_1",
+                            "DENIED_CIPHER_SUITE_2",
+                            "DENIED_CIPHER_SUITE_3"
+                        ]
+                    }
+                }
+                """;
+        Tls tls = readTls(json);
+        assertThat(tls).isEqualTo(new Tls(
+                null,
+                null,
+                new AllowDeny<>(
+                        List.of("ALLOWED_CIPHER_SUITE_1", "ALLOWED_CIPHER_SUITE_2", "ALLOWED_CIPHER_SUITE_3"),
+                        Set.of("DENIED_CIPHER_SUITE_1", "DENIED_CIPHER_SUITE_2", "DENIED_CIPHER_SUITE_3")),
+                null));
+    }
+
+    @Test
+    void testEnabledProtocolsProvider() throws IOException {
+        String json = """
+                {
+                    "protocols": {
+                        "allowed": [
+                            "TLSv1.2",
+                            "TLSv1.3"
+                        ],
+                        "denied": [
+                            "TLSv1.1"
+                        ]
+                    }
+                }
+                """;
+        Tls tls = readTls(json);
+        assertThat(tls).isEqualTo(new Tls(
+                null,
+                null,
+                null,
+                new AllowDeny<>(
+                        List.of("TLSv1.2", "TLSv1.3"),
+                        Set.of("TLSv1.1"))));
     }
 
     private Tls readTls(String json) throws IOException {

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/config/tls/TlsTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/config/tls/TlsTest.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.proxy.config.tls;
 
 import java.security.KeyStore;
+import java.util.List;
 import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
@@ -28,21 +29,33 @@ class TlsTest {
 
     @Test
     void testKeyDefined() {
-        Tls tls = new Tls(new KeyPair("/tmp/key", "/tmp/cert", null), null);
+        Tls tls = new Tls(new KeyPair("/tmp/key", "/tmp/cert", null), null, null, null);
         assertThat(tls.definesKey()).isTrue();
     }
 
     @Test
     void testKeyNotDefined() {
-        Tls tls = new Tls(null, null);
+        Tls tls = new Tls(null, null, null, null);
         assertThat(tls.definesKey()).isFalse();
     }
 
     @Test
     void testTrustDefined() {
-        Tls tls = new Tls(null, new TrustStore("/tmp/certs", new InlinePassword("pass"), null));
+        Tls tls = new Tls(null, new TrustStore("/tmp/certs", new InlinePassword("pass"), null), null, null);
         assertThat(tls.trust()).isNotNull();
         assertThat(tls.definesKey()).isFalse();
+    }
+
+    @Test
+    void testCipherSuitesDefined() {
+        Tls tls = new Tls(null, null, new AllowDeny<String>(List.of("ALLOWED_CIPHER_SUITES"), null), null);
+        assertThat(tls.cipherSuites()).isNotNull();
+    }
+
+    @Test
+    void testEnabledProtocolsDefined() {
+        Tls tls = new Tls(null, null, null, new AllowDeny<>(List.of("TLSv1.2"), null));
+        assertThat(tls.protocols()).isNotNull();
     }
 
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/DenyCipherSuiteFilter.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/DenyCipherSuiteFilter.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.model;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.StreamSupport;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.handler.ssl.CipherSuiteFilter;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * This class has been built to filter cipher suites based on requirements for Kroxylicious
+ * If no ciphers are declared then the default platform ciphers will be used
+ * If ciphers are declared then they are used instead of the default platform ciphers
+ * Both lists would then have anything removed that wasn't supported or in the deniedCiphers
+ */
+public final class DenyCipherSuiteFilter implements CipherSuiteFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DenyCipherSuiteFilter.class);
+
+    public DenyCipherSuiteFilter(@Nullable Set<String> deniedCiphers) {
+        this.deniedCiphers = deniedCiphers == null ? new HashSet<>() : deniedCiphers;
+    }
+
+    private final Set<String> deniedCiphers;
+
+    @Override
+    public String[] filterCipherSuites(Iterable<String> ciphers, List<String> defaultCiphers,
+                                       Set<String> supportedCiphers) {
+        var actualCiphers = (ciphers == null || !ciphers.iterator().hasNext()) ? defaultCiphers : ciphers;
+
+        StreamSupport.stream(actualCiphers.spliterator(), false)
+                .filter(Predicate.not(supportedCiphers::contains))
+                .forEach(unsupportedCipher -> LOGGER.warn("Ignoring allowed cipher '{}' as it is not recognized by this platform (supported ciphers: {})",
+                        unsupportedCipher, supportedCiphers));
+
+        deniedCiphers.stream()
+                .filter(Predicate.not(supportedCiphers::contains))
+                .forEach(unsupportedCipher -> LOGGER.warn("Ignoring denied cipher '{}' as it is not recognized by this platform (supported ciphers: {})",
+                        unsupportedCipher, supportedCiphers));
+
+        return StreamSupport.stream(actualCiphers.spliterator(), false)
+                .filter(supportedCiphers::contains)
+                .filter(Predicate.not(deniedCiphers::contains))
+                .toList()
+                .toArray(new String[]{});
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
@@ -6,6 +6,9 @@
 package io.kroxylicious.proxy.model;
 
 import java.io.UncheckedIOException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -13,7 +16,9 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLParameters;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,8 +26,10 @@ import org.slf4j.LoggerFactory;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 
+import io.kroxylicious.proxy.config.IllegalConfigurationException;
 import io.kroxylicious.proxy.config.NamedFilterDefinition;
 import io.kroxylicious.proxy.config.TargetCluster;
+import io.kroxylicious.proxy.config.tls.AllowDeny;
 import io.kroxylicious.proxy.config.tls.NettyKeyProvider;
 import io.kroxylicious.proxy.config.tls.NettyTrustProvider;
 import io.kroxylicious.proxy.config.tls.PlatformTrustProvider;
@@ -94,21 +101,39 @@ public class VirtualCluster implements ClusterNetworkAddressConfigProvider {
                                                  ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider,
                                                  Optional<Tls> tls) {
         try {
-            var downstreamTls = tls.map(t -> Optional.ofNullable(t.trust())
-                    .map(TrustProvider::trustOptions)
-                    .map(TrustOptions::toString)
-                    .orElse("-"))
-                    .map(options -> " (TLS: " + options + ")")
-                    .orElse("");
             HostPort downstreamBootstrap = clusterNetworkAddressConfigProvider.getClusterBootstrapAddress();
-            var upstreamTls = targetCluster.tls().map(tls1 -> " (TLS)").orElse("");
+            var downstreamTlsSummary = generateTlsSummary(tls);
+
             HostPort upstreamHostPort = targetCluster.bootstrapServersList().get(0);
+            var upstreamTlsSummary = generateTlsSummary(targetCluster.tls());
+
             LOGGER.info("Virtual Cluster: {}, Downstream {}{} => Upstream {}{}",
-                    clusterName, downstreamBootstrap, downstreamTls, upstreamHostPort, upstreamTls);
+                    clusterName, downstreamBootstrap, downstreamTlsSummary, upstreamHostPort, upstreamTlsSummary);
         }
         catch (Exception e) {
             LOGGER.warn("Failed to log summary for Virtual Cluster: {}", clusterName, e);
         }
+    }
+
+    private static String generateTlsSummary(Optional<Tls> tlsToSummarize) {
+        var tls = tlsToSummarize.map(t -> Optional.ofNullable(t.trust())
+                .map(TrustProvider::trustOptions)
+                .map(TrustOptions::toString).orElse("-"))
+                .map(options -> " (TLS: " + options + ") ").orElse("");
+        var cipherSuitesAllowed = tlsToSummarize.map(t -> Optional.ofNullable(t.cipherSuites())
+                .map(AllowDeny::allowed).orElse(Collections.emptyList()))
+                .map(allowedCiphers -> " (Allowed Ciphers: " + allowedCiphers + ")").orElse("");
+        var cipherSuitesDenied = tlsToSummarize.map(t -> Optional.ofNullable(t.cipherSuites())
+                .map(AllowDeny::denied).orElse(Collections.emptySet()))
+                .map(deniedCiphers -> " (Denied Ciphers: " + deniedCiphers + ")").orElse("");
+        var protocolsAllowed = tlsToSummarize.map(t -> Optional.ofNullable(t.protocols())
+                .map(AllowDeny::allowed).orElse(Collections.emptyList()))
+                .map(protocols -> " (Allowed Protocols: " + protocols + ")").orElse("");
+        var protocolsDenied = tlsToSummarize.map(t -> Optional.ofNullable(t.protocols())
+                .map(AllowDeny::denied).orElse(Collections.emptySet()))
+                .map(protocols -> " (Denied Protocols: " + protocols + ")").orElse("");
+
+        return tls + cipherSuitesAllowed + cipherSuitesDenied + protocolsAllowed + protocolsDenied;
     }
 
     public String getClusterName() {
@@ -207,6 +232,9 @@ public class VirtualCluster implements ClusterNetworkAddressConfigProvider {
                 var sslContextBuilder = Optional.of(tlsConfiguration.key()).map(NettyKeyProvider::new).map(NettyKeyProvider::forServer)
                         .orElseThrow();
 
+                configureCipherSuites(sslContextBuilder, tlsConfiguration);
+                configureEnabledProtocols(sslContextBuilder, tlsConfiguration);
+
                 return configureTrustProvider(tlsConfiguration).apply(sslContextBuilder).build();
             }
             catch (SSLException e) {
@@ -221,11 +249,14 @@ public class VirtualCluster implements ClusterNetworkAddressConfigProvider {
                 var sslContextBuilder = Optional.ofNullable(targetClusterTls.key()).map(NettyKeyProvider::new).map(NettyKeyProvider::forClient)
                         .orElse(SslContextBuilder.forClient());
 
+                configureCipherSuites(sslContextBuilder, targetClusterTls);
+                configureEnabledProtocols(sslContextBuilder, targetClusterTls);
+
                 Optional.ofNullable(targetClusterTls.trust())
                         .map(TrustProvider::trustOptions)
                         .filter(Predicate.not(TrustOptions::forClient))
                         .ifPresent(to -> {
-                            throw new IllegalStateException("Cannot apply trust options " + to + " to upstream (client) TLS.)");
+                            throw new IllegalConfigurationException("Cannot apply trust options " + to + " to upstream (client) TLS.)");
                         });
 
                 var withTrust = configureTrustProvider(targetClusterTls).apply(sslContextBuilder);
@@ -242,6 +273,67 @@ public class VirtualCluster implements ClusterNetworkAddressConfigProvider {
     private static NettyTrustProvider configureTrustProvider(Tls tlsConfiguration) {
         final TrustProvider trustProvider = Optional.ofNullable(tlsConfiguration.trust()).orElse(PlatformTrustProvider.INSTANCE);
         return new NettyTrustProvider(trustProvider);
+    }
+
+    private static void configureCipherSuites(SslContextBuilder sslContextBuilder, Tls tlsConfiguration) {
+        Optional.ofNullable(tlsConfiguration.cipherSuites())
+                .ifPresent(ciphers -> sslContextBuilder.ciphers(
+                        tlsConfiguration.cipherSuites().allowed(),
+                        new DenyCipherSuiteFilter(tlsConfiguration.cipherSuites().denied())));
+    }
+
+    private static void configureEnabledProtocols(SslContextBuilder sslContextBuilder, Tls tlsConfiguration) {
+        var protocols = Optional.ofNullable(tlsConfiguration.protocols());
+        var defaultProtocols = Arrays.stream(getDefaultSSLParameters().getProtocols()).toList();
+        var supportedProtocols = Arrays.stream(getSupportedSSLParameters().getProtocols()).toList();
+
+        protocols.ifPresent(allowDeny -> {
+            var allowedProtocols = protocols.map(AllowDeny::allowed).orElse(defaultProtocols);
+
+            var deniedProtocols = protocols.map(AllowDeny::denied).orElse(Set.of());
+
+            allowedProtocols.stream()
+                    .filter(Predicate.not(supportedProtocols::contains))
+                    .forEach(unsupportedProtocol -> LOGGER.warn("Ignoring allowed protocol '{}' as it is not recognized by this platform (supported protocols: {})",
+                            unsupportedProtocol, supportedProtocols));
+
+            deniedProtocols.stream()
+                    .filter(Predicate.not(supportedProtocols::contains))
+                    .forEach(unsupportedProtocol -> LOGGER.warn("Ignoring denied protocol '{}' as it is not recognized by this platform (supported protocols: {})",
+                            unsupportedProtocol, supportedProtocols));
+
+            var protocolsToUse = allowedProtocols.stream()
+                    .filter(supportedProtocols::contains)
+                    .filter(Predicate.not(deniedProtocols::contains))
+                    .toList();
+
+            if (!protocolsToUse.isEmpty()) {
+                sslContextBuilder.protocols(protocolsToUse);
+            }
+            else {
+                throw new IllegalConfigurationException(
+                        "The protocols configuration you have in place has resulted in no protocols being set. Allowed: " + allowedProtocols + ", Denied: "
+                                + deniedProtocols);
+            }
+        });
+    }
+
+    private static SSLParameters getDefaultSSLParameters() {
+        try {
+            return SSLContext.getDefault().getDefaultSSLParameters();
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static SSLParameters getSupportedSSLParameters() {
+        try {
+            return SSLContext.getDefault().getSupportedSSLParameters();
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private static void validatePortUsage(ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/DenyCipherSuiteFilterTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/DenyCipherSuiteFilterTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.model;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.Streams;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DenyCipherSuiteFilterTest {
+
+    private final List<String> defaultCiphers = List.of("CIPHER_SUITE_1", "CIPHER_SUITE_2", "CIPHER_SUITE_3", "CIPHER_SUITE_4");
+
+    // Test platform supports the default ciphers plus a deprecated one.
+    private final Set<String> supportedCiphers = Streams.concat(defaultCiphers.stream(), Stream.of("DEPRECATED_CIPHER_SUITE_1")).collect(Collectors.toSet());
+
+    @Test
+    void defaultsToDefaultCiphers() {
+        var filtered = new DenyCipherSuiteFilter(null)
+                .filterCipherSuites(null, defaultCiphers, supportedCiphers);
+        assertThat(filtered).containsExactlyElementsOf(defaultCiphers);
+    }
+
+    @Test
+    void emptyCiphersGivesDefault() {
+        var filtered = new DenyCipherSuiteFilter(null)
+                .filterCipherSuites(List.of(), defaultCiphers, supportedCiphers);
+        assertThat(filtered).containsExactlyElementsOf(defaultCiphers);
+    }
+
+    @Test
+    void denyCiphers() {
+        var deniedCiphers = Set.of("CIPHER_SUITE_2", "CIPHER_SUITE_4");
+        var expectedAllowedCiphers = List.of("CIPHER_SUITE_1", "CIPHER_SUITE_3");
+
+        var filtered = new DenyCipherSuiteFilter(deniedCiphers)
+                .filterCipherSuites(null, defaultCiphers, supportedCiphers);
+        assertThat(filtered).containsExactlyElementsOf(expectedAllowedCiphers);
+    }
+
+    @Test
+    void allowCiphers() {
+        var allowedCiphers = List.of("CIPHER_SUITE_1", "CIPHER_SUITE_2");
+
+        var filtered = new DenyCipherSuiteFilter(null)
+                .filterCipherSuites(allowedCiphers, defaultCiphers, supportedCiphers);
+        assertThat(filtered).containsExactlyElementsOf(allowedCiphers);
+    }
+
+    @Test
+    void allowAndDenyCiphers() {
+        var allowedCiphers = List.of("CIPHER_SUITE_3", "CIPHER_SUITE_1", "CIPHER_SUITE_2");
+        var deniedCiphers = Set.of("CIPHER_SUITE_1");
+        var expectedAllowedCiphers = List.of("CIPHER_SUITE_3", "CIPHER_SUITE_2");
+
+        var filtered = new DenyCipherSuiteFilter(deniedCiphers)
+                .filterCipherSuites(allowedCiphers, defaultCiphers, supportedCiphers);
+        assertThat(filtered).containsExactlyElementsOf(expectedAllowedCiphers);
+    }
+
+    @Test
+    void allowRespectsReordering() {
+        var allowedCiphers = List.of("CIPHER_SUITE_3", "CIPHER_SUITE_1", "CIPHER_SUITE_2");
+
+        var filtered = new DenyCipherSuiteFilter(null)
+                .filterCipherSuites(allowedCiphers, defaultCiphers, supportedCiphers);
+        assertThat(filtered).containsExactlyElementsOf(allowedCiphers);
+    }
+
+    @Test
+    void allowsSupportedCipherToBeEnabled() {
+        var allowedCiphers = List.of("DEPRECATED_CIPHER_SUITE_1", "CIPHER_SUITE_1");
+
+        var filtered = new DenyCipherSuiteFilter(null)
+                .filterCipherSuites(allowedCiphers, defaultCiphers, supportedCiphers);
+        assertThat(filtered).containsExactlyElementsOf(allowedCiphers);
+    }
+
+    @Test
+    void ignoresUnrecognizedAllowCipher() {
+        var allowedCiphers = List.of("CIPHER_SUITE_1", "CIPHER_SUITE_2", "UNKNOWN_CIPHER");
+        var expectedAllowedCiphers = List.of("CIPHER_SUITE_1", "CIPHER_SUITE_2");
+
+        var filtered = new DenyCipherSuiteFilter(null)
+                .filterCipherSuites(allowedCiphers, defaultCiphers, supportedCiphers);
+        assertThat(filtered).containsExactlyElementsOf(expectedAllowedCiphers);
+    }
+
+    @Test
+    void ignoresUnrecognizedDenyCipher() {
+        var deniedCipher = Set.of("CIPHER_SUITE_2", "CIPHER_SUITE_3", "UNKNOWN_CIPHER");
+        var expectedAllowedCiphers = List.of("CIPHER_SUITE_1", "CIPHER_SUITE_4");
+
+        var filtered = new DenyCipherSuiteFilter(deniedCipher)
+                .filterCipherSuites(null, defaultCiphers, supportedCiphers);
+        assertThat(filtered).containsExactlyElementsOf(expectedAllowedCiphers);
+    }
+
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterTest.java
@@ -6,10 +6,14 @@
 
 package io.kroxylicious.proxy.model;
 
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
+import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -20,8 +24,10 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import io.netty.buffer.ByteBufAllocator;
 
+import io.kroxylicious.proxy.config.IllegalConfigurationException;
 import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.config.secret.InlinePassword;
+import io.kroxylicious.proxy.config.tls.AllowDeny;
 import io.kroxylicious.proxy.config.tls.InsecureTls;
 import io.kroxylicious.proxy.config.tls.KeyPair;
 import io.kroxylicious.proxy.config.tls.ServerOptions;
@@ -30,7 +36,10 @@ import io.kroxylicious.proxy.config.tls.TlsClientAuth;
 import io.kroxylicious.proxy.config.tls.TlsTestConstants;
 import io.kroxylicious.proxy.config.tls.TrustStore;
 import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.PortPerBrokerClusterNetworkAddressConfigProvider;
+import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.PortPerBrokerClusterNetworkAddressConfigProvider.PortPerBrokerClusterNetworkAddressConfigProviderConfig;
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static io.kroxylicious.proxy.service.HostPort.parse;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,33 +48,45 @@ import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 class VirtualClusterTest {
 
-    private String privateKeyFile;
-    private String cert;
+    private static final InlinePassword PASSWORD_PROVIDER = new InlinePassword("storepass");
+
+    private static final String KNOWN_CIPHER_SUITE;
+
+    static {
+        try {
+            var defaultSSLParameters = SSLContext.getDefault().getDefaultSSLParameters();
+            KNOWN_CIPHER_SUITE = defaultSSLParameters.getCipherSuites()[0];
+            assertThat(KNOWN_CIPHER_SUITE).isNotNull();
+            assertThat(defaultSSLParameters.getProtocols()).contains("TLSv1.2", "TLSv1.3");
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
     private String client;
+    private KeyPair keyPair;
 
     @BeforeEach
     void setUp() {
-        privateKeyFile = TlsTestConstants.getResourceLocationOnFilesystem("server.key");
-        cert = TlsTestConstants.getResourceLocationOnFilesystem("server.crt");
+        String privateKeyFile = TlsTestConstants.getResourceLocationOnFilesystem("server.key");
+        String cert = TlsTestConstants.getResourceLocationOnFilesystem("server.crt");
         client = TlsTestConstants.getResourceLocationOnFilesystem("client.jks");
+        keyPair = new KeyPair(privateKeyFile, cert, null);
     }
 
     @Test
     void shouldBuildSslContext() {
         // Given
-        final KeyPair keyPair = new KeyPair(privateKeyFile, cert, null);
-        final Optional<Tls> tls = Optional.of(
+        final Optional<Tls> downstreamTls = Optional.of(
                 new Tls(keyPair,
-                        new InsecureTls(false)));
-        final PortPerBrokerClusterNetworkAddressConfigProvider.PortPerBrokerClusterNetworkAddressConfigProviderConfig clusterNetworkAddressConfigProviderConfig = new PortPerBrokerClusterNetworkAddressConfigProvider.PortPerBrokerClusterNetworkAddressConfigProviderConfig(
-                parse("localhost:1235"),
-                "localhost", 19092, 0, 1);
-        final ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider = new PortPerBrokerClusterNetworkAddressConfigProvider().build(
-                clusterNetworkAddressConfigProviderConfig);
+                        new InsecureTls(false), null, null));
+        final ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider = createTestClusterNetworkAddressConfigProvider();
 
         // When
 
-        final VirtualCluster virtualCluster = new VirtualCluster("wibble", new TargetCluster("bootstrap:9092", tls), clusterNetworkAddressConfigProvider, tls, false,
+        final VirtualCluster virtualCluster = new VirtualCluster("wibble", new TargetCluster("bootstrap:9092", downstreamTls), clusterNetworkAddressConfigProvider,
+                downstreamTls, false,
                 false);
 
         // Then
@@ -73,38 +94,6 @@ class VirtualClusterTest {
         assertThat(virtualCluster)
                 .isNotNull()
                 .satisfies(vc -> assertThat(vc.getUpstreamSslContext()).isPresent());
-    }
-
-    @ParameterizedTest
-    @MethodSource("clientAuthSettings")
-    void shouldRequireDownstreamClientAuth(TlsClientAuth clientAuth, Consumer<SSLEngine> sslEngineAssertions) {
-        // Given
-        final KeyPair keyPair = new KeyPair(privateKeyFile,
-                cert,
-                null);
-        final Optional<Tls> tls = Optional.of(new Tls(keyPair, new TrustStore(client, new InlinePassword("storepass"), null, new ServerOptions(clientAuth))));
-        final PortPerBrokerClusterNetworkAddressConfigProvider.PortPerBrokerClusterNetworkAddressConfigProviderConfig clusterNetworkAddressConfigProviderConfig = new PortPerBrokerClusterNetworkAddressConfigProvider.PortPerBrokerClusterNetworkAddressConfigProviderConfig(
-                parse("localhost:1235"),
-                "localhost", 19092, 0, 1);
-        final ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider = new PortPerBrokerClusterNetworkAddressConfigProvider().build(
-                clusterNetworkAddressConfigProviderConfig);
-        final TargetCluster targetCluster = new TargetCluster("bootstrap:9092", Optional.empty());
-
-        // When
-        final VirtualCluster virtualCluster = new VirtualCluster("wibble", targetCluster, clusterNetworkAddressConfigProvider, tls, false,
-                false);
-
-        // Then
-        assertThat(virtualCluster)
-                .isNotNull()
-                .satisfies(vc -> assertThat(vc.getDownstreamSslContext())
-                        .isPresent()
-                        .hasValueSatisfying(
-                                sslContext -> {
-                                    assertThat(sslContext.isClient()).isFalse();
-                                    assertThat(sslContext.isServer()).isTrue();
-                                    assertThat(sslContext.newEngine(ByteBufAllocator.DEFAULT)).satisfies(sslEngineAssertions);
-                                }));
     }
 
     static Stream<Arguments> clientAuthSettings() {
@@ -129,25 +118,122 @@ class VirtualClusterTest {
                         }));
     }
 
+    @ParameterizedTest
+    @MethodSource("clientAuthSettings")
+    void shouldRequireDownstreamClientAuth(TlsClientAuth clientAuth, Consumer<SSLEngine> sslEngineAssertions) {
+        // Given
+        final Optional<Tls> downstreamTls = Optional.of(new Tls(keyPair, new TrustStore(client, PASSWORD_PROVIDER, null, new ServerOptions(clientAuth)), null, null));
+        final ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider = createTestClusterNetworkAddressConfigProvider();
+        final TargetCluster targetCluster = new TargetCluster("bootstrap:9092", Optional.empty());
+
+        // When
+        final VirtualCluster virtualCluster = new VirtualCluster("wibble", targetCluster, clusterNetworkAddressConfigProvider, downstreamTls, false,
+                false);
+
+        // Then
+        assertThat(virtualCluster)
+                .isNotNull()
+                .satisfies(vc -> assertThat(vc.getDownstreamSslContext())
+                        .isPresent()
+                        .hasValueSatisfying(
+                                sslContext -> {
+                                    assertThat(sslContext.isClient()).isFalse();
+                                    assertThat(sslContext.isServer()).isTrue();
+                                    assertThat(sslContext.newEngine(ByteBufAllocator.DEFAULT)).satisfies(sslEngineAssertions);
+                                }));
+    }
+
     @Test
     void shouldNotAllowUpstreamToProvideTlsServerOptions() {
         // Given
-        final KeyPair keyPair = new KeyPair(privateKeyFile,
-                cert,
-                null);
-        final Optional<Tls> tls = Optional.of(new Tls(keyPair, new TrustStore(client, new InlinePassword("storepass"), null, new ServerOptions(TlsClientAuth.REQUIRED))));
-        final PortPerBrokerClusterNetworkAddressConfigProvider.PortPerBrokerClusterNetworkAddressConfigProviderConfig clusterNetworkAddressConfigProviderConfig = new PortPerBrokerClusterNetworkAddressConfigProvider.PortPerBrokerClusterNetworkAddressConfigProviderConfig(
-                parse("localhost:1235"),
-                "localhost", 19092, 0, 1);
-        final ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider = new PortPerBrokerClusterNetworkAddressConfigProvider().build(
-                clusterNetworkAddressConfigProviderConfig);
-        final TargetCluster targetCluster = new TargetCluster("bootstrap:9092", tls);
+        final Optional<Tls> downstreamTls = Optional
+                .of(new Tls(keyPair, new TrustStore(client, PASSWORD_PROVIDER, null, new ServerOptions(TlsClientAuth.REQUIRED)), null, null));
+        final ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider = createTestClusterNetworkAddressConfigProvider();
+        final TargetCluster targetCluster = new TargetCluster("bootstrap:9092", downstreamTls);
 
         // When/Then
         assertThatThrownBy(() -> new VirtualCluster("wibble", targetCluster, clusterNetworkAddressConfigProvider, Optional.empty(), false,
                 false))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("Cannot apply trust options");
     }
 
+    static Stream<Arguments> protocolRestrictions() {
+        return Stream.of(
+                argumentSet("allow single protocol",
+                        new AllowDeny<>(List.of("TLSv1.3"), null),
+                        (Consumer<SSLEngine>) (SSLEngine sslEngine) -> assertThat(sslEngine.getEnabledProtocols()).containsExactly("TLSv1.3")),
+                argumentSet("deny single protocol",
+                        new AllowDeny<>(null, Set.of("TLSv1.2")),
+                        (Consumer<SSLEngine>) (SSLEngine sslEngine) -> assertThat(sslEngine.getEnabledProtocols()).doesNotContain("TLSv1.2")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("protocolRestrictions")
+    void shouldApplyDownstreamProtocolRestriction(AllowDeny<String> protocolAllowDeny, Consumer<SSLEngine> sslEngineAssertions) {
+        // Given
+        final Optional<Tls> tls = Optional.of(new Tls(keyPair, new TrustStore(client, PASSWORD_PROVIDER, null, null), null, protocolAllowDeny));
+        final ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider = createTestClusterNetworkAddressConfigProvider();
+        final TargetCluster targetCluster = new TargetCluster("bootstrap:9092", Optional.empty());
+
+        // When
+        final VirtualCluster virtualCluster = new VirtualCluster("wibble", targetCluster, clusterNetworkAddressConfigProvider, tls, false,
+                false);
+
+        // Then
+        assertThat(virtualCluster)
+                .isNotNull()
+                .satisfies(vc -> assertThat(vc.getDownstreamSslContext())
+                        .isPresent()
+                        .hasValueSatisfying(
+                                sslContext -> {
+                                    assertThat(sslContext.isClient()).isFalse();
+                                    assertThat(sslContext.isServer()).isTrue();
+                                    assertThat(sslContext.newEngine(ByteBufAllocator.DEFAULT)).satisfies(sslEngineAssertions);
+                                }));
+    }
+
+    static Stream<Arguments> cipherSuiteRestrictions() {
+        return Stream.of(
+                argumentSet("allow single ciphersuite",
+                        new AllowDeny<>(List.of(KNOWN_CIPHER_SUITE), null),
+                        (Consumer<SSLEngine>) (SSLEngine sslEngine) -> assertThat(sslEngine.getEnabledCipherSuites()).containsExactly(KNOWN_CIPHER_SUITE)),
+                argumentSet("deny single ciphersuite",
+                        new AllowDeny<>(null, Set.of(KNOWN_CIPHER_SUITE)),
+                        (Consumer<SSLEngine>) (SSLEngine sslEngine) -> assertThat(sslEngine.getEnabledProtocols()).doesNotContain(KNOWN_CIPHER_SUITE)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("cipherSuiteRestrictions")
+    void shouldApplyDownstreamCipherSuiteRestriction(AllowDeny<String> cipherSuiteAllowDeny, Consumer<SSLEngine> sslEngineAssertions) {
+        // Given
+        final Optional<Tls> tls = Optional.of(new Tls(keyPair, new TrustStore(client, PASSWORD_PROVIDER, null, null), cipherSuiteAllowDeny, null));
+        final ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider = createTestClusterNetworkAddressConfigProvider();
+        final TargetCluster targetCluster = new TargetCluster("bootstrap:9092", Optional.empty());
+
+        // When
+        final VirtualCluster virtualCluster = new VirtualCluster("wibble", targetCluster, clusterNetworkAddressConfigProvider, tls, false,
+                false);
+
+        // Then
+        assertThat(virtualCluster)
+                .isNotNull()
+                .satisfies(vc -> assertThat(vc.getDownstreamSslContext())
+                        .isPresent()
+                        .hasValueSatisfying(
+                                sslContext -> {
+                                    assertThat(sslContext.isClient()).isFalse();
+                                    assertThat(sslContext.isServer()).isTrue();
+                                    assertThat(sslContext.newEngine(ByteBufAllocator.DEFAULT)).satisfies(sslEngineAssertions);
+                                }));
+    }
+
+    @NonNull
+    private ClusterNetworkAddressConfigProvider createTestClusterNetworkAddressConfigProvider() {
+        final PortPerBrokerClusterNetworkAddressConfigProviderConfig clusterNetworkAddressConfigProviderConfig = new PortPerBrokerClusterNetworkAddressConfigProviderConfig(
+                parse("localhost:1235"),
+                "localhost", 19092, 0, 1);
+        return new PortPerBrokerClusterNetworkAddressConfigProvider().build(
+                clusterNetworkAddressConfigProviderConfig);
+    }
 }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Attempt at allowing users to pass Cipher Suites and Enabled Protocols in TLS Configuration so they are set when the SSLContext is built.

### Additional Context

This is to address https://github.com/kroxylicious/kroxylicious/issues/1006

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
