### PR TITLE
Comply with the recommendation that AWS metadata endpoint is addressed using /latest/

### DIFF
--- a/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/credentials/Ec2MetadataCredentialsProvider.java
+++ b/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/credentials/Ec2MetadataCredentialsProvider.java
@@ -84,9 +84,10 @@ public class Ec2MetadataCredentialsProvider implements CredentialsProvider {
     private static final String TOKEN_RETRIEVAL_ENDPOINT = "/latest/api/token";
 
     /**
-     * EC2 Meta-data security credentials endpoint.
+     * EC2 Meta-data security credentials endpoint.  AWS recommend that latest is used.  That's the approach taken by their
+     * own SDK.
      */
-    private static final String META_DATA_IAM_SECURITY_CREDENTIALS_ENDPOINT = "/2024-04-11/meta-data/iam/security-credentials/";
+    private static final String META_DATA_IAM_SECURITY_CREDENTIALS_ENDPOINT = "/latest/meta-data/iam/security-credentials/";
 
     private final Clock systemClock;
     private final AtomicReference<CompletableFuture<SecurityCredentials>> current = new AtomicReference<>();


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

AWS recommend that the metadata endpoint is addressed using `/latest`.

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html#imds-considerations:~:text=Metadata%20version,the%20version%20number.

They also use that practice in their own SDK.

The PR adopts that position and adds a test to make sure that we won't fail if a new field appears.


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
