### PR TITLE
Performance tweaks for logging

### DIFF
--- a/kroxylicious-app/pom.xml
+++ b/kroxylicious-app/pom.xml
@@ -89,6 +89,7 @@
         <dependency>
             <groupId>com.lmax</groupId>
             <artifactId>disruptor</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <!--support yaml logging configuration-->
         <dependency>

--- a/kroxylicious-app/pom.xml
+++ b/kroxylicious-app/pom.xml
@@ -86,6 +86,10 @@
             <artifactId>log4j-slf4j2-impl</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>com.lmax</groupId>
+            <artifactId>disruptor</artifactId>
+        </dependency>
         <!--support yaml logging configuration-->
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -192,6 +196,9 @@
                             <descriptors>
                                 <descriptor>src/assembly/binary-distribution.xml</descriptor>
                             </descriptors>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
                         </configuration>
                         <executions>
                             <execution>

--- a/kroxylicious-app/src/assembly/kroxylicious-start.sh
+++ b/kroxylicious-app/src/assembly/kroxylicious-start.sh
@@ -26,7 +26,7 @@ classpath() {
 }
 
 if [ "${KROXYLICIOUS_LOGGING_OPTIONS+set}" != set ]; then
-  KROXYLICIOUS_LOGGING_OPTIONS="-Dlog4j2.configurationFile=$(script_dir)/../config/log4j2.yaml"
+  KROXYLICIOUS_LOGGING_OPTIONS="-Dlog4j2.configurationFile=$(script_dir)/../config/log4j2.yaml -Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector"
 fi
 export JAVA_OPTIONS="${KROXYLICIOUS_LOGGING_OPTIONS} ${JAVA_OPTIONS:-}"
 JAVA_CLASSPATH="$(classpath)"

--- a/kroxylicious-app/src/main/resources/log4j2.yaml
+++ b/kroxylicious-app/src/main/resources/log4j2.yaml
@@ -13,7 +13,7 @@ Configuration:
       name: STDOUT
       target: SYSTEM_OUT
       PatternLayout:
-        pattern: "%d{yyyy-MM-dd HH:mm:ss} <%t> %-5p %c:%L - %m%n"
+        pattern: "%d{yyyy-MM-dd HH:mm:ss} <%t> %-5p %c - %m%n"
   Loggers:
     Root:
       level: "${env:KROXYLICIOUS_ROOT_LOG_LEVEL:-WARN}"

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 
         <impsort-maven-plugin.goal>sort</impsort-maven-plugin.goal>
 
+        <disruptor.version>3.3.4</disruptor.version>
         <freemarker.version>2.3.33</freemarker.version>
         <guava.version>33.3.1-jre</guava.version>
         <hamcrest.version>3.0</hamcrest.version>
@@ -254,6 +255,11 @@
                 <version>${log4j.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>com.lmax</groupId>
+                <artifactId>disruptor</artifactId>
+                <version>${disruptor.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.freemarker</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
         <impsort-maven-plugin.goal>sort</impsort-maven-plugin.goal>
 
-        <disruptor.version>3.3.4</disruptor.version>
+        <disruptor.version>4.0.0</disruptor.version>
         <freemarker.version>2.3.33</freemarker.version>
         <guava.version>33.3.1-jre</guava.version>
         <hamcrest.version>3.0</hamcrest.version>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Adds LMAX Disruptor dependency and sets `-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector` in the kroxylicious logging options, so that we use log4j2's async loggers in the Kroxylicious image.

Removes [costly `%L` line number lookup](https://logging.apache.org/log4j/2.12.x/manual/async.html#Location) from log4j2 template.

### Additional Context

Using async loggers notably reduces the number of logs that go missing under load when DEBUG logging is enabled on Kubernetes (#1634). They offer [significant performance improvements](https://logging.apache.org/log4j/2.12.x/manual/async.html) over the defaults, so there's little reason not to use them here.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
