### PR TITLE
Remove leading newline in the doc index template that breaks the asciidoc rendering

### DIFF
--- a/scripts/stage-docs.sh
+++ b/scripts/stage-docs.sh
@@ -125,8 +125,7 @@ cp -R "${KROXYLICIOUS_DOCS_LOCATION}" "${WEBSITE_DOCS_LOCATION}/_files"
 rm -f "${WEBSITE_DOCS_LOCATION}/_files/README.md"
 
 echo "Creating AsciiDoc entrypoint file at ${WEBSITE_DOCS_LOCATION}/index.adoc"
-RELEASE_DOCS_INDEX_TEMPLATE="
----
+RELEASE_DOCS_INDEX_TEMPLATE="---
 title: Kroxylicious Proxy ${RELEASE_TAG}
 ---
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Remove leading newline in the doc index template that breaks the asciidoc rendering.

We made this fix manually for 0.9.0 --> https://github.com/kroxylicious/kroxylicious.github.io/pull/91.


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
