### PR TITLE
Build and push SNAPSHOT operator images

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -22,7 +22,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ vars.REGISTRY_SERVER != '' && vars.REGISTRY_USERNAME != '' && vars.REGISTRY_DESTINATION != '' }}
+    if: ${{ vars.REGISTRY_SERVER != '' && vars.REGISTRY_USERNAME != '' && vars.REGISTRY_ORGANISATION != '' && vars.PROXY_IMAGE_NAME != '' && vars.OPERATOR_IMAGE_NAME != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,16 +35,18 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: Set Release version env variable
+      - name: Set env variables
         run: |
           echo "RELEASE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
+          echo "PROXY_IMAGE=${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.PROXY_IMAGE_NAME }}" >> $GITHUB_ENV
+          echo "OPERATOR_IMAGE=${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.OPERATOR_IMAGE_NAME }}" >> $GITHUB_ENV
       - name: Login to container registry
         uses: docker/login-action@v3
         with:
           registry: ${{ vars.REGISTRY_SERVER }}
           username: ${{ vars.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_TOKEN }}
-      - name: Build
+      - name: Build and push Proxy image
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -52,4 +54,16 @@ jobs:
           push: true
           build-args: |
             KROXYLICIOUS_VERSION=${{ env.RELEASE_VERSION }} 
-          tags: ${{ vars.REGISTRY_DESTINATION }}:${{ env.RELEASE_VERSION }}
+          tags: ${{ env.PROXY_IMAGE }}:${{ env.RELEASE_VERSION }}
+      - name: Maven build operator code
+        run: |
+          mvn package --projects :kroxylicious-operator --also-make -DskipTests -B
+      - name: Build and maybe push Operator image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./kroxylicious-operator/
+          platforms: linux/amd64,linux/arm64
+          push: ${{ endsWith(env.RELEASE_VERSION, 'SNAPSHOT') }}
+          build-args: |
+            KROXYLICIOUS_VERSION=${{ env.RELEASE_VERSION }}
+          tags: ${{ env.OPERATOR_IMAGE }}:${{ env.RELEASE_VERSION }},${{ env.OPERATOR_IMAGE }}:latest

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -55,13 +55,11 @@ jobs:
           build-args: |
             KROXYLICIOUS_VERSION=${{ env.RELEASE_VERSION }} 
           tags: ${{ env.PROXY_IMAGE }}:${{ env.RELEASE_VERSION }}
-      - name: Maven build operator code
-        run: |
-          mvn package --projects :kroxylicious-operator --also-make -DskipTests -B
       - name: Build and maybe push Operator image
         uses: docker/build-push-action@v6
         with:
-          context: ./kroxylicious-operator/
+          context: .
+          file: ./Dockerfile.operator
           platforms: linux/amd64,linux/arm64
           push: ${{ endsWith(env.RELEASE_VERSION, 'SNAPSHOT') }}
           build-args: |

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -437,9 +437,10 @@ To enable the docker workflow, you need to configure three repository [variables
 and one repository [secret](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
 
 * `REGISTRY_SERVER` variable - the server of the container registry service e.g. `quay.io` or `docker.io`
+* `REGISTRY_ORGANISATION` variable - the organization of the container registry service e.g. `kroxylicious` or `yourusername`
+* `PROXY_IMAGE_NAME` variable - the image name e.g. `kroxylicious`
+* `OPERATOR_IMAGE_NAME` variable - the image name e.g. `operator`
 * `REGISTRY_USERNAME` variable - your username on the service (or username of your robot account)
-* `REGISTRY_DESTINATION` variable - the push destination (without tag portion) e.g. `quay.io/<my org>/kroxylicious`
-
 * `REGISTRY_TOKEN` secret - the access token that corresponds to `REGISTRY_USERNAME` 
 
 The workflow will push the container image to `${REGISTRY_DESTINATION}` so ensure that the `${REGISTRY_USERNAME}` user has sufficient write privileges. 

--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -4,6 +4,14 @@
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
+from registry.access.redhat.com/ubi9/openjdk-17:1.20 as builder
+
+user root
+workdir /opt/kroxylicious
+copy . .
+run mvn -q -B clean package -Pdist -Dquick
+user 185
+
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
 
 ARG JAVA_VERSION=17
@@ -46,7 +54,7 @@ RUN set -ex; \
         chmod +x /usr/bin/tini; \
     fi
 
-COPY target/kroxylicious-operator-${KROXYLICIOUS_VERSION}-bin/kroxylicious-operator-${KROXYLICIOUS_VERSION} /opt/kroxylicious-operator
+COPY --from=builder /opt/kroxylicious/kroxylicious-operator/target/kroxylicious-operator-${KROXYLICIOUS_VERSION}-bin/kroxylicious-operator-${KROXYLICIOUS_VERSION} /opt/kroxylicious-operator
 
 RUN if [[ -n "${CURRENT_USER}" && "${CURRENT_USER}" != "root" ]] ; then groupadd -r -g "${CURRENT_USER_UID}" "${CURRENT_USER}" && useradd -m -r -u "${CURRENT_USER_UID}" -g "${CURRENT_USER}" "${CURRENT_USER}"; fi
 

--- a/scripts/run-operator.sh
+++ b/scripts/run-operator.sh
@@ -7,10 +7,7 @@
 
 # simple script to build and run the operator
 cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" || exit
-cd ..
-echo "building operator maven project"
-mvn package --projects :kroxylicious-operator --also-make -DskipTests
-cd kroxylicious-operator || exit
+cd .. || exit
 
 if ! minikube status
 then
@@ -20,8 +17,9 @@ fi
 
 echo "building operator image in minikube"
 KROXYLICIOUS_VERSION=${KROXYLICIOUS_VERSION:-$(mvn org.apache.maven.plugins:maven-help-plugin:3.4.0:evaluate -Dexpression=project.version -q -DforceStdout)}
-minikube image build . -t quay.io/kroxylicious/operator:latest --build-opt=build-arg=KROXYLICIOUS_VERSION="${KROXYLICIOUS_VERSION}"
+minikube image build . -f Dockerfile.operator -t quay.io/kroxylicious/operator:latest --build-opt=build-arg=KROXYLICIOUS_VERSION="${KROXYLICIOUS_VERSION}"
 
+cd kroxylicious-operator || exit
 echo "installing kafka (no-op if already installed)"
 kubectl create namespace kafka
 kubectl create -n kafka -f 'https://strimzi.io/install/latest?namespace=kafka'


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

We have a PR beginning to add system tests for the operator but we want to pull an operator image from quay. This PR starts publishing snapshot operator images to quay.

Note that we need a quay repo and to update some variables in github actions.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
