### PR TITLE
Fix SNI TLS kubernetes example script path

### DIFF
--- a/kubernetes-examples/network-topologies/snirouting_tls/postinstall.sh
+++ b/kubernetes-examples/network-topologies/snirouting_tls/postinstall.sh
@@ -12,7 +12,7 @@ YELLOW='\033[1;33m'
 NOCOLOR='\033[0m'
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-. "${SCRIPT_DIR}/../../scripts/common.sh"
+. "${SCRIPT_DIR}/../../../scripts/common.sh"
 
 KAFKA_TOOL_SUFFIX=".sh"
 if [ "$OS" = 'Darwin'  ]; then


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Running the `snirouting_tls` example failed with:

```
$ minikube delete && ./scripts/run-example.sh kubernetes-examples/network-topologies/snirouting_tls
... snip
kubernetes-examples/network-topologies/snirouting_tls/postinstall.sh: line 15: /home/robeyoun/development/upstream/kroxylicious/kubernetes-examples/network-topologies/snirouting_tls/../../scripts/common.sh: No such file or directory
```

The examples were restructed as part of #1280 and this path got missed

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
