### PR TITLE
Operator docker documentation and scripting fixes

### DIFF
--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -4,13 +4,13 @@
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
-from registry.access.redhat.com/ubi9/openjdk-17:1.20 as builder
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.20 AS builder
 
-user root
-workdir /opt/kroxylicious
-copy . .
-run mvn -q -B clean package -Pdist -Dquick
-user 185
+USER root
+WORKDIR /opt/kroxylicious
+COPY . .
+RUN mvn -q -B clean package -Pdist -Dquick
+USER 185
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
 

--- a/kroxylicious-operator/DEV_GUIDE.md
+++ b/kroxylicious-operator/DEV_GUIDE.md
@@ -52,7 +52,7 @@ should produce a `target/kroxylicious-operator-0.10.0-SNAPSHOT-bin` directory.
 Build the operator image. For development purposes you can use the minikube registry directly using `minikube image build`, which will be faster than alternatives like pushing to quay.io from your host only for kube to pull the same image right back when you deploy the operator.
 
 ```bash
-minikube image build . -t quay.io/kroxylicious/operator:latest \
+minikube image build -f Dockerfile.operator  .. -t quay.io/kroxylicious/operator:latest \
 --build-opt=build-arg=KROXYLICIOUS_VERSION=0.10.0-SNAPSHOT
 ```
 

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -58,6 +58,7 @@ if [[ -z ${REGISTRY_DESTINATION:-} ]]; then
 fi
 
 IMAGE="${REGISTRY_DESTINATION}:${KROXYLICIOUS_VERSION}"
+CONTAINERFILE="${CONTAINERFILE:-Dockerfile}"
 
 if [ -n "${IMAGE_EXPIRY:-}" ]; then
   LABELS+=("quay.expires-after=${IMAGE_EXPIRY}")
@@ -67,7 +68,7 @@ LABEL_ARGS=$(array_to_arg_line "label" "${LABELS[@]:""}")
 TAG_ARGS=$(array_to_arg_line "tag" "${IMAGE_TAGS[@]:""}")
 
 # shellcheck disable=SC2086 #we are passing additional arguments here so word splitting is intended
-${CONTAINER_ENGINE} build -t "${IMAGE}" ${LABEL_ARGS} ${TAG_ARGS} \
+${CONTAINER_ENGINE} build -f "${CONTAINERFILE}" -t "${IMAGE}" ${LABEL_ARGS} ${TAG_ARGS} \
                                         --build-arg "KROXYLICIOUS_VERSION=${KROXYLICIOUS_VERSION}" \
                                         --build-arg "CURRENT_USER=${USER}" \
                                         --build-arg "CURRENT_USER_UID=$(id -u)" \


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

1. Fix up the build commands since the operator Dockerfile moved.
2. Update the case of the commands in the operator image build as they are inconsistent
3. Updates the `build-image.sh` script so that it can build the operator image and push it to a personal quay.io account, using an optional `CONTAINERFILE` env var to control which file we build:

```
REGISTRY_DESTINATION=quay.io/robeyoun/operator CONTAINERFILE=Dockerfile.operator ./scripts/build-image.sh
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
