### PR TITLE
Cluster-scoped filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format `<github issue/pr number>: <short description>`.
 
 * [#1698](https://github.com/kroxylicious/kroxylicious/pull/1698) Bump netty.io_uring.version from 0.0.25.Final to 0.0.26.Final #1698
 * [#1672](https://github.com/kroxylicious/kroxylicious/pull/1672) Limited Fortanix DSM backed KMS integration
+* [#1709](https://github.com/kroxylicious/kroxylicious/pull/1709) Deprecate the existing top level `filters` configuration property; add support for named `filterDefinitions`, which can be scoped to a cluster.
 * [#1643](https://github.com/kroxylicious/kroxylicious/pull/1643) Improve Encryption DEK co-ordination across threads
 * [#1705](https://github.com/kroxylicious/kroxylicious/pull/1705) Replace usages of Contributor with new Plugin mechanism and delete Contributor
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Format `<github issue/pr number>: <short description>`.
 * [#1643](https://github.com/kroxylicious/kroxylicious/pull/1643) Improve Encryption DEK co-ordination across threads
 * [#1705](https://github.com/kroxylicious/kroxylicious/pull/1705) Replace usages of Contributor with new Plugin mechanism and delete Contributor
 
+### Changes, deprecations and removals
+
+* The top level `filters` configuration property is deprecated. Configurations should use `filterDefinitions` and `defaultFilters` instead.
+
 ## 0.9.0
 
 * [#1668](https://github.com/kroxylicious/kroxylicious/pull/1668) Bump apicurio-registry.version from 2.6.5.Final to 2.6.6.Final

--- a/kroxylicious-app/example-proxy-config.yaml
+++ b/kroxylicious-app/example-proxy-config.yaml
@@ -18,9 +18,12 @@ virtualClusters:
         bootstrapAddress: localhost:9192
     logNetwork: false
     logFrames: false
-filters:
-#- type: ProduceRequestTransformationFilterFactory
+filterDefinitions:
+#- name: toUpper
+#  type: ProduceRequestTransformationFilterFactory
 #  config:
 #    transformation: UpperCasing
 #    transformationConfig:
 #      charset: UTF-8
+#defaultFilters:
+#  - toUpper

--- a/kroxylicious-app/src/test/resources/proxy-config.yaml
+++ b/kroxylicious-app/src/test/resources/proxy-config.yaml
@@ -18,4 +18,4 @@ virtualClusters:
         bootstrapAddress: localhost:9192
     logNetwork: false
     logFrames: false
-filters: []
+defaultFilters: []

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/proxy/config/FilterDefinitionBuilder.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/proxy/config/FilterDefinitionBuilder.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import io.kroxylicious.proxy.filter.FilterFactory;
 
+@Deprecated
 public class FilterDefinitionBuilder extends AbstractDefinitionBuilder<FilterDefinition> {
     public FilterDefinitionBuilder(String type) {
         super(type);

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/proxy/config/NamedFilterDefinitionBuilder.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/proxy/config/NamedFilterDefinitionBuilder.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config;
+
+import java.util.Map;
+
+import io.kroxylicious.proxy.filter.FilterFactory;
+
+public class NamedFilterDefinitionBuilder extends AbstractDefinitionBuilder<NamedFilterDefinition> {
+    private final String name;
+
+    public NamedFilterDefinitionBuilder(String name, String type) {
+        super(type);
+        this.name = name;
+    }
+
+    @Override
+    protected NamedFilterDefinition buildInternal(String type, Map<String, Object> config) {
+        var configType = new ServiceBasedPluginFactoryRegistry().pluginFactory(FilterFactory.class).configType(type);
+        return new NamedFilterDefinition(name, type, mapper.convertValue(config, configType));
+    }
+
+    public String name() {
+        return name;
+    }
+}

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
@@ -333,7 +333,7 @@ class ConfigurationTest {
                 false,
                 development))
                 .isInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("`filters` and `filterDefinitions` can't both be set");
+                .hasMessage("'filters' and 'filterDefinitions' can't both be set");
     }
 
     @Test
@@ -351,7 +351,7 @@ class ConfigurationTest {
                 false,
                 development))
                 .isInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("`filterDefinitions` contains multiple items with the same names: [foo]");
+                .hasMessage("'filterDefinitions' contains multiple items with the same names: [foo]");
     }
 
     @Test
@@ -365,7 +365,7 @@ class ConfigurationTest {
                 null, false,
                 development))
                 .isInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("`defaultFilters` references filters not defined in `filterDefinitions`: [missing]");
+                .hasMessage("'defaultFilters' references filters not defined in 'filterDefinitions': [missing]");
     }
 
     @Test
@@ -380,7 +380,28 @@ class ConfigurationTest {
                 null, false,
                 development))
                 .isInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("`virtualClusters.vc1.filterRefs` references filters not defined in `filterDefinitions`: [missing]");
+                .hasMessage("'virtualClusters.vc1.filterRefs' references filters not defined in 'filterDefinitions': [missing]");
+    }
+
+    @Test
+    void shouldRejectUnusedFilterDefinition() {
+        Optional<Map<String, Object>> development = Optional.empty();
+        List<NamedFilterDefinition> filterDefinitions = List.of(
+                new NamedFilterDefinition("used1", "", ""),
+                new NamedFilterDefinition("unused", "", ""),
+                new NamedFilterDefinition("used2", "", "")
+
+        );
+
+        List<String> defaultFilters = List.of("used1");
+        Map<String, VirtualCluster> virtualClusters = Map.of("vc1", new VirtualCluster(null, null, null, false, false, List.of("used2")));
+        assertThatThrownBy(() -> new Configuration(null, filterDefinitions,
+                defaultFilters,
+                virtualClusters,
+                null, false,
+                development))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessage("'filterDefinitions' defines filters which are not used in 'defaultFilters' or in any virtual cluster's 'filters': [unused]");
     }
 
     @Test

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
@@ -323,6 +323,7 @@ class ConfigurationTest {
     void shouldRejectBothFiltersAndFilterDefinitions() {
         List<NamedFilterDefinition> filterDefinitions = List.of(new NamedFilterDefinition("", "", ""));
         List<FilterDefinition> filters = List.of(new FilterDefinition("", ""));
+        Optional<Map<String, Object>> development = Optional.empty();
         assertThatThrownBy(() -> new Configuration(null,
                 filterDefinitions,
                 null,
@@ -330,7 +331,7 @@ class ConfigurationTest {
                 filters,
                 null,
                 false,
-                Optional.empty()))
+                development))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("`filters` and `filterDefinitions` can't both be set");
     }
@@ -340,6 +341,7 @@ class ConfigurationTest {
         List<NamedFilterDefinition> filterDefinitions = List.of(
                 new NamedFilterDefinition("foo", "", ""),
                 new NamedFilterDefinition("foo", "", ""));
+        Optional<Map<String, Object>> development = Optional.empty();
         assertThatThrownBy(() -> new Configuration(null,
                 filterDefinitions,
                 null,
@@ -347,34 +349,38 @@ class ConfigurationTest {
                 null,
                 null,
                 false,
-                Optional.empty()))
+                development))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("`filterDefinitions` contains multiple items with the same names: [foo]");
     }
 
     @Test
     void shouldRejectMissingDefaultFilter() {
+        Optional<Map<String, Object>> development = Optional.empty();
         assertThatThrownBy(() -> new Configuration(List.of(),
                 List.of("missing"),
                 null,
                 false,
                 null,
                 null,
-                Optional.empty()))
+                development))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("`defaultFilters` references filters not defined in `filterDefinitions`: [missing]");
     }
 
     @Test
     void shouldRejectMissingClusterFilter() {
+        Optional<Map<String, Object>> development = Optional.empty();
+        List<NamedFilterDefinition> filterDefinitions = List.of();
+        Map<String, VirtualCluster> virtualClusters = Map.of("vc1", new VirtualCluster(null, null, null, false, false, List.of("missing")));
         assertThatThrownBy(() -> new Configuration(
-                List.of(),
+                filterDefinitions,
                 null,
-                Map.of("vc1", new VirtualCluster(null, null, null, false, false, List.of("missing"))),
+                virtualClusters,
                 false,
                 null,
                 null,
-                Optional.empty()))
+                development))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("`virtualClusters.vc1.filterRefs` references filters not defined in `filterDefinitions`: [missing]");
     }

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
@@ -405,6 +405,22 @@ class ConfigurationTest {
     }
 
     @Test
+    void shouldRejectVirtualClusterFiltersWhenTopLevelFilters() {
+        Optional<Map<String, Object>> development = Optional.empty();
+        Map<String, VirtualCluster> virtualClusters = Map.of("vc1", new VirtualCluster(null, null, null, false, false, List.of()));
+        assertThatThrownBy(() -> new Configuration(
+                null,
+                null,
+                null,
+                virtualClusters,
+                List.<FilterDefinition>of(),
+                null, false,
+                development))
+                .isInstanceOf(IllegalConfigurationException.class)
+                .hasMessage("'filters' cannot be specified on a virtual cluster when 'filters' is defined at the top level.");
+    }
+
+    @Test
     void virtualClusterModelShouldUseCorrectFilters() {
         // Given
         List<NamedFilterDefinition> filterDefinitions = List.of(

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
@@ -313,7 +313,7 @@ class ConfigurationTest {
                 new FilterDefinition("Bar", "1"),
                 new FilterDefinition("Foo", "2"),
                 new FilterDefinition("Bar", "3"));
-        assertThat(Configuration.namedFilterDefinitions(filters)).isEqualTo(List.of(
+        assertThat(Configuration.toNamedFilterDefinitions(filters)).isEqualTo(List.of(
                 new NamedFilterDefinition("Bar-0", "Bar", "1"),
                 new NamedFilterDefinition("Foo", "Foo", "2"),
                 new NamedFilterDefinition("Bar-1", "Bar", "3")));

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
@@ -308,7 +308,7 @@ class ConfigurationTest {
     }
 
     @Test
-    void shouldGenerateUniqueNamed() {
+    void shouldGenerateUniqueNames() {
         List<FilterDefinition> filters = List.of(
                 new FilterDefinition("Bar", "1"),
                 new FilterDefinition("Foo", "2"),

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
@@ -321,7 +321,7 @@ class ConfigurationTest {
 
     @Test
     void shouldRejectBothFiltersAndFilterDefinitions() {
-        List<NamedFilterDefinition> filterDefinitions = List.of(new NamedFilterDefinition("", "", ""));
+        List<NamedFilterDefinition> filterDefinitions = List.of(new NamedFilterDefinition("foo", "", ""));
         List<FilterDefinition> filters = List.of(new FilterDefinition("", ""));
         Optional<Map<String, Object>> development = Optional.empty();
         assertThatThrownBy(() -> new Configuration(null,

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
@@ -359,12 +359,10 @@ class ConfigurationTest {
         Optional<Map<String, Object>> development = Optional.empty();
         List<NamedFilterDefinition> filterDefinitions = List.of();
         List<String> defaultFilters = List.of("missing");
-        assertThatThrownBy(() -> new Configuration(filterDefinitions,
+        assertThatThrownBy(() -> new Configuration(null, filterDefinitions,
                 defaultFilters,
                 null,
-                false,
-                null,
-                null,
+                null, false,
                 development))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("`defaultFilters` references filters not defined in `filterDefinitions`: [missing]");
@@ -376,12 +374,10 @@ class ConfigurationTest {
         List<NamedFilterDefinition> filterDefinitions = List.of();
         Map<String, VirtualCluster> virtualClusters = Map.of("vc1", new VirtualCluster(null, null, null, false, false, List.of("missing")));
         assertThatThrownBy(() -> new Configuration(
-                filterDefinitions,
+                null, filterDefinitions,
                 null,
                 virtualClusters,
-                false,
-                null,
-                null,
+                null, false,
                 development))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessage("`virtualClusters.vc1.filterRefs` references filters not defined in `filterDefinitions`: [missing]");
@@ -412,13 +408,11 @@ class ConfigurationTest {
                 null); // filters not defined => should default to the top level
 
         Configuration configuration = new Configuration(
-                filterDefinitions,
+                null, filterDefinitions,
                 List.of("bar"),
                 Map.of("direct", direct,
                         "defaulted", defaulted),
-                false,
-                null,
-                null,
+                null, false,
                 Optional.empty());
 
         // When

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
@@ -380,7 +380,7 @@ class ConfigurationTest {
                 null, false,
                 development))
                 .isInstanceOf(IllegalConfigurationException.class)
-                .hasMessage("'virtualClusters.vc1.filterRefs' references filters not defined in 'filterDefinitions': [missing]");
+                .hasMessage("'virtualClusters.vc1.filters' references filters not defined in 'filterDefinitions': [missing]");
     }
 
     @Test
@@ -413,7 +413,7 @@ class ConfigurationTest {
                 null,
                 null,
                 virtualClusters,
-                List.<FilterDefinition>of(),
+                List.<FilterDefinition> of(),
                 null, false,
                 development))
                 .isInstanceOf(IllegalConfigurationException.class)

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
@@ -357,8 +357,10 @@ class ConfigurationTest {
     @Test
     void shouldRejectMissingDefaultFilter() {
         Optional<Map<String, Object>> development = Optional.empty();
-        assertThatThrownBy(() -> new Configuration(List.of(),
-                List.of("missing"),
+        List<NamedFilterDefinition> filterDefinitions = List.of();
+        List<String> defaultFilters = List.of("missing");
+        assertThatThrownBy(() -> new Configuration(filterDefinitions,
+                defaultFilters,
                 null,
                 false,
                 null,

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/DeprecatedConfigurationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/DeprecatedConfigurationIT.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.Serdes;
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.config.FilterDefinition;
+import io.kroxylicious.proxy.config.NamedFilterDefinitionBuilder;
+import io.kroxylicious.proxy.filter.simpletransform.FetchResponseTransformationFilterFactory;
+import io.kroxylicious.proxy.filter.simpletransform.UpperCasing;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.junit5ext.Topic;
+
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
+import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
+import static org.apache.kafka.clients.producer.ProducerConfig.CLIENT_ID_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests of deprecated configurations and features
+ */
+public class DeprecatedConfigurationIT extends BaseIT {
+
+    @Test
+    void shouldSupportTopLevelFiltersProperty(KafkaCluster cluster, Topic topic1) throws Exception {
+
+        FilterDefinition filterDefinition = new NamedFilterDefinitionBuilder(
+                "filter-1", FetchResponseTransformationFilterFactory.class.getName())
+                .withConfig("transformation", UpperCasing.class.getName())
+                .withConfig("transformationConfig", Map.of("charset", "UTF-8")).build().asFilterDefinition();
+        var config = proxy(cluster)
+                .addToFilters(filterDefinition);
+
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer(Serdes.String(), Serdes.String(),
+                        Map.of(CLIENT_ID_CONFIG, "shouldSupportTopLevelFiltersProperty",
+                                DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000));
+                var consumer = tester.consumer(Serdes.String(), Serdes.String(),
+                        Map.of(
+                                ConsumerConfig.GROUP_ID_CONFIG, UUID.randomUUID().toString(),
+                                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"))) {
+
+            producer.send(new ProducerRecord<>(topic1.name(), "my-key", "hello")).get();
+            producer.flush();
+
+            consumer.subscribe(Set.of(topic1.name()));
+            var records = consumer.poll(Duration.ofSeconds(100));
+            assertThat(records).hasSize(1);
+            assertThat(records.records(topic1.name()))
+                    .singleElement()
+                    .extracting(ConsumerRecord::value)
+                    .isEqualTo("HELLO");
+        }
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/FilterIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/FilterIT.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
 
 import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
+import io.kroxylicious.proxy.config.NamedFilterDefinitionBuilder;
 import io.kroxylicious.proxy.filter.ForwardingStyle;
 import io.kroxylicious.proxy.filter.RejectingCreateTopicFilter;
 import io.kroxylicious.proxy.filter.RejectingCreateTopicFilterFactory;
@@ -501,9 +502,11 @@ class FilterIT {
         var encoded1 = encode(topic1.name(), ByteBuffer.wrap(bytes)).array();
         var encoded2 = encode(topic2.name(), ByteBuffer.wrap(bytes)).array();
 
+        NamedFilterDefinitionBuilder filterDefinitionBuilder = new NamedFilterDefinitionBuilder("filter-1", FetchResponseTransformationFilterFactory.class.getName());
         var config = proxy(cluster)
-                .addToFilters(new FilterDefinitionBuilder(FetchResponseTransformationFilterFactory.class.getName())
-                        .withConfig("transformation", TestDecoderFactory.class.getName()).build());
+                .addToFilterDefinitions(filterDefinitionBuilder
+                        .withConfig("transformation", TestDecoderFactory.class.getName()).build())
+                .addToDefaultFilters(filterDefinitionBuilder.name());
 
         try (var tester = kroxyliciousTester(config);
                 var producer = tester.producer(Serdes.String(), Serdes.ByteArray(),

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/InvocationCountingFilterFactory.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/InvocationCountingFilterFactory.java
@@ -25,11 +25,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Plugin(configType = InvocationCountingFilterFactory.Config.class)
 public class InvocationCountingFilterFactory implements FilterFactory<InvocationCountingFilterFactory.Config, InvocationCountingFilterFactory.Config> {
 
-    private static final Map<UUID, AtomicInteger> invocationTracker = new ConcurrentHashMap<>();
+    private static final Map<UUID, AtomicInteger> initializeCounts = new ConcurrentHashMap<>();
+    private static final Map<UUID, AtomicInteger> closeCounts = new ConcurrentHashMap<>();
 
     @Override
     public Config initialize(FilterFactoryContext context, Config config) throws PluginConfigurationException {
-        invocationTracker.computeIfAbsent(config.configInstanceId, uuid -> new AtomicInteger(0)).getAndIncrement();
+        initializeCounts.computeIfAbsent(config.configInstanceId, uuid -> new AtomicInteger(0)).getAndIncrement();
         return config;
     }
 
@@ -39,8 +40,28 @@ public class InvocationCountingFilterFactory implements FilterFactory<Invocation
         return (RequestFilter) (apiKey, header, request, requestFilterContext) -> requestFilterContext.forwardRequest(header, request);
     }
 
-    public static void assertInvocationCount(UUID configId, int count) {
-        assertThat(invocationTracker.get(configId)).hasValue(count);
+    @Override
+    public void close(Config config) {
+        closeCounts.computeIfAbsent(config.configInstanceId, uuid -> new AtomicInteger(0)).getAndIncrement();
+    }
+
+    public static void assertInitializationCount(UUID configId, int count) {
+        assertThat(initializeCounts.get(configId)).hasValue(count);
+    }
+
+    public static void assertAllClosedAndResetCounts() {
+        // Everything that was initialised gets closed
+        for (var entry : initializeCounts.entrySet()) {
+            UUID uuid = entry.getKey();
+            assertThat(closeCounts.get(uuid)).hasValue(entry.getValue().intValue());
+        }
+        // Nothing what closed that wasn't initialized
+        closeCounts.keySet().forEach(uuid -> {
+            assertThat(initializeCounts).containsKey(uuid);
+        });
+
+        initializeCounts.clear();
+        closeCounts.clear();
     }
 
     public record Config(UUID configInstanceId) {

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/InvocationCountingFilterFactory.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/InvocationCountingFilterFactory.java
@@ -56,9 +56,7 @@ public class InvocationCountingFilterFactory implements FilterFactory<Invocation
             assertThat(closeCounts.get(uuid)).hasValue(entry.getValue().intValue());
         }
         // Nothing what closed that wasn't initialized
-        closeCounts.keySet().forEach(uuid -> {
-            assertThat(initializeCounts).containsKey(uuid);
-        });
+        assertThat(closeCounts.keySet()).isEqualTo(initializeCounts.keySet());
 
         initializeCounts.clear();
         closeCounts.clear();

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ProxyRpcTest.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ProxyRpcTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
 
-import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
+import io.kroxylicious.proxy.config.NamedFilterDefinitionBuilder;
 import io.kroxylicious.proxy.filter.FixedClientIdFilterFactory;
 import io.kroxylicious.test.ApiMessageSampleGenerator;
 import io.kroxylicious.test.ApiMessageSampleGenerator.ApiAndVersion;
@@ -62,8 +62,10 @@ public class ProxyRpcTest {
 
     @BeforeAll
     public static void beforeAll() {
+        NamedFilterDefinitionBuilder filterDefinitionBuilder = new NamedFilterDefinitionBuilder("filter-3", FixedClientIdFilterFactory.class.getName());
         mockTester = mockKafkaKroxyliciousTester(mockBootstrap -> proxy(mockBootstrap)
-                .addToFilters(new FilterDefinitionBuilder(FixedClientIdFilterFactory.class.getName()).withConfig("clientId", "fixed").build()));
+                .addToFilterDefinitions(filterDefinitionBuilder.withConfig("clientId", "fixed").build())
+                .addToDefaultFilters(filterDefinitionBuilder.name()));
     }
 
     @BeforeEach

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/SingleFilterFactoryInstanceTest.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/SingleFilterFactoryInstanceTest.java
@@ -29,6 +29,7 @@ public class SingleFilterFactoryInstanceTest {
     public void afterEach() {
         if (mockTester != null) {
             mockTester.close();
+            InvocationCountingFilterFactory.assertAllClosedAndResetCounts();
         }
     }
 
@@ -43,7 +44,8 @@ public class SingleFilterFactoryInstanceTest {
                         .build()));
 
         // Then
-        InvocationCountingFilterFactory.assertInvocationCount(configInstance, 1);
+        InvocationCountingFilterFactory.assertInitializationCount(configInstance, 1);
+
     }
 
     @Test
@@ -58,8 +60,8 @@ public class SingleFilterFactoryInstanceTest {
                 .addToFilters(new FilterDefinitionBuilder("InvocationCountingFilterFactory").withConfig(INITIALISATION_COUNTER, configInstanceB).build()));
 
         // Then
-        InvocationCountingFilterFactory.assertInvocationCount(configInstanceA, 1);
-        InvocationCountingFilterFactory.assertInvocationCount(configInstanceB, 1);
+        InvocationCountingFilterFactory.assertInitializationCount(configInstanceA, 1);
+        InvocationCountingFilterFactory.assertInitializationCount(configInstanceB, 1);
     }
 
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/RecordEncryptionFilterIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/RecordEncryptionFilterIT.java
@@ -59,8 +59,8 @@ import io.kroxylicious.kms.provider.kroxylicious.inmemory.InMemoryKms;
 import io.kroxylicious.kms.provider.kroxylicious.inmemory.InMemoryTestKmsFacade;
 import io.kroxylicious.kms.service.TestKmsFacade;
 import io.kroxylicious.kms.service.TestKmsFacadeInvocationContextProvider;
-import io.kroxylicious.proxy.config.FilterDefinition;
-import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
+import io.kroxylicious.proxy.config.NamedFilterDefinition;
+import io.kroxylicious.proxy.config.NamedFilterDefinitionBuilder;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.common.BrokerConfig;
 import io.kroxylicious.testing.kafka.common.ClientConfig;
@@ -93,7 +93,9 @@ class RecordEncryptionFilterIT {
 
         var builder = proxy(cluster);
 
-        builder.addToFilters(buildEncryptionFilterDefinition(testKmsFacade));
+        NamedFilterDefinition namedFilterDefinition = buildEncryptionFilterDefinition(testKmsFacade);
+        builder.addToFilterDefinitions(namedFilterDefinition);
+        builder.addToDefaultFilters(namedFilterDefinition.name());
 
         try (var tester = kroxyliciousTester(builder);
                 var producer = tester.producer();
@@ -118,7 +120,9 @@ class RecordEncryptionFilterIT {
 
         var builder = proxy(cluster);
 
-        builder.addToFilters(buildEncryptionFilterDefinition(testKmsFacade));
+        NamedFilterDefinition namedFilterDefinition = buildEncryptionFilterDefinition(testKmsFacade);
+        builder.addToFilterDefinitions(namedFilterDefinition);
+        builder.addToDefaultFilters(namedFilterDefinition.name());
 
         try (var tester = kroxyliciousTester(builder);
                 var producer = tester.producer(Map.of(ProducerConfig.TRANSACTIONAL_ID_CONFIG, UUID.randomUUID().toString()));
@@ -147,7 +151,9 @@ class RecordEncryptionFilterIT {
 
         var builder = proxy(cluster);
 
-        builder.addToFilters(buildEncryptionFilterDefinition(testKmsFacade));
+        NamedFilterDefinition namedFilterDefinition = buildEncryptionFilterDefinition(testKmsFacade);
+        builder.addToFilterDefinitions(namedFilterDefinition);
+        builder.addToDefaultFilters(namedFilterDefinition.name());
 
         try (var tester = kroxyliciousTester(builder);
                 var producer = tester.producer(Map.of(ProducerConfig.TRANSACTIONAL_ID_CONFIG, UUID.randomUUID().toString()));
@@ -183,7 +189,9 @@ class RecordEncryptionFilterIT {
 
         var builder = proxy(cluster);
 
-        builder.addToFilters(buildEncryptionFilterDefinition(testKmsFacade));
+        NamedFilterDefinition namedFilterDefinition = buildEncryptionFilterDefinition(testKmsFacade);
+        builder.addToFilterDefinitions(namedFilterDefinition);
+        builder.addToDefaultFilters(namedFilterDefinition.name());
 
         try (var tester = kroxyliciousTester(builder);
                 var producer = tester.producer(Map.of(ProducerConfig.TRANSACTIONAL_ID_CONFIG, UUID.randomUUID().toString()));
@@ -221,7 +229,9 @@ class RecordEncryptionFilterIT {
 
         var builder = proxy(cluster);
 
-        builder.addToFilters(buildEncryptionFilterDefinition(testKmsFacade));
+        NamedFilterDefinition namedFilterDefinition = buildEncryptionFilterDefinition(testKmsFacade);
+        builder.addToFilterDefinitions(namedFilterDefinition);
+        builder.addToDefaultFilters(namedFilterDefinition.name());
 
         try (var tester = kroxyliciousTester(builder);
                 var producer1 = tester.producer();
@@ -256,13 +266,15 @@ class RecordEncryptionFilterIT {
         var builder = proxy(cluster);
         // 1 second is the current minimum configurable value
         Duration edekExpiry = Duration.ofSeconds(1);
-        builder.addToFilters(new FilterDefinitionBuilder(RecordEncryption.class.getSimpleName())
+        NamedFilterDefinitionBuilder filterDefinitionBuilder = new NamedFilterDefinitionBuilder("encrypt", RecordEncryption.class.getSimpleName());
+        builder.addToFilterDefinitions(filterDefinitionBuilder
                 .withConfig("kms", testKmsFacade.getKmsServiceClass().getSimpleName())
                 .withConfig("kmsConfig", testKmsFacade.getKmsServiceConfig())
                 .withConfig("experimental", Map.of("encryptionDekRefreshAfterWriteSeconds", edekExpiry.toSeconds()))
                 .withConfig("selector", TemplateKekSelector.class.getSimpleName())
                 .withConfig("selectorConfig", Map.of("template", TEMPLATE_KEK_SELECTOR_PATTERN))
-                .build());
+                .build())
+                .addToDefaultFilters(filterDefinitionBuilder.name());
 
         var message = "hello world";
         try (var tester = kroxyliciousTester(builder);
@@ -290,7 +302,8 @@ class RecordEncryptionFilterIT {
         var builder = proxy(cluster);
         // 1 second is the current minimum configurable value
         Duration edekExpiry = Duration.ofSeconds(1);
-        builder.addToFilters(new FilterDefinitionBuilder(RecordEncryption.class.getSimpleName())
+        NamedFilterDefinitionBuilder filterDefinitionBuilder = new NamedFilterDefinitionBuilder("encrypt", RecordEncryption.class.getSimpleName());
+        builder.addToFilterDefinitions(filterDefinitionBuilder
                 .withConfig("kms", testKmsFacade.getKmsServiceClass().getSimpleName())
                 .withConfig("kmsConfig", testKmsFacade.getKmsServiceConfig())
                 .withConfig("experimental", Map.of(
@@ -298,7 +311,8 @@ class RecordEncryptionFilterIT {
                         "maxEncryptionsPerDek", 1))
                 .withConfig("selector", TemplateKekSelector.class.getSimpleName())
                 .withConfig("selectorConfig", Map.of("template", TEMPLATE_KEK_SELECTOR_PATTERN))
-                .build());
+                .build())
+                .addToDefaultFilters(filterDefinitionBuilder.name());
         var messageOne = "hello world";
         var messageTwo = "hello world2";
         final String clientId = "producer-" + topic.name();
@@ -355,7 +369,9 @@ class RecordEncryptionFilterIT {
         testKekManager.generateKek(topic.name());
 
         var builder = proxy(cluster);
-        builder.addToFilters(buildEncryptionFilterDefinition(testKmsFacade));
+        NamedFilterDefinition namedFilterDefinition = buildEncryptionFilterDefinition(testKmsFacade);
+        builder.addToFilterDefinitions(namedFilterDefinition);
+        builder.addToDefaultFilters(namedFilterDefinition.name());
 
         var messageBeforeKeyRotation = "hello world, old key";
         var messageAfterKeyRotation = "hello world, new key";
@@ -386,7 +402,9 @@ class RecordEncryptionFilterIT {
         testKekManager.generateKek(topic.name());
 
         var builder = proxy(cluster);
-        builder.addToFilters(buildEncryptionFilterDefinition(testKmsFacade));
+        NamedFilterDefinition namedFilterDefinition = buildEncryptionFilterDefinition(testKmsFacade);
+        builder.addToFilterDefinitions(namedFilterDefinition);
+        builder.addToDefaultFilters(namedFilterDefinition.name());
 
         try (var tester = kroxyliciousTester(builder);
                 var producer = tester.producer()) {
@@ -413,7 +431,9 @@ class RecordEncryptionFilterIT {
         testKekManager.generateKek(topic.name());
 
         var builder = proxy(cluster);
-        builder.addToFilters(buildEncryptionFilterDefinition(testKmsFacade));
+        NamedFilterDefinition namedFilterDefinition = buildEncryptionFilterDefinition(testKmsFacade);
+        builder.addToFilterDefinitions(namedFilterDefinition);
+        builder.addToDefaultFilters(namedFilterDefinition.name());
 
         try (var tester = kroxyliciousTester(builder);
                 var producer = tester.producer();
@@ -443,7 +463,9 @@ class RecordEncryptionFilterIT {
         testKekManager.generateKek(topic.name());
 
         var builder = proxy(cluster);
-        builder.addToFilters(buildEncryptionFilterDefinition(testKmsFacade));
+        NamedFilterDefinition namedFilterDefinition = buildEncryptionFilterDefinition(testKmsFacade);
+        builder.addToFilterDefinitions(namedFilterDefinition);
+        builder.addToDefaultFilters(namedFilterDefinition.name());
 
         try (var tester = kroxyliciousTester(builder);
                 var producer = tester.producer();
@@ -475,7 +497,9 @@ class RecordEncryptionFilterIT {
         testKekManager.generateKek(encryptedTopic.name());
 
         var builder = proxy(cluster);
-        builder.addToFilters(buildEncryptionFilterDefinition(testKmsFacade));
+        NamedFilterDefinition namedFilterDefinition = buildEncryptionFilterDefinition(testKmsFacade);
+        builder.addToFilterDefinitions(namedFilterDefinition);
+        builder.addToDefaultFilters(namedFilterDefinition.name());
 
         try (var tester = kroxyliciousTester(builder);
                 var producer = tester.producer(Map.of(ProducerConfig.LINGER_MS_CONFIG, 1000, ProducerConfig.BATCH_SIZE_CONFIG, 2));
@@ -514,7 +538,9 @@ class RecordEncryptionFilterIT {
 
         var builder = proxy(cluster);
 
-        builder.addToFilters(buildEncryptionFilterDefinition(testKmsFacade));
+        NamedFilterDefinition namedFilterDefinition = buildEncryptionFilterDefinition(testKmsFacade);
+        builder.addToFilterDefinitions(namedFilterDefinition);
+        builder.addToDefaultFilters(namedFilterDefinition.name());
 
         try (var tester = kroxyliciousTester(builder);
                 var proxyProducer = tester.producer();
@@ -576,7 +602,9 @@ class RecordEncryptionFilterIT {
         testKekManager.generateKek(topic.name());
 
         var builder = proxy(cluster);
-        builder.addToFilters(buildEncryptionFilterDefinition(testKmsFacade));
+        NamedFilterDefinition namedFilterDefinition = buildEncryptionFilterDefinition(testKmsFacade);
+        builder.addToFilterDefinitions(namedFilterDefinition);
+        builder.addToDefaultFilters(namedFilterDefinition.name());
 
         try (var tester = kroxyliciousTester(builder);
                 var producer = tester.producer(Map.of(ProducerConfig.LINGER_MS_CONFIG, 0));
@@ -611,8 +639,8 @@ class RecordEncryptionFilterIT {
 
     }
 
-    private FilterDefinition buildEncryptionFilterDefinition(TestKmsFacade<?, ?, ?> testKmsFacade) {
-        return new FilterDefinitionBuilder(RecordEncryption.class.getSimpleName())
+    private NamedFilterDefinition buildEncryptionFilterDefinition(TestKmsFacade<?, ?, ?> testKmsFacade) {
+        return new NamedFilterDefinitionBuilder("filter-1", RecordEncryption.class.getSimpleName())
                 .withConfig("kms", testKmsFacade.getKmsServiceClass().getSimpleName())
                 .withConfig("kmsConfig", testKmsFacade.getKmsServiceConfig())
                 .withConfig("selector", TemplateKekSelector.class.getSimpleName())

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationIT.java
@@ -40,7 +40,8 @@ import org.testcontainers.utility.DockerImageName;
 import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
 
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
-import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
+import io.kroxylicious.proxy.config.NamedFilterDefinition;
+import io.kroxylicious.proxy.config.NamedFilterDefinitionBuilder;
 import io.kroxylicious.test.tester.SimpleMetric;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.common.BrokerConfig;
@@ -185,6 +186,12 @@ class OauthBearerValidationIT {
     }
 
     private ConfigurationBuilder getConfiguredProxyBuilder() {
+        NamedFilterDefinition filterDefinition = new NamedFilterDefinitionBuilder(
+                "oauth",
+                OauthBearerValidation.class.getName())
+                .withConfig("jwksEndpointUrl", JWKS_ENDPOINT_URL,
+                        "expectedAudience", EXPECTED_AUDIENCE)
+                .build();
         return proxy(cluster)
                 .withNewAdminHttp()
                 .withNewEndpoints()
@@ -192,11 +199,8 @@ class OauthBearerValidationIT {
                 .endPrometheus()
                 .endEndpoints()
                 .endAdminHttp()
-                .addToFilters(new FilterDefinitionBuilder(
-                        OauthBearerValidation.class.getName())
-                        .withConfig("jwksEndpointUrl", JWKS_ENDPOINT_URL,
-                                "expectedAudience", EXPECTED_AUDIENCE)
-                        .build());
+                .addToFilterDefinitions(filterDefinition)
+                .addToDefaultFilters(filterDefinition.name());
     }
 
     @NonNull

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/validation/ProduceRequestValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/validation/ProduceRequestValidationIT.java
@@ -14,7 +14,7 @@ import org.apache.kafka.common.InvalidRecordException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
+import io.kroxylicious.proxy.config.NamedFilterDefinitionBuilder;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 import io.kroxylicious.testing.kafka.junit5ext.Topic;
@@ -33,11 +33,13 @@ class ProduceRequestValidationIT extends RecordValidationBaseIT {
 
     @Test
     void validJsonProduceAcceptedUsingDeprecatedFactoryName(KafkaCluster cluster, Topic topic) {
+        NamedFilterDefinitionBuilder filterDefinitionBuilder = new NamedFilterDefinitionBuilder(SIMPLE_NAME, SIMPLE_NAME);
         var config = proxy(cluster)
-                .addToFilters(new FilterDefinitionBuilder(SIMPLE_NAME).withConfig("rules",
+                .addToFilterDefinitions(filterDefinitionBuilder.withConfig("rules",
                         List.of(Map.of("topicNames", List.of(topic.name()), "valueRule",
                                 Map.of("syntacticallyCorrectJson", Map.of()))))
-                        .build());
+                        .build())
+                .addToDefaultFilters(filterDefinitionBuilder.name());
 
         try (var tester = kroxyliciousTester(config);
                 var producer = tester.producer()) {
@@ -55,11 +57,13 @@ class ProduceRequestValidationIT extends RecordValidationBaseIT {
 
     @Test
     void invalidJsonProduceRejected(KafkaCluster cluster, Topic topic) {
+        NamedFilterDefinitionBuilder filterDefinitionBuilder = new NamedFilterDefinitionBuilder(SIMPLE_NAME, SIMPLE_NAME);
         var config = proxy(cluster)
-                .addToFilters(new FilterDefinitionBuilder(SIMPLE_NAME).withConfig("rules",
+                .addToFilterDefinitions(filterDefinitionBuilder.withConfig("rules",
                         List.of(Map.of("topicNames", List.of(topic.name()), "valueRule",
                                 Map.of("syntacticallyCorrectJson", Map.of()))))
-                        .build());
+                        .build())
+                .addToDefaultFilters(filterDefinitionBuilder.name());
         try (var tester = kroxyliciousTester(config);
                 var producer = tester.producer()) {
             var invalid = producer.send(new ProducerRecord<>(topic.name(), "my-key", SYNTACTICALLY_INCORRECT_JSON));

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/multitenant/BaseMultiTenantIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/multitenant/BaseMultiTenantIT.java
@@ -41,7 +41,7 @@ import io.kroxylicious.net.IntegrationTestInetAddressResolverProvider;
 import io.kroxylicious.proxy.BaseIT;
 import io.kroxylicious.proxy.config.ClusterNetworkAddressConfigProviderDefinitionBuilder;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
-import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
+import io.kroxylicious.proxy.config.NamedFilterDefinitionBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.proxy.filter.multitenant.MultiTenantTransformationFilterFactory;
 import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.PortPerBrokerClusterNetworkAddressConfigProvider;
@@ -94,7 +94,7 @@ public abstract class BaseMultiTenantIT extends BaseIT {
     }
 
     static ConfigurationBuilder getConfig(KafkaCluster cluster, KeytoolCertificateGenerator certificateGenerator, Map<String, Object> filterConfig) {
-        var filterBuilder = new FilterDefinitionBuilder(MultiTenantTransformationFilterFactory.class.getName());
+        var filterBuilder = new NamedFilterDefinitionBuilder("filter-1", MultiTenantTransformationFilterFactory.class.getName());
         Optional.ofNullable(filterConfig).ifPresent(filterBuilder::withConfig);
         return new ConfigurationBuilder()
                 .addToVirtualClusters(TENANT_1_CLUSTER, new VirtualClusterBuilder()
@@ -127,7 +127,8 @@ public abstract class BaseMultiTenantIT extends BaseIT {
                         .endKeyStoreKey()
                         .endTls()
                         .build())
-                .addToFilters(filterBuilder.build());
+                .addToFilterDefinitions(filterBuilder.build())
+                .addToDefaultFilters(filterBuilder.name());
     }
 
     Consumer<String, String> getConsumerWithConfig(KroxyliciousTester tester, String virtualCluster, String groupId, Map<String, Object> baseConfig,

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ClusterCondition.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ClusterCondition.java
@@ -14,6 +14,11 @@ public record ClusterCondition(String cluster, ConditionType type, Status status
         return new ClusterCondition(cluster, ConditionType.Accepted, Status.TRUE, null, null);
     }
 
+    static ClusterCondition filterInvalid(String cluster, String filterName, String reason) {
+        return new ClusterCondition(cluster, ConditionType.Accepted, Status.FALSE, "Invalid",
+                "Filter \"" + filterName + "\" is invalid: " + reason);
+    }
+
     static ClusterCondition filterNotExists(String cluster, String filterName) {
         return new ClusterCondition(cluster, ConditionType.Accepted, Status.FALSE, "Invalid",
                 "Filter \"" + filterName + "\" does not exist.");

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ClusterCondition.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ClusterCondition.java
@@ -10,23 +10,25 @@ import static io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.clusters.
 
 public record ClusterCondition(String cluster, ConditionType type, Status status, String reason, String message) {
 
+    public static final String INVALID = "Invalid";
+
     static ClusterCondition accepted(String cluster) {
         return new ClusterCondition(cluster, ConditionType.Accepted, Status.TRUE, null, null);
     }
 
     static ClusterCondition filterInvalid(String cluster, String filterName, String reason) {
-        return new ClusterCondition(cluster, ConditionType.Accepted, Status.FALSE, "Invalid",
-                "Filter \"" + filterName + "\" is invalid: " + reason);
+        return new ClusterCondition(cluster, ConditionType.Accepted, Status.FALSE, INVALID,
+                String.format("Filter \"%s\" is invalid: %s", filterName, reason));
     }
 
     static ClusterCondition filterNotExists(String cluster, String filterName) {
-        return new ClusterCondition(cluster, ConditionType.Accepted, Status.FALSE, "Invalid",
-                "Filter \"" + filterName + "\" does not exist.");
+        return new ClusterCondition(cluster, ConditionType.Accepted, Status.FALSE, INVALID,
+                String.format("Filter \"%s\" does not exist.", filterName));
     }
 
     static ClusterCondition filterKindNotKnown(String cluster, String filterName, String kind) {
-        return new ClusterCondition(cluster, ConditionType.Accepted, Status.FALSE, "Invalid",
-                "Filter \"" + filterName + "\" has a kind \"" + kind + "\" that is not known to this operator.");
+        return new ClusterCondition(cluster, ConditionType.Accepted, Status.FALSE, INVALID,
+                String.format("Filter \"%s\" has a kind %s that is not known to this operator.", filterName, kind));
     }
 
 }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigSecret.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigSecret.java
@@ -135,7 +135,7 @@ public class ProxyConfigSecret
 
     @NonNull
     private static String filterDefinitionName(Filters filterCrRef) {
-        return filterCrRef.getName() + ":" + filterCrRef.getKind() + "." + filterCrRef.getGroup();
+        return filterCrRef.getName() + "." + filterCrRef.getKind() + "." + filterCrRef.getGroup();
     }
 
     @NonNull

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigSecret.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigSecret.java
@@ -114,12 +114,11 @@ public class ProxyConfigSecret
                         LinkedHashMap::new));
 
         Configuration configuration = new Configuration(
-                filterDefinitions,
+                new AdminHttpConfiguration(null, null, new EndpointsConfiguration(new PrometheusMetricsConfig())), filterDefinitions,
                 null, // no defaultFilters <= each of the virtualClusters specifies its own
                 virtualClusters,
-                false,
-                List.of(), // micrometer
-                new AdminHttpConfiguration(null, null, new EndpointsConfiguration(new PrometheusMetricsConfig())),
+                List.of(), false,
+                // micrometer
                 Optional.empty());
 
         return toYaml(configuration);

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.kubernetes.operator;
 
+import org.assertj.core.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 class OperatorMainIT {
@@ -13,6 +14,7 @@ class OperatorMainIT {
 
     @Test
     void run() {
+        Assumptions.assumeThat(OperatorTestUtils.isKubeClientAvailable()).describedAs("Test requires a viable kube client").isTrue();
         OperatorMain.run();
     }
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorTestUtils.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorTestUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+public class OperatorTestUtils {
+    static @Nullable KubernetesClient kubeClientIfAvailable() {
+        var client = new KubernetesClientBuilder().build();
+        try {
+            client.namespaces().list();
+            return client;
+        }
+        catch (KubernetesClientException e) {
+            client.close();
+            return null;
+        }
+    }
+
+    static boolean isKubeClientAvailable() {
+        try (var client = kubeClientIfAvailable()) {
+            return client != null;
+        }
+    }
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerIT.java
@@ -11,9 +11,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.assertj.core.api.Assumptions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -25,8 +25,6 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientBuilder;
-import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
@@ -50,17 +48,8 @@ class ProxyReconcilerIT {
 
     @BeforeAll
     static void checkKubeAvailable() {
-        boolean haveKube;
-        client = new KubernetesClientBuilder().build();
-        try {
-            client.namespaces().list();
-            haveKube = true;
-        }
-        catch (KubernetesClientException e) {
-            haveKube = false;
-            client.close();
-        }
-        Assumptions.assumeTrue(haveKube, "Test requires a viable kube client");
+        client = OperatorTestUtils.kubeClientIfAvailable();
+        Assumptions.assumeThat(client).describedAs("Test requires a viable kube client").isNotNull();
     }
 
     @RegisterExtension

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Secret-example.yaml
@@ -48,6 +48,6 @@ stringData:
             brokerAddressPattern: "bar.proxy-ns.svc.cluster.local"
             brokerStartPort: 9393
             numberOfBrokerPorts: 3
-        filterRefs:
+        filters:
         - "filter-one.Filter.filter.kroxylicious.io"
         - "filter-two.Filter.filter.kroxylicious.io"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Secret-example.yaml
@@ -28,6 +28,16 @@ stringData:
       port: 9190
       endpoints:
         prometheus: {}
+    filterDefinitions:
+    - name: "filter-one:Filter.filter.kroxylicious.io"
+      type: "org.example.some.java.Class"
+      config:
+        filterOneConfig: true
+    - name: "filter-two:Filter.filter.kroxylicious.io"
+      type: "com.example.what.Ever"
+      config:
+        filterTwoConfig: 42
+    - name: "missing:Filter.filter.kroxylicious.io"
     virtualClusters:
       bar:
         targetCluster:
@@ -39,10 +49,6 @@ stringData:
             brokerAddressPattern: "bar.proxy-ns.svc.cluster.local"
             brokerStartPort: 9393
             numberOfBrokerPorts: 3
-    filters:
-    - type: "org.example.some.java.Class"
-      config:
-        filterOneConfig: true
-    - type: "com.example.what.Ever"
-      config:
-        filterTwoConfig: 42
+        filterRefs:
+        - "filter-one:Filter.filter.kroxylicious.io"
+        - "filter-two:Filter.filter.kroxylicious.io"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Secret-example.yaml
@@ -37,7 +37,6 @@ stringData:
       type: "com.example.what.Ever"
       config:
         filterTwoConfig: 42
-    - name: "missing.Filter.filter.kroxylicious.io"
     virtualClusters:
       bar:
         targetCluster:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Secret-example.yaml
@@ -29,15 +29,15 @@ stringData:
       endpoints:
         prometheus: {}
     filterDefinitions:
-    - name: "filter-one:Filter.filter.kroxylicious.io"
+    - name: "filter-one.Filter.filter.kroxylicious.io"
       type: "org.example.some.java.Class"
       config:
         filterOneConfig: true
-    - name: "filter-two:Filter.filter.kroxylicious.io"
+    - name: "filter-two.Filter.filter.kroxylicious.io"
       type: "com.example.what.Ever"
       config:
         filterTwoConfig: 42
-    - name: "missing:Filter.filter.kroxylicious.io"
+    - name: "missing.Filter.filter.kroxylicious.io"
     virtualClusters:
       bar:
         targetCluster:
@@ -50,5 +50,5 @@ stringData:
             brokerStartPort: 9393
             numberOfBrokerPorts: 3
         filterRefs:
-        - "filter-one:Filter.filter.kroxylicious.io"
-        - "filter-two:Filter.filter.kroxylicious.io"
+        - "filter-one.Filter.filter.kroxylicious.io"
+        - "filter-two.Filter.filter.kroxylicious.io"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Secret-example.yaml
@@ -29,11 +29,11 @@ stringData:
       endpoints:
         prometheus: {}
     filterDefinitions:
-    - name: "filter-one:Filter.filter.kroxylicious.io"
+    - name: "filter-one.Filter.filter.kroxylicious.io"
       type: "org.example.some.java.Class"
       config:
         filterOneConfig: true
-    - name: "filter-two:Filter.filter.kroxylicious.io"
+    - name: "filter-two.Filter.filter.kroxylicious.io"
       type: "com.example.what.Ever"
       config:
         filterTwoConfig: 42
@@ -49,5 +49,5 @@ stringData:
             brokerStartPort: 9293
             numberOfBrokerPorts: 3
         filterRefs:
-        - "filter-one:Filter.filter.kroxylicious.io"
-        - "filter-two:Filter.filter.kroxylicious.io"
+        - "filter-one.Filter.filter.kroxylicious.io"
+        - "filter-two.Filter.filter.kroxylicious.io"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Secret-example.yaml
@@ -48,6 +48,6 @@ stringData:
             brokerAddressPattern: "foo.proxy-ns.svc.cluster.local"
             brokerStartPort: 9293
             numberOfBrokerPorts: 3
-        filterRefs:
+        filters:
         - "filter-one.Filter.filter.kroxylicious.io"
         - "filter-two.Filter.filter.kroxylicious.io"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Secret-example.yaml
@@ -21,13 +21,22 @@ metadata:
       kind: "KafkaProxy"
       name: "example"
 stringData:
-  proxy-config.yaml: | 
+  proxy-config.yaml: |
     ---
     adminHttp:
       host: "0.0.0.0"
       port: 9190
       endpoints:
         prometheus: {}
+    filterDefinitions:
+    - name: "filter-one:Filter.filter.kroxylicious.io"
+      type: "org.example.some.java.Class"
+      config:
+        filterOneConfig: true
+    - name: "filter-two:Filter.filter.kroxylicious.io"
+      type: "com.example.what.Ever"
+      config:
+        filterTwoConfig: 42
     virtualClusters:
       foo:
         targetCluster:
@@ -39,10 +48,6 @@ stringData:
             brokerAddressPattern: "foo.proxy-ns.svc.cluster.local"
             brokerStartPort: 9293
             numberOfBrokerPorts: 3
-    filters:
-    - type: "org.example.some.java.Class"
-      config:
-        filterOneConfig: true
-    - type: "com.example.what.Ever"
-      config:
-        filterTwoConfig: 42
+        filterRefs:
+        - "filter-one:Filter.filter.kroxylicious.io"
+        - "filter-two:Filter.filter.kroxylicious.io"

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -110,6 +110,7 @@ public final class KafkaProxy implements AutoCloseable {
      * Starts this proxy.
      * @return This proxy.
      */
+    @SuppressWarnings("java:S5738")
     public KafkaProxy startup() throws InterruptedException {
         if (running.getAndSet(true)) {
             throw new IllegalStateException("This proxy is already running");

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -131,7 +131,7 @@ public final class KafkaProxy implements AutoCloseable {
 
             var overrideMap = getApiKeyMaxVersionOverride(config);
             ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl(overrideMap);
-            this.filterChainFactory = new FilterChainFactory(pfr, config.namedFilterDefinitions());
+            this.filterChainFactory = new FilterChainFactory(pfr, config.toNamedFilterDefinitions());
 
             var tlsServerBootstrap = buildServerBootstrap(serverEventGroup,
                     new KafkaProxyInitializer(filterChainFactory, pfr, true, endpointRegistry, endpointRegistry, false, Map.of(), apiVersionsService));

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -131,7 +131,8 @@ public final class KafkaProxy implements AutoCloseable {
 
             var overrideMap = getApiKeyMaxVersionOverride(config);
             ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl(overrideMap);
-            this.filterChainFactory = new FilterChainFactory(pfr, config.filters());
+            this.filterChainFactory = new FilterChainFactory(pfr, config.namedFilterDefinitions());
+
             var tlsServerBootstrap = buildServerBootstrap(serverEventGroup,
                     new KafkaProxyInitializer(filterChainFactory, pfr, true, endpointRegistry, endpointRegistry, false, Map.of(), apiVersionsService));
             var plainServerBootstrap = buildServerBootstrap(serverEventGroup,
@@ -280,7 +281,6 @@ public final class KafkaProxy implements AutoCloseable {
             serverEventGroup = null;
             metricsChannel = null;
             meterRegistries = null;
-            filterChainFactory = null;
             shutdown.complete(null);
             LOGGER.info("Shut down completed.");
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -281,6 +281,7 @@ public final class KafkaProxy implements AutoCloseable {
             serverEventGroup = null;
             metricsChannel = null;
             meterRegistries = null;
+            filterChainFactory = null;
             shutdown.complete(null);
             LOGGER.info("Shut down completed.");
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -6,12 +6,13 @@
 package io.kroxylicious.proxy.bootstrap;
 
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import io.kroxylicious.proxy.config.FilterDefinition;
+import io.kroxylicious.proxy.config.NamedFilterDefinition;
 import io.kroxylicious.proxy.config.PluginFactory;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
 import io.kroxylicious.proxy.filter.Filter;
@@ -22,6 +23,7 @@ import io.kroxylicious.proxy.filter.FilterFactoryContext;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Abstracts the creation of a chain of filter instances, hiding the configuration
@@ -79,14 +81,14 @@ public class FilterChainFactory implements AutoCloseable {
 
     }
 
-    private final List<Wrapper> initialized;
+    private final Map<String, Wrapper> initialized;
 
-    public FilterChainFactory(PluginFactoryRegistry pfr, List<FilterDefinition> filterDefinitions) {
+    public FilterChainFactory(PluginFactoryRegistry pfr, List<NamedFilterDefinition> filterDefinitions) {
         @SuppressWarnings({ "unchecked", "rawtypes" })
         Class<FilterFactory<? super Object, ? super Object>> type = (Class) FilterFactory.class;
         PluginFactory<FilterFactory<? super Object, ? super Object>> pluginFactory = pfr.pluginFactory(type);
-        if (filterDefinitions == null || ((Collection<FilterDefinition>) filterDefinitions).isEmpty()) {
-            this.initialized = List.of();
+        if (filterDefinitions == null || filterDefinitions.isEmpty()) {
+            this.initialized = Map.of();
         }
         else {
             FilterFactoryContext context = new FilterFactoryContext() {
@@ -105,14 +107,14 @@ public class FilterChainFactory implements AutoCloseable {
                     return pfr.pluginFactory(pluginClass).pluginInstance(instanceName);
                 }
             };
-            this.initialized = new ArrayList<>(filterDefinitions.size());
+            this.initialized = new LinkedHashMap<>(filterDefinitions.size());
             try {
                 for (var fd : filterDefinitions) {
                     FilterFactory<? super Object, ? super Object> filterFactory = pluginFactory.pluginInstance(fd.type());
                     Class<?> configType = pluginFactory.configType(fd.type());
                     if (fd.config() == null || configType.isInstance(fd.config())) {
-                        Wrapper uninitializedFilterFactory = new Wrapper(context, fd.type(), filterFactory, fd.config());
-                        this.initialized.add(uninitializedFilterFactory);
+                        Wrapper uninitializedFilterFactory = new Wrapper(context, fd.name(), filterFactory, fd.config());
+                        this.initialized.put(fd.name(), uninitializedFilterFactory);
                     }
                     else {
                         throw new PluginConfigurationException("accepts config of type " +
@@ -131,8 +133,9 @@ public class FilterChainFactory implements AutoCloseable {
     @Override
     public void close() {
         RuntimeException firstThrown = null;
-        for (int i = initialized.size() - 1; i >= 0; i--) {
-            Wrapper wrapper = initialized.get(i);
+        var list = new ArrayList<>(initialized.values());
+        for (int i = list.size() - 1; i >= 0; i--) {
+            Wrapper wrapper = list.get(i);
             try {
                 wrapper.close();
             }
@@ -155,10 +158,13 @@ public class FilterChainFactory implements AutoCloseable {
      *
      * @return the new chain.
      */
-    public List<FilterAndInvoker> createFilters(FilterFactoryContext context) {
-        return initialized
+    public List<FilterAndInvoker> createFilters(FilterFactoryContext context, @Nullable List<NamedFilterDefinition> filterChain) {
+        if (filterChain == null) {
+            return List.of();
+        }
+        return filterChain
                 .stream()
-                .flatMap(wrapper -> FilterAndInvoker.build(wrapper.create(context)).stream())
+                .flatMap(filterDefinition -> FilterAndInvoker.build(initialized.get(filterDefinition.name()).create(context)).stream())
                 .toList();
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -15,6 +15,9 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
@@ -36,6 +39,8 @@ public record Configuration(
                             List<MicrometerDefinition> micrometer,
                             boolean useIoUring,
                             @NonNull Optional<Map<String, Object>> development) {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Configuration.class);
 
     private static void checkNamedFiltersAreDefined(Set<String> filterDefsByName,
                                                     @Nullable List<String> filterNames,
@@ -90,6 +95,11 @@ public record Configuration(
                 var virtualCluster = entry.getValue();
                 checkNamedFiltersAreDefined(filterDefsByName, virtualCluster.filterRefs(), "virtualClusters." + virtualClusterName + ".filterRefs");
             }
+        }
+
+        if (filters != null) {
+            LOGGER.warn("Configuration using 'filters' is deprecated and will be removed in a future release. "
+                    + "Configurations should be updated to use 'filterDefinitions' and 'defaultFilters'.");
         }
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -134,14 +134,16 @@ public record Configuration(
     }
 
     /**
+     * @deprecated This will be removed when support for {@code filters} is removed.
      * @return NamedFilterDefinition for all the filters defined in the configuration, generating names if the config specified {@link #filters()}.
      */
-    public @NonNull List<NamedFilterDefinition> namedFilterDefinitions() {
+    @Deprecated(since = "0.10.0", forRemoval = true)
+    public @NonNull List<NamedFilterDefinition> toNamedFilterDefinitions() {
         if (filterDefinitions != null) {
             return filterDefinitions;
         }
         else {
-            return namedFilterDefinitions(filters != null ? filters : List.of());
+            return toNamedFilterDefinitions(filters != null ? filters : List.of());
         }
     }
 
@@ -153,7 +155,7 @@ public record Configuration(
      * @return The named filters.
      */
     @NonNull
-    public static List<NamedFilterDefinition> namedFilterDefinitions(List<FilterDefinition> filters) {
+    public static List<NamedFilterDefinition> toNamedFilterDefinitions(List<FilterDefinition> filters) {
         var multipleTypes = filters.stream()
                 .collect(Collectors.groupingBy(FilterDefinition::type))
                 .entrySet().stream()
@@ -200,7 +202,7 @@ public record Configuration(
             filterDefinitions = resolveFilterNames(filterDefinitionsByName, defaultFilters);
         }
         else {
-            filterDefinitions = namedFilterDefinitions(filters != null ? filters : List.of());
+            filterDefinitions = toNamedFilterDefinitions(filters != null ? filters : List.of());
         }
         return filterDefinitions;
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -5,24 +5,118 @@
  */
 package io.kroxylicious.proxy.config;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import io.kroxylicious.proxy.config.admin.AdminHttpConfiguration;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
-public record Configuration(@Nullable AdminHttpConfiguration adminHttp,
+/**
+ * The root of the proxy configuration.
+ * @param adminHttp
+ * @param filterDefinitions A list of named filter definitions (names must be unique)
+ * @param defaultFilters The names of the {@link #filterDefinitions()} to be use when a {@link VirtualCluster} doesn't specify its own {@link VirtualCluster#filterRefs()}.
+ * @param virtualClusters The virtual clusters
+ * @param filters Deprecated. The filter definitions to be used for all virtual clusters. Can only be specified if {@link #filterDefinitions()} is null.
+ * @param micrometer The micrometer config
+ * @param useIoUring true to use iouring
+ * @param development Development options
+ */
+@JsonPropertyOrder({ "adminHttp", "filterDefinitions", "defaultFilters", "virtualClusters", "filters", "micrometer", "useIoUring", "development" })
+public record Configuration(
+                            @Nullable AdminHttpConfiguration adminHttp,
+                            @Nullable List<NamedFilterDefinition> filterDefinitions,
+                            @Nullable List<String> defaultFilters,
                             Map<String, VirtualCluster> virtualClusters,
-                            List<FilterDefinition> filters,
+                            @Nullable List<FilterDefinition> filters,
                             List<MicrometerDefinition> micrometer,
                             boolean useIoUring,
                             @NonNull Optional<Map<String, Object>> development) {
+
+    private static void checkNamedFiltersAreDefined(Set<String> filterDefsByName,
+                                                    @Nullable List<String> filterNames,
+                                                    String componentName) {
+        var unknown = Optional.ofNullable(filterNames)
+                .orElse(List.of())
+                .stream()
+                .filter(filterName -> !filterDefsByName.contains(filterName))
+                .toList();
+        if (!unknown.isEmpty()) {
+            throw new IllegalConfigurationException("`" + componentName + "` references filters not defined in `filterDefinitions`: " + unknown);
+        }
+    }
+
+    @JsonCreator
     public Configuration {
         Objects.requireNonNull(development);
+        // Enforce post condition: filters and filterDefinitions are not both set
+        if (filters != null && filterDefinitions != null) {
+            throw new IllegalConfigurationException("`filters` and `filterDefinitions` can't both be set");
+        }
+
+        // Enforce post condition: filterDefinitions have a unique name
+        if (filterDefinitions != null) {
+            Map<String, List<NamedFilterDefinition>> groupdByName = filterDefinitions.stream().collect(Collectors.groupingBy(NamedFilterDefinition::name));
+            var duplicatedNames = groupdByName.entrySet().stream().filter(entry -> entry.getValue().size() > 1).map(Map.Entry::getKey).toList();
+            if (!duplicatedNames.isEmpty()) {
+                throw new IllegalConfigurationException("`filterDefinitions` contains multiple items with the same names: " + duplicatedNames);
+            }
+        }
+
+        // Enforce post condition: Every filter referenced by a name is defined in the filterDefinitions
+        Set<String> filterDefsByName = Optional.ofNullable(filterDefinitions).orElse(List.of()).stream().map(NamedFilterDefinition::name).collect(
+                Collectors.toSet());
+        checkNamedFiltersAreDefined(filterDefsByName, defaultFilters, "defaultFilters");
+        if (virtualClusters != null) {
+            for (var entry : virtualClusters.entrySet()) {
+                var virtualClusterName = entry.getKey();
+                var virtualCluster = entry.getValue();
+                checkNamedFiltersAreDefined(filterDefsByName, virtualCluster.filterRefs(), "virtualClusters." + virtualClusterName + ".filterRefs");
+            }
+        }
+    }
+
+    /**
+     * @deprecated This constructor is currently retained to be source compatible the call sites that are passing the deprecated `filters` parameter.
+     * Replaced by {@link #Configuration(List, List, Map, boolean, List, AdminHttpConfiguration, Optional)}.
+     */
+    @Deprecated(since = "0.10.0", forRemoval = true)
+    public Configuration(
+                         @Nullable AdminHttpConfiguration adminHttp,
+                         Map<String, VirtualCluster> virtualClusters,
+                         @Nullable List<FilterDefinition> filters,
+                         List<MicrometerDefinition> micrometer,
+                         boolean useIoUring,
+                         @NonNull Optional<Map<String, Object>> development
+
+    ) {
+        this(adminHttp, null, null, virtualClusters, filters, micrometer, useIoUring, development);
+    }
+
+    /**
+     * This constructor uses the new style `defaultFilters` and `filterDefinitions` parameters instead of the deprecated `filters`.
+     */
+    public Configuration(
+                         @Nullable List<NamedFilterDefinition> filterDefinitions,
+                         @Nullable List<String> defaultFilters,
+                         Map<String, VirtualCluster> virtualClusters,
+                         boolean useIoUring,
+                         List<MicrometerDefinition> micrometer,
+                         @Nullable AdminHttpConfiguration adminHttp,
+                         @NonNull Optional<Map<String, Object>> development) {
+        this(adminHttp, filterDefinitions, defaultFilters, virtualClusters, null, micrometer, useIoUring, development);
     }
 
     public @Nullable AdminHttpConfiguration adminHttpConfig() {
@@ -37,9 +131,83 @@ public record Configuration(@Nullable AdminHttpConfiguration adminHttp,
         return useIoUring();
     }
 
+    /**
+     * @return NamedFilterDefinition for all the filters defined in the configuration, generating names if the config specified {@link #filters()}.
+     */
+    public @NonNull List<NamedFilterDefinition> namedFilterDefinitions() {
+        if (filterDefinitions != null) {
+            return filterDefinitions;
+        }
+        else {
+            return namedFilterDefinitions(filters != null ? filters : List.of());
+        }
+    }
+
+    /**
+     * Generate named filters for the given anonymous filters.
+     * The filter's type is used as the name, unless this is ambiguous, in which case the type is disambiguated
+     * using a suffix based on the index of the filter within the list.
+     * @param filters The anonymous filters.
+     * @return The named filters.
+     */
+    @NonNull
+    public static List<NamedFilterDefinition> namedFilterDefinitions(List<FilterDefinition> filters) {
+        var multipleTypes = filters.stream()
+                .collect(Collectors.groupingBy(FilterDefinition::type))
+                .entrySet().stream()
+                .filter(entry -> entry.getValue().size() > 1)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
+        List<NamedFilterDefinition> filterDefinitions;
+        filterDefinitions = new ArrayList<>();
+        HashMap<String, Integer> typeCounts = new HashMap<>(1 + (int) (multipleTypes.size() / 0.75f));
+        for (FilterDefinition anonymousFilter : Optional.ofNullable(filters).orElse(List.of())) {
+            String filterName = anonymousFilter.type();
+            if (multipleTypes.contains(anonymousFilter.type())) {
+                int count = typeCounts.compute(anonymousFilter.type(), (type, typeCount) -> typeCount == null ? 0 : ++typeCount);
+                filterName += "-" + count;
+            }
+            filterDefinitions.add(new NamedFilterDefinition(filterName, anonymousFilter.type(), anonymousFilter.config()));
+        }
+        return filterDefinitions;
+    }
+
     public @NonNull List<io.kroxylicious.proxy.model.VirtualCluster> virtualClusterModel(PluginFactoryRegistry pfr) {
+        var filterDefinitionsByName = Optional.ofNullable(this.filterDefinitions()).orElse(List.of())
+                .stream()
+                .collect(Collectors.toMap(NamedFilterDefinition::name, Function.identity()));
+
         return virtualClusters.entrySet().stream()
-                .map(entry -> entry.getValue().toVirtualClusterModel(pfr, entry.getKey()))
+                .map(entry -> {
+                    VirtualCluster virtualCluster = entry.getValue();
+                    List<NamedFilterDefinition> filterDefinitions = namedFilterDefinitionsForCluster(filterDefinitionsByName, virtualCluster);
+                    return virtualCluster.toVirtualClusterModel(pfr, filterDefinitions, entry.getKey());
+                })
+                .toList();
+    }
+
+    @NonNull
+    private List<NamedFilterDefinition> namedFilterDefinitionsForCluster(Map<String, NamedFilterDefinition> filterDefinitionsByName,
+                                                                         VirtualCluster virtualCluster) {
+        List<NamedFilterDefinition> filterDefinitions;
+        List<String> clusterFilterRefs = virtualCluster.filterRefs();
+        if (clusterFilterRefs != null) {
+            filterDefinitions = resolveFilterNames(filterDefinitionsByName, clusterFilterRefs);
+        }
+        else if (defaultFilters != null) {
+            filterDefinitions = resolveFilterNames(filterDefinitionsByName, defaultFilters);
+        }
+        else {
+            filterDefinitions = namedFilterDefinitions(filters != null ? filters : List.of());
+        }
+        return filterDefinitions;
+    }
+
+    @NonNull
+    private List<NamedFilterDefinition> resolveFilterNames(Map<String, NamedFilterDefinition> filterDefinitionsByName, List<String> filterNames) {
+        return filterNames.stream()
+                // Note: filterDefinitionsByName.get() returns non-null because of constructor post cindition
+                .map(filterDefinitionsByName::get)
                 .toList();
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -118,6 +118,13 @@ public record Configuration(
             }
         }
 
+        if (filters != null && virtualClusters != null && virtualClusters.values().stream()
+                .map(VirtualCluster::filters)
+                .anyMatch(Objects::nonNull)) {
+            throw new IllegalConfigurationException(
+                    "'filters' cannot be specified on a virtual cluster when 'filters' is defined at the top level.");
+        }
+
         if (filters != null) {
             LOGGER.warn("The 'filters' configuration property is deprecated and will be removed in a future release. "
                     + "Configurations should be updated to use 'filterDefinitions' and 'defaultFilters'.");

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -25,14 +25,6 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * The root of the proxy configuration.
- * @param adminHttp
- * @param filterDefinitions A list of named filter definitions (names must be unique)
- * @param defaultFilters The names of the {@link #filterDefinitions()} to be use when a {@link VirtualCluster} doesn't specify its own {@link VirtualCluster#filterRefs()}.
- * @param virtualClusters The virtual clusters
- * @param filters Deprecated. The filter definitions to be used for all virtual clusters. Can only be specified if {@link #filterDefinitions()} is null.
- * @param micrometer The micrometer config
- * @param useIoUring true to use iouring
- * @param development Development options
  */
 @JsonPropertyOrder({ "adminHttp", "filterDefinitions", "defaultFilters", "virtualClusters", "filters", "micrometer", "useIoUring", "development" })
 public record Configuration(
@@ -40,7 +32,7 @@ public record Configuration(
                             @Nullable List<NamedFilterDefinition> filterDefinitions,
                             @Nullable List<String> defaultFilters,
                             Map<String, VirtualCluster> virtualClusters,
-                            @Nullable List<FilterDefinition> filters,
+                            @Deprecated @Nullable List<FilterDefinition> filters,
                             List<MicrometerDefinition> micrometer,
                             boolean useIoUring,
                             @NonNull Optional<Map<String, Object>> development) {
@@ -58,6 +50,19 @@ public record Configuration(
         }
     }
 
+    /**
+     * Specifying {@code filters} is deprecated.
+     * Use the {@link Configuration#Configuration(AdminHttpConfiguration, List, List, Map, List, boolean, Optional)} constructor instead.
+     * @param adminHttp
+     * @param filterDefinitions A list of named filter definitions (names must be unique)
+     * @param defaultFilters The names of the {@link #filterDefinitions()} to be use when a {@link VirtualCluster} doesn't specify its own {@link VirtualCluster#filterRefs()}.
+     * @param virtualClusters The virtual clusters
+     * @param filters Deprecated. The filter definitions to be used for all virtual clusters. Can only be specified if {@link #filterDefinitions()} is null.
+     * @param micrometer The micrometer config
+     * @param useIoUring true to use iouring
+     * @param development Development options
+     */
+    @Deprecated(since = "0.10.0", forRemoval = true)
     @JsonCreator
     public Configuration {
         Objects.requireNonNull(development);
@@ -90,7 +95,7 @@ public record Configuration(
 
     /**
      * @deprecated This constructor is currently retained to be source compatible the call sites that are passing the deprecated `filters` parameter.
-     * Replaced by {@link #Configuration(List, List, Map, boolean, List, AdminHttpConfiguration, Optional)}.
+     * Replaced by {@link #Configuration(AdminHttpConfiguration, List, List, Map, List, boolean, Optional)}.
      */
     @Deprecated(since = "0.10.0", forRemoval = true)
     public Configuration(
@@ -100,7 +105,6 @@ public record Configuration(
                          List<MicrometerDefinition> micrometer,
                          boolean useIoUring,
                          @NonNull Optional<Map<String, Object>> development
-
     ) {
         this(adminHttp, null, null, virtualClusters, filters, micrometer, useIoUring, development);
     }
@@ -109,13 +113,11 @@ public record Configuration(
      * This constructor uses the new style `defaultFilters` and `filterDefinitions` parameters instead of the deprecated `filters`.
      */
     public Configuration(
-                         @Nullable List<NamedFilterDefinition> filterDefinitions,
-                         @Nullable List<String> defaultFilters,
-                         Map<String, VirtualCluster> virtualClusters,
-                         boolean useIoUring,
-                         List<MicrometerDefinition> micrometer,
-                         @Nullable AdminHttpConfiguration adminHttp,
-                         @NonNull Optional<Map<String, Object>> development) {
+            @Nullable AdminHttpConfiguration adminHttp, @Nullable List<NamedFilterDefinition> filterDefinitions,
+            @Nullable List<String> defaultFilters,
+            Map<String, VirtualCluster> virtualClusters,
+            List<MicrometerDefinition> micrometer, boolean useIoUring,
+            @NonNull Optional<Map<String, Object>> development) {
         this(adminHttp, filterDefinitions, defaultFilters, virtualClusters, null, micrometer, useIoUring, development);
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -62,7 +62,7 @@ public record Configuration(
      * Use the {@link Configuration#Configuration(AdminHttpConfiguration, List, List, Map, List, boolean, Optional)} constructor instead.
      * @param adminHttp
      * @param filterDefinitions A list of named filter definitions (names must be unique)
-     * @param defaultFilters The names of the {@link #filterDefinitions()} to be use when a {@link VirtualCluster} doesn't specify its own {@link VirtualCluster#filterRefs()}.
+     * @param defaultFilters The names of the {@link #filterDefinitions()} to be use when a {@link VirtualCluster} doesn't specify its own {@link VirtualCluster#filters()}.
      * @param virtualClusters The virtual clusters
      * @param filters Deprecated. The filter definitions to be used for all virtual clusters. Can only be specified if {@link #filterDefinitions()} is null.
      * @param micrometer The micrometer config
@@ -95,7 +95,7 @@ public record Configuration(
             for (var entry : virtualClusters.entrySet()) {
                 var virtualClusterName = entry.getKey();
                 var virtualCluster = entry.getValue();
-                checkNamedFiltersAreDefined(filterDefsByName, virtualCluster.filterRefs(), "virtualClusters." + virtualClusterName + ".filterRefs");
+                checkNamedFiltersAreDefined(filterDefsByName, virtualCluster.filters(), "virtualClusters." + virtualClusterName + ".filterRefs");
             }
         }
 
@@ -107,7 +107,7 @@ public record Configuration(
             }
             if (virtualClusters != null) {
                 virtualClusters.values().stream()
-                        .map(VirtualCluster::filterRefs)
+                        .map(VirtualCluster::filters)
                         .filter(Objects::nonNull)
                         .flatMap(Collection::stream)
                         .forEach(defined::remove);
@@ -224,7 +224,7 @@ public record Configuration(
     private List<NamedFilterDefinition> namedFilterDefinitionsForCluster(Map<String, NamedFilterDefinition> filterDefinitionsByName,
                                                                          VirtualCluster virtualCluster) {
         List<NamedFilterDefinition> filterDefinitions;
-        List<String> clusterFilterRefs = virtualCluster.filterRefs();
+        List<String> clusterFilterRefs = virtualCluster.filters();
         if (clusterFilterRefs != null) {
             filterDefinitions = resolveFilterNames(filterDefinitionsByName, clusterFilterRefs);
         }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -114,8 +114,7 @@ public record Configuration(
                          @Nullable List<FilterDefinition> filters,
                          List<MicrometerDefinition> micrometer,
                          boolean useIoUring,
-                         @NonNull Optional<Map<String, Object>> development
-    ) {
+                         @NonNull Optional<Map<String, Object>> development) {
         this(adminHttp, null, null, virtualClusters, filters, micrometer, useIoUring, development);
     }
 
@@ -123,11 +122,11 @@ public record Configuration(
      * This constructor uses the new style `defaultFilters` and `filterDefinitions` parameters instead of the deprecated `filters`.
      */
     public Configuration(
-            @Nullable AdminHttpConfiguration adminHttp, @Nullable List<NamedFilterDefinition> filterDefinitions,
-            @Nullable List<String> defaultFilters,
-            Map<String, VirtualCluster> virtualClusters,
-            List<MicrometerDefinition> micrometer, boolean useIoUring,
-            @NonNull Optional<Map<String, Object>> development) {
+                         @Nullable AdminHttpConfiguration adminHttp, @Nullable List<NamedFilterDefinition> filterDefinitions,
+                         @Nullable List<String> defaultFilters,
+                         Map<String, VirtualCluster> virtualClusters,
+                         List<MicrometerDefinition> micrometer, boolean useIoUring,
+                         @NonNull Optional<Map<String, Object>> development) {
         this(adminHttp, filterDefinitions, defaultFilters, virtualClusters, null, micrometer, useIoUring, development);
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -95,7 +95,7 @@ public record Configuration(
             for (var entry : virtualClusters.entrySet()) {
                 var virtualClusterName = entry.getKey();
                 var virtualCluster = entry.getValue();
-                checkNamedFiltersAreDefined(filterDefsByName, virtualCluster.filters(), "virtualClusters." + virtualClusterName + ".filterRefs");
+                checkNamedFiltersAreDefined(filterDefsByName, virtualCluster.filters(), "virtualClusters." + virtualClusterName + ".filters");
             }
         }
 
@@ -231,9 +231,9 @@ public record Configuration(
     private List<NamedFilterDefinition> namedFilterDefinitionsForCluster(Map<String, NamedFilterDefinition> filterDefinitionsByName,
                                                                          VirtualCluster virtualCluster) {
         List<NamedFilterDefinition> filterDefinitions;
-        List<String> clusterFilterRefs = virtualCluster.filters();
-        if (clusterFilterRefs != null) {
-            filterDefinitions = resolveFilterNames(filterDefinitionsByName, clusterFilterRefs);
+        List<String> clusterFilters = virtualCluster.filters();
+        if (clusterFilters != null) {
+            filterDefinitions = resolveFilterNames(filterDefinitionsByName, clusterFilters);
         }
         else if (defaultFilters != null) {
             filterDefinitions = resolveFilterNames(filterDefinitionsByName, defaultFilters);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/NamedFilterDefinition.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/NamedFilterDefinition.java
@@ -36,7 +36,6 @@ public record NamedFilterDefinition(
         if (!NAME_PATTERN.matcher(name).matches()) {
             throw new IllegalArgumentException("Invalid filter name '" + name + "' (should match '" + NAME_PATTERN.pattern() + "')");
         }
-        // TODO should probably constrain the allowd chars in the name
         Objects.requireNonNull(type);
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/NamedFilterDefinition.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/NamedFilterDefinition.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.proxy.config;
 
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -27,9 +28,16 @@ public record NamedFilterDefinition(
                                     @PluginImplName(FilterFactory.class) @JsonProperty(required = true) String type,
                                     @PluginImplConfig(implNameProperty = "type") Object config) {
 
+    private static final Pattern NAME_PATTERN = Pattern.compile("[a-z0-9A-Z](?:[a-z0-9_.-]*[a-z0-9A-Z])?");
+
     @JsonCreator
     public NamedFilterDefinition {
         Objects.requireNonNull(name);
+        if (name.length() == 0
+                || type.length() > 63
+                || !NAME_PATTERN.matcher(name).matches()) {
+            throw new IllegalArgumentException("Invalid filter name " + name);
+        }
         // TODO should probably constrain the allowd chars in the name
         Objects.requireNonNull(type);
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/NamedFilterDefinition.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/NamedFilterDefinition.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.kroxylicious.proxy.filter.FilterFactory;
+import io.kroxylicious.proxy.plugin.PluginImplConfig;
+import io.kroxylicious.proxy.plugin.PluginImplName;
+
+/**
+ * A named filter definition
+ * @param name The name of the filter instance.
+ * @param type
+ * @param config
+ * @see Configuration#filterDefinitions()
+ */
+public record NamedFilterDefinition(
+                                    @JsonProperty(required = true) String name,
+                                    @PluginImplName(FilterFactory.class) @JsonProperty(required = true) String type,
+                                    @PluginImplConfig(implNameProperty = "type") Object config) {
+
+    @JsonCreator
+    public NamedFilterDefinition {
+        Objects.requireNonNull(name);
+        // TODO should probably constrain the allowd chars in the name
+        Objects.requireNonNull(type);
+    }
+
+    public FilterDefinition asFilterDefinition() {
+        return new FilterDefinition(type, config);
+    }
+
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/NamedFilterDefinition.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/NamedFilterDefinition.java
@@ -28,15 +28,13 @@ public record NamedFilterDefinition(
                                     @PluginImplName(FilterFactory.class) @JsonProperty(required = true) String type,
                                     @PluginImplConfig(implNameProperty = "type") Object config) {
 
-    private static final Pattern NAME_PATTERN = Pattern.compile("[a-z0-9A-Z](?:[a-z0-9_.-]*[a-z0-9A-Z])?");
+    private static final Pattern NAME_PATTERN = Pattern.compile("[a-z0-9A-Z](?:[a-z0-9A-Z_.-]{0,251}[a-z0-9A-Z])?");
 
     @JsonCreator
     public NamedFilterDefinition {
         Objects.requireNonNull(name);
-        if (name.length() == 0
-                || type.length() > 63
-                || !NAME_PATTERN.matcher(name).matches()) {
-            throw new IllegalArgumentException("Invalid filter name " + name);
+        if (!NAME_PATTERN.matcher(name).matches()) {
+            throw new IllegalArgumentException("Invalid filter name '" + name + "' (should match '" + NAME_PATTERN.pattern() + "')");
         }
         // TODO should probably constrain the allowd chars in the name
         Objects.requireNonNull(type);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
@@ -5,6 +5,7 @@
  */
 package io.kroxylicious.proxy.config;
 
+import java.util.List;
 import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -13,21 +14,30 @@ import io.kroxylicious.proxy.config.tls.Tls;
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProviderService;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 public record VirtualCluster(TargetCluster targetCluster,
                              @JsonProperty(required = true) ClusterNetworkAddressConfigProviderDefinition clusterNetworkAddressConfigProvider,
-
                              @JsonProperty() Optional<Tls> tls,
                              boolean logNetwork,
-                             boolean logFrames) {
-    public io.kroxylicious.proxy.model.VirtualCluster toVirtualClusterModel(PluginFactoryRegistry pfr, String virtualClusterNodeName) {
+                             boolean logFrames,
+                             @Nullable List<String> filterRefs) {
+
+    public io.kroxylicious.proxy.model.VirtualCluster toVirtualClusterModel(@NonNull PluginFactoryRegistry pfr,
+                                                                            @NonNull List<NamedFilterDefinition> filterDefinitions,
+                                                                            @NonNull String virtualClusterNodeName) {
+
         return new io.kroxylicious.proxy.model.VirtualCluster(virtualClusterNodeName,
                 targetCluster(),
                 toClusterNetworkAddressConfigProviderModel(pfr),
                 tls(),
-                logNetwork(), logFrames());
+                logNetwork(),
+                logFrames(),
+                filterDefinitions);
     }
 
-    private ClusterNetworkAddressConfigProvider toClusterNetworkAddressConfigProviderModel(PluginFactoryRegistry registry) {
+    private ClusterNetworkAddressConfigProvider toClusterNetworkAddressConfigProviderModel(@NonNull PluginFactoryRegistry registry) {
         ClusterNetworkAddressConfigProviderService provider = registry.pluginFactory(ClusterNetworkAddressConfigProviderService.class)
                 .pluginInstance(clusterNetworkAddressConfigProvider.type());
         return provider.build(clusterNetworkAddressConfigProvider.config());

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
@@ -22,7 +22,7 @@ public record VirtualCluster(TargetCluster targetCluster,
                              @JsonProperty() Optional<Tls> tls,
                              boolean logNetwork,
                              boolean logFrames,
-                             @Nullable List<String> filterRefs) {
+                             @Nullable List<String> filters) {
 
     public io.kroxylicious.proxy.model.VirtualCluster toVirtualClusterModel(@NonNull PluginFactoryRegistry pfr,
                                                                             @NonNull List<NamedFilterDefinition> filterDefinitions,

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
@@ -6,6 +6,7 @@
 package io.kroxylicious.proxy.model;
 
 import java.io.UncheckedIOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -20,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 
+import io.kroxylicious.proxy.config.NamedFilterDefinition;
 import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.config.tls.NettyKeyProvider;
 import io.kroxylicious.proxy.config.tls.NettyTrustProvider;
@@ -46,6 +48,8 @@ public class VirtualCluster implements ClusterNetworkAddressConfigProvider {
 
     private final ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider;
 
+    private final List<NamedFilterDefinition> filters;
+
     private final Optional<SslContext> upstreamSslContext;
 
     private final Optional<SslContext> downstreamSslContext;
@@ -58,12 +62,23 @@ public class VirtualCluster implements ClusterNetworkAddressConfigProvider {
                           Optional<Tls> tls,
                           boolean logNetwork,
                           boolean logFrames) {
+        this(clusterName, targetCluster, clusterNetworkAddressConfigProvider, tls, logNetwork, logFrames, null);
+    }
+
+    public VirtualCluster(String clusterName,
+                          TargetCluster targetCluster,
+                          ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider,
+                          Optional<Tls> tls,
+                          boolean logNetwork,
+                          boolean logFrames,
+                          @NonNull List<NamedFilterDefinition> filters) {
         this.clusterName = clusterName;
         this.tls = tls;
         this.targetCluster = targetCluster;
         this.logNetwork = logNetwork;
         this.logFrames = logFrames;
         this.clusterNetworkAddressConfigProvider = clusterNetworkAddressConfigProvider;
+        this.filters = filters;
 
         validateTLsSettings(clusterNetworkAddressConfigProvider, tls);
         validatePortUsage(clusterNetworkAddressConfigProvider);
@@ -242,5 +257,9 @@ public class VirtualCluster implements ClusterNetworkAddressConfigProvider {
         if (clusterNetworkAddressConfigProvider.requiresTls() && (tls.isEmpty() || !tls.get().definesKey())) {
             throw new IllegalStateException("Cluster endpoint provider requires server TLS, but this virtual cluster does not define it.");
         }
+    }
+
+    public @NonNull List<NamedFilterDefinition> getFilters() {
+        return filters;
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
@@ -62,7 +62,7 @@ public class VirtualCluster implements ClusterNetworkAddressConfigProvider {
                           Optional<Tls> tls,
                           boolean logNetwork,
                           boolean logFrames) {
-        this(clusterName, targetCluster, clusterNetworkAddressConfigProvider, tls, logNetwork, logFrames, null);
+        this(clusterName, targetCluster, clusterNetworkAddressConfigProvider, tls, logNetwork, logFrames, List.of());
     }
 
     public VirtualCluster(String clusterName,

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
@@ -19,7 +19,6 @@ import org.mockito.Mockito;
 
 import io.kroxylicious.proxy.config.ConfigParser;
 import io.kroxylicious.proxy.config.Configuration;
-import io.kroxylicious.proxy.config.FilterDefinition;
 import io.kroxylicious.proxy.config.IllegalConfigurationException;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
 import io.kroxylicious.proxy.internal.config.Features;
@@ -155,7 +154,7 @@ class KafkaProxyTest {
     @Test
     void invalidConfigurationForFeatures() {
         Optional<Map<String, Object>> a = Optional.of(Map.of("a", "b"));
-        Configuration configuration = new Configuration(null, null, List.<FilterDefinition> of(), null, false, a);
+        Configuration configuration = new Configuration(List.of(), null, null, false, null, null, a);
         Features features = Features.defaultFeatures();
         assertThatThrownBy(() -> {
             KafkaProxy.validate(configuration, features);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
@@ -19,6 +19,7 @@ import org.mockito.Mockito;
 
 import io.kroxylicious.proxy.config.ConfigParser;
 import io.kroxylicious.proxy.config.Configuration;
+import io.kroxylicious.proxy.config.FilterDefinition;
 import io.kroxylicious.proxy.config.IllegalConfigurationException;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
 import io.kroxylicious.proxy.internal.config.Features;
@@ -154,7 +155,7 @@ class KafkaProxyTest {
     @Test
     void invalidConfigurationForFeatures() {
         Optional<Map<String, Object>> a = Optional.of(Map.of("a", "b"));
-        Configuration configuration = new Configuration(null, null, List.of(), null, false, a);
+        Configuration configuration = new Configuration(null, null, List.<FilterDefinition> of(), null, false, a);
         Features features = Features.defaultFeatures();
         assertThatThrownBy(() -> {
             KafkaProxy.validate(configuration, features);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
@@ -154,7 +154,7 @@ class KafkaProxyTest {
     @Test
     void invalidConfigurationForFeatures() {
         Optional<Map<String, Object>> a = Optional.of(Map.of("a", "b"));
-        Configuration configuration = new Configuration(List.of(), null, null, false, null, null, a);
+        Configuration configuration = new Configuration(null, List.of(), null, null, null, false, a);
         Features features = Features.defaultFeatures();
         assertThatThrownBy(() -> {
             KafkaProxy.validate(configuration, features);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
@@ -158,7 +158,7 @@ class FilterChainFactoryTest {
     @Test
     void shouldReturnInvalidFilterNameIfFilterRequiresConfigAndNoneIsSupplied() {
         // Given
-        final List<NamedFilterDefinition> filters = Configuration.namedFilterDefinitions(List.of(new FilterDefinition(TestFilterFactory.class.getName(), config),
+        final List<NamedFilterDefinition> filters = Configuration.toNamedFilterDefinitions(List.of(new FilterDefinition(TestFilterFactory.class.getName(), config),
                 new FilterDefinition(TestFilterFactory.class.getName(), null)));
 
         // When
@@ -171,7 +171,7 @@ class FilterChainFactoryTest {
     @Test
     void shouldReturnInvalidFilterNamesForAllFiltersWithoutRequiredConfig() {
         // Given
-        final List<NamedFilterDefinition> filters = Configuration.namedFilterDefinitions(List.of(new FilterDefinition(TestFilterFactory.class.getName(), null),
+        final List<NamedFilterDefinition> filters = Configuration.toNamedFilterDefinitions(List.of(new FilterDefinition(TestFilterFactory.class.getName(), null),
                 new FilterDefinition(TestFilterFactory.class.getName(), null),
                 new FilterDefinition(OptionalConfigFactory.class.getName(), null)));
 
@@ -186,7 +186,7 @@ class FilterChainFactoryTest {
     void shouldPassValidationWhenAllFiltersHaveConfiguration() {
         // Given
         final List<NamedFilterDefinition> filterDefinitions = Configuration
-                .namedFilterDefinitions(List.of(new FilterDefinition(TestFilterFactory.class.getName(), config),
+                .toNamedFilterDefinitions(List.of(new FilterDefinition(TestFilterFactory.class.getName(), config),
                         new FilterDefinition(TestFilterFactory.class.getName(), config)));
 
         // When
@@ -200,7 +200,7 @@ class FilterChainFactoryTest {
     void shouldPassValidationWhenFiltersWithOptionalConfigurationAreMissingConfiguration() {
         // Given
         final List<NamedFilterDefinition> filterDefinitions = Configuration
-                .namedFilterDefinitions(List.of(new FilterDefinition(TestFilterFactory.class.getName(), config),
+                .toNamedFilterDefinitions(List.of(new FilterDefinition(TestFilterFactory.class.getName(), config),
                         new FilterDefinition(TestFilterFactory.class.getName(), config),
                         new FilterDefinition(OptionalConfigFactory.class.getName(), null)));
 
@@ -214,7 +214,7 @@ class FilterChainFactoryTest {
     void shouldFailValidationIfRequireConfigMissing() {
         // Given
         final FilterDefinition requiredConfig = new FilterDefinition(RequiresConfigFactory.class.getName(), null);
-        List<NamedFilterDefinition> list = Configuration.namedFilterDefinitions(List.of(requiredConfig));
+        List<NamedFilterDefinition> list = Configuration.toNamedFilterDefinitions(List.of(requiredConfig));
 
         // When
 
@@ -230,7 +230,7 @@ class FilterChainFactoryTest {
         // When
 
         // Then
-        assertThat(new FilterChainFactory(pfr, Configuration.namedFilterDefinitions(List.of(requiredConfig)))).isNotNull();
+        assertThat(new FilterChainFactory(pfr, Configuration.toNamedFilterDefinitions(List.of(requiredConfig)))).isNotNull();
     }
 
     @Test
@@ -241,7 +241,7 @@ class FilterChainFactoryTest {
         // When
 
         // Then
-        assertThat(new FilterChainFactory(pfr, Configuration.namedFilterDefinitions(List.of(requiredConfig)))).isNotNull();
+        assertThat(new FilterChainFactory(pfr, Configuration.toNamedFilterDefinitions(List.of(requiredConfig)))).isNotNull();
     }
 
     @Test
@@ -252,11 +252,11 @@ class FilterChainFactoryTest {
         // When
 
         // Then
-        assertThat(new FilterChainFactory(pfr, Configuration.namedFilterDefinitions(List.of(missingConfig)))).isNotNull();
+        assertThat(new FilterChainFactory(pfr, Configuration.toNamedFilterDefinitions(List.of(missingConfig)))).isNotNull();
     }
 
     private ListAssert<FilterAndInvoker> assertFiltersCreated(List<FilterDefinition> filterDefinitions) {
-        List<NamedFilterDefinition> filterDefinitions1 = Configuration.namedFilterDefinitions(filterDefinitions);
+        List<NamedFilterDefinition> filterDefinitions1 = Configuration.toNamedFilterDefinitions(filterDefinitions);
         FilterChainFactory filterChainFactory = new FilterChainFactory(pfr, filterDefinitions1);
         NettyFilterContext context = new NettyFilterContext(eventLoop, pfr);
         List<FilterAndInvoker> filters = filterChainFactory.createFilters(context, filterDefinitions1);
@@ -278,7 +278,7 @@ class FilterChainFactoryTest {
         var onClose1 = new Counter();
         var onInitialize2 = new Counter();
         var onClose2 = new Counter();
-        List<NamedFilterDefinition> list = Configuration.namedFilterDefinitions(List.of(
+        List<NamedFilterDefinition> list = Configuration.toNamedFilterDefinitions(List.of(
                 new FilterDefinition(FlakyFactory.class.getName(), new FlakyConfig(null, null, null,
                         onInitialize1::increment, onClose1::increment)),
                 new FilterDefinition(FlakyFactory.class.getName(), new FlakyConfig("foo", null, null,
@@ -305,7 +305,7 @@ class FilterChainFactoryTest {
         var onClose1 = new Counter();
         var onInitialize2 = new Counter();
         var onClose2 = new Counter();
-        List<NamedFilterDefinition> list = Configuration.namedFilterDefinitions(List.of(
+        List<NamedFilterDefinition> list = Configuration.toNamedFilterDefinitions(List.of(
                 new FilterDefinition(FlakyFactory.class.getName(), new FlakyConfig(null, null, null,
                         onInitialize1::increment, onClose1::increment)),
                 new FilterDefinition(FlakyFactory.class.getName(), new FlakyConfig(null, "foo", null,
@@ -353,7 +353,7 @@ class FilterChainFactoryTest {
         FlakyConfig flakyConfig2 = new FlakyConfig(null, null, "foo",
                 ((Consumer<FlakyConfig>) onInitialize2::increment).andThen(initializeOrder::add),
                 ((Consumer<FlakyConfig>) onClose2::increment).andThen(closeOrder::add));
-        List<NamedFilterDefinition> list = Configuration.namedFilterDefinitions(List.of(
+        List<NamedFilterDefinition> list = Configuration.toNamedFilterDefinitions(List.of(
                 new FilterDefinition(FlakyFactory.class.getName(), flakyConfig1),
                 new FilterDefinition(FlakyFactory.class.getName(), flakyConfig2)));
         try (var fcf = new FilterChainFactory(pfr, list)) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
@@ -21,7 +21,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import io.netty.channel.DefaultEventLoop;
 import io.netty.channel.EventLoop;
 
+import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.FilterDefinition;
+import io.kroxylicious.proxy.config.NamedFilterDefinition;
 import io.kroxylicious.proxy.config.PluginFactory;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
@@ -102,7 +104,7 @@ class FilterChainFactoryTest {
     void testNullFiltersInConfigResultsInEmptyList() {
         EventLoop eventLoop = new DefaultEventLoop();
         FilterChainFactory filterChainFactory = new FilterChainFactory(pfr, null);
-        List<FilterAndInvoker> filters = filterChainFactory.createFilters(new NettyFilterContext(eventLoop, pfr));
+        List<FilterAndInvoker> filters = filterChainFactory.createFilters(new NettyFilterContext(eventLoop, pfr), null);
         assertNotNull(filters, "Filters list should not be null");
         assertTrue(filters.isEmpty(), "Filters list should be empty");
     }
@@ -156,8 +158,8 @@ class FilterChainFactoryTest {
     @Test
     void shouldReturnInvalidFilterNameIfFilterRequiresConfigAndNoneIsSupplied() {
         // Given
-        final List<FilterDefinition> filters = List.of(new FilterDefinition(TestFilterFactory.class.getName(), config),
-                new FilterDefinition(TestFilterFactory.class.getName(), null));
+        final List<NamedFilterDefinition> filters = Configuration.namedFilterDefinitions(List.of(new FilterDefinition(TestFilterFactory.class.getName(), config),
+                new FilterDefinition(TestFilterFactory.class.getName(), null)));
 
         // When
         var ex = assertThrows(PluginConfigurationException.class, () -> new FilterChainFactory(pfr, filters));
@@ -169,9 +171,9 @@ class FilterChainFactoryTest {
     @Test
     void shouldReturnInvalidFilterNamesForAllFiltersWithoutRequiredConfig() {
         // Given
-        final List<FilterDefinition> filters = List.of(new FilterDefinition(TestFilterFactory.class.getName(), null),
+        final List<NamedFilterDefinition> filters = Configuration.namedFilterDefinitions(List.of(new FilterDefinition(TestFilterFactory.class.getName(), null),
                 new FilterDefinition(TestFilterFactory.class.getName(), null),
-                new FilterDefinition(OptionalConfigFactory.class.getName(), null));
+                new FilterDefinition(OptionalConfigFactory.class.getName(), null)));
 
         // When
         var ex = assertThrows(PluginConfigurationException.class, () -> new FilterChainFactory(pfr, filters));
@@ -183,8 +185,9 @@ class FilterChainFactoryTest {
     @Test
     void shouldPassValidationWhenAllFiltersHaveConfiguration() {
         // Given
-        final List<FilterDefinition> filterDefinitions = List.of(new FilterDefinition(TestFilterFactory.class.getName(), config),
-                new FilterDefinition(TestFilterFactory.class.getName(), config));
+        final List<NamedFilterDefinition> filterDefinitions = Configuration
+                .namedFilterDefinitions(List.of(new FilterDefinition(TestFilterFactory.class.getName(), config),
+                        new FilterDefinition(TestFilterFactory.class.getName(), config)));
 
         // When
 
@@ -196,9 +199,10 @@ class FilterChainFactoryTest {
     @Test
     void shouldPassValidationWhenFiltersWithOptionalConfigurationAreMissingConfiguration() {
         // Given
-        final List<FilterDefinition> filterDefinitions = List.of(new FilterDefinition(TestFilterFactory.class.getName(), config),
-                new FilterDefinition(TestFilterFactory.class.getName(), config),
-                new FilterDefinition(OptionalConfigFactory.class.getName(), null));
+        final List<NamedFilterDefinition> filterDefinitions = Configuration
+                .namedFilterDefinitions(List.of(new FilterDefinition(TestFilterFactory.class.getName(), config),
+                        new FilterDefinition(TestFilterFactory.class.getName(), config),
+                        new FilterDefinition(OptionalConfigFactory.class.getName(), null)));
 
         // When
 
@@ -210,7 +214,7 @@ class FilterChainFactoryTest {
     void shouldFailValidationIfRequireConfigMissing() {
         // Given
         final FilterDefinition requiredConfig = new FilterDefinition(RequiresConfigFactory.class.getName(), null);
-        List<FilterDefinition> list = List.of(requiredConfig);
+        List<NamedFilterDefinition> list = Configuration.namedFilterDefinitions(List.of(requiredConfig));
 
         // When
 
@@ -226,7 +230,7 @@ class FilterChainFactoryTest {
         // When
 
         // Then
-        assertThat(new FilterChainFactory(pfr, List.of(requiredConfig))).isNotNull();
+        assertThat(new FilterChainFactory(pfr, Configuration.namedFilterDefinitions(List.of(requiredConfig)))).isNotNull();
     }
 
     @Test
@@ -237,7 +241,7 @@ class FilterChainFactoryTest {
         // When
 
         // Then
-        assertThat(new FilterChainFactory(pfr, List.of(requiredConfig))).isNotNull();
+        assertThat(new FilterChainFactory(pfr, Configuration.namedFilterDefinitions(List.of(requiredConfig)))).isNotNull();
     }
 
     @Test
@@ -248,13 +252,14 @@ class FilterChainFactoryTest {
         // When
 
         // Then
-        assertThat(new FilterChainFactory(pfr, List.of(missingConfig))).isNotNull();
+        assertThat(new FilterChainFactory(pfr, Configuration.namedFilterDefinitions(List.of(missingConfig)))).isNotNull();
     }
 
     private ListAssert<FilterAndInvoker> assertFiltersCreated(List<FilterDefinition> filterDefinitions) {
-        FilterChainFactory filterChainFactory = new FilterChainFactory(pfr, filterDefinitions);
+        List<NamedFilterDefinition> filterDefinitions1 = Configuration.namedFilterDefinitions(filterDefinitions);
+        FilterChainFactory filterChainFactory = new FilterChainFactory(pfr, filterDefinitions1);
         NettyFilterContext context = new NettyFilterContext(eventLoop, pfr);
-        List<FilterAndInvoker> filters = filterChainFactory.createFilters(context);
+        List<FilterAndInvoker> filters = filterChainFactory.createFilters(context, filterDefinitions1);
         return assertThat(filters).hasSameSizeAs(filterDefinitions);
     }
 
@@ -273,11 +278,11 @@ class FilterChainFactoryTest {
         var onClose1 = new Counter();
         var onInitialize2 = new Counter();
         var onClose2 = new Counter();
-        List<FilterDefinition> list = List.of(
+        List<NamedFilterDefinition> list = Configuration.namedFilterDefinitions(List.of(
                 new FilterDefinition(FlakyFactory.class.getName(), new FlakyConfig(null, null, null,
                         onInitialize1::increment, onClose1::increment)),
                 new FilterDefinition(FlakyFactory.class.getName(), new FlakyConfig("foo", null, null,
-                        onInitialize2::increment, onClose2::increment)));
+                        onInitialize2::increment, onClose2::increment))));
 
         // When
 
@@ -300,11 +305,11 @@ class FilterChainFactoryTest {
         var onClose1 = new Counter();
         var onInitialize2 = new Counter();
         var onClose2 = new Counter();
-        List<FilterDefinition> list = List.of(
+        List<NamedFilterDefinition> list = Configuration.namedFilterDefinitions(List.of(
                 new FilterDefinition(FlakyFactory.class.getName(), new FlakyConfig(null, null, null,
                         onInitialize1::increment, onClose1::increment)),
                 new FilterDefinition(FlakyFactory.class.getName(), new FlakyConfig(null, "foo", null,
-                        onInitialize2::increment, onClose2::increment)));
+                        onInitialize2::increment, onClose2::increment))));
         NettyFilterContext context = new NettyFilterContext(eventLoop, pfr);
 
         try (var fcf = new FilterChainFactory(pfr, list)) {
@@ -315,7 +320,7 @@ class FilterChainFactoryTest {
             // When
 
             // Then
-            assertThatThrownBy(() -> fcf.createFilters(context))
+            assertThatThrownBy(() -> fcf.createFilters(context, list))
                     .isExactlyInstanceOf(PluginConfigurationException.class)
                     .cause()
                     .isExactlyInstanceOf(RuntimeException.class)
@@ -348,9 +353,9 @@ class FilterChainFactoryTest {
         FlakyConfig flakyConfig2 = new FlakyConfig(null, null, "foo",
                 ((Consumer<FlakyConfig>) onInitialize2::increment).andThen(initializeOrder::add),
                 ((Consumer<FlakyConfig>) onClose2::increment).andThen(closeOrder::add));
-        List<FilterDefinition> list = List.of(
+        List<NamedFilterDefinition> list = Configuration.namedFilterDefinitions(List.of(
                 new FilterDefinition(FlakyFactory.class.getName(), flakyConfig1),
-                new FilterDefinition(FlakyFactory.class.getName(), flakyConfig2));
+                new FilterDefinition(FlakyFactory.class.getName(), flakyConfig2)));
         try (var fcf = new FilterChainFactory(pfr, list)) {
             // When
             assertThat(onInitialize1.count).isEqualTo(1);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.flipkart.zjsonpatch.JsonDiff;
 
+import io.kroxylicious.proxy.config.admin.AdminHttpConfiguration;
 import io.kroxylicious.proxy.config.secret.PasswordProvider;
 import io.kroxylicious.proxy.config.tls.KeyStore;
 import io.kroxylicious.proxy.config.tls.Tls;
@@ -400,7 +401,8 @@ class ConfigParserTest {
 
     @Test
     void shouldThrowWhenSerializingUnserializableObject() {
-        var config = new Configuration(null, null, List.of(new FilterDefinition("", new NonSerializableConfig(""))), null, false, Optional.empty());
+        var config = new Configuration((AdminHttpConfiguration) null, null, List.of(new FilterDefinition("", new NonSerializableConfig(""))), null, false,
+                Optional.empty());
 
         ConfigParser cp = new ConfigParser();
         assertThatThrownBy(() -> {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.flipkart.zjsonpatch.JsonDiff;
 
-import io.kroxylicious.proxy.config.admin.AdminHttpConfiguration;
 import io.kroxylicious.proxy.config.secret.PasswordProvider;
 import io.kroxylicious.proxy.config.tls.KeyStore;
 import io.kroxylicious.proxy.config.tls.Tls;
@@ -401,7 +400,8 @@ class ConfigParserTest {
 
     @Test
     void shouldThrowWhenSerializingUnserializableObject() {
-        var config = new Configuration((AdminHttpConfiguration) null, null, List.of(new FilterDefinition("", new NonSerializableConfig(""))), null, false,
+        var config = new Configuration(List.of(new NamedFilterDefinition("foo", "", new NonSerializableConfig(""))),
+                List.of("foo"), null, false, null, null,
                 Optional.empty());
 
         ConfigParser cp = new ConfigParser();

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -400,8 +400,8 @@ class ConfigParserTest {
 
     @Test
     void shouldThrowWhenSerializingUnserializableObject() {
-        var config = new Configuration(List.of(new NamedFilterDefinition("foo", "", new NonSerializableConfig(""))),
-                List.of("foo"), null, false, null, null,
+        var config = new Configuration(null, List.of(new NamedFilterDefinition("foo", "", new NonSerializableConfig(""))),
+                List.of("foo"), null, null, false,
                 Optional.empty());
 
         ConfigParser cp = new ConfigParser();

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/NamedFilterDefinitionTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/NamedFilterDefinitionTest.java
@@ -8,6 +8,7 @@ package io.kroxylicious.proxy.config;
 
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class NamedFilterDefinitionTest {
@@ -15,12 +16,12 @@ class NamedFilterDefinitionTest {
     @Test
     void shouldAcceptValidNames() {
         // Should work without throwing
-        new NamedFilterDefinition("a", "", "");
-        new NamedFilterDefinition("1", "", "");
-        new NamedFilterDefinition("a1", "", "");
-        new NamedFilterDefinition("a1.b2", "", "");
-        new NamedFilterDefinition("a1.B2-C3.d4", "", "");
-        new NamedFilterDefinition("io.kroxylicious.proxy.internal.filter.OptionalConfigFactory", "", "");
+        assertThatCode(() -> new NamedFilterDefinition("a", "", "")).doesNotThrowAnyException();
+        assertThatCode(() -> new NamedFilterDefinition("1", "", "")).doesNotThrowAnyException();
+        assertThatCode(() -> new NamedFilterDefinition("a1", "", "")).doesNotThrowAnyException();
+        assertThatCode(() -> new NamedFilterDefinition("a1.b2", "", "")).doesNotThrowAnyException();
+        assertThatCode(() -> new NamedFilterDefinition("a1.B2-C3.d4", "", "")).doesNotThrowAnyException();
+        assertThatCode(() -> new NamedFilterDefinition("io.kroxylicious.proxy.internal.filter.OptionalConfigFactory", "", "")).doesNotThrowAnyException();
     }
 
     @Test
@@ -28,7 +29,8 @@ class NamedFilterDefinitionTest {
         assertThatThrownBy(() -> new NamedFilterDefinition("", "", ""))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Invalid filter name '' (should match '[a-z0-9A-Z](?:[a-z0-9A-Z_.-]{0,251}[a-z0-9A-Z])?')");
-        assertThatThrownBy(() -> new NamedFilterDefinition("x".repeat(254), "", ""))
+        String tooLong = "x".repeat(254);
+        assertThatThrownBy(() -> new NamedFilterDefinition(tooLong, "", ""))
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> new NamedFilterDefinition(".foo", "", ""))
                 .isInstanceOf(IllegalArgumentException.class);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/NamedFilterDefinitionTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/NamedFilterDefinitionTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NamedFilterDefinitionTest {
+
+    @Test
+    void shouldAcceptValidNames() {
+        // Should work without throwing
+        new NamedFilterDefinition("a", "", "");
+        new NamedFilterDefinition("1", "", "");
+        new NamedFilterDefinition("a1", "", "");
+        new NamedFilterDefinition("a1.b2", "", "");
+        new NamedFilterDefinition("a1.B2-C3.d4", "", "");
+        new NamedFilterDefinition("io.kroxylicious.proxy.internal.filter.OptionalConfigFactory", "", "");
+    }
+
+    @Test
+    void shouldRejectInvalidNames() {
+        assertThatThrownBy(() -> new NamedFilterDefinition("", "", ""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid filter name '' (should match '[a-z0-9A-Z](?:[a-z0-9A-Z_.-]{0,251}[a-z0-9A-Z])?')");
+        assertThatThrownBy(() -> new NamedFilterDefinition("x".repeat(254), "", ""))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new NamedFilterDefinition(".foo", "", ""))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new NamedFilterDefinition("-foo", "", ""))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -297,15 +297,21 @@ class KafkaProxyInitializerTest {
         when(vcb.upstreamTarget()).thenReturn(new HostPort("upstream.broker.kafka", 9090));
         ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl();
         final KafkaProxyInitializer.InitalizerNetFilter initalizerNetFilter = new KafkaProxyInitializer.InitalizerNetFilter(mock(SaslDecodePredicate.class),
-                channel, vcb, pfr, fcf, (virtualCluster1, upstreamNodes) -> null,
-                new ApiVersionsIntersectFilter(apiVersionsService), new ApiVersionsDowngradeFilter(apiVersionsService));
+                channel,
+                vcb,
+                pfr,
+                fcf,
+                List.of(),
+                (virtualCluster1, upstreamNodes) -> null,
+                new ApiVersionsIntersectFilter(apiVersionsService),
+                new ApiVersionsDowngradeFilter(apiVersionsService));
         final NetFilter.NetFilterContext netFilterContext = mock(NetFilter.NetFilterContext.class);
 
         // When
         initalizerNetFilter.selectServer(netFilterContext);
 
         // Then
-        verify(fcf).createFilters(any(FilterFactoryContext.class));
+        verify(fcf).createFilters(any(FilterFactoryContext.class), any(List.class));
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/config/FeaturesTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/config/FeaturesTest.java
@@ -61,6 +61,7 @@ class FeaturesTest {
 
     @ParameterizedTest
     @MethodSource
+    @SuppressWarnings("java:S5738")
     void supportsValidTestConfiguration(Features features, Map<String, Object> config) {
         Configuration configuration = new Configuration(null, null, List.of(), null, false, Optional.ofNullable(config));
         List<String> errorMessages = features.supports(configuration);
@@ -68,6 +69,7 @@ class FeaturesTest {
     }
 
     @Test
+    @SuppressWarnings("java:S5738")
     void supportsReturnsErrorOnTestConfigurationPresentWithFeatureDisabled() {
         Optional<Map<String, Object>> a = Optional.of(Map.of("a", "b"));
         Configuration configuration = new Configuration(null, null, List.of(), null, false, a);

--- a/kroxylicious-runtime/src/test/resources/config.yaml
+++ b/kroxylicious-runtime/src/test/resources/config.yaml
@@ -21,4 +21,4 @@ virtualClusters:
         bootstrapAddress: localhost:9192
     logNetwork: true
     logFrames: true
-filters:
+defaultFilters:

--- a/kroxylicious-sample/sample-proxy-config.yaml
+++ b/kroxylicious-sample/sample-proxy-config.yaml
@@ -18,12 +18,17 @@ virtualClusters:
         bootstrapAddress: localhost:9192
     logNetwork: false
     logFrames: false
-filters:
-  - type: SampleProduceRequestFilterFactory
+filterDefinitions:
+  - name: produce-request-filter
+    type: SampleProduceRequestFilterFactory
     config:
       findValue: foo
       replacementValue: bar
-  - type: SampleFetchResponseFilterFactory
+  - name: fetch-response-filter
+    type: SampleFetchResponseFilterFactory
     config:
       findValue: bar
       replacementValue: baz
+defaultFilters:
+  - produce-request-filter
+  - fetch-response-filter

--- a/kroxylicious-sample/src/test/java/io/kroxylicious/sample/SampleFilterIT.java
+++ b/kroxylicious-sample/src/test/java/io/kroxylicious/sample/SampleFilterIT.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
-import io.kroxylicious.proxy.config.FilterDefinitionBuilder;
+import io.kroxylicious.proxy.config.NamedFilterDefinitionBuilder;
 import io.kroxylicious.test.tester.KroxyliciousTester;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.common.BrokerCluster;
@@ -154,7 +154,9 @@ class SampleFilterIT {
         FilterIntegrationTest(TestFilter... filters) {
             ConfigurationBuilder builder = proxy(cluster);
             for (TestFilter filter : filters) {
-                builder.addToFilters(new FilterDefinitionBuilder(filter.name()).withConfig(filter.config()).build());
+                NamedFilterDefinitionBuilder filterDefinitionBuilder = new NamedFilterDefinitionBuilder(filter.name(), filter.name());
+                builder.addToFilterDefinitions(filterDefinitionBuilder.withConfig(filter.config()).build());
+                builder.addToDefaultFilters(filterDefinitionBuilder.name());
             }
             tester = kroxyliciousTester(builder);
             producer = tester.producer();

--- a/kubernetes-examples/filters/multi-tenant/base/kroxylicious/kroxylicious-config.yaml
+++ b/kubernetes-examples/filters/multi-tenant/base/kroxylicious/kroxylicious-config.yaml
@@ -11,8 +11,11 @@ metadata:
   name: kroxylicious-config
 data:
   config.yaml: |
-    filters:
-    - type: MultiTenantTransformationFilterFactory
+    filterDefinitions:
+    - name: multi-tenant
+      type: MultiTenantTransformationFilterFactory
+    defaultFilters:
+      - multi-tenant
     adminHttp:
       endpoints:
         prometheus: {}

--- a/kubernetes-examples/filters/record-encryption/base/kroxylicious/kroxylicious-config.yaml
+++ b/kubernetes-examples/filters/record-encryption/base/kroxylicious/kroxylicious-config.yaml
@@ -28,8 +28,9 @@ data:
           # declares the kafka cluster that is being proxied
           bootstrap_servers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
         logFrames: false
-    filters:
-    - type: RecordEncryption
+    filterDefinitions:
+    - name: encrypt
+      type: RecordEncryption
       config:
         kms: VaultKmsService
         kmsConfig:
@@ -39,3 +40,5 @@ data:
         selector: TemplateKekSelector
         selectorConfig:
           template: "${topicName}"
+    defaultFilters:
+      - encrypt

--- a/performance-tests/02-no-filters/config.yaml
+++ b/performance-tests/02-no-filters/config.yaml
@@ -18,4 +18,4 @@ virtualClusters:
         bootstrapAddress: kroxylicious:9092
     logNetwork: false
     logFrames: false
-filters: []
+defaultFilters: []

--- a/performance-tests/03-transform-filter/config.yaml
+++ b/performance-tests/03-transform-filter/config.yaml
@@ -18,15 +18,20 @@ virtualClusters:
         bootstrapAddress: kroxylicious:9092
     logNetwork: false
     logFrames: false
-filters:
-- type: ProduceRequestTransformationFilterFactory
+filterDefinitions:
+- name: produce
+  type: ProduceRequestTransformationFilterFactory
   config:
     transformation: UpperCasing
     transformationConfig:
       charset: UTF-8
-- type: FetchResponseTransformationFilterFactory
+- name: fetch
+  type: FetchResponseTransformationFilterFactory
   config:
     transformation: UpperCasing
     transformationConfig:
       charset: UTF-8
 
+defaultFilters:
+  - produce
+  - fetch

--- a/performance-tests/04-record-encryption-filter/config.yaml
+++ b/performance-tests/04-record-encryption-filter/config.yaml
@@ -18,7 +18,8 @@ virtualClusters:
         bootstrapAddress: kroxylicious:9092
     logNetwork: false
     logFrames: false
-filters:
+filterDefinitions:
+- name: encrypt
 - type: RecordEncryption
   config:
     kms: VaultKmsService
@@ -29,3 +30,5 @@ filters:
     selector: TemplateKekSelector
     selectorConfig:
       template: "KEK_${topicName}"
+defaultFilters:
+  - encrypt


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

* Implement the idea sketched in #1704 option 2, using named `filterDefinitions` and references to them on clusters, or a top level default.
* Handle the old-style anonymous `filters` by internally generating names.
* Refactor `FilterChainFactory` so it operates on named filters.
* `FilterChainFactory` contains all the `filterDefinitions` and the list of filters to create is now passed at create time.
* Rework the operator's `ProxyConfigSecret` to use per-cluster filters
* Add tests

