### PR TITLE
FortanixKMS /Github CI integration

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -64,12 +64,20 @@ jobs:
         if: github.ref_name != 'main' || env.SONAR_TOKEN_SET != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # These variables/secrets support the Fortanix/KMS integration tests.   If the secrets are absent, the
+          # tests will be skipped.
+          KROYXLICIOUS_KMS_FORTANIX_API_ENDPOINT: ${{ vars.KROYXLICIOUS_KMS_FORTANIX_API_ENDPOINT }}
+          KROYXLICIOUS_KMS_FORTANIX_ADMIN_API_KEY: ${{ secrets.KROYXLICIOUS_KMS_FORTANIX_ADMIN_API_KEY }}
+          KROYXLICIOUS_KMS_FORTANIX_API_KEY: ${{ secrets.KROYXLICIOUS_KMS_FORTANIX_API_KEY }}
         run: mvn -B clean verify -Pci -Djapicmp.skip=${REFERENCE_RELEASE_UNPUBLISHED}
       - name: 'Build Kroxylicious maven project on main with Sonar'
         if: github.event_name == 'push' && github.ref_name == 'main' && env.SONAR_TOKEN_SET == 'true'
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KROYXLICIOUS_KMS_FORTANIX_API_ENDPOINT: ${{ vars.KROYXLICIOUS_KMS_FORTANIX_API_ENDPOINT }}
+          KROYXLICIOUS_KMS_FORTANIX_ADMIN_API_KEY: ${{ secrets.KROYXLICIOUS_KMS_FORTANIX_ADMIN_API_KEY }}
+          KROYXLICIOUS_KMS_FORTANIX_API_KEY: ${{ secrets.KROYXLICIOUS_KMS_FORTANIX_API_KEY }}
         run: mvn -B clean verify -Pci -Djapicmp.skip=${REFERENCE_RELEASE_UNPUBLISHED} org.sonarsource.scanner.maven:sonar-maven-plugin:3.9.1.2184:sonar -Dsonar.projectKey=kroxylicious_kroxylicious
       - name: Save PR number to file
         if: github.event_name == 'pull_request' && ${{ matrix.os }} == 'ubuntu-latest'


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Enabling the Fortanix KMS CI integration.  We just need to set some environment variables to allow Maven to run integration tests.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
