### PR TITLE
Docs for per cluster filters

### DIFF
--- a/docs/assemblies/assembly-configuring-proxy.adoc
+++ b/docs/assemblies/assembly-configuring-proxy.adoc
@@ -2,10 +2,16 @@
 = Configuring proxies
 
 [role="_abstract"]
-Fine-tune your deployment by configuring proxies to include additional features according to your specific requirements.  
+Fine-tune your deployment by configuring proxies to include additional features according to your specific requirements.
 
+include::../modules/configuring/con-configuration-outline.adoc[leveloffset=+1]
+include::../modules/configuring/con-configuring-filters.adoc[leveloffset=+1]
 include::../modules/configuring/con-configuring-virtual-clusters.adoc[leveloffset=+1]
+include::../modules/configuring/con-configuring-vc-network-addresses.adoc[leveloffset=+1]
+include::../modules/configuring/con-configuring-vc-client-tls.adoc[leveloffset=+1]
+include::../modules/configuring/con-configuring-vc-target-tls.adoc[leveloffset=+1]
+
+include::../modules/configuring/con-configuring-vc-other-settings.adoc[leveloffset=+1]
+include::../modules/configuring/con-configuring-toplevel-other-settings.adoc[leveloffset=+1]
+
 include::../modules/configuring/ref-configuring-proxy-example.adoc[leveloffset=+1]
-include::../modules/configuring/con-configuring-client-connections.adoc[leveloffset=+1]
-include::../modules/configuring/con-configuring-target-cluster-connections.adoc[leveloffset=+1]
-include::../modules/configuring/con-configuring-network-addresses.adoc[leveloffset=+1]

--- a/docs/modules/configuring/con-configuration-outline.adoc
+++ b/docs/modules/configuring/con-configuration-outline.adoc
@@ -1,0 +1,36 @@
+[id='con-configuration-outline-{context}']
+= Outline of a Kroxylicious configuration
+
+[role="_abstract"]
+The following example shows the overall outline of a simple Kroxylicious configuration. 
+While not complete (as indicated by `# ...`), it illustrates the essential structure.
+
+[id='con-basic-structure-{context}']
+.Basic outline of a Kroxylicious configuration
+[source,yaml]
+----
+filterDefinitions: # <1>
+  - name: example # <2>
+    type: org.example.filter.Example # <3>
+    config: # <4>
+      # ...
+defaultFilters: <5>
+  - example
+virtualClusters: # <6>
+  my-cluster-proxy:
+    targetCluster: # <7>
+      # ...
+    clusterNetworkAddressConfigProvider: # <8>
+      # ...
+# ...
+----
+<1> A list of named filter definitions.
+<2> A filter definition called `example`. The definitions must each have a unique name.
+<3> The name of the filter class implementation for the `example` filter. Required.
+<4> The configuration for the `example` filter instance. Usually required for non-trivial filters.
+<5> A list of default filters. It's possible to override this list at the virtual cluster level.
+<6> List of virtual clusters specified by name, with cluster-specific configurations.
+<7> Configuration of the actual Kafka cluster that is proxied by the 'my-cluster-proxy' virtual cluster.
+<8> Configuration of the networking model for this virtual cluster.
+
+

--- a/docs/modules/configuring/con-configuring-filters.adoc
+++ b/docs/modules/configuring/con-configuring-filters.adoc
@@ -1,0 +1,65 @@
+[id='ref-configuring-filters-{context}']
+= Defining filters
+
+Filters in Kroxylicious can be defined globally with `filterDefinitions`, applied by default using `defaultFilters`, or customized for specific virtual clusters. 
+The following example shows how these elements work together flexibly:
+
+[id='con-filterDefinitions-defaultFilters-{context}']
+.Example configuration showing global filter definitions applied as defaults and to virtual cluster
+[source,yaml]
+----
+filterDefinitions:
+  - name: encryption
+    type: RecordEncryption
+    config:
+      # ...
+  - name: validation
+    type: RecordValidation
+    config:
+      # ...
+  - name: special-encryption
+    type: RecordEncryption
+    config:
+      # ...
+defaultFilters:
+  - validation
+  - encryption
+virtualClusters:
+  my-proxy-with-default-filters:
+    # ...
+  my-proxy-with-custom-filters:
+    filters:
+      - validation
+      - special-encryption
+    # ...
+# ...
+----
+
+* The order of definitions in `filterDefinitions` does not matter.
+* Each filter definition in `filterDefinitions` must have a unique `name`, but you can have multiple definitions with the same type and different configurations (as with `encryption` and `special-encryption` in the example).
+* The order of `defaultFilters` determines the sequence in which the filters are applied to incoming client requests. In the example, records are first validated and then encrypted.
+* The `defaultFilters` are used for all virtual clusters which don't define their own `filters`, such as `my-proxy-with-default-filters`.
+* The `defaultFilters` property is optional. It is useful when all virtual clusters must use the same filters. There's no need to specify it if all virtual clusters have specific `filters` defined.
+* When a virtual cluster has defined `filters`, like `my-proxy-with-custom-filters`, then those filters are used instead of the `defaultFilters`.
+* When using `defaultFilters` or a virtual cluster's `filters` to reference a filter definition, you must define a filter with the corresponding name in `filterDefinitions`.
+
+The top-level `filters` property allows defining _anonymous_ filters without a `name`.
+
+WARNING: The `filters` property is deprecated and will be removed in a future version of Kroxylicious. Update existing configurations to use `filterDefinitions` instead.
+
+[id='con-filters-{context}']
+.The deprecated `filters` property
+[source,yaml]
+----
+filters: # deprecated!
+  - type: RecordEncryption
+    config:
+      # ...
+virtualClusters:
+  my-proxy-with-default-filters:
+    # ...
+----
+
+The top-level `filters` property applies to all virtual clusters in the configuration. 
+You cannot use both the top-level `filters` and `filterDefinitions` properties in the same configuration.
+

--- a/docs/modules/configuring/con-configuring-toplevel-other-settings.adoc
+++ b/docs/modules/configuring/con-configuring-toplevel-other-settings.adoc
@@ -1,0 +1,24 @@
+[id='ref-configuring-toplevel-other-settings-{context}']
+= Configuring other top level settings
+
+== Management HTTP endpoints
+
+The proxy can run an HTTP server for exposing basic management information.
+This is configured with the top level `adminHttp` property.
+
+[id='con-configuring-admin-http-{context}']
+.Configuration fragment showing the `adminHttp` property
+[source,yaml]
+----
+# ... (filterDefinitions, virtualClusters etc)
+adminHttp:
+  host: 0.0.0.0 <1>
+  port: 9190 <2>
+  endpoints: # <3>
+    prometheus: {} # <4>
+----
+<1> The address the HTTP server should bind to. Defaults to `0.0.0.0`.
+<2> The port the HTTP server should bind to.
+<3> Control over the exposed endpoints
+<4> If present and not null, exposes a Prometheus scrape endpoint at path `/metrics`.
+

--- a/docs/modules/configuring/con-configuring-vc-client-tls.adoc
+++ b/docs/modules/configuring/con-configuring-vc-client-tls.adoc
@@ -22,8 +22,10 @@ NOTE: TLS is recommended on Kafka clients and virtual clusters for production co
 .Example applying a PKCS #12 server certificate to a virtual cluster
 [source,yaml]
 ----
+# ...
 virtualClusters:
   my-cluster-proxy:
+    # ...
     tls:
       key:
         storeFile: <path>/server.p12  # <1>             
@@ -33,6 +35,7 @@ virtualClusters:
           passwordFile: <path>/key.password # <3>       
         storeType: PKCS12 # <4>                            
       # ...
+# ...
 ----
 <1> PKCS #12 store containing the private-key and certificate/intermediates of the virtual cluster.
 <2> Password to protect the PKCS #12 store.
@@ -42,15 +45,17 @@ virtualClusters:
 .Example applying a PEM server certificate and key pair to a virtual cluster
 [source,yaml]
 ----
+# ...
 virtualClusters:
   my-cluster-proxy:
+    # ...
     tls:
       key:
         privateKeyFile: <path>/server.key   # <1>       
         certificateFile: <path>/server.crt # <2> 
         keyPassword:
           passwordFile: <path>/key.password # <3>
-# …
+# ...
 ----
 <1> Private key of the virtual cluster.
 <2> Public certificate of the virtual cluster.
@@ -63,8 +68,10 @@ If verification fails, the client's connection is refused.
 .Example applying TLS client authentication using a PKCS #12 truststore
 [source,yaml]
 ----
+# ...
 virtualClusters:
   demo:
+    # ...
     tls:
       key:
         # ...
@@ -75,7 +82,7 @@ virtualClusters:
         storeType: PKCS12 # <3>
         trustOptions:
           clientAuth: REQUIRED # <4>
-# …
+# ...
 ----
 <1> PKCS #12 store containing CA certificate(s) used to verify that the client's certificate is trusted.
 <2> (Optional) Password to protect the PKCS #12 store.

--- a/docs/modules/configuring/con-configuring-vc-network-addresses.adoc
+++ b/docs/modules/configuring/con-configuring-vc-network-addresses.adoc
@@ -1,8 +1,8 @@
 [id='con-configuring-network-addresses-{context}']
-= Configuring network addresses
+= Configuring virtual cluster network addresses
 
 [role="_abstract"]
-Virtual cluster configuration requires a network address configuration provider that manages network communication and provides broker address information to clients.
+Virtual cluster configuration requires a network address configuration provider that determines how the brokers in the Kafka cluster are presented to clients in terms of broker ids, hostnames, and ports.
 
 Kroxylicious has the following built-in providers:
 
@@ -24,18 +24,25 @@ Ideally, the target cluster should have sequential, stable broker IDs and a know
 
 The provider supports both cleartext and TLS downstream connections.
 
+[id='con-networkAddressProvider-{context}']
 .Example broker address configuration
 [source,yaml]
 ----
-clusterNetworkAddressConfigProvider:
-  type: PortPerBrokerClusterNetworkAddressConfigProvider
-  config:
-    bootstrapAddress: mycluster.kafka.com:9192 # <1>                
-    brokerAddressPattern: mybroker-$(nodeId).mycluster.kafka.com # <2>
-    brokerStartPort: 9193 # <3>                                    
-    numberOfBrokerPorts: 3 # <4>   
-    lowestTargetBrokerId: 1000 # <5>                                 
-    bindAddress: 192.168.0.1 # <6>
+# ...
+virtualClusters:
+  my-cluster-proxy:
+    # ...
+    clusterNetworkAddressConfigProvider:
+      type: PortPerBrokerClusterNetworkAddressConfigProvider
+      config:
+        bootstrapAddress: mycluster.kafka.com:9192 # <1>
+        brokerAddressPattern: mybroker-$(nodeId).mycluster.kafka.com # <2>
+        brokerStartPort: 9193 # <3>
+        numberOfBrokerPorts: 3 # <4>
+        lowestTargetBrokerId: 1000 # <5>
+        bindAddress: 192.168.0.1 # <6>
+    # ...
+# ...
 ----
 <1> The hostname and port of the bootstrap address used by Kafka clients.
 <2> (Optional) The broker address pattern used to form broker addresses. If not defined, it defaults to the hostname part of the bootstrap address and the port number allocated to the broker. 
@@ -78,19 +85,25 @@ This ensures a deterministic mapping of node IDs to ports while minimizing the n
 .Example node ID ranges configuration
 [source, yaml]
 ----
-clusterNetworkAddressConfigProvider:
-  type: RangeAwarePortPerNodeClusterNetworkAddressConfigProvider
-  config:
-    bootstrapAddress: mycluster.kafka.com:9192
-    brokerAddressPattern: mybroker-$(nodeId).mycluster.kafka.com
-    brokerStartPort: 9193
-    nodeIdRanges: # <1>
-      - name: brokers # <2>
-        range:
-          startInclusive: 0 # <3>
-          endExclusive: 3 # <4>
+# ...
+virtualClusters:
+  my-cluster-proxy:
+    # ...
+    clusterNetworkAddressConfigProvider:
+      type: RangeAwarePortPerNodeClusterNetworkAddressConfigProvider
+      config:
+        bootstrapAddress: mycluster.kafka.com:9192
+        brokerAddressPattern: mybroker-$(nodeId).mycluster.kafka.com
+        brokerStartPort: 9193
+        nodeIdRanges: # <1>
+          - name: brokers # <2>
+            range:
+              startInclusive: 0 # <3>
+              endExclusive: 3 # <4>
+    # ...
+# ...
 ----
-<1> The list of Node ID ranges, which must be non-empty.
+<1> The list of Node ID ranges, which must not be empty.
 <2> The name of the range, which must be unique within the `nodeIdRanges` list.
 <3> The start of the range (inclusive).
 <4> The end of the range (exclusive). It must be greater than `startInclusive`; empty ranges are not allowed.
@@ -113,6 +126,10 @@ This can be modeled as three node ID ranges, as shown in the following example.
 .Example node ID ranges configuration with KRaft roles
 [source, yaml]
 ----
+# ...
+virtualClusters:
+  my-cluster-proxy:
+    # ...
     clusterNetworkAddressConfigProvider:
       type: RangeAwarePortPerNodeClusterNetworkAddressConfigProvider
       config:
@@ -130,6 +147,8 @@ This can be modeled as three node ID ranges, as shown in the following example.
             range:
               startInclusive: 99999
               endExclusive: 100000
+    # ...
+# ...
 ----
 
 This configuration results in the following mapping from node ID to port:
@@ -151,12 +170,18 @@ The SNI routing provider uses SNI information to determine where to route the tr
 .Example SNI routing address provider configuration
 [source,yaml]
 ----
-clusterNetworkAddressConfigProvider:
-  type: SniRoutingClusterNetworkAddressConfigProvider
-  config:
-    bootstrapAddress: mycluster.kafka.com:9192 # <1>                 
-    advertisedBrokerAddressPattern: mybroker-$(nodeId).mycluster.kafka.com  
-    bindAddress: 192.168.0.1
+# ...
+virtualClusters:
+  my-cluster-proxy:
+    # ...
+    clusterNetworkAddressConfigProvider:
+      type: SniRoutingClusterNetworkAddressConfigProvider
+      config:
+        bootstrapAddress: mycluster.kafka.com:9192 # <1>
+        brokerAddressPattern: mybroker-$(nodeId).mycluster.kafka.com
+        bindAddress: 192.168.0.1
+    # ...
+# ...
 ----
 <1> A single address for all traffic, including bootstrap address and brokers.
                                       

--- a/docs/modules/configuring/con-configuring-vc-other-settings.adoc
+++ b/docs/modules/configuring/con-configuring-vc-other-settings.adoc
@@ -1,0 +1,25 @@
+[id='ref-configuring-vc-other-settings-{context}']
+= Configuring other Virtual Cluster settings
+
+== Per-virtual cluster logging
+
+You can enable low level logging on a per-virtual cluster basis.
+The `logNetwork` property controls logging of information about requests and responses at the network level, before they've been decoded into Kafka requests and responses.
+The `logFrames` property controls logging of the decoded requests and responses.
+
+
+[id='con-configuring-vc-logging-{context}']
+.Configuration fragment showing logging properties
+[source,yaml]
+----
+# ...
+virtualClusters:
+  my-cluster-proxy:
+    # ...
+    logNetwork: true <1>
+    logFrames: true <2>
+    # ...
+----
+<1> Enables low-level network logging for the virtual cluster.
+<2> Enables low-level protocol frame logging for the virtual cluster.
+

--- a/docs/modules/configuring/con-configuring-vc-target-tls.adoc
+++ b/docs/modules/configuring/con-configuring-vc-target-tls.adoc
@@ -22,12 +22,14 @@ certificate signed by a public CA and the platform's defaults are suitable.
 .Example enabling TLS for a target cluster using platform defaults
 [source,yaml]
 ----
+# ...
 virtualClusters:
   my-cluster-proxy:
+    # ...
     targetCluster:
       bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
-      tls: {}                                         
-      #...
+      tls: {}
+# ...
 ----
 
 If it is using a TLS certificate signed by a private CA, you must add truststore configuration for the target cluster.
@@ -36,8 +38,10 @@ The example illustrates using PKCS #12 format. PEM format is supported too.
 .Example specifying a truststore
 [source,yaml]
 ----
+# ...
 virtualClusters:
   my-cluster-proxy:
+    # ...
     targetCluster:
       bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
       tls:
@@ -45,8 +49,8 @@ virtualClusters:
           storeFile: <path>/trust.p12 # <1>                
           storePassword:
             passwordFile: <path>/store.password # <2>    
-          storeType: PKCS12 # <3>                             
-      #...
+          storeType: PKCS12 # <3>
+# ...
 ----
 <1> PKCS #12 store for the public CA certificate of the Kafka cluster.
 <2> Password to access the public Kafka cluster CA certificate.
@@ -59,8 +63,10 @@ PKCS #12 keystore format is supported too.
 .Example configuring mutual TLS
 [source,yaml]
 ----
+# ...
 virtualClusters:
   my-cluster-proxy:
+    # ...
     targetCluster:
       bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
       tls:
@@ -77,8 +83,10 @@ The TLS protocols and cipher suites available to the TLS connection may also be 
 .Example restricting TLS protocols using an allow list
 [source,yaml]
 ----
+# ...
 virtualClusters:
   my-cluster-proxy:
+    # ...
     targetCluster:
       bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
       tls:
@@ -153,6 +161,6 @@ virtualClusters:
       bootstrapServers: dev-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
       tls:
         trust:
-          insecure: true                                
-      #...
+          insecure: true
+# ...
 ----

--- a/docs/modules/configuring/ref-configuring-proxy-example.adoc
+++ b/docs/modules/configuring/ref-configuring-proxy-example.adoc
@@ -1,9 +1,6 @@
 [id='ref-configuring-proxy-example-{context}']
 = Example Kroxylicious configuration
 
-[role="_abstract"]
-The following example shows essential Kroxylicious configuration to specify the following:
-
 * Virtual clusters that represent the Kafka clusters
 * Network addresses for broker communication in a Kafka cluster
 * Filters to introduce additional functionality to the Kafka deployment
@@ -14,61 +11,58 @@ In this example, configuration for the Record Encryption filter is shown.
 .Example Kroxylicious configuration
 [source,yaml]
 ----
-adminHttp: # <1>
-      endpoints:
-        prometheus: {}
-    virtualClusters: # <2>
-      my-cluster-proxy: # <3>
-        targetCluster:
-          bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093 # <4>
-          tls: # <5>
-            trust:
-              storeFile: /opt/proxy/trust/ca.p12
-              storePassword:
-                passwordFile: /opt/proxy/trust/ca.password
-        clusterNetworkAddressConfigProvider: # <6>
-          type: SniRoutingClusterNetworkAddressConfigProvider # <7>
-          Config:
-            bootstrapAddress: my-cluster-proxy.kafka:9092 # <8>
-            advertisedBrokerAddressPattern: broker$(nodeId).my-cluster-proxy.kafka
-        logNetwork: false # <9>
-        logFrames: false
-        tls: # <10>
-          key:
-            storeFile: /opt/proxy/server/key-material/keystore.p12
-            storePassword:
-              passwordFile: /opt/proxy/server/keystore-password/storePassword
-filters: # <11>
-  - type: RecordEncryption # <12>
-    config: # <13>
+filterDefinitions: # <1>
+  - name: encryption
+    type: RecordEncryption # <2>
+    config: # <3>
       kms: VaultKmsService
       kmsConfig:
         vaultTransitEngineUrl: https://vault.vault.svc.cluster.local:8200/v1/transit
         vaultToken:
           passwordFile: /opt/proxy/server/token.txt
-        tls: # <14>
+        tls: # <4>
           key:
             storeFile: /opt/cert/server.p12
             storePassword:
               passwordFile: /opt/cert/store.password
             keyPassword:
               passwordFile: /opt/cert/key.password
-            storeType: PKCS12    
+            storeType: PKCS12
       selector: TemplateKekSelector
       selectorConfig:
-        template: "${topicName}"    
+        template: "${topicName}"
+defaultFilters:
+  - encryption
+virtualClusters: # <5>
+  my-cluster-proxy: # <6>
+    targetCluster:
+      bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093 # <7>
+      tls: # <8>
+        trust:
+          storeFile: /opt/proxy/trust/ca.p12
+          storePassword:
+            passwordFile: /opt/proxy/trust/ca.password
+    clusterNetworkAddressConfigProvider: # <9>
+      type: SniRoutingClusterNetworkAddressConfigProvider # <10>
+      config:
+        bootstrapAddress: my-cluster-proxy.kafka:9092 # <11>
+        advertisedBrokerAddressPattern: broker$(nodeId).my-cluster-proxy.kafka
+    tls: # <12>
+      key:
+        storeFile: /opt/proxy/server/key-material/keystore.p12
+        storePassword:
+          passwordFile: /opt/proxy/server/keystore-password/storePassword
 ----
-<1> Enables metrics for the proxy.
-<2> Virtual cluster configuration.
-<3> The name of the virtual cluster.
-<4> The bootstrap address of the target physical Kafka Cluster being proxied.
-<5> TLS configuration for the connection to the target cluster.
-<6> The configuration for the cluster network address configuration provider that controls how the virtual cluster is presented to the network.
-<7> The built-in types are `PortPerBrokerClusterNetworkAddressConfigProvider` and `SniRoutingClusterNetworkAddressConfigProvider`.
-<8> The hostname and port of the bootstrap used by the Kafka clients. The hostname must be resolved by the clients.
-<9> Logging is disabled by default. Enable logging related to network activity (`logNetwork`) and messages (`logFrames`) by setting the logging properties to `true`.
-<10> TLS encryption for securing connections with the clients.
-<11> Filter configuration.
-<12> The type of filter, which is the Record Encryption filter using Vault as the KMS in this example.
-<13> The configuration specific to the type of filter.
-<14> If required, you can also specify the credentials for TLS authentication with the KMS, with key names under which TLS certificates are stored.
+<1> A list of named filter configurations.
+<2> The type of filter, which is the Record Encryption filter using Vault as the KMS in this example.
+<3> The configuration specific to the type of filter.
+<4> If required, you can also specify the credentials for TLS authentication with the KMS, with key names under which TLS certificates are stored.
+<5> Virtual cluster configuration.
+<6> The name of the virtual cluster.
+<7> The bootstrap address of the target physical Kafka Cluster being proxied.
+<8> TLS configuration for the connection to the target cluster.
+<9> The configuration for the cluster network address configuration provider that controls how the virtual cluster is presented to the network.
+<10> The built-in network address configuration provider types are `PortPerBrokerClusterNetworkAddressConfigProvider` and `SniRoutingClusterNetworkAddressConfigProvider`.
+<11> The hostname and port of the bootstrap used by the Kafka clients. The hostname must be resolved by the clients.
+<12> TLS encryption for securing connections with the clients.
+


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This is the documentation changes for #1709. 

### Additional Context

I've also taken the liberty of rejigging the rest of the configuration section with the aim of making it more comprehensible. I've done this by introducing the overall structure first, with the following sections each expanding on part of it, and also by changing the order of presentation (I think it's more natural to introduce the virtual cluster networking before trying to explain how to add TLS for client or server, for example).

