### PR TITLE
fix issue with docker hub for Vault and LocalStack

### DIFF
--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
@@ -11,166 +11,169 @@ import java.time.Duration;
 /**
  * The interface Constants.
  */
-public interface Constants {
+public final class Constants {
     /**
      * The deployment name for kroxylicous
      */
-    String KROXY_DEPLOYMENT_NAME = "kroxylicious-proxy";
+    public static final String KROXY_DEPLOYMENT_NAME = "kroxylicious-proxy";
     /**
      * The service name for kroxylicious. Used for the bootstrap url
      */
-    String KROXY_SERVICE_NAME = "kroxylicious-service";
+    public static final String KROXY_SERVICE_NAME = "kroxylicious-service";
     /**
      * The constant KROXY_CONFIG_NAME.
      */
-    String KROXY_CONFIG_NAME = "kroxylicious-config";
+    public static final String KROXY_CONFIG_NAME = "kroxylicious-config";
     /**
      * Strimzi cluster operator deployment name
      */
-    String STRIMZI_DEPLOYMENT_NAME = "strimzi-cluster-operator";
+    public static final String STRIMZI_DEPLOYMENT_NAME = "strimzi-cluster-operator";
     /**
      * The default namespace used for kubernetes deployment
      */
-    String KAFKA_DEFAULT_NAMESPACE = "kafka";
+    public static final String KAFKA_DEFAULT_NAMESPACE = "kafka";
 
     /**
      * The cert-manager namespace for kubernetes deployment
      */
-    String CERT_MANAGER_NAMESPACE = "cert-manager";
+    public static final String CERT_MANAGER_NAMESPACE = "cert-manager";
 
     /**
      * API versions of Strimzi CustomResources
      */
-    String KAFKA_API_VERSION_V1BETA2 = "kafka.strimzi.io/v1beta2";
+    public static final String KAFKA_API_VERSION_V1BETA2 = "kafka.strimzi.io/v1beta2";
 
     /**
      * Kind of Strimzi CustomResources
      */
-    String KAFKA_KIND = "Kafka";
+    public static final String KAFKA_KIND = "Kafka";
 
     /**
      * Kind of kafka users
      */
-    String KAFKA_USER_KIND = "KafkaUser";
+    public static final String KAFKA_USER_KIND = "KafkaUser";
     /**
      * Kind of kafka node pools
      */
-    String KAFKA_NODE_POOL_KIND = "KafkaNodePool";
+    public static final String KAFKA_NODE_POOL_KIND = "KafkaNodePool";
     /**
      * Kind of pods
      */
-    String POD_KIND = "Pod";
+    public static final String POD_KIND = "Pod";
 
     /**
      * Kind of config maps
      */
-    String CONFIG_MAP_KIND = "ConfigMap";
+    public static final String CONFIG_MAP_KIND = "ConfigMap";
 
     /**
      * Kind of jobs
      */
-    String JOB = "Job";
+    public static final String JOB = "Job";
 
     /**
      * Kind of services
      */
-    String SERVICE_KIND = "Service";
+    public static final String SERVICE_KIND = "Service";
 
     /**
      * Kind of secret
      */
-    String SECRET_KIND = "Secret";
+    public static final String SECRET_KIND = "Secret";
 
     /**
      * Load balancer type name.
      */
-    String LOAD_BALANCER_TYPE = "LoadBalancer";
+    public static final String LOAD_BALANCER_TYPE = "LoadBalancer";
 
     /**
      * Listener names for Kafka cluster
      */
-    String PLAIN_LISTENER_NAME = "plain";
+    public static final String PLAIN_LISTENER_NAME = "plain";
     /**
      * Listener name for tls
      */
-    String TLS_LISTENER_NAME = "tls";
+    public static final String TLS_LISTENER_NAME = "tls";
 
     /**
      * Strimzi related labels and annotations
      */
-    String STRIMZI_DOMAIN = "strimzi.io/";
+    public static final String STRIMZI_DOMAIN = "strimzi.io/";
     /**
      * Strimzi cluster label
      */
-    String STRIMZI_CLUSTER_LABEL = STRIMZI_DOMAIN + "cluster";
+    public static final String STRIMZI_CLUSTER_LABEL = STRIMZI_DOMAIN + "cluster";
 
     /**
      * Polls and timeouts constants
      */
-    Duration POLL_INTERVAL_FOR_RESOURCE_READINESS = Duration.ofSeconds(2);
+    public static final Duration POLL_INTERVAL_FOR_RESOURCE_READINESS = Duration.ofSeconds(2);
     /**
      * Poll interval for resource deletion
      */
-    Duration POLL_INTERVAL_FOR_RESOURCE_DELETION = Duration.ofSeconds(1);
+    public static final Duration POLL_INTERVAL_FOR_RESOURCE_DELETION = Duration.ofSeconds(1);
 
     /**
      * Global timeout
      */
-    Duration GLOBAL_TIMEOUT = Duration.ofMinutes(5);
+    public static final Duration GLOBAL_TIMEOUT = Duration.ofMinutes(5);
     /**
      * Global Poll interval
      */
-    Duration GLOBAL_POLL_INTERVAL = Duration.ofSeconds(1);
-    Duration RECONCILIATION_INTERVAL = Duration.ofSeconds(30);
-    Duration GLOBAL_POLL_INTERVAL_MEDIUM = Duration.ofSeconds(10);
-    Duration GLOBAL_STATUS_TIMEOUT = Duration.ofMinutes(3);
-    Duration GLOBAL_TIMEOUT_SHORT = Duration.ofMinutes(2);
+    public static final Duration GLOBAL_POLL_INTERVAL = Duration.ofSeconds(1);
+    public static final Duration RECONCILIATION_INTERVAL = Duration.ofSeconds(30);
+    public static final Duration GLOBAL_POLL_INTERVAL_MEDIUM = Duration.ofSeconds(10);
+    public static final Duration GLOBAL_STATUS_TIMEOUT = Duration.ofMinutes(3);
+    public static final Duration GLOBAL_TIMEOUT_SHORT = Duration.ofMinutes(2);
 
     /**
      * Kubernetes related constants
      */
-    String DEPLOYMENT = "Deployment";
+    public static final String DEPLOYMENT = "Deployment";
 
     /**
      * Test clients image url
      */
-    String TEST_CLIENTS_IMAGE = "quay.io/strimzi-test-clients/test-clients:latest-kafka-" + Environment.KAFKA_VERSION;
-    String KCAT_CLIENT_IMAGE = "quay.io/kroxylicious/kcat:1.7.1";
-    String KAF_CLIENT_IMAGE = "quay.io/kroxylicious/kaf:v0.2.7";
+    public static final String TEST_CLIENTS_IMAGE = "quay.io/strimzi-test-clients/test-clients:latest-kafka-" + Environment.KAFKA_VERSION;
+    public static final String KCAT_CLIENT_IMAGE = "quay.io/kroxylicious/kcat:1.7.1";
+    public static final String KAF_CLIENT_IMAGE = "quay.io/kroxylicious/kaf:v0.2.7";
 
     /**
      * The cert manager url to install it on kubernetes
      */
-    String CERT_MANAGER_URL = "https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml";
+    public static final String CERT_MANAGER_URL = "https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml";
     /**
      * kafka consumer client label to identify the consumer test client
      */
-    String KAFKA_CONSUMER_CLIENT_LABEL = "kafka-consumer-client";
+    public static final String KAFKA_CONSUMER_CLIENT_LABEL = "kafka-consumer-client";
     /**
      * kafka producer client label to identify the producer test client
      */
-    String KAFKA_PRODUCER_CLIENT_LABEL = "kafka-producer-client";
+    public static final String KAFKA_PRODUCER_CLIENT_LABEL = "kafka-producer-client";
     /**
      * kafka admin client label to identify the admin test client
      */
-    String KAFKA_ADMIN_CLIENT_LABEL = "admin-client-cli";
+    public static final String KAFKA_ADMIN_CLIENT_LABEL = "admin-client-cli";
     /**
      * Image pull policies
      */
-    String PULL_IMAGE_IF_NOT_PRESENT = "IfNotPresent";
-    String PULL_IMAGE_ALWAYS = "Always";
+    public static final String PULL_IMAGE_IF_NOT_PRESENT = "IfNotPresent";
+    public static final String PULL_IMAGE_ALWAYS = "Always";
 
     /**
      * Restart policies
      */
-    String RESTART_POLICY_ONFAILURE = "OnFailure";
-    String RESTART_POLICY_NEVER = "Never";
+    public static final String RESTART_POLICY_ONFAILURE = "OnFailure";
+    public static final String RESTART_POLICY_NEVER = "Never";
 
     /**
      * Scraper pod labels
      */
-    String SCRAPER_LABEL_KEY = "user-test-app";
-    String SCRAPER_LABEL_VALUE = "scraper";
-    String SCRAPER_NAME = "Scraper";
-    String DEPLOYMENT_TYPE_LABEL_KEY = "deployment-type";
+    public static final String SCRAPER_LABEL_KEY = "user-test-app";
+    public static final String SCRAPER_LABEL_VALUE = "scraper";
+    public static final String SCRAPER_NAME = "Scraper";
+    public static final String DEPLOYMENT_TYPE_LABEL_KEY = "deployment-type";
+
+    public static final String DOCKER_REGISTRY_AWS_MIRROR = "public.ecr.aws/docker";
+    public static final String DOCKER_REGISTRY_GCR_MIRROR = "mirror.gcr.io";
 }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kms/aws/LocalStack.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kms/aws/LocalStack.java
@@ -13,6 +13,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.Optional;
 
 import org.slf4j.Logger;
@@ -20,6 +21,7 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.kroxylicious.systemtests.Constants;
 import io.kroxylicious.systemtests.Environment;
 import io.kroxylicious.systemtests.resources.manager.ResourceManager;
 import io.kroxylicious.systemtests.utils.DeploymentUtils;
@@ -98,7 +100,7 @@ public class LocalStack implements AwsKmsClient {
         ResourceManager.helmClient().namespace(deploymentNamespace).install(LOCALSTACK_HELM_CHART_NAME, LOCALSTACK_SERVICE_NAME,
                 Optional.of(Environment.AWS_LOCALSTACK_CHART_VERSION),
                 Optional.of(Path.of(TestUtils.getResourcesURI("helm_localstack_overrides.yaml"))),
-                Optional.empty());
+                Optional.of(Map.of("image.repository", Constants.DOCKER_REGISTRY_GCR_MIRROR + "/" + LOCALSTACK_HELM_CHART_NAME)));
     }
 
     @Override

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kms/vault/Vault.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kms/vault/Vault.java
@@ -19,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import io.fabric8.openshift.api.model.operator.v1.IngressControllerList;
 import io.fabric8.openshift.client.OpenShiftClient;
 
+import io.kroxylicious.systemtests.Constants;
 import io.kroxylicious.systemtests.Environment;
 import io.kroxylicious.systemtests.executor.ExecResult;
 import io.kroxylicious.systemtests.k8s.exception.KubeClusterException;
@@ -107,7 +108,8 @@ public class Vault {
         ResourceManager.helmClient().namespace(deploymentNamespace).install(VAULT_HELM_CHART_NAME, VAULT_SERVICE_NAME,
                 Optional.of(Environment.VAULT_CHART_VERSION),
                 Optional.of(Path.of(TestUtils.getResourcesURI("helm_vault_overrides.yaml"))),
-                Optional.of(Map.of("server.dev.devRootToken", vaultRootToken,
+                Optional.of(Map.of("image.repository", Constants.DOCKER_REGISTRY_GCR_MIRROR + "/" + VAULT_HELM_CHART_NAME,
+                        "server.dev.devRootToken", vaultRootToken,
                         "global.openshift", String.valueOf(openshiftCluster),
                         "server.route.enabled", String.valueOf(openshiftCluster),
                         "server.route.host", VAULT_SERVICE_NAME + "." + getIngressDomain(openshiftCluster),


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Since the access to DockerHub has been revoked, we need to get the LocalStack and Vault images from a mirror. I have selected GCP mirror due the images are not available in public ECR.

### Checklist

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
