### PR TITLE
Add kubernetes example demonstrating in-cluster SNI access using services

### DIFF
--- a/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/README.md
+++ b/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/README.md
@@ -1,0 +1,7 @@
+# SNI Networking Scheme with Kubernetes ClusterIP Services
+
+This examples illustrates Kroxylicious's SNI networking scheme exposed with a kubernetes cluster using
+ClusterIP services. Note that we need to use a set of services, one for each broker and our convenience
+bootstrap service.
+
+We use [cert-manager](https://cert-manager.io) to configure these services as SANs (Service Alternate Name) in the proxy certificate.

--- a/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/base/kafka/kafka-persistent.yaml
+++ b/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/base/kafka/kafka-persistent.yaml
@@ -1,0 +1,47 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: dual-role
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 3
+  roles:
+    - controller
+    - broker
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 10Gi
+        deleteClaim: false
+        kraftMetadata: shared
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: my-cluster
+  annotations:
+    strimzi.io/node-pools: enabled
+    strimzi.io/kraft: enabled
+spec:
+  kafka:
+    listeners:
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+    config:
+      offsets.topic.replication.factor: 2
+      transaction.state.log.replication.factor: 2
+      transaction.state.log.min.isr: 2
+      default.replication.factor: 2
+      min.insync.replicas: 2

--- a/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/base/kafka/kustomization.yaml
+++ b/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/base/kafka/kustomization.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kafka
+
+resources:
+- kafka-persistent.yaml
+

--- a/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/base/kroxylicious/kroxylicious-config.yaml
+++ b/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/base/kroxylicious/kroxylicious-config.yaml
@@ -1,0 +1,37 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kroxylicious-config
+data:
+  config.yaml: |
+    adminHttp:
+      endpoints:
+        prometheus: {}
+    virtualClusters:
+      my-cluster-proxy:
+        targetCluster:
+          bootstrap_servers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
+          tls:
+            trust:
+              storeFile: /opt/kroxylicious/trust/ca.p12
+              storePassword:
+                passwordFile: /opt/kroxylicious/trust/ca.password
+        clusterNetworkAddressConfigProvider:
+          type: SniRoutingClusterNetworkAddressConfigProvider
+          config:
+            bootstrapAddress: my-cluster-proxy.kroxylicious:9092
+            brokerAddressPattern: my-cluster-proxy-broker-$(nodeId).kroxylicious
+        logNetwork: false
+        logFrames: false
+        tls:
+          key:
+            storeFile: /opt/kroxylicious/server/key-material/keystore.p12
+            storePassword:
+              passwordFile: /opt/kroxylicious/server/keystore-password/storePassword

--- a/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/base/kroxylicious/kroxylicious-deployment.yaml
+++ b/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/base/kroxylicious/kroxylicious-deployment.yaml
@@ -1,0 +1,58 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kroxylicious-proxy
+  labels:
+    app: kroxylicious
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kroxylicious
+  template:
+    metadata:
+      labels:
+        app: kroxylicious
+    spec:
+      containers:
+      - name: kroxylicious
+        image: quay.io/kroxylicious/kroxylicious:0.10.0-SNAPSHOT
+        imagePullPolicy: Always
+        args: ["--config", "/opt/kroxylicious/config/config.yaml"]
+        ports:
+        - containerPort: 9190
+          name: metrics
+        - containerPort: 9092
+        volumeMounts:
+        - name: config-volume
+          mountPath: /opt/kroxylicious/config/config.yaml
+          subPath: config.yaml
+        - name: kafka-cluster-ca-cert
+          readOnly: true
+          mountPath: /opt/kroxylicious/trust
+        - name: kroxy-server-key-material-volume
+          readOnly: true
+          mountPath: /opt/kroxylicious/server/key-material
+        - name: kroxy-server-keystore-password-volume
+          readOnly: true
+          mountPath: /opt/kroxylicious/server/keystore-password
+      volumes:
+      - name: config-volume
+        configMap:
+          name: kroxylicious-config
+      - name: kafka-cluster-ca-cert
+        secret:
+          secretName: my-cluster-cluster-ca-cert
+      - name: kroxy-server-key-material-volume
+        secret:
+          secretName: kroxy-server-key-material
+      - name: kroxy-server-keystore-password-volume
+        secret:
+          secretName: kroxy-server-keystore-password

--- a/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/base/kroxylicious/kroxylicious-namespace.yaml
+++ b/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/base/kroxylicious/kroxylicious-namespace.yaml
@@ -1,0 +1,10 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kroxylicious

--- a/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/base/kroxylicious/kroxylicious-service.yaml
+++ b/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/base/kroxylicious/kroxylicious-service.yaml
@@ -1,0 +1,62 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-cluster-proxy
+spec:
+  selector:
+    app: kroxylicious
+  type: ClusterIP
+  ports:
+  - name: port-9092
+    protocol: TCP
+    port: 9092
+    targetPort: 9092
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-cluster-proxy-broker-0
+spec:
+  selector:
+    app: kroxylicious
+  type: ClusterIP
+  ports:
+  - name: port-9092
+    protocol: TCP
+    port: 9092
+    targetPort: 9092
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-cluster-proxy-broker-1
+spec:
+  selector:
+    app: kroxylicious
+  type: ClusterIP
+  ports:
+  - name: port-9092
+    protocol: TCP
+    port: 9092
+    targetPort: 9092
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-cluster-proxy-broker-2
+spec:
+  selector:
+    app: kroxylicious
+  type: ClusterIP
+  ports:
+  - name: port-9092
+    protocol: TCP
+    port: 9092
+    targetPort: 9092

--- a/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/base/kroxylicious/kustomization.yaml
+++ b/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/base/kroxylicious/kustomization.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kroxylicious
+
+resources:
+- kroxylicious-namespace.yaml
+- kroxylicious-config.yaml
+- kroxylicious-deployment.yaml
+- kroxylicious-service.yaml
+

--- a/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/base/kustomization.yaml
+++ b/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/base/kustomization.yaml
@@ -1,0 +1,14 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- kroxylicious
+- kafka
+

--- a/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/overlays/minikube/kroxylicious/kroxy-server-keystore-password.yaml
+++ b/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/overlays/minikube/kroxylicious/kroxy-server-keystore-password.yaml
@@ -1,0 +1,13 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kroxy-server-keystore-password
+stringData:
+  storePassword: "password123"

--- a/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/overlays/minikube/kroxylicious/kustomization.yaml
+++ b/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/overlays/minikube/kroxylicious/kustomization.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kroxylicious
+
+resources:
+- self-signed-issuer.yaml
+- server-certificate.yaml
+- kroxy-server-keystore-password.yaml

--- a/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/overlays/minikube/kroxylicious/self-signed-issuer.yaml
+++ b/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/overlays/minikube/kroxylicious/self-signed-issuer.yaml
@@ -1,0 +1,13 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}

--- a/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/overlays/minikube/kroxylicious/server-certificate.yaml
+++ b/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/overlays/minikube/kroxylicious/server-certificate.yaml
@@ -1,0 +1,38 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: server-certificate
+spec:
+  isCA: true
+  commonName: mycluster-proxy.kafka
+  secretName: kroxy-server-key-material
+  privateKey:
+    algorithm: RSA
+    size: 4096
+    # Note the cert-manager default is PKCS1. The tls.key generated won't work with Kroxylicious unless you put
+    # Bouncy Castle in the classpath.  PKCS8 works without the classpath addition.
+    encoding: PKCS8
+  keystores:
+   pkcs12:
+     create: true
+     passwordSecretRef:
+       name: kroxy-server-keystore-password
+       key: storePassword
+  dnsNames:
+    - my-cluster-proxy.kroxylicious
+    - my-cluster-proxy-broker-0.kroxylicious
+    - my-cluster-proxy-broker-1.kroxylicious
+    - my-cluster-proxy-broker-2.kroxylicious
+  usages:
+    - server auth
+  issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io

--- a/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/overlays/minikube/kustomization.yaml
+++ b/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/overlays/minikube/kustomization.yaml
@@ -1,0 +1,12 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+- kroxylicious

--- a/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/postinstall.sh
+++ b/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/postinstall.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+set -eo pipefail
+
+echo "to produce run:"
+echo 'kubectl exec -it -nkafka my-cluster-dual-role-0 -- bash -c "echo $(kubectl get secret -n kroxylicious kroxy-server-key-material -o json | jq -r ".data.\"tls.crt\"") | base64 -d > /tmp/certo && ./bin/kafka-console-producer.sh --bootstrap-server my-cluster-proxy.kroxylicious:9092 --topic my-topic --producer-property ssl.truststore.type=PEM --producer-property security.protocol=SSL --producer-property ssl.truststore.location=/tmp/certo"'
+echo "to consume run:"
+echo 'kubectl exec -it -nkafka my-cluster-dual-role-0 -- bash -c "echo $(kubectl get secret -n kroxylicious kroxy-server-key-material -o json | jq -r ".data.\"tls.crt\"") | base64 -d > /tmp/certo && ./bin/kafka-console-consumer.sh --bootstrap-server my-cluster-proxy.kroxylicious:9092 --topic my-topic --from-beginning --consumer-property ssl.truststore.type=PEM --consumer-property security.protocol=SSL --consumer-property ssl.truststore.location=/tmp/certo"'


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Add kubernetes example demonstrating in-cluster SNI access using kubernetes services.

With this technique we need to create a k8s Service for the bootstrap, and a k8s Service for every kafka broker id in the target cluster and ensure that the services are in the VirtualCluster's certificate's SAN list.

### Additional Context

#1683 hit on the problem that with our existing SNI example, in-cluster access isn't possible. You need external DNS and a LoadBalancer Service to access the proxy. Users will also want/need a way to access the proxy from the same k8s cluster. This technique is one way to achieve that.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
