### PR TITLE
Manually set RENOVATE_GIT_AUTHOR in renovate configuration

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,7 +1,29 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one or more
+#  contributor license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright ownership.
+#  The ASF licenses this file to You under the Apache License, Version 2.0
+#  (the "License"); you may not use this file except in compliance with
+#  the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
 name: Renovate
+
+# Renovates Kroxylicious - current scope is to update container references in code.
+#
+# If secret `KROXYLICIOUS_GITHUB_READWRITE_TOKEN` is available, it will be used for the
+# interactions.  Otherwise, the action's initiator's token is used.
 on:
   schedule:
-    - cron: '0/30 * * * *'
+    - cron: '0 0/9 * * 1-5'
   workflow_dispatch:
 jobs:
   renovate:
@@ -20,4 +42,5 @@ jobs:
         env:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_ONBOARDING: "false"
+          RENOVATE_GIT_AUTHOR: "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
           LOG_LEVEL: debug


### PR DESCRIPTION

also reduced the frequency with which renovate runs.

### Type of change

_Select the type of your PR_

- Bugfix

### Description

why:  PR where being raised without signoffs.

why why:  renovatebot uses https://api.github.com/user/emails endpoint to determine the git author. However it seems it is not possible to permission that endpoint when using organizational fine grain tokens.


_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
