### PR TITLE
Draft: Operator in-cluster SNI-based exposition

### DIFF
--- a/kroxylicious-operator/examples/simple/01.self-signed-issuer.yaml
+++ b/kroxylicious-operator/examples/simple/01.self-signed-issuer.yaml
@@ -1,0 +1,14 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: my-proxy
+spec:
+  selfSigned: {}

--- a/kroxylicious-operator/examples/simple/02.server-certificate.yaml
+++ b/kroxylicious-operator/examples/simple/02.server-certificate.yaml
@@ -1,0 +1,33 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: server-certificate
+  namespace: my-proxy
+spec:
+  isCA: true
+  commonName: my-cluster-bootstrap.my-proxy.svc.cluster.local
+  secretName: kroxy-server-key-material
+  privateKey:
+    algorithm: RSA
+    size: 4096
+    # Note the cert-manager default is PKCS1. The tls.key generated won't work with Kroxylicious unless you put
+    # Bouncy Castle in the classpath.  PKCS8 works without the classpath addition.
+    encoding: PKCS8
+  dnsNames:
+    - my-cluster-bootstrap.my-proxy.svc.cluster.local
+    - my-cluster-broker-0.my-proxy.svc.cluster.local
+    - my-cluster-broker-1.my-proxy.svc.cluster.local
+    - my-cluster-broker-2.my-proxy.svc.cluster.local
+  usages:
+    - server auth
+  issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io

--- a/kroxylicious-operator/examples/simple/03.KafkaProxy.simple.yaml
+++ b/kroxylicious-operator/examples/simple/03.KafkaProxy.simple.yaml
@@ -11,8 +11,19 @@ metadata:
   name: simple
   namespace: my-proxy
 spec:
+  listeners:
+    - name: my-listener
+      port: 9092
+      protocol: kafka-tls
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: kroxy-server-key-material
   clusters:
     - name: "my-cluster"
       upstream:
         bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+      advertisedBrokers: [0, 1, 2, 3, 4] 
+      hostnames: 
+      - my-cluster-%.my-proxy.svc.cluster.local
       filters: []

--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -150,7 +150,24 @@
             <artifactId>kroxylicious-runtime</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <!-- This dep is because the operator uses the type safe API for generating proxy config
+                 it should be replaced with a dependency on some kind of runtime-config-api module -->
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
 
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ClusterService.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ClusterService.java
@@ -6,12 +6,10 @@
 package io.kroxylicious.kubernetes.operator;
 
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.Service;
@@ -40,92 +38,45 @@ public class ClusterService
         super(Service.class);
     }
 
-    /**
-     * @return The {@code metadata.name} of the desired {@code Service}.
-     */
-    static String serviceName(Clusters cluster) {
-        Objects.requireNonNull(cluster);
-        return cluster.getName();
-    }
-
-    /**
-     * @return the fully qualified service hostname
-     */
-    static String absoluteServiceHost(KafkaProxy primary, Clusters cluster) {
-        return serviceName(cluster) + "." + primary.getMetadata().getNamespace() + ".svc.cluster.local";
-    }
-
-    /**
-     * The inverse of {@link #serviceName(Clusters)}
-     * @param service A service
-     * @return  The name of the cluster corresponding to the given Service
-     */
-    static String clusterName(Service service) {
-        return service.getMetadata().getName();
-    }
-
-    static Map<Integer, String> clusterPorts(KafkaProxy primary, Context<KafkaProxy> context, Clusters cluster) {
-        var clusters = primary.getSpec().getClusters();
-        for (int clusterNum = 0; clusterNum < clusters.size(); clusterNum++) {
-            if (clusters.get(clusterNum).getName().equals(cluster.getName())) {
-                if (SharedKafkaProxyContext.isBroken(context, cluster)) {
-                    return Map.of();
-                }
-                int startPort = 9292 + (100 * clusterNum);
-                int numBrokerPorts = 4;
-                return IntStream.range(startPort, startPort + numBrokerPorts).boxed()
-                        .collect(Collectors.<Integer, Integer, String, TreeMap<Integer, String>> toMap(
-                                portNum -> portNum,
-                                portNum -> cluster.getName() + "-" + portNum,
-                                (v1, v2) -> {
-                                    throw new IllegalStateException();
-                                },
-                                TreeMap::new));
-            }
-        }
-        throw new IllegalArgumentException("Couldn't find cluster with name " + cluster.getName());
-    }
-
-    protected Service clusterService(KafkaProxy primary,
-                                     Context<KafkaProxy> context,
-                                     Clusters cluster) {
-        // @formatter:off
-        var serviceSpecBuilder = new ServiceBuilder()
-                .withNewMetadata()
-                    .withName(serviceName(cluster))
-                    .withNamespace(primary.getMetadata().getNamespace())
-                    .addToLabels(standardLabels(primary))
-                    .addNewOwnerReferenceLike(ResourcesUtil.ownerReferenceTo(primary)).endOwnerReference()
-                .endMetadata()
-                .withNewSpec()
-                    .withSelector(ProxyDeployment.podLabels());
-        for (var portNumEntry : clusterPorts(primary, context, cluster).entrySet()) {
-            serviceSpecBuilder = serviceSpecBuilder
-                    .addNewPort()
-                        .withName(portNumEntry.getValue())
-                        .withPort(portNumEntry.getKey())
-                        .withTargetPort(new IntOrString(portNumEntry.getKey()))
-                        .withProtocol("TCP")
-                    .endPort();
-        }
-
-        return serviceSpecBuilder
-                .endSpec()
-                .build();
-        // @formatter:on
-    }
-
     @Override
     public Map<String, Service> desiredResources(
                                                  KafkaProxy primary,
                                                  Context<KafkaProxy> context) {
         var clusters = ResourcesUtil.distinctClusters(primary);
-
         return clusters.stream()
                 .filter(cluster -> !SharedKafkaProxyContext.isBroken(context, cluster))
+                .flatMap(cluster -> servicesFor(cluster, primary))
                 .collect(Collectors.toMap(
-                        Clusters::getName,
-                        cluster -> clusterService(primary, context, cluster)));
+                        s -> s.getMetadata().getName(),
+                        s -> s));
+    }
+
+    private Stream<Service> servicesFor(Clusters cluster, KafkaProxy primary) {
+        ClusterSniExposition exposition = ClusterSniExposition.planExposition(primary, cluster);
+        return exposition.getExpositions().stream().sorted().flatMap(host -> servicesFor(host, primary));
+    }
+
+    private Stream<Service> servicesFor(ClusterSniExposition.HostnameExposition exposition, KafkaProxy primary) {
+        return exposition.services().stream().map(service -> {
+            var serviceSpecBuilder = new ServiceBuilder()
+                    .withNewMetadata()
+                    .withName(service.name())
+                    .withNamespace(primary.getMetadata().getNamespace())
+                    .addToLabels(standardLabels(primary))
+                    .addNewOwnerReferenceLike(ResourcesUtil.ownerReferenceTo(primary)).endOwnerReference()
+                    .endMetadata()
+                    .withNewSpec()
+                    .withType(service.type())
+                    .withSelector(ProxyDeployment.podLabels());
+            Integer port = exposition.listener().getPort();
+            serviceSpecBuilder.addNewPort()
+                    .withName("tls")
+                    .withPort(port)
+                    .withTargetPort(new IntOrString(port))
+                    .withProtocol("TCP")
+                    .endPort();
+            return serviceSpecBuilder.endSpec().build();
+        });
     }
 
     @Override
@@ -136,7 +87,7 @@ public class ClusterService
                 .getSecondaryResources(primary);
         return secondaryResources.stream()
                 .collect(Collectors.toMap(
-                        ClusterService::clusterName,
+                        (s) -> s.getMetadata().getName(), // TODO what should this map to? Used to be that service name == vcluster name, no longer
                         Function.identity()));
     }
 }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ClusterSniExposition.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ClusterSniExposition.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyspec.Clusters;
+import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyspec.Listeners;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static java.util.function.Function.identity;
+
+/**
+ * Calculates how to expose a cluster via SNI.
+ * For a listener + hostname combination we need to calculate the
+ * services to expose and the corresponding SNI hostname
+ */
+public final class ClusterSniExposition {
+    private final List<HostnameExposition> expositions;
+
+    /**
+     */
+    private ClusterSniExposition(List<HostnameExposition> expositions) {
+        this.expositions = expositions;
+    }
+
+    public static ClusterSniExposition planExposition(KafkaProxy proxy, Clusters cluster) {
+        Map<String, Listeners> namedListeners = proxy.getSpec().getListeners().stream().collect(Collectors.toMap(Listeners::getName, identity()));
+        List<HostnameExposition> expositions = cluster.getHostnames().stream().map(HostnamePattern::new).map(hostnamePattern -> {
+            // todo add parentRefs to cluster and lookup listener by name
+            Listeners listenerForHostname = namedListeners.values().stream().findFirst().get();
+            Stream<String> brokerServiceNames = cluster.getAdvertisedBrokers().stream().map(hostnamePattern::resolveBrokerServiceName);
+            Stream<String> bootstrapServiceNames = Stream.of(hostnamePattern.resolveBootstrapServiceName());
+            Stream<String> allServices = Stream.concat(bootstrapServiceNames, brokerServiceNames);
+            List<Service> serviceNames = allServices.map(name -> new Service(name, "ClusterIP")).toList();
+            return new HostnameExposition(listenerForHostname, hostnamePattern.bootstrapHostname(), hostnamePattern.brokerPattern(), serviceNames);
+        }).toList();
+        return new ClusterSniExposition(expositions);
+    }
+
+    public List<HostnameExposition> getExpositions() {
+        return expositions;
+    }
+
+    public record HostnameExposition(Listeners listener, String sniBootstrapHostname, String sniBrokerPattern, List<Service> services) {
+
+    }
+
+    public record Service(String name, String type) {}
+
+    private record HostnamePattern(String hostname) {
+
+        public static final String NODE_ID_PATTERN = "$(nodeId)";
+
+        HostnamePattern {
+            if (!hostname.contains("%") || hostname.indexOf("%") != hostname.lastIndexOf("%")) {
+                throw new RuntimeException("host must contain a single '%'");
+            }
+            // todo, check that it contains the right namespace and no extra parts
+            if (!hostname.endsWith("svc.cluster.local")) {
+                throw new RuntimeException("host must end with 'svc.cluster.local'");
+            }
+            String servicePrefix = hostname.substring(0, hostname.indexOf("%"));
+            if (servicePrefix.contains(".")) {
+                throw new RuntimeException("% must be in the first host segment");
+            }
+        }
+
+        public String bootstrapHostname() {
+            return hostname.replace("%", "bootstrap");
+        }
+
+        public String brokerPattern() {
+            return hostname.replace("%", "broker-" + NODE_ID_PATTERN);
+        }
+
+        public String resolveBrokerServiceName(Integer brokerId) {
+            String fullyQualified = brokerPattern().replace(NODE_ID_PATTERN, brokerId.toString());
+            // if hostname is xyz-broker-1.my-ns.svc.local.cluster service name should be xyz-broker-1
+            return firstHostnameSection(fullyQualified);
+        }
+
+        public String resolveBootstrapServiceName() {
+            String fullyQualified = bootstrapHostname();
+            // if hostname is xyz-bootstrap.my-ns.svc.local.cluster service name should be xyz-bootstrap
+            return firstHostnameSection(fullyQualified);
+        }
+    }
+
+    private static @NonNull String firstHostnameSection(String fullyQualified) {
+        return fullyQualified.substring(0, fullyQualified.indexOf("."));
+    }
+}

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/TlsSecrets.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/TlsSecrets.java
@@ -8,6 +8,7 @@ package io.kroxylicious.kubernetes.operator;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 
@@ -18,9 +19,10 @@ public record TlsSecrets(Path path, String volumeName, String secretName) {
     private static final String KEY = "tls.key";
 
     public static List<TlsSecrets> tlsSecretsFor(KafkaProxy proxy) {
+        final AtomicInteger counter = new AtomicInteger(0);
         return proxy.getSpec().getListeners().stream().flatMap(listeners -> listeners.getTls().getCertificateRefs().stream().map(cert -> {
             Path resolve = TLS_SECRETS_ROOT_DIR.resolve(listeners.getName()).resolve(cert.getName());
-            return new TlsSecrets(resolve, "tls-secrets-" + listeners.getName() + "-" + cert.getName(), cert.getName());
+            return new TlsSecrets(resolve, "tls-secrets-" + counter.getAndIncrement(), cert.getName());
         })).toList();
     }
 

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/TlsSecrets.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/TlsSecrets.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+
+public record TlsSecrets(Path path, String volumeName, String secretName) {
+
+    private static final Path TLS_SECRETS_ROOT_DIR = Path.of("/opt/kroxylicious/secrets/tls");
+    private static final String CERTIFICATE = "tls.crt";
+    private static final String KEY = "tls.key";
+
+    public static List<TlsSecrets> tlsSecretsFor(KafkaProxy proxy) {
+        return proxy.getSpec().getListeners().stream().flatMap(listeners -> listeners.getTls().getCertificateRefs().stream().map(cert -> {
+            Path resolve = TLS_SECRETS_ROOT_DIR.resolve(listeners.getName()).resolve(cert.getName());
+            return new TlsSecrets(resolve, "tls-secrets-" + listeners.getName() + "-" + cert.getName(), cert.getName());
+        })).toList();
+    }
+
+    public Path privateKeyPath() {
+        return path.resolve(KEY);
+    }
+
+    public Path certificatePath() {
+        return path.resolve(CERTIFICATE);
+    }
+}

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
@@ -42,15 +42,106 @@ spec:
                   pattern: "[a-z0-9]([a-z0-9-]*[a-z0-9])?"
             spec:
               type: object
-              required: ["clusters"]
+              required: ["clusters", "listeners"]
               properties:
+                listeners:
+                  type: array
+                  x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys: ["name"]
+                  minItems: 1
+                  maxItems: 1 # is it a pain to have to evolve this in the CRD, vs erroring in the operator code?
+                  items:
+                    type: object
+                    required: ["name", "port", "protocol", "tls"] # difference from Gateway - tls required
+                    properties:
+                      name:
+                        description: |-
+                          Name is the name of the Listener. This name MUST be unique within a
+                          KafkaGateway.
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      port:
+                        description: |-
+                          Port is the network port. Multiple listeners may use the
+                          same port, subject to the Listener compatibility rules.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      protocol:
+                        description: |-
+                          Protocol specifies the network protocol this listener expects to receive.
+                        maxLength: 255
+                        minLength: 1
+                        pattern: ^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
+                        type: string
+                      tls:
+                        type: object
+                        required: ["certificateRefs"] #difference from Gateway - certRefs required because we always terminate TLS
+                        properties:
+                          certificateRefs:
+                            type: array
+                            maxItems: 64 # limit from gateway API experimental 1.20
+                            items:
+                              type: object
+                              required: ["name"]
+                              properties:
+                                group:
+                                  default: ""
+                                  description: |-
+                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                    When unspecified or empty string, core API group is inferred.
+                                  maxLength: 253
+                                  pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                kind:
+                                  default: Secret
+                                  description: Kind is kind of the referent. For example
+                                    "Secret".
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                  type: string
+                                name:
+                                  description: Name is the name of the referent.
+                                  maxLength: 253
+                                  minLength: 1
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace is the namespace of the referenced object. When unspecified, the local
+                                    namespace is inferred.
+                                    
+                                    Note that when a namespace different than the local namespace is specified,
+                                    a ReferenceGrant object is required in the referent namespace to allow that
+                                    namespace's owner to accept the reference. See the ReferenceGrant
+                                    documentation for details.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                          mode:
+                            default: Terminate
+                            description: |-
+                              Mode defines the TLS behavior for the TLS session initiated by the client.
+                              There is one possible mode:
+                              
+                              - Terminate: The TLS session between the downstream client and the
+                                Gateway is terminated at the Gateway. This mode requires certificates
+                                to be specified in some way, such as populating the certificateRefs
+                                field.
+                            enum: # difference from Gateway, Passthrough not allowed
+                              - Terminate
+                            type: string
                 clusters:
                   type: array
                   x-kubernetes-list-type: map
                   x-kubernetes-list-map-keys: ["name"]
                   items:
                     type: object
-                    required: ["name", "upstream"]
+                    required: ["name", "upstream", "advertisedBrokers", "hostnames"]
                     properties:
                       name:
                         type: string
@@ -68,6 +159,22 @@ spec:
                               This could be a single address if the cluster has a highly available (loadbalanced) bootstrap address. 
                               Otherwise you should list addresses for several brokers, so that a broker being down does not prevent bootstrapping.
                             type: string
+                      advertisedBrokers:
+                        type: array
+                        x-kubernetes-list-type: set
+                        items:
+                          format: int32
+                          type: integer
+                      hostnames:
+                        type: array
+                        x-kubernetes-list-type: set
+                        minItems: 1
+                        maxItems: 1
+                        items:
+                          type: string
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9%])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ # Gateway regex plus we allow a % as last character of first section of domain, wildcard prefix not allowed
                       filters:
                         description: The filters to be used for this cluster. Each filter is a separate resource.
                         type: array

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/CertificateGenerator.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/CertificateGenerator.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class CertificateGenerator {
+
+    public static KeyPair generateRsaKeyPair() {
+        try {
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+            generator.initialize(1024, new SecureRandom());
+            return generator.generateKeyPair();
+        }
+        catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String toRsaPrivateKeyPem(KeyPair pair) {
+        try {
+            return toPemString(pair.getPrivate());
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @NonNull
+    private static String toPemString(Object obj) throws IOException {
+        try (StringWriter out = new StringWriter()) {
+            try (JcaPEMWriter pemWriter = new JcaPEMWriter(out)) {
+                pemWriter.writeObject(obj);
+            }
+            return out.toString();
+        }
+    }
+
+    public static String toCertPem(X509Certificate certificate) {
+        try {
+            return toPemString(certificate);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static X509Certificate generateSelfSignedX509Certificate(KeyPair pair) {
+        try {
+            var subPubKeyInfo = SubjectPublicKeyInfo.getInstance(pair.getPublic().getEncoded());
+            var now = Instant.now();
+            var validFrom = Date.from(now);
+            var validTo = Date.from(now.plus(Duration.ofDays(9999)));
+            var certBuilder = new X509v3CertificateBuilder(
+                    new X500Name("CN=localhost"),
+                    BigInteger.ONE,
+                    validFrom,
+                    validTo,
+                    new X500Name("CN=localhost"),
+                    subPubKeyInfo);
+            var signer = new JcaContentSignerBuilder("SHA256WithRSA")
+                    .setProvider(new BouncyCastleProvider())
+                    .build(pair.getPrivate());
+            X509CertificateHolder holder = certBuilder.build(signer);
+            JcaX509CertificateConverter converter = new JcaX509CertificateConverter();
+            return converter.getCertificate(holder);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/TlsSecretsTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/TlsSecretsTest.java
@@ -43,7 +43,7 @@ class TlsSecretsTest {
                 .endSpec()
                 .build();
         List<TlsSecrets> tlsSecrets = TlsSecrets.tlsSecretsFor(proxy);
-        TlsSecrets expected = expectedSecret(LISTENER_NAME, SECRET_NAME);
+        TlsSecrets expected = expectedSecret(LISTENER_NAME, SECRET_NAME, 0);
         assertThat(tlsSecrets).containsExactly(expected);
         assertNoCollisions(tlsSecrets);
     }
@@ -71,8 +71,8 @@ class TlsSecretsTest {
                 .endSpec()
                 .build();
         List<TlsSecrets> tlsSecrets = TlsSecrets.tlsSecretsFor(proxy);
-        TlsSecrets first = expectedSecret(LISTENER_NAME, SECRET_NAME);
-        TlsSecrets second = expectedSecret(LISTENER_NAME, SECRET_NAME2);
+        TlsSecrets first = expectedSecret(LISTENER_NAME, SECRET_NAME, 0);
+        TlsSecrets second = expectedSecret(LISTENER_NAME, SECRET_NAME2, 1);
         assertThat(tlsSecrets).containsExactly(first, second);
         assertNoCollisions(tlsSecrets);
     }
@@ -111,16 +111,16 @@ class TlsSecretsTest {
                 .endSpec()
                 .build();
         List<TlsSecrets> tlsSecrets = TlsSecrets.tlsSecretsFor(proxy);
-        TlsSecrets first = expectedSecret(LISTENER_NAME, SECRET_NAME);
-        TlsSecrets second = expectedSecret(LISTENER_NAME2, SECRET_NAME);
-        TlsSecrets third = expectedSecret(LISTENER_NAME2, SECRET_NAME2);
+        TlsSecrets first = expectedSecret(LISTENER_NAME, SECRET_NAME, 0);
+        TlsSecrets second = expectedSecret(LISTENER_NAME2, SECRET_NAME, 1);
+        TlsSecrets third = expectedSecret(LISTENER_NAME2, SECRET_NAME2, 2);
         assertThat(tlsSecrets).containsExactly(first, second, third);
         assertNoCollisions(tlsSecrets);
     }
 
-    private static @NonNull TlsSecrets expectedSecret(String listenerName, String secretName) {
+    private static @NonNull TlsSecrets expectedSecret(String listenerName, String secretName, int volumeNameIndex) {
         String mountPath = "/opt/kroxylicious/secrets/tls/" + listenerName + "/" + secretName;
-        String expectedVolumeName = "tls-secrets-" + listenerName + "-" + secretName;
+        String expectedVolumeName = "tls-secrets-" + volumeNameIndex;
         return new TlsSecrets(Path.of(mountPath), expectedVolumeName, secretName);
     }
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/TlsSecretsTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/TlsSecretsTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TlsSecretsTest {
+
+    private static final String LISTENER_NAME = "my-listener";
+    private static final String LISTENER_NAME2 = "another-listener";
+    private static final String SECRET_NAME = "certs";
+    private static final String SECRET_NAME2 = "another-secret";
+
+    @Test
+    public void singleListener() {
+        var proxy = new KafkaProxyBuilder()
+                .withNewSpec()
+                .withListeners()
+                .addNewListener()
+                .withName(LISTENER_NAME)
+                .withProtocol("kafka-tls")
+                .withPort(9092)
+                .withNewTls()
+                .addNewCertificateRef()
+                .withKind("Secret")
+                .withName(SECRET_NAME)
+                .endCertificateRef()
+                .endTls()
+                .endListener()
+                .endSpec()
+                .build();
+        List<TlsSecrets> tlsSecrets = TlsSecrets.tlsSecretsFor(proxy);
+        TlsSecrets expected = expectedSecret(LISTENER_NAME, SECRET_NAME);
+        assertThat(tlsSecrets).containsExactly(expected);
+        assertNoCollisions(tlsSecrets);
+    }
+
+    @Test
+    public void multipleCerts() {
+        var proxy = new KafkaProxyBuilder()
+                .withNewSpec()
+                .withListeners()
+                .addNewListener()
+                .withName(LISTENER_NAME)
+                .withProtocol("kafka-tls")
+                .withPort(9092)
+                .withNewTls()
+                .addNewCertificateRef()
+                .withKind("Secret")
+                .withName(SECRET_NAME)
+                .endCertificateRef()
+                .addNewCertificateRef()
+                .withKind("Secret")
+                .withName(SECRET_NAME2)
+                .endCertificateRef()
+                .endTls()
+                .endListener()
+                .endSpec()
+                .build();
+        List<TlsSecrets> tlsSecrets = TlsSecrets.tlsSecretsFor(proxy);
+        TlsSecrets first = expectedSecret(LISTENER_NAME, SECRET_NAME);
+        TlsSecrets second = expectedSecret(LISTENER_NAME, SECRET_NAME2);
+        assertThat(tlsSecrets).containsExactly(first, second);
+        assertNoCollisions(tlsSecrets);
+    }
+
+    @Test
+    public void multipleListeners() {
+        var proxy = new KafkaProxyBuilder()
+                .withNewSpec()
+                .withListeners()
+                .addNewListener()
+                .withName(LISTENER_NAME)
+                .withProtocol("kafka-tls")
+                .withPort(9092)
+                .withNewTls()
+                .addNewCertificateRef()
+                .withKind("Secret")
+                .withName(SECRET_NAME)
+                .endCertificateRef()
+                .endTls()
+                .endListener()
+                .addNewListener()
+                .withName(LISTENER_NAME2)
+                .withProtocol("kafka-tls")
+                .withPort(9092)
+                .withNewTls()
+                .addNewCertificateRef()
+                .withKind("Secret")
+                .withName(SECRET_NAME)
+                .endCertificateRef()
+                .addNewCertificateRef()
+                .withKind("Secret")
+                .withName(SECRET_NAME2)
+                .endCertificateRef()
+                .endTls()
+                .endListener()
+                .endSpec()
+                .build();
+        List<TlsSecrets> tlsSecrets = TlsSecrets.tlsSecretsFor(proxy);
+        TlsSecrets first = expectedSecret(LISTENER_NAME, SECRET_NAME);
+        TlsSecrets second = expectedSecret(LISTENER_NAME2, SECRET_NAME);
+        TlsSecrets third = expectedSecret(LISTENER_NAME2, SECRET_NAME2);
+        assertThat(tlsSecrets).containsExactly(first, second, third);
+        assertNoCollisions(tlsSecrets);
+    }
+
+    private static @NonNull TlsSecrets expectedSecret(String listenerName, String secretName) {
+        String mountPath = "/opt/kroxylicious/secrets/tls/" + listenerName + "/" + secretName;
+        String expectedVolumeName = "tls-secrets-" + listenerName + "-" + secretName;
+        return new TlsSecrets(Path.of(mountPath), expectedVolumeName, secretName);
+    }
+
+    /**
+     * sanity check general property that we want all mounted secrets to have distinct mount path and volume name
+     */
+    private void assertNoCollisions(List<TlsSecrets> secrets) {
+        int numSecrets = secrets.size();
+        long distinctPaths = secrets.stream().map(TlsSecrets::certificatePath).distinct().count();
+        assertThat(distinctPaths).describedAs("expect all secret paths that will be mounted into proxy container to be distinct").isEqualTo(numSecrets);
+        long distinctVolumeNames = secrets.stream().map(TlsSecrets::volumeName).distinct().count();
+        assertThat(distinctVolumeNames).describedAs("expect all volume names that will be mounted into proxy container to be distinct").isEqualTo(numSecrets);
+    }
+
+}

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-KafkaProxy.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-KafkaProxy.yaml
@@ -11,9 +11,20 @@ metadata:
   name: example
   namespace: proxy-ns
 spec:
+  listeners:
+    - name: my-listener
+      port: 9092
+      protocol: kafka-tls
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: kroxy-server-key-material
   clusters:
     - name: "foo"
       # This cluster should be absent from the output proxy-operator-operator-operator-config.yaml, because there is no Two with name missing
+      advertisedBrokers: [ 0 ]
+      hostnames:
+        - my-cluster-%.proxy-ns.svc.cluster.local
       upstream:
         bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
       filters:
@@ -25,6 +36,9 @@ spec:
           name: missing # this does not exist
     - name: "bar"
       # This cluster should be present in the output proxy-operator-operator-operator-config.yaml, because both these filters exist
+      advertisedBrokers: [ 0 ]
+      hostnames:
+        - my-cluster-2-%.proxy-ns.svc.cluster.local
       upstream:
         bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
       filters:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Deployment-example.yaml
@@ -40,15 +40,18 @@ spec:
           ports:
             - containerPort: 9190
               name: "metrics"
-            - containerPort: 9392
-            - containerPort: 9393
-            - containerPort: 9394
-            - containerPort: 9395
+            - containerPort: 9092
+              name: "my-listener"
           volumeMounts:
             - mountPath: "/opt/kroxylicious/config/proxy-config.yaml"
               name: "config-volume"
               subPath: "proxy-config.yaml"
+            - mountPath: "/opt/kroxylicious/secrets/tls/my-listener/kroxy-server-key-material"
+              name: "tls-secrets-my-listener-kroxy-server-key-material"
       volumes:
         - name: "config-volume"
           secret:
             secretName: "example"
+        - name: "tls-secrets-my-listener-kroxy-server-key-material"
+          secret:
+            secretName: "kroxy-server-key-material"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Deployment-example.yaml
@@ -47,11 +47,11 @@ spec:
               name: "config-volume"
               subPath: "proxy-config.yaml"
             - mountPath: "/opt/kroxylicious/secrets/tls/my-listener/kroxy-server-key-material"
-              name: "tls-secrets-my-listener-kroxy-server-key-material"
+              name: "tls-secrets-0"
       volumes:
         - name: "config-volume"
           secret:
             secretName: "example"
-        - name: "tls-secrets-my-listener-kroxy-server-key-material"
+        - name: "tls-secrets-0"
           secret:
             secretName: "kroxy-server-key-material"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Secret-example.yaml
@@ -38,16 +38,18 @@ stringData:
       config:
         filterTwoConfig: 42
     virtualClusters:
-      bar:
+      bar-my-listener-my-cluster-2-bootstrap.proxy-ns.svc.cluster.local:
         targetCluster:
           bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
         clusterNetworkAddressConfigProvider:
-          type: "PortPerBrokerClusterNetworkAddressConfigProvider"
+          type: "SniRoutingClusterNetworkAddressConfigProvider"
           config:
-            bootstrapAddress: "localhost:9392"
-            brokerAddressPattern: "bar.proxy-ns.svc.cluster.local"
-            brokerStartPort: 9393
-            numberOfBrokerPorts: 3
+            bootstrapAddress: "my-cluster-2-bootstrap.proxy-ns.svc.cluster.local:9092"
+            brokerAddressPattern: "my-cluster-2-broker-$(nodeId).proxy-ns.svc.cluster.local"
+        tls:
+          key:
+            privateKeyFile: "/opt/kroxylicious/secrets/tls/my-listener/kroxy-server-key-material/tls.key"
+            certificateFile: "/opt/kroxylicious/secrets/tls/my-listener/kroxy-server-key-material/tls.crt"
         filters:
         - "filter-one.Filter.filter.kroxylicious.io"
         - "filter-two.Filter.filter.kroxylicious.io"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Service-my-cluster-2-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Service-my-cluster-2-bootstrap.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/instance: "example"
+    app.kubernetes.io/component: "proxy"
+  name: "my-cluster-2-bootstrap"
+  namespace: "proxy-ns"
+  ownerReferences:
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxy"
+      name: "example"
+spec:
+  ports:
+    - name: "tls"
+      port: 9092
+      protocol: "TCP"
+      targetPort: 9092
+  selector:
+    app: "kroxylicious"
+  type: "ClusterIP"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Service-my-cluster-2-broker-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Service-my-cluster-2-broker-0.yaml
@@ -12,31 +12,20 @@ metadata:
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/part-of: "kafka"
-    app.kubernetes.io/instance: "use-pod-template-spec"
+    app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
-  name: "one"
-  namespace: proxy-ns
+  name: "my-cluster-2-broker-0"
+  namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"
-      name: "use-pod-template-spec"
+      name: "example"
 spec:
   ports:
-    - name: "one-9292"
-      port: 9292
+    - name: "tls"
+      port: 9092
       protocol: "TCP"
-      targetPort: 9292
-    - name: "one-9293"
-      port: 9293
-      protocol: "TCP"
-      targetPort: 9293
-    - name: "one-9294"
-      port: 9294
-      protocol: "TCP"
-      targetPort: 9294
-    - name: "one-9295"
-      port: 9295
-      protocol: "TCP"
-      targetPort: 9295
+      targetPort: 9092
   selector:
     app: "kroxylicious"
+  type: "ClusterIP"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/in-KafkaProxy.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/in-KafkaProxy.yaml
@@ -11,7 +11,18 @@ metadata:
   name: minimal
   namespace: proxy-ns
 spec:
+  listeners:
+    - name: my-listener
+      port: 9092
+      protocol: kafka-tls
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: kroxy-server-key-material
   clusters:
   - name: "one"
+    advertisedBrokers: [ 0 ]
+    hostnames:
+      - my-cluster-%.proxy-ns.svc.cluster.local
     upstream:
       bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Deployment-minimal.yaml
@@ -40,15 +40,18 @@ spec:
           ports:
             - containerPort: 9190
               name: "metrics"
-            - containerPort: 9292
-            - containerPort: 9293
-            - containerPort: 9294
-            - containerPort: 9295
+            - containerPort: 9092
+              name: "my-listener"
           volumeMounts:
             - mountPath: "/opt/kroxylicious/config/proxy-config.yaml"
               name: "config-volume"
               subPath: "proxy-config.yaml"
+            - mountPath: "/opt/kroxylicious/secrets/tls/my-listener/kroxy-server-key-material"
+              name: "tls-secrets-my-listener-kroxy-server-key-material"
       volumes:
         - name: "config-volume"
           secret:
             secretName: "minimal"
+        - name: "tls-secrets-my-listener-kroxy-server-key-material"
+          secret:
+            secretName: "kroxy-server-key-material"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Deployment-minimal.yaml
@@ -47,11 +47,11 @@ spec:
               name: "config-volume"
               subPath: "proxy-config.yaml"
             - mountPath: "/opt/kroxylicious/secrets/tls/my-listener/kroxy-server-key-material"
-              name: "tls-secrets-my-listener-kroxy-server-key-material"
+              name: "tls-secrets-0"
       volumes:
         - name: "config-volume"
           secret:
             secretName: "minimal"
-        - name: "tls-secrets-my-listener-kroxy-server-key-material"
+        - name: "tls-secrets-0"
           secret:
             secretName: "kroxy-server-key-material"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Secret-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Secret-minimal.yaml
@@ -29,13 +29,15 @@ stringData:
       endpoints:
         prometheus: {}
     virtualClusters:
-      one:
+      one-my-listener-my-cluster-bootstrap.proxy-ns.svc.cluster.local:
         targetCluster:
           bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
         clusterNetworkAddressConfigProvider:
-          type: "PortPerBrokerClusterNetworkAddressConfigProvider"
+          type: "SniRoutingClusterNetworkAddressConfigProvider"
           config:
-            bootstrapAddress: "localhost:9292"
-            brokerAddressPattern: "one.proxy-ns.svc.cluster.local"
-            brokerStartPort: 9293
-            numberOfBrokerPorts: 3
+            bootstrapAddress: "my-cluster-bootstrap.proxy-ns.svc.cluster.local:9092"
+            brokerAddressPattern: "my-cluster-broker-$(nodeId).proxy-ns.svc.cluster.local"
+        tls:
+          key:
+            privateKeyFile: "/opt/kroxylicious/secrets/tls/my-listener/kroxy-server-key-material/tls.key"
+            certificateFile: "/opt/kroxylicious/secrets/tls/my-listener/kroxy-server-key-material/tls.crt"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Service-my-cluster-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Service-my-cluster-bootstrap.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/instance: "minimal"
+    app.kubernetes.io/component: "proxy"
+  name: "my-cluster-bootstrap"
+  namespace: "proxy-ns"
+  ownerReferences:
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxy"
+      name: "minimal"
+spec:
+  ports:
+  - name: "tls"
+    port: 9092
+    protocol: "TCP"
+    targetPort: 9092
+  selector:
+    app: "kroxylicious"
+  type: "ClusterIP"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Service-my-cluster-broker-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Service-my-cluster-broker-0.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/instance: "minimal"
+    app.kubernetes.io/component: "proxy"
+  name: "my-cluster-broker-0"
+  namespace: "proxy-ns"
+  ownerReferences:
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxy"
+      name: "minimal"
+spec:
+  ports:
+    - name: "tls"
+      port: 9092
+      protocol: "TCP"
+      targetPort: 9092
+  selector:
+    app: "kroxylicious"
+  type: "ClusterIP"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/in-KafkaProxy.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/in-KafkaProxy.yaml
@@ -11,10 +11,24 @@ metadata:
   name: twocluster
   namespace: proxy-ns
 spec:
+  listeners:
+    - name: my-listener
+      port: 9092
+      protocol: kafka-tls
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: kroxy-server-key-material
   clusters:
     - name: foo
+      advertisedBrokers: [ 0 ]
+      hostnames:
+        - my-cluster-%.proxy-ns.svc.cluster.local
       upstream:
         bootstrapServers: first-kafka.kafka1.svc.cluster.local:9092
     - name: bar
+      advertisedBrokers: [ 0 ]
+      hostnames:
+        - my-cluster-2-%.proxy-ns.svc.cluster.local
       upstream:
         bootstrapServers: second-kafka.kafka2.svc.cluster.local:9092

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Deployment-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Deployment-twocluster.yaml
@@ -47,11 +47,11 @@ spec:
               name: "config-volume"
               subPath: "proxy-config.yaml"
             - mountPath: "/opt/kroxylicious/secrets/tls/my-listener/kroxy-server-key-material"
-              name: "tls-secrets-my-listener-kroxy-server-key-material"
+              name: "tls-secrets-0"
       volumes:
         - name: "config-volume"
           secret:
             secretName: "twocluster"
-        - name: "tls-secrets-my-listener-kroxy-server-key-material"
+        - name: "tls-secrets-0"
           secret:
             secretName: "kroxy-server-key-material"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Deployment-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Deployment-twocluster.yaml
@@ -40,19 +40,18 @@ spec:
           ports:
             - containerPort: 9190
               name: "metrics"
-            - containerPort: 9292
-            - containerPort: 9293
-            - containerPort: 9294
-            - containerPort: 9295
-            - containerPort: 9392
-            - containerPort: 9393
-            - containerPort: 9394
-            - containerPort: 9395
+            - containerPort: 9092
+              name: "my-listener"
           volumeMounts:
             - mountPath: "/opt/kroxylicious/config/proxy-config.yaml"
               name: "config-volume"
               subPath: "proxy-config.yaml"
+            - mountPath: "/opt/kroxylicious/secrets/tls/my-listener/kroxy-server-key-material"
+              name: "tls-secrets-my-listener-kroxy-server-key-material"
       volumes:
         - name: "config-volume"
           secret:
             secretName: "twocluster"
+        - name: "tls-secrets-my-listener-kroxy-server-key-material"
+          secret:
+            secretName: "kroxy-server-key-material"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Secret-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Secret-twocluster.yaml
@@ -29,23 +29,27 @@ stringData:
       endpoints:
         prometheus: {}
     virtualClusters:
-      foo:
+      foo-my-listener-my-cluster-bootstrap.proxy-ns.svc.cluster.local:
         targetCluster:
           bootstrapServers: "first-kafka.kafka1.svc.cluster.local:9092"
         clusterNetworkAddressConfigProvider:
-          type: "PortPerBrokerClusterNetworkAddressConfigProvider"
+          type: "SniRoutingClusterNetworkAddressConfigProvider"
           config:
-            bootstrapAddress: "localhost:9292"
-            brokerAddressPattern: "foo.proxy-ns.svc.cluster.local"
-            brokerStartPort: 9293
-            numberOfBrokerPorts: 3
-      bar:
+            bootstrapAddress: "my-cluster-bootstrap.proxy-ns.svc.cluster.local:9092"
+            brokerAddressPattern: "my-cluster-broker-$(nodeId).proxy-ns.svc.cluster.local"
+        tls:
+          key:
+            privateKeyFile: "/opt/kroxylicious/secrets/tls/my-listener/kroxy-server-key-material/tls.key"
+            certificateFile: "/opt/kroxylicious/secrets/tls/my-listener/kroxy-server-key-material/tls.crt"
+      bar-my-listener-my-cluster-2-bootstrap.proxy-ns.svc.cluster.local:
         targetCluster:
           bootstrapServers: "second-kafka.kafka2.svc.cluster.local:9092"
         clusterNetworkAddressConfigProvider:
-          type: "PortPerBrokerClusterNetworkAddressConfigProvider"
+          type: "SniRoutingClusterNetworkAddressConfigProvider"
           config:
-            bootstrapAddress: "localhost:9392"
-            brokerAddressPattern: "bar.proxy-ns.svc.cluster.local"
-            brokerStartPort: 9393
-            numberOfBrokerPorts: 3
+            bootstrapAddress: "my-cluster-2-bootstrap.proxy-ns.svc.cluster.local:9092"
+            brokerAddressPattern: "my-cluster-2-broker-$(nodeId).proxy-ns.svc.cluster.local"
+        tls:
+          key:
+            privateKeyFile: "/opt/kroxylicious/secrets/tls/my-listener/kroxy-server-key-material/tls.key"
+            certificateFile: "/opt/kroxylicious/secrets/tls/my-listener/kroxy-server-key-material/tls.crt"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Service-my-cluster-2-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Service-my-cluster-2-bootstrap.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/instance: "twocluster"
+    app.kubernetes.io/component: "proxy"
+  name: "my-cluster-2-bootstrap"
+  namespace: "proxy-ns"
+  ownerReferences:
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxy"
+      name: "twocluster"
+spec:
+  ports:
+  - name: "tls"
+    port: 9092
+    protocol: "TCP"
+    targetPort: 9092
+  selector:
+    app: "kroxylicious"
+  type: "ClusterIP"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Service-my-cluster-2-broker-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Service-my-cluster-2-broker-0.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/instance: "twocluster"
+    app.kubernetes.io/component: "proxy"
+  name: "my-cluster-2-broker-0"
+  namespace: "proxy-ns"
+  ownerReferences:
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxy"
+      name: "twocluster"
+spec:
+  ports:
+    - name: "tls"
+      port: 9092
+      protocol: "TCP"
+      targetPort: 9092
+  selector:
+    app: "kroxylicious"
+  type: "ClusterIP"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Service-my-cluster-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Service-my-cluster-bootstrap.yaml
@@ -12,31 +12,20 @@ metadata:
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/part-of: "kafka"
-    app.kubernetes.io/instance: "example"
+    app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
-  name: "bar"
+  name: "my-cluster-bootstrap"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"
-      name: "example"
+      name: "twocluster"
 spec:
   ports:
-    - name: "bar-9392"
-      port: 9392
-      protocol: "TCP"
-      targetPort: 9392
-    - name: "bar-9393"
-      port: 9393
-      protocol: "TCP"
-      targetPort: 9393
-    - name: "bar-9394"
-      port: 9394
-      protocol: "TCP"
-      targetPort: 9394
-    - name: "bar-9395"
-      port: 9395
-      protocol: "TCP"
-      targetPort: 9395
+  - name: "tls"
+    port: 9092
+    protocol: "TCP"
+    targetPort: 9092
   selector:
     app: "kroxylicious"
+  type: "ClusterIP"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Service-my-cluster-broker-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Service-my-cluster-broker-0.yaml
@@ -12,31 +12,20 @@ metadata:
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/part-of: "kafka"
-    app.kubernetes.io/instance: "minimal"
+    app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
-  name: "one"
+  name: "my-cluster-broker-0"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"
-      name: "minimal"
+      name: "twocluster"
 spec:
   ports:
-    - name: "one-9292"
-      port: 9292
+    - name: "tls"
+      port: 9092
       protocol: "TCP"
-      targetPort: 9292
-    - name: "one-9293"
-      port: 9293
-      protocol: "TCP"
-      targetPort: 9293
-    - name: "one-9294"
-      port: 9294
-      protocol: "TCP"
-      targetPort: 9294
-    - name: "one-9295"
-      port: 9295
-      protocol: "TCP"
-      targetPort: 9295
+      targetPort: 9092
   selector:
     app: "kroxylicious"
+  type: "ClusterIP"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/in-KafkaProxy.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/in-KafkaProxy.yaml
@@ -11,8 +11,19 @@ metadata:
   name: example
   namespace: proxy-ns
 spec:
+  listeners:
+    - name: my-listener
+      port: 9092
+      protocol: kafka-tls
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: kroxy-server-key-material
   clusters:
   - name: "foo"
+    advertisedBrokers: [ 0 ]
+    hostnames:
+      - my-cluster-%.proxy-ns.svc.cluster.local
     upstream:
       bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
     filters:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Deployment-example.yaml
@@ -47,11 +47,11 @@ spec:
               name: "config-volume"
               subPath: "proxy-config.yaml"
             - mountPath: "/opt/kroxylicious/secrets/tls/my-listener/kroxy-server-key-material"
-              name: "tls-secrets-my-listener-kroxy-server-key-material"
+              name: "tls-secrets-0"
       volumes:
         - name: "config-volume"
           secret:
             secretName: "example"
-        - name: "tls-secrets-my-listener-kroxy-server-key-material"
+        - name: "tls-secrets-0"
           secret:
             secretName: "kroxy-server-key-material"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Deployment-example.yaml
@@ -40,15 +40,18 @@ spec:
           ports:
             - containerPort: 9190
               name: "metrics"
-            - containerPort: 9292
-            - containerPort: 9293
-            - containerPort: 9294
-            - containerPort: 9295
+            - containerPort: 9092
+              name: "my-listener"
           volumeMounts:
             - mountPath: "/opt/kroxylicious/config/proxy-config.yaml"
               name: "config-volume"
               subPath: "proxy-config.yaml"
+            - mountPath: "/opt/kroxylicious/secrets/tls/my-listener/kroxy-server-key-material"
+              name: "tls-secrets-my-listener-kroxy-server-key-material"
       volumes:
         - name: "config-volume"
           secret:
             secretName: "example"
+        - name: "tls-secrets-my-listener-kroxy-server-key-material"
+          secret:
+            secretName: "kroxy-server-key-material"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Secret-example.yaml
@@ -38,16 +38,18 @@ stringData:
       config:
         filterTwoConfig: 42
     virtualClusters:
-      foo:
+      foo-my-listener-my-cluster-bootstrap.proxy-ns.svc.cluster.local:
         targetCluster:
           bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
         clusterNetworkAddressConfigProvider:
-          type: "PortPerBrokerClusterNetworkAddressConfigProvider"
+          type: "SniRoutingClusterNetworkAddressConfigProvider"
           config:
-            bootstrapAddress: "localhost:9292"
-            brokerAddressPattern: "foo.proxy-ns.svc.cluster.local"
-            brokerStartPort: 9293
-            numberOfBrokerPorts: 3
+            bootstrapAddress: "my-cluster-bootstrap.proxy-ns.svc.cluster.local:9092"
+            brokerAddressPattern: "my-cluster-broker-$(nodeId).proxy-ns.svc.cluster.local"
+        tls:
+          key:
+            privateKeyFile: "/opt/kroxylicious/secrets/tls/my-listener/kroxy-server-key-material/tls.key"
+            certificateFile: "/opt/kroxylicious/secrets/tls/my-listener/kroxy-server-key-material/tls.crt"
         filters:
         - "filter-one.Filter.filter.kroxylicious.io"
         - "filter-two.Filter.filter.kroxylicious.io"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Service-my-cluster-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Service-my-cluster-bootstrap.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
-  name: "foo"
+  name: "my-cluster-bootstrap"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
@@ -22,21 +22,10 @@ metadata:
       name: "example"
 spec:
   ports:
-    - name: "foo-9292"
-      port: 9292
-      protocol: "TCP"
-      targetPort: 9292
-    - name: "foo-9293"
-      port: 9293
-      protocol: "TCP"
-      targetPort: 9293
-    - name: "foo-9294"
-      port: 9294
-      protocol: "TCP"
-      targetPort: 9294
-    - name: "foo-9295"
-      port: 9295
-      protocol: "TCP"
-      targetPort: 9295
+  - name: "tls"
+    port: 9092
+    protocol: "TCP"
+    targetPort: 9092
   selector:
     app: "kroxylicious"
+  type: "ClusterIP"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Service-my-cluster-broker-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Service-my-cluster-broker-0.yaml
@@ -12,31 +12,20 @@ metadata:
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/part-of: "kafka"
-    app.kubernetes.io/instance: "twocluster"
+    app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
-  name: "bar"
+  name: "my-cluster-broker-0"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"
-      name: "twocluster"
+      name: "example"
 spec:
   ports:
-    - name: "bar-9392"
-      port: 9392
+    - name: "tls"
+      port: 9092
       protocol: "TCP"
-      targetPort: 9392
-    - name: "bar-9393"
-      port: 9393
-      protocol: "TCP"
-      targetPort: 9393
-    - name: "bar-9394"
-      port: 9394
-      protocol: "TCP"
-      targetPort: 9394
-    - name: "bar-9395"
-      port: 9395
-      protocol: "TCP"
-      targetPort: 9395
+      targetPort: 9092
   selector:
     app: "kroxylicious"
+  type: "ClusterIP"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/in-KafkaProxy.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/in-KafkaProxy.yaml
@@ -11,8 +11,19 @@ metadata:
   name: use-pod-template-spec
   namespace: proxy-ns
 spec:
+  listeners:
+    - name: my-listener
+      port: 9092
+      protocol: kafka-tls
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: kroxy-server-key-material
   clusters:
   - name: "one"
+    advertisedBrokers: [ 0 ]
+    hostnames:
+      - my-cluster-%.proxy-ns.svc.cluster.local
     upstream:
       bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
   podTemplate:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Deployment-use-pod-template-spec.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Deployment-use-pod-template-spec.yaml
@@ -48,11 +48,11 @@ spec:
               name: "config-volume"
               subPath: "proxy-config.yaml"
             - mountPath: "/opt/kroxylicious/secrets/tls/my-listener/kroxy-server-key-material"
-              name: "tls-secrets-my-listener-kroxy-server-key-material"
+              name: "tls-secrets-0"
       volumes:
         - name: "config-volume"
           secret:
             secretName: "use-pod-template-spec"
-        - name: "tls-secrets-my-listener-kroxy-server-key-material"
+        - name: "tls-secrets-0"
           secret:
             secretName: "kroxy-server-key-material"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Deployment-use-pod-template-spec.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Deployment-use-pod-template-spec.yaml
@@ -41,15 +41,18 @@ spec:
           ports:
             - containerPort: 9190
               name: "metrics"
-            - containerPort: 9292
-            - containerPort: 9293
-            - containerPort: 9294
-            - containerPort: 9295
+            - containerPort: 9092
+              name: "my-listener"
           volumeMounts:
             - mountPath: "/opt/kroxylicious/config/proxy-config.yaml"
               name: "config-volume"
               subPath: "proxy-config.yaml"
+            - mountPath: "/opt/kroxylicious/secrets/tls/my-listener/kroxy-server-key-material"
+              name: "tls-secrets-my-listener-kroxy-server-key-material"
       volumes:
         - name: "config-volume"
           secret:
             secretName: "use-pod-template-spec"
+        - name: "tls-secrets-my-listener-kroxy-server-key-material"
+          secret:
+            secretName: "kroxy-server-key-material"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Secret-use-pod-template-spec.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Secret-use-pod-template-spec.yaml
@@ -29,13 +29,15 @@ stringData:
       endpoints:
         prometheus: {}
     virtualClusters:
-      one:
+      one-my-listener-my-cluster-bootstrap.proxy-ns.svc.cluster.local:
         targetCluster:
           bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
         clusterNetworkAddressConfigProvider:
-          type: "PortPerBrokerClusterNetworkAddressConfigProvider"
+          type: "SniRoutingClusterNetworkAddressConfigProvider"
           config:
-            bootstrapAddress: "localhost:9292"
-            brokerAddressPattern: "one.proxy-ns.svc.cluster.local"
-            brokerStartPort: 9293
-            numberOfBrokerPorts: 3
+            bootstrapAddress: "my-cluster-bootstrap.proxy-ns.svc.cluster.local:9092"
+            brokerAddressPattern: "my-cluster-broker-$(nodeId).proxy-ns.svc.cluster.local"
+        tls:
+          key:
+            privateKeyFile: "/opt/kroxylicious/secrets/tls/my-listener/kroxy-server-key-material/tls.key"
+            certificateFile: "/opt/kroxylicious/secrets/tls/my-listener/kroxy-server-key-material/tls.crt"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Service-my-cluster-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Service-my-cluster-bootstrap.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/instance: "use-pod-template-spec"
+    app.kubernetes.io/component: "proxy"
+  name: "my-cluster-bootstrap"
+  namespace: "proxy-ns"
+  ownerReferences:
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxy"
+      name: "use-pod-template-spec"
+spec:
+  ports:
+  - name: "tls"
+    port: 9092
+    protocol: "TCP"
+    targetPort: 9092
+  selector:
+    app: "kroxylicious"
+  type: "ClusterIP"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Service-my-cluster-broker-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Service-my-cluster-broker-0.yaml
@@ -12,31 +12,20 @@ metadata:
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/part-of: "kafka"
-    app.kubernetes.io/instance: "twocluster"
+    app.kubernetes.io/instance: "use-pod-template-spec"
     app.kubernetes.io/component: "proxy"
-  name: "foo"
+  name: "my-cluster-broker-0"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"
-      name: "twocluster"
+      name: "use-pod-template-spec"
 spec:
   ports:
-    - name: "foo-9292"
-      port: 9292
+    - name: "tls"
+      port: 9092
       protocol: "TCP"
-      targetPort: 9292
-    - name: "foo-9293"
-      port: 9293
-      protocol: "TCP"
-      targetPort: 9293
-    - name: "foo-9294"
-      port: 9294
-      protocol: "TCP"
-      targetPort: 9294
-    - name: "foo-9295"
-      port: 9295
-      protocol: "TCP"
-      targetPort: 9295
+      targetPort: 9092
   selector:
     app: "kroxylicious"
+  type: "ClusterIP"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This replaces the port-per-broker exposition scheme hardcoded into the operator with SNI based access using kubernetes ClusterIP services.

Because of the nature of SNI exposition this means we require TLS between the client and proxy, therefore we require certificates. We don't want to make the operator responsible for orchestrating any certificate generation. Instead we integrate conveniently with [cert-manager](https://cert-manager.io). The operator will expect secrets containing cert-manager naming (`tls.key` and `tls.crt`).

We also are exploring moving the CRD design towards the Gateway API. We think it's valuable to align with a standard people will be familiar with, and that has already solved many of the API design issues around declaring how proxies should route traffic.

Port-per-broker is really not a good match for this (_understatement, i think it's incompatible with Gateway API_) since we need multiple ports to expose a cluster and cannot share ports across virtual clusters, each port addresses a single virtual broker. In the Gateway API a listener represents an ip/port and a route can be associated with a listener. Therefore we would need a listener for every virtual broker and would be unable to configure a KafkaRoute independently from the KafkaGateway, they would have to move in lockstep.

SNI fits better with Gateway. We can use a single port to address numerous virtual clusters and brokers. So it's possible to have this separation where we define a listener, and separately (in a separate CR in future) describe which hostnames we want a cluster to be exposed as. Then the operator can configure the Virtual Clusters to all be on the same port, with hostnames mapped appropriately.

I haven't looked at splitting the CR (Tom's planning to explore this soon) but have made the KafkaProxy try and represent the split responsibilities.

For example the simple KafkaProxy CR has become:
```
kind: KafkaProxy
apiVersion: kroxylicious.io/v1alpha1
metadata:
  name: simple
  namespace: my-proxy
spec:
  listeners:
    - name: my-listener
      port: 9092
      protocol: kafka-tls
      tls:
        certificateRefs:
          - kind: Secret
            name: kroxy-server-key-material
  clusters:
    - name: "my-cluster"
      upstream:
        bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
      advertisedBrokers: [0, 1, 2]
      hostnames:
      - my-cluster-%.my-proxy.svc.cluster.local
      filters: []
 ```
 
Where we define a listener on 9092 that all proxy instances will listen on (and a certificate secret provided by cert-manager). Then `my-cluster` declares it is to be exposed on `my-cluster-%.my-proxy.svc.cluster.local`. It also declares
it's `advertisedBrokers` ids. From this the operator will:

1. create ClusterIP services named `my-cluster-bootstrap`, `my-cluster-broker-0`, `my-cluster-broker-1`, `my-cluster-broker-2` in the  `my-proxy` namespace.
2. add the `kroxy-server-key-material` secret to the pod, mounting it at `/opt/kroxylicious/secrets/tls/my-listener/kroxy-server-key-material`
3. configures the proxy for SNI with bootstrap `my-cluster-bootstrap.my-proxy.svc.cluster.local` and broker pattern `my-cluster-broker-$(nodeId).my-proxy.svc.cluster.local`
4. configures the proxy virtualcluster to refer to the `tls.key` and `tls.crt` in the secret mounted in step 2

To see it in action you can use `scripts/run-operator.sh`

Currently it only supports:
1. a single listener (need to add parentRefs so that we can target a listener)
2. single cert per listener (we don't have a mechanism yet to use different certs per hostname)
3. a single hostname per cluster

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
