### PR TITLE
ensure that AWS integration and system tests upgrade localstack lockstep

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,10 +27,13 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["kroxylicious-kms-provider-aws-kms-test-support/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsTestKmsFacade.java"],
+      "fileMatch": ["kroxylicious-kms-provider-aws-kms-test-support/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsTestKmsFacade.java",
+                    "kroxylicious-systemtests/src/main/resources/helm_localstack_overrides.yaml"],
       "matchStrings": [
-        "DockerImageName\\.parse\\(\"(?<depName>localstack/localstack):(?<currentValue>\\d+\\.\\d+)\"\\)"
+        "DockerImageName\\.parse\\(\"localstack/localstack:(?<currentValue>\\d+\\.\\d+.\\d+)\"\\)",
+        "tag:.*\"(?<currentValue>\\d+\\.\\d+.\\d+)\""
       ],
+      "depNameTemplate": "localstack/localstack",
       "datasourceTemplate": "docker"
     },
     {

--- a/kroxylicious-kms-provider-aws-kms-test-support/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsTestKmsFacade.java
+++ b/kroxylicious-kms-provider-aws-kms-test-support/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsTestKmsFacade.java
@@ -18,7 +18,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 public class AwsKmsTestKmsFacade extends AbstractAwsKmsTestKmsFacade {
     private static final Logger LOG = LoggerFactory.getLogger(AwsKmsTestKmsFacade.class);
-    public static final DockerImageName LOCALSTACK_IMAGE = DockerImageName.parse("localstack/localstack:3.5");
+    public static final DockerImageName LOCALSTACK_IMAGE = DockerImageName.parse("localstack/localstack:3.5.0");
     private LocalStackContainer localStackContainer;
 
     @Override


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Ensure that AWS integration and system tests upgrade localstack lockstep.

I ran renovatebot on my fork.  This is what will result with this change https://github.com/k-wall/kroxylicious/pull/48

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
