### PR TITLE
Draft: Explore configuring virtual cluster TLS with a set of key pairs

### DIFF
--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/KeyPair.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/KeyPair.java
@@ -6,13 +6,28 @@
 
 package io.kroxylicious.proxy.config.tls;
 
+import java.io.ByteArrayInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.kroxylicious.proxy.config.secret.PasswordProvider;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import static java.util.stream.Collectors.toSet;
 
 /**
  * A {@link KeyProvider} backed by a private-key/certificate pair expressed in PEM format.
@@ -30,6 +45,9 @@ public record KeyPair(@JsonProperty(required = true) String privateKeyFile,
                       @JsonProperty(value = "keyPassword") PasswordProvider keyPasswordProvider)
         implements KeyProvider {
 
+    public static final String BEGIN_CERTIFICATE = "-----BEGIN CERTIFICATE-----";
+    public static final String END_CERTIFICATE = "-----END CERTIFICATE-----";
+
     public KeyPair {
         Objects.requireNonNull(privateKeyFile);
         Objects.requireNonNull(certificateFile);
@@ -39,4 +57,76 @@ public record KeyPair(@JsonProperty(required = true) String privateKeyFile,
     public <T> T accept(KeyProviderVisitor<T> visitor) {
         return visitor.visit(this);
     }
+
+    /**
+     * Test if this certificate has SANs matching a set of hostnames
+     * @param hostnames hostnames
+     * @return true if all hostnames match an SAN of this certificate
+     */
+    public boolean matchesHostnames(Set<String> hostnames) {
+        Set<Pattern> patterns = hostnamePatterns();
+        return hostnames.stream().allMatch(hostname -> patterns.stream().map(pattern -> pattern.matcher(hostname)).anyMatch(Matcher::matches));
+    }
+
+    private Set<Pattern> hostnamePatterns() {
+        try {
+            Path certPath = Path.of(certificateFile);
+            String pemString = Files.readString(certPath);
+            X509Certificate certificate = parsePemX509(pemString);
+            Set<String> dnsSubjectAlternativeNames = getDnsSubjectAlternativeNames(certificate);
+            // fallback to common name
+            if (dnsSubjectAlternativeNames.isEmpty()) {
+                String name = certificate.getSubjectX500Principal().getName();
+                if (name.startsWith("CN=")) {
+                    dnsSubjectAlternativeNames = Set.of(name.substring("CN=".length()));
+                }
+                else {
+                    throw new RuntimeException("failed to extract common name from certificate");
+                }
+            }
+            return dnsSubjectAlternativeNames.stream().map(KeyPair::toHostnamePattern).collect(toSet());
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // need to handle wildcard (*.xyz) and literal (abc.xyz)
+    private static Pattern toHostnamePattern(String san) {
+        if (san.startsWith("*.")) {
+            String remnant = san.substring(2);
+            return Pattern.compile(".*\\." + Pattern.quote(remnant));
+        }
+        return Pattern.compile(Pattern.quote(san));
+    }
+
+    private static Set<String> getDnsSubjectAlternativeNames(X509Certificate certificate) throws CertificateParsingException {
+        Collection<List<?>> subjectAlternativeNames = certificate.getSubjectAlternativeNames();
+        if (subjectAlternativeNames == null) {
+            return Set.of();
+        }
+        // type 2 is dNSName IA5String
+        return subjectAlternativeNames.stream().filter(san -> ((int) san.get(0)) == 2).map(san -> (String) san.get(1)).collect(toSet());
+    }
+
+    private static X509Certificate parsePemX509(String pemString) {
+        try {
+            int start = pemString.indexOf(BEGIN_CERTIFICATE);
+            int end = pemString.indexOf(END_CERTIFICATE);
+            String certBase64 = pemString.substring(start + BEGIN_CERTIFICATE.length(), end).replace("\n", "").strip();
+            byte[] decoded = Base64.getDecoder().decode(certBase64);
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            Certificate cert = cf.generateCertificate(new ByteArrayInputStream(decoded));
+            if (cert instanceof X509Certificate) {
+                return (X509Certificate) cert;
+            }
+            else {
+                throw new RuntimeException("cert is not X509Certificate");
+            }
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/KeyPairSet.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/KeyPairSet.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config.tls;
+
+import java.util.List;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents a set of KeyPairs, from which we can select one for each VirtualCluster
+ * that has SANs containing the bootstrap host.
+ * @param keyPairs
+ */
+public record KeyPairSet(@JsonProperty(required = true) List<KeyPair> keyPairs) implements KeyProvider {
+
+    @Override
+    public <T> T accept(KeyProviderVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+
+    // we want to obtain a key pair where all target hostnames match a SAN, literal or wildcard in the certificate
+    KeyPair getKeyPair(Set<String> hostnames) {
+        List<KeyPair> keyPairStream = keyPairs.stream().filter(k -> k.matchesHostnames(hostnames)).toList();
+        if (keyPairStream.isEmpty()) {
+            throw new IllegalStateException(
+                    "No key pair found with certificate containing VirtualCluster hostnames: " + hostnames + " in SubjectAlternativeNames or common name");
+        }
+        else if (keyPairStream.size() > 1) {
+            throw new IllegalStateException("Multiple key pairs found for hostnames: " + hostnames);
+        }
+        return keyPairStream.get(0);
+    }
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/KeyProvider.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/KeyProvider.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  * </ul>
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
-@JsonSubTypes({ @JsonSubTypes.Type(KeyPair.class), @JsonSubTypes.Type(KeyStore.class) })
+@JsonSubTypes({ @JsonSubTypes.Type(KeyPair.class), @JsonSubTypes.Type(KeyStore.class), @JsonSubTypes.Type(KeyPairSet.class) })
 public interface KeyProvider {
 
     /**

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/KeyProviderVisitor.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/KeyProviderVisitor.java
@@ -16,4 +16,5 @@ public interface KeyProviderVisitor<T> {
 
     T visit(KeyStore keyStore);
 
+    T visit(KeyPairSet keyPairSet);
 }

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/config/tls/KeyPairTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/config/tls/KeyPairTest.java
@@ -26,6 +26,11 @@ class KeyPairTest {
             public KeyPair visit(KeyStore keyStore) {
                 throw new RuntimeException("unexpected call to visit(KeyStore)");
             }
+
+            @Override
+            public KeyPair visit(KeyPairSet keyPairSet) {
+                throw new RuntimeException("unexpected call to visit(KeyPairSet)");
+            }
         });
         assertThat(result).isSameAs(keyProvider);
     }

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/config/tls/KeyStoreTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/config/tls/KeyStoreTest.java
@@ -53,6 +53,11 @@ class KeyStoreTest {
             public KeyStore visit(KeyStore keyStore) {
                 return keyStore;
             }
+
+            @Override
+            public KeyStore visit(KeyPairSet keyPairSet) {
+                throw new RuntimeException("unexpected call to visit(KeyPairSet)");
+            }
         });
         assertThat(result).isSameAs(keyProvider);
     }

--- a/kroxylicious-kms-tls-support/src/main/java/io/kroxylicious/proxy/tls/JdkTls.java
+++ b/kroxylicious-kms-tls-support/src/main/java/io/kroxylicious/proxy/tls/JdkTls.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import io.kroxylicious.proxy.config.secret.PasswordProvider;
 import io.kroxylicious.proxy.config.tls.InsecureTls;
 import io.kroxylicious.proxy.config.tls.KeyPair;
+import io.kroxylicious.proxy.config.tls.KeyPairSet;
 import io.kroxylicious.proxy.config.tls.KeyProvider;
 import io.kroxylicious.proxy.config.tls.KeyProviderVisitor;
 import io.kroxylicious.proxy.config.tls.PlatformTrustProvider;
@@ -127,6 +128,11 @@ public record JdkTls(Tls tls) {
                 catch (Exception e) {
                     throw new SslConfigurationException(e);
                 }
+            }
+
+            @Override
+            public KeyManager[] visit(KeyPairSet keyPairSet) {
+                throw new SslConfigurationException("KeyPairSet is not supported by vault KMS yet");
             }
 
             @Nullable

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
@@ -229,7 +229,8 @@ public class VirtualCluster implements ClusterNetworkAddressConfigProvider {
     private Optional<SslContext> buildDownstreamSslContext() {
         return tls.map(tlsConfiguration -> {
             try {
-                var sslContextBuilder = Optional.of(tlsConfiguration.key()).map(NettyKeyProvider::new).map(NettyKeyProvider::forServer)
+                var sslContextBuilder = Optional.of(tlsConfiguration.key()).map(NettyKeyProvider::new)
+                        .map(nettyKeyProvider -> nettyKeyProvider.forServer(clusterNetworkAddressConfigProvider))
                         .orElseThrow();
 
                 configureCipherSuites(sslContextBuilder, tlsConfiguration);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -124,6 +124,28 @@ class ConfigParserTest {
                                 bootstrapAddress: cluster1:9192
                                 brokerAddressPattern: broker-$(nodeId)
                         """),
+                Arguments.of("Downstream TLS with key pair set", """
+                        virtualClusters:
+                          demo1:
+                            tls:
+                                key:
+                                  keyPairs:
+                                    - privateKeyFile: /tmp/tls.key
+                                      certificateFile: /tmp/tls.crt
+                            targetCluster:
+                              bootstrapServers: kafka.example:1234
+                              tls:
+                                trust:
+                                 storeFile: /tmp/foo.jks
+                                 storePassword:
+                                   password: password
+                                 storeType: JKS
+                            clusterNetworkAddressConfigProvider:
+                              type: SniRoutingClusterNetworkAddressConfigProvider
+                              config:
+                                bootstrapAddress: cluster1:9192
+                                brokerAddressPattern: broker-$(nodeId)
+                        """),
                 Arguments.of("Downstream/Upstream TLS with password files", """
                         virtualClusters:
                           demo1:

--- a/kubernetes-examples/network-topologies/snirouting_tls/base/kroxylicious/kroxylicious-config.yaml
+++ b/kubernetes-examples/network-topologies/snirouting_tls/base/kroxylicious/kroxylicious-config.yaml
@@ -32,6 +32,30 @@ data:
         logFrames: false
         tls:
           key:
-            storeFile: /opt/kroxylicious/server/key-material/keystore.p12
-            storePassword:
-              passwordFile: /opt/kroxylicious/server/keystore-password/storePassword
+            keyPairs:
+              - privateKeyFile: /opt/kroxylicious/server/key-material/tls.key
+                certificateFile: /opt/kroxylicious/server/key-material/tls.crt
+              - privateKeyFile: /opt/kroxylicious/server/key-material-2/tls.key
+                certificateFile: /opt/kroxylicious/server/key-material-2/tls.crt
+      my-cluster-proxy-2:
+        targetCluster:
+          bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
+          tls:
+            trust:
+              storeFile: /opt/kroxylicious/trust/ca.p12
+              storePassword:
+                passwordFile: /opt/kroxylicious/trust/ca.password
+        clusterNetworkAddressConfigProvider:
+          type: SniRoutingClusterNetworkAddressConfigProvider
+          config:
+            bootstrapAddress: mycluster-proxy-2.kafka:9092
+            brokerAddressPattern: broker$(nodeId).mycluster-proxy-2.kafka
+        logNetwork: false
+        logFrames: false
+        tls:
+          key:
+            keyPairs:
+              - privateKeyFile: /opt/kroxylicious/server/key-material/tls.key
+                certificateFile: /opt/kroxylicious/server/key-material/tls.crt
+              - privateKeyFile: /opt/kroxylicious/server/key-material-2/tls.key
+                certificateFile: /opt/kroxylicious/server/key-material-2/tls.crt

--- a/kubernetes-examples/network-topologies/snirouting_tls/base/kroxylicious/kroxylicious-deployment.yaml
+++ b/kubernetes-examples/network-topologies/snirouting_tls/base/kroxylicious/kroxylicious-deployment.yaml
@@ -40,6 +40,9 @@ spec:
         - name: kroxy-server-key-material-volume
           readOnly: true
           mountPath: /opt/kroxylicious/server/key-material
+        - name: kroxy-server-key-material-volume-2
+          readOnly: true
+          mountPath: /opt/kroxylicious/server/key-material-2
         - name: kroxy-server-keystore-password-volume
           readOnly: true
           mountPath: /opt/kroxylicious/server/keystore-password
@@ -53,6 +56,9 @@ spec:
       - name: kroxy-server-key-material-volume
         secret:
           secretName: kroxy-server-key-material
+      - name: kroxy-server-key-material-volume-2
+        secret:
+          secretName: kroxy-server-key-material-2
       - name: kroxy-server-keystore-password-volume
         secret:
           secretName: kroxy-server-keystore-password

--- a/kubernetes-examples/network-topologies/snirouting_tls/overlays/minikube/kroxylicious/server-certificate.yaml
+++ b/kubernetes-examples/network-topologies/snirouting_tls/overlays/minikube/kroxylicious/server-certificate.yaml
@@ -37,3 +37,37 @@ spec:
     name: selfsigned-issuer
     kind: Issuer
     group: cert-manager.io
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: server-certificate-2
+spec:
+  isCA: true
+  commonName: mycluster-proxy-2.kafka
+  secretName: kroxy-server-key-material-2
+  privateKey:
+    algorithm: RSA
+    size: 4096
+    # Note the cert-manager default is PKCS1. The tls.key generated won't work with Kroxylicious unless you put
+    # Bouncy Castle in the classpath.  PKCS8 works without the classpath addition.
+    encoding: PKCS8
+  keystores:
+   pkcs12:
+     create: true
+     passwordSecretRef:
+       name: kroxy-server-keystore-password
+       key: storePassword
+  dnsNames:
+    # Note that the postinstall.sh scripts relies on the bootstrap address being first.
+    - mycluster-proxy-2.kafka
+    - broker0.mycluster-proxy-2.kafka
+    - broker1.mycluster-proxy-2.kafka
+    - broker2.mycluster-proxy-2.kafka
+  usages:
+    - server auth
+  issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Users can configure a list of KeyPairs for a virtual clusters server TLS. When selecting the KeyPair for that virtual cluster we select one of the keypairs. The criteria for selection is:

1. The certificate of the keypair has SANs containing the virtual cluster bootstrap hostname.
2. Or, if the cert has no SANs, the bootstrap address matches the subject common name.

It is an error to match multiple certificates.

### Additional Context

We are investigating implementing the Gateway API in the Kroxylicious Opeartor. In the Gateway API a Gateway has listeners, equivalent to an ip+port. A listener can have an associated list of certificateRefs. But in the Proxy currently multiple virtual clusters attached to the same port may have distinct certificates, as they are exposing different hostnames. The Gateway API doesn't give us a way to associate certain certificates with certain routes.

So this is one idea to work around this. We would instead supply the virtual cluster with all the certificates of the gateway, and then select the appropriate certificate for that Virtual Cluster by looking at each certificate's SANs. This demonstration expects the exposed bootstrap hostname to match a SAN in exactly one of the certificates.

Note that for SNI we will not currently be able to check that all the broker ids have an appropriate SAN (once templated into the brokerPattern) as we are not aware of the node ids of the target cluster in advance. We can only check our bootstrap hostname.

The same kind of logic could be done in the Operator, but it feels neater to not have the operator output influenced by the certificate contents. Rather we could deterministically manifest our proxy deployment and configuration, and let the proxy deal with inspecting the certificates and selecting appropriate certs for each Virtual Cluster.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
