### PR TITLE
fix renovate for localstack helm chart

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -68,7 +68,9 @@
         "AWS_LOCALSTACK_CHART_VERSION_DEFAULT = \"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
       ],
       "datasourceTemplate": "github-tags",
-      "depNameTemplate": "localstack/helm-charts"
+      "depNameTemplate": "localstack/helm-charts",
+      "extractVersionTemplate": "^localstack-(?<version>.*)$",
+      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fix renovate helm chart for Localstack as I didn't realize that the real tag used in localstack/helm-charts is `localstack-X.Y.Z` instead of `X.Y.Z`

### Additional Context

I have tested the solution locally and works fine.
```
 "branchesInformation": [
         {
           "branchName": "renovate/localstack-helm-charts-0.x",
           "prNo": null,
           "prTitle": "chore(deps): update dependency localstack/helm-charts to v0.6.20",
           "result": "no-work",
           "upgrades": [
             {
               "datasource": "github-tags",
               "depName": "localstack/helm-charts",
               "displayPending": "",
               "fixedVersion": "0.6.15",
               "currentVersion": "0.6.15",
               "currentValue": "0.6.15",
               "newValue": "0.6.20",
               "newVersion": "0.6.20",
               "packageFile": "kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java",
               "updateType": "patch",
               "packageName": "localstack/helm-charts"
             }
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
