### PR TITLE
Refactor Vault unit tests to use Wiremock too

### DIFF
--- a/kroxylicious-kms-provider-hashicorp-vault/pom.xml
+++ b/kroxylicious-kms-provider-hashicorp-vault/pom.xml
@@ -36,6 +36,17 @@
             <artifactId>kroxylicious-api</artifactId>
         </dependency>
 
+        <!-- project dependencies - test -->
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-kms-test-support</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-kms-tls-support</artifactId>
+        </dependency>
+
         <!-- third party dependencies - build and compile -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -86,13 +97,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.kroxylicious</groupId>
-            <artifactId>kroxylicious-kms-test-support</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.kroxylicious</groupId>
-            <artifactId>kroxylicious-kms-tls-support</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

Use wiremock in Vault unit tests rather than hand rolling HTTP servers.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
