### PR TITLE
Fix #1380: Remove deprecated FilterFactoryContext#eventLoop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
-* [#1445](https://github.com/kroxylicious/kroxylicious/issues/1445) Remove deprecated ProduceValidationFilterFactory, replacement is RecordValidation.
+* [#1380](https://github.com/kroxylicious/kroxylicious/issues/1380) Deprecated FilterFactoryContext#eventLoop() is removed.
 * [#1747](https://github.com/kroxylicious/kroxylicious/pull/1747) Bump io.micrometer:micrometer-bom from 1.14.2 to 1.14.3
 * [#1745](https://github.com/kroxylicious/kroxylicious/pull/1745) Bump com.github.ben-manes.caffeine:caffeine from 3.1.8 to 3.2.0
 * [#1006](https://github.com/kroxylicious/kroxylicious/pull/1660) Allow CipherSuites and TLS Protocols to be passed via Configuration
@@ -23,6 +23,7 @@ Format `<github issue/pr number>: <short description>`.
 * The top level `filters` configuration property is deprecated. Configurations should use `filterDefinitions` and `defaultFilters` instead.
 * The `bootstrap_servers` property of a virtual cluster's `targetCluster` is deprecated. It is replaced by a property called `bootstrapServers`.
 * As per deprecation notice made at 0.7.0, `ProduceValidationFilterFactory` filter is removed.  Use `RecordValidation` instead.
+* As per deprecation notice made at 0.7.0, `FilterFactoryContext#eventLoop()` is removed. Use `FilterFactoryContext#filterDispatchExecutor()` instead..
 
 ## 0.9.0
 

--- a/kroxylicious-api/pom.xml
+++ b/kroxylicious-api/pom.xml
@@ -162,6 +162,7 @@
                         <breakBuildBasedOnSemanticVersioningForMajorVersionZero>${ApiCompatability.EnforceForMajorVersionZero}</breakBuildBasedOnSemanticVersioningForMajorVersionZero>
                         <excludes>
                             <exclude>io.kroxylicious.proxy.config.secret.FilePasswordFilePath</exclude>  <!-- used purely in config files and the name still exists (as a JSON alias) -->
+                            <exclude>io.kroxylicious.proxy.filter.FilterFactoryContext#eventLoop()</exclude> <!-- https://github.com/kroxylicious/kroxylicious/issues/1380 scheduled removal of deprecated API method -->
                         </excludes>
                         <!-- see documentation -->
                     </parameter>

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactoryContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactoryContext.java
@@ -6,8 +6,6 @@
 
 package io.kroxylicious.proxy.filter;
 
-import java.util.concurrent.ScheduledExecutorService;
-
 import io.kroxylicious.proxy.plugin.UnknownPluginInstanceException;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -17,17 +15,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * to the FilterFactory when it is creating a new instance of the Filter. see {@link FilterFactory#createFilter(FilterFactoryContext, Object)}
  */
 public interface FilterFactoryContext {
-
-    /**
-     * The event loop that this Filter's channel is assigned to.
-     * Null if the factory is not bound to a channel yet.
-     * Should be safe
-     * to mutate Filter members from this executor.
-     * @return executor, or null
-     * @deprecated use {@link #filterDispatchExecutor()} instead
-     */
-    @Deprecated(since = "0.7.0")
-    ScheduledExecutorService eventLoop();
 
     /**
      * An executor backed by the single Thread responsible for dispatching

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.kroxylicious.proxy.config.NamedFilterDefinition;
@@ -95,10 +94,6 @@ public class FilterChainFactory implements AutoCloseable {
         }
         else {
             FilterFactoryContext context = new FilterFactoryContext() {
-                @Override
-                public ScheduledExecutorService eventLoop() {
-                    return null;
-                }
 
                 @Override
                 public FilterDispatchExecutor filterDispatchExecutor() {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/NettyFilterContext.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/NettyFilterContext.java
@@ -6,8 +6,6 @@
 
 package io.kroxylicious.proxy.internal.filter;
 
-import java.util.concurrent.ScheduledExecutorService;
-
 import io.netty.channel.EventLoop;
 
 import io.kroxylicious.proxy.config.PluginFactory;
@@ -26,11 +24,6 @@ public class NettyFilterContext implements FilterFactoryContext {
                               PluginFactoryRegistry pluginFactoryRegistry) {
         this.dispatchExecutor = NettyFilterDispatchExecutor.eventLoopExecutor(eventLoop);
         this.pluginFactoryRegistry = pluginFactoryRegistry;
-    }
-
-    @Override
-    public ScheduledExecutorService eventLoop() {
-        return filterDispatchExecutor();
     }
 
     @Override

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/bootstrap/FilterChainFactoryTest.java
@@ -121,7 +121,7 @@ class FilterChainFactoryTest {
             assertThat(testFilterImpl.getContributorClass()).isEqualTo(TestFilterFactory.class);
             FilterDispatchExecutor filterDispatchExecutor = testFilterImpl.getContext().filterDispatchExecutor();
             assertThat(filterDispatchExecutor).isNotNull();
-            assertThat(testFilterImpl.getContext().eventLoop()).isSameAs(filterDispatchExecutor);
+            assertThat(testFilterImpl.getContext().filterDispatchExecutor()).isSameAs(filterDispatchExecutor);
             assertThat(testFilterImpl.getExampleConfig()).isSameAs(config);
         });
     }
@@ -136,14 +136,14 @@ class FilterChainFactoryTest {
                     assertThat(testFilterImpl.getContributorClass()).isEqualTo(factoryClass);
                     FilterDispatchExecutor filterDispatchExecutor = testFilterImpl.getContext().filterDispatchExecutor();
                     assertThat(filterDispatchExecutor).isNotNull();
-                    assertThat(testFilterImpl.getContext().eventLoop()).isSameAs(filterDispatchExecutor);
+                    assertThat(testFilterImpl.getContext().filterDispatchExecutor()).isSameAs(filterDispatchExecutor);
                     assertThat(testFilterImpl.getExampleConfig()).isSameAs(config);
                 });
         listAssert.element(1).extracting(FilterAndInvoker::filter).isInstanceOfSatisfying(expectedFilterClass, testFilterImpl -> {
             assertThat(testFilterImpl.getContributorClass()).isEqualTo(factoryClass);
             FilterDispatchExecutor filterDispatchExecutor = testFilterImpl.getContext().filterDispatchExecutor();
             assertThat(filterDispatchExecutor).isNotNull();
-            assertThat(testFilterImpl.getContext().eventLoop()).isSameAs(filterDispatchExecutor);
+            assertThat(testFilterImpl.getContext().filterDispatchExecutor()).isSameAs(filterDispatchExecutor);
             assertThat(testFilterImpl.getExampleConfig()).isSameAs(config);
         });
     }


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Refactoring

### Description

why: as per deprecation notice given in 0.7.0, it is replaced by #filterDispatchExecutor().


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
