### PR TITLE
SNI exposition: user can control advertised broker port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#1761](https://github.com/kroxylicious/kroxylicious/pull/1761) SNI exposition: user can control advertised broker port
 * [#1766](https://github.com/kroxylicious/kroxylicious/issues/1766) Bump apicurio-registry.version from 2.6.6.Final to 2.6.7.Final
 * [#1380](https://github.com/kroxylicious/kroxylicious/issues/1380) Deprecated FilterFactoryContext#eventLoop() is removed.
 * [#1747](https://github.com/kroxylicious/kroxylicious/pull/1747) Bump io.micrometer:micrometer-bom from 1.14.2 to 1.14.3
@@ -25,6 +26,9 @@ Format `<github issue/pr number>: <short description>`.
 * The `bootstrap_servers` property of a virtual cluster's `targetCluster` is deprecated. It is replaced by a property called `bootstrapServers`.
 * As per deprecation notice made at 0.7.0, `ProduceValidationFilterFactory` filter is removed.  Use `RecordValidation` instead.
 * As per deprecation notice made at 0.7.0, `FilterFactoryContext#eventLoop()` is removed. Use `FilterFactoryContext#filterDispatchExecutor()` instead..
+* SniRoutingClusterNetworkAddressConfigProvider configuration property `brokerAddressPattern` is deprecated. It is replaced by a property called
+`advertisedBrokerAddressPattern`. These properties now also support the user optionally specifying a port, which will be the port advertised to
+Kafka clients. This is to enable use-cases where Kroxylicious is behind some other proxy technology using a different port scheme.
 
 ## 0.9.0
 

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousConfigUtils.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousConfigUtils.java
@@ -99,7 +99,7 @@ public class KroxyliciousConfigUtils {
             return c.getBootstrapAddress().toString();
         }
         else if (provider.config() instanceof SniRoutingClusterNetworkAddressConfigProviderConfig c) {
-            return c.getBootstrapAddress().toString();
+            return new HostPort(c.getBootstrapAddress().host(), c.getAdvertisedPort()).toString();
         }
         else {
             throw new IllegalStateException("I don't know how to handle ClusterEndpointConfigProvider type:" + provider.type());

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
@@ -127,7 +127,7 @@ class ConfigurationTest {
                                     defaultFilters:
                                       - filter-1
                                 """),
-                argumentSet("With Virtual Cluster",
+                argumentSet("With Virtual Cluster - deprecated brokerAddressPattern",
                         new ConfigurationBuilder()
                                 .addToVirtualClusters("demo", new VirtualClusterBuilder()
                                         .withNewTargetCluster()
@@ -151,6 +151,30 @@ class ConfigurationTest {
                                         bootstrapAddress: cluster1:9192
                                         brokerAddressPattern: broker-$(nodeId)
                                 """),
+                argumentSet("With Virtual Cluster",
+                        new ConfigurationBuilder()
+                                .addToVirtualClusters("demo", new VirtualClusterBuilder()
+                                        .withNewTargetCluster()
+                                        .withBootstrapServers("kafka.example:1234")
+                                        .endTargetCluster()
+                                        .withClusterNetworkAddressConfigProvider(
+                                                new ClusterNetworkAddressConfigProviderDefinitionBuilder(
+                                                        "SniRoutingClusterNetworkAddressConfigProvider")
+                                                        .withConfig("bootstrapAddress", "cluster1:9192", "advertisedBrokerAddressPattern", "broker-$(nodeId)")
+                                                        .build())
+                                        .build())
+                                .build(),
+                        """
+                                virtualClusters:
+                                  demo:
+                                    targetCluster:
+                                      bootstrapServers: kafka.example:1234
+                                    clusterNetworkAddressConfigProvider:
+                                      type: SniRoutingClusterNetworkAddressConfigProvider
+                                      config:
+                                        bootstrapAddress: cluster1:9192
+                                        advertisedBrokerAddressPattern: broker-$(nodeId)
+                                """),
                 argumentSet("Downstream TLS - default client auth",
                         new ConfigurationBuilder()
                                 .addToVirtualClusters("demo", new VirtualClusterBuilder()
@@ -167,7 +191,7 @@ class ConfigurationTest {
                                         .withClusterNetworkAddressConfigProvider(
                                                 new ClusterNetworkAddressConfigProviderDefinitionBuilder(
                                                         "SniRoutingClusterNetworkAddressConfigProvider")
-                                                        .withConfig("bootstrapAddress", "cluster1:9192", "brokerAddressPattern", "broker-$(nodeId)")
+                                                        .withConfig("bootstrapAddress", "cluster1:9192", "advertisedBrokerAddressPattern", "broker-$(nodeId)")
                                                         .build())
                                         .build())
                                 .build(),
@@ -186,7 +210,7 @@ class ConfigurationTest {
                                       type: SniRoutingClusterNetworkAddressConfigProvider
                                       config:
                                         bootstrapAddress: cluster1:9192
-                                        brokerAddressPattern: broker-$(nodeId)
+                                        advertisedBrokerAddressPattern: broker-$(nodeId)
                                 """),
                 argumentSet("Downstream TLS - required client auth",
                         new ConfigurationBuilder()
@@ -210,7 +234,7 @@ class ConfigurationTest {
                                         .withClusterNetworkAddressConfigProvider(
                                                 new ClusterNetworkAddressConfigProviderDefinitionBuilder(
                                                         "SniRoutingClusterNetworkAddressConfigProvider")
-                                                        .withConfig("bootstrapAddress", "cluster1:9192", "brokerAddressPattern", "broker-$(nodeId)")
+                                                        .withConfig("bootstrapAddress", "cluster1:9192", "advertisedBrokerAddressPattern", "broker-$(nodeId)")
                                                         .build())
                                         .build())
                                 .build(),
@@ -233,7 +257,7 @@ class ConfigurationTest {
                                       type: SniRoutingClusterNetworkAddressConfigProvider
                                       config:
                                         bootstrapAddress: cluster1:9192
-                                        brokerAddressPattern: broker-$(nodeId)
+                                        advertisedBrokerAddressPattern: broker-$(nodeId)
                                 """),
                 argumentSet("Upstream TLS - platform trust",
                         new ConfigurationBuilder()
@@ -246,7 +270,7 @@ class ConfigurationTest {
                                         .withClusterNetworkAddressConfigProvider(
                                                 new ClusterNetworkAddressConfigProviderDefinitionBuilder(
                                                         "SniRoutingClusterNetworkAddressConfigProvider")
-                                                        .withConfig("bootstrapAddress", "cluster1:9192", "brokerAddressPattern", "broker-$(nodeId)")
+                                                        .withConfig("bootstrapAddress", "cluster1:9192", "advertisedBrokerAddressPattern", "broker-$(nodeId)")
                                                         .build())
                                         .build())
                                 .build(),
@@ -260,7 +284,7 @@ class ConfigurationTest {
                                       type: SniRoutingClusterNetworkAddressConfigProvider
                                       config:
                                         bootstrapAddress: cluster1:9192
-                                        brokerAddressPattern: broker-$(nodeId)
+                                        advertisedBrokerAddressPattern: broker-$(nodeId)
                                 """),
                 argumentSet("Upstream TLS - trust from truststore",
                         new ConfigurationBuilder()
@@ -278,7 +302,7 @@ class ConfigurationTest {
                                         .withClusterNetworkAddressConfigProvider(
                                                 new ClusterNetworkAddressConfigProviderDefinitionBuilder(
                                                         "SniRoutingClusterNetworkAddressConfigProvider")
-                                                        .withConfig("bootstrapAddress", "cluster1:9192", "brokerAddressPattern", "broker-$(nodeId)")
+                                                        .withConfig("bootstrapAddress", "cluster1:9192", "advertisedBrokerAddressPattern", "broker-$(nodeId)")
                                                         .build())
                                         .build())
                                 .build(),
@@ -297,7 +321,7 @@ class ConfigurationTest {
                                       type: SniRoutingClusterNetworkAddressConfigProvider
                                       config:
                                         bootstrapAddress: cluster1:9192
-                                        brokerAddressPattern: broker-$(nodeId)
+                                        advertisedBrokerAddressPattern: broker-$(nodeId)
                                 """),
                 argumentSet("Upstream TLS - trust from truststore, password from file",
                         new ConfigurationBuilder()
@@ -315,7 +339,7 @@ class ConfigurationTest {
                                         .withClusterNetworkAddressConfigProvider(
                                                 new ClusterNetworkAddressConfigProviderDefinitionBuilder(
                                                         "SniRoutingClusterNetworkAddressConfigProvider")
-                                                        .withConfig("bootstrapAddress", "cluster1:9192", "brokerAddressPattern", "broker-$(nodeId)")
+                                                        .withConfig("bootstrapAddress", "cluster1:9192", "advertisedBrokerAddressPattern", "broker-$(nodeId)")
                                                         .build())
                                         .build())
                                 .build(),
@@ -334,7 +358,7 @@ class ConfigurationTest {
                                       type: SniRoutingClusterNetworkAddressConfigProvider
                                       config:
                                         bootstrapAddress: cluster1:9192
-                                        brokerAddressPattern: broker-$(nodeId)
+                                        advertisedBrokerAddressPattern: broker-$(nodeId)
                                 """),
                 argumentSet("Upstream TLS - insecure",
                         new ConfigurationBuilder()
@@ -348,7 +372,7 @@ class ConfigurationTest {
                                         .withClusterNetworkAddressConfigProvider(
                                                 new ClusterNetworkAddressConfigProviderDefinitionBuilder(
                                                         "SniRoutingClusterNetworkAddressConfigProvider")
-                                                        .withConfig("bootstrapAddress", "cluster1:9192", "brokerAddressPattern", "broker-$(nodeId)")
+                                                        .withConfig("bootstrapAddress", "cluster1:9192", "advertisedBrokerAddressPattern", "broker-$(nodeId)")
                                                         .build())
                                         .build())
                                 .build(),
@@ -364,7 +388,7 @@ class ConfigurationTest {
                                       type: SniRoutingClusterNetworkAddressConfigProvider
                                       config:
                                         bootstrapAddress: cluster1:9192
-                                        brokerAddressPattern: broker-$(nodeId)
+                                        advertisedBrokerAddressPattern: broker-$(nodeId)
                                 """)
 
         );

--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -132,6 +132,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>
@@ -139,6 +144,16 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/net/PassthroughProxy.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/net/PassthroughProxy.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.net;
+
+import java.io.Closeable;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+
+/**
+ * A Proxy server that listens on a random ephemeral port, and proxies all data received to
+ * a remote host/port. This is to enable us to test cases where Kroxylicious sits behind
+ * yet another proxy using a different port scheme, and we need the clients to be told
+ * how to connect to the outer proxy.
+ */
+public class PassthroughProxy implements Closeable {
+    private final ChannelFuture future;
+    private static final Logger LOGGER = LoggerFactory.getLogger(PassthroughProxy.class);
+
+    public PassthroughProxy(int remotePort, String remoteHost) {
+        ServerBootstrap b = new ServerBootstrap();
+        EventLoopGroup bossGroup = new NioEventLoopGroup(1);
+        EventLoopGroup workerGroup = new NioEventLoopGroup();
+        future = b.group(bossGroup, workerGroup)
+                .channel(NioServerSocketChannel.class)
+                .childHandler(new PassthroughProxyInitiailizer(remoteHost, remotePort))
+                .childOption(ChannelOption.AUTO_READ, false)
+                .bind(0);
+    }
+
+    public int getLocalPort() {
+        try {
+            future.get(5, TimeUnit.SECONDS);
+            SocketAddress socketAddress = future.channel().localAddress();
+            if (socketAddress instanceof InetSocketAddress) {
+                return ((InetSocketAddress) socketAddress).getPort();
+            }
+            else {
+                throw new RuntimeException("Unexpected socket address type: " + socketAddress.toString());
+            }
+        }
+        catch (Exception e) {
+            LOGGER.error("channel future did not complete within 5 seconds");
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close() {
+        future.addListener(
+                (ChannelFutureListener) channelFuture -> channelFuture.channel().close()
+                        .addListener((ChannelFutureListener) channelFuture1 -> LOGGER.info("passthrough proxy closed")));
+    }
+
+    private static class PassthroughProxyInitiailizer extends ChannelInitializer<SocketChannel> {
+        private final String remoteHost;
+        private final int remotePort;
+
+        private PassthroughProxyInitiailizer(String remoteHost, int remotePort) {
+            this.remoteHost = remoteHost;
+            this.remotePort = remotePort;
+        }
+
+        @Override
+        public void initChannel(SocketChannel ch) {
+            ch.pipeline().addLast(new PassthroughProxyFrontendHandler(remoteHost, remotePort));
+        }
+
+    }
+
+    private static class PassthroughProxyFrontendHandler extends ChannelInboundHandlerAdapter {
+        private final String remoteHost;
+        private final int remotePort;
+
+        private PassthroughProxyFrontendHandler(String remoteHost, int remotePort) {
+            this.remoteHost = remoteHost;
+            this.remotePort = remotePort;
+        }
+
+        private Channel outboundChannel;
+
+        @Override
+        public void channelActive(ChannelHandlerContext ctx) {
+            final Channel inboundChannel = ctx.channel();
+
+            Bootstrap b = new Bootstrap();
+            b.group(inboundChannel.eventLoop())
+                    .channel(ctx.channel().getClass())
+                    .handler(new PassthroughProxyBackendHandler(inboundChannel))
+                    .option(ChannelOption.AUTO_READ, false);
+            ChannelFuture f = b.connect(remoteHost, remotePort);
+            outboundChannel = f.channel();
+            f.addListener((ChannelFutureListener) channelFuture -> {
+                if (channelFuture.isSuccess()) {
+                    inboundChannel.read();
+                }
+                else {
+                    inboundChannel.close();
+                }
+            });
+        }
+
+        @Override
+        public void channelRead(final ChannelHandlerContext ctx, Object msg) {
+            if (outboundChannel.isActive()) {
+                outboundChannel.writeAndFlush(msg).addListener((ChannelFutureListener) channelFuture -> {
+                    if (channelFuture.isSuccess()) {
+                        ctx.channel().read();
+                    }
+                    else {
+                        channelFuture.channel().close();
+                    }
+                });
+            }
+        }
+
+        @Override
+        public void channelInactive(ChannelHandlerContext ctx) {
+            if (outboundChannel != null) {
+                closeOnFlush(outboundChannel);
+            }
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            LOGGER.info("exception caught in frontend handler", cause);
+            closeOnFlush(ctx.channel());
+        }
+
+        /**
+         * Closes the specified channel after all queued write requests are flushed.
+         */
+        static void closeOnFlush(Channel ch) {
+            if (ch.isActive()) {
+                ch.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
+            }
+        }
+    }
+
+    private static class PassthroughProxyBackendHandler extends ChannelInboundHandlerAdapter {
+        private final Channel inboundChannel;
+
+        private PassthroughProxyBackendHandler(Channel inboundChannel) {
+            this.inboundChannel = inboundChannel;
+        }
+
+        @Override
+        public void channelActive(ChannelHandlerContext ctx) {
+            if (!inboundChannel.isActive()) {
+                PassthroughProxyFrontendHandler.closeOnFlush(ctx.channel());
+            }
+            else {
+                ctx.read();
+            }
+        }
+
+        @Override
+        public void channelRead(final ChannelHandlerContext ctx, Object msg) {
+            inboundChannel.writeAndFlush(msg).addListener((ChannelFutureListener) channelFuture -> {
+                if (channelFuture.isSuccess()) {
+                    ctx.channel().read();
+                }
+                else {
+                    channelFuture.channel().close();
+                }
+            });
+        }
+
+        @Override
+        public void channelInactive(ChannelHandlerContext ctx) {
+            PassthroughProxyFrontendHandler.closeOnFlush(inboundChannel);
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+            LOGGER.info("exception caught on backend handler", cause);
+            PassthroughProxyFrontendHandler.closeOnFlush(ctx.channel());
+        }
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/net/PassthroughProxyTest.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/net/PassthroughProxyTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.net;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WireMockTest
+public class PassthroughProxyTest {
+
+    public static final String BODY = "hello";
+
+    @Test
+    void testProxy(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        try (var proxy = new PassthroughProxy(wmRuntimeInfo.getHttpPort(), "localhost");
+                var httpClient = HttpClient.newHttpClient();) {
+            stubFor(WireMock.get(urlEqualTo("/")).willReturn(WireMock.aResponse().withBody(BODY)));
+            URI uri = URI.create("http://localhost:" + proxy.getLocalPort());
+            HttpRequest request = HttpRequest.newBuilder(uri).GET().build();
+            HttpResponse<String> send = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            assertThat(send.body()).isEqualTo(BODY);
+        }
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/SniRoutingClusterNetworkAddressConfigProvider.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/SniRoutingClusterNetworkAddressConfigProvider.java
@@ -9,9 +9,13 @@ package io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.BrokerAddressPatternUtils.PatternAndPort;
 import io.kroxylicious.proxy.plugin.Plugin;
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProviderService;
@@ -25,14 +29,16 @@ import static io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider
 import static io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.BrokerAddressPatternUtils.validateStringContainsRequiredTokens;
 
 /**
- * A ClusterNetworkAddressConfigProvider implementation that uses a single, shared, port for bootstrap and
- * all brokers.  SNI information is used to route the connection to the correct target.
+ * A ClusterNetworkAddressConfigProvider implementation that binds to a single, shared, port for bootstrap and
+ * all brokers. SNI information is used to route the connection to the correct target.
  * <br/>
  * The following configuration is required:
  * <ul>
  *    <li>{@code bootstrapAddress} a {@link HostPort} defining the host and port of the bootstrap address.</li>
- *    <li>{@code brokerAddressPattern} an address pattern used to form broker addresses.  It is addresses made from this pattern that are returned to the kafka
- *  *    client in the Metadata response so must be resolvable by the client.  One pattern is supported: {@code $(nodeId)} which interpolates the node id into the address.
+ *    <li>Either {@code brokerAddressPattern} (deprecated) or ${@code advertisedBrokerAddressPattern} must be set (but not both).  These properties contain an address
+ *    pattern used to advertise broker addresses.  It is addresses made from this pattern that are returned to the kafka client in the Metadata response so must be
+ *    resolvable by the client.  Optionally these properties can specify a port which will be advertised to the clients.  One pattern is supported: {@code $(nodeId)}
+ *    which interpolates the node id into the address.
  * </ul>
  */
 @Plugin(configType = SniRoutingClusterNetworkAddressConfigProvider.SniRoutingClusterNetworkAddressConfigProviderConfig.class)
@@ -49,6 +55,7 @@ public class SniRoutingClusterNetworkAddressConfigProvider implements
         private final HostPort bootstrapAddress;
         private final String brokerAddressPattern;
         private final Pattern brokerAddressNodeIdCapturingRegex;
+        private final int advertisedPort;
 
         /**
          * Creates the provider.
@@ -57,8 +64,9 @@ public class SniRoutingClusterNetworkAddressConfigProvider implements
          */
         private Provider(SniRoutingClusterNetworkAddressConfigProviderConfig config) {
             this.bootstrapAddress = config.bootstrapAddress;
-            this.brokerAddressPattern = config.brokerAddressPattern;
+            this.brokerAddressPattern = config.parsedBrokerAddressPattern;
             this.brokerAddressNodeIdCapturingRegex = config.brokerAddressNodeIdCapturingRegex;
+            advertisedPort = config.getAdvertisedPort();
         }
 
         @Override
@@ -74,6 +82,12 @@ public class SniRoutingClusterNetworkAddressConfigProvider implements
             }
             // TODO: consider introducing an cache (LRU?)
             return new HostPort(BrokerAddressPatternUtils.replaceLiteralNodeId(brokerAddressPattern, nodeId), bootstrapAddress.port());
+        }
+
+        @Override
+        public HostPort getAdvertisedBrokerAddress(int nodeId) {
+            HostPort brokerAddress = getBrokerAddress(nodeId);
+            return new HostPort(brokerAddress.host(), advertisedPort);
         }
 
         @Override
@@ -111,43 +125,84 @@ public class SniRoutingClusterNetworkAddressConfigProvider implements
      */
     public static class SniRoutingClusterNetworkAddressConfigProviderConfig {
 
+        private static final Logger LOGGER = LoggerFactory.getLogger(SniRoutingClusterNetworkAddressConfigProviderConfig.class);
+        private static final String ADVERTISED_BROKER_ADDRESS_PATTERN = "advertisedBrokerAddressPattern";
+        public static final String BROKER_ADDRESS_PATTERN = "brokerAddressPattern";
+
         private final HostPort bootstrapAddress;
 
-        private final String brokerAddressPattern;
+        @JsonIgnore
+        private final String parsedBrokerAddressPattern;
         @JsonIgnore
         private final Pattern brokerAddressNodeIdCapturingRegex;
+        @JsonIgnore
+        private final Integer advertisedPort;
+        // present for serialize/deserialize fidelity
+        @SuppressWarnings("unused")
+        private final String brokerAddressPattern;
+        // present for serialize/deserialize fidelity
+        @SuppressWarnings("unused")
+        private final String advertisedBrokerAddressPattern;
 
         public SniRoutingClusterNetworkAddressConfigProviderConfig(@JsonProperty(required = true) HostPort bootstrapAddress,
-                                                                   @JsonProperty(required = true) String brokerAddressPattern) {
+                                                                   @Deprecated(forRemoval = true, since = "0.10.0") @JsonProperty String brokerAddressPattern,
+                                                                   @JsonProperty String advertisedBrokerAddressPattern) {
+            this.brokerAddressPattern = brokerAddressPattern;
+            this.advertisedBrokerAddressPattern = advertisedBrokerAddressPattern;
             if (bootstrapAddress == null) {
                 throw new IllegalArgumentException("bootstrapAddress cannot be null");
             }
-            if (brokerAddressPattern == null) {
-                throw new IllegalArgumentException("brokerAddressPattern cannot be null");
+            validateOneSpecified(brokerAddressPattern, advertisedBrokerAddressPattern);
+            String brokerAddressPatternProp;
+            String brokerAddressPatternToParse;
+            if (advertisedBrokerAddressPattern != null) {
+                brokerAddressPatternProp = ADVERTISED_BROKER_ADDRESS_PATTERN;
+                brokerAddressPatternToParse = advertisedBrokerAddressPattern;
+            }
+            else {
+                LOGGER.warn("{} is deprecated, replaced by {}", BROKER_ADDRESS_PATTERN, ADVERTISED_BROKER_ADDRESS_PATTERN);
+                brokerAddressPatternProp = BROKER_ADDRESS_PATTERN;
+                brokerAddressPatternToParse = brokerAddressPattern;
             }
 
-            validatePortSpecifier(brokerAddressPattern, s -> {
-                throw new IllegalArgumentException("brokerAddressPattern cannot have port specifier.  Found port : " + s + " within " + brokerAddressPattern);
+            PatternAndPort patternAndPort = BrokerAddressPatternUtils.parse(brokerAddressPatternToParse);
+            String brokerAddressPatternPart = patternAndPort.addressPattern();
+            advertisedPort = patternAndPort.port().orElse(bootstrapAddress.port());
+
+            validatePortSpecifier(brokerAddressPatternPart, s -> {
+                throw new IllegalArgumentException(
+                        brokerAddressPatternProp + " address pattern cannot have port specifier.  Found port : " + s + " within " + brokerAddressPatternPart);
             });
 
-            validateStringContainsOnlyExpectedTokens(brokerAddressPattern, EXPECTED_TOKEN_SET, (tok) -> {
-                throw new IllegalArgumentException("brokerAddressPattern contains an unexpected replacement token '" + tok + "'");
+            validateStringContainsOnlyExpectedTokens(brokerAddressPatternPart, EXPECTED_TOKEN_SET, tok -> {
+                throw new IllegalArgumentException(brokerAddressPatternProp + " contains an unexpected replacement token '" + tok + "'");
             });
 
-            validateStringContainsRequiredTokens(brokerAddressPattern, EXPECTED_TOKEN_SET, (tok) -> {
-                throw new IllegalArgumentException("brokerAddressPattern must contain at least one nodeId replacement pattern '" + tok + "'");
+            validateStringContainsRequiredTokens(brokerAddressPatternPart, EXPECTED_TOKEN_SET, tok -> {
+                throw new IllegalArgumentException(brokerAddressPatternProp + " must contain at least one nodeId replacement pattern '" + tok + "'");
             });
 
             this.bootstrapAddress = bootstrapAddress;
-            this.brokerAddressPattern = brokerAddressPattern;
-            this.brokerAddressNodeIdCapturingRegex = BrokerAddressPatternUtils.createNodeIdCapturingRegex(brokerAddressPattern);
+            this.parsedBrokerAddressPattern = brokerAddressPatternPart;
+            this.brokerAddressNodeIdCapturingRegex = BrokerAddressPatternUtils.createNodeIdCapturingRegex(brokerAddressPatternPart);
+        }
 
+        private static void validateOneSpecified(String brokerAddressPattern, String advertisedBrokerAddressPattern) {
+            if (brokerAddressPattern != null && advertisedBrokerAddressPattern != null) {
+                throw new IllegalArgumentException("brokerAddressPattern and advertisedBrokerAddressPattern cannot both be specified");
+            }
+            if (brokerAddressPattern == null && advertisedBrokerAddressPattern == null) {
+                throw new IllegalArgumentException("brokerAddressPattern and advertisedBrokerAddressPattern are both null");
+            }
         }
 
         public HostPort getBootstrapAddress() {
             return bootstrapAddress;
         }
 
+        public int getAdvertisedPort() {
+            return advertisedPort;
+        }
     }
 
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilter.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilter.java
@@ -165,11 +165,12 @@ public class BrokerAddressFilter implements MetadataResponseFilter, FindCoordina
         String incomingHost = hostGetter.apply(broker);
         int incomingPort = portGetter.applyAsInt(broker);
 
-        var downstreamAddress = virtualCluster.getBrokerAddress(nodeIdGetter.apply(broker));
+        Integer nodeId = nodeIdGetter.apply(broker);
+        var advertisedAddress = virtualCluster.getAdvertisedBrokerAddress(nodeId);
 
-        LOGGER.trace("{}: Rewriting broker address in response {}:{} -> {}", context, incomingHost, incomingPort, downstreamAddress);
-        hostSetter.accept(broker, downstreamAddress.host());
-        portSetter.accept(broker, downstreamAddress.port());
+        LOGGER.trace("{}: Rewriting broker address in response {}:{} -> {}", context, incomingHost, incomingPort, advertisedAddress);
+        hostSetter.accept(broker, advertisedAddress.host());
+        portSetter.accept(broker, advertisedAddress.port());
     }
 
     private CompletionStage<ResponseFilterResult> doReconcileThenForwardResponse(ResponseHeaderData header, ApiMessage data, FilterContext context,

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
@@ -354,4 +354,9 @@ public class VirtualCluster implements ClusterNetworkAddressConfigProvider {
     public @NonNull List<NamedFilterDefinition> getFilters() {
         return filters;
     }
+
+    @Override
+    public HostPort getAdvertisedBrokerAddress(int nodeId) {
+        return clusterNetworkAddressConfigProvider.getAdvertisedBrokerAddress(nodeId);
+    }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/service/ClusterNetworkAddressConfigProvider.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/service/ClusterNetworkAddressConfigProvider.java
@@ -22,7 +22,7 @@ public interface ClusterNetworkAddressConfigProvider {
     HostPort getClusterBootstrapAddress();
 
     /**
-     * Address of broker with the given node id, includes the port. Note that
+     * Address of broker with the given node id, (advertised hostname and bind port). Note that
      * {@code nodeId} are generally expected to be consecutively numbered and starting from zero. However,
      * gaps in the sequence can potentially emerge as the target cluster topology evolves.
      *
@@ -33,10 +33,22 @@ public interface ClusterNetworkAddressConfigProvider {
     HostPort getBrokerAddress(int nodeId) throws IllegalArgumentException;
 
     /**
-     * Generates the node id implied by the given broker address. This method make sense only for
-     * implementation that embed node id information into the broker address.  This information is
-     * used at startup time to allow a client that already in possession of a broker address
-     * to reconnect to the cluster via Kroxylicious using only that address.
+     * Advertised address of broker with the given node id, (advertised hostname and advertised port). This is
+     * what is returned to clients and may differ from the node's bind port as presented by {@link #getBrokerAddress(int)}.
+     * This enables Kroxylicious to sit behind yet another proxy that uses a different port from the kroxylicious bind port.
+     * @param nodeId node id
+     * @return the port to advertise for the nodeId
+     * @throws IllegalArgumentException if this provider cannot produce a broker address for the given nodeId.
+     */
+    default HostPort getAdvertisedBrokerAddress(int nodeId) throws IllegalArgumentException {
+        return getBrokerAddress(nodeId);
+    }
+
+    /**
+     * Generates the node id implied by the given broker address (advertised hostname and bind port).
+     * This method make sense only for implementation that embed node id information into the broker
+     * address.  This information is used at startup time to allow a client that already in possession
+     * of a broker address to reconnect to the cluster via Kroxylicious using only that address.
      * <br/>
      * This is an optional method. An implementation can return null.
      *

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
@@ -117,7 +117,7 @@ class KafkaProxyTest {
                       type: SniRoutingClusterNetworkAddressConfigProvider
                       config:
                         bootstrapAddress: cluster1:9192
-                        brokerAddressPattern:  broker-$(nodeId)
+                        advertisedBrokerAddressPattern:  broker-$(nodeId)
                     targetCluster:
                       bootstrapServers: kafka.example:1234
                 """, "Cluster endpoint provider requires server TLS, but this virtual cluster does not define it"));

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -101,6 +101,17 @@ class ConfigParserTest {
                                 bootstrapAddress: cluster1:9192
                                 brokerAddressPattern: broker-$(nodeId)
                         """),
+                Arguments.of("Virtual cluster (SniRouting) advertised port", """
+                        virtualClusters:
+                          demo1:
+                            targetCluster:
+                              bootstrapServers: kafka.example:1234
+                            clusterNetworkAddressConfigProvider:
+                              type: SniRoutingClusterNetworkAddressConfigProvider
+                              config:
+                                bootstrapAddress: cluster1:9192
+                                advertisedBrokerAddressPattern: brozker-$(nodeId):23
+                        """),
                 Arguments.of("Downstream/Upstream TLS with inline passwords", """
                         virtualClusters:
                           demo1:

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilterTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilterTest.java
@@ -106,6 +106,7 @@ class BrokerAddressFilterTest {
         filter = new BrokerAddressFilter(virtualCluster, endpointReconciler);
         invoker = getOnlyElement(FilterAndInvoker.build(filter)).invoker();
         lenient().when(virtualCluster.getBrokerAddress(0)).thenReturn(HostPort.parse("downstream:19199"));
+        lenient().when(virtualCluster.getAdvertisedBrokerAddress(0)).thenReturn(HostPort.parse("downstream:19200"));
 
         var nodeMap = Map.of(0, HostPort.parse("upstream:9199"));
         lenient().when(endpointReconciler.reconcile(Mockito.eq(virtualCluster), Mockito.eq(nodeMap)))

--- a/kroxylicious-runtime/src/test/resources/io/kroxylicious/proxy/internal/filter/DescribeCluster.test.yaml
+++ b/kroxylicious-runtime/src/test/resources/io/kroxylicious/proxy/internal/filter/DescribeCluster.test.yaml
@@ -25,5 +25,5 @@
         value: downstream
       - op: replace
         path: "/brokers/0/port"
-        value: 19199
+        value: 19200
   disabled: false

--- a/kroxylicious-runtime/src/test/resources/io/kroxylicious/proxy/internal/filter/Fetch.test.yaml
+++ b/kroxylicious-runtime/src/test/resources/io/kroxylicious/proxy/internal/filter/Fetch.test.yaml
@@ -58,7 +58,7 @@
         value: downstream
       - op: replace
         path: "/nodeEndpoints/0/port"
-        value: 19199
+        value: 19200
   disabled: false
 - apiMessageType: FETCH
   description: Fetch v16 without nodeEndpoints

--- a/kroxylicious-runtime/src/test/resources/io/kroxylicious/proxy/internal/filter/FindCoordinator.test.yaml
+++ b/kroxylicious-runtime/src/test/resources/io/kroxylicious/proxy/internal/filter/FindCoordinator.test.yaml
@@ -22,7 +22,7 @@
         value: downstream
       - op: replace
         path: "/coordinators/0/port"
-        value: 19199
+        value: 19200
   disabled: false
 - apiMessageType: FIND_COORDINATOR
   version: 3
@@ -40,5 +40,5 @@
         value: downstream
       - op: replace
         path: "/port"
-        value: 19199
+        value: 19200
   disabled: false

--- a/kroxylicious-runtime/src/test/resources/io/kroxylicious/proxy/internal/filter/Metadata.test.yaml
+++ b/kroxylicious-runtime/src/test/resources/io/kroxylicious/proxy/internal/filter/Metadata.test.yaml
@@ -23,5 +23,5 @@
         value: downstream
       - op: replace
         path: "/brokers/0/port"
-        value: 19199
+        value: 19200
   disabled: false

--- a/kroxylicious-runtime/src/test/resources/io/kroxylicious/proxy/internal/filter/Produce.test.yaml
+++ b/kroxylicious-runtime/src/test/resources/io/kroxylicious/proxy/internal/filter/Produce.test.yaml
@@ -56,7 +56,7 @@
         value: downstream
       - op: replace
         path: "/nodeEndpoints/0/port"
-        value: 19199
+        value: 19200
   disabled: false
 - apiMessageType: PRODUCE
   description: Fetch v10 without nodeEndpoints

--- a/kroxylicious-runtime/src/test/resources/io/kroxylicious/proxy/internal/filter/ShareAcknowledge.test.yaml
+++ b/kroxylicious-runtime/src/test/resources/io/kroxylicious/proxy/internal/filter/ShareAcknowledge.test.yaml
@@ -24,5 +24,5 @@
         value: downstream
       - op: replace
         path: "/nodeEndpoints/0/port"
-        value: 19199
+        value: 19200
   disabled: false

--- a/kroxylicious-runtime/src/test/resources/io/kroxylicious/proxy/internal/filter/ShareFetch.test.yaml
+++ b/kroxylicious-runtime/src/test/resources/io/kroxylicious/proxy/internal/filter/ShareFetch.test.yaml
@@ -24,5 +24,5 @@
         value: downstream
       - op: replace
         path: "/nodeEndpoints/0/port"
-        value: 19199
+        value: 19200
   disabled: false

--- a/kubernetes-examples/network-topologies/snirouting_tls/base/kroxylicious/kroxylicious-config.yaml
+++ b/kubernetes-examples/network-topologies/snirouting_tls/base/kroxylicious/kroxylicious-config.yaml
@@ -27,7 +27,7 @@ data:
           type: SniRoutingClusterNetworkAddressConfigProvider
           config:
             bootstrapAddress: mycluster-proxy.kafka:9092
-            brokerAddressPattern: broker$(nodeId).mycluster-proxy.kafka
+            advertisedBrokerAddressPattern: broker$(nodeId).mycluster-proxy.kafka
         logNetwork: false
         logFrames: false
         tls:

--- a/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/base/kroxylicious/kroxylicious-config.yaml
+++ b/kubernetes-examples/network-topologies/snirouting_tls_in_cluster/base/kroxylicious/kroxylicious-config.yaml
@@ -27,7 +27,7 @@ data:
           type: SniRoutingClusterNetworkAddressConfigProvider
           config:
             bootstrapAddress: my-cluster-proxy.kroxylicious:9092
-            brokerAddressPattern: my-cluster-proxy-broker-$(nodeId).kroxylicious
+            advertisedBrokerAddressPattern: my-cluster-proxy-broker-$(nodeId).kroxylicious
         logNetwork: false
         logFrames: false
         tls:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

1. Introduces `advertisedBrokerAddressPattern` to the SNI configuration.
2. Deprecates `brokerAddressPattern` in SNI configuration.
3. `advertisedBrokerAddressPattern` or `brokerAddressPattern` must be specified, but not both
4. `brokerAddressPattern` and `advertisedBrokerAddressPattern` can optionally end with an advertised port specifier `:[1-9][0-9]*$`. If specified, this port is the port returned to clients when we inject broker addresses into Kafka RPCs using the `BrokerAddressFilter`. It may differ from the port the VirtualCluster listens on.

Example configuration where we want kroxylicious to listen on 9092, but tell clients to connect to 443:

```
        clusterNetworkAddressConfigProvider:
          type: SniRoutingClusterNetworkAddressConfigProvider
          config:
            bootstrapAddress: mycluster-proxy.kafka:9092
            advertisedBrokerAddressPattern: broker$(nodeId).mycluster-proxy.kafka:443
```

Leaves documentation change for a separate PR

Closes #1760 

### Additional Context

It may be convenient to put Kroxylicious behind yet-another-proxy that uses a different port scheme. For example OpenShift Routes for TLS passthrough will all be exposed on port 443 by default. Having to align the proxy with this port scheme is a bit of a pain as we won't be running as root in container, so can't bind to the privileged low port.

Instead, we can give users control over the advertised port, so that Kroxylicious can present the brokers as being available on the client-facing port.

This is related to Kroxylicious Operator as we are wondering whether we should integrate directly with ingress routers.

### Checklist

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
