### PR TITLE
feat: KekSelector that is capable of deriving a KEK from a topic name prefix

### DIFF
--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/TemplateKekSelector.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/TemplateKekSelector.java
@@ -6,21 +6,75 @@
 
 package io.kroxylicious.filter.encryption;
 
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
 import io.kroxylicious.filter.encryption.config.KekSelectorService;
-import io.kroxylicious.filter.encryption.config.TemplateConfig;
 import io.kroxylicious.filter.encryption.config.TopicNameBasedKekSelector;
 import io.kroxylicious.kms.service.Kms;
 import io.kroxylicious.proxy.plugin.Plugin;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+import static io.kroxylicious.filter.encryption.TemplateKekSelector.TemplateConfig;
+
+/**
+ * Simple {@link KekSelectorService} that uses a template to derive a KEK alias.  The template
+ * may include {@code ${topicName}} substitution variable.  If this variable is included, it is replaced
+ * by the topic name.
+ *
+ * @param <K> The type of Key Encryption Key id.
+ */
 @Plugin(configType = TemplateConfig.class)
 public class TemplateKekSelector<K> implements KekSelectorService<TemplateConfig, K> {
 
+    private static final Pattern PATTERN = Pattern.compile("\\$\\{(.*?)}");
+
     @NonNull
     @Override
-    public TopicNameBasedKekSelector<K> buildSelector(@NonNull Kms<K, ?> kms, TemplateConfig config) {
-        return new TemplateTopicNameKekSelector<>(kms, config.template());
+    public TopicNameBasedKekSelector<K> buildSelector(@NonNull Kms<K, ?> kms, @NonNull TemplateConfig config) {
+        Objects.requireNonNull(kms);
+        Objects.requireNonNull(config);
+        return new Selector<>(kms, config);
     }
 
+    /**
+     * Configuration for the {@link TemplateKekSelector}.
+     *
+     * @param template template string
+     */
+    public record TemplateConfig(@NonNull String template) {
+        public TemplateConfig {
+            Objects.requireNonNull(template);
+        }
+    }
+
+    private static class Selector<K> extends AbstractTemplateTopicNameKekSelector<K> {
+
+        private static final String PARAMETER_NAME = "topicName";
+
+        Selector(Kms<K, ?> kms, TemplateConfig config) {
+            super(kms, PATTERN, config.template(), PARAMETER_NAME);
+        }
+
+        @Override
+        protected Optional<String> evaluateTemplate(String topicName) {
+            var matcher = PATTERN.matcher(template);
+            StringBuilder sb = new StringBuilder();
+            while (matcher.find()) {
+                String replacement;
+                if (matcher.group(1).equals(PARAMETER_NAME)) {
+                    replacement = topicName;
+                }
+                else { // this should be impossible because of the check in the constructor
+                    throw new IllegalStateException();
+                }
+                matcher.appendReplacement(sb, replacement);
+            }
+            matcher.appendTail(sb);
+            return Optional.of(sb.toString());
+        }
+
+    }
 }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/TopicPrefixBasedKekSelector.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/TopicPrefixBasedKekSelector.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import io.kroxylicious.filter.encryption.config.KekSelectorService;
+import io.kroxylicious.filter.encryption.config.TopicNameBasedKekSelector;
+import io.kroxylicious.kms.service.Kms;
+import io.kroxylicious.proxy.plugin.Plugin;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static io.kroxylicious.filter.encryption.TopicPrefixBasedKekSelector.TemplateConfig;
+
+/**
+ * Simple {@link KekSelectorService} that derives the KEK alias using a template and topic name prefix.
+ * <br/>
+ * This topic prefix is demarcated by the first occurrence of a {@code prefixSeparator} within the topic's name.
+ * <br/>
+ * The template is used to form the KEK alias.  It may include the substitution variable
+ * {@code ${topicPrefix}} which gets replaced by the value of the topic name prefix (without the separator).
+ * <br/>
+ * If the topic name does not include the {@code prefixSeparator} or the prefix is the empty string,
+ * no KEK will be selected for that topic.
+ *
+ * @param <K> The type of Key Encryption Key id.
+ */
+
+@Plugin(configType = TemplateConfig.class)
+public class TopicPrefixBasedKekSelector<K> implements KekSelectorService<TemplateConfig, K> {
+
+    @NonNull
+    @Override
+    public TopicNameBasedKekSelector<K> buildSelector(@NonNull Kms<K, ?> kms, TemplateConfig config) {
+        return new Selector<>(kms, config.template(), config.prefixSeparator());
+    }
+
+    public record TemplateConfig(
+                                 @NonNull String prefixSeparator,
+                                 @NonNull String template) {}
+
+    private static class Selector<K> extends AbstractTemplateTopicNameKekSelector<K> {
+
+        private static final Pattern PATTERN = Pattern.compile("\\$\\{(.*?)}");
+        public static final String TOPIC_PREFIX = "topicPrefix";
+        private final String prefixSeparator;
+
+        Selector(@NonNull Kms<K, ?> kms, @NonNull String template, String prefixSeparator) {
+            super(kms, PATTERN, template, TOPIC_PREFIX);
+            this.prefixSeparator = Objects.requireNonNull(prefixSeparator);
+
+            if (prefixSeparator.isEmpty()) {
+                throw new IllegalArgumentException("Prefix separator cannot be empty");
+            }
+        }
+
+        protected Optional<String> evaluateTemplate(String topicName) {
+            var separatorIndex = topicName.indexOf(prefixSeparator);
+            if (separatorIndex < 0) {
+                return Optional.empty();
+            }
+            var prefix = topicName.substring(0, separatorIndex);
+            var matcher = PATTERN.matcher(template);
+            StringBuilder sb = new StringBuilder();
+            while (matcher.find()) {
+                String replacement;
+                if (matcher.group(1).equals(TOPIC_PREFIX)) {
+                    replacement = prefix;
+                }
+                else { // this should be impossible because of the check in the constructor
+                    throw new IllegalStateException();
+                }
+                matcher.appendReplacement(sb, replacement);
+            }
+            matcher.appendTail(sb);
+            return Optional.of(sb.toString());
+        }
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/TemplateConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/TemplateConfig.java
@@ -1,9 +1,0 @@
-/*
- * Copyright Kroxylicious Authors.
- *
- * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
- */
-
-package io.kroxylicious.filter.encryption.config;
-
-public record TemplateConfig(String template) {}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/TopicNameBasedKekSelector.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/TopicNameBasedKekSelector.java
@@ -20,7 +20,9 @@ public abstract class TopicNameBasedKekSelector<K> {
 
     /**
      * Returns a completion stage whose value, on successful completion, is a map from each of the given topic
-     * names to the KEK id to use for encrypting records in that topic.
+     * names to the KEK id to use for encrypting records in that topic.  If there is no non KEK id for a given
+     * topic, its value will be null.
+     *
      * @param topicNames A set of topic names
      * @return A completion stage for the map form topic name to KEK id.
      */

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/resources/META-INF/services/io.kroxylicious.filter.encryption.config.KekSelectorService
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/resources/META-INF/services/io.kroxylicious.filter.encryption.config.KekSelectorService
@@ -1,1 +1,7 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
 io.kroxylicious.filter.encryption.TemplateKekSelector
+io.kroxylicious.filter.encryption.TopicPrefixBasedKekSelector

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/TemplateKekSelectorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/TemplateKekSelectorTest.java
@@ -11,7 +11,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterEach;
@@ -95,7 +94,7 @@ class TemplateKekSelectorTest {
     }
 
     @Test
-    void shouldNotThrowWhenAliasDoesNotExist_UnknownAliasExceptionWrappedInCompletionException() throws ExecutionException, InterruptedException {
+    void shouldNotThrowWhenAliasDoesNotExist_UnknownAliasExceptionWrappedInCompletionException() {
         var mockKms = mock(InMemoryKms.class);
         var result = CompletableFuture.completedFuture(null)
                 .<UUID> thenApply(u -> {

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/TemplateKekSelectorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/TemplateKekSelectorTest.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-package io.kroxylicious.filter.encryption.encrypt;
+package io.kroxylicious.filter.encryption;
 
 import java.time.Duration;
 import java.util.Optional;
@@ -13,12 +13,11 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import io.kroxylicious.filter.encryption.TemplateKekSelector;
-import io.kroxylicious.filter.encryption.config.TemplateConfig;
 import io.kroxylicious.filter.encryption.config.TopicNameBasedKekSelector;
 import io.kroxylicious.kms.provider.kroxylicious.inmemory.InMemoryKms;
 import io.kroxylicious.kms.provider.kroxylicious.inmemory.UnitTestingKmsService;
@@ -37,10 +36,13 @@ import static org.mockito.Mockito.when;
 class TemplateKekSelectorTest {
 
     private UnitTestingKmsService kmsService;
+    private InMemoryKms kms;
 
     @BeforeEach
     void beforeEach() {
         kmsService = UnitTestingKmsService.newInstance();
+        kmsService.initialize(new UnitTestingKmsService.Config());
+        kms = kmsService.buildKms();
     }
 
     @AfterEach
@@ -50,62 +52,73 @@ class TemplateKekSelectorTest {
 
     @Test
     void shouldRejectUnknownPlaceholders() {
-        assertThatThrownBy(() -> getSelector(null, "foo-${topicId}-bar"))
+        assertThatThrownBy(() -> getSelector(kms, "foo-${topicId}-bar"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Unknown template parameter: topicId");
     }
 
     @Test
     void shouldResolveWhenAliasExists() {
-        kmsService.initialize(new UnitTestingKmsService.Config());
-        var kms = kmsService.buildKms();
         var selector = getSelector(kms, "topic-${topicName}");
 
         var kek = kms.generateKey();
         kms.createAlias(kek, "topic-my-topic");
-        var map = selector.selectKek(Set.of("my-topic")).toCompletableFuture().join();
-        assertThat(map)
+        assertThat(selector.selectKek(Set.of("my-topic")))
+                .succeedsWithin(Duration.ofSeconds(1))
+                .asInstanceOf(InstanceOfAssertFactories.map(String.class, UUID.class))
+                .hasSize(1)
+                .containsEntry("my-topic", kek);
+    }
+
+    @Test
+    void supportTemplateWithoutTopicPlaceholders() {
+        var selector = getSelector(kms, "fixed");
+
+        var kek = kms.generateKey();
+        kms.createAlias(kek, "fixed");
+        assertThat(selector.selectKek(Set.of("my-topic")))
+                .succeedsWithin(Duration.ofSeconds(1))
+                .asInstanceOf(InstanceOfAssertFactories.map(String.class, UUID.class))
                 .hasSize(1)
                 .containsEntry("my-topic", kek);
     }
 
     @Test
     void shouldNotThrowWhenAliasDoesNotExist() {
-        kmsService.initialize(new UnitTestingKmsService.Config());
-        var kms = kmsService.buildKms();
         var selector = getSelector(kms, "topic-${topicName}");
 
-        var map = selector.selectKek(Set.of("my-topic")).toCompletableFuture().join();
-        assertThat(map)
+        assertThat(selector.selectKek(Set.of("my-topic")))
+                .succeedsWithin(Duration.ofSeconds(1))
+                .asInstanceOf(InstanceOfAssertFactories.map(String.class, UUID.class))
                 .hasSize(1)
                 .containsEntry("my-topic", null);
     }
 
     @Test
     void shouldNotThrowWhenAliasDoesNotExist_UnknownAliasExceptionWrappedInCompletionException() throws ExecutionException, InterruptedException {
-        var kms = mock(InMemoryKms.class);
+        var mockKms = mock(InMemoryKms.class);
         var result = CompletableFuture.completedFuture(null)
-                .<UUID> thenApply((u) -> {
+                .<UUID> thenApply(u -> {
                     // this exception will be wrapped by a CompletionException
                     throw new UnknownAliasException("mock alias exception");
                 });
-        when(kms.resolveAlias(anyString())).thenReturn(result);
-        var selector = getSelector(kms, "topic-${topicName}");
-        var map = selector.selectKek(Set.of("my-topic")).toCompletableFuture().get();
-        assertThat(map)
+        when(mockKms.resolveAlias(anyString())).thenReturn(result);
+        var selector = getSelector(mockKms, "topic-${topicName}");
+        assertThat(selector.selectKek(Set.of("my-topic")))
+                .succeedsWithin(Duration.ofSeconds(1))
+                .asInstanceOf(InstanceOfAssertFactories.map(String.class, UUID.class))
                 .hasSize(1)
                 .containsEntry("my-topic", null);
     }
 
     @Test
     void serviceExceptionsArePropagated() {
-        var kms = mock(InMemoryKms.class);
+        var mockKms = mock(InMemoryKms.class);
         var result = CompletableFuture.<UUID> failedFuture(new KmsException("bang!"));
-        when(kms.resolveAlias(anyString())).thenReturn(result);
+        when(mockKms.resolveAlias(anyString())).thenReturn(result);
 
-        var selector = getSelector(kms, "topic-${topicName}");
-        var stage = selector.selectKek(Set.of("my-topic"));
-        assertThat(stage)
+        var selector = getSelector(mockKms, "topic-${topicName}");
+        assertThat(selector.selectKek(Set.of("my-topic")))
                 .isCompletedExceptionally()
                 .failsWithin(Duration.ZERO)
                 .withThrowableThat()
@@ -114,7 +127,7 @@ class TemplateKekSelectorTest {
 
     @NonNull
     private <K> TopicNameBasedKekSelector<K> getSelector(Kms<K, ?> kms, String template) {
-        var config = new TemplateConfig(template);
+        var config = new TemplateKekSelector.TemplateConfig(template);
         return new TemplateKekSelector<K>().buildSelector(kms, config);
     }
 

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/TopicPrefixBasedKekSelectorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/TopicPrefixBasedKekSelectorTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import io.kroxylicious.filter.encryption.config.TopicNameBasedKekSelector;
+import io.kroxylicious.kms.provider.kroxylicious.inmemory.InMemoryKms;
+import io.kroxylicious.kms.provider.kroxylicious.inmemory.UnitTestingKmsService;
+import io.kroxylicious.kms.service.Kms;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TopicPrefixBasedKekSelectorTest {
+
+    private UnitTestingKmsService kmsService;
+    private InMemoryKms kms;
+
+    @BeforeEach
+    void beforeEach() {
+        kmsService = UnitTestingKmsService.newInstance();
+        kmsService.initialize(new UnitTestingKmsService.Config());
+        kms = kmsService.buildKms();
+    }
+
+    @AfterEach
+    public void afterEach() {
+        Optional.ofNullable(kmsService).ifPresent(UnitTestingKmsService::close);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "foo-${topicName}", "foo-${topicId}" })
+    void shouldRejectUnknownPlaceholders(String template) {
+        assertThatThrownBy(() -> getSelector(kms, template, "-"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unknown template parameter:");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "" })
+    void shouldRejectMissingSeparator(String parameter) {
+        assertThatThrownBy(() -> getSelector(kms, "foo-${topicPrefix}", parameter))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Prefix separator cannot be empty");
+    }
+
+    @Test
+    void shouldResolveWhenAliasExists() {
+        var selector = getSelector(kms, "kek-${topicPrefix}", "-");
+
+        var kek = kms.generateKey();
+        kms.createAlias(kek, "kek-sales");
+        assertThat(selector.selectKek(Set.of("sales-inventory")))
+                .succeedsWithin(Duration.ofSeconds(1))
+                .asInstanceOf(InstanceOfAssertFactories.map(String.class, UUID.class))
+                .hasSize(1)
+                .containsEntry("sales-inventory", kek);
+    }
+
+    @Test
+    void supportTemplateWithoutTopicPlaceholders() {
+        var selector = getSelector(kms, "kek", "-");
+
+        var kek = kms.generateKey();
+        kms.createAlias(kek, "kek");
+        assertThat(selector.selectKek(Set.of("sales-inventory")))
+                .succeedsWithin(Duration.ofSeconds(1))
+                .asInstanceOf(InstanceOfAssertFactories.map(String.class, UUID.class))
+                .hasSize(1)
+                .containsEntry("sales-inventory", kek);
+    }
+
+    @Test
+    void shouldNotThrowWhenAliasDoesNotExist() {
+        var selector = getSelector(kms, "kek-${topicPrefix}", "-");
+
+        assertThat(selector.selectKek(Set.of("sales-inventory")))
+                .succeedsWithin(Duration.ofSeconds(1))
+                .asInstanceOf(InstanceOfAssertFactories.map(String.class, UUID.class))
+                .hasSize(1)
+                .containsEntry("sales-inventory", null);
+    }
+
+    @Test
+    void shouldNotThrowWhenTopicDoesNotContainPrefix() {
+        var selector = getSelector(kms, "kek-${topicPrefix}", "-");
+
+        assertThat(selector.selectKek(Set.of("sales")))
+                .succeedsWithin(Duration.ofSeconds(1))
+                .asInstanceOf(InstanceOfAssertFactories.map(String.class, UUID.class))
+                .hasSize(1)
+                .containsEntry("sales", null);
+    }
+
+    @NonNull
+    private <K> TopicNameBasedKekSelector<K> getSelector(Kms<K, ?> kms, String template, String separator) {
+        var config = new TopicPrefixBasedKekSelector.TemplateConfig(separator, template);
+        return new TopicPrefixBasedKekSelector<K>().buildSelector(kms, config);
+    }
+
+}


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Organisations sometimes use a topic naming convention where topic name prefixes are used sub-divide the topic namespace.

For instance topic with names starting `sales-` might belong to a sales unit, `marketing-` might belong to a marketing business unit.   Such organisation might wish to assign a KEK per business unit.  This KekSelector supports this use-case.

```
      selector: TopicPrefixBasedKekSelector
      selectorConfig:
        template: "KEK-${topicPrefix}"
        prefixSeparator: "-" 
```

With this configuration, record produced to a topic called `sales-event-feed` or `sales-audit` will be encrypted using a KEK called `KEK-sales`.

If a topic name is encountered that doesn't contain the separator, the records sent to the topic won't be encrypted.  

### Additional Context

The existing KEK selector is quite limited.   It forces the user to either have a KEK per topic (`template: KEK_${topicName}`) which potentially is expensive for customers using, say AWS, which charges per key, or a single KEK used for the whole KMS (`template: KEK`), which means there is no blast radius control if a key is every leaked.

We did consider an alternative implementation based on RE.  However using REs have some drawbacks.  REs are potentially difficult to use, and there's a potential for catastrophic backtracking with careless constructed REs. 


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
