### PR TITLE
Document advertisedBrokerAddressPattern

### DIFF
--- a/docs/modules/configuring/con-configuring-network-addresses.adoc
+++ b/docs/modules/configuring/con-configuring-network-addresses.adoc
@@ -155,12 +155,27 @@ clusterNetworkAddressConfigProvider:
   type: SniRoutingClusterNetworkAddressConfigProvider
   config:
     bootstrapAddress: mycluster.kafka.com:9192 # <1>                 
-    brokerAddressPattern: mybroker-$(nodeId).mycluster.kafka.com  
+    advertisedBrokerAddressPattern: mybroker-$(nodeId).mycluster.kafka.com  
     bindAddress: 192.168.0.1
 ----
 <1> A single address for all traffic, including bootstrap address and brokers.
                                       
-In the SNI routing address configuration, the `brokerAddressPattern` specification is mandatory, as it is required to generate routes for each broker. 
+In the SNI routing address configuration, the `advertisedBrokerAddressPattern` specification is mandatory, as it is required to generate routes for each broker.
+`advertisedBrokerAddressPattern` can optionally end with a port specifier, which is the port that will be advertised to the client. This is only relevant if
+Kroxylicious is being deployed behind another proxy using a different port scheme. For example:
+
+.Example SNI routing address provider configuration with advertised port
+[source,yaml]
+----
+clusterNetworkAddressConfigProvider:
+  type: SniRoutingClusterNetworkAddressConfigProvider
+  config:
+    bootstrapAddress: mycluster.kafka.com:9192                 
+    advertisedBrokerAddressPattern: mybroker-$(nodeId).mycluster.kafka.com:443
+    bindAddress: 192.168.0.1
+----
+
+This configuration instructs Kroxylicious to listen on port 9192, but advertise brokers of this virtual cluster as being available on port 443.
 
 NOTE: Single port operation may have cost advantages when using load balancers of public clouds, as it allows
 a single cloud provider load balancer to be shared across all virtual clusters.

--- a/docs/modules/configuring/con-configuring-network-addresses.adoc
+++ b/docs/modules/configuring/con-configuring-network-addresses.adoc
@@ -162,7 +162,7 @@ clusterNetworkAddressConfigProvider:
                                       
 In the SNI routing address configuration, the `advertisedBrokerAddressPattern` specification is mandatory, as it is required to generate routes for each broker.
 `advertisedBrokerAddressPattern` can optionally end with a port specifier, which is the port that will be advertised to the client. This is only relevant if
-Kroxylicious is being deployed behind another proxy using a different port scheme. For example:
+Kroxylicious is being deployed behind another proxy using a different port scheme, such as an secure OpenShift route on port 443. An example config snippet:
 
 .Example SNI routing address provider configuration with advertised port
 [source,yaml]

--- a/docs/modules/configuring/ref-configuring-proxy-example.adoc
+++ b/docs/modules/configuring/ref-configuring-proxy-example.adoc
@@ -30,7 +30,7 @@ adminHttp: # <1>
           type: SniRoutingClusterNetworkAddressConfigProvider # <7>
           Config:
             bootstrapAddress: my-cluster-proxy.kafka:9092 # <8>
-            brokerAddressPattern: broker$(nodeId).my-cluster-proxy.kafka
+            advertisedBrokerAddressPattern: broker$(nodeId).my-cluster-proxy.kafka
         logNetwork: false # <9>
         logFrames: false
         tls: # <10>


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Document SNI `advertisedBrokerAddressPattern`, with example usage

### Additional Context

We deprecated brokerAddressPattern for SNI and added the ability to specify an advertised port. This is to enable Kroxylicious to run behind another proxy, like a kubernetes ingress, that uses a different port scheme. The proxy can advertise it's brokers as being available on a different port than the bind port.

Depends on #1761 being merged first.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
