### PR TITLE
Record Encryption: enable user to specify policy when we cannot resolve a Key for a topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format `<github issue/pr number>: <short description>`.
 ## SNAPSHOT
 ## 0.10.0
 
+* [#1768](https://github.com/kroxylicious/kroxylicious/pull/1768) Record Encryption: enable user to specify policy when we cannot resolve a Key for a topic
 * [#1770](https://github.com/kroxylicious/kroxylicious/pull/1770) Name filter factories consistently
 * [#1743](https://github.com/kroxylicious/kroxylicious/pull/1743) Apply TLS protocol and cipher suite restrictions to HTTP Clients used by KMS impls too
 * [#1761](https://github.com/kroxylicious/kroxylicious/pull/1761) SNI exposition: user can control advertised broker port

--- a/docs/modules/record-encryption/proc-configuring-record-encryption-filter.adoc
+++ b/docs/modules/record-encryption/proc-configuring-record-encryption-filter.adoc
@@ -35,10 +35,11 @@ filters:
       selector: <KEK_selector_service_name> # <3>
       selectorConfig:
         template: "KEK_${topicName}" # <4>
+      unresolvedKeyPolicy: PASSTHROUGH_UNENCRYPTED # <5>
       experimental:
-        encryptionDekRefreshAfterWriteSeconds: 3600 # <5>
-        encryptionDekExpireAfterWriteSeconds: 7200 # <6>
-        maxEncryptionsPerDek: 5000000 # <7>
+        encryptionDekRefreshAfterWriteSeconds: 3600 # <6>
+        encryptionDekExpireAfterWriteSeconds: 7200 # <7>
+        maxEncryptionsPerDek: 5000000 # <8>
 ----
 <1> The KMS service name.
 <2> Configuration specific to the KMS provider.
@@ -46,9 +47,13 @@ filters:
 For example, if using the `TemplateKekSelector` with the template `KEK_$\{topicName}`, create a key for every topic that
 is to be encrypted with the key name matching the topic name, prefixed by the string `KEK_`.
 <4> The template for deriving the KEK, based on a specific topic name.
-<5> How long after creation of a DEK before it becomes eligible for rotation. On the **next** encryption request, the cache will asynchronously create a new DEK.  Encryption requests will continue to use the old DEK until the new DEK is ready.
-<6> How long after creation of a DEK until it is removed from the cache. This setting puts an upper bound on how long a DEK can remain cached.
-<7> The maximum number of records any DEK should be used to encrypt. After this limit is hit, that DEK will be destroyed and a new one created.
+<5> Optional policy governing the behaviour when the KMS does not contain a key. The default is `PASSTHROUGH_UNENCRYPTED` which
+causes the record to be forwarded, unencrypted, to the target cluster. Users can alternatively specify `REJECT` which
+will cause the entire produce request to be rejected. This is a safer alternative if you know that all traffic sent
+to the Virtual Cluster should be encrypted because unencrypted data will never be forwarded.
+<6> How long after creation of a DEK before it becomes eligible for rotation. On the **next** encryption request, the cache will asynchronously create a new DEK.  Encryption requests will continue to use the old DEK until the new DEK is ready.
+<7> How long after creation of a DEK until it is removed from the cache. This setting puts an upper bound on how long a DEK can remain cached.
+<8> The maximum number of records any DEK should be used to encrypt. After this limit is hit, that DEK will be destroyed and a new one created.
 +
 `encryptionDekRefreshAfterWriteSeconds` and `encryptionDekExpireAfterWriteSeconds` help govern the "originator usage period" of the DEK. That is the period of time the DEK will be used to encrypt records.  Keeping the period short helps reduce the blast radius in the event that DEK key material is leaked. However, there is a trade-off. The additional KMS API calls will increase produce/consume latency and may increase your KMS provider costs. 
 +

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryption.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryption.java
@@ -138,9 +138,10 @@ public class RecordEncryption<K, E> implements FilterFactory<RecordEncryptionCon
                 sharedEncryptionContext.decryptionDekCache(),
                 executor);
 
-        KekSelectorService<Object, K> ksPlugin = context.pluginInstance(KekSelectorService.class, sharedEncryptionContext.configuration().selector());
-        TopicNameBasedKekSelector<K> kekSelector = ksPlugin.buildSelector(sharedEncryptionContext.kms(), sharedEncryptionContext.configuration().selectorConfig());
-        return new RecordEncryptionFilter<>(encryptionManager, decryptionManager, kekSelector, executor);
+        RecordEncryptionConfig configuration = sharedEncryptionContext.configuration();
+        KekSelectorService<Object, K> ksPlugin = context.pluginInstance(KekSelectorService.class, configuration.selector());
+        TopicNameBasedKekSelector<K> kekSelector = ksPlugin.buildSelector(sharedEncryptionContext.kms(), configuration.selectorConfig());
+        return new RecordEncryptionFilter<>(encryptionManager, decryptionManager, kekSelector, executor, configuration.unresolvedKeyPolicy());
     }
 
     @NonNull

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryptionFilter.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryptionFilter.java
@@ -9,6 +9,7 @@ package io.kroxylicious.filter.encryption;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
@@ -31,6 +32,7 @@ import io.kroxylicious.filter.encryption.common.RecordEncryptionUtil;
 import io.kroxylicious.filter.encryption.config.RecordField;
 import io.kroxylicious.filter.encryption.config.TopicNameBasedKekSelector;
 import io.kroxylicious.filter.encryption.config.TopicNameKekSelection;
+import io.kroxylicious.filter.encryption.config.UnresolvedKeyPolicy;
 import io.kroxylicious.filter.encryption.decrypt.DecryptionManager;
 import io.kroxylicious.filter.encryption.encrypt.EncryptionManager;
 import io.kroxylicious.filter.encryption.encrypt.EncryptionScheme;
@@ -56,15 +58,18 @@ public class RecordEncryptionFilter<K>
     private final EncryptionManager<K> encryptionManager;
     private final DecryptionManager decryptionManager;
     private final FilterThreadExecutor filterThreadExecutor;
+    private final UnresolvedKeyPolicy unresolvedKeyPolicy;
 
     RecordEncryptionFilter(EncryptionManager<K> encryptionManager,
                            DecryptionManager decryptionManager,
                            TopicNameBasedKekSelector<K> kekSelector,
-                           @NonNull FilterThreadExecutor filterThreadExecutor) {
+                           @NonNull FilterThreadExecutor filterThreadExecutor,
+                           UnresolvedKeyPolicy unresolvedKeyPolicy) {
         this.kekSelector = kekSelector;
         this.encryptionManager = encryptionManager;
         this.decryptionManager = decryptionManager;
         this.filterThreadExecutor = filterThreadExecutor;
+        this.unresolvedKeyPolicy = unresolvedKeyPolicy;
     }
 
     @Override
@@ -105,6 +110,10 @@ public class RecordEncryptionFilter<K>
         CompletionStage<TopicNameKekSelection<K>> keks = filterThreadExecutor.completingOnFilterThread(kekSelector.selectKek(topicNameToData.keySet()));
         return keks // figure out what keks we need
                 .thenCompose(kekSelection -> {
+                    Set<String> unresolvedTopicNames = kekSelection.unresolvedTopicNames();
+                    if (!unresolvedTopicNames.isEmpty() && unresolvedKeyPolicy == UnresolvedKeyPolicy.REJECT) {
+                        return CompletableFuture.failedFuture(new UnresolvedKeyException("failed to resolve key for: " + unresolvedTopicNames));
+                    }
                     var futures = kekSelection.topicNameToKekId().entrySet().stream().flatMap(e -> {
                         String topicName = e.getKey();
                         var kekId = e.getValue();

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/UnresolvedKeyException.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/UnresolvedKeyException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+import io.kroxylicious.filter.encryption.common.EncryptionException;
+
+/**
+ * The encryption operation failed because we could not resolve a Key for some of the records.
+ */
+public class UnresolvedKeyException extends EncryptionException {
+    public UnresolvedKeyException(String message) {
+        super(message);
+    }
+}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/RecordEncryptionConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/RecordEncryptionConfig.java
@@ -22,7 +22,8 @@ public record RecordEncryptionConfig(@JsonProperty(required = true) @PluginImplN
 
                                      @JsonProperty(required = true) @PluginImplName(KekSelectorService.class) String selector,
                                      @PluginImplConfig(implNameProperty = "selector") Object selectorConfig,
-                                     @JsonProperty Map<String, Object> experimental) {
+                                     @JsonProperty Map<String, Object> experimental,
+                                     @JsonProperty UnresolvedKeyPolicy unresolvedKeyPolicy) {
     public RecordEncryptionConfig {
         experimental = experimental == null ? Map.of() : experimental;
     }
@@ -76,4 +77,8 @@ public record RecordEncryptionConfig(@JsonProperty(required = true) @PluginImplN
         }).orElse(null);
     }
 
+    @Override
+    public UnresolvedKeyPolicy unresolvedKeyPolicy() {
+        return unresolvedKeyPolicy == null ? UnresolvedKeyPolicy.PASSTHROUGH_UNENCRYPTED : unresolvedKeyPolicy;
+    }
 }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/TopicNameBasedKekSelector.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/TopicNameBasedKekSelector.java
@@ -21,7 +21,7 @@ public abstract class TopicNameBasedKekSelector<K> {
      * Returns a completion stage whose value, on successful completion, is a topic name selection containing the
      * resolved key ids for topics which could be resolved, and a set of unresolved topic names.
      * @param topicNames A set of topic names
-     * @return A completion stage containing a topic name selection
+     * @return A completion stage for the topic name selection
      */
     public abstract @NonNull CompletionStage<TopicNameKekSelection<K>> selectKek(@NonNull Set<String> topicNames);
 }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/TopicNameBasedKekSelector.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/TopicNameBasedKekSelector.java
@@ -6,7 +6,6 @@
 
 package io.kroxylicious.filter.encryption.config;
 
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
@@ -19,10 +18,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public abstract class TopicNameBasedKekSelector<K> {
 
     /**
-     * Returns a completion stage whose value, on successful completion, is a map from each of the given topic
-     * names to the KEK id to use for encrypting records in that topic.
+     * Returns a completion stage whose value, on successful completion, is a topic name selection containing the
+     * resolved key ids for topics which could be resolved, and a set of unresolved topic names.
      * @param topicNames A set of topic names
-     * @return A completion stage for the map form topic name to KEK id.
+     * @return A completion stage containing a topic name selection
      */
-    public abstract @NonNull CompletionStage<Map<String, K>> selectKek(@NonNull Set<String> topicNames);
+    public abstract @NonNull CompletionStage<TopicNameKekSelection<K>> selectKek(@NonNull Set<String> topicNames);
 }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/TopicNameKekSelection.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/TopicNameKekSelection.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.config;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Selection of keys
+ * @param topicNameToKekId topic name to key, key must not be null
+ * @param unresolvedTopicNames topic names which could not have a key selected
+ * @param <K> the type of key
+ */
+public record TopicNameKekSelection<K>(@NonNull Map<String, K> topicNameToKekId, @NonNull Set<String> unresolvedTopicNames) {
+    public TopicNameKekSelection {
+        Objects.requireNonNull(topicNameToKekId);
+        List<Map.Entry<String, K>> entriesWithNullValue = topicNameToKekId.entrySet().stream().filter(e -> e.getValue() == null).toList();
+        if (!entriesWithNullValue.isEmpty()) {
+            List<String> topicNames = entriesWithNullValue.stream().map(Map.Entry::getKey).toList();
+            throw new IllegalArgumentException("values in topicNameToKekId must not be null, keys with null values: " + topicNames);
+        }
+        Objects.requireNonNull(unresolvedTopicNames);
+    }
+}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/UnresolvedKeyPolicy.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/UnresolvedKeyPolicy.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.config;
+
+/**
+ * This policy determines what the Filter should do with records when we cannot
+ * resolve a Key for that record.
+ */
+public enum UnresolvedKeyPolicy {
+    /**
+     * Passthrough the record unencrypted. This is the default policy, it allows unencrypted and encrypted topics to be handled by
+     * the same Filter.
+     */
+    PASSTHROUGH_UNENCRYPTED,
+    /**
+     * Reject the record. This will cause the entire ProductRequest to be rejected and an appropriate error message will be returned
+     * to the client. This is a safer policy if you know that all traffic sent to the virtual cluster should be encrypted.
+     */
+    REJECT
+}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionFilterTest.java
@@ -54,6 +54,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.kroxylicious.filter.encryption.common.FilterThreadExecutor;
 import io.kroxylicious.filter.encryption.config.TopicNameBasedKekSelector;
+import io.kroxylicious.filter.encryption.config.TopicNameKekSelection;
 import io.kroxylicious.filter.encryption.decrypt.DecryptionManager;
 import io.kroxylicious.filter.encryption.encrypt.EncryptionManager;
 import io.kroxylicious.filter.encryption.encrypt.RequestNotSatisfiable;
@@ -125,14 +126,13 @@ class RecordEncryptionFilterTest {
         });
 
         final Map<String, String> topicNameToKekId = new HashMap<>();
-        topicNameToKekId.put(UNENCRYPTED_TOPIC, null);
         topicNameToKekId.put(ENCRYPTED_TOPIC, KEK_ID_1);
 
         when(kekSelector.selectKek(anySet())).thenAnswer(invocationOnMock -> {
             Set<String> wanted = invocationOnMock.getArgument(0);
             var copy = new HashMap<>(topicNameToKekId);
             copy.keySet().retainAll(wanted);
-            return CompletableFuture.completedFuture(copy);
+            return CompletableFuture.completedFuture(new TopicNameKekSelection<>(topicNameToKekId, Set.of(UNENCRYPTED_TOPIC)));
         });
 
         when(encryptionManager.encrypt(any(), anyInt(), any(), any(), any()))

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionFilterTest.java
@@ -17,10 +17,12 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.LongStream;
 
+import org.apache.kafka.common.InvalidRecordException;
 import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.errors.NetworkException;
@@ -49,12 +51,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.hamcrest.MockitoHamcrest;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.kroxylicious.filter.encryption.common.FilterThreadExecutor;
 import io.kroxylicious.filter.encryption.config.TopicNameBasedKekSelector;
 import io.kroxylicious.filter.encryption.config.TopicNameKekSelection;
+import io.kroxylicious.filter.encryption.config.UnresolvedKeyPolicy;
 import io.kroxylicious.filter.encryption.decrypt.DecryptionManager;
 import io.kroxylicious.filter.encryption.encrypt.EncryptionManager;
 import io.kroxylicious.filter.encryption.encrypt.RequestNotSatisfiable;
@@ -83,7 +87,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class RecordEncryptionFilterTest {
 
-    private static final String UNENCRYPTED_TOPIC = "unencrypted";
+    private static final String UNRESOLVED_TOPIC = "unresolved";
     private static final String ENCRYPTED_TOPIC = "encrypt_me";
     private static final String KEK_ID_1 = "KEK_ID_1";
     private static final byte[] HELLO_PLAIN_WORLD = "Hello World".getBytes(UTF_8);
@@ -102,6 +106,12 @@ class RecordEncryptionFilterTest {
 
     @Mock(strictness = LENIENT)
     private FilterContext context;
+
+    @Mock(strictness = LENIENT)
+    RequestFilterResultBuilder requestFilterResultBuilder;
+
+    @Mock(strictness = LENIENT)
+    private CloseOrTerminalStage<RequestFilterResult> closeOrTerminalStage;
 
     @Captor
     private ArgumentCaptor<ApiMessage> apiMessageCaptor;
@@ -132,7 +142,7 @@ class RecordEncryptionFilterTest {
             Set<String> wanted = invocationOnMock.getArgument(0);
             var copy = new HashMap<>(topicNameToKekId);
             copy.keySet().retainAll(wanted);
-            return CompletableFuture.completedFuture(new TopicNameKekSelection<>(topicNameToKekId, Set.of(UNENCRYPTED_TOPIC)));
+            return CompletableFuture.completedFuture(new TopicNameKekSelection<>(topicNameToKekId, Set.of(UNRESOLVED_TOPIC)));
         });
 
         when(encryptionManager.encrypt(any(), anyInt(), any(), any(), any()))
@@ -141,14 +151,15 @@ class RecordEncryptionFilterTest {
         when(decryptionManager.decrypt(any(), anyInt(), any(), any()))
                 .thenReturn(CompletableFuture.completedFuture(RecordTestUtils.singleElementMemoryRecords("decrypt", "decrypt")));
 
-        encryptionFilter = new RecordEncryptionFilter<>(encryptionManager, decryptionManager, kekSelector, new FilterThreadExecutor(Runnable::run));
+        encryptionFilter = new RecordEncryptionFilter<>(encryptionManager, decryptionManager, kekSelector, new FilterThreadExecutor(Runnable::run),
+                UnresolvedKeyPolicy.PASSTHROUGH_UNENCRYPTED);
     }
 
     @Test
     void shouldNotEncryptTopicWithoutKeyId() {
         // Given
         var produceRequestData = buildProduceRequestData(new TopicProduceData()
-                .setName(UNENCRYPTED_TOPIC)
+                .setName(UNRESOLVED_TOPIC)
                 .setPartitionData(List.of(new PartitionProduceData().setRecords(makeRecord(HELLO_PLAIN_WORLD)))));
 
         // When
@@ -179,7 +190,7 @@ class RecordEncryptionFilterTest {
                 .setName(ENCRYPTED_TOPIC)
                 .setPartitionData(List.of(new PartitionProduceData().setRecords(makeRecord(HELLO_CIPHER_WORLD)))),
                 new TopicProduceData()
-                        .setName(UNENCRYPTED_TOPIC)
+                        .setName(UNRESOLVED_TOPIC)
                         .setPartitionData(List.of(new PartitionProduceData().setRecords(makeRecord(HELLO_PLAIN_WORLD)))));
 
         // When
@@ -194,10 +205,41 @@ class RecordEncryptionFilterTest {
     }
 
     @Test
+    void shouldRejectWholeMessageIfPolicyIsToRejectUnresolvedKeys() {
+        // Given
+        var produceRequestData = buildProduceRequestData(new TopicProduceData()
+                .setName(ENCRYPTED_TOPIC)
+                .setPartitionData(List.of(new PartitionProduceData().setRecords(makeRecord(HELLO_CIPHER_WORLD)))),
+                new TopicProduceData()
+                        .setName(UNRESOLVED_TOPIC)
+                        .setPartitionData(List.of(new PartitionProduceData().setRecords(makeRecord(HELLO_PLAIN_WORLD)))));
+
+        when(context.requestFilterResultBuilder()).thenReturn(requestFilterResultBuilder);
+        when(requestFilterResultBuilder.errorResponse(any(), any(), any())).thenReturn(closeOrTerminalStage);
+        RuntimeException exception = new RuntimeException("exception");
+        CompletableFuture<RequestFilterResult> completed = CompletableFuture.failedFuture(exception);
+        when(closeOrTerminalStage.completed()).thenReturn(completed);
+
+        // When
+        var rejectUnresolvedFilter = new RecordEncryptionFilter<>(encryptionManager, decryptionManager, kekSelector, new FilterThreadExecutor(Runnable::run),
+                UnresolvedKeyPolicy.REJECT);
+        CompletionStage<RequestFilterResult> stage = rejectUnresolvedFilter.onProduceRequest(ProduceRequestData.HIGHEST_SUPPORTED_VERSION,
+                new RequestHeaderData(), produceRequestData, context);
+
+        // Then
+        verify(encryptionManager, never()).encrypt(any(), anyInt(), any(), any(), any());
+        verify(requestFilterResultBuilder).errorResponse(any(), any(),
+                Mockito.argThat(e -> e instanceof InvalidRecordException && e.getMessage().equals("failed to resolve key for: [unresolved]")));
+
+        assertThat(stage).failsWithin(0, TimeUnit.SECONDS).withThrowableThat().withCause(exception);
+
+    }
+
+    @Test
     void shouldPassThroughUnencryptedRecords() {
         // Given
         var fetchResponseData = buildFetchResponseData(new FetchableTopicResponse()
-                .setTopic(UNENCRYPTED_TOPIC)
+                .setTopic(UNRESOLVED_TOPIC)
                 .setPartitions(List.of(new PartitionData().setRecords(makeRecord(HELLO_PLAIN_WORLD)))));
 
         // When
@@ -253,7 +295,7 @@ class RecordEncryptionFilterTest {
     void shouldPropagateResponseExceptions() {
         // Given
         var fetchResponseData = buildFetchResponseData(new FetchableTopicResponse()
-                .setTopic(UNENCRYPTED_TOPIC)
+                .setTopic(UNRESOLVED_TOPIC)
                 .setPartitions(List.of(new PartitionData().setRecords(makeRecord(HELLO_PLAIN_WORLD)))));
         RuntimeException exception = new RuntimeException("boom");
         when(decryptionManager.decrypt(any(), anyInt(), any(), any())).thenReturn(CompletableFuture.failedFuture(exception));

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionTest.java
@@ -23,6 +23,7 @@ import io.kroxylicious.filter.encryption.config.KekSelectorService;
 import io.kroxylicious.filter.encryption.config.KmsCacheConfig;
 import io.kroxylicious.filter.encryption.config.RecordEncryptionConfig;
 import io.kroxylicious.filter.encryption.config.TopicNameBasedKekSelector;
+import io.kroxylicious.filter.encryption.config.UnresolvedKeyPolicy;
 import io.kroxylicious.filter.encryption.dek.DekException;
 import io.kroxylicious.kms.service.Kms;
 import io.kroxylicious.kms.service.KmsService;
@@ -58,7 +59,7 @@ class RecordEncryptionTest {
     @SuppressWarnings("unchecked")
     void shouldInitAndCreateFilter() {
         var kmsConfig = new Object();
-        var config = new RecordEncryptionConfig("KMS", kmsConfig, "SELECTOR", null, null);
+        var config = new RecordEncryptionConfig("KMS", kmsConfig, "SELECTOR", null, null, UnresolvedKeyPolicy.PASSTHROUGH_UNENCRYPTED);
         var recordEncryption = new RecordEncryption<>();
         var fc = mock(FilterFactoryContext.class);
         var kmsService = mock(KmsService.class);
@@ -85,7 +86,7 @@ class RecordEncryptionTest {
     @Test
     void closePropagatedToKmsService() {
         var kmsConfig = new Object();
-        var config = new RecordEncryptionConfig("KMS", kmsConfig, "SELECTOR", null, null);
+        var config = new RecordEncryptionConfig("KMS", kmsConfig, "SELECTOR", null, null, UnresolvedKeyPolicy.PASSTHROUGH_UNENCRYPTED);
         var recordEncryption = new RecordEncryption<>();
         var fc = mock(FilterFactoryContext.class);
         var kmsService = mock(KmsService.class);
@@ -102,7 +103,7 @@ class RecordEncryptionTest {
 
     @Test
     void testKmsCacheConfigDefaults() {
-        KmsCacheConfig config = new RecordEncryptionConfig("vault", 1L, "selector", 1L, null).kmsCache();
+        KmsCacheConfig config = new RecordEncryptionConfig("vault", 1L, "selector", 1L, null, UnresolvedKeyPolicy.PASSTHROUGH_UNENCRYPTED).kmsCache();
         assertThat(config.decryptedDekCacheSize()).isEqualTo(1000);
         assertThat(config.decryptedDekExpireAfterAccessDuration()).isEqualTo(Duration.ofHours(1));
         assertThat(config.resolvedAliasCacheSize()).isEqualTo(1000);
@@ -115,7 +116,7 @@ class RecordEncryptionTest {
 
     @Test
     void testDekManagerConfigDefaults() {
-        var config = new RecordEncryptionConfig("vault", 1L, "selector", 1L, null).dekManager();
+        var config = new RecordEncryptionConfig("vault", 1L, "selector", 1L, null, UnresolvedKeyPolicy.PASSTHROUGH_UNENCRYPTED).dekManager();
         assertThat(config.maxEncryptionsPerDek()).isEqualTo(5_000_000L);
     }
 
@@ -131,7 +132,7 @@ class RecordEncryptionTest {
         experimental.put("encryptionDekRefreshAfterWriteSeconds", null);
         experimental.put("encryptionDekExpireAfterWriteSeconds", null);
         KmsCacheConfig config = new RecordEncryptionConfig("vault", 1L, "selector", 1L,
-                experimental).kmsCache();
+                experimental, UnresolvedKeyPolicy.PASSTHROUGH_UNENCRYPTED).kmsCache();
         assertThat(config.decryptedDekCacheSize()).isEqualTo(1000);
         assertThat(config.decryptedDekExpireAfterAccessDuration()).isEqualTo(Duration.ofHours(1));
         assertThat(config.resolvedAliasCacheSize()).isEqualTo(1000);
@@ -147,7 +148,7 @@ class RecordEncryptionTest {
         Map<String, Object> experimental = new HashMap<>();
         experimental.put("maxEncryptionsPerDek", null);
 
-        var config = new RecordEncryptionConfig("vault", 1L, "selector", 1L, null).dekManager();
+        var config = new RecordEncryptionConfig("vault", 1L, "selector", 1L, null, UnresolvedKeyPolicy.PASSTHROUGH_UNENCRYPTED).dekManager();
         assertThat(config.maxEncryptionsPerDek()).isEqualTo(5_000_000L);
     }
 
@@ -172,7 +173,7 @@ class RecordEncryptionTest {
         experimental.put("notFoundAliasExpireAfterWriteSeconds", 6);
         experimental.put("encryptionDekRefreshAfterWriteSeconds", 7);
         experimental.put("encryptionDekExpireAfterWriteSeconds", 8);
-        KmsCacheConfig config = new RecordEncryptionConfig("vault", 1L, "selector", 1L, experimental).kmsCache();
+        KmsCacheConfig config = new RecordEncryptionConfig("vault", 1L, "selector", 1L, experimental, UnresolvedKeyPolicy.PASSTHROUGH_UNENCRYPTED).kmsCache();
         assertThat(config).isEqualTo(kmsCacheConfig);
     }
 
@@ -184,7 +185,7 @@ class RecordEncryptionTest {
         Map<String, Object> experimental = new HashMap<>();
         experimental.put("maxEncryptionsPerDek", 1_000L);
 
-        var config = new RecordEncryptionConfig("vault", 1L, "selector", 1L, experimental).dekManager();
+        var config = new RecordEncryptionConfig("vault", 1L, "selector", 1L, experimental, UnresolvedKeyPolicy.PASSTHROUGH_UNENCRYPTED).dekManager();
         assertThat(config).isEqualTo(dekManagerCacheConfig);
     }
 

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/config/RecordEncryptionConfigTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/config/RecordEncryptionConfigTest.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -103,6 +104,18 @@ class RecordEncryptionConfigTest {
         assertThatThrownBy(config::kmsCache).isInstanceOf(IllegalArgumentException.class);
     }
 
+    @Test
+    void defaultUnresolvedEncryptionPolicy() {
+        RecordEncryptionConfig config = new RecordEncryptionConfig("kms", 1L, "selector", 2L, Map.of(), null);
+        assertThat(config.unresolvedKeyPolicy()).isEqualTo(UnresolvedKeyPolicy.PASSTHROUGH_UNENCRYPTED);
+    }
+
+    @Test
+    void specifiedUnresolvedEncryptionPolicy() {
+        RecordEncryptionConfig config = new RecordEncryptionConfig("kms", 1L, "selector", 2L, Map.of(), UnresolvedKeyPolicy.REJECT);
+        assertThat(config.unresolvedKeyPolicy()).isEqualTo(UnresolvedKeyPolicy.REJECT);
+    }
+
     private static @NonNull KmsCacheConfig getKmsCacheConfig(String key, Object value) {
         HashMap<String, Object> map = new HashMap<>();
         map.put(key, value);
@@ -111,7 +124,7 @@ class RecordEncryptionConfigTest {
     }
 
     private static @NonNull RecordEncryptionConfig createConfig(Map<String, Object> map) {
-        return new RecordEncryptionConfig("kms", 1L, "selector", 2L, map);
+        return new RecordEncryptionConfig("kms", 1L, "selector", 2L, map, UnresolvedKeyPolicy.PASSTHROUGH_UNENCRYPTED);
     }
 
 }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/config/TopicNameKekSelectionTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/config/TopicNameKekSelectionTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TopicNameKekSelectionTest {
+
+    public static Stream<Arguments> invalidConstructorArgs() {
+        Arguments nullSelection = Arguments.of(null, Set.of(), NullPointerException.class);
+        Arguments nullUnresolved = Arguments.of(Map.of(), null, NullPointerException.class);
+        HashMap<Object, Object> map = new HashMap<>();
+        map.put("abc", null);
+        Arguments nullMapValue = Arguments.of(map, Set.of(), IllegalArgumentException.class);
+        return Stream.of(nullSelection, nullUnresolved, nullMapValue);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void invalidConstructorArgs(Map<String, Integer> selection, Set<String> unresolvedTopicNames, Class<Exception> exceptionClass) {
+        Assertions.assertThatThrownBy(() -> new TopicNameKekSelection<>(selection, unresolvedTopicNames)).isInstanceOf(exceptionClass);
+    }
+
+    @Test
+    void validConstructor() {
+        Map<String, Integer> selection = Map.of("abc", 1);
+        Set<String> unresolved = Set.of("def");
+        TopicNameKekSelection<Integer> kekSelection = new TopicNameKekSelection<>(selection, unresolved);
+        assertThat(kekSelection.topicNameToKekId()).isEqualTo(selection);
+        assertThat(kekSelection.unresolvedTopicNames()).isEqualTo(unresolved);
+    }
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds an optional Record Encryption configuration property `unresolvedKeyPolicy` with possible values:
- `PASSTHROUGH_UNENCRYPTED` (default)
- `REJECT`

If we cannot resolve a Key for some topics in a produce request then we will decide what to do based on this policy.

`PASSTHROUGH_UNENCRYPTED` will not modify the data for those unresolved topics and pass them along the chain. This is the current behaviour.

`REJECT` will cause the entire produce request to be rejected if any topic could not be resolved to a Key, an error response will be sent to the client.

Example configuration:
```yaml
filterDefinitions:
- name: encrypt
  type: RecordEncryption
  config:
    kms: VaultKmsService
    kmsConfig:
      vaultTransitEngineUrl: http://vault:8200/v1/transit
      vaultToken:
        password: token
    selector: TemplateKekSelector
    selectorConfig:
      template: "KEK_${topicName}"
    unresolvedKeyPolicy: REJECT
```

### Additional Context

Currently when we are unable to resolve a Key for a topic, we interpret that as meaning the topic should not be encrypted. This fail-open policy leaves the possibility for misconfigurations to permissively allow unencrypted data to flow into the target cluster.

Some users may wish to set up the proxy such that only encrypted traffic should flow through it, in this case they can have a harsher fail-closed policy in the case where we can't resolve a key for a topic. This will be safer, in terms of PII/data-governance requirements as the proxy will never decide to passthrough unencrypted data. Any misconfiguration in the Proxy or KMS where the naming doesn't align will result in failure to produce, rather than unencrypted data being sent to the target cluster.

See discussion in #1762 and #811.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
