### PR TITLE
Fix surefire failure during kroxylicious-operator unit tests.

### DIFF
--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -274,7 +274,7 @@
                     <!-- https://junit-pioneer.org/docs/environment-variables/#warnings-for-reflective-access
                          https://maven.apache.org/surefire/maven-surefire-plugin/faq.html#late-property-evaluation (required to propagate Jacoco args etc) -->
                     <argLine>
-                        @{argLine}
+                        @{jacoco.argline}
                         --add-opens java.base/java.util=ALL-UNNAMED
                         --add-opens java.base/java.lang=ALL-UNNAMED
                     </argLine>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <maven.compiler.testRelease>${java.test.version}</maven.compiler.testRelease>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <jacoco.argline/>
 
         <skipTests>false</skipTests>
         <skipITs>${skipTests}</skipITs>
@@ -745,6 +746,9 @@
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>${jacoco-maven-plugin.version}</version>
+                    <configuration>
+                        <propertyName>jacoco.argline</propertyName>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

In another channel, @tombentley reported that Maven surefire was failing in the kroxylicious-opertor modole.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.5.2:test (default-test) on project kroxylicious-operator: 
[ERROR] 
[ERROR] See /home/tom/messaging/kroxylicious/kroxylicious-operator/target/surefire-reports for the individual test results.
[ERROR] See dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[ERROR] Command was /bin/sh -c cd '/home/tom/messaging/kroxylicious/kroxylicious-operator' && '/home/tom/.sdkman/candidates/java/21.0.2-tem/bin/java' '@{argLine}' '--add-opens' 'java.base/java.util=ALL-UNNAMED' '--add-opens' 'java.base/java.lang=ALL-UNNAMED' '-jar' '/home/tom/messaging/kroxylicious/kroxylicious-operator/target/surefire/surefirebooter-20250128174729303_560.jar' '/home/tom/messaging/kroxylicious/kroxylicious-operator/target/surefire' '2025-01-28T17-41-38_856-jvmRun1' 'surefire-20250128174729303_558tmp' 'surefire_24-20250128174729303_559tmp'
```

The issue is that `argLine` has no value unless Jacoco is enabled.

Fix change ensure that Jacoco's argline always has a value `""`, even if Jacoco isn't being run.  This means `@{}` will always produce a value (or empty).

Also configured Jacoco plugin to use property `jacoco.argline` rather than `argLine`, just so it is clear where the value is coming from.

I've tested this locally with/withour Sonar, it seems to be the right thing.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
