### PR TITLE
Refactor and rename `model.VirtualCluster` to `model.VirtualClusterModel`

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -18,12 +18,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import io.kroxylicious.proxy.config.tls.AllowDeny;
-import io.kroxylicious.proxy.config.tls.Tls;
-import io.kroxylicious.proxy.config.tls.TrustOptions;
-import io.kroxylicious.proxy.config.tls.TrustProvider;
-import io.kroxylicious.proxy.service.HostPort;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,9 +25,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import io.kroxylicious.proxy.config.admin.AdminHttpConfiguration;
+import io.kroxylicious.proxy.config.tls.AllowDeny;
+import io.kroxylicious.proxy.config.tls.Tls;
+import io.kroxylicious.proxy.config.tls.TrustOptions;
+import io.kroxylicious.proxy.config.tls.TrustProvider;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProviderService;
+import io.kroxylicious.proxy.service.HostPort;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -180,10 +179,10 @@ public record Configuration(
                 virtualCluster.logNetwork(),
                 virtualCluster.logFrames(),
                 filterDefinitions);
-        logVirtualClusterSummary(virtualClusterModel.getClusterName(), virtualClusterModel.targetCluster(), virtualClusterModel.getClusterNetworkAddressConfigProvider(), virtualCluster.tls());
+        logVirtualClusterSummary(virtualClusterModel.getClusterName(), virtualClusterModel.targetCluster(), virtualClusterModel.getClusterNetworkAddressConfigProvider(),
+                virtualCluster.tls());
         return virtualClusterModel;
     }
-
 
     @SuppressWarnings("java:S1874") // the classes are deprecated because we don't want them in the API module
     private static void logVirtualClusterSummary(String clusterName,
@@ -207,20 +206,20 @@ public record Configuration(
 
     private static String generateTlsSummary(Optional<Tls> tlsToSummarize) {
         var tls = tlsToSummarize.map(t -> Optional.ofNullable(t.trust())
-                        .map(TrustProvider::trustOptions)
-                        .map(TrustOptions::toString).orElse("-"))
+                .map(TrustProvider::trustOptions)
+                .map(TrustOptions::toString).orElse("-"))
                 .map(options -> " (TLS: " + options + ") ").orElse("");
         var cipherSuitesAllowed = tlsToSummarize.map(t -> Optional.ofNullable(t.cipherSuites())
-                        .map(AllowDeny::allowed).orElse(Collections.emptyList()))
+                .map(AllowDeny::allowed).orElse(Collections.emptyList()))
                 .map(allowedCiphers -> " (Allowed Ciphers: " + allowedCiphers + ")").orElse("");
         var cipherSuitesDenied = tlsToSummarize.map(t -> Optional.ofNullable(t.cipherSuites())
-                        .map(AllowDeny::denied).orElse(Collections.emptySet()))
+                .map(AllowDeny::denied).orElse(Collections.emptySet()))
                 .map(deniedCiphers -> " (Denied Ciphers: " + deniedCiphers + ")").orElse("");
         var protocolsAllowed = tlsToSummarize.map(t -> Optional.ofNullable(t.protocols())
-                        .map(AllowDeny::allowed).orElse(Collections.emptyList()))
+                .map(AllowDeny::allowed).orElse(Collections.emptyList()))
                 .map(protocols -> " (Allowed Protocols: " + protocols + ")").orElse("");
         var protocolsDenied = tlsToSummarize.map(t -> Optional.ofNullable(t.protocols())
-                        .map(AllowDeny::denied).orElse(Collections.emptySet()))
+                .map(AllowDeny::denied).orElse(Collections.emptySet()))
                 .map(protocols -> " (Denied Protocols: " + protocols + ")").orElse("");
 
         return tls + cipherSuitesAllowed + cipherSuitesDenied + protocolsAllowed + protocolsDenied;

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -7,6 +7,7 @@ package io.kroxylicious.proxy.config;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -16,6 +17,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import io.kroxylicious.proxy.config.tls.AllowDeny;
+import io.kroxylicious.proxy.config.tls.Tls;
+import io.kroxylicious.proxy.config.tls.TrustOptions;
+import io.kroxylicious.proxy.config.tls.TrustProvider;
+import io.kroxylicious.proxy.service.HostPort;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -166,13 +173,57 @@ public record Configuration(
                                                             @NonNull List<NamedFilterDefinition> filterDefinitions,
                                                             @NonNull String virtualClusterNodeName) {
 
-        return new VirtualClusterModel(virtualClusterNodeName,
+        VirtualClusterModel virtualClusterModel = new VirtualClusterModel(virtualClusterNodeName,
                 virtualCluster.targetCluster(),
                 buildAddressProviderService(virtualCluster, pfr),
                 virtualCluster.tls(),
                 virtualCluster.logNetwork(),
                 virtualCluster.logFrames(),
                 filterDefinitions);
+        logVirtualClusterSummary(virtualClusterModel.getClusterName(), virtualClusterModel.targetCluster(), virtualClusterModel.getClusterNetworkAddressConfigProvider(), virtualCluster.tls());
+        return virtualClusterModel;
+    }
+
+
+    @SuppressWarnings("java:S1874") // the classes are deprecated because we don't want them in the API module
+    private static void logVirtualClusterSummary(String clusterName,
+                                                 TargetCluster targetCluster,
+                                                 ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider,
+                                                 Optional<Tls> tls) {
+        try {
+            HostPort downstreamBootstrap = clusterNetworkAddressConfigProvider.getClusterBootstrapAddress();
+            var downstreamTlsSummary = generateTlsSummary(tls);
+
+            HostPort upstreamHostPort = targetCluster.bootstrapServersList().get(0);
+            var upstreamTlsSummary = generateTlsSummary(targetCluster.tls());
+
+            LOGGER.info("Virtual Cluster: {}, Downstream {}{} => Upstream {}{}",
+                    clusterName, downstreamBootstrap, downstreamTlsSummary, upstreamHostPort, upstreamTlsSummary);
+        }
+        catch (Exception e) {
+            LOGGER.warn("Failed to log summary for Virtual Cluster: {}", clusterName, e);
+        }
+    }
+
+    private static String generateTlsSummary(Optional<Tls> tlsToSummarize) {
+        var tls = tlsToSummarize.map(t -> Optional.ofNullable(t.trust())
+                        .map(TrustProvider::trustOptions)
+                        .map(TrustOptions::toString).orElse("-"))
+                .map(options -> " (TLS: " + options + ") ").orElse("");
+        var cipherSuitesAllowed = tlsToSummarize.map(t -> Optional.ofNullable(t.cipherSuites())
+                        .map(AllowDeny::allowed).orElse(Collections.emptyList()))
+                .map(allowedCiphers -> " (Allowed Ciphers: " + allowedCiphers + ")").orElse("");
+        var cipherSuitesDenied = tlsToSummarize.map(t -> Optional.ofNullable(t.cipherSuites())
+                        .map(AllowDeny::denied).orElse(Collections.emptySet()))
+                .map(deniedCiphers -> " (Denied Ciphers: " + deniedCiphers + ")").orElse("");
+        var protocolsAllowed = tlsToSummarize.map(t -> Optional.ofNullable(t.protocols())
+                        .map(AllowDeny::allowed).orElse(Collections.emptyList()))
+                .map(protocols -> " (Allowed Protocols: " + protocols + ")").orElse("");
+        var protocolsDenied = tlsToSummarize.map(t -> Optional.ofNullable(t.protocols())
+                        .map(AllowDeny::denied).orElse(Collections.emptySet()))
+                .map(protocols -> " (Denied Protocols: " + protocols + ")").orElse("");
+
+        return tls + cipherSuitesAllowed + cipherSuitesDenied + protocolsAllowed + protocolsDenied;
     }
 
     private static ClusterNetworkAddressConfigProvider buildAddressProviderService(@NonNull VirtualCluster virtualCluster,

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
@@ -11,10 +11,7 @@ import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.kroxylicious.proxy.config.tls.Tls;
-import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
-import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProviderService;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 public record VirtualCluster(TargetCluster targetCluster,
@@ -24,22 +21,4 @@ public record VirtualCluster(TargetCluster targetCluster,
                              boolean logFrames,
                              @Nullable List<String> filters) {
 
-    public io.kroxylicious.proxy.model.VirtualCluster toVirtualClusterModel(@NonNull PluginFactoryRegistry pfr,
-                                                                            @NonNull List<NamedFilterDefinition> filterDefinitions,
-                                                                            @NonNull String virtualClusterNodeName) {
-
-        return new io.kroxylicious.proxy.model.VirtualCluster(virtualClusterNodeName,
-                targetCluster(),
-                toClusterNetworkAddressConfigProviderModel(pfr),
-                tls(),
-                logNetwork(),
-                logFrames(),
-                filterDefinitions);
-    }
-
-    private ClusterNetworkAddressConfigProvider toClusterNetworkAddressConfigProviderModel(@NonNull PluginFactoryRegistry registry) {
-        ClusterNetworkAddressConfigProviderService provider = registry.pluginFactory(ClusterNetworkAddressConfigProviderService.class)
-                .pluginInstance(clusterNetworkAddressConfigProvider.type());
-        return provider.build(clusterNetworkAddressConfigProvider.config());
-    }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -47,7 +47,7 @@ import io.kroxylicious.proxy.internal.filter.RequestFilterResultBuilderImpl;
 import io.kroxylicious.proxy.internal.filter.ResponseFilterResultBuilderImpl;
 import io.kroxylicious.proxy.internal.util.Assertions;
 import io.kroxylicious.proxy.internal.util.ByteBufOutputStream;
-import io.kroxylicious.proxy.model.VirtualCluster;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -62,19 +62,19 @@ public class FilterHandler extends ChannelDuplexHandler {
     private final FilterInvoker invoker;
     private final long timeoutMs;
     private final String sniHostname;
-    private final VirtualCluster virtualCluster;
+    private final VirtualClusterModel virtualClusterModel;
     private final Channel inboundChannel;
     private CompletableFuture<Void> writeFuture = CompletableFuture.completedFuture(null);
     private CompletableFuture<Void> readFuture = CompletableFuture.completedFuture(null);
     private ChannelHandlerContext ctx;
     private PromiseFactory promiseFactory;
 
-    public FilterHandler(FilterAndInvoker filterAndInvoker, long timeoutMs, String sniHostname, VirtualCluster virtualCluster, Channel inboundChannel) {
+    public FilterHandler(FilterAndInvoker filterAndInvoker, long timeoutMs, String sniHostname, VirtualClusterModel virtualClusterModel, Channel inboundChannel) {
         this.filter = Objects.requireNonNull(filterAndInvoker).filter();
         this.invoker = filterAndInvoker.invoker();
         this.timeoutMs = Assertions.requireStrictlyPositive(timeoutMs, "timeout");
         this.sniHostname = sniHostname;
-        this.virtualCluster = virtualCluster;
+        this.virtualClusterModel = virtualClusterModel;
         this.inboundChannel = inboundChannel;
     }
 
@@ -442,7 +442,7 @@ public class FilterHandler extends ChannelDuplexHandler {
         }
 
         public String getVirtualClusterName() {
-            return virtualCluster.getClusterName();
+            return virtualClusterModel.getClusterName();
         }
 
         @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyBackendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyBackendHandler.java
@@ -19,7 +19,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 
-import io.kroxylicious.proxy.model.VirtualCluster;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 public class KafkaProxyBackendHandler extends ChannelInboundHandlerAdapter {
@@ -33,9 +33,9 @@ public class KafkaProxyBackendHandler extends ChannelInboundHandlerAdapter {
     ChannelHandlerContext serverCtx;
     private boolean pendingServerFlushes;
 
-    public KafkaProxyBackendHandler(ProxyChannelStateMachine proxyChannelStateMachine, VirtualCluster virtualCluster) {
+    public KafkaProxyBackendHandler(ProxyChannelStateMachine proxyChannelStateMachine, VirtualClusterModel virtualClusterModel) {
         this.proxyChannelStateMachine = Objects.requireNonNull(proxyChannelStateMachine);
-        Optional<SslContext> upstreamSslContext = virtualCluster.getUpstreamSslContext();
+        Optional<SslContext> upstreamSslContext = virtualClusterModel.getUpstreamSslContext();
         this.sslContext = upstreamSslContext.orElse(null);
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachine.java
@@ -27,7 +27,7 @@ import io.kroxylicious.proxy.frame.RequestFrame;
 import io.kroxylicious.proxy.internal.ProxyChannelState.Closed;
 import io.kroxylicious.proxy.internal.ProxyChannelState.Forwarding;
 import io.kroxylicious.proxy.internal.codec.FrameOversizedException;
-import io.kroxylicious.proxy.model.VirtualCluster;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
@@ -121,7 +121,7 @@ public class ProxyChannelStateMachine {
     private KafkaProxyFrontendHandler frontendHandler = null;
 
     /**
-     * The backend handler. Non-null if {@link #onNetFilterInitiateConnect(HostPort, List, VirtualCluster, NetFilter)}
+     * The backend handler. Non-null if {@link #onNetFilterInitiateConnect(HostPort, List, VirtualClusterModel, NetFilter)}
      * has been called
      */
     @VisibleForTesting
@@ -217,16 +217,16 @@ public class ProxyChannelStateMachine {
      * Notify the statemachine that the netfilter has chosen an outbound peer.
      * @param peer the upstream host to connect to.
      * @param filters the set of filters to be applied to the session
-     * @param virtualCluster the virtual cluster the client is connecting too
+     * @param virtualClusterModel the virtual cluster the client is connecting too
      * @param netFilter the netFilter which selected the upstream peer.
      */
     void onNetFilterInitiateConnect(
                                     @NonNull HostPort peer,
                                     @NonNull List<FilterAndInvoker> filters,
-                                    VirtualCluster virtualCluster,
+                                    VirtualClusterModel virtualClusterModel,
                                     NetFilter netFilter) {
         if (state instanceof ProxyChannelState.SelectingServer selectingServerState) {
-            toConnecting(selectingServerState.toConnecting(peer), filters, virtualCluster);
+            toConnecting(selectingServerState.toConnecting(peer), filters, virtualClusterModel);
         }
         else {
             illegalState(DUPLICATE_INITIATE_CONNECT_ERROR + " : netFilter='" + netFilter + "'");
@@ -408,9 +408,9 @@ public class ProxyChannelStateMachine {
     private void toConnecting(
                               ProxyChannelState.Connecting connecting,
                               @NonNull List<FilterAndInvoker> filters,
-                              VirtualCluster virtualCluster) {
+                              VirtualClusterModel virtualClusterModel) {
         setState(connecting);
-        backendHandler = new KafkaProxyBackendHandler(this, virtualCluster);
+        backendHandler = new KafkaProxyBackendHandler(this, virtualClusterModel);
         frontendHandler.inConnecting(connecting.remote(), filters, backendHandler);
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilter.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilter.java
@@ -38,7 +38,7 @@ import io.kroxylicious.proxy.filter.ResponseFilterResult;
 import io.kroxylicious.proxy.filter.ShareAcknowledgeResponseFilter;
 import io.kroxylicious.proxy.filter.ShareFetchResponseFilter;
 import io.kroxylicious.proxy.internal.net.EndpointReconciler;
-import io.kroxylicious.proxy.model.VirtualCluster;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
 
 /**
@@ -50,11 +50,11 @@ public class BrokerAddressFilter implements MetadataResponseFilter, FindCoordina
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BrokerAddressFilter.class);
 
-    private final VirtualCluster virtualCluster;
+    private final VirtualClusterModel virtualClusterModel;
     private final EndpointReconciler reconciler;
 
-    public BrokerAddressFilter(VirtualCluster virtualCluster, EndpointReconciler reconciler) {
-        this.virtualCluster = virtualCluster;
+    public BrokerAddressFilter(VirtualClusterModel virtualClusterModel, EndpointReconciler reconciler) {
+        this.virtualClusterModel = virtualClusterModel;
         this.reconciler = reconciler;
     }
 
@@ -166,7 +166,7 @@ public class BrokerAddressFilter implements MetadataResponseFilter, FindCoordina
         int incomingPort = portGetter.applyAsInt(broker);
 
         Integer nodeId = nodeIdGetter.apply(broker);
-        var advertisedAddress = virtualCluster.getAdvertisedBrokerAddress(nodeId);
+        var advertisedAddress = virtualClusterModel.getAdvertisedBrokerAddress(nodeId);
 
         LOGGER.trace("{}: Rewriting broker address in response {}:{} -> {}", context, incomingHost, incomingPort, advertisedAddress);
         hostSetter.accept(broker, advertisedAddress.host());
@@ -175,9 +175,9 @@ public class BrokerAddressFilter implements MetadataResponseFilter, FindCoordina
 
     private CompletionStage<ResponseFilterResult> doReconcileThenForwardResponse(ResponseHeaderData header, ApiMessage data, FilterContext context,
                                                                                  Map<Integer, HostPort> nodeMap) {
-        return reconciler.reconcile(virtualCluster, nodeMap).toCompletableFuture()
+        return reconciler.reconcile(virtualClusterModel, nodeMap).toCompletableFuture()
                 .thenCompose(u -> {
-                    LOGGER.debug("Endpoint reconciliation complete for virtual cluster {}", virtualCluster);
+                    LOGGER.debug("Endpoint reconciliation complete for virtual cluster {}", virtualClusterModel);
                     return context.responseFilterResultBuilder().forward(header, data).completed();
                 });
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointReconciler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointReconciler.java
@@ -9,7 +9,7 @@ package io.kroxylicious.proxy.internal.net;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
-import io.kroxylicious.proxy.model.VirtualCluster;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
 
 public interface EndpointReconciler {
@@ -19,9 +19,9 @@ public interface EndpointReconciler {
      * current set of nodes for this virtual cluster.  Once any necessary alterations to the
      * endpoint bindings have been realised, the returned CompletionStage will be completed.
      *
-     * @param virtualCluster virtual cluster
+     * @param virtualClusterModel virtual cluster
      * @param upstreamNodes  current set of node ids
      * @return CompletionStage that is used to signal completion of the work.
      */
-    CompletionStage<Void> reconcile(VirtualCluster virtualCluster, Map<Integer, HostPort> upstreamNodes);
+    CompletionStage<Void> reconcile(VirtualClusterModel virtualClusterModel, Map<Integer, HostPort> upstreamNodes);
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/VirtualClusterBinding.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/VirtualClusterBinding.java
@@ -6,7 +6,7 @@
 
 package io.kroxylicious.proxy.internal.net;
 
-import io.kroxylicious.proxy.model.VirtualCluster;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
 
 /**
@@ -18,7 +18,7 @@ public interface VirtualClusterBinding {
      *
      * @return virtual cluster.
      */
-    VirtualCluster virtualCluster();
+    VirtualClusterModel virtualClusterModel();
 
     /**
      * The upstream target of this binding.

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/VirtualClusterBootstrapBinding.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/VirtualClusterBootstrapBinding.java
@@ -8,26 +8,26 @@ package io.kroxylicious.proxy.internal.net;
 
 import java.util.Objects;
 
-import io.kroxylicious.proxy.model.VirtualCluster;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
 
 /**
  * A binding to a virtual cluster bootstrap.
  *
- * @param virtualCluster the virtual cluster
+ * @param virtualClusterModel the virtual cluster
  * @param upstreamTarget the upstream bootstrap target
  */
-public record VirtualClusterBootstrapBinding(VirtualCluster virtualCluster, HostPort upstreamTarget) implements VirtualClusterBinding {
+public record VirtualClusterBootstrapBinding(VirtualClusterModel virtualClusterModel, HostPort upstreamTarget) implements VirtualClusterBinding {
 
     public VirtualClusterBootstrapBinding {
-        Objects.requireNonNull(virtualCluster, "virtualCluster cannot be null");
+        Objects.requireNonNull(virtualClusterModel, "virtualCluster cannot be null");
         Objects.requireNonNull(upstreamTarget, "upstreamTarget cannot be null");
     }
 
     @Override
     public String toString() {
         return "VirtualClusterBrokerBinding[" +
-                "virtualCluster=" + this.virtualCluster() + ", " +
+                "virtualCluster=" + this.virtualClusterModel() + ", " +
                 "upstreamTarget=" + this.upstreamTarget() + ']';
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/VirtualClusterBrokerBinding.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/VirtualClusterBrokerBinding.java
@@ -8,35 +8,35 @@ package io.kroxylicious.proxy.internal.net;
 
 import java.util.Objects;
 
-import io.kroxylicious.proxy.model.VirtualCluster;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
 
 /**
  * A broker specific virtual cluster binding.
  *
- * @param virtualCluster                       the virtual cluster
+ * @param virtualClusterModel                       the virtual cluster
  * @param upstreamTarget                       the upstream target of this binding
  * @param nodeId                               kafka nodeId of the target broker
  * @param restrictUpstreamToMetadataDiscovery  true if the upstreamTarget corresponds to a broker, false if it points at a bootstrap.
  */
-public record VirtualClusterBrokerBinding(VirtualCluster virtualCluster, HostPort upstreamTarget, int nodeId, boolean restrictUpstreamToMetadataDiscovery)
+public record VirtualClusterBrokerBinding(VirtualClusterModel virtualClusterModel, HostPort upstreamTarget, int nodeId, boolean restrictUpstreamToMetadataDiscovery)
         implements VirtualClusterBinding {
     public VirtualClusterBrokerBinding {
-        Objects.requireNonNull(virtualCluster, "virtualCluster must not be null");
+        Objects.requireNonNull(virtualClusterModel, "virtualCluster must not be null");
         Objects.requireNonNull(upstreamTarget, "upstreamTarget must not be null");
     }
 
     @Override
     public String toString() {
         return "VirtualClusterBrokerBinding[" +
-                "virtualCluster=" + this.virtualCluster() + ", " +
+                "virtualCluster=" + this.virtualClusterModel() + ", " +
                 "upstreamTarget=" + this.upstreamTarget() + ", " +
                 "restrictUpstreamToMetadataDiscovery=" + this.restrictUpstreamToMetadataDiscovery() + ", " +
                 "nodeId=" + nodeId + ']';
     }
 
     public boolean refersToSameVirtualClusterAndNode(VirtualClusterBrokerBinding other) {
-        return other != null && other.nodeId == this.nodeId && Objects.equals(other.virtualCluster, this.virtualCluster);
+        return other != null && other.nodeId == this.nodeId && Objects.equals(other.virtualClusterModel, this.virtualClusterModel);
     }
 
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualCluster.java
@@ -42,7 +42,7 @@ import io.kroxylicious.proxy.service.HostPort;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-public class VirtualCluster implements ClusterNetworkAddressConfigProvider {
+public class VirtualCluster {
     public static final int DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES = 104857600;
     private final String clusterName;
 
@@ -178,42 +178,34 @@ public class VirtualCluster implements ClusterNetworkAddressConfigProvider {
                 '}';
     }
 
-    @Override
     public HostPort getClusterBootstrapAddress() {
         return clusterNetworkAddressConfigProvider.getClusterBootstrapAddress();
     }
 
-    @Override
     public HostPort getBrokerAddress(int nodeId) throws IllegalArgumentException {
         return clusterNetworkAddressConfigProvider.getBrokerAddress(nodeId);
     }
 
-    @Override
     public Optional<String> getBindAddress() {
         return clusterNetworkAddressConfigProvider.getBindAddress();
     }
 
-    @Override
     public boolean requiresTls() {
         return clusterNetworkAddressConfigProvider.requiresTls();
     }
 
-    @Override
     public Set<Integer> getExclusivePorts() {
         return clusterNetworkAddressConfigProvider.getExclusivePorts();
     }
 
-    @Override
     public Set<Integer> getSharedPorts() {
         return clusterNetworkAddressConfigProvider.getSharedPorts();
     }
 
-    @Override
     public Map<Integer, HostPort> discoveryAddressMap() {
         return clusterNetworkAddressConfigProvider.discoveryAddressMap();
     }
 
-    @Override
     public Integer getBrokerIdFromBrokerAddress(HostPort brokerAddress) {
         return clusterNetworkAddressConfigProvider.getBrokerIdFromBrokerAddress(brokerAddress);
     }
@@ -355,7 +347,6 @@ public class VirtualCluster implements ClusterNetworkAddressConfigProvider {
         return filters;
     }
 
-    @Override
     public HostPort getAdvertisedBrokerAddress(int nodeId) {
         return clusterNetworkAddressConfigProvider.getAdvertisedBrokerAddress(nodeId);
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -93,47 +93,6 @@ public class VirtualClusterModel {
         // TODO: https://github.com/kroxylicious/kroxylicious/issues/104 be prepared to reload the SslContext at runtime.
         this.upstreamSslContext = buildUpstreamSslContext();
         this.downstreamSslContext = buildDownstreamSslContext();
-        logVirtualClusterSummary(clusterName, targetCluster, clusterNetworkAddressConfigProvider, tls);
-    }
-
-    @SuppressWarnings("java:S1874") // the classes are deprecated because we don't want them in the API module
-    private static void logVirtualClusterSummary(String clusterName, TargetCluster targetCluster,
-                                                 ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider,
-                                                 Optional<Tls> tls) {
-        try {
-            HostPort downstreamBootstrap = clusterNetworkAddressConfigProvider.getClusterBootstrapAddress();
-            var downstreamTlsSummary = generateTlsSummary(tls);
-
-            HostPort upstreamHostPort = targetCluster.bootstrapServersList().get(0);
-            var upstreamTlsSummary = generateTlsSummary(targetCluster.tls());
-
-            LOGGER.info("Virtual Cluster: {}, Downstream {}{} => Upstream {}{}",
-                    clusterName, downstreamBootstrap, downstreamTlsSummary, upstreamHostPort, upstreamTlsSummary);
-        }
-        catch (Exception e) {
-            LOGGER.warn("Failed to log summary for Virtual Cluster: {}", clusterName, e);
-        }
-    }
-
-    private static String generateTlsSummary(Optional<Tls> tlsToSummarize) {
-        var tls = tlsToSummarize.map(t -> Optional.ofNullable(t.trust())
-                .map(TrustProvider::trustOptions)
-                .map(TrustOptions::toString).orElse("-"))
-                .map(options -> " (TLS: " + options + ") ").orElse("");
-        var cipherSuitesAllowed = tlsToSummarize.map(t -> Optional.ofNullable(t.cipherSuites())
-                .map(AllowDeny::allowed).orElse(Collections.emptyList()))
-                .map(allowedCiphers -> " (Allowed Ciphers: " + allowedCiphers + ")").orElse("");
-        var cipherSuitesDenied = tlsToSummarize.map(t -> Optional.ofNullable(t.cipherSuites())
-                .map(AllowDeny::denied).orElse(Collections.emptySet()))
-                .map(deniedCiphers -> " (Denied Ciphers: " + deniedCiphers + ")").orElse("");
-        var protocolsAllowed = tlsToSummarize.map(t -> Optional.ofNullable(t.protocols())
-                .map(AllowDeny::allowed).orElse(Collections.emptyList()))
-                .map(protocols -> " (Allowed Protocols: " + protocols + ")").orElse("");
-        var protocolsDenied = tlsToSummarize.map(t -> Optional.ofNullable(t.protocols())
-                .map(AllowDeny::denied).orElse(Collections.emptySet()))
-                .map(protocols -> " (Denied Protocols: " + protocols + ")").orElse("");
-
-        return tls + cipherSuitesAllowed + cipherSuitesDenied + protocolsAllowed + protocolsDenied;
     }
 
     public String getClusterName() {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -138,35 +138,35 @@ public class VirtualClusterModel {
     }
 
     public HostPort getClusterBootstrapAddress() {
-        return clusterNetworkAddressConfigProvider.getClusterBootstrapAddress();
+        return getClusterNetworkAddressConfigProvider().getClusterBootstrapAddress();
     }
 
     public HostPort getBrokerAddress(int nodeId) throws IllegalArgumentException {
-        return clusterNetworkAddressConfigProvider.getBrokerAddress(nodeId);
+        return getClusterNetworkAddressConfigProvider().getBrokerAddress(nodeId);
     }
 
     public Optional<String> getBindAddress() {
-        return clusterNetworkAddressConfigProvider.getBindAddress();
+        return getClusterNetworkAddressConfigProvider().getBindAddress();
     }
 
     public boolean requiresTls() {
-        return clusterNetworkAddressConfigProvider.requiresTls();
+        return getClusterNetworkAddressConfigProvider().requiresTls();
     }
 
     public Set<Integer> getExclusivePorts() {
-        return clusterNetworkAddressConfigProvider.getExclusivePorts();
+        return getClusterNetworkAddressConfigProvider().getExclusivePorts();
     }
 
     public Set<Integer> getSharedPorts() {
-        return clusterNetworkAddressConfigProvider.getSharedPorts();
+        return getClusterNetworkAddressConfigProvider().getSharedPorts();
     }
 
     public Map<Integer, HostPort> discoveryAddressMap() {
-        return clusterNetworkAddressConfigProvider.discoveryAddressMap();
+        return getClusterNetworkAddressConfigProvider().discoveryAddressMap();
     }
 
     public Integer getBrokerIdFromBrokerAddress(HostPort brokerAddress) {
-        return clusterNetworkAddressConfigProvider.getBrokerIdFromBrokerAddress(brokerAddress);
+        return getClusterNetworkAddressConfigProvider().getBrokerIdFromBrokerAddress(brokerAddress);
     }
 
     public Optional<SslContext> getDownstreamSslContext() {
@@ -307,6 +307,6 @@ public class VirtualClusterModel {
     }
 
     public HostPort getAdvertisedBrokerAddress(int nodeId) {
-        return clusterNetworkAddressConfigProvider.getAdvertisedBrokerAddress(nodeId);
+        return getClusterNetworkAddressConfigProvider().getAdvertisedBrokerAddress(nodeId);
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -42,7 +42,7 @@ import io.kroxylicious.proxy.service.HostPort;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-public class VirtualCluster {
+public class VirtualClusterModel {
     public static final int DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES = 104857600;
     private final String clusterName;
 
@@ -61,24 +61,24 @@ public class VirtualCluster {
 
     private final Optional<SslContext> downstreamSslContext;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(VirtualCluster.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(VirtualClusterModel.class);
 
-    public VirtualCluster(String clusterName,
-                          TargetCluster targetCluster,
-                          ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider,
-                          Optional<Tls> tls,
-                          boolean logNetwork,
-                          boolean logFrames) {
+    public VirtualClusterModel(String clusterName,
+                               TargetCluster targetCluster,
+                               ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider,
+                               Optional<Tls> tls,
+                               boolean logNetwork,
+                               boolean logFrames) {
         this(clusterName, targetCluster, clusterNetworkAddressConfigProvider, tls, logNetwork, logFrames, List.of());
     }
 
-    public VirtualCluster(String clusterName,
-                          TargetCluster targetCluster,
-                          ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider,
-                          Optional<Tls> tls,
-                          boolean logNetwork,
-                          boolean logFrames,
-                          @NonNull List<NamedFilterDefinition> filters) {
+    public VirtualClusterModel(String clusterName,
+                               TargetCluster targetCluster,
+                               ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider,
+                               Optional<Tls> tls,
+                               boolean logNetwork,
+                               boolean logFrames,
+                               @NonNull List<NamedFilterDefinition> filters) {
         this.clusterName = clusterName;
         this.tls = tls;
         this.targetCluster = targetCluster;

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -42,12 +42,15 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class VirtualClusterModel {
+
     public static final int DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES = 104857600;
+
     private final String clusterName;
 
     private final TargetCluster targetCluster;
 
     private final Optional<Tls> tls;
+
     private final boolean logNetwork;
 
     private final boolean logFrames;

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -8,7 +8,6 @@ package io.kroxylicious.proxy.model;
 import java.io.UncheckedIOException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -62,15 +61,6 @@ public class VirtualClusterModel {
     private final Optional<SslContext> downstreamSslContext;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(VirtualClusterModel.class);
-
-    public VirtualClusterModel(String clusterName,
-                               TargetCluster targetCluster,
-                               ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider,
-                               Optional<Tls> tls,
-                               boolean logNetwork,
-                               boolean logFrames) {
-        this(clusterName, targetCluster, clusterNetworkAddressConfigProvider, tls, logNetwork, logFrames, List.of());
-    }
 
     public VirtualClusterModel(String clusterName,
                                TargetCluster targetCluster,

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -40,6 +40,7 @@ import io.kroxylicious.proxy.internal.filter.FieldInjectionConfig;
 import io.kroxylicious.proxy.internal.filter.NestedPluginConfigFactory;
 import io.kroxylicious.proxy.internal.filter.RecordConfig;
 import io.kroxylicious.proxy.internal.filter.SetterInjectionConfig;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.plugin.UnknownPluginInstanceException;
 import io.kroxylicious.proxy.service.HostPort;
 
@@ -260,7 +261,7 @@ class ConfigParserTest {
                         brokerStartPort: 9193
                 """);
         // When
-        final List<io.kroxylicious.proxy.model.VirtualCluster> actualValidClusters = configurationModel.virtualClusterModel(new ServiceBasedPluginFactoryRegistry());
+        final List<VirtualClusterModel> actualValidClusters = configurationModel.virtualClusterModel(new ServiceBasedPluginFactoryRegistry());
 
         // Then
         assertThat(actualValidClusters).singleElement().extracting("clusterName").isEqualTo("myAwesomeCluster");

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
@@ -36,7 +36,7 @@ import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 import io.kroxylicious.proxy.frame.OpaqueRequestFrame;
 import io.kroxylicious.proxy.frame.OpaqueResponseFrame;
-import io.kroxylicious.proxy.model.VirtualCluster;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
 import io.kroxylicious.proxy.service.HostPort;
 
@@ -78,7 +78,7 @@ public abstract class FilterHarness {
 
         final TargetCluster targetCluster = mock(TargetCluster.class);
         when(targetCluster.bootstrapServersList()).thenReturn(TARGET_CLUSTER_BOOTSTRAP);
-        var testVirtualCluster = new VirtualCluster("TestVirtualCluster", targetCluster, mock(ClusterNetworkAddressConfigProvider.class), Optional.empty(),
+        var testVirtualCluster = new VirtualClusterModel("TestVirtualCluster", targetCluster, mock(ClusterNetworkAddressConfigProvider.class), Optional.empty(),
                 false, false);
         var inboundChannel = new EmbeddedChannel();
         var channelProcessors = Stream.<ChannelHandler> of(new InternalRequestTracker(), new CorrelationIdIssuer());

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
@@ -78,8 +78,8 @@ public abstract class FilterHarness {
 
         final TargetCluster targetCluster = mock(TargetCluster.class);
         when(targetCluster.bootstrapServersList()).thenReturn(TARGET_CLUSTER_BOOTSTRAP);
-        var testVirtualCluster = new VirtualClusterModel("TestVirtualCluster", targetCluster, mock(ClusterNetworkAddressConfigProvider.class), Optional.empty(),
-                false, false);
+        var testVirtualCluster = new VirtualClusterModel("TestVirtualCluster", targetCluster, mock(ClusterNetworkAddressConfigProvider.class), Optional.empty(), false,
+                false, List.of());
         var inboundChannel = new EmbeddedChannel();
         var channelProcessors = Stream.<ChannelHandler> of(new InternalRequestTracker(), new CorrelationIdIssuer());
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyBackendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyBackendHandlerTest.java
@@ -28,7 +28,7 @@ import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 
 import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.PortPerBrokerClusterNetworkAddressConfigProvider;
-import io.kroxylicious.proxy.model.VirtualCluster;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
 import io.kroxylicious.proxy.service.HostPort;
 
@@ -55,7 +55,7 @@ class KafkaProxyBackendHandlerTest {
     void setUp() {
         outboundChannel = new EmbeddedChannel();
         kafkaProxyBackendHandler = new KafkaProxyBackendHandler(proxyChannelStateMachine,
-                new VirtualCluster("wibble", new TargetCluster("localhost:9090", Optional.empty()),
+                new VirtualClusterModel("wibble", new TargetCluster("localhost:9090", Optional.empty()),
                         ADDRESS_CONFIG_PROVIDER, Optional.empty(), false, false));
         outboundChannel.pipeline().addFirst(kafkaProxyBackendHandler);
         outboundContext = outboundChannel.pipeline().firstContext();

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyBackendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyBackendHandlerTest.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.proxy.internal;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -55,8 +56,7 @@ class KafkaProxyBackendHandlerTest {
     void setUp() {
         outboundChannel = new EmbeddedChannel();
         kafkaProxyBackendHandler = new KafkaProxyBackendHandler(proxyChannelStateMachine,
-                new VirtualClusterModel("wibble", new TargetCluster("localhost:9090", Optional.empty()),
-                        ADDRESS_CONFIG_PROVIDER, Optional.empty(), false, false));
+                new VirtualClusterModel("wibble", new TargetCluster("localhost:9090", Optional.empty()), ADDRESS_CONFIG_PROVIDER, Optional.empty(), false, false, List.of()));
         outboundChannel.pipeline().addFirst(kafkaProxyBackendHandler);
         outboundContext = outboundChannel.pipeline().firstContext();
     }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyBackendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyBackendHandlerTest.java
@@ -56,7 +56,8 @@ class KafkaProxyBackendHandlerTest {
     void setUp() {
         outboundChannel = new EmbeddedChannel();
         kafkaProxyBackendHandler = new KafkaProxyBackendHandler(proxyChannelStateMachine,
-                new VirtualClusterModel("wibble", new TargetCluster("localhost:9090", Optional.empty()), ADDRESS_CONFIG_PROVIDER, Optional.empty(), false, false, List.of()));
+                new VirtualClusterModel("wibble", new TargetCluster("localhost:9090", Optional.empty()), ADDRESS_CONFIG_PROVIDER, Optional.empty(), false, false,
+                        List.of()));
         outboundChannel.pipeline().addFirst(kafkaProxyBackendHandler);
         outboundContext = outboundChannel.pipeline().firstContext();
     }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerMockCollaboratorsTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerMockCollaboratorsTest.java
@@ -25,7 +25,7 @@ import io.netty.handler.codec.haproxy.HAProxyProtocolVersion;
 import io.netty.handler.codec.haproxy.HAProxyProxiedProtocol;
 
 import io.kroxylicious.proxy.filter.NetFilter;
-import io.kroxylicious.proxy.model.VirtualCluster;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -47,7 +47,7 @@ class KafkaProxyFrontendHandlerMockCollaboratorsTest {
     NetFilter netFilter;
 
     @Mock
-    VirtualCluster vc;
+    VirtualClusterModel vc;
 
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     ChannelHandlerContext clientCtx;

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -47,7 +47,7 @@ import io.kroxylicious.proxy.internal.filter.ApiVersionsIntersectFilter;
 import io.kroxylicious.proxy.internal.net.Endpoint;
 import io.kroxylicious.proxy.internal.net.VirtualClusterBinding;
 import io.kroxylicious.proxy.internal.net.VirtualClusterBindingResolver;
-import io.kroxylicious.proxy.model.VirtualCluster;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
 import io.kroxylicious.proxy.service.HostPort;
 
@@ -85,12 +85,12 @@ class KafkaProxyInitializerTest {
     private ServiceBasedPluginFactoryRegistry pfr;
     private KafkaProxyInitializer kafkaProxyInitializer;
     private CompletionStage<VirtualClusterBinding> bindingStage;
-    private VirtualCluster virtualCluster;
+    private VirtualClusterModel virtualClusterModel;
     private FilterChainFactory filterChainFactory;
 
     @BeforeEach
     void setUp() {
-        virtualCluster = buildVirtualCluster(false, false);
+        virtualClusterModel = buildVirtualCluster(false, false);
         pfr = new ServiceBasedPluginFactoryRegistry();
         bindingStage = CompletableFuture.completedStage(vcb);
         filterChainFactory = new FilterChainFactory(pfr, List.of());
@@ -101,12 +101,12 @@ class KafkaProxyInitializerTest {
         when(channel.localAddress()).thenReturn(InetSocketAddress.createUnresolved("localhost", 9099));
 
         when(serverSocketChannel.localAddress()).thenReturn(localhost);
-        when(vcb.virtualCluster()).thenReturn(virtualCluster);
+        when(vcb.virtualClusterModel()).thenReturn(virtualClusterModel);
     }
 
-    private VirtualCluster buildVirtualCluster(boolean logNetwork, boolean logFrames) {
+    private VirtualClusterModel buildVirtualCluster(boolean logNetwork, boolean logFrames) {
         final Optional<Tls> tls = Optional.empty();
-        return new VirtualCluster("testCluster",
+        return new VirtualClusterModel("testCluster",
                 new TargetCluster("localhost:9090", tls),
                 mock(ClusterNetworkAddressConfigProvider.class),
                 tls,
@@ -184,8 +184,8 @@ class KafkaProxyInitializerTest {
     @ValueSource(booleans = { true, false })
     void shouldAddCommonHandlersOnBindingComplete(boolean tls) {
         // Given
-        when(vcb.virtualCluster())
-                .thenReturn(virtualCluster);
+        when(vcb.virtualClusterModel())
+                .thenReturn(virtualClusterModel);
         kafkaProxyInitializer = new KafkaProxyInitializer(filterChainFactory,
                 pfr,
                 tls,
@@ -209,8 +209,8 @@ class KafkaProxyInitializerTest {
     @ValueSource(booleans = { true, false })
     void shouldAddFrameLoggerOnBindingComplete(boolean tls) {
         // Given
-        virtualCluster = buildVirtualCluster(false, true);
-        when(vcb.virtualCluster()).thenReturn(virtualCluster);
+        virtualClusterModel = buildVirtualCluster(false, true);
+        when(vcb.virtualClusterModel()).thenReturn(virtualClusterModel);
         kafkaProxyInitializer = new KafkaProxyInitializer(filterChainFactory,
                 pfr,
                 tls,
@@ -230,8 +230,8 @@ class KafkaProxyInitializerTest {
     @ValueSource(booleans = { true, false })
     void shouldAddNetworkLoggerOnBindingComplete(boolean tls) {
         // Given
-        virtualCluster = buildVirtualCluster(true, false);
-        when(vcb.virtualCluster()).thenReturn(virtualCluster);
+        virtualClusterModel = buildVirtualCluster(true, false);
+        when(vcb.virtualClusterModel()).thenReturn(virtualClusterModel);
         kafkaProxyInitializer = new KafkaProxyInitializer(filterChainFactory,
                 pfr,
                 tls,
@@ -251,8 +251,8 @@ class KafkaProxyInitializerTest {
     @ValueSource(booleans = { true, false })
     void shouldAddAuthnHandlersOnBindingComplete(boolean tls) {
         // Given
-        virtualCluster = buildVirtualCluster(true, false);
-        when(vcb.virtualCluster()).thenReturn(virtualCluster);
+        virtualClusterModel = buildVirtualCluster(true, false);
+        when(vcb.virtualClusterModel()).thenReturn(virtualClusterModel);
         final AuthenticateCallbackHandler plainHandler = mock(AuthenticateCallbackHandler.class);
         kafkaProxyInitializer = new KafkaProxyInitializer(filterChainFactory,
                 pfr,
@@ -273,8 +273,8 @@ class KafkaProxyInitializerTest {
     @ValueSource(booleans = { true, false })
     void shouldNotAddAuthnHandlersWithoutConfiguredMechanism(boolean tls) {
         // Given
-        virtualCluster = buildVirtualCluster(true, false);
-        when(vcb.virtualCluster()).thenReturn(virtualCluster);
+        virtualClusterModel = buildVirtualCluster(true, false);
+        when(vcb.virtualClusterModel()).thenReturn(virtualClusterModel);
         kafkaProxyInitializer = new KafkaProxyInitializer(filterChainFactory,
                 pfr,
                 tls,

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -106,12 +106,8 @@ class KafkaProxyInitializerTest {
 
     private VirtualClusterModel buildVirtualCluster(boolean logNetwork, boolean logFrames) {
         final Optional<Tls> tls = Optional.empty();
-        return new VirtualClusterModel("testCluster",
-                new TargetCluster("localhost:9090", tls),
-                mock(ClusterNetworkAddressConfigProvider.class),
-                tls,
-                logNetwork,
-                logFrames);
+        return new VirtualClusterModel("testCluster", new TargetCluster("localhost:9090", tls), mock(ClusterNetworkAddressConfigProvider.class), tls, logNetwork,
+                logFrames, List.of());
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/PortConflictDetectorTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/PortConflictDetectorTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import io.kroxylicious.proxy.model.VirtualCluster;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -149,8 +149,9 @@ class PortConflictDetectorTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource
-    void portConflict(String name, VirtualCluster virtualCluster1, VirtualCluster virtualCluster2, String expectedMessageSuffix, HostPort otherExclusivePort) {
-        var clusters = List.of(virtualCluster1, virtualCluster2);
+    void portConflict(String name, VirtualClusterModel virtualClusterModel1, VirtualClusterModel virtualClusterModel2, String expectedMessageSuffix,
+                      HostPort otherExclusivePort) {
+        var clusters = List.of(virtualClusterModel1, virtualClusterModel2);
         Optional<HostPort> maybeOtherExclusivePort = Optional.ofNullable(otherExclusivePort);
         if (expectedMessageSuffix == null) {
             detector.validate(clusters, maybeOtherExclusivePort);
@@ -161,12 +162,13 @@ class PortConflictDetectorTest {
         }
     }
 
-    private static VirtualCluster createMockVirtualCluster(String clusterName, Set<Integer> exclusivePorts, Set<Integer> sharedPorts, String bindAddress) {
+    private static VirtualClusterModel createMockVirtualCluster(String clusterName, Set<Integer> exclusivePorts, Set<Integer> sharedPorts, String bindAddress) {
         return createMockVirtualCluster(clusterName, exclusivePorts, sharedPorts, bindAddress, false);
     }
 
-    private static VirtualCluster createMockVirtualCluster(String clusterName, Set<Integer> exclusivePorts, Set<Integer> sharedPorts, String bindAddress, boolean tls) {
-        VirtualCluster cluster = mock(VirtualCluster.class);
+    private static VirtualClusterModel createMockVirtualCluster(String clusterName, Set<Integer> exclusivePorts, Set<Integer> sharedPorts, String bindAddress,
+                                                                boolean tls) {
+        VirtualClusterModel cluster = mock(VirtualClusterModel.class);
         when(cluster.getClusterName()).thenReturn(clusterName);
         when(cluster.getExclusivePorts()).thenReturn(exclusivePorts);
         when(cluster.getSharedPorts()).thenReturn(sharedPorts);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineEndToEndTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineEndToEndTest.java
@@ -61,7 +61,7 @@ import io.kroxylicious.proxy.filter.NetFilter;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 import io.kroxylicious.proxy.internal.codec.FrameOversizedException;
-import io.kroxylicious.proxy.model.VirtualCluster;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -644,8 +644,8 @@ class ProxyChannelStateMachineEndToEndTest {
     private KafkaProxyFrontendHandler handler(
                                               NetFilter filter,
                                               SaslDecodePredicate dp,
-                                              VirtualCluster virtualCluster) {
-        return new KafkaProxyFrontendHandler(filter, dp, virtualCluster, proxyChannelStateMachine) {
+                                              VirtualClusterModel virtualClusterModel) {
+        return new KafkaProxyFrontendHandler(filter, dp, virtualClusterModel, proxyChannelStateMachine) {
             @NonNull
             @Override
             Bootstrap configureBootstrap(KafkaProxyBackendHandler capturedBackendHandler, Channel inboundChannel) {
@@ -685,7 +685,7 @@ class ProxyChannelStateMachineEndToEndTest {
         var dp = new SaslDecodePredicate(saslOffloadConfigured);
         NetFilter filter = mock(NetFilter.class);
         doAnswer(filterSelectServerBehaviour).when(filter).selectServer(any());
-        VirtualCluster virtualCluster = mock(VirtualCluster.class);
+        VirtualClusterModel virtualClusterModel = mock(VirtualClusterModel.class);
         final Optional<SslContext> sslContext;
         try {
             sslContext = Optional.ofNullable(tlsConfigured ? SslContextBuilder.forClient().build() : null);
@@ -693,9 +693,9 @@ class ProxyChannelStateMachineEndToEndTest {
         catch (SSLException e) {
             throw new RuntimeException(e);
         }
-        when(virtualCluster.getUpstreamSslContext()).thenReturn(sslContext);
+        when(virtualClusterModel.getUpstreamSslContext()).thenReturn(sslContext);
 
-        this.handler = handler(filter, dp, virtualCluster);
+        this.handler = handler(filter, dp, virtualClusterModel);
         this.inboundCtx = mock(ChannelHandlerContext.class);
         when(inboundCtx.channel()).thenReturn(inboundChannel);
         when(inboundCtx.pipeline()).thenReturn(inboundChannel.pipeline());

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
@@ -48,7 +48,7 @@ import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 import io.kroxylicious.proxy.internal.ProxyChannelState.ApiVersions;
 import io.kroxylicious.proxy.internal.ProxyChannelState.SelectingServer;
 import io.kroxylicious.proxy.internal.codec.FrameOversizedException;
-import io.kroxylicious.proxy.model.VirtualCluster;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -366,7 +366,7 @@ class ProxyChannelStateMachineTest {
         HostPort brokerAddress = new HostPort("localhost", 9092);
         stateMachineInSelectingServer();
         var filters = List.<FilterAndInvoker> of();
-        var vc = mock(VirtualCluster.class);
+        var vc = mock(VirtualClusterModel.class);
         doReturn(configureSsl ? Optional.of(SslContextBuilder.forClient().build()) : Optional.empty()).when(vc).getUpstreamSslContext();
         var nf = mock(NetFilter.class);
 
@@ -386,7 +386,7 @@ class ProxyChannelStateMachineTest {
         HostPort brokerAddress = new HostPort("localhost", 9092);
         stateMachineInClientActive();
         var filters = List.<FilterAndInvoker> of();
-        var vc = mock(VirtualCluster.class);
+        var vc = mock(VirtualClusterModel.class);
         var nf = mock(NetFilter.class);
 
         // When
@@ -405,7 +405,7 @@ class ProxyChannelStateMachineTest {
         stateMachineInConnecting();
 
         var filters = List.<FilterAndInvoker> of();
-        var vc = mock(VirtualCluster.class);
+        var vc = mock(VirtualClusterModel.class);
         var nf = mock(NetFilter.class);
 
         // When

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/RequestDecoderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/RequestDecoderTest.java
@@ -36,7 +36,7 @@ import io.kroxylicious.proxy.internal.ApiVersionsServiceImpl;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static io.kroxylicious.proxy.internal.codec.ByteBufs.writeByteBuf;
-import static io.kroxylicious.proxy.model.VirtualCluster.DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES;
+import static io.kroxylicious.proxy.model.VirtualClusterModel.DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/ResponseDecoderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/ResponseDecoderTest.java
@@ -26,7 +26,7 @@ import io.kroxylicious.proxy.frame.OpaqueResponseFrame;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static io.kroxylicious.proxy.internal.codec.ByteBufs.writeByteBuf;
-import static io.kroxylicious.proxy.model.VirtualCluster.DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES;
+import static io.kroxylicious.proxy.model.VirtualClusterModel.DEFAULT_SOCKET_FRAME_MAX_SIZE_BYTES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilterTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilterTest.java
@@ -38,7 +38,7 @@ import io.kroxylicious.proxy.filter.FilterAndInvoker;
 import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.FilterInvoker;
 import io.kroxylicious.proxy.internal.net.EndpointReconciler;
-import io.kroxylicious.proxy.model.VirtualCluster;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.test.requestresponsetestdef.ApiMessageTestDef;
 import io.kroxylicious.test.requestresponsetestdef.RequestResponseTestDef;
@@ -70,7 +70,7 @@ class BrokerAddressFilterTest {
     }
 
     @Mock
-    private VirtualCluster virtualCluster;
+    private VirtualClusterModel virtualClusterModel;
 
     @Mock
     private EndpointReconciler endpointReconciler;
@@ -103,13 +103,13 @@ class BrokerAddressFilterTest {
 
     @BeforeEach
     public void beforeEach() {
-        filter = new BrokerAddressFilter(virtualCluster, endpointReconciler);
+        filter = new BrokerAddressFilter(virtualClusterModel, endpointReconciler);
         invoker = getOnlyElement(FilterAndInvoker.build(filter)).invoker();
-        lenient().when(virtualCluster.getBrokerAddress(0)).thenReturn(HostPort.parse("downstream:19199"));
-        lenient().when(virtualCluster.getAdvertisedBrokerAddress(0)).thenReturn(HostPort.parse("downstream:19200"));
+        lenient().when(virtualClusterModel.getBrokerAddress(0)).thenReturn(HostPort.parse("downstream:19199"));
+        lenient().when(virtualClusterModel.getAdvertisedBrokerAddress(0)).thenReturn(HostPort.parse("downstream:19200"));
 
         var nodeMap = Map.of(0, HostPort.parse("upstream:9199"));
-        lenient().when(endpointReconciler.reconcile(Mockito.eq(virtualCluster), Mockito.eq(nodeMap)))
+        lenient().when(endpointReconciler.reconcile(Mockito.eq(virtualClusterModel), Mockito.eq(nodeMap)))
                 .thenReturn(CompletableFuture.completedStage(null));
     }
 
@@ -128,7 +128,7 @@ class BrokerAddressFilterTest {
             throws Exception {
 
         filterResponseAndVerify(apiMessageType, header, responseTestDef);
-        verify(endpointReconciler, times(1)).reconcile(Mockito.eq(virtualCluster), Mockito.anyMap());
+        verify(endpointReconciler, times(1)).reconcile(Mockito.eq(virtualClusterModel), Mockito.anyMap());
     }
 
     private void filterResponseAndVerify(ApiMessageType apiMessageType, RequestHeaderData header, ApiMessageTestDef responseTestDef) throws Exception {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
@@ -49,7 +49,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 import static org.mockito.Mockito.when;
 
-class VirtualClusterTest {
+class VirtualClusterModelTest {
 
     private static final InlinePassword PASSWORD_PROVIDER = new InlinePassword("storepass");
 
@@ -81,7 +81,7 @@ class VirtualClusterTest {
     @Test
     void delegatesToProviderForAdvertisedPort() {
         ClusterNetworkAddressConfigProvider mock = Mockito.mock(ClusterNetworkAddressConfigProvider.class);
-        VirtualCluster cluster = new VirtualCluster("cluster", new TargetCluster("bootstrap:9092", Optional.empty()), mock, Optional.empty(), false, false);
+        VirtualClusterModel cluster = new VirtualClusterModel("cluster", new TargetCluster("bootstrap:9092", Optional.empty()), mock, Optional.empty(), false, false);
         HostPort advertisedHostPort = new HostPort("broker", 55);
         when(mock.getAdvertisedBrokerAddress(0)).thenReturn(advertisedHostPort);
         assertThat(cluster.getAdvertisedBrokerAddress(0)).isEqualTo(advertisedHostPort);
@@ -97,13 +97,14 @@ class VirtualClusterTest {
 
         // When
 
-        final VirtualCluster virtualCluster = new VirtualCluster("wibble", new TargetCluster("bootstrap:9092", downstreamTls), clusterNetworkAddressConfigProvider,
+        final VirtualClusterModel virtualClusterModel = new VirtualClusterModel("wibble", new TargetCluster("bootstrap:9092", downstreamTls),
+                clusterNetworkAddressConfigProvider,
                 downstreamTls, false,
                 false);
 
         // Then
-        assertThat(virtualCluster).isNotNull().extracting("downstreamSslContext").isNotNull();
-        assertThat(virtualCluster)
+        assertThat(virtualClusterModel).isNotNull().extracting("downstreamSslContext").isNotNull();
+        assertThat(virtualClusterModel)
                 .isNotNull()
                 .satisfies(vc -> assertThat(vc.getUpstreamSslContext()).isPresent());
     }
@@ -139,11 +140,11 @@ class VirtualClusterTest {
         final TargetCluster targetCluster = new TargetCluster("bootstrap:9092", Optional.empty());
 
         // When
-        final VirtualCluster virtualCluster = new VirtualCluster("wibble", targetCluster, clusterNetworkAddressConfigProvider, downstreamTls, false,
+        final VirtualClusterModel virtualClusterModel = new VirtualClusterModel("wibble", targetCluster, clusterNetworkAddressConfigProvider, downstreamTls, false,
                 false);
 
         // Then
-        assertThat(virtualCluster)
+        assertThat(virtualClusterModel)
                 .isNotNull()
                 .satisfies(vc -> assertThat(vc.getDownstreamSslContext())
                         .isPresent()
@@ -164,7 +165,7 @@ class VirtualClusterTest {
         final TargetCluster targetCluster = new TargetCluster("bootstrap:9092", downstreamTls);
 
         // When/Then
-        assertThatThrownBy(() -> new VirtualCluster("wibble", targetCluster, clusterNetworkAddressConfigProvider, Optional.empty(), false,
+        assertThatThrownBy(() -> new VirtualClusterModel("wibble", targetCluster, clusterNetworkAddressConfigProvider, Optional.empty(), false,
                 false))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("Cannot apply trust options");
@@ -189,11 +190,11 @@ class VirtualClusterTest {
         final TargetCluster targetCluster = new TargetCluster("bootstrap:9092", Optional.empty());
 
         // When
-        final VirtualCluster virtualCluster = new VirtualCluster("wibble", targetCluster, clusterNetworkAddressConfigProvider, tls, false,
+        final VirtualClusterModel virtualClusterModel = new VirtualClusterModel("wibble", targetCluster, clusterNetworkAddressConfigProvider, tls, false,
                 false);
 
         // Then
-        assertThat(virtualCluster)
+        assertThat(virtualClusterModel)
                 .isNotNull()
                 .satisfies(vc -> assertThat(vc.getDownstreamSslContext())
                         .isPresent()
@@ -224,11 +225,11 @@ class VirtualClusterTest {
         final TargetCluster targetCluster = new TargetCluster("bootstrap:9092", Optional.empty());
 
         // When
-        final VirtualCluster virtualCluster = new VirtualCluster("wibble", targetCluster, clusterNetworkAddressConfigProvider, tls, false,
+        final VirtualClusterModel virtualClusterModel = new VirtualClusterModel("wibble", targetCluster, clusterNetworkAddressConfigProvider, tls, false,
                 false);
 
         // Then
-        assertThat(virtualCluster)
+        assertThat(virtualClusterModel)
                 .isNotNull()
                 .satisfies(vc -> assertThat(vc.getDownstreamSslContext())
                         .isPresent()

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
@@ -81,7 +81,8 @@ class VirtualClusterModelTest {
     @Test
     void delegatesToProviderForAdvertisedPort() {
         ClusterNetworkAddressConfigProvider mock = Mockito.mock(ClusterNetworkAddressConfigProvider.class);
-        VirtualClusterModel cluster = new VirtualClusterModel("cluster", new TargetCluster("bootstrap:9092", Optional.empty()), mock, Optional.empty(), false, false, List.of());
+        VirtualClusterModel cluster = new VirtualClusterModel("cluster", new TargetCluster("bootstrap:9092", Optional.empty()), mock, Optional.empty(), false, false,
+                List.of());
         HostPort advertisedHostPort = new HostPort("broker", 55);
         when(mock.getAdvertisedBrokerAddress(0)).thenReturn(advertisedHostPort);
         assertThat(cluster.getAdvertisedBrokerAddress(0)).isEqualTo(advertisedHostPort);
@@ -97,7 +98,8 @@ class VirtualClusterModelTest {
 
         // When
 
-        final VirtualClusterModel virtualClusterModel = new VirtualClusterModel("wibble", new TargetCluster("bootstrap:9092", downstreamTls), clusterNetworkAddressConfigProvider, downstreamTls, false, false, List.of());
+        final VirtualClusterModel virtualClusterModel = new VirtualClusterModel("wibble", new TargetCluster("bootstrap:9092", downstreamTls),
+                clusterNetworkAddressConfigProvider, downstreamTls, false, false, List.of());
 
         // Then
         assertThat(virtualClusterModel).isNotNull().extracting("downstreamSslContext").isNotNull();
@@ -137,7 +139,8 @@ class VirtualClusterModelTest {
         final TargetCluster targetCluster = new TargetCluster("bootstrap:9092", Optional.empty());
 
         // When
-        final VirtualClusterModel virtualClusterModel = new VirtualClusterModel("wibble", targetCluster, clusterNetworkAddressConfigProvider, downstreamTls, false, false, List.of());
+        final VirtualClusterModel virtualClusterModel = new VirtualClusterModel("wibble", targetCluster, clusterNetworkAddressConfigProvider, downstreamTls, false, false,
+                List.of());
 
         // Then
         assertThat(virtualClusterModel)
@@ -185,7 +188,8 @@ class VirtualClusterModelTest {
         final TargetCluster targetCluster = new TargetCluster("bootstrap:9092", Optional.empty());
 
         // When
-        final VirtualClusterModel virtualClusterModel = new VirtualClusterModel("wibble", targetCluster, clusterNetworkAddressConfigProvider, tls, false, false, List.of());
+        final VirtualClusterModel virtualClusterModel = new VirtualClusterModel("wibble", targetCluster, clusterNetworkAddressConfigProvider, tls, false, false,
+                List.of());
 
         // Then
         assertThat(virtualClusterModel)
@@ -219,7 +223,8 @@ class VirtualClusterModelTest {
         final TargetCluster targetCluster = new TargetCluster("bootstrap:9092", Optional.empty());
 
         // When
-        final VirtualClusterModel virtualClusterModel = new VirtualClusterModel("wibble", targetCluster, clusterNetworkAddressConfigProvider, tls, false, false, List.of());
+        final VirtualClusterModel virtualClusterModel = new VirtualClusterModel("wibble", targetCluster, clusterNetworkAddressConfigProvider, tls, false, false,
+                List.of());
 
         // Then
         assertThat(virtualClusterModel)

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
@@ -81,7 +81,7 @@ class VirtualClusterModelTest {
     @Test
     void delegatesToProviderForAdvertisedPort() {
         ClusterNetworkAddressConfigProvider mock = Mockito.mock(ClusterNetworkAddressConfigProvider.class);
-        VirtualClusterModel cluster = new VirtualClusterModel("cluster", new TargetCluster("bootstrap:9092", Optional.empty()), mock, Optional.empty(), false, false);
+        VirtualClusterModel cluster = new VirtualClusterModel("cluster", new TargetCluster("bootstrap:9092", Optional.empty()), mock, Optional.empty(), false, false, List.of());
         HostPort advertisedHostPort = new HostPort("broker", 55);
         when(mock.getAdvertisedBrokerAddress(0)).thenReturn(advertisedHostPort);
         assertThat(cluster.getAdvertisedBrokerAddress(0)).isEqualTo(advertisedHostPort);
@@ -97,10 +97,7 @@ class VirtualClusterModelTest {
 
         // When
 
-        final VirtualClusterModel virtualClusterModel = new VirtualClusterModel("wibble", new TargetCluster("bootstrap:9092", downstreamTls),
-                clusterNetworkAddressConfigProvider,
-                downstreamTls, false,
-                false);
+        final VirtualClusterModel virtualClusterModel = new VirtualClusterModel("wibble", new TargetCluster("bootstrap:9092", downstreamTls), clusterNetworkAddressConfigProvider, downstreamTls, false, false, List.of());
 
         // Then
         assertThat(virtualClusterModel).isNotNull().extracting("downstreamSslContext").isNotNull();
@@ -140,8 +137,7 @@ class VirtualClusterModelTest {
         final TargetCluster targetCluster = new TargetCluster("bootstrap:9092", Optional.empty());
 
         // When
-        final VirtualClusterModel virtualClusterModel = new VirtualClusterModel("wibble", targetCluster, clusterNetworkAddressConfigProvider, downstreamTls, false,
-                false);
+        final VirtualClusterModel virtualClusterModel = new VirtualClusterModel("wibble", targetCluster, clusterNetworkAddressConfigProvider, downstreamTls, false, false, List.of());
 
         // Then
         assertThat(virtualClusterModel)
@@ -165,8 +161,7 @@ class VirtualClusterModelTest {
         final TargetCluster targetCluster = new TargetCluster("bootstrap:9092", downstreamTls);
 
         // When/Then
-        assertThatThrownBy(() -> new VirtualClusterModel("wibble", targetCluster, clusterNetworkAddressConfigProvider, Optional.empty(), false,
-                false))
+        assertThatThrownBy(() -> new VirtualClusterModel("wibble", targetCluster, clusterNetworkAddressConfigProvider, Optional.empty(), false, false, List.of()))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("Cannot apply trust options");
     }
@@ -190,8 +185,7 @@ class VirtualClusterModelTest {
         final TargetCluster targetCluster = new TargetCluster("bootstrap:9092", Optional.empty());
 
         // When
-        final VirtualClusterModel virtualClusterModel = new VirtualClusterModel("wibble", targetCluster, clusterNetworkAddressConfigProvider, tls, false,
-                false);
+        final VirtualClusterModel virtualClusterModel = new VirtualClusterModel("wibble", targetCluster, clusterNetworkAddressConfigProvider, tls, false, false, List.of());
 
         // Then
         assertThat(virtualClusterModel)
@@ -225,8 +219,7 @@ class VirtualClusterModelTest {
         final TargetCluster targetCluster = new TargetCluster("bootstrap:9092", Optional.empty());
 
         // When
-        final VirtualClusterModel virtualClusterModel = new VirtualClusterModel("wibble", targetCluster, clusterNetworkAddressConfigProvider, tls, false,
-                false);
+        final VirtualClusterModel virtualClusterModel = new VirtualClusterModel("wibble", targetCluster, clusterNetworkAddressConfigProvider, tls, false, false, List.of());
 
         // Then
         assertThat(virtualClusterModel)


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

This refactoring tidies up the `model.VirtualCluster` class a little:

* Most noisily it renames it to `model.VirtualClusterModel`, to avoid an annoying name conflict with the `VirtualCluster` class from the `config` package.
* It removes the `implements ClusterNetworkAddressConfigProvider`, because no where did we rely on the substitutability that this conferred, and having the inheritance was confusing, because there was a `ClusterNetworkAddressConfigProvider` implementation which did not correspond to any configurable virtual cluster type.
* It moves some of the code from `VirtualClusterModel` to `Configuration`, because in general we're trying to move in the direction of configuration classes being simple `record` classes without any extra methods beyond the component accessors (in anticipation of generating the config classes from JSON Schemas in the future).
* It removes the overloaded constructor which was just being used to supply a default value for the `filters`.
* It changes the `PortConflictDetector` so it it less coupled with `VirtualClusterModel` and more coupled with the `ClusterNetworkAddressConfigProvider`. It's not clear that hiding the `ClusterNetworkAddressConfigProvider` in the model was gaining us anything. I haven't attempted a similar change with the `EndpointRegistry` yet, because that looks like a rather complicated piece of code.

