### PR TITLE
Record Encryption: Enable user to specify a default topic encryption policy requiring encryption

### DIFF
--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/EncryptionPolicyException.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/EncryptionPolicyException.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+import io.kroxylicious.filter.encryption.common.EncryptionException;
+
+/**
+ * An encryption operation could not be completed due to an encryption policy. For example
+ * if all topics are required to be encrypted, and we cannot resolve an encryption key for
+ * topic X, then we cannot fulfil the policy and fail with this exception.
+ */
+public class EncryptionPolicyException extends EncryptionException {
+    public EncryptionPolicyException(String message) {
+        super(message);
+    }
+}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryption.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryption.java
@@ -47,6 +47,7 @@ import io.kroxylicious.filter.encryption.kms.InstrumentedKms;
 import io.kroxylicious.filter.encryption.kms.KmsMetrics;
 import io.kroxylicious.filter.encryption.kms.MicrometerKmsMetrics;
 import io.kroxylicious.filter.encryption.kms.ResilientKms;
+import io.kroxylicious.filter.encryption.policy.TopicEncryptionPolicyResolvers;
 import io.kroxylicious.kms.service.Kms;
 import io.kroxylicious.kms.service.KmsService;
 import io.kroxylicious.proxy.filter.FilterFactory;
@@ -140,7 +141,7 @@ public class RecordEncryption<K, E> implements FilterFactory<RecordEncryptionCon
 
         KekSelectorService<Object, K> ksPlugin = context.pluginInstance(KekSelectorService.class, sharedEncryptionContext.configuration().selector());
         TopicNameBasedKekSelector<K> kekSelector = ksPlugin.buildSelector(sharedEncryptionContext.kms(), sharedEncryptionContext.configuration().selectorConfig());
-        return new RecordEncryptionFilter<>(encryptionManager, decryptionManager, kekSelector, executor);
+        return new RecordEncryptionFilter<>(encryptionManager, decryptionManager, kekSelector, executor, TopicEncryptionPolicyResolvers.legacy());
     }
 
     @NonNull

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/DefaultTopicEncryptionPolicy.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/DefaultTopicEncryptionPolicy.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.config;
+
+/**
+ * In no specific TopicEncryptionPolicy can be determined for a topic, this defines the default policy to be applied.
+ * (Note that currently there is no mechanism to specify a TopicEncryptionPolicy per topic)
+ */
+public enum DefaultTopicEncryptionPolicy {
+    /**
+     * All data must be encrypted to be forwarded towards the target cluster
+     */
+    REQUIRE_ENCRYPTION
+}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/RecordEncryptionConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/RecordEncryptionConfig.java
@@ -22,7 +22,8 @@ public record RecordEncryptionConfig(@JsonProperty(required = true) @PluginImplN
 
                                      @JsonProperty(required = true) @PluginImplName(KekSelectorService.class) String selector,
                                      @PluginImplConfig(implNameProperty = "selector") Object selectorConfig,
-                                     @JsonProperty Map<String, Object> experimental) {
+                                     @JsonProperty Map<String, Object> experimental,
+                                     @JsonProperty Optional<DefaultTopicEncryptionPolicy> defaultTopicEncryptionPolicy) {
     public RecordEncryptionConfig {
         experimental = experimental == null ? Map.of() : experimental;
     }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/TopicNameBasedKekSelector.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/TopicNameBasedKekSelector.java
@@ -6,7 +6,6 @@
 
 package io.kroxylicious.filter.encryption.config;
 
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
@@ -19,10 +18,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public abstract class TopicNameBasedKekSelector<K> {
 
     /**
-     * Returns a completion stage whose value, on successful completion, is a map from each of the given topic
-     * names to the KEK id to use for encrypting records in that topic.
+     * Returns a completion stage whose value, on successful completion, is a topic name selection containing the
+     * resolved key ids for topics which could be resolved, and a set of unresolved topic names.
      * @param topicNames A set of topic names
-     * @return A completion stage for the map form topic name to KEK id.
+     * @return A completion stage containing a topic name selection
      */
-    public abstract @NonNull CompletionStage<Map<String, K>> selectKek(@NonNull Set<String> topicNames);
+    public abstract @NonNull CompletionStage<TopicNameKekSelection<K>> selectKek(@NonNull Set<String> topicNames);
 }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/TopicNameKekSelection.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/TopicNameKekSelection.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.config;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Selection of keys
+ * @param topicNameToKekId topic name to key, key must not be null
+ * @param unresolvedTopicNames topic names which could not have a key selected
+ * @param <K> the type of key
+ */
+public record TopicNameKekSelection<K>(@NonNull Map<String, K> topicNameToKekId, @NonNull Set<String> unresolvedTopicNames) {
+    public TopicNameKekSelection {
+        Objects.requireNonNull(topicNameToKekId);
+        List<Map.Entry<String, K>> entriesWithNullValue = topicNameToKekId.entrySet().stream().filter(e -> e.getValue() == null).toList();
+        if (!entriesWithNullValue.isEmpty()) {
+            List<String> topicNames = entriesWithNullValue.stream().map(Map.Entry::getKey).toList();
+            throw new IllegalArgumentException("values in topicNameToKekId must not be null, keys with null values: " + topicNames);
+        }
+        Objects.requireNonNull(unresolvedTopicNames);
+    }
+}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/policy/TopicEncryptionPolicy.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/policy/TopicEncryptionPolicy.java
@@ -13,8 +13,25 @@ public enum TopicEncryptionPolicy {
         public boolean shouldAttemptKeyResolution() {
             return true;
         }
+
+        @Override
+        public UnresolvedKeyAction unresolvedKeyAction() {
+            return UnresolvedKeyAction.PASSTHROUGH_UNENCRYPTED;
+        }
+    },
+    REQUIRE_ENCRYPTION {
+        @Override
+        public boolean shouldAttemptKeyResolution() {
+            return true;
+        }
+
+        @Override
+        public UnresolvedKeyAction unresolvedKeyAction() {
+            return UnresolvedKeyAction.REJECT_PRODUCE_REQUEST;
+        }
     };
 
     public abstract boolean shouldAttemptKeyResolution();
 
+    public abstract UnresolvedKeyAction unresolvedKeyAction();
 }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/policy/TopicEncryptionPolicy.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/policy/TopicEncryptionPolicy.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.policy;
+
+public enum TopicEncryptionPolicy {
+
+    LEGACY {
+        @Override
+        public boolean shouldAttemptKeyResolution() {
+            return true;
+        }
+    };
+
+    public abstract boolean shouldAttemptKeyResolution();
+
+}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/policy/TopicEncryptionPolicyResolver.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/policy/TopicEncryptionPolicyResolver.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.policy;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A resolver for obtaining TopicEncryptionPolicies for a set of topic names. This interface is
+ * asynchronous to allow for future implementations to retrieve remote topic metadata to inform
+ * the encryption policy.
+ */
+public interface TopicEncryptionPolicyResolver {
+
+    /**
+     * Resolves a TopicPolicy for every input topicName
+     * @param topicNames topic names, non-null
+     * @return a completionstage for a map with a non-null value for every name in {@code topicNames}
+     * @throws NullPointerException if topicNames is null
+     */
+    CompletionStage<Map<String, TopicEncryptionPolicy>> apply(@NonNull Set<String> topicNames);
+
+}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/policy/TopicEncryptionPolicyResolvers.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/policy/TopicEncryptionPolicyResolvers.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.policy;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+public class TopicEncryptionPolicyResolvers {
+
+    private static final TopicEncryptionPolicyResolver LEGACY_RESOLVER = allTopics(TopicEncryptionPolicy.LEGACY);
+
+    public static TopicEncryptionPolicyResolver legacy() {
+        return LEGACY_RESOLVER;
+    }
+
+    private static TopicEncryptionPolicyResolver allTopics(TopicEncryptionPolicy policy) {
+        Objects.requireNonNull(policy);
+        return topics -> {
+            Objects.requireNonNull(topics);
+            return CompletableFuture.completedFuture(
+                    topics.stream().collect(Collectors.toMap(t -> t, t -> policy)));
+        };
+    }
+}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/policy/TopicEncryptionPolicyResolvers.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/policy/TopicEncryptionPolicyResolvers.java
@@ -13,9 +13,14 @@ import java.util.stream.Collectors;
 public class TopicEncryptionPolicyResolvers {
 
     private static final TopicEncryptionPolicyResolver LEGACY_RESOLVER = allTopics(TopicEncryptionPolicy.LEGACY);
+    private static final TopicEncryptionPolicyResolver REQUIRE_ENCRYPTION = allTopics(TopicEncryptionPolicy.REQUIRE_ENCRYPTION);
 
     public static TopicEncryptionPolicyResolver legacy() {
         return LEGACY_RESOLVER;
+    }
+
+    public static TopicEncryptionPolicyResolver requireEncryption() {
+        return REQUIRE_ENCRYPTION;
     }
 
     private static TopicEncryptionPolicyResolver allTopics(TopicEncryptionPolicy policy) {

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/policy/UnresolvedKeyAction.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/policy/UnresolvedKeyAction.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.policy;
+
+public enum UnresolvedKeyAction {
+    PASSTHROUGH_UNENCRYPTED,
+    REJECT_PRODUCE_REQUEST
+}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionFilterTest.java
@@ -54,6 +54,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.kroxylicious.filter.encryption.common.FilterThreadExecutor;
 import io.kroxylicious.filter.encryption.config.TopicNameBasedKekSelector;
+import io.kroxylicious.filter.encryption.config.TopicNameKekSelection;
 import io.kroxylicious.filter.encryption.decrypt.DecryptionManager;
 import io.kroxylicious.filter.encryption.encrypt.EncryptionManager;
 import io.kroxylicious.filter.encryption.encrypt.RequestNotSatisfiable;
@@ -125,14 +126,13 @@ class RecordEncryptionFilterTest {
         });
 
         final Map<String, String> topicNameToKekId = new HashMap<>();
-        topicNameToKekId.put(UNENCRYPTED_TOPIC, null);
         topicNameToKekId.put(ENCRYPTED_TOPIC, KEK_ID_1);
 
         when(kekSelector.selectKek(anySet())).thenAnswer(invocationOnMock -> {
             Set<String> wanted = invocationOnMock.getArgument(0);
             var copy = new HashMap<>(topicNameToKekId);
             copy.keySet().retainAll(wanted);
-            return CompletableFuture.completedFuture(copy);
+            return CompletableFuture.completedFuture(new TopicNameKekSelection<>(topicNameToKekId, Set.of(UNENCRYPTED_TOPIC)));
         });
 
         when(encryptionManager.encrypt(any(), anyInt(), any(), any(), any()))

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionFilterTest.java
@@ -58,6 +58,7 @@ import io.kroxylicious.filter.encryption.config.TopicNameKekSelection;
 import io.kroxylicious.filter.encryption.decrypt.DecryptionManager;
 import io.kroxylicious.filter.encryption.encrypt.EncryptionManager;
 import io.kroxylicious.filter.encryption.encrypt.RequestNotSatisfiable;
+import io.kroxylicious.filter.encryption.policy.TopicEncryptionPolicyResolvers;
 import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.filter.RequestFilterResultBuilder;
@@ -141,7 +142,8 @@ class RecordEncryptionFilterTest {
         when(decryptionManager.decrypt(any(), anyInt(), any(), any()))
                 .thenReturn(CompletableFuture.completedFuture(RecordTestUtils.singleElementMemoryRecords("decrypt", "decrypt")));
 
-        encryptionFilter = new RecordEncryptionFilter<>(encryptionManager, decryptionManager, kekSelector, new FilterThreadExecutor(Runnable::run));
+        encryptionFilter = new RecordEncryptionFilter<>(encryptionManager, decryptionManager, kekSelector, new FilterThreadExecutor(Runnable::run),
+                TopicEncryptionPolicyResolvers.legacy());
     }
 
     @Test

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionTest.java
@@ -9,6 +9,7 @@ package io.kroxylicious.filter.encryption;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Future;
 
 import javax.crypto.Cipher;
@@ -58,7 +59,7 @@ class RecordEncryptionTest {
     @SuppressWarnings("unchecked")
     void shouldInitAndCreateFilter() {
         var kmsConfig = new Object();
-        var config = new RecordEncryptionConfig("KMS", kmsConfig, "SELECTOR", null, null);
+        var config = new RecordEncryptionConfig("KMS", kmsConfig, "SELECTOR", null, null, Optional.empty());
         var recordEncryption = new RecordEncryption<>();
         var fc = mock(FilterFactoryContext.class);
         var kmsService = mock(KmsService.class);
@@ -85,7 +86,7 @@ class RecordEncryptionTest {
     @Test
     void closePropagatedToKmsService() {
         var kmsConfig = new Object();
-        var config = new RecordEncryptionConfig("KMS", kmsConfig, "SELECTOR", null, null);
+        var config = new RecordEncryptionConfig("KMS", kmsConfig, "SELECTOR", null, null, Optional.empty());
         var recordEncryption = new RecordEncryption<>();
         var fc = mock(FilterFactoryContext.class);
         var kmsService = mock(KmsService.class);
@@ -102,7 +103,7 @@ class RecordEncryptionTest {
 
     @Test
     void testKmsCacheConfigDefaults() {
-        KmsCacheConfig config = new RecordEncryptionConfig("vault", 1L, "selector", 1L, null).kmsCache();
+        KmsCacheConfig config = new RecordEncryptionConfig("vault", 1L, "selector", 1L, null, Optional.empty()).kmsCache();
         assertThat(config.decryptedDekCacheSize()).isEqualTo(1000);
         assertThat(config.decryptedDekExpireAfterAccessDuration()).isEqualTo(Duration.ofHours(1));
         assertThat(config.resolvedAliasCacheSize()).isEqualTo(1000);
@@ -115,7 +116,7 @@ class RecordEncryptionTest {
 
     @Test
     void testDekManagerConfigDefaults() {
-        var config = new RecordEncryptionConfig("vault", 1L, "selector", 1L, null).dekManager();
+        var config = new RecordEncryptionConfig("vault", 1L, "selector", 1L, null, Optional.empty()).dekManager();
         assertThat(config.maxEncryptionsPerDek()).isEqualTo(5_000_000L);
     }
 
@@ -131,7 +132,7 @@ class RecordEncryptionTest {
         experimental.put("encryptionDekRefreshAfterWriteSeconds", null);
         experimental.put("encryptionDekExpireAfterWriteSeconds", null);
         KmsCacheConfig config = new RecordEncryptionConfig("vault", 1L, "selector", 1L,
-                experimental).kmsCache();
+                experimental, Optional.empty()).kmsCache();
         assertThat(config.decryptedDekCacheSize()).isEqualTo(1000);
         assertThat(config.decryptedDekExpireAfterAccessDuration()).isEqualTo(Duration.ofHours(1));
         assertThat(config.resolvedAliasCacheSize()).isEqualTo(1000);
@@ -147,7 +148,7 @@ class RecordEncryptionTest {
         Map<String, Object> experimental = new HashMap<>();
         experimental.put("maxEncryptionsPerDek", null);
 
-        var config = new RecordEncryptionConfig("vault", 1L, "selector", 1L, null).dekManager();
+        var config = new RecordEncryptionConfig("vault", 1L, "selector", 1L, null, Optional.empty()).dekManager();
         assertThat(config.maxEncryptionsPerDek()).isEqualTo(5_000_000L);
     }
 
@@ -172,7 +173,7 @@ class RecordEncryptionTest {
         experimental.put("notFoundAliasExpireAfterWriteSeconds", 6);
         experimental.put("encryptionDekRefreshAfterWriteSeconds", 7);
         experimental.put("encryptionDekExpireAfterWriteSeconds", 8);
-        KmsCacheConfig config = new RecordEncryptionConfig("vault", 1L, "selector", 1L, experimental).kmsCache();
+        KmsCacheConfig config = new RecordEncryptionConfig("vault", 1L, "selector", 1L, experimental, Optional.empty()).kmsCache();
         assertThat(config).isEqualTo(kmsCacheConfig);
     }
 
@@ -184,7 +185,7 @@ class RecordEncryptionTest {
         Map<String, Object> experimental = new HashMap<>();
         experimental.put("maxEncryptionsPerDek", 1_000L);
 
-        var config = new RecordEncryptionConfig("vault", 1L, "selector", 1L, experimental).dekManager();
+        var config = new RecordEncryptionConfig("vault", 1L, "selector", 1L, experimental, Optional.empty()).dekManager();
         assertThat(config).isEqualTo(dekManagerCacheConfig);
     }
 

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/config/RecordEncryptionConfigTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/config/RecordEncryptionConfigTest.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -111,7 +112,7 @@ class RecordEncryptionConfigTest {
     }
 
     private static @NonNull RecordEncryptionConfig createConfig(Map<String, Object> map) {
-        return new RecordEncryptionConfig("kms", 1L, "selector", 2L, map);
+        return new RecordEncryptionConfig("kms", 1L, "selector", 2L, map, Optional.empty());
     }
 
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds optional config option defaultTopicEncryptionPolicy to RecordEncryption, for example:
```
filterDefinitions:
- name: encrypt
  type: RecordEncryption
  config:
    kms: VaultKmsService
    kmsConfig:
      vaultTransitEngineUrl: http://vault:8200/v1/transit
      vaultToken:
        password: token
    selector: TemplateKekSelector
    selectorConfig:
      template: "KEK_${topicName}"
    defaultTopicEncryptionPolicy: REQUIRE_ENCRYPTION
```

If `defaultTopicEncryptionPolicy` is set to `REQUIRE_ENCRYPTION` then we require all topics in a `ProduceRequest` to have their data encrypted. If we fail to resolve an alias for any topic in the request, then we reject the entire `ProduceRequest` and return an `InvalidRecordException` to the client.

If `defaultTopicEncryptionPolicy` is not set then we use the legacy behaviour, using the KMS response to determine whether we should encrypt or passthrough a topic's data unencrypted.

Why:

Currently we are using a problematic strategy where we use the response from the KMS to determine whether or not to encrypt. If we could not resolve a key for a topic, we pass it through unencrypted. This permissive strategy means a misconfiguration could allow unencrypted data through due to a misconfiguration in the KMS or proxy.

Some users would prefer a harsher default policy where we require ALL data sent to the proxy to be encrypted. This means they will not be able to produce to unencrypted topics, but would have some protection against unencrypted data being written to their target cluster unexpectedly.

In future we could imagine having different policies per topic, which is why we have named this the default topic encryption policy. In the absence of any topic specific policy this is the applied policy. This would enable users to safely use a virtual cluster for encrypted and unencrypted data as we can determine if a topic should be encrypted, rather than using the KMS response.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
