### PR TITLE
Jacoco PR coverage recording fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -693,6 +693,9 @@
                                 implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
                             <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
                         </statelessTestsetReporter>
+                        <argLine>
+                            @{jacoco.argline}
+                        </argLine>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Default the surefire command line to pass through any jacoco arg

### Type of change

_Select the type of your PR_

- Bugfix

### Description

My previous change resulted in the coverage not being recorded for the modules apart from `kroxylicious-operator`.

This change fixes tha by ensure jacoco arguments (if set) are passed to surefire by default.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
