### PR TITLE
make fortanix test a little more lenient

### DIFF
--- a/kroxylicious-kms-provider-fortanix-dsm/src/test/java/io/kroxylicious/kms/provider/fortanix/dsm/session/ApiKeySessionProviderTest.java
+++ b/kroxylicious-kms-provider-fortanix-dsm/src/test/java/io/kroxylicious/kms/provider/fortanix/dsm/session/ApiKeySessionProviderTest.java
@@ -24,8 +24,6 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
-import com.github.tomakehurst.wiremock.client.CountMatchingStrategy;
-import com.github.tomakehurst.wiremock.client.WireMock;
 
 import io.kroxylicious.kms.provider.fortanix.dsm.config.ApiKeySessionProviderConfig;
 import io.kroxylicious.kms.provider.fortanix.dsm.config.Config;

--- a/kroxylicious-kms-provider-fortanix-dsm/src/test/java/io/kroxylicious/kms/provider/fortanix/dsm/session/ApiKeySessionProviderTest.java
+++ b/kroxylicious-kms-provider-fortanix-dsm/src/test/java/io/kroxylicious/kms/provider/fortanix/dsm/session/ApiKeySessionProviderTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Test;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.CountMatchingStrategy;
+import com.github.tomakehurst.wiremock.client.WireMock;
 
 import io.kroxylicious.kms.provider.fortanix.dsm.config.ApiKeySessionProviderConfig;
 import io.kroxylicious.kms.provider.fortanix.dsm.config.Config;
@@ -32,6 +34,7 @@ import io.kroxylicious.proxy.config.secret.InlinePassword;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.moreThanOrExactly;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
@@ -222,7 +225,7 @@ class ApiKeySessionProviderTest {
 
             await().atMost(Duration.ofSeconds(5))
                     .untilAsserted(() -> {
-                        server.verify(1, postRequestedFor(urlEqualTo(SESSION_TERMINATE_ENDPOINT)));
+                        server.verify(moreThanOrExactly(1), postRequestedFor(urlEqualTo(SESSION_TERMINATE_ENDPOINT)));
                     });
         }
     }

--- a/kroxylicious-kms-provider-fortanix-dsm/src/test/java/io/kroxylicious/kms/provider/fortanix/dsm/session/ApiKeySessionProviderTest.java
+++ b/kroxylicious-kms-provider-fortanix-dsm/src/test/java/io/kroxylicious/kms/provider/fortanix/dsm/session/ApiKeySessionProviderTest.java
@@ -14,6 +14,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -32,7 +33,7 @@ import io.kroxylicious.proxy.config.secret.InlinePassword;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
-import static com.github.tomakehurst.wiremock.client.WireMock.moreThanOrExactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
@@ -203,7 +204,10 @@ class ApiKeySessionProviderTest {
         var now = Instant.now();
         var expiresInSecs = 10;
 
-        var initial = createTestCredential("Bearer", expiresInSecs, "firstToken");
+        var initialToken = "firstToken-" + UUID.randomUUID();
+        var secondToken = "secondToken-" + UUID.randomUUID();
+
+        var initial = createTestCredential("Bearer", expiresInSecs, initialToken);
 
         server.stubFor(
                 post(urlEqualTo(SESSION_AUTH_ENDPOINT))
@@ -214,16 +218,17 @@ class ApiKeySessionProviderTest {
             var sessionStage = provider.getSession();
             assertThat(sessionStage)
                     .succeedsWithin(Duration.ofSeconds(1))
-                    .satisfies(s -> assertThat(s.authorizationHeader()).isEqualTo("Bearer firstToken"));
+                    .satisfies(s -> assertThat(s.authorizationHeader()).isEqualTo("Bearer " + initialToken));
 
-            var refreshed = createTestCredential("Bearer", expiresInSecs, "secondToken");
+            var refreshed = createTestCredential("Bearer", expiresInSecs, secondToken);
             server.stubFor(
                     post(urlEqualTo(SESSION_AUTH_ENDPOINT))
                             .willReturn(aResponse().withBody(toJson(refreshed))));
 
             await().atMost(Duration.ofSeconds(5))
                     .untilAsserted(() -> {
-                        server.verify(moreThanOrExactly(1), postRequestedFor(urlEqualTo(SESSION_TERMINATE_ENDPOINT)));
+                        server.verify(1, postRequestedFor(urlEqualTo(SESSION_TERMINATE_ENDPOINT))
+                                .withHeader(AUTHORIZATION_HEADER, equalTo("Bearer " + initialToken)));
                     });
         }
     }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

A docs only PR failed to build (https://github.com/kroxylicious/kroxylicious/actions/runs/13043544196/job/36390149272#step:9:3584) because the server was invoked multiple times. 

### Additional Context

I'm not clear on the exact intent of the test but expecting exactly one call when checking with awaitly seemed a little restrictive so this PR relaxes things to be at least once.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
