### PR TITLE
Simpler direct test of sessionTermination

### DIFF
--- a/kroxylicious-kms-provider-fortanix-dsm/src/main/java/io/kroxylicious/kms/provider/fortanix/dsm/session/ApiKeySessionProvider.java
+++ b/kroxylicious-kms-provider-fortanix-dsm/src/main/java/io/kroxylicious/kms/provider/fortanix/dsm/session/ApiKeySessionProvider.java
@@ -266,7 +266,8 @@ public class ApiKeySessionProvider implements SessionProvider {
      * end the last session.  This will allow the server side to clean up resources in a timely way.
      * @param stage session future.
      */
-    private void terminateSessionOnServer(@NonNull CompletionStage<Session> stage) {
+    @VisibleForTesting
+    protected void terminateSessionOnServer(@NonNull CompletionStage<Session> stage) {
 
         try {
             var s = stage.toCompletableFuture().getNow(null);

--- a/kroxylicious-kms-provider-fortanix-dsm/src/test/java/io/kroxylicious/kms/provider/fortanix/dsm/session/ApiKeySessionProviderTest.java
+++ b/kroxylicious-kms-provider-fortanix-dsm/src/test/java/io/kroxylicious/kms/provider/fortanix/dsm/session/ApiKeySessionProviderTest.java
@@ -15,8 +15,6 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

A simpler direct test of the session termination that avoids worrying about background scheduling.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
