### PR TITLE
Draft: Topic name lookup facility

### DIFF
--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
@@ -5,10 +5,13 @@
  */
 package io.kroxylicious.proxy.filter;
 
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
 import javax.annotation.Nullable;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
@@ -139,5 +142,14 @@ public interface FilterContext {
      */
     String getVirtualClusterName();
     // TODO an API to allow a filter to add/remove another filter from the pipeline
+
+    /**
+     * Resolves all topicUuids in a Set to topic names.
+     * @param topicUuids topic uuids to resolve
+     * @return CompletionStage for a map containing an entry for each topicUuid, mapping the uuid to the topicName. The Map is unmodifiable.
+     * The Map may contain mappings for UUIDs of topics belonging to the filter's Virtual Cluster other than the ones contained in topicUuids.
+     * The stage will be completed exceptionally if a mapping for any uuid in the Set cannot be resolved.
+     */
+    CompletionStage<Map<Uuid, String>> getTopicNames(@NonNull Set<Uuid> topicUuids);
 
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/TopicIdToNameResponseStamper.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/TopicIdToNameResponseStamper.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.types.RawTaggedField;
+
+import io.kroxylicious.UnknownTaggedFields;
+import io.kroxylicious.proxy.plugin.Plugin;
+import io.kroxylicious.proxy.plugin.PluginConfigurationException;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Filter that intercepts all requests and if they have an unknownTaggedField with id {@link #TOPIC_ID_TAG}
+ * we expect that tag to contain a comma separated set of {@link Uuid} topic ids (in toString form). The Filter will
+ * look up the corresponding topic names for those topic ids. Then when the response is intercepted we will add
+ * an unknownTaggedField with id {@link #TOPIC_NAME_TAG} containing a comma-separated set of topic names.
+ */
+@Plugin(configType = Void.class)
+public class TopicIdToNameResponseStamper implements FilterFactory<Void, Void> {
+
+    public static final int TOPIC_ID_TAG = 98;
+    public static final int TOPIC_NAME_TAG = 99;
+
+    @Override
+    public Void initialize(FilterFactoryContext context, Void config) throws PluginConfigurationException {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public Filter createFilter(FilterFactoryContext context, Void initializationData) {
+        return new TopicIdToNameResponseStamperFilter();
+    }
+
+    public static class TopicIdToNameResponseStamperFilter implements RequestFilter, ResponseFilter {
+
+        Map<Integer, Set<String>> correlated = new HashMap<>();
+
+        @Override
+        public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage request, FilterContext context) {
+            List<String> list = UnknownTaggedFields.unknownTaggedFieldsToStrings(request, TOPIC_ID_TAG).toList();
+            if (list.isEmpty()) {
+                return context.forwardRequest(header, request);
+            }
+
+            Set<Uuid> uuids = Arrays.stream(list.getFirst().split(",")).map(Uuid::fromString).collect(Collectors.toSet());
+            return context.getTopicNames(uuids).thenCompose(topicNames -> {
+                Set<String> topicNameSet = uuids.stream().map(topicNames::get).collect(Collectors.toSet());
+                correlated.put(header.correlationId(), topicNameSet);
+                return context.forwardRequest(header, request);
+            });
+        }
+
+        @Override
+        public CompletionStage<ResponseFilterResult> onResponse(ApiKeys apiKey, ResponseHeaderData header, ApiMessage response, FilterContext context) {
+            Set<String> topicNames = correlated.remove(header.correlationId());
+            if (topicNames == null) {
+                return context.forwardResponse(header, response);
+            }
+            else {
+                String collect = topicNames.stream().collect(Collectors.joining(","));
+                response.unknownTaggedFields().add(new RawTaggedField(TOPIC_NAME_TAG, collect.getBytes(StandardCharsets.UTF_8)));
+                return context.forwardResponse(header, response);
+            }
+        }
+    }
+}

--- a/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
+++ b/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
@@ -2,4 +2,5 @@ io.kroxylicious.proxy.filter.FixedClientIdFilterFactory
 io.kroxylicious.proxy.filter.RequestResponseMarkingFilterFactory
 io.kroxylicious.proxy.filter.OutOfBandSendFilterFactory
 io.kroxylicious.proxy.filter.RejectingCreateTopicFilterFactory
+io.kroxylicious.proxy.filter.TopicIdToNameResponseStamper
 io.kroxylicious.proxy.InvocationCountingFilterFactory

--- a/kroxylicious-microbenchmarks/src/main/java/io/kroxylicious/microbenchmarks/InvokerDispatchBenchmark.java
+++ b/kroxylicious-microbenchmarks/src/main/java/io/kroxylicious/microbenchmarks/InvokerDispatchBenchmark.java
@@ -7,9 +7,12 @@
 package io.kroxylicious.microbenchmarks;
 
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ApiVersionsRequestData;
 import org.apache.kafka.common.message.FetchRequestData;
 import org.apache.kafka.common.message.ProduceRequestData;
@@ -176,6 +179,11 @@ public class InvokerDispatchBenchmark {
         @Override
         public String getVirtualClusterName() {
             return null;
+        }
+
+        @Override
+        public CompletionStage<Map<Uuid, String>> getTopicNames(Set<Uuid> topicUuids) {
+            return CompletableFuture.completedFuture(Map.of());
         }
 
         @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -38,6 +38,7 @@ import io.kroxylicious.proxy.internal.filter.ApiVersionsIntersectFilter;
 import io.kroxylicious.proxy.internal.filter.BrokerAddressFilter;
 import io.kroxylicious.proxy.internal.filter.EagerMetadataLearner;
 import io.kroxylicious.proxy.internal.filter.NettyFilterContext;
+import io.kroxylicious.proxy.internal.filter.TopicNameLearningFilter;
 import io.kroxylicious.proxy.internal.net.Endpoint;
 import io.kroxylicious.proxy.internal.net.EndpointReconciler;
 import io.kroxylicious.proxy.internal.net.VirtualClusterBinding;
@@ -254,6 +255,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
             NettyFilterContext filterContext = new NettyFilterContext(ch.eventLoop(), pfr);
             List<FilterAndInvoker> filterChain = filterChainFactory.createFilters(filterContext, filterDefinitions);
             List<FilterAndInvoker> brokerAddressFilters = FilterAndInvoker.build(new BrokerAddressFilter(virtualClusterModel, endpointReconciler));
+            List<FilterAndInvoker> topicNameLearner = FilterAndInvoker.build(new TopicNameLearningFilter(virtualClusterModel));
             var filters = new ArrayList<>(apiVersionFilters);
             filters.addAll(FilterAndInvoker.build(apiVersionsDowngradeFilter));
             filters.addAll(filterChain);
@@ -261,6 +263,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
                 filters.addAll(FilterAndInvoker.build(new EagerMetadataLearner()));
             }
             filters.addAll(brokerAddressFilters);
+            filters.addAll(topicNameLearner);
 
             var target = binding.upstreamTarget();
             if (target == null) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/TopicIdMappingException.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/TopicIdMappingException.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+/**
+ * Indicates the proxy could not map a topic id to a topic name
+ */
+public class TopicIdMappingException extends RuntimeException {
+    public TopicIdMappingException(String message) {
+        super(message);
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/TopicNameLearningFilter.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/TopicNameLearningFilter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.MetadataResponseFilter;
+import io.kroxylicious.proxy.filter.ResponseFilterResult;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
+
+public record TopicNameLearningFilter(VirtualClusterModel model) implements MetadataResponseFilter {
+    @Override
+    public CompletionStage<ResponseFilterResult> onMetadataResponse(short apiVersion, ResponseHeaderData header, MetadataResponseData response, FilterContext context) {
+        MetadataResponseData.MetadataResponseTopicCollection topics = response.topics();
+        if (topics != null) {
+            topics.forEach(topic -> {
+                String topicName = topic.name();
+                Uuid topicId = topic.topicId();
+                if (topicId != null && !topicId.equals(Uuid.ZERO_UUID) && topicName != null && !topicName.isEmpty()) {
+                    model.rememberTopicIdMapping(topicId, topicName);
+                }
+            });
+        }
+        return context.forwardResponse(header, response);
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/TopicNameLearningFilter.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/TopicNameLearningFilter.java
@@ -7,29 +7,57 @@
 package io.kroxylicious.proxy.internal.filter;
 
 import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
 
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 
+import io.kroxylicious.proxy.filter.CreateTopicsResponseFilter;
 import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.MetadataResponseFilter;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 
-public record TopicNameLearningFilter(VirtualClusterModel model) implements MetadataResponseFilter {
+public record TopicNameLearningFilter(VirtualClusterModel model) implements MetadataResponseFilter, CreateTopicsResponseFilter {
+
+    @Override
+    public boolean shouldHandleMetadataResponse(short apiVersion) {
+        // topic ids won't be set below version 12
+        return apiVersion >= 12;
+    }
+
     @Override
     public CompletionStage<ResponseFilterResult> onMetadataResponse(short apiVersion, ResponseHeaderData header, MetadataResponseData response, FilterContext context) {
         MetadataResponseData.MetadataResponseTopicCollection topics = response.topics();
         if (topics != null) {
-            topics.forEach(topic -> {
-                String topicName = topic.name();
-                Uuid topicId = topic.topicId();
-                if (topicId != null && !topicId.equals(Uuid.ZERO_UUID) && topicName != null && !topicName.isEmpty()) {
-                    model.rememberTopicIdMapping(topicId, topicName);
-                }
-            });
+            topics.forEach(topic -> rememberTopicName(topic::name, topic::topicId));
         }
         return context.forwardResponse(header, response);
     }
+
+    @Override
+    public boolean shouldHandleCreateTopicsResponse(short apiVersion) {
+        // topic ids won't be set below version 7
+        return apiVersion >= 7;
+    }
+
+    @Override
+    public CompletionStage<ResponseFilterResult> onCreateTopicsResponse(short apiVersion, ResponseHeaderData header, CreateTopicsResponseData response,
+                                                                        FilterContext context) {
+        if (response.topics() != null) {
+            response.topics().forEach(topic -> rememberTopicName(topic::name, topic::topicId));
+        }
+        return context.forwardResponse(header, response);
+    }
+
+    private void rememberTopicName(Supplier<String> topicNameSupplier, Supplier<Uuid> topicIdSupplier) {
+        String topicName = topicNameSupplier.get();
+        Uuid topicId = topicIdSupplier.get();
+        if (topicId != null && !topicId.equals(Uuid.ZERO_UUID) && topicName != null && !topicName.isEmpty()) {
+            model.rememberTopicIdMapping(topicId, topicName);
+        }
+    }
+
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
@@ -56,6 +56,7 @@ public abstract class FilterHarness {
     private final AtomicInteger outboundCorrelationId = new AtomicInteger(1);
     private final Map<Integer, Correlation> pendingInternalRequestMap = new HashMap<>();
     private long timeoutMs = 1000L;
+    protected VirtualClusterModel testVirtualCluster;
 
     /**
      * Sets the timeout for applied to the filters.
@@ -78,7 +79,7 @@ public abstract class FilterHarness {
 
         final TargetCluster targetCluster = mock(TargetCluster.class);
         when(targetCluster.bootstrapServersList()).thenReturn(TARGET_CLUSTER_BOOTSTRAP);
-        var testVirtualCluster = new VirtualClusterModel("TestVirtualCluster", targetCluster, mock(ClusterNetworkAddressConfigProvider.class), Optional.empty(), false,
+        testVirtualCluster = new VirtualClusterModel("TestVirtualCluster", targetCluster, mock(ClusterNetworkAddressConfigProvider.class), Optional.empty(), false,
                 false, List.of());
         var inboundChannel = new EmbeddedChannel();
         var channelProcessors = Stream.<ChannelHandler> of(new InternalRequestTracker(), new CorrelationIdIssuer());

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/TopicNameLearningFilterTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/TopicNameLearningFilterTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.ResponseFilterResult;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TopicNameLearningFilterTest {
+
+    private static final CompletableFuture<ResponseFilterResult> FORWARD_FUTURE = CompletableFuture.completedFuture(null);
+    private static final Uuid TOPIC_UUID = Uuid.randomUuid();
+    private static final String TOPIC_NAME = "topic";
+
+    @Mock
+    VirtualClusterModel virtualClusterModel;
+
+    @Mock
+    FilterContext filterContext;
+
+    TopicNameLearningFilter topicNameLearningFilter;
+
+    @BeforeEach
+    void beforeEach() {
+        topicNameLearningFilter = new TopicNameLearningFilter(virtualClusterModel);
+        when(filterContext.forwardResponse(any(), any())).thenReturn(FORWARD_FUTURE);
+    }
+
+    static Stream<MetadataResponseData> learnsNothingFromMetadataAndForwards() {
+        MetadataResponseData empty = new MetadataResponseData();
+        MetadataResponseData nullTopic = new MetadataResponseData().setTopics(null);
+        MetadataResponseData topicWithDefaultName = withSingleTopic(t -> {
+            t.setTopicId(TOPIC_UUID);
+        });
+        MetadataResponseData topicWithNullName = withSingleTopic(t -> {
+            t.setTopicId(TOPIC_UUID);
+            t.setName(null);
+        });
+        MetadataResponseData topicWithDefaultTopicId = withSingleTopic(t -> {
+            t.setName(TOPIC_NAME);
+        });
+        MetadataResponseData topicWithNullTopidId = withSingleTopic(t -> {
+            t.setTopicId(null);
+            t.setName(TOPIC_NAME);
+        });
+        return Stream.of(empty, nullTopic, topicWithDefaultName, topicWithNullName, topicWithDefaultTopicId, topicWithNullTopidId);
+    }
+
+    private static MetadataResponseData withSingleTopic(Consumer<MetadataResponseData.MetadataResponseTopic> topicModifier) {
+        MetadataResponseData response = new MetadataResponseData();
+        MetadataResponseData.MetadataResponseTopic topic = new MetadataResponseData.MetadataResponseTopic();
+        topicModifier.accept(topic);
+        response.topics().add(topic);
+        return response;
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void learnsNothingFromMetadataAndForwards(MetadataResponseData data) {
+        CompletionStage<ResponseFilterResult> resultStage = onMetadataResponse(data);
+        assertThat(resultStage).isSameAs(FORWARD_FUTURE);
+        verify(virtualClusterModel, never()).rememberTopicIdMapping(any(), any());
+    }
+
+    @Test
+    void learnsTopicName() {
+        MetadataResponseData metadataResponseData = withSingleTopic(t -> {
+            t.setName(TOPIC_NAME);
+            t.setTopicId(TOPIC_UUID);
+        });
+        CompletionStage<ResponseFilterResult> response1 = onMetadataResponse(metadataResponseData);
+        assertThat(response1).isSameAs(FORWARD_FUTURE);
+        verify(virtualClusterModel).rememberTopicIdMapping(TOPIC_UUID, TOPIC_NAME);
+    }
+
+    @Test
+    void learnsAllTopicNames() {
+        MetadataResponseData response = new MetadataResponseData();
+        MetadataResponseData.MetadataResponseTopic topic = new MetadataResponseData.MetadataResponseTopic();
+        topic.setName(TOPIC_NAME);
+        topic.setTopicId(TOPIC_UUID);
+        response.topics().add(topic);
+
+        MetadataResponseData.MetadataResponseTopic topic2 = new MetadataResponseData.MetadataResponseTopic();
+        String topicName2 = "topic2";
+        Uuid topicId2 = Uuid.randomUuid();
+        topic2.setName(topicName2);
+        topic2.setTopicId(topicId2);
+        response.topics().add(topic2);
+
+        CompletionStage<ResponseFilterResult> response1 = onMetadataResponse(response);
+        assertThat(response1).isSameAs(FORWARD_FUTURE);
+        verify(virtualClusterModel).rememberTopicIdMapping(TOPIC_UUID, TOPIC_NAME);
+        verify(virtualClusterModel).rememberTopicIdMapping(topicId2, topicName2);
+    }
+
+    private CompletionStage<ResponseFilterResult> onMetadataResponse(MetadataResponseData data) {
+        return topicNameLearningFilter.onMetadataResponse((short) 12, new ResponseHeaderData(), data,
+                filterContext);
+    }
+
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/TopicNameLearningFilterTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/TopicNameLearningFilterTest.java
@@ -9,11 +9,14 @@ package io.kroxylicious.proxy.internal.filter;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.CreateTopicsResponseData;
 import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -50,58 +53,109 @@ class TopicNameLearningFilterTest {
     @BeforeEach
     void beforeEach() {
         topicNameLearningFilter = new TopicNameLearningFilter(virtualClusterModel);
-        when(filterContext.forwardResponse(any(), any())).thenReturn(FORWARD_FUTURE);
+    }
+
+    @Test
+    void onlyInterceptMetadataThatCanCarryTopicIds() {
+        IntStream tooOld = IntStream.range(ApiKeys.METADATA.oldestVersion(), 12);
+        IntStream hasTopicIds = IntStream.range(12, ApiKeys.METADATA.latestVersion(true));
+        tooOld.forEach(i -> assertThat(topicNameLearningFilter.shouldHandleMetadataResponse((short) i)).isFalse());
+        hasTopicIds.forEach(i -> assertThat(topicNameLearningFilter.shouldHandleMetadataResponse((short) i)).isTrue());
+    }
+
+    @Test
+    void onlyInterceptCreateTopicResponseVersionsThatCanCarryTopicIds() {
+        IntStream tooOld = IntStream.range(ApiKeys.CREATE_TOPICS.oldestVersion(), 7);
+        IntStream hasTopicIds = IntStream.range(7, ApiKeys.CREATE_TOPICS.latestVersion(true));
+        tooOld.forEach(i -> assertThat(topicNameLearningFilter.shouldHandleCreateTopicsResponse((short) i)).isFalse());
+        hasTopicIds.forEach(i -> assertThat(topicNameLearningFilter.shouldHandleCreateTopicsResponse((short) i)).isTrue());
     }
 
     static Stream<MetadataResponseData> learnsNothingFromMetadataAndForwards() {
         MetadataResponseData empty = new MetadataResponseData();
         MetadataResponseData nullTopic = new MetadataResponseData().setTopics(null);
-        MetadataResponseData topicWithDefaultName = withSingleTopic(t -> {
+        MetadataResponseData topicWithDefaultName = metadataWithSingleTopic(t -> {
             t.setTopicId(TOPIC_UUID);
         });
-        MetadataResponseData topicWithNullName = withSingleTopic(t -> {
+        MetadataResponseData topicWithNullName = metadataWithSingleTopic(t -> {
             t.setTopicId(TOPIC_UUID);
             t.setName(null);
         });
-        MetadataResponseData topicWithDefaultTopicId = withSingleTopic(t -> {
+        MetadataResponseData topicWithDefaultTopicId = metadataWithSingleTopic(t -> {
             t.setName(TOPIC_NAME);
         });
-        MetadataResponseData topicWithNullTopidId = withSingleTopic(t -> {
+        MetadataResponseData topicWithNullTopidId = metadataWithSingleTopic(t -> {
             t.setTopicId(null);
             t.setName(TOPIC_NAME);
         });
         return Stream.of(empty, nullTopic, topicWithDefaultName, topicWithNullName, topicWithDefaultTopicId, topicWithNullTopidId);
     }
 
-    private static MetadataResponseData withSingleTopic(Consumer<MetadataResponseData.MetadataResponseTopic> topicModifier) {
-        MetadataResponseData response = new MetadataResponseData();
-        MetadataResponseData.MetadataResponseTopic topic = new MetadataResponseData.MetadataResponseTopic();
-        topicModifier.accept(topic);
-        response.topics().add(topic);
-        return response;
+    public static Stream<CreateTopicsResponseData> learnsNothingFromCreateTopicResponseAndForwards() {
+        CreateTopicsResponseData empty = new CreateTopicsResponseData();
+        CreateTopicsResponseData nullTopics = new CreateTopicsResponseData().setTopics(null);
+        CreateTopicsResponseData topicWithDefaultName = createTopicWithSingleTopic(t -> {
+            t.setTopicId(TOPIC_UUID);
+        });
+        CreateTopicsResponseData topicWithNullName = createTopicWithSingleTopic(t -> {
+            t.setTopicId(TOPIC_UUID);
+            t.setName(null);
+        });
+        CreateTopicsResponseData topicWithDefaultTopicId = createTopicWithSingleTopic(t -> {
+            t.setName(TOPIC_NAME);
+        });
+        CreateTopicsResponseData topicWithNullTopidId = createTopicWithSingleTopic(t -> {
+            t.setTopicId(null);
+            t.setName(TOPIC_NAME);
+        });
+        return Stream.of(empty, nullTopics, topicWithDefaultName, topicWithNullName, topicWithDefaultTopicId, topicWithNullTopidId);
     }
 
     @ParameterizedTest
     @MethodSource
     void learnsNothingFromMetadataAndForwards(MetadataResponseData data) {
+        when(filterContext.forwardResponse(any(), any())).thenReturn(FORWARD_FUTURE);
         CompletionStage<ResponseFilterResult> resultStage = onMetadataResponse(data);
         assertThat(resultStage).isSameAs(FORWARD_FUTURE);
         verify(virtualClusterModel, never()).rememberTopicIdMapping(any(), any());
     }
 
+    @ParameterizedTest
+    @MethodSource
+    void learnsNothingFromCreateTopicResponseAndForwards(CreateTopicsResponseData data) {
+        when(filterContext.forwardResponse(any(), any())).thenReturn(FORWARD_FUTURE);
+        CompletionStage<ResponseFilterResult> resultStage = onCreateTopicsResponse(data);
+        assertThat(resultStage).isSameAs(FORWARD_FUTURE);
+        verify(virtualClusterModel, never()).rememberTopicIdMapping(any(), any());
+    }
+
     @Test
-    void learnsTopicName() {
-        MetadataResponseData metadataResponseData = withSingleTopic(t -> {
+    void learnsTopicNameFromMetadataAndForwards() {
+        when(filterContext.forwardResponse(any(), any())).thenReturn(FORWARD_FUTURE);
+        MetadataResponseData metadataResponseData = metadataWithSingleTopic(t -> {
             t.setName(TOPIC_NAME);
             t.setTopicId(TOPIC_UUID);
         });
-        CompletionStage<ResponseFilterResult> response1 = onMetadataResponse(metadataResponseData);
-        assertThat(response1).isSameAs(FORWARD_FUTURE);
+        CompletionStage<ResponseFilterResult> filterResult = onMetadataResponse(metadataResponseData);
+        assertThat(filterResult).isSameAs(FORWARD_FUTURE);
         verify(virtualClusterModel).rememberTopicIdMapping(TOPIC_UUID, TOPIC_NAME);
     }
 
     @Test
-    void learnsAllTopicNames() {
+    void learnsTopicNameFromCreateTopicAndForwards() {
+        when(filterContext.forwardResponse(any(), any())).thenReturn(FORWARD_FUTURE);
+        CreateTopicsResponseData response = createTopicWithSingleTopic(t -> {
+            t.setName(TOPIC_NAME);
+            t.setTopicId(TOPIC_UUID);
+        });
+        CompletionStage<ResponseFilterResult> filterResult = onCreateTopicsResponse(response);
+        assertThat(filterResult).isSameAs(FORWARD_FUTURE);
+        verify(virtualClusterModel).rememberTopicIdMapping(TOPIC_UUID, TOPIC_NAME);
+    }
+
+    @Test
+    void learnsAllTopicNameFromMetadataAndForwards() {
+        when(filterContext.forwardResponse(any(), any())).thenReturn(FORWARD_FUTURE);
         MetadataResponseData response = new MetadataResponseData();
         MetadataResponseData.MetadataResponseTopic topic = new MetadataResponseData.MetadataResponseTopic();
         topic.setName(TOPIC_NAME);
@@ -121,9 +175,52 @@ class TopicNameLearningFilterTest {
         verify(virtualClusterModel).rememberTopicIdMapping(topicId2, topicName2);
     }
 
+    @Test
+    void learnsAllTopicNameFromCreateTopicAndForwards() {
+        when(filterContext.forwardResponse(any(), any())).thenReturn(FORWARD_FUTURE);
+        CreateTopicsResponseData response = new CreateTopicsResponseData();
+        CreateTopicsResponseData.CreatableTopicResult topic = new CreateTopicsResponseData.CreatableTopicResult();
+        topic.setName(TOPIC_NAME);
+        topic.setTopicId(TOPIC_UUID);
+        response.topics().add(topic);
+
+        CreateTopicsResponseData.CreatableTopicResult topic2 = new CreateTopicsResponseData.CreatableTopicResult();
+        String topicName2 = "topic2";
+        Uuid topicId2 = Uuid.randomUuid();
+        topic2.setName(topicName2);
+        topic2.setTopicId(topicId2);
+        response.topics().add(topic2);
+
+        CompletionStage<ResponseFilterResult> filterResult = onCreateTopicsResponse(response);
+        assertThat(filterResult).isSameAs(FORWARD_FUTURE);
+        verify(virtualClusterModel).rememberTopicIdMapping(TOPIC_UUID, TOPIC_NAME);
+        verify(virtualClusterModel).rememberTopicIdMapping(topicId2, topicName2);
+    }
+
     private CompletionStage<ResponseFilterResult> onMetadataResponse(MetadataResponseData data) {
         return topicNameLearningFilter.onMetadataResponse((short) 12, new ResponseHeaderData(), data,
                 filterContext);
+    }
+
+    private CompletionStage<ResponseFilterResult> onCreateTopicsResponse(CreateTopicsResponseData data) {
+        return topicNameLearningFilter.onCreateTopicsResponse((short) 7, new ResponseHeaderData(), data,
+                filterContext);
+    }
+
+    private static MetadataResponseData metadataWithSingleTopic(Consumer<MetadataResponseData.MetadataResponseTopic> topicModifier) {
+        MetadataResponseData response = new MetadataResponseData();
+        MetadataResponseData.MetadataResponseTopic topic = new MetadataResponseData.MetadataResponseTopic();
+        topicModifier.accept(topic);
+        response.topics().add(topic);
+        return response;
+    }
+
+    private static CreateTopicsResponseData createTopicWithSingleTopic(Consumer<CreateTopicsResponseData.CreatableTopicResult> topicModifier) {
+        CreateTopicsResponseData response = new CreateTopicsResponseData();
+        CreateTopicsResponseData.CreatableTopicResult topic = new CreateTopicsResponseData.CreatableTopicResult();
+        topicModifier.accept(topic);
+        response.topics().add(topic);
+        return response;
     }
 
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds `CompletionStage<Map<Uuid, String>> getTopicNames(Set<Uuid> topicUuids)` to `FilterContext`. This returns a stage that will be completed with a Map containing an entry for every topicUuid requested, if any can not be mapped to a name the stage is completed exceptionally.

The Map returned is allowed to contain mappings for a superset of uuids. This is to enable us to return an unmodifiable wrapper around a single `ConcurrentMap` stored on the `VirtualClusterModel`. It is assumed is that a topic id will always refer to a single topic name and can therefore be cached forever for a Virtual Cluster. By never removing entries from the map we can safely hand off references to this Map and be confident the Filter can obtain the data it requires.

If the proxy has not encountered those topicIds before, we send an out of band v12 Metadata request to the broker to obtain the topic names. The Proxy intercepts the response and learns the name mappings. We can then complete the future with the Map.

If the proxy has already learned those mappings, then we can return a completed stage immediately.

We can also learn the topic id for newly created topics and eagerly cache that, the CreateTopicResponse RPC carries the id and name.

Why:

[KIP-516](https://cwiki.apache.org/confluence/display/KAFKA/KIP-516%3A+Topic+Identifiers#KIP516:TopicIdentifiers-OffsetForLeaderResponsev4) introduced Topic Ids to address some issues with using topic names as the identifier. Stale topics (topic named X is deleted and a new topic named X is created) cause edge cases around log dir cleanup.

Many RPCs now operate on topic ids instead of names. This poses a challenge to some of our Filters. For example users may wish to define policies for their topics like "encrypt all data for topic named X,Y or Z". Generally, users will be working with topic names and Kafka's internal topic ids are an implementation detail they are unlikely to be interested in.

This means eventually we are going to have to handle ProduceRequests identifying topics by topic id, mapping them to topic names so that we can apply the users key selection policy.

More generally there is a class of Filters that are topic-oriented, users will want different behaviour per-topic. Mask this topic, schema validate this topic, etc. We should enable users to declare their intent using topic names and give Filter Authors the means to obtain the filter names.

Closes #1318

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
