### PR TITLE
[System Tests] added STRIMZI_NAMESPACE env variable

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -337,6 +337,7 @@ has been applied ineffectively.
 * `KROXYLICIOUS_VERSION`: version of kroxylicious to be used. Default value: `${project.version}` in pom file
 * `KAFKA_VERSION`: kafka version to be used. Default value: `${kafka.version}` in pom file
 * `STRIMZI_VERSION`: strimzi version to be used. Default value: `${strimzi.version}` in pom file
+* `STRIMZI_NAMESPACE`: namespace used for strimzi cluster operator installation. Useful when strimzi is previously installed. Default value: `kafka`
 * `SKIP_TEARDOWN`: variable for development purposes to avoid keep deploying and deleting deployments each run. Default value: `false`
 * `CONTAINER_CONFIG_PATH`: directory where `config.json` file is located. This file contains the pull secrets to be used by
 the container engine. Default value: `$HOME/.docker/config.json`

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
@@ -78,7 +78,6 @@ public class Environment {
      */
     private static final String SKIP_TEARDOWN_DEFAULT = "false";
     private static final String STRIMZI_FEATURE_GATES_DEFAULT = "";
-    private static final String STRIMZI_NAMESPACE_DEFAULT = Constants.KAFKA_DEFAULT_NAMESPACE;
     private static final String CONTAINER_CONFIG_PATH_DEFAULT = System.getProperty("user.home") + "/.docker/config.json";
     private static final String SKIP_STRIMZI_INSTALL_DEFAULT = "false";
     private static final String KAFKA_CLIENT_DEFAULT = "strimzi_test_client";
@@ -119,7 +118,7 @@ public class Environment {
 
     public static final String STRIMZI_VERSION = getOrDefault(STRIMZI_VERSION_ENV, STRIMZI_VERSION_DEFAULT);
 
-    public static final String STRIMZI_NAMESPACE = getOrDefault(STRIMZI_NAMESPACE_ENV, STRIMZI_NAMESPACE_DEFAULT);
+    public static final String STRIMZI_NAMESPACE = getOrDefault(STRIMZI_NAMESPACE_ENV, Constants.KAFKA_DEFAULT_NAMESPACE);
 
     public static final String CLUSTER_DUMP_DIR = getOrDefault(CLUSTER_DUMP_DIR_ENV, CLUSTER_DUMP_DIR_DEFAULT);
 

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
@@ -32,6 +32,7 @@ public class Environment {
     private static final String SKIP_STRIMZI_INSTALL_ENV = "SKIP_STRIMZI_INSTALL";
     private static final String KAFKA_CLIENT_ENV = "KAFKA_CLIENT";
     private static final String STRIMZI_VERSION_ENV = "STRIMZI_VERSION";
+    private static final String STRIMZI_NAMESPACE_ENV = "STRIMZI_NAMESPACE";
     private static final String CLUSTER_DUMP_DIR_ENV = "CLUSTER_DUMP_DIR";
     private static final String AWS_ACCESS_KEY_ID_ENV = "AWS_ACCESS_KEY_ID";
     private static final String AWS_SECRET_ACCESS_KEY_ENV = "AWS_SECRET_ACCESS_KEY";
@@ -77,6 +78,7 @@ public class Environment {
      */
     private static final String SKIP_TEARDOWN_DEFAULT = "false";
     private static final String STRIMZI_FEATURE_GATES_DEFAULT = "";
+    private static final String STRIMZI_NAMESPACE_DEFAULT = Constants.KAFKA_DEFAULT_NAMESPACE;
     private static final String CONTAINER_CONFIG_PATH_DEFAULT = System.getProperty("user.home") + "/.docker/config.json";
     private static final String SKIP_STRIMZI_INSTALL_DEFAULT = "false";
     private static final String KAFKA_CLIENT_DEFAULT = "strimzi_test_client";
@@ -117,6 +119,8 @@ public class Environment {
 
     public static final String STRIMZI_VERSION = getOrDefault(STRIMZI_VERSION_ENV, STRIMZI_VERSION_DEFAULT);
 
+    public static final String STRIMZI_NAMESPACE = getOrDefault(STRIMZI_NAMESPACE_ENV, STRIMZI_NAMESPACE_DEFAULT);
+
     public static final String CLUSTER_DUMP_DIR = getOrDefault(CLUSTER_DUMP_DIR_ENV, CLUSTER_DUMP_DIR_DEFAULT);
 
     public static final String AWS_ACCESS_KEY_ID = getOrDefault(AWS_ACCESS_KEY_ID_ENV, AWS_ACCESS_KEY_ID_DEFAULT);
@@ -140,12 +144,12 @@ public class Environment {
     }
 
     private static String readMetadataProperty(String property) {
-        var p = new Properties();
+        Properties p = new Properties();
         var metadataProps = "/metadata.properties";
         try (var stream = Environment.class.getResourceAsStream(metadataProps)) {
             Objects.requireNonNull(stream, metadataProps + " is not present on the classpath");
             p.load(stream);
-            var version = p.getProperty(property);
+            String version = p.getProperty(property);
             if (version == null) {
                 throw new IllegalStateException(property + " key absent in " + metadataProps);
             }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
@@ -143,7 +143,7 @@ public class Environment {
     }
 
     private static String readMetadataProperty(String property) {
-        Properties p = new Properties();
+        var p = new Properties();
         var metadataProps = "/metadata.properties";
         try (var stream = Environment.class.getResourceAsStream(metadataProps)) {
             Objects.requireNonNull(stream, metadataProps + " is not present on the classpath");

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/utils/DeploymentUtils.java
@@ -260,7 +260,7 @@ public class DeploymentUtils {
                 .withZone(ZoneOffset.UTC)
                 .format(Instant.now());
         List<String> executableCommand = List.of(cmdKubeClient(namespace).toString(), "cluster-info", "dump",
-                "--namespaces", String.join(",", namespace, Constants.KAFKA_DEFAULT_NAMESPACE),
+                "--namespaces", String.join(",", namespace, Constants.KAFKA_DEFAULT_NAMESPACE, Environment.STRIMZI_NAMESPACE),
                 "--output-directory", Environment.CLUSTER_DUMP_DIR + "/" + testClassName.replace(".", "_") + "_" +
                         testMethodName + "_cluster_dump_" + formattedDate);
         ExecResult result = Exec.exec(null, executableCommand, Duration.ofSeconds(20), true, false, null);

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/AbstractST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/AbstractST.java
@@ -68,7 +68,7 @@ public class AbstractST {
         LOGGER.info(String.join("", Collections.nCopies(76, "#")));
         LOGGER.info(String.format("%s Test Suite - STARTED", testInfo.getTestClass().get().getName()));
         cluster = KubeClusterResource.getInstance();
-        strimziOperator = new Strimzi(Constants.KAFKA_DEFAULT_NAMESPACE);
+        strimziOperator = new Strimzi(Environment.STRIMZI_NAMESPACE);
 
         NamespaceUtils.createNamespaceWithWait(Constants.KAFKA_DEFAULT_NAMESPACE);
         strimziOperator.deploy();
@@ -86,7 +86,6 @@ public class AbstractST {
             if (strimziOperator != null) {
                 strimziOperator.delete();
             }
-            NamespaceUtils.deleteNamespaceWithWait(Constants.KAFKA_DEFAULT_NAMESPACE);
         }
         else {
             LOGGER.warn("Teardown was skipped because SKIP_TEARDOWN was set to 'true'");

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/extensions/KroxyliciousExtension.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/extensions/KroxyliciousExtension.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.kroxylicious.systemtests.Constants;
+import io.kroxylicious.systemtests.Environment;
 import io.kroxylicious.systemtests.utils.DeploymentUtils;
 import io.kroxylicious.systemtests.utils.NamespaceUtils;
 
@@ -66,6 +67,9 @@ public class KroxyliciousExtension implements ParameterResolver, BeforeEachCallb
             if (exception.isPresent()) {
                 DeploymentUtils.collectClusterInfo("default", extensionContext.getRequiredTestClass().getSimpleName(), "");
             }
+        }
+        if (!Environment.SKIP_TEARDOWN) {
+            NamespaceUtils.deleteNamespaceWithWait(Constants.KAFKA_DEFAULT_NAMESPACE);
         }
     }
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

In order to be able to collect cluster dumps from Strimzi cluster operator namespace, we should add this new `STRIMZI_NAMESPACE` env variable in case it is installed in a different namespace than the default one. 

Also, we should remove the `kafka` namespace before collecting the dumps, not after. Otherwise the collection is useless.

### Additional Context

The need of doing that came up when strimzi cluster operator was failing to install but no dumps where collected from the proper namespace.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
