### PR TITLE
Fix misspelt Fortanix env vars and secrets causing failures on CI's main pipeline

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -66,9 +66,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # These variables/secrets support the Fortanix/KMS integration tests.   If the secrets are absent, the
           # tests will be skipped.
-          KROYXLICIOUS_KMS_FORTANIX_API_ENDPOINT: ${{ vars.KROYXLICIOUS_KMS_FORTANIX_API_ENDPOINT }}
-          KROYXLICIOUS_KMS_FORTANIX_ADMIN_API_KEY: ${{ secrets.KROYXLICIOUS_KMS_FORTANIX_ADMIN_API_KEY }}
-          KROYXLICIOUS_KMS_FORTANIX_API_KEY: ${{ secrets.KROYXLICIOUS_KMS_FORTANIX_API_KEY }}
+          KROXYLICIOUS_KMS_FORTANIX_API_ENDPOINT: ${{ vars.KROXYLICIOUS_KMS_FORTANIX_API_ENDPOINT }}
+          KROXYLICIOUS_KMS_FORTANIX_ADMIN_API_KEY: ${{ secrets.KROXYLICIOUS_KMS_FORTANIX_ADMIN_API_KEY }}
+          KROXYLICIOUS_KMS_FORTANIX_API_KEY: ${{ secrets.KROXYLICIOUS_KMS_FORTANIX_API_KEY }}
         run: mvn -B clean verify -Pci -Djapicmp.skip=${REFERENCE_RELEASE_UNPUBLISHED}
       - name: 'Build Kroxylicious maven project on main with Sonar'
         if: github.event_name == 'push' && github.ref_name == 'main' && env.SONAR_TOKEN_SET == 'true'

--- a/kroxylicious-kms-provider-fortanix-dsm-test-support/src/main/java/io/kroxylicious/kms/provider/fortanix/dsm/FortanixDsmKmsTestKmsFacade.java
+++ b/kroxylicious-kms-provider-fortanix-dsm-test-support/src/main/java/io/kroxylicious/kms/provider/fortanix/dsm/FortanixDsmKmsTestKmsFacade.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Predicate;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,12 +74,15 @@ class FortanixDsmKmsTestKmsFacade implements TestKmsFacade<Config, String, Forta
     private static final String TEST_RUN_INSTANCE_ID_METADATA_KEY = "testInstance";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    private static final Optional<URI> KROXYLICIOUS_KMS_FORTANIX_API_ENDPOINT = Optional.ofNullable(System.getenv().get("KROXYLICIOUS_KMS_FORTANIX_API_ENDPOINT"))
-            .map(URI::create);
+    private static final Optional<URI> KROXYLICIOUS_KMS_FORTANIX_API_ENDPOINT = Optional.ofNullable(System.getenv().get("KROXYLICIOUS_KMS_FORTANIX_API_ENDPOINT")).filter(
+            Predicate.not(String::isEmpty)).map(URI::create);
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    private static final Optional<String> KROXYLICIOUS_KMS_FORTANIX_ADMIN_API_KEY = Optional.ofNullable(System.getenv().get("KROXYLICIOUS_KMS_FORTANIX_ADMIN_API_KEY"));
+    private static final Optional<String> KROXYLICIOUS_KMS_FORTANIX_ADMIN_API_KEY = Optional.ofNullable(System.getenv().get("KROXYLICIOUS_KMS_FORTANIX_ADMIN_API_KEY"))
+            .filter(
+                    Predicate.not(String::isEmpty));
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    private static final Optional<String> KROXYLICIOUS_KMS_FORTANIX_API_KEY = Optional.ofNullable(System.getenv().get("KROXYLICIOUS_KMS_FORTANIX_API_KEY"));
+    private static final Optional<String> KROXYLICIOUS_KMS_FORTANIX_API_KEY = Optional.ofNullable(System.getenv().get("KROXYLICIOUS_KMS_FORTANIX_API_KEY")).filter(
+            Predicate.not(String::isEmpty));
 
     private static final TypeReference<List<KeyResponse>> KEY_LIST_RESPONSE_RESPONSE = new TypeReference<>() {
     };

--- a/kroxylicious-kms-provider-fortanix-dsm/DEV_GUIDE.md
+++ b/kroxylicious-kms-provider-fortanix-dsm/DEV_GUIDE.md
@@ -15,7 +15,7 @@ If you don't have a Fortanix DSM SaaS account, create a trial account.   Create 
 It is the former that we use.   Copy the single string "API Key".  Use those values to set the two API_KEY environment variables.
 
 Once you've done these steps you can run the the io.kroxylicious.kms.service.KmsIT and io.kroxylicious.proxy.encryption.RecordEncryptionFilterIT.
-The integration test will execute the Fortanix KMS integration. You can set `KROYXLICIOUS_KMS_FACADE_CLASS_NAME_FILTER` to `.*Fortanix.*` so that
+The integration test will execute the Fortanix KMS integration. You can set `KROXYLICIOUS_KMS_FACADE_CLASS_NAME_FILTER` to `.*Fortanix.*` so that
 only the integrations for the other KMS providers are skipped.
 
 ## CLI

--- a/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKmsFacadeInvocationContextProvider.java
+++ b/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKmsFacadeInvocationContextProvider.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.extension.support.TypeBasedParameterResolver;
 /**
  * Junit Context Provider providing available {@link TestKmsFacade}s to integration tests.
  * <br/>
- * The variable {@code KROYXLICIOUS_KMS_FACADE_CLASS_NAME_FILTER} is a regular expression that limits the facades available
+ * The variable {@code KROXYLICIOUS_KMS_FACADE_CLASS_NAME_FILTER} is a regular expression that limits the facades available
  * to the test.  It matches against the facade class name.
  */
 public class TestKmsFacadeInvocationContextProvider implements TestTemplateInvocationContextProvider, ParameterResolver {
@@ -38,7 +38,7 @@ public class TestKmsFacadeInvocationContextProvider implements TestTemplateInvoc
     private static final ExtensionContext.Namespace STORE_NAMESPACE = ExtensionContext.Namespace.create("TEST_KMS");
     private static final String FACADE_FACTORIES = "KMS_FACADE_FACTORIES";
 
-    private static final Pattern FACADE_CLASS_NAME_FILTER = Optional.ofNullable(System.getenv("KROYXLICIOUS_KMS_FACADE_CLASS_NAME_FILTER")).map(Pattern::compile)
+    private static final Pattern FACADE_CLASS_NAME_FILTER = Optional.ofNullable(System.getenv("KROXYLICIOUS_KMS_FACADE_CLASS_NAME_FILTER")).map(Pattern::compile)
             .orElse(Pattern.compile(".*"));
 
     @Override


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Fix misspelt Fortanix env vars and secrets causing failures on CI's main pipeline

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
