### PR TITLE
adding kroxylicious robot for Jenkins

### DIFF
--- a/.github/AUTOMATION_README.md
+++ b/.github/AUTOMATION_README.md
@@ -33,4 +33,8 @@ workflows turn those Github secrets/variable into environment variables (for the
 The Fortanix DSM SaaS account is a long-lived account so should not expire.  When discussing the account with the Fortanix, quote the account id
 found on this page https://uk.smartkey.io/#/settings.
 
+## Jenkins integration
+
+In order to be able to run the system and performance tests for our Pull Requests (PR) using Jenkins, we have defined the following Personal Access Token (PAT) 
+`KROXYLICIOUS_JENKINS_TOKEN` to allow `kroxylicious-robot` writing comments with the results of the test execution and adding a new status check in the PR.
 

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -385,7 +385,7 @@ When a PR is created and the system tests are needed, if you are a member of
 [Developers](https://github.com/orgs/kroxylicious/teams/developers), you may add the following comment into the PR to trigger the run.
 
 ```
-@tealc-ci run system tests
+@kroxylicious-robot run system tests
 ```
 
 It will launch the `kroxylicious-system-tests-pr` build, that will insert a comment with a summary into the PR.

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -84,7 +84,7 @@ When a PR is created and the performance tests are needed, if you are a member o
 [Developers](https://github.com/orgs/kroxylicious/teams/developers), you may add the following comment into the PR to trigger the run.
 
 ```
-@tealc-ci run perf
+@kroxylicious-robot run perf
 ```
 
 It will launch the `kroxylicious-performance-tests-pr` build, that will insert a comment with a summary into the PR comparing the results with the previous execution.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Adding `kroxylicious-robot` to launch system and performance tests from the PRs when needed

### Additional Context

Using `tealc-ci` is causing a lot of noise for QE team with many spam emails generated.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
