### PR TITLE
Rename KafkaProxy to Proxy and use proxy.kroxylicious.io group

### DIFF
--- a/etc/checkstyle-suppressions.xml
+++ b/etc/checkstyle-suppressions.xml
@@ -15,7 +15,7 @@
     <suppress checks=".*"
               files="io[/\\]kroxylicious[/\\]proxy[/\\].*(Builder|Editable|Fluent|Nested|Visitor|Visitable).*\.java"/>
     <suppress checks=".*"
-              files="io[/\\]kroxylicious[/\\]kubernetes[/\\]api[/\\].*\.java"/>
+              files="io[/\\]kroxylicious[/\\]kubernetes[/\\]proxy[/\\]api[/\\].*\.java"/>
     <suppress checks=".*"
               files="io[/\\]kroxylicious[/\\]kubernetes[/\\]filter[/\\]api[/\\].*\.java"/>
     <suppress checks=".*"

--- a/kroxylicious-operator/DEV_GUIDE.md
+++ b/kroxylicious-operator/DEV_GUIDE.md
@@ -18,7 +18,7 @@ If you want to run the `OperatorMain` (e.g. from your IDE, maybe for dubugging) 
 kubectl apply -f src/main/resources/META-INF/fabric8
 ```
 
-You should now be able to play around with `KafkaProxy` CRs; read the "Creating a `KafkaProxy`" section.
+You should now be able to play around with `Proxy` CRs; read the "Creating a `Proxy`" section.
 
 Alternatively you can build the operator properly and run it within Kube...
 
@@ -71,7 +71,7 @@ kubectl logs -n kroxylicious-operator pods/kroxylicious-operator-7cd88454c8-fjcx
 
 (your pod hash suffix will differ)
 
-# Creating a `KafkaProxy`
+# Creating a `Proxy`
 
 ```bash
 kubectl apply -f examples/simple/

--- a/kroxylicious-operator/examples/record-encryption/00.Namespace.my-proxy.yaml
+++ b/kroxylicious-operator/examples/record-encryption/00.Namespace.my-proxy.yaml
@@ -5,7 +5,7 @@
 #
 
 ---
-# A Namespace for a single KafkaProxy instance
+# A Namespace for a single Proxy instance
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kroxylicious-operator/examples/record-encryption/01.KafkaProxy.simple.yaml
+++ b/kroxylicious-operator/examples/record-encryption/01.KafkaProxy.simple.yaml
@@ -5,8 +5,8 @@
 #
 
 ---
-kind: KafkaProxy
-apiVersion: kroxylicious.io/v1alpha1
+kind: Proxy
+apiVersion: proxy.kroxylicious.io/v1alpha1
 metadata:
   name: simple
   namespace: my-proxy

--- a/kroxylicious-operator/examples/record-validation/00.Namespace.my-proxy.yaml
+++ b/kroxylicious-operator/examples/record-validation/00.Namespace.my-proxy.yaml
@@ -5,7 +5,7 @@
 #
 
 ---
-# A Namespace for a single KafkaProxy instance
+# A Namespace for a single Proxy instance
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kroxylicious-operator/examples/record-validation/01.KafkaProxy.simple.yaml
+++ b/kroxylicious-operator/examples/record-validation/01.KafkaProxy.simple.yaml
@@ -5,8 +5,8 @@
 #
 
 ---
-kind: KafkaProxy
-apiVersion: kroxylicious.io/v1alpha1
+kind: Proxy
+apiVersion: proxy.kroxylicious.io/v1alpha1
 metadata:
   name: simple
   namespace: my-proxy

--- a/kroxylicious-operator/examples/simple/00.Namespace.my-proxy.yaml
+++ b/kroxylicious-operator/examples/simple/00.Namespace.my-proxy.yaml
@@ -5,7 +5,7 @@
 #
 
 ---
-# A Namespace for a single KafkaProxy instance
+# A Namespace for a single Proxy instance
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kroxylicious-operator/examples/simple/01.KafkaProxy.simple.yaml
+++ b/kroxylicious-operator/examples/simple/01.KafkaProxy.simple.yaml
@@ -5,8 +5,8 @@
 #
 
 ---
-kind: KafkaProxy
-apiVersion: kroxylicious.io/v1alpha1
+kind: Proxy
+apiVersion: proxy.kroxylicious.io/v1alpha1
 metadata:
   name: simple
   namespace: my-proxy

--- a/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-watched.yaml
+++ b/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-watched.yaml
@@ -15,9 +15,9 @@ metadata:
     app.kubernetes.io/component: operator
 rules:
   - apiGroups:
-      - "kroxylicious.io"
+      - "proxy.kroxylicious.io"
     resources:
-      - kafkaproxies
+      - proxies
     verbs:
       - get
       - list
@@ -26,9 +26,9 @@ rules:
       # - patch
       # - update
   - apiGroups:
-      - "kroxylicious.io"
+      - "proxy.kroxylicious.io"
     resources:
-      - kafkaproxies/status
+      - proxies/status
     verbs:
       - get
       - patch

--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -256,13 +256,13 @@
                     <source>src/main/resources/META-INF/fabric8</source>
                     <extraAnnotations>true</extraAnnotations>
                     <existingJavaTypes>
-                        <io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyspec.PodTemplate>
+                        <io.kroxylicious.kubernetes.proxy.api.v1alpha1.proxyspec.PodTemplate>
                             io.fabric8.kubernetes.api.model.PodTemplateSpec
-                        </io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyspec.PodTemplate>
+                        </io.kroxylicious.kubernetes.proxy.api.v1alpha1.proxyspec.PodTemplate>
                     </existingJavaTypes>
                     <packageOverrides>
                         <!-- the default package name ($apiGroup.$apiVersion) doesn't work for us -->
-                        <io.kroxylicious.v1alpha1>io.kroxylicious.kubernetes.api.v1alpha1</io.kroxylicious.v1alpha1>
+                        <io.kroxylicious.proxy.v1alpha1>io.kroxylicious.kubernetes.proxy.api.v1alpha1</io.kroxylicious.proxy.v1alpha1>
                         <io.kroxylicious.filter.v1alpha1>io.kroxylicious.kubernetes.filter.api.v1alpha1</io.kroxylicious.filter.v1alpha1>
                     </packageOverrides>
                 </configuration>

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ClusterCondition.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ClusterCondition.java
@@ -6,7 +6,7 @@
 
 package io.kroxylicious.kubernetes.operator;
 
-import static io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.clusters.Conditions.Status;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.proxystatus.clusters.Conditions.Status;
 
 public record ClusterCondition(String cluster, ConditionType type, Status status, String reason, String message) {
 

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/DeploymentReadyCondition.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/DeploymentReadyCondition.java
@@ -14,11 +14,11 @@ import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 import io.javaoperatorsdk.operator.processing.dependent.workflow.Condition;
 
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.Proxy;
 
-public class DeploymentReadyCondition implements Condition<Deployment, KafkaProxy> {
+public class DeploymentReadyCondition implements Condition<Deployment, Proxy> {
     @Override
-    public boolean isMet(DependentResource<Deployment, KafkaProxy> dependentResource, KafkaProxy primary, Context<KafkaProxy> context) {
+    public boolean isMet(DependentResource<Deployment, Proxy> dependentResource, Proxy primary, Context<Proxy> context) {
         var optionalResource = dependentResource.getSecondaryResource(primary, context);
         if (optionalResource.isEmpty()) {
             return false;

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/Labels.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/Labels.java
@@ -9,11 +9,11 @@ package io.kroxylicious.kubernetes.operator;
 import java.util.HashMap;
 import java.util.Map;
 
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.Proxy;
 
 public class Labels {
 
-    public static Map<String, String> standardLabels(KafkaProxy proxy) {
+    public static Map<String, String> standardLabels(Proxy proxy) {
         HashMap<String, String> labels = new HashMap<>();
         labels.put("app.kubernetes.io/part-of", "kafka");
         labels.put("app.kubernetes.io/managed-by", "kroxylicious-operator");

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorConfigurationException.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorConfigurationException.java
@@ -8,7 +8,7 @@ package io.kroxylicious.kubernetes.operator;
 
 /**
  * A problem with the operator itself (e.g. which prevents it being able to start up).
- * Such problems exist independently of any particular {@code KafkaProxy} resource.
+ * Such problems exist independently of any particular {@code Proxy} resource.
  */
 public class OperatorConfigurationException extends RuntimeException {
     public OperatorConfigurationException(String msg, Exception cause) {

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
@@ -15,8 +15,8 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
-import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyspec.Clusters;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.Proxy;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.proxyspec.Clusters;
 
 public class ResourcesUtil {
     private ResourcesUtil() {
@@ -31,7 +31,7 @@ public class ResourcesUtil {
                 .build();
     }
 
-    static List<Clusters> distinctClusters(KafkaProxy primary) {
+    static List<Clusters> distinctClusters(Proxy primary) {
         return distinctClusters(primary.getSpec().getClusters());
     }
 

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/SharedProxyContext.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/SharedProxyContext.java
@@ -13,17 +13,17 @@ import java.util.Optional;
 
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
-import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyspec.Clusters;
 import io.kroxylicious.kubernetes.operator.config.RuntimeDecl;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.Proxy;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.proxyspec.Clusters;
 
 /**
- * Encapsulates access to the mutable state in the {@link Context<KafkaProxy>} shared between
+ * Encapsulates access to the mutable state in the {@link Context<Proxy>} shared between
  * {@link ProxyReconciler} its dependent resources.
  */
-public class SharedKafkaProxyContext {
+public class SharedProxyContext {
 
-    private SharedKafkaProxyContext() {
+    private SharedProxyContext() {
     }
 
     static final String RUNTIME_DECL_KEY = "runtime";
@@ -32,21 +32,21 @@ public class SharedKafkaProxyContext {
     /**
      * Set the RuntimeDecl
      */
-    static void runtimeDecl(Context<KafkaProxy> context, RuntimeDecl runtimeDecl) {
+    static void runtimeDecl(Context<Proxy> context, RuntimeDecl runtimeDecl) {
         context.managedDependentResourceContext().put(RUNTIME_DECL_KEY, runtimeDecl);
     }
 
     /**
      * Get the RuntimeDecl
      */
-    static RuntimeDecl runtimeDecl(Context<KafkaProxy> context) {
+    static RuntimeDecl runtimeDecl(Context<Proxy> context) {
         return context.managedDependentResourceContext().getMandatory(RUNTIME_DECL_KEY, RuntimeDecl.class);
     }
 
     /**
      * Associate a condition with a specific cluster.
      */
-    static void addClusterCondition(Context<KafkaProxy> context, Clusters cluster, ClusterCondition clusterCondition) {
+    static void addClusterCondition(Context<Proxy> context, Clusters cluster, ClusterCondition clusterCondition) {
         Map<String, ClusterCondition> map = context.managedDependentResourceContext().get(CLUSTER_CONDITIONS_KEY, Map.class).orElse(null);
         if (map == null) {
             map = Collections.synchronizedMap(new HashMap<>());
@@ -55,7 +55,7 @@ public class SharedKafkaProxyContext {
         map.put(cluster.getName(), clusterCondition);
     }
 
-    static boolean isBroken(Context<KafkaProxy> context, Clusters cluster) {
+    static boolean isBroken(Context<Proxy> context, Clusters cluster) {
         Map<String, ClusterCondition> map = context.managedDependentResourceContext().get(CLUSTER_CONDITIONS_KEY, Map.class).orElse(Map.of());
         return map.containsKey(cluster.getName());
     }
@@ -66,7 +66,7 @@ public class SharedKafkaProxyContext {
      * @param cluster The cluster
      * @return The conditions specific to the given cluster; or empty if there were none.
      */
-    static ClusterCondition clusterCondition(Context<KafkaProxy> context, Clusters cluster) {
+    static ClusterCondition clusterCondition(Context<Proxy> context, Clusters cluster) {
         Optional<Map<String, ClusterCondition>> map = (Optional) context.managedDependentResourceContext().get(CLUSTER_CONDITIONS_KEY, Map.class);
         return map.orElse(Map.of()).getOrDefault(cluster.getName(), ClusterCondition.accepted(cluster.getName()));
     }

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/proxies.proxy.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/proxies.proxy.kroxylicious.io-v1.yml
@@ -11,17 +11,17 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
-  name: kafkaproxies.kroxylicious.io
+  name: proxies.proxy.kroxylicious.io
 spec:
   # group name to use for REST API: /apis/<group>/<version>
-  group: kroxylicious.io
+  group: proxy.kroxylicious.io
   scope: Namespaced
   names:
-    plural: kafkaproxies
-    singular: kafkaproxy
-    kind: KafkaProxy
+    plural: proxies
+    singular: proxy
+    kind: Proxy
     shortNames:
-      - kp
+      - p
   # list of versions supported by this CustomResourceDefinition
   versions:
     - name: v1alpha1

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/DeploymentReadyConditionTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/DeploymentReadyConditionTest.java
@@ -19,7 +19,7 @@ import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
 
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.Proxy;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
@@ -27,11 +27,11 @@ import static org.mockito.Mockito.doReturn;
 class DeploymentReadyConditionTest {
 
     @Mock
-    DependentResource<Deployment, io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy> dependentResource;
+    DependentResource<Deployment, io.kroxylicious.kubernetes.proxy.api.v1alpha1.Proxy> dependentResource;
     @Mock
-    KafkaProxy primary;
+    Proxy primary;
     @Mock
-    Context<KafkaProxy> context;
+    Context<Proxy> context;
 
     private AutoCloseable closeable;
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerIT.java
@@ -27,9 +27,9 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
 import io.kroxylicious.kubernetes.operator.config.RuntimeDecl;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.Proxy;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.ProxyBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -72,7 +72,7 @@ class ProxyReconcilerIT {
         doCreate();
     }
 
-    KafkaProxy doCreate() {
+    Proxy doCreate() {
         final var cr = extension.create(testResource());
 
         await().alias("Secret as expected").untilAsserted(() -> {
@@ -132,7 +132,7 @@ class ProxyReconcilerIT {
     void testUpdate() {
         final var cr = doCreate();
         // @formatter:off
-        var changedCr = new KafkaProxyBuilder(cr)
+        var changedCr = new ProxyBuilder(cr)
                 .editSpec()
                     .removeMatchingFromClusters(cluster -> CLUSTER_FOO.equals(cluster.getName()))
                 .endSpec()
@@ -176,9 +176,9 @@ class ProxyReconcilerIT {
                 entry -> new String(Base64.getDecoder().decode(entry.getValue()))));
     }
 
-    KafkaProxy testResource() {
+    Proxy testResource() {
         // @formatter:off
-        return new KafkaProxyBuilder()
+        return new ProxyBuilder()
                 .withNewMetadata()
                     .withName(RESOURCE_NAME)
                 .endMetadata()

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerTest.java
@@ -23,12 +23,12 @@ import org.mockito.MockitoAnnotations;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.managed.ManagedDependentResourceContext;
 
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyStatus;
-import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Conditions;
 import io.kroxylicious.kubernetes.operator.assertj.AssertFactory;
 import io.kroxylicious.kubernetes.operator.config.RuntimeDecl;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.Proxy;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.ProxyBuilder;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.ProxyStatus;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.proxystatus.Conditions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.doReturn;
 class ProxyReconcilerTest {
 
     @Mock
-    Context<KafkaProxy> context;
+    Context<Proxy> context;
 
     @Mock
     ManagedDependentResourceContext mdrc;
@@ -58,7 +58,7 @@ class ProxyReconcilerTest {
         // Given
         // @formatter:off
         long generation = 42L;
-        var primary = new KafkaProxyBuilder()
+        var primary = new ProxyBuilder()
                 .withNewMetadata()
                     .withGeneration(generation)
                     .withName("my-proxy")
@@ -72,9 +72,9 @@ class ProxyReconcilerTest {
         // Then
         assertThat(updateControl.isPatchStatus()).isTrue();
         var statusAssert = assertThat(updateControl.getResource()).isNotNull()
-                .extracting(KafkaProxy::getStatus);
-        statusAssert.extracting(KafkaProxyStatus::getObservedGeneration).isEqualTo(generation);
-        ObjectAssert<Conditions> first = statusAssert.extracting(KafkaProxyStatus::getConditions, InstanceOfAssertFactories.list(Conditions.class))
+                .extracting(Proxy::getStatus);
+        statusAssert.extracting(ProxyStatus::getObservedGeneration).isEqualTo(generation);
+        ObjectAssert<Conditions> first = statusAssert.extracting(ProxyStatus::getConditions, InstanceOfAssertFactories.list(Conditions.class))
                 .first();
         first.extracting(Conditions::getObservedGeneration).isEqualTo(generation);
         first.extracting(Conditions::getLastTransitionTime).isNotNull();
@@ -89,7 +89,7 @@ class ProxyReconcilerTest {
         // Given
         // @formatter:off
         long generation = 42L;
-        var primary = new KafkaProxyBuilder()
+        var primary = new ProxyBuilder()
                 .withNewMetadata()
                 .withGeneration(generation)
                 .withName("my-proxy")
@@ -104,9 +104,9 @@ class ProxyReconcilerTest {
         assertThat(updateControl.isPatch()).isTrue();
         var statusAssert = assertThat(updateControl.getResource()).isNotNull()
                 .isPresent().get()
-                .extracting(KafkaProxy::getStatus);
-        statusAssert.extracting(KafkaProxyStatus::getObservedGeneration).isEqualTo(generation);
-        ObjectAssert<Conditions> first = statusAssert.extracting(KafkaProxyStatus::getConditions, InstanceOfAssertFactories.list(Conditions.class))
+                .extracting(Proxy::getStatus);
+        statusAssert.extracting(ProxyStatus::getObservedGeneration).isEqualTo(generation);
+        ObjectAssert<Conditions> first = statusAssert.extracting(ProxyStatus::getConditions, InstanceOfAssertFactories.list(Conditions.class))
                 .first();
         first.extracting(Conditions::getObservedGeneration).isEqualTo(generation);
         first.extracting(Conditions::getLastTransitionTime).isNotNull();
@@ -122,7 +122,7 @@ class ProxyReconcilerTest {
         long generation = 42L;
         var time = ZonedDateTime.now(ZoneId.of("Z"));
         // @formatter:off
-        var primary = new KafkaProxyBuilder()
+        var primary = new ProxyBuilder()
                 .withNewMetadata()
                     .withGeneration(generation)
                     .withName("my-proxy")
@@ -145,9 +145,9 @@ class ProxyReconcilerTest {
         // Then
         assertThat(updateControl.isPatchStatus()).isTrue();
         var statusAssert = assertThat(updateControl.getResource()).isNotNull()
-                .extracting(KafkaProxy::getStatus);
-        statusAssert.extracting(KafkaProxyStatus::getObservedGeneration).isEqualTo(generation);
-        ObjectAssert<Conditions> first = statusAssert.extracting(KafkaProxyStatus::getConditions, InstanceOfAssertFactories.list(Conditions.class))
+                .extracting(Proxy::getStatus);
+        statusAssert.extracting(ProxyStatus::getObservedGeneration).isEqualTo(generation);
+        ObjectAssert<Conditions> first = statusAssert.extracting(ProxyStatus::getConditions, InstanceOfAssertFactories.list(Conditions.class))
                 .first();
         first.extracting(Conditions::getObservedGeneration).isEqualTo(generation);
         first.extracting(Conditions::getLastTransitionTime).isEqualTo(time);
@@ -163,7 +163,7 @@ class ProxyReconcilerTest {
         long generation = 42L;
         var time = ZonedDateTime.now(ZoneId.of("Z"));
         // @formatter:off
-        var primary = new KafkaProxyBuilder()
+        var primary = new ProxyBuilder()
                 .withNewMetadata()
                     .withGeneration(generation)
                     .withName("my-proxy")
@@ -186,9 +186,9 @@ class ProxyReconcilerTest {
         // Then
         assertThat(updateControl.isPatch()).isTrue();
         var statusAssert = assertThat(updateControl.getResource()).isNotNull().isPresent().get()
-                .extracting(KafkaProxy::getStatus);
-        statusAssert.extracting(KafkaProxyStatus::getObservedGeneration).isEqualTo(generation);
-        ObjectAssert<Conditions> first = statusAssert.extracting(KafkaProxyStatus::getConditions, InstanceOfAssertFactories.list(Conditions.class))
+                .extracting(Proxy::getStatus);
+        statusAssert.extracting(ProxyStatus::getObservedGeneration).isEqualTo(generation);
+        ObjectAssert<Conditions> first = statusAssert.extracting(ProxyStatus::getConditions, InstanceOfAssertFactories.list(Conditions.class))
                 .first();
         first.extracting(Conditions::getObservedGeneration).isEqualTo(generation);
         first.extracting(Conditions::getLastTransitionTime).isNotEqualTo(time);
@@ -204,7 +204,7 @@ class ProxyReconcilerTest {
         long generation = 42L;
         var time = ZonedDateTime.now(ZoneId.of("Z"));
         // @formatter:off
-        var primary = new KafkaProxyBuilder()
+        var primary = new ProxyBuilder()
                  .withNewMetadata()
                     .withGeneration(generation)
                     .withName("my-proxy")
@@ -227,9 +227,9 @@ class ProxyReconcilerTest {
         // Then
         assertThat(updateControl.isPatch()).isTrue();
         var statusAssert = assertThat(updateControl.getResource()).isNotNull().isPresent().get()
-                .extracting(KafkaProxy::getStatus);
-        statusAssert.extracting(KafkaProxyStatus::getObservedGeneration).isEqualTo(generation);
-        ObjectAssert<Conditions> first = statusAssert.extracting(KafkaProxyStatus::getConditions, InstanceOfAssertFactories.list(Conditions.class))
+                .extracting(Proxy::getStatus);
+        statusAssert.extracting(ProxyStatus::getObservedGeneration).isEqualTo(generation);
+        ObjectAssert<Conditions> first = statusAssert.extracting(ProxyStatus::getConditions, InstanceOfAssertFactories.list(Conditions.class))
                 .first();
         first.extracting(Conditions::getObservedGeneration).isEqualTo(generation);
         first.extracting(Conditions::getLastTransitionTime).isEqualTo(time);
@@ -245,7 +245,7 @@ class ProxyReconcilerTest {
         long generation = 42L;
         var time = ZonedDateTime.now(ZoneId.of("Z"));
         // @formatter:off
-        var primary = new KafkaProxyBuilder()
+        var primary = new ProxyBuilder()
                 .withNewMetadata()
                     .withGeneration(generation)
                     .withName("my-proxy")
@@ -268,9 +268,9 @@ class ProxyReconcilerTest {
         // Then
         assertThat(updateControl.isPatchStatus()).isTrue();
         var statusAssert = assertThat(updateControl.getResource()).isNotNull()
-                .extracting(KafkaProxy::getStatus);
-        statusAssert.extracting(KafkaProxyStatus::getObservedGeneration).isEqualTo(generation);
-        ObjectAssert<Conditions> first = statusAssert.extracting(KafkaProxyStatus::getConditions, InstanceOfAssertFactories.list(Conditions.class))
+                .extracting(Proxy::getStatus);
+        statusAssert.extracting(ProxyStatus::getObservedGeneration).isEqualTo(generation);
+        ObjectAssert<Conditions> first = statusAssert.extracting(ProxyStatus::getConditions, InstanceOfAssertFactories.list(Conditions.class))
                 .first();
         first.extracting(Conditions::getObservedGeneration).isEqualTo(generation);
         first.extracting(Conditions::getLastTransitionTime).isNotEqualTo(time);
@@ -286,7 +286,7 @@ class ProxyReconcilerTest {
         long generation = 42L;
         var time = ZonedDateTime.now(ZoneId.of("Z"));
         // @formatter:off
-        var primary = new KafkaProxyBuilder()
+        var primary = new ProxyBuilder()
                 .withNewMetadata()
                     .withGeneration(generation)
                     .withName("my-proxy")
@@ -310,9 +310,9 @@ class ProxyReconcilerTest {
         // @formatter:on
         doReturn(mdrc).when(context).managedDependentResourceContext();
         doReturn(Optional.of(Map.of("my-cluster", ClusterCondition.filterNotExists("my-cluster", "MissingFilter")))).when(mdrc).get(
-                SharedKafkaProxyContext.CLUSTER_CONDITIONS_KEY,
+                SharedProxyContext.CLUSTER_CONDITIONS_KEY,
                 Map.class);
-        doReturn(new RuntimeDecl(List.of())).when(mdrc).getMandatory(SharedKafkaProxyContext.RUNTIME_DECL_KEY, Map.class);
+        doReturn(new RuntimeDecl(List.of())).when(mdrc).getMandatory(SharedProxyContext.RUNTIME_DECL_KEY, Map.class);
 
         // When
         var updateControl = new ProxyReconciler(new RuntimeDecl(List.of())).reconcile(primary, context);
@@ -321,7 +321,7 @@ class ProxyReconcilerTest {
         assertThat(updateControl.isPatchStatus()).isTrue();
         var statusAssert = assertThat(updateControl.getResource())
                 .isNotNull()
-                .extracting(KafkaProxy::getStatus, AssertFactory.status());
+                .extracting(Proxy::getStatus, AssertFactory.status());
         statusAssert.observedGeneration().isEqualTo(generation);
         statusAssert.singleCondition()
                 .isReady()

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ResourcesUtilTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ResourcesUtilTest.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyspec.ClustersBuilder;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.proxyspec.ClustersBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/AssertFactory.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/AssertFactory.java
@@ -8,13 +8,13 @@ package io.kroxylicious.kubernetes.operator.assertj;
 
 import org.assertj.core.api.InstanceOfAssertFactory;
 
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyStatus;
-import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Clusters;
-import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Conditions;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.ProxyStatus;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.proxystatus.Clusters;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.proxystatus.Conditions;
 
 public class AssertFactory {
-    public static InstanceOfAssertFactory<KafkaProxyStatus, StatusAssert> status() {
-        return new InstanceOfAssertFactory<>(KafkaProxyStatus.class, StatusAssert::assertThat);
+    public static InstanceOfAssertFactory<ProxyStatus, StatusAssert> status() {
+        return new InstanceOfAssertFactory<>(ProxyStatus.class, StatusAssert::assertThat);
     }
 
     public static InstanceOfAssertFactory<Conditions, ProxyConditionAssert> proxyCondition() {
@@ -25,7 +25,7 @@ public class AssertFactory {
         return new InstanceOfAssertFactory<>(Clusters.class, ClusterAssert::assertThat);
     }
 
-    public static InstanceOfAssertFactory<io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.clusters.Conditions, ClusterConditionAssert> clusterCondition() {
-        return new InstanceOfAssertFactory<>(io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.clusters.Conditions.class, ClusterConditionAssert::assertThat);
+    public static InstanceOfAssertFactory<io.kroxylicious.kubernetes.proxy.api.v1alpha1.proxystatus.clusters.Conditions, ClusterConditionAssert> clusterCondition() {
+        return new InstanceOfAssertFactory<>(io.kroxylicious.kubernetes.proxy.api.v1alpha1.proxystatus.clusters.Conditions.class, ClusterConditionAssert::assertThat);
     }
 }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/ClusterAssert.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/ClusterAssert.java
@@ -12,8 +12,8 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.ListAssert;
 
-import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Clusters;
-import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.clusters.Conditions;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.proxystatus.Clusters;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.proxystatus.clusters.Conditions;
 
 public class ClusterAssert extends AbstractObjectAssert<ClusterAssert, Clusters> {
     protected ClusterAssert(

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/ClusterConditionAssert.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/ClusterConditionAssert.java
@@ -16,7 +16,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.ObjectAssert;
 
-import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.clusters.Conditions;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.proxystatus.clusters.Conditions;
 
 public class ClusterConditionAssert extends AbstractObjectAssert<ClusterConditionAssert, Conditions> {
     protected ClusterConditionAssert(

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/OperatorAssertions.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/OperatorAssertions.java
@@ -6,12 +6,12 @@
 
 package io.kroxylicious.kubernetes.operator.assertj;
 
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyStatus;
-import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Clusters;
-import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.clusters.Conditions;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.ProxyStatus;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.proxystatus.Clusters;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.proxystatus.clusters.Conditions;
 
 public class OperatorAssertions {
-    public static StatusAssert assertThat(KafkaProxyStatus actual) {
+    public static StatusAssert assertThat(ProxyStatus actual) {
         return StatusAssert.assertThat(actual);
     }
 
@@ -23,7 +23,7 @@ public class OperatorAssertions {
         return ClusterConditionAssert.assertThat(actual);
     }
 
-    public static ProxyConditionAssert assertThat(io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Conditions actual) {
+    public static ProxyConditionAssert assertThat(io.kroxylicious.kubernetes.proxy.api.v1alpha1.proxystatus.Conditions actual) {
         return ProxyConditionAssert.assertThat(actual);
     }
 }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/ProxyConditionAssert.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/ProxyConditionAssert.java
@@ -16,7 +16,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.ObjectAssert;
 
-import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Conditions;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.proxystatus.Conditions;
 
 public class ProxyConditionAssert extends AbstractObjectAssert<ProxyConditionAssert, Conditions> {
     protected ProxyConditionAssert(

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/StatusAssert.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/StatusAssert.java
@@ -12,17 +12,17 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.ListAssert;
 
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyStatus;
-import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Clusters;
-import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Conditions;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.ProxyStatus;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.proxystatus.Clusters;
+import io.kroxylicious.kubernetes.proxy.api.v1alpha1.proxystatus.Conditions;
 
-public class StatusAssert extends AbstractObjectAssert<StatusAssert, KafkaProxyStatus> {
+public class StatusAssert extends AbstractObjectAssert<StatusAssert, ProxyStatus> {
     protected StatusAssert(
-                           KafkaProxyStatus o) {
+                           ProxyStatus o) {
         super(o, StatusAssert.class);
     }
 
-    public static StatusAssert assertThat(KafkaProxyStatus actual) {
+    public static StatusAssert assertThat(ProxyStatus actual) {
         return new StatusAssert(actual);
     }
 
@@ -41,7 +41,7 @@ public class StatusAssert extends AbstractObjectAssert<StatusAssert, KafkaProxyS
 
     public ListAssert<Clusters> clusters() {
         return Assertions.assertThat(actual.getClusters())
-                .asInstanceOf(InstanceOfAssertFactories.list(io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Clusters.class));
+                .asInstanceOf(InstanceOfAssertFactories.list(io.kroxylicious.kubernetes.proxy.api.v1alpha1.proxystatus.Clusters.class));
     }
 
     public ClusterAssert singleCluster() {

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/filter-resource-not-found/in-Proxy.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/filter-resource-not-found/in-Proxy.yaml
@@ -5,8 +5,8 @@
 #
 
 ---
-kind: KafkaProxy
-apiVersion: kroxylicious.io/v1alpha1
+kind: Proxy
+apiVersion: proxy.kroxylicious.io/v1alpha1
 metadata:
   name: example
   namespace: proxy-ns

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/filter-resource-not-found/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/filter-resource-not-found/out-Deployment-example.yaml
@@ -18,8 +18,8 @@ metadata:
   name: "example"
   namespace: "proxy-ns"
   ownerReferences:
-    - apiVersion: "kroxylicious.io/v1alpha1"
-      kind: "KafkaProxy"
+    - apiVersion: "proxy.kroxylicious.io/v1alpha1"
+      kind: "Proxy"
       name: "example"
 spec:
   replicas: 1

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/filter-resource-not-found/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/filter-resource-not-found/out-Secret-example.yaml
@@ -17,8 +17,8 @@ metadata:
   name: "example"
   namespace: "proxy-ns"
   ownerReferences:
-    - apiVersion: "kroxylicious.io/v1alpha1"
-      kind: "KafkaProxy"
+    - apiVersion: "proxy.kroxylicious.io/v1alpha1"
+      kind: "Proxy"
       name: "example"
 stringData:
   proxy-config.yaml: |

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/filter-resource-not-found/out-Service-bar.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/filter-resource-not-found/out-Service-bar.yaml
@@ -17,8 +17,8 @@ metadata:
   name: "bar"
   namespace: "proxy-ns"
   ownerReferences:
-    - apiVersion: "kroxylicious.io/v1alpha1"
-      kind: "KafkaProxy"
+    - apiVersion: "proxy.kroxylicious.io/v1alpha1"
+      kind: "Proxy"
       name: "example"
 spec:
   ports:

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/minimal/in-Proxy.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/minimal/in-Proxy.yaml
@@ -5,8 +5,8 @@
 #
 
 ---
-kind: KafkaProxy
-apiVersion: kroxylicious.io/v1alpha1
+kind: Proxy
+apiVersion: proxy.kroxylicious.io/v1alpha1
 metadata:
   name: minimal
   namespace: proxy-ns

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/minimal/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/minimal/out-Deployment-minimal.yaml
@@ -18,8 +18,8 @@ metadata:
   name: "minimal"
   namespace: "proxy-ns"
   ownerReferences:
-    - apiVersion: "kroxylicious.io/v1alpha1"
-      kind: "KafkaProxy"
+    - apiVersion: "proxy.kroxylicious.io/v1alpha1"
+      kind: "Proxy"
       name: "minimal"
 spec:
   replicas: 1

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/minimal/out-Secret-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/minimal/out-Secret-minimal.yaml
@@ -17,8 +17,8 @@ metadata:
   name: "minimal"
   namespace: "proxy-ns"
   ownerReferences:
-    - apiVersion: "kroxylicious.io/v1alpha1"
-      kind: "KafkaProxy"
+    - apiVersion: "proxy.kroxylicious.io/v1alpha1"
+      kind: "Proxy"
       name: "minimal"
 stringData:
   proxy-config.yaml: | 

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/minimal/out-Service-one.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/minimal/out-Service-one.yaml
@@ -17,8 +17,8 @@ metadata:
   name: "one"
   namespace: "proxy-ns"
   ownerReferences:
-    - apiVersion: "kroxylicious.io/v1alpha1"
-      kind: "KafkaProxy"
+    - apiVersion: "proxy.kroxylicious.io/v1alpha1"
+      kind: "Proxy"
       name: "minimal"
 spec:
   ports:

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-clusters/in-Proxy.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-clusters/in-Proxy.yaml
@@ -5,8 +5,8 @@
 #
 
 ---
-kind: KafkaProxy
-apiVersion: kroxylicious.io/v1alpha1
+kind: Proxy
+apiVersion: proxy.kroxylicious.io/v1alpha1
 metadata:
   name: twocluster
   namespace: proxy-ns

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-clusters/out-Deployment-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-clusters/out-Deployment-twocluster.yaml
@@ -18,8 +18,8 @@ metadata:
   name: "twocluster"
   namespace: "proxy-ns"
   ownerReferences:
-    - apiVersion: "kroxylicious.io/v1alpha1"
-      kind: "KafkaProxy"
+    - apiVersion: "proxy.kroxylicious.io/v1alpha1"
+      kind: "Proxy"
       name: "twocluster"
 spec:
   replicas: 1

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-clusters/out-Secret-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-clusters/out-Secret-twocluster.yaml
@@ -17,8 +17,8 @@ metadata:
   name: "twocluster"
   namespace: "proxy-ns"
   ownerReferences:
-    - apiVersion: "kroxylicious.io/v1alpha1"
-      kind: "KafkaProxy"
+    - apiVersion: "proxy.kroxylicious.io/v1alpha1"
+      kind: "Proxy"
       name: "twocluster"
 stringData:
   proxy-config.yaml: |

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-clusters/out-Service-bar.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-clusters/out-Service-bar.yaml
@@ -17,8 +17,8 @@ metadata:
   name: "bar"
   namespace: "proxy-ns"
   ownerReferences:
-    - apiVersion: "kroxylicious.io/v1alpha1"
-      kind: "KafkaProxy"
+    - apiVersion: "proxy.kroxylicious.io/v1alpha1"
+      kind: "Proxy"
       name: "twocluster"
 spec:
   ports:

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-clusters/out-Service-foo.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-clusters/out-Service-foo.yaml
@@ -17,8 +17,8 @@ metadata:
   name: "foo"
   namespace: "proxy-ns"
   ownerReferences:
-    - apiVersion: "kroxylicious.io/v1alpha1"
-      kind: "KafkaProxy"
+    - apiVersion: "proxy.kroxylicious.io/v1alpha1"
+      kind: "Proxy"
       name: "twocluster"
 spec:
   ports:

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-filters/in-Proxy.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-filters/in-Proxy.yaml
@@ -5,8 +5,8 @@
 #
 
 ---
-kind: KafkaProxy
-apiVersion: kroxylicious.io/v1alpha1
+kind: Proxy
+apiVersion: proxy.kroxylicious.io/v1alpha1
 metadata:
   name: example
   namespace: proxy-ns

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-filters/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-filters/out-Deployment-example.yaml
@@ -18,8 +18,8 @@ metadata:
   name: "example"
   namespace: "proxy-ns"
   ownerReferences:
-    - apiVersion: "kroxylicious.io/v1alpha1"
-      kind: "KafkaProxy"
+    - apiVersion: "proxy.kroxylicious.io/v1alpha1"
+      kind: "Proxy"
       name: "example"
 spec:
   replicas: 1

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-filters/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-filters/out-Secret-example.yaml
@@ -17,8 +17,8 @@ metadata:
   name: "example"
   namespace: "proxy-ns"
   ownerReferences:
-    - apiVersion: "kroxylicious.io/v1alpha1"
-      kind: "KafkaProxy"
+    - apiVersion: "proxy.kroxylicious.io/v1alpha1"
+      kind: "Proxy"
       name: "example"
 stringData:
   proxy-config.yaml: |

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-filters/out-Service-foo.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-filters/out-Service-foo.yaml
@@ -17,8 +17,8 @@ metadata:
   name: "foo"
   namespace: "proxy-ns"
   ownerReferences:
-    - apiVersion: "kroxylicious.io/v1alpha1"
-      kind: "KafkaProxy"
+    - apiVersion: "proxy.kroxylicious.io/v1alpha1"
+      kind: "Proxy"
       name: "example"
 spec:
   ports:

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/use-pod-template-spec/in-Proxy.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/use-pod-template-spec/in-Proxy.yaml
@@ -5,8 +5,8 @@
 #
 
 ---
-kind: KafkaProxy
-apiVersion: kroxylicious.io/v1alpha1
+kind: Proxy
+apiVersion: proxy.kroxylicious.io/v1alpha1
 metadata:
   name: use-pod-template-spec
   namespace: proxy-ns

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/use-pod-template-spec/out-Deployment-use-pod-template-spec.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/use-pod-template-spec/out-Deployment-use-pod-template-spec.yaml
@@ -18,8 +18,8 @@ metadata:
   name: "use-pod-template-spec"
   namespace: proxy-ns
   ownerReferences:
-    - apiVersion: "kroxylicious.io/v1alpha1"
-      kind: "KafkaProxy"
+    - apiVersion: "proxy.kroxylicious.io/v1alpha1"
+      kind: "Proxy"
       name: "use-pod-template-spec"
 spec:
   replicas: 1

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/use-pod-template-spec/out-Secret-use-pod-template-spec.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/use-pod-template-spec/out-Secret-use-pod-template-spec.yaml
@@ -17,8 +17,8 @@ metadata:
   name: "use-pod-template-spec"
   namespace: proxy-ns
   ownerReferences:
-    - apiVersion: "kroxylicious.io/v1alpha1"
-      kind: "KafkaProxy"
+    - apiVersion: "proxy.kroxylicious.io/v1alpha1"
+      kind: "Proxy"
       name: "use-pod-template-spec"
 stringData:
   proxy-config.yaml: | 

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/use-pod-template-spec/out-Service-one.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/use-pod-template-spec/out-Service-one.yaml
@@ -17,8 +17,8 @@ metadata:
   name: "one"
   namespace: proxy-ns
   ownerReferences:
-    - apiVersion: "kroxylicious.io/v1alpha1"
-      kind: "KafkaProxy"
+    - apiVersion: "proxy.kroxylicious.io/v1alpha1"
+      kind: "Proxy"
       name: "use-pod-template-spec"
 spec:
   ports:


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Following our design https://github.com/kroxylicious/design/blob/main/proposals/kroxylicious-operator-api-alternative.md#proxy

`KafkaProxy` becomes Proxy and the group is specialized to `proxy.kroxylicious.io`

Contributes to #1824

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
