### PR TITLE
refactoring - rename method requiresTls -> requiresServerNameIndication

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/SniRoutingClusterNetworkAddressConfigProvider.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/SniRoutingClusterNetworkAddressConfigProvider.java
@@ -114,7 +114,7 @@ public class SniRoutingClusterNetworkAddressConfigProvider implements
         }
 
         @Override
-        public boolean requiresTls() {
+        public boolean requiresServerNameIndication() {
             return true;
         }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointListener.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointListener.java
@@ -34,10 +34,12 @@ public interface EndpointListener {
     boolean isUseTls();
 
     /**
-     * true if this listener requires TLS (in other words, use SNI).
-     * @return true if this listener requires TLS.
+     * Indicates if the provider requires that connections utilise the Server Name Indication (SNI)
+     * extension to TLS.  If this is true, then the provider cannot support plain connections.
+     *
+     * @return true if this provider requires Server Name Indication (SNI).
      */
-    boolean requiresTls();
+    boolean requiresServerNameIndication();
 
     VirtualClusterModel virtualCluster();
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointRegistry.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/EndpointRegistry.java
@@ -465,7 +465,7 @@ public class EndpointRegistry implements EndpointReconciler, EndpointBindingReso
                 var bindings = acceptorChannel.attr(CHANNEL_BINDINGS);
                 bindings.setIfAbsent(new ConcurrentHashMap<>());
                 var bindingMap = bindings.get();
-                var bindingKey = virtualCluster.requiresTls() ? RoutingKey.createBindingKey(host) : RoutingKey.NULL_ROUTING_KEY;
+                var bindingKey = virtualCluster.requiresServerNameIndication() ? RoutingKey.createBindingKey(host) : RoutingKey.NULL_ROUTING_KEY;
 
                 // we use a bindingMap attached to the channel to record the bindings to the channel. the #deregisterBinding path
                 // knows to tear down the acceptorChannel when the map becomes empty.

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -116,8 +116,6 @@ public class VirtualClusterModel {
     }
 
     public void addListener(String name, ClusterNetworkAddressConfigProvider provider, Optional<Tls> tls) {
-        validateTLsSettings(provider, tls);
-        validatePortUsage(provider);
         listeners.put(name, new VirtualClusterListenerModel(this, provider, tls, name));
     }
 
@@ -250,21 +248,6 @@ public class VirtualClusterModel {
         }
     }
 
-    private static void validatePortUsage(ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider) {
-        var conflicts = clusterNetworkAddressConfigProvider.getExclusivePorts().stream().filter(p -> clusterNetworkAddressConfigProvider.getSharedPorts().contains(p))
-                .collect(Collectors.toSet());
-        if (!conflicts.isEmpty()) {
-            throw new IllegalStateException(
-                    "The set of exclusive ports described by the cluster endpoint provider must be distinct from those described as shared. Intersection: " + conflicts);
-        }
-    }
-
-    private static void validateTLsSettings(ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider, Optional<Tls> tls) {
-        if (clusterNetworkAddressConfigProvider.requiresServerNameIndication() && (tls.isEmpty() || !tls.get().definesKey())) {
-            throw new IllegalStateException("Cluster endpoint provider requires server TLS, but this virtual cluster does not define it.");
-        }
-    }
-
     public @NonNull List<NamedFilterDefinition> getFilters() {
         return filters;
     }
@@ -286,8 +269,29 @@ public class VirtualClusterModel {
             this.virtualCluster = virtualCluster;
             this.provider = provider;
             this.tls = tls;
-            this.downstreamSslContext = buildDownstreamSslContext();
             this.name = name;
+            validatePortUsage(provider);
+            validateTLsSettings(provider, tls);
+            this.downstreamSslContext = buildDownstreamSslContext();
+        }
+
+        private void validatePortUsage(ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider) {
+            // This validation seems misplaced.
+            var conflicts = clusterNetworkAddressConfigProvider.getExclusivePorts().stream().filter(p -> clusterNetworkAddressConfigProvider.getSharedPorts().contains(p))
+                    .collect(Collectors.toSet());
+            if (!conflicts.isEmpty()) {
+                throw new IllegalStateException(
+                        "The set of exclusive ports described by the cluster endpoint provider must be distinct from those described as shared. Intersection: "
+                                + conflicts);
+            }
+        }
+
+        private void validateTLsSettings(ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider, Optional<Tls> tls) {
+            if (clusterNetworkAddressConfigProvider.requiresServerNameIndication() && (tls.isEmpty() || !tls.get().definesKey())) {
+                throw new IllegalStateException(
+                        "Cluster endpoint provider requires ServerNameIndication, but virtual cluster listener '%s' does not configure TLS and provide a certificate for the server"
+                                .formatted(name()));
+            }
         }
 
         @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -260,7 +260,7 @@ public class VirtualClusterModel {
     }
 
     private static void validateTLsSettings(ClusterNetworkAddressConfigProvider clusterNetworkAddressConfigProvider, Optional<Tls> tls) {
-        if (clusterNetworkAddressConfigProvider.requiresTls() && (tls.isEmpty() || !tls.get().definesKey())) {
+        if (clusterNetworkAddressConfigProvider.requiresServerNameIndication() && (tls.isEmpty() || !tls.get().definesKey())) {
             throw new IllegalStateException("Cluster endpoint provider requires server TLS, but this virtual cluster does not define it.");
         }
     }
@@ -320,8 +320,8 @@ public class VirtualClusterModel {
         }
 
         @Override
-        public boolean requiresTls() {
-            return getClusterNetworkAddressConfigProvider().requiresTls();
+        public boolean requiresServerNameIndication() {
+            return getClusterNetworkAddressConfigProvider().requiresServerNameIndication();
         }
 
         @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/service/ClusterNetworkAddressConfigProvider.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/service/ClusterNetworkAddressConfigProvider.java
@@ -69,11 +69,12 @@ public interface ClusterNetworkAddressConfigProvider {
     }
 
     /**
-     * Indicates if this provider requires the use of TLS.
+     * Indicates if the provider requires that connections utilise the Server Name Indication (SNI)
+     * extension to TLS.  If this is true, then the provider cannot support plain connections.
      *
-     * @return true if this provider requires the use of TLS.
+     * @return true if this provider requires Server Name Indication (SNI).
      */
-    default boolean requiresTls() {
+    default boolean requiresServerNameIndication() {
         return false;
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
@@ -120,7 +120,8 @@ class KafkaProxyTest {
                         advertisedBrokerAddressPattern:  broker-$(nodeId)
                     targetCluster:
                       bootstrapServers: kafka.example:1234
-                """, "Cluster endpoint provider requires server TLS, but this virtual cluster does not define it"));
+                """,
+                "Cluster endpoint provider requires ServerNameIndication, but virtual cluster listener 'default' does not configure TLS and provide a certificate for the server"));
     }
 
     @ParameterizedTest(name = "{0}")

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/net/EndpointRegistryTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/net/EndpointRegistryTest.java
@@ -733,7 +733,7 @@ class EndpointRegistryTest {
                                              Map<Integer, HostPort> discoveryAddressMap) {
         when(cluster.getClusterBootstrapAddress()).thenReturn(downstreamBootstrap);
         when(cluster.isUseTls()).thenReturn(tls);
-        when(cluster.requiresTls()).thenReturn(sni);
+        when(cluster.requiresServerNameIndication()).thenReturn(sni);
         when(cluster.discoveryAddressMap()).thenReturn(discoveryAddressMap);
         when(cluster.targetCluster()).thenReturn(new TargetCluster(upstreamBootstrap.toString(), null));
         when(cluster.getBrokerIdFromBrokerAddress(any(HostPort.class))).thenReturn(null);


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring
- Documentation

### Description

To better communicate the reliance on the [Server Name Indication](https://datatracker.ietf.org/doc/html/rfc6066#page-6) TLS extension.

why: renamed for clarity.

No functional change.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
