### PR TITLE
Rename Filter to KafkaProtocolFilter

### DIFF
--- a/kroxylicious-operator/examples/record-encryption/01.KafkaProxy.simple.yaml
+++ b/kroxylicious-operator/examples/record-encryption/01.KafkaProxy.simple.yaml
@@ -17,5 +17,5 @@ spec:
         bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
       filters:
       - group: filter.kroxylicious.io
-        kind: Filter
+        kind: KafkaProtocolFilter
         name: encryption

--- a/kroxylicious-operator/examples/record-encryption/02.Filter.encryption.yaml
+++ b/kroxylicious-operator/examples/record-encryption/02.Filter.encryption.yaml
@@ -5,7 +5,7 @@
 #
 
 ---
-kind: Filter
+kind: KafkaProtocolFilter
 apiVersion: filter.kroxylicious.io/v1alpha1
 metadata:
   name: encryption

--- a/kroxylicious-operator/examples/record-validation/02.Filter.validation.yaml
+++ b/kroxylicious-operator/examples/record-validation/02.Filter.validation.yaml
@@ -5,7 +5,7 @@
 #
 
 ---
-kind: Filter
+kind: KafkaProtocolFilter
 apiVersion: filter.kroxylicious.io/v1alpha1
 metadata:
   name: validation

--- a/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-filter-generic.yaml
+++ b/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-filter-generic.yaml
@@ -17,7 +17,7 @@ rules:
   - apiGroups:
       - "filter.kroxylicious.io"
     resources:
-      - filters
+      - kafkaprotocolfilters
     verbs:
       - get
       - list

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
@@ -48,6 +48,6 @@ public class OperatorMain {
     static RuntimeDecl runtimeDecl() {
         // TODO read these from some configuration CR
         return new RuntimeDecl(List.of(
-                new FilterApiDecl("filter.kroxylicious.io", "v1alpha1", "Filter")));
+                new FilterApiDecl("filter.kroxylicious.io", "v1alpha1", "KafkaProtocolFilter")));
     }
 }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/config/FilterApiDecl.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/config/FilterApiDecl.java
@@ -16,7 +16,7 @@ import io.javaoperatorsdk.operator.processing.GroupVersionKind;
  */
 public record FilterApiDecl(String group, String version, String kind) {
 
-    public static FilterApiDecl GENERIC_FILTER = new FilterApiDecl("filter.kroxylicious.io", "v1alpha1", "Filter");
+    public static FilterApiDecl GENERIC_FILTER = new FilterApiDecl("filter.kroxylicious.io", "v1alpha1", "KafkaProtocolFilter");
 
     public GroupVersionKind groupVersionKind() {
         return new GroupVersionKind(group, version, kind);

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/filters.filter.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/filters.filter.kroxylicious.io-v1.yml
@@ -11,7 +11,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
-  name: filters.filter.kroxylicious.io
+  name: kafkaprotocolfilters.filter.kroxylicious.io
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: filter.kroxylicious.io
@@ -19,11 +19,11 @@ spec:
   names:
     categories:
       - kroxylicious-plugins
-    plural: filters
-    singular: filter
-    kind: Filter
+    plural: kafkaprotocolfilters
+    singular: kafkaprotocolfilter
+    kind: KafkaProtocolFilter
     shortNames:
-      - kf
+      - kpf
   # list of versions supported by this CustomResourceDefinition
   versions:
     - name: v1alpha1

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/filter-resource-not-found/in-KafkaProtocolFilter-filter-one.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/filter-resource-not-found/in-KafkaProtocolFilter-filter-one.yaml
@@ -5,12 +5,12 @@
 #
 
 ---
-kind: Filter
+kind: KafkaProtocolFilter
 apiVersion: filter.kroxylicious.io/v1alpha1
 metadata:
-  name: filter-two
+  name: filter-one
   namespace: proxy-ns
 spec:
-  type: com.example.what.Ever
+  type: org.example.some.java.Class
   config:
-    filterTwoConfig: 42
+    filterOneConfig: true

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/filter-resource-not-found/in-KafkaProtocolFilter-filter-two.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/filter-resource-not-found/in-KafkaProtocolFilter-filter-two.yaml
@@ -5,12 +5,12 @@
 #
 
 ---
-kind: Filter
+kind: KafkaProtocolFilter
 apiVersion: filter.kroxylicious.io/v1alpha1
 metadata:
-  name: filter-one
+  name: filter-two
   namespace: proxy-ns
 spec:
-  type: org.example.some.java.Class
+  type: com.example.what.Ever
   config:
-    filterOneConfig: true
+    filterTwoConfig: 42

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/filter-resource-not-found/in-KafkaProxy.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/filter-resource-not-found/in-KafkaProxy.yaml
@@ -18,10 +18,10 @@ spec:
         bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
       filters:
         - group: filter.kroxylicious.io
-          kind: Filter
+          kind: KafkaProtocolFilter
           name: filter-one
         - group: filter.kroxylicious.io
-          kind: Filter
+          kind: KafkaProtocolFilter
           name: missing # this does not exist
     - name: "bar"
       # This cluster should be present in the output proxy-operator-operator-operator-config.yaml, because both these filters exist
@@ -29,8 +29,8 @@ spec:
         bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
       filters:
         - group: filter.kroxylicious.io
-          kind: Filter
+          kind: KafkaProtocolFilter
           name: filter-one
         - group: filter.kroxylicious.io
-          kind: Filter
+          kind: KafkaProtocolFilter
           name: filter-two

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/filter-resource-not-found/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/filter-resource-not-found/out-Secret-example.yaml
@@ -29,11 +29,11 @@ stringData:
       endpoints:
         prometheus: {}
     filterDefinitions:
-    - name: "filter-one.Filter.filter.kroxylicious.io"
+    - name: "filter-one.KafkaProtocolFilter.filter.kroxylicious.io"
       type: "org.example.some.java.Class"
       config:
         filterOneConfig: true
-    - name: "filter-two.Filter.filter.kroxylicious.io"
+    - name: "filter-two.KafkaProtocolFilter.filter.kroxylicious.io"
       type: "com.example.what.Ever"
       config:
         filterTwoConfig: 42
@@ -51,5 +51,5 @@ stringData:
               brokerStartPort: 9393
               numberOfBrokerPorts: 3
         filters:
-        - "filter-one.Filter.filter.kroxylicious.io"
-        - "filter-two.Filter.filter.kroxylicious.io"
+        - "filter-one.KafkaProtocolFilter.filter.kroxylicious.io"
+        - "filter-two.KafkaProtocolFilter.filter.kroxylicious.io"

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-filters/in-KafkaProtocolFilter-filter-one.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-filters/in-KafkaProtocolFilter-filter-one.yaml
@@ -5,7 +5,7 @@
 #
 
 ---
-kind: Filter
+kind: KafkaProtocolFilter
 apiVersion: filter.kroxylicious.io/v1alpha1
 metadata:
   name: filter-one

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-filters/in-KafkaProtocolFilter-filter-two.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-filters/in-KafkaProtocolFilter-filter-two.yaml
@@ -5,7 +5,7 @@
 #
 
 ---
-kind: Filter
+kind: KafkaProtocolFilter
 apiVersion: filter.kroxylicious.io/v1alpha1
 metadata:
   name: filter-two

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-filters/in-KafkaProxy.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-filters/in-KafkaProxy.yaml
@@ -17,8 +17,8 @@ spec:
       bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
     filters:
       - group: filter.kroxylicious.io
-        kind: Filter
+        kind: KafkaProtocolFilter
         name: filter-one
       - group: filter.kroxylicious.io
-        kind: Filter
+        kind: KafkaProtocolFilter
         name: filter-two

--- a/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-filters/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources-filtered/DerivedResourcesTest/two-filters/out-Secret-example.yaml
@@ -29,11 +29,11 @@ stringData:
       endpoints:
         prometheus: {}
     filterDefinitions:
-    - name: "filter-one.Filter.filter.kroxylicious.io"
+    - name: "filter-one.KafkaProtocolFilter.filter.kroxylicious.io"
       type: "org.example.some.java.Class"
       config:
         filterOneConfig: true
-    - name: "filter-two.Filter.filter.kroxylicious.io"
+    - name: "filter-two.KafkaProtocolFilter.filter.kroxylicious.io"
       type: "com.example.what.Ever"
       config:
         filterTwoConfig: 42
@@ -51,5 +51,5 @@ stringData:
               brokerStartPort: 9293
               numberOfBrokerPorts: 3
         filters:
-        - "filter-one.Filter.filter.kroxylicious.io"
-        - "filter-two.Filter.filter.kroxylicious.io"
+        - "filter-one.KafkaProtocolFilter.filter.kroxylicious.io"
+        - "filter-two.KafkaProtocolFilter.filter.kroxylicious.io"


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Draft as the naming hasn't been finalised. See https://github.com/kroxylicious/design/pull/55

We want to allow for other Filter variants to arrive in the future, in case we want to have specialised CR support for specific filters, or target other granularities than the RPC. For instance we could introduce a concept of RecordFilter as a more convenient way to operate on Records, for filters that are only concerned with record manipulation.

It is also less likely to collide with other CRDs than a generic `Filter`, so there's some small benefit to cli tools.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
