### PR TITLE
Operator metrics

### DIFF
--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -201,11 +201,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit-pioneer</groupId>
             <artifactId>junit-pioneer</artifactId>
             <scope>test</scope>

--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -28,7 +28,7 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- note, we're inheriting the jackson BOM from our parent pom -->
+            <!-- note, we're inheriting the jackson & micrometer BOMs from our parent pom -->
 
             <dependency>
                 <groupId>io.javaoperatorsdk</groupId>
@@ -51,6 +51,10 @@
         <dependency>
             <groupId>io.javaoperatorsdk</groupId>
             <artifactId>operator-framework-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.javaoperatorsdk</groupId>
+            <artifactId>micrometer-support</artifactId>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
@@ -149,6 +153,11 @@
             <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-runtime</artifactId>
             <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
         </dependency>
 
         <dependency>

--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -201,8 +201,24 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit-pioneer</groupId>
             <artifactId>junit-pioneer</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-server-mock</artifactId>
+            <scope>test</scope>
+            <!-- TODO exclude okhttp -->
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -221,6 +221,11 @@
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-apiextensions</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -218,11 +218,6 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>mockwebserver</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-model-apiextensions</artifactId>
             <scope>test</scope>
         </dependency>

--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -161,6 +161,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
@@ -7,17 +7,14 @@ package io.kroxylicious.kubernetes.operator;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.Operator;
 import io.javaoperatorsdk.operator.monitoring.micrometer.MicrometerMetrics;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.prometheusmetrics.PrometheusConfig;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 
@@ -26,7 +23,6 @@ import io.kroxylicious.kubernetes.operator.config.RuntimeDecl;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * The {@code main} method entrypoint for the operator
@@ -36,22 +32,12 @@ public class OperatorMain {
     private static final Logger LOGGER = LoggerFactory.getLogger(OperatorMain.class);
     private MeterRegistry registry;
     private final Operator operator;
-    private final Supplier<CompositeMeterRegistry> globalRegistrySupplier;
 
     public OperatorMain() {
-        this(() -> Metrics.globalRegistry, null);
-    }
-
-    @VisibleForTesting
-    OperatorMain(Supplier<CompositeMeterRegistry> globalRegistrySupplier, @Nullable KubernetesClient client) {
-        this.globalRegistrySupplier = globalRegistrySupplier;
         final MicrometerMetrics metrics = enablePrometheusMetrics();
         // o.withMetrics is invoked multiple times so can cause issues with enabling metrics.
         operator = new Operator(o -> {
             o.withMetrics(metrics);
-            if (client != null) {
-                o.withKubernetesClient(client);
-            }
         });
     }
 
@@ -100,7 +86,7 @@ public class OperatorMain {
 
     private MicrometerMetrics enablePrometheusMetrics() {
         registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
-        globalRegistrySupplier.get().add(registry);
+        Metrics.globalRegistry.add(registry);
         return MicrometerMetrics.newPerResourceCollectingMicrometerMetricsBuilder(registry)
                 .withCleanUpDelayInSeconds(35)
                 .withCleaningThreadNumber(1)

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
@@ -38,8 +38,8 @@ public class OperatorMain {
     private final Operator operator;
     private final Supplier<CompositeMeterRegistry> globalRegistrySupplier;
 
-    public OperatorMain(Supplier<CompositeMeterRegistry> globalRegistrySupplier) {
-        this(globalRegistrySupplier, null);
+    public OperatorMain() {
+        this(() -> Metrics.globalRegistry, null);
     }
 
     @VisibleForTesting
@@ -57,7 +57,7 @@ public class OperatorMain {
 
     public static void main(String[] args) {
         try {
-            new OperatorMain(() -> Metrics.globalRegistry).run();
+            new OperatorMain().run();
         }
         catch (Exception e) {
             LOGGER.error("Operator has thrown exception during startup. Will now exit.", e);

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
@@ -21,7 +21,6 @@ import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 
 import io.kroxylicious.kubernetes.operator.config.FilterApiDecl;
 import io.kroxylicious.kubernetes.operator.config.RuntimeDecl;
-import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -74,11 +73,6 @@ public class OperatorMain {
     void stop() {
         operator.stop();
         LOGGER.info("Operator stopped.");
-    }
-
-    @VisibleForTesting
-    MeterRegistry getRegistry() {
-        return registry;
     }
 
     @NonNull

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
@@ -55,7 +55,7 @@ public class OperatorMain {
         LOGGER.info("Operator started.");
     }
 
-    public void close() {
+    void stop() {
         // remove the meters we contributed to the global registry.
         var copy = List.copyOf(registry.getMeters());
         copy.forEach(Metrics.globalRegistry::remove);

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
@@ -57,7 +57,7 @@ public class OperatorMain {
 
     public static void main(String[] args) {
         try {
-            new OperatorMain().run();
+            new OperatorMain().start();
         }
         catch (Exception e) {
             LOGGER.error("Operator has thrown exception during startup. Will now exit.", e);
@@ -65,7 +65,10 @@ public class OperatorMain {
         }
     }
 
-    void run() {
+    /**
+     * Starts the operator instance and returns once that has completed successfully.
+     */
+    void start() {
         operator.installShutdownHook(Duration.ofSeconds(10));
         var registeredController = operator.register(new ProxyReconciler(runtimeDecl()));
         // TODO couple the health of the registeredController to the operator's HTTP healthchecks

--- a/kroxylicious-operator/src/main/resources/log4j2.yaml
+++ b/kroxylicious-operator/src/main/resources/log4j2.yaml
@@ -36,3 +36,8 @@ Configuration:
         additivity: false
         AppenderRef:
           - ref: STDOUT
+      - name: io.fabric8.kubernetes.client.http
+        level: TRACE
+        additivity: true
+        AppenderRef:
+          - ref: STDOUT

--- a/kroxylicious-operator/src/main/resources/log4j2.yaml
+++ b/kroxylicious-operator/src/main/resources/log4j2.yaml
@@ -38,6 +38,6 @@ Configuration:
           - ref: STDOUT
       - name: io.fabric8.kubernetes.client.http
         level: INFO
-        additivity: true
+        additivity: false
         AppenderRef:
           - ref: STDOUT

--- a/kroxylicious-operator/src/main/resources/log4j2.yaml
+++ b/kroxylicious-operator/src/main/resources/log4j2.yaml
@@ -37,7 +37,7 @@ Configuration:
         AppenderRef:
           - ref: STDOUT
       - name: io.fabric8.kubernetes.client.http
-        level: TRACE
+        level: INFO
         additivity: true
         AppenderRef:
           - ref: STDOUT

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
@@ -32,7 +32,7 @@ class OperatorMainIT {
     }
 
     @Test
-    void shouldRegisterMetrics() {
+    void shouldRegisterPrometheusMetrics() {
         // Given
 
         // When
@@ -46,5 +46,28 @@ class OperatorMainIT {
                 .satisfies(meterRegistry ->
                         assertThat(meterRegistry.get("operator.sdk.reconciliations.success"))
                                 .isNotNull());
+    }
+
+    @Test
+    void shouldRegisterOperatorMetrics() {
+        // Given
+
+        // When
+        OperatorMain.run();
+
+        // Then
+        assertThat(Metrics.globalRegistry.get("operator.sdk.reconciliations.success"))
+                .isNotNull();
+    }
+
+    @Test
+    void shouldRegisterMetricsForProxyReconciler() {
+        // Given
+
+        // When
+        OperatorMain.run();
+
+        // Then
+        assertThat(Metrics.globalRegistry.get("operator.sdk.reconciliations.proxyreconciler.success")).isNotNull();
     }
 }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
@@ -31,7 +31,7 @@ class OperatorMainIT {
     @AfterEach
     void afterEach() {
         if (operatorMain != null) {
-            operatorMain.close();
+            operatorMain.stop();
         }
         assertThat(Metrics.globalRegistry.getMeters()).isEmpty();
     }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
@@ -10,9 +10,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.javaoperatorsdk.operator.OperatorException;
+import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 import io.micrometer.core.instrument.Metrics;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.filter.api.v1alpha1.KafkaProtocolFilter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -21,6 +26,13 @@ import static org.assertj.core.api.Assertions.fail;
 class OperatorMainIT {
     private OperatorMain operatorMain;
     // This is an IT because it depends on having a running Kube cluster
+
+    @RegisterExtension
+    static final LocallyRunOperatorExtension operatorExtension = LocallyRunOperatorExtension.builder()
+            .withAdditionalCustomResourceDefinition(KafkaProtocolFilter.class)
+            .withAdditionalCustomResourceDefinition(KafkaProxy.class)
+            .withKubernetesClient(OperatorTestUtils.kubeClientIfAvailable())
+            .build();
 
     @BeforeEach
     void beforeEach() {

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
@@ -62,9 +62,9 @@ class OperatorMainIT {
     }
 
     @Test
-    void run() {
+    void start() {
         try {
-            operatorMain.run();
+            operatorMain.start();
         }
         catch (OperatorException e) {
             fail("Exception occurred starting operator: " + e.getMessage());
@@ -77,7 +77,7 @@ class OperatorMainIT {
         // Given
 
         // When
-        operatorMain.run();
+        operatorMain.start();
 
         // Then
         assertThat(Metrics.globalRegistry.getRegistries())
@@ -90,7 +90,7 @@ class OperatorMainIT {
         // Given
 
         // When
-        operatorMain.run();
+        operatorMain.start();
 
         // Then
         Awaitility.await()
@@ -113,7 +113,7 @@ class OperatorMainIT {
         // Given
 
         // When
-        operatorMain.run();
+        operatorMain.start();
 
         // Then
         assertThat(operatorMain.getRegistry().get("operator.sdk.reconciliations.executions.proxyreconciler").meter().getId()).isNotNull();

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
@@ -56,6 +56,7 @@ class OperatorMainIT {
                 kubernetesClient.resources(KafkaProtocolFilter.class).delete();
                 kubernetesClient.resources(KafkaProxy.class).delete();
                 kubernetesClient.resources(VirtualKafkaCluster.class).delete();
+                kubernetesClient.resources(KafkaClusterRef.class).delete();
             }
         }
     }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
@@ -26,6 +26,7 @@ import io.micrometer.core.instrument.search.MeterNotFoundException;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.filter.api.v1alpha1.KafkaProtocolFilter;
 
@@ -100,9 +101,11 @@ class OperatorMainIT {
     @Test
     void shouldRegisterOperatorMetrics() {
         // Given
+        final KafkaProxyBuilder proxyBuilder = new KafkaProxyBuilder().withKind("KafkaProxy").withNewMetadata().withName("mycoolproxy").endMetadata();
+        operatorMain.start();
 
         // When
-        operatorMain.start();
+        OperatorTestUtils.kubeClientIfAvailable().resource(proxyBuilder.build()).create();
 
         // Then
         Awaitility.await()

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
@@ -38,7 +38,7 @@ class OperatorMainIT {
         LocallyRunOperatorExtension.applyCrd(KafkaProxy.class, OperatorTestUtils.kubeClientIfAvailable());
         LocallyRunOperatorExtension.applyCrd(VirtualKafkaCluster.class, OperatorTestUtils.kubeClientIfAvailable());
         assertThat(Metrics.globalRegistry.getMeters()).isEmpty();
-        operatorMain = new OperatorMain(() -> Metrics.globalRegistry);
+        operatorMain = new OperatorMain();
     }
 
     @AfterEach

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
@@ -6,6 +6,9 @@
 
 package io.kroxylicious.kubernetes.operator;
 
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -15,6 +18,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.OperatorException;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
@@ -84,7 +88,10 @@ class OperatorMainIT {
         operatorMain.run();
 
         // Then
-        assertThat(operatorMain.getRegistry().get("operator.sdk.events.received").meter().getId()).isNotNull();
+        Awaitility.await()
+                .atMost(10, TimeUnit.SECONDS)
+                .ignoreException(MeterNotFoundException.class)
+                .untilAsserted(() -> assertThat(operatorMain.getRegistry().get("operator.sdk.events.received").meter().getId()).isNotNull());
     }
 
     @Test

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
@@ -25,7 +25,7 @@ class OperatorMainIT {
     @BeforeEach
     void beforeEach() {
         assertThat(Metrics.globalRegistry.getMeters()).isEmpty();
-        operatorMain = new OperatorMain();
+        operatorMain = new OperatorMain(() -> Metrics.globalRegistry);
     }
 
     @AfterEach

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.kubernetes.operator;
 
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -43,6 +44,13 @@ class OperatorMainTest {
     void setUp() {
         expectApiResources();
         operatorMain = new OperatorMain(kubeClient);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (operatorMain != null) {
+            operatorMain.stop();
+        }
     }
 
     @Test

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
@@ -19,6 +19,7 @@ import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
+import io.micrometer.core.instrument.search.RequiredSearch;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 
 import java.util.concurrent.TimeUnit;
@@ -102,8 +103,8 @@ class OperatorMainTest {
         operatorMain.stop();
 
         // Then
-        assertThatThrownBy(() -> Metrics.globalRegistry.get("operator.sdk.reconciliations.executions.proxyreconciler")
-                .meter()).isInstanceOf(MeterNotFoundException.class);
+        final RequiredSearch metricSearch = Metrics.globalRegistry.get("operator.sdk.reconciliations.executions.proxyreconciler");
+        assertThatThrownBy(metricSearch::meter).isInstanceOf(MeterNotFoundException.class);
     }
 
     private void expectApiResources() {

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.kubernetes.operator;
 
+import java.util.concurrent.TimeUnit;
+
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,10 +21,7 @@ import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
-import io.micrometer.core.instrument.search.RequiredSearch;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
-
-import java.util.concurrent.TimeUnit;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
@@ -31,7 +30,6 @@ import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.filter.api.v1alpha1.KafkaProtocolFilter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @EnableKubernetesMockClient(crud = true)
 class OperatorMainTest {
@@ -66,7 +64,6 @@ class OperatorMainTest {
                 .hasAtLeastOneElementOfType(PrometheusMeterRegistry.class);
     }
 
-
     @Test
     void shouldRegisterOperatorMetrics() {
         // Given
@@ -93,18 +90,6 @@ class OperatorMainTest {
 
         // Then
         assertThat(Metrics.globalRegistry.get("operator.sdk.reconciliations.executions.proxyreconciler").meter().getId()).isNotNull();
-    }
-
-    @Test
-    void shouldRemoveMetricsOnStop() {
-        // Given
-
-        // When
-        operatorMain.stop();
-
-        // Then
-        final RequiredSearch metricSearch = Metrics.globalRegistry.get("operator.sdk.reconciliations.executions.proxyreconciler");
-        assertThatThrownBy(metricSearch::meter).isInstanceOf(MeterNotFoundException.class);
     }
 
     private void expectApiResources() {

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
@@ -54,7 +54,7 @@ class OperatorMainTest {
         // Given
 
         // When
-        operatorMain.run();
+        operatorMain.start();
 
         // Then
         verify(globalRegistry).add(argThat(PrometheusMeterRegistry.class::isInstance));
@@ -65,7 +65,7 @@ class OperatorMainTest {
     void shouldRegisterOperatorMetrics() {
         // Given
         final KafkaProxyBuilder proxyBuilder = new KafkaProxyBuilder().withKind("KafkaProxy").withNewMetadata().withName("myCoolProxy").endMetadata();
-        operatorMain.run();
+        operatorMain.start();
 
         // When
         kubeClient.resource(proxyBuilder.build()).create();
@@ -83,7 +83,7 @@ class OperatorMainTest {
         // Given
 
         // When
-        operatorMain.run();
+        operatorMain.start();
 
         // Then
         assertThat(operatorMain.getRegistry().get("operator.sdk.reconciliations.executions.proxyreconciler").meter().getId()).isNotNull();

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
@@ -40,6 +40,7 @@ import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.filter.api.v1alpha1.KafkaProtocolFilter;
 
 import lombok.SneakyThrows;
@@ -65,7 +66,8 @@ class OperatorMainTest {
     void setUp() {
         expectApiResources();
 
-        expectWatchOn("/apis/kroxylicious.io/v1alpha1/kafkaproxies", KafkaProxy.class, "kafkaproxie", "kroxylicious.io/v1alpha1", 1000);
+        expectWatchOn("/apis/kroxylicious.io/v1alpha1/kafkaproxies", KafkaProxy.class, "kafkaproxy", "kroxylicious.io/v1alpha1", 1000);
+        expectWatchOn("/apis/kroxylicious.io/v1alpha1/virtualkafkaclusters", VirtualKafkaCluster.class, "virtualkafkacluster", "kroxylicious.io/v1alpha1", 1000);
         expectWatchOn("/apis/filter.kroxylicious.io/v1alpha1/kafkaprotocolfilters", KafkaProtocolFilter.class, "kafkaprotocolfilter", "kroxylicious.io/v1alpha1", 0);
         expectWatchOn("/apis/apps/v1/deployments", Deployment.class, "deployment", "v1", 1000);
         expectWatchOn("/api/v1/secrets", Secret.class, "secret", "v1", 1000);

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
@@ -6,12 +6,9 @@
 
 package io.kroxylicious.kubernetes.operator;
 
-import java.util.concurrent.TimeUnit;
-
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIf;
 
 import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.CustomResource;
@@ -22,6 +19,8 @@ import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+
+import java.util.concurrent.TimeUnit;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
@@ -58,35 +57,6 @@ class OperatorMainTest {
                 .hasAtLeastOneElementOfType(PrometheusMeterRegistry.class);
     }
 
-    @Test
-    void shouldUseDefaultKubernetesClient() {
-        // Given
-
-        // When
-        final OperatorMain usesDefaultClient = new OperatorMain();
-
-        // Then
-        assertThat(usesDefaultClient).extracting("operator")
-                .isNotNull()
-                .extracting("configurationService")
-                .isNotNull()
-                .extracting("client")
-                .isNotNull()
-                .isNotSameAs(kubeClient);
-    }
-
-    @Test
-    @EnabledIf(value = "io.kroxylicious.kubernetes.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
-    void shouldRegisterPrometheusMeterRegistryViaDefaultConstructor() {
-        // Given
-
-        // When
-        new OperatorMain().start();
-
-        // Then
-        assertThat(Metrics.globalRegistry.getRegistries())
-                .hasAtLeastOneElementOfType(PrometheusMeterRegistry.class);
-    }
 
     @Test
     void shouldRegisterOperatorMetrics() {

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.net.HttpURLConnection;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.fabric8.kubernetes.api.model.APIResource;
+import io.fabric8.kubernetes.api.model.APIResourceBuilder;
+import io.fabric8.kubernetes.api.model.APIResourceList;
+import io.fabric8.kubernetes.api.model.APIResourceListBuilder;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResourceBuilder;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.ListMetaBuilder;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.WatchEvent;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import io.fabric8.mockwebserver.dsl.Emitable;
+import io.fabric8.mockwebserver.dsl.EventDoneable;
+import io.fabric8.mockwebserver.dsl.TimesOnceableOrHttpHeaderable;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.filter.api.v1alpha1.KafkaProtocolFilter;
+
+import lombok.SneakyThrows;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@EnableKubernetesMockClient()
+class OperatorMainTest {
+
+    private static final String START_RESOURCE_VERSION = "1000";
+    KubernetesClient kubeClient;
+    KubernetesMockServer mockServer;
+
+    private OperatorMain operatorMain;
+
+    @Mock
+    CompositeMeterRegistry globalRegistry;
+
+    @BeforeEach
+    void setUp() {
+        expectApiResources();
+
+        expectWatchOn("/apis/kroxylicious.io/v1alpha1/kafkaproxies", KafkaProxy.class, "kafkaproxie", "kroxylicious.io/v1alpha1", 1000);
+        expectWatchOn("/apis/filter.kroxylicious.io/v1alpha1/kafkaprotocolfilters", KafkaProtocolFilter.class, "kafkaprotocolfilter", "kroxylicious.io/v1alpha1", 0);
+        expectWatchOn("/apis/apps/v1/deployments", Deployment.class, "deployment", "v1", 1000);
+        expectWatchOn("/api/v1/secrets", Secret.class, "secret", "v1", 1000);
+        expectWatchOn("/api/v1/services", Service.class, "service", "v1", 1000);
+
+        operatorMain = new OperatorMain(() -> globalRegistry, kubeClient);
+    }
+
+    @Test
+    void shouldRegisterPrometheusMeterRegistry() {
+        // Given
+
+        // When
+        operatorMain.run();
+
+        // Then
+        verify(globalRegistry).add(argThat(PrometheusMeterRegistry.class::isInstance));
+        mockServer.shutdown();
+    }
+
+    @Test
+    void shouldRegisterOperatorMetrics() {
+        // Given
+
+        // When
+        operatorMain.run();
+
+        // Then
+        Awaitility.await()
+                .atMost(10, TimeUnit.SECONDS)
+                .ignoreException(MeterNotFoundException.class)
+                .untilAsserted(() -> assertThat(operatorMain.getRegistry().get("operator.sdk.events.received").meter().getId()).isNotNull());
+
+    }
+
+    @Test
+    void shouldRegisterMetricsForProxyReconciler() {
+        // Given
+
+        // When
+        operatorMain.run();
+
+        // Then
+        assertThat(operatorMain.getRegistry().get("operator.sdk.reconciliations.executions.proxyreconciler").meter().getId()).isNotNull();
+    }
+
+    private void expectApiResources() {
+        final APIResource kafkaProtocolFilterCrd = new APIResourceBuilder()
+                .withCategories("kroxylicious-plugins")
+                .withKind("KafkaProtocolFilter")
+                .withName("kafkaprotocolfilters")
+                .withNamespaced(true)
+                .withShortNames("kpf")
+                .withSingularName("kafkaprotocolfilter")
+                .withVerbs("delete", "deletecollection", "get", "list", "patch", "create", "update", "watch")
+                .build();
+
+        final APIResourceList apiResourceList = new APIResourceListBuilder()
+                .withGroupVersion("filter.kroxylicious.io/v1alpha1")
+                .withApiVersion("v1")
+                .addToResources(kafkaProtocolFilterCrd)
+                .build();
+
+        mockServer.expect()
+                .get()
+                .withPath("/apis/filter.kroxylicious.io/v1alpha1")
+                .andReturn(HttpURLConnection.HTTP_OK, apiResourceList)
+                .always();
+
+        mockServer.expect()
+                .get()
+                .withPath("/apis/kroxylicious.io/v1alpha1/namespaces/randomNs/kafkaproxies")
+                .andReturn(HttpURLConnection.HTTP_OK, new GenericKubernetesResourceBuilder()
+                        .withKind("KafkProxy")
+                        .withApiVersion("kroxylicious.io/v1alpha1")
+                        .withNewMetadata()
+                        .withName("random")
+                        .withNamespace("randomNs")
+                        .endMetadata()
+                        .build())
+                .always();
+    }
+
+    @SneakyThrows
+    private <T extends HasMetadata> void expectWatchOn(String path, Class<T> resultType, String kind, String apiVersion, int delayMs) {
+        mockServer.expect()
+                .get()
+                .withPath(path + "?resourceVersion=0")
+                .andReturn(HttpURLConnection.HTTP_OK, getList(resultType, kind, apiVersion))
+                .always();
+        final EventDoneable<TimesOnceableOrHttpHeaderable<Void>> websocket = mockServer.expect()
+                .withPath(path + "?allowWatchBookmarks=true&resourceVersion=" + START_RESOURCE_VERSION + "&timeoutSeconds=600&watch=true")
+                .andUpgradeToWebSocket()
+                .open();
+        configureDelay(delayMs, websocket)
+                .andEmit(new WatchEvent(new GenericKubernetesResourceBuilder()
+                        .withKind(kind)
+                        .withApiVersion(apiVersion)
+                        .withNewMetadata()
+                        .withName("random")
+                        .withNamespace("randomNs")
+                        .endMetadata()
+                        .build(), "ADDED"))
+                .done()
+                .always();
+    }
+
+    private static Emitable<EventDoneable<TimesOnceableOrHttpHeaderable<Void>>> configureDelay(int delayMs,
+                                                                                               EventDoneable<TimesOnceableOrHttpHeaderable<Void>> websocket) {
+        if (delayMs > 0) {
+            return websocket.waitFor(delayMs);
+        }
+        else {
+            return websocket.immediately();
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private <T extends HasMetadata> KubernetesList getList(Class<T> resourceClass, String kind, String apiVersion) {
+        return new KubernetesListBuilder()
+                .withKind(kind)
+                .withApiVersion(apiVersion)
+                .withMetadata(new ListMetaBuilder().withResourceVersion(START_RESOURCE_VERSION).build())
+                .build();
+    }
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
@@ -64,7 +64,7 @@ class OperatorMainTest {
     @Test
     void shouldRegisterOperatorMetrics() {
         // Given
-        final KafkaProxyBuilder proxyBuilder = new KafkaProxyBuilder().withKind("KafkaProxy").withNewMetadata().withName("myCoolProxy").endMetadata();
+        final KafkaProxyBuilder proxyBuilder = new KafkaProxyBuilder().withKind("KafkaProxy").withNewMetadata().withName("mycoolproxy").endMetadata();
         operatorMain.start();
 
         // When

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
@@ -86,9 +86,10 @@ class OperatorMainTest {
     @Test
     void shouldRegisterOperatorMetrics() {
         // Given
+        operatorMain.run();
 
         // When
-        operatorMain.run();
+
 
         // Then
         Awaitility.await()
@@ -130,19 +131,6 @@ class OperatorMainTest {
                 .get()
                 .withPath("/apis/filter.kroxylicious.io/v1alpha1")
                 .andReturn(HttpURLConnection.HTTP_OK, apiResourceList)
-                .always();
-
-        mockServer.expect()
-                .get()
-                .withPath("/apis/kroxylicious.io/v1alpha1/namespaces/randomNs/kafkaproxies")
-                .andReturn(HttpURLConnection.HTTP_OK, new GenericKubernetesResourceBuilder()
-                        .withKind("KafkProxy")
-                        .withApiVersion("kroxylicious.io/v1alpha1")
-                        .withNewMetadata()
-                        .withName("random")
-                        .withNamespace("randomNs")
-                        .endMetadata()
-                        .build())
                 .always();
     }
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.kubernetes.operator;
 
+import java.util.concurrent.TimeUnit;
+
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,8 +20,6 @@ import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
-
-import java.util.concurrent.TimeUnit;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
 import io.kroxylicious.kubernetes.filter.api.v1alpha1.KafkaProtocolFilter;
@@ -75,9 +75,9 @@ class OperatorMainTest {
 
         // Then
         Awaitility.await()
-                  .atMost(10, TimeUnit.SECONDS)
-                  .ignoreException(MeterNotFoundException.class)
-                  .untilAsserted(() -> assertThat(operatorMain.getRegistry().get("operator.sdk.events.received").meter().getId()).isNotNull());
+                .atMost(10, TimeUnit.SECONDS)
+                .ignoreException(MeterNotFoundException.class)
+                .untilAsserted(() -> assertThat(operatorMain.getRegistry().get("operator.sdk.events.received").meter().getId()).isNotNull());
 
     }
 
@@ -94,12 +94,12 @@ class OperatorMainTest {
 
     private void expectApiResources() {
         final CustomResourceDefinition kafkaProtocolFilterCrd = CustomResourceDefinitionContext.v1CRDFromCustomResourceType(KafkaProtocolFilter.class).withNewMetadata()
-                                                                                               .endMetadata()
-                                                                                               .build();
+                .endMetadata()
+                .build();
         mockServer.expectCustomResource(CustomResourceDefinitionContext.fromCrd(kafkaProtocolFilterCrd));
         final CustomResourceDefinition kafkaProxyCrd = CustomResourceDefinitionContext.v1CRDFromCustomResourceType(KafkaProtocolFilter.class).withNewMetadata()
-                                                                                      .endMetadata()
-                                                                                      .build();
+                .endMetadata()
+                .build();
         mockServer.expectCustomResource(CustomResourceDefinitionContext.fromCrd(kafkaProxyCrd));
     }
 }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
@@ -44,8 +44,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 
-import lombok.SneakyThrows;
-
 @ExtendWith(MockitoExtension.class)
 @EnableKubernetesMockClient(crud = true)
 class OperatorMainTest {
@@ -148,7 +146,6 @@ class OperatorMainTest {
                 .always();
     }
 
-    @SneakyThrows
     private <T extends HasMetadata> void expectWatchOn(String path, Class<T> resultType, String kind, String apiVersion, int delayMs) {
         mockServer.expect()
                 .get()

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
@@ -6,7 +6,6 @@
 
 package io.kroxylicious.kubernetes.operator;
 
-import java.net.HttpURLConnection;
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
@@ -16,28 +15,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import io.fabric8.kubernetes.api.model.APIResource;
-import io.fabric8.kubernetes.api.model.APIResourceBuilder;
-import io.fabric8.kubernetes.api.model.APIResourceList;
-import io.fabric8.kubernetes.api.model.APIResourceListBuilder;
-import io.fabric8.kubernetes.api.model.GenericKubernetesResourceBuilder;
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
-import io.fabric8.kubernetes.api.model.ListMetaBuilder;
-import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.WatchEvent;
-import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.base.CustomResourceDefinitionContext;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
-import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
 import io.kroxylicious.kubernetes.filter.api.v1alpha1.KafkaProtocolFilter;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,7 +35,6 @@ import static org.mockito.Mockito.verify;
 @EnableKubernetesMockClient(crud = true)
 class OperatorMainTest {
 
-    private static final String START_RESOURCE_VERSION = "1000";
     KubernetesClient kubeClient;
     KubernetesMockServer mockServer;
 
@@ -60,14 +46,6 @@ class OperatorMainTest {
     @BeforeEach
     void setUp() {
         expectApiResources();
-
-        expectWatchOn("/apis/kroxylicious.io/v1alpha1/kafkaproxies", KafkaProxy.class, "kafkaproxy", "kroxylicious.io/v1alpha1", 1000);
-        expectWatchOn("/apis/kroxylicious.io/v1alpha1/virtualkafkaclusters", VirtualKafkaCluster.class, "virtualkafkacluster", "kroxylicious.io/v1alpha1", 1000);
-        expectWatchOn("/apis/filter.kroxylicious.io/v1alpha1/kafkaprotocolfilters", KafkaProtocolFilter.class, "kafkaprotocolfilter", "kroxylicious.io/v1alpha1", 0);
-        expectWatchOn("/apis/apps/v1/deployments", Deployment.class, "deployment", "v1", 1000);
-        expectWatchOn("/api/v1/secrets", Secret.class, "secret", "v1", 1000);
-        expectWatchOn("/api/v1/services", Service.class, "service", "v1", 1000);
-
         operatorMain = new OperatorMain(() -> globalRegistry, kubeClient);
     }
 
@@ -86,10 +64,11 @@ class OperatorMainTest {
     @Test
     void shouldRegisterOperatorMetrics() {
         // Given
+        final KafkaProxyBuilder proxyBuilder = new KafkaProxyBuilder().withKind("KafkaProxy").withNewMetadata().withName("myCoolProxy").endMetadata();
         operatorMain.run();
 
         // When
-
+        kubeClient.resource(proxyBuilder.build()).create();
 
         // Then
         Awaitility.await()
@@ -111,58 +90,13 @@ class OperatorMainTest {
     }
 
     private void expectApiResources() {
-        final APIResource kafkaProtocolFilterCrd = new APIResourceBuilder()
-                .withCategories("kroxylicious-plugins")
-                .withKind("KafkaProtocolFilter")
-                .withName("kafkaprotocolfilters")
-                .withNamespaced(true)
-                .withShortNames("kpf")
-                .withSingularName("kafkaprotocolfilter")
-                .withVerbs("delete", "deletecollection", "get", "list", "patch", "create", "update", "watch")
+        final CustomResourceDefinition kafkaProtocolFilterCrd = CustomResourceDefinitionContext.v1CRDFromCustomResourceType(KafkaProtocolFilter.class).withNewMetadata()
+                .endMetadata()
                 .build();
-
-        final APIResourceList apiResourceList = new APIResourceListBuilder()
-                .withGroupVersion("filter.kroxylicious.io/v1alpha1")
-                .withApiVersion("v1")
-                .addToResources(kafkaProtocolFilterCrd)
+        mockServer.expectCustomResource(CustomResourceDefinitionContext.fromCrd(kafkaProtocolFilterCrd));
+        final CustomResourceDefinition kafkaProxyCrd = CustomResourceDefinitionContext.v1CRDFromCustomResourceType(KafkaProtocolFilter.class).withNewMetadata()
+                .endMetadata()
                 .build();
-
-        mockServer.expect()
-                .get()
-                .withPath("/apis/filter.kroxylicious.io/v1alpha1")
-                .andReturn(HttpURLConnection.HTTP_OK, apiResourceList)
-                .always();
-    }
-
-    private <T extends HasMetadata> void expectWatchOn(String path, Class<T> resultType, String kind, String apiVersion, int delayMs) {
-        mockServer.expect()
-                .get()
-                .withPath(path + "?resourceVersion=0")
-                .andReturn(HttpURLConnection.HTTP_OK, getList(resultType, kind, apiVersion))
-                .always();
-        mockServer.expect()
-                .withPath(path + "?allowWatchBookmarks=true&resourceVersion=" + START_RESOURCE_VERSION + "&timeoutSeconds=600&watch=true")
-                .andUpgradeToWebSocket()
-                .open()
-                .waitFor(delayMs)
-                .andEmit(new WatchEvent(new GenericKubernetesResourceBuilder()
-                        .withKind(kind)
-                        .withApiVersion(apiVersion)
-                        .withNewMetadata()
-                        .withName("random")
-                        .withNamespace("randomNs")
-                        .endMetadata()
-                        .build(), "ADDED"))
-                .done()
-                .always();
-    }
-
-    @SuppressWarnings("unused")
-    private <T extends HasMetadata> KubernetesList getList(Class<T> resourceClass, String kind, String apiVersion) {
-        return new KubernetesListBuilder()
-                .withKind(kind)
-                .withApiVersion(apiVersion)
-                .withMetadata(new ListMetaBuilder().withResourceVersion(START_RESOURCE_VERSION).build())
-                .build();
+        mockServer.expectCustomResource(CustomResourceDefinitionContext.fromCrd(kafkaProxyCrd));
     }
 }


### PR DESCRIPTION
### Type of change


- Enhancement / new feature

### Description

Fixes #1865 by enabling the collection of operator standard metrics.

### Additional Context
#1866 will be needed to make these metric available to the cluster monitoring systems.


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
