### PR TITLE
Change virtual cluster map into a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#1847](https://github.com/kroxylicious/kroxylicious/pull/1847) Remodel virtual cluster map as a list (with explicit names).
 * [#1840](https://github.com/kroxylicious/kroxylicious/pull/1840) Refactor virtual cluster configuration model
 * [#1823](https://github.com/kroxylicious/kroxylicious/pull/1823) Allow VirtualClusters to express more than one listener
 * [#1868](https://github.com/kroxylicious/kroxylicious/pull/1868) Support use of `$()` in KEK selector templates, deprecating `${}`
@@ -23,6 +24,9 @@ Format `<github issue/pr number>: <short description>`.
   are deprecated.  Define a virtual cluster gateway with `portIdentifiesNode` to express your networking requirements.
 * The networking scheme `SniRoutingClusterNetworkAddressConfigProvider` is deprecated.  Define a virtual cluster gateway with
   `sniHostIdentifiesNode` to express your networking requirements.
+* The `virtualClusters` configuration property now expects a list of `virtualCluster` objects (rather than a mapping
+  of `name` to `virtualCluster`).  Furthermore, the `virtualCluster` object now requires a `name` configuration property.
+  For backward compatibility, support for the map (and values without `name`) continues, but this will be removed in a future release.
 
 ## 0.10.0
 

--- a/docs/modules/configuring/con-configuration-outline.adoc
+++ b/docs/modules/configuring/con-configuration-outline.adoc
@@ -17,7 +17,7 @@ filterDefinitions: # <1>
 defaultFilters: <5>
   - example
 virtualClusters: # <6>
-  my-cluster-proxy:
+  - name: my-cluster-proxy
     targetCluster: # <7>
       # ...
     gateways: # <8>

--- a/docs/modules/configuring/con-configuring-filters.adoc
+++ b/docs/modules/configuring/con-configuring-filters.adoc
@@ -25,9 +25,9 @@ defaultFilters:
   - validation
   - encryption
 virtualClusters:
-  my-proxy-with-default-filters:
+  - name: my-proxy-with-default-filters
     # ...
-  my-proxy-with-custom-filters:
+  - name: my-proxy-with-custom-filters
     filters:
       - validation
       - special-encryption
@@ -56,7 +56,7 @@ filters: # deprecated!
     config:
       # ...
 virtualClusters:
-  my-proxy-with-default-filters:
+  - name: my-proxy-with-default-filters
     # ...
 ----
 

--- a/docs/modules/configuring/con-configuring-vc-client-tls.adoc
+++ b/docs/modules/configuring/con-configuring-vc-client-tls.adoc
@@ -24,7 +24,7 @@ NOTE: TLS is recommended for production configurations.
 ----
 # ...
 virtualClusters:
-  my-cluster-proxy:
+  - name: my-cluster-proxy
     # ...
     gateways:
     - name: mygateway
@@ -49,7 +49,7 @@ virtualClusters:
 ----
 # ...
 virtualClusters:
-  my-cluster-proxy:
+  - name: my-cluster-proxy
     # ...
     gateways:
     - name: mygateway
@@ -75,7 +75,7 @@ If verification fails, the client's connection is refused.
 ----
 # ...
 virtualClusters:
-  my-cluster-proxy:
+  - name: my-cluster-proxy
     # ...
     gateways:
     - name: mygateway
@@ -119,7 +119,7 @@ The names of the TLS protocols are defined by {java-17-specs}/security/standard-
 [source,yaml]
 ----
 virtualClusters:
-  my-cluster-proxy:
+  - name: my-cluster-proxy
     # ...
     gateways:
     - name: mygateway
@@ -138,7 +138,7 @@ virtualClusters:
 [source,yaml]
 ----
 virtualClusters:
-  my-cluster-proxy:
+  - name: my-cluster-proxy
     # ...
     gateways:
     - name: mygateway
@@ -167,6 +167,7 @@ The names of the cipher suite are defined by {java-17-specs}/security/standard-n
 [source,yaml]
 ----
 virtualClusters:
+  - name: my-cluster-proxy
     # ...
     gateways:
     - name: mygateway
@@ -185,6 +186,7 @@ virtualClusters:
 [source,yaml]
 ----
 virtualClusters:
+  - name: my-cluster-proxy
     # ...
     gateways:
     - name: mygateway

--- a/docs/modules/configuring/con-configuring-vc-gateways.adoc
+++ b/docs/modules/configuring/con-configuring-vc-gateways.adoc
@@ -38,7 +38,7 @@ IMPORTANT: When using this scheme, you have the responsibility to avoid port num
 ----
 # ...
 virtualClusters:
-  my-cluster-proxy:
+  - name: my-cluster-proxy
     # ...
     gateways:
     - name: mygateway
@@ -74,7 +74,7 @@ The gateway exposes the following three broker addresses:
 ----
 # ...
 virtualClusters:
-  my-cluster-proxy:
+  - name: my-cluster-proxy
     # ...
     gateways:
     - name: mygateway
@@ -114,7 +114,7 @@ The gateway exposes the following three broker addresses:
 ----
 # ...
 virtualClusters:
-  my-cluster-proxy:
+  - name: my-cluster-proxy
     # ...
     gateways:
     - name: mygateway
@@ -187,7 +187,7 @@ to an IP address that is routed to the proxy. Wildcard DNS is one way to achieve
 ----
 # ...
 virtualClusters:
-  my-cluster-proxy:
+  - name: my-cluster-proxy
     # ...
     gateways:
     - name: mygateway
@@ -231,7 +231,7 @@ The gateway exposes the following broker addresses:
 ----
 # ...
 virtualClusters:
-  my-cluster-proxy:
+  - name: my-cluster-proxy
     # ...
     gateways:
     - name: mygateway

--- a/docs/modules/configuring/con-configuring-vc-other-settings.adoc
+++ b/docs/modules/configuring/con-configuring-vc-other-settings.adoc
@@ -14,7 +14,7 @@ The `logFrames` property controls logging of the decoded requests and responses.
 ----
 # ...
 virtualClusters:
-  my-cluster-proxy:
+  - name: my-cluster-proxy
     # ...
     logNetwork: true <1>
     logFrames: true <2>

--- a/docs/modules/configuring/con-configuring-vc-target-tls.adoc
+++ b/docs/modules/configuring/con-configuring-vc-target-tls.adoc
@@ -24,7 +24,7 @@ certificate signed by a public CA and the platform's defaults are suitable.
 ----
 # ...
 virtualClusters:
-  my-cluster-proxy:
+  - name: my-cluster-proxy
     # ...
     targetCluster:
       bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
@@ -40,7 +40,7 @@ The example illustrates using PKCS #12 format. PEM format is supported too.
 ----
 # ...
 virtualClusters:
-  my-cluster-proxy:
+  - name: my-cluster-proxy
     # ...
     targetCluster:
       bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
@@ -65,7 +65,7 @@ PKCS #12 keystore format is supported too.
 ----
 # ...
 virtualClusters:
-  my-cluster-proxy:
+  - name: my-cluster-proxy
     # ...
     targetCluster:
       bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
@@ -85,7 +85,7 @@ The TLS protocols and cipher suites available to the TLS connection may also be 
 ----
 # ...
 virtualClusters:
-  my-cluster-proxy:
+  - name: my-cluster-proxy
     # ...
     targetCluster:
       bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
@@ -103,7 +103,7 @@ virtualClusters:
 [source,yaml]
 ----
 virtualClusters:
-  my-cluster-proxy:
+  - name: my-cluster-proxy
     targetCluster:
       bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
       tls:
@@ -119,7 +119,7 @@ virtualClusters:
 [source,yaml]
 ----
 virtualClusters:
-  my-cluster-proxy:
+  - name: my-cluster-proxy
     targetCluster:
       bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
       tls:
@@ -136,8 +136,7 @@ virtualClusters:
 [source,yaml]
 ----
 virtualClusters:
-  demo:
-  my-cluster-proxy:
+  - name: my-cluster-proxy
     targetCluster:
       bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
       tls:
@@ -156,7 +155,7 @@ any Kafka cluster.
 [source,yaml]
 ----
 virtualClusters:
-  my-cluster-proxy:
+  - name: my-cluster-proxy
     targetCluster:
       bootstrapServers: dev-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
       tls:

--- a/docs/modules/configuring/ref-configuring-proxy-example.adoc
+++ b/docs/modules/configuring/ref-configuring-proxy-example.adoc
@@ -34,7 +34,7 @@ filterDefinitions: # <1>
 defaultFilters:
   - encryption
 virtualClusters: # <5>
-  my-cluster-proxy: # <6>
+  - name: my-cluster-proxy # <6>
     targetCluster:
       bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093 # <7>
       tls: # <8>

--- a/kroxylicious-app/example-proxy-config.yaml
+++ b/kroxylicious-app/example-proxy-config.yaml
@@ -9,7 +9,7 @@ adminHttp:
   endpoints:
     prometheus: {}
 virtualClusters:
-  demo:
+  - name: demo
     targetCluster:
       bootstrapServers: localhost:9092
     gateways:

--- a/kroxylicious-app/src/test/resources/proxy-config.yaml
+++ b/kroxylicious-app/src/test/resources/proxy-config.yaml
@@ -9,7 +9,7 @@ adminHttp:
   endpoints:
     prometheus: {}
 virtualClusters:
-  demo:
+  - name: demo
     targetCluster:
       bootstrapServers: localhost:9092
     gateways:

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
@@ -83,7 +83,7 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     private String onlyVirtualCluster() {
         int numVirtualClusters = kroxyliciousConfig.virtualClusters().size();
         if (numVirtualClusters == 1) {
-            return kroxyliciousConfig.virtualClusters().keySet().stream().findFirst().orElseThrow();
+            return kroxyliciousConfig.virtualClusters().stream().map(VirtualCluster::name).findFirst().orElseThrow();
         }
         else {
             throw new AmbiguousVirtualClusterException(
@@ -118,10 +118,10 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     }
 
     private void configureClientTls(String virtualCluster, Map<String, Object> defaultClientConfig, String gateway) {
-        final VirtualCluster definedCluster = kroxyliciousConfig.virtualClusters().get(virtualCluster);
-        if (definedCluster != null) {
+        var definedCluster = kroxyliciousConfig.virtualClusters().stream().filter(v -> v.name().equals(virtualCluster)).findFirst();
+        definedCluster.ifPresent(cluster -> {
 
-            var first = getVirtualClusterGatewayStream(definedCluster).filter(g -> g.name().equals(gateway)).findFirst();
+            var first = getVirtualClusterGatewayStream(cluster).filter(g -> g.name().equals(gateway)).findFirst();
             var vcl = first.orElseThrow(() -> new IllegalArgumentException("cluster " + virtualCluster + " does not contain gateway named " + gateway));
             final Optional<Tls> tls = vcl.tls();
             if (tls.isPresent()) {
@@ -132,7 +132,7 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
                     defaultClientConfig.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, storeConfiguration.trustStorePassword());
                 }
             }
-        }
+        });
     }
 
     @Override

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
@@ -52,6 +52,7 @@ class ConfigurationTest {
     void shouldAcceptOldBootstrapServers() throws IOException {
         var vc = MAPPER.readValue(
                 """
+                              name: cluster
                               targetCluster:
                                 bootstrap_servers: kafka.example:1234
                               gateways:
@@ -109,6 +110,7 @@ class ConfigurationTest {
         assertThatThrownBy(() -> {
             MAPPER.readValue(
                     """
+                              name: cluster
                               targetCluster:
                                 bootstrap_servers: kafka.example:1234
                             """, VirtualCluster.class);
@@ -122,6 +124,7 @@ class ConfigurationTest {
         assertThatThrownBy(() -> {
             MAPPER.readValue(
                     """
+                              name: cluster
                               targetCluster:
                                 bootstrap_servers: kafka.example:1234
                               gateways: null
@@ -136,6 +139,7 @@ class ConfigurationTest {
         assertThatThrownBy(() -> {
             MAPPER.readValue(
                     """
+                              name: cluster
                               targetCluster:
                                 bootstrap_servers: kafka.example:1234
                               gateways: [null]
@@ -150,6 +154,7 @@ class ConfigurationTest {
         assertThatThrownBy(() -> {
             MAPPER.readValue(
                     """
+                              name: cluster
                               targetCluster:
                                 bootstrap_servers: kafka.example:1234
                               tls:
@@ -169,6 +174,7 @@ class ConfigurationTest {
         assertThatThrownBy(() -> {
             MAPPER.readValue(
                     """
+                              name: cluster
                               targetCluster:
                                 bootstrap_servers: kafka.example:1234
                               tls:
@@ -189,6 +195,7 @@ class ConfigurationTest {
         assertThatThrownBy(() -> {
             MAPPER.readValue(
                     """
+                              name: cluster
                               targetCluster:
                                 bootstrap_servers: kafka.example:1234
                               gateways:
@@ -216,6 +223,7 @@ class ConfigurationTest {
     void shouldAcceptDeprecatedTopLevelNetworkConfigProvider() throws IOException {
         var vc = MAPPER.readValue(
                 """
+                                  name: cluster
                                   targetCluster:
                                     bootstrap_servers: kafka.example:1234
                                   clusterNetworkAddressConfigProvider:
@@ -234,6 +242,7 @@ class ConfigurationTest {
     void shouldAcceptDeprecatedTopLevelTls() throws IOException {
         var vc = MAPPER.readValue(
                 """
+                                  name: cluster
                                   targetCluster:
                                     bootstrap_servers: kafka.example:1234
                                   clusterNetworkAddressConfigProvider:
@@ -296,7 +305,8 @@ class ConfigurationTest {
                                 """),
                 argumentSet("With Virtual Cluster - single gateway",
                         new ConfigurationBuilder()
-                                .addToVirtualClusters("demo", new VirtualClusterBuilder()
+                                .addToVirtualClusters(new VirtualClusterBuilder()
+                                        .withName("demo")
                                         .withNewTargetCluster()
                                         .withBootstrapServers("kafka.example:1234")
                                         .endTargetCluster()
@@ -305,7 +315,7 @@ class ConfigurationTest {
                                 .build(),
                         """
                                 virtualClusters:
-                                  demo:
+                                  - name: demo
                                     targetCluster:
                                       bootstrapServers: kafka.example:1234
                                     gateways:
@@ -315,7 +325,8 @@ class ConfigurationTest {
                                 """),
                 argumentSet("With Virtual Cluster - multiple gateways",
                         new ConfigurationBuilder()
-                                .addToVirtualClusters("demo", new VirtualClusterBuilder()
+                                .addToVirtualClusters(new VirtualClusterBuilder()
+                                        .withName("demo")
                                         .withNewTargetCluster()
                                         .withBootstrapServers("kafka.example:1234")
                                         .endTargetCluster()
@@ -335,7 +346,7 @@ class ConfigurationTest {
                                 .build(),
                         """
                                 virtualClusters:
-                                  demo:
+                                  - name: demo
                                     targetCluster:
                                       bootstrapServers: kafka.example:1234
                                     gateways:
@@ -348,7 +359,8 @@ class ConfigurationTest {
                                 """),
                 argumentSet("Downstream TLS - default client auth",
                         new ConfigurationBuilder()
-                                .addToVirtualClusters("demo", new VirtualClusterBuilder()
+                                .addToVirtualClusters(new VirtualClusterBuilder()
+                                        .withName("demo")
                                         .withNewTargetCluster()
                                         .withBootstrapServers("kafka.example:1234")
                                         .endTargetCluster()
@@ -365,7 +377,7 @@ class ConfigurationTest {
                                 .build(),
                         """
                                 virtualClusters:
-                                  demo:
+                                  - name: demo
                                     targetCluster:
                                       bootstrapServers: kafka.example:1234
                                     gateways:
@@ -382,7 +394,8 @@ class ConfigurationTest {
                                 """),
                 argumentSet("Downstream TLS - required client auth",
                         new ConfigurationBuilder()
-                                .addToVirtualClusters("demo", new VirtualClusterBuilder()
+                                .addToVirtualClusters(new VirtualClusterBuilder()
+                                        .withName("demo")
                                         .withNewTargetCluster()
                                         .withBootstrapServers("kafka.example:1234")
                                         .endTargetCluster()
@@ -404,7 +417,7 @@ class ConfigurationTest {
                                 .build(),
                         """
                                 virtualClusters:
-                                  demo:
+                                  - name: demo
                                     targetCluster:
                                       bootstrapServers: kafka.example:1234
                                     gateways:
@@ -425,7 +438,8 @@ class ConfigurationTest {
                                 """),
                 argumentSet("Upstream TLS - platform trust",
                         new ConfigurationBuilder()
-                                .addToVirtualClusters("demo", new VirtualClusterBuilder()
+                                .addToVirtualClusters(new VirtualClusterBuilder()
+                                        .withName("demo")
                                         .withNewTargetCluster()
                                         .withBootstrapServers("kafka.example:1234")
                                         .withNewTls()
@@ -436,7 +450,7 @@ class ConfigurationTest {
                                 .build(),
                         """
                                 virtualClusters:
-                                  demo:
+                                  - name: demo
                                     targetCluster:
                                       bootstrapServers: kafka.example:1234
                                       tls: {}
@@ -447,7 +461,8 @@ class ConfigurationTest {
                                 """),
                 argumentSet("Upstream TLS - trust from truststore",
                         new ConfigurationBuilder()
-                                .addToVirtualClusters("demo", new VirtualClusterBuilder()
+                                .addToVirtualClusters(new VirtualClusterBuilder()
+                                        .withName("demo")
                                         .withNewTargetCluster()
                                         .withBootstrapServers("kafka.example:1234")
                                         .withNewTls()
@@ -463,7 +478,7 @@ class ConfigurationTest {
                                 .build(),
                         """
                                 virtualClusters:
-                                  demo:
+                                  - name: demo
                                     targetCluster:
                                       bootstrapServers: kafka.example:1234
                                       tls:
@@ -479,7 +494,8 @@ class ConfigurationTest {
                                 """),
                 argumentSet("Upstream TLS - trust from truststore, password from file",
                         new ConfigurationBuilder()
-                                .addToVirtualClusters("demo", new VirtualClusterBuilder()
+                                .addToVirtualClusters(new VirtualClusterBuilder()
+                                        .withName("demo")
                                         .withNewTargetCluster()
                                         .withBootstrapServers("kafka.example:1234")
                                         .withNewTls()
@@ -495,7 +511,7 @@ class ConfigurationTest {
                                 .build(),
                         """
                                 virtualClusters:
-                                  demo:
+                                  - name: demo
                                     targetCluster:
                                       bootstrapServers: kafka.example:1234
                                       tls:
@@ -511,7 +527,8 @@ class ConfigurationTest {
                                 """),
                 argumentSet("Upstream TLS - insecure",
                         new ConfigurationBuilder()
-                                .addToVirtualClusters("demo", new VirtualClusterBuilder()
+                                .addToVirtualClusters(new VirtualClusterBuilder()
+                                        .withName("demo")
                                         .withNewTargetCluster()
                                         .withBootstrapServers("kafka.example:1234")
                                         .withNewTls()
@@ -523,7 +540,7 @@ class ConfigurationTest {
                                 .build(),
                         """
                                 virtualClusters:
-                                  demo:
+                                  - name: demo
                                     targetCluster:
                                       bootstrapServers: kafka.example:1234
                                       tls:
@@ -561,7 +578,7 @@ class ConfigurationTest {
     }
 
     @Test
-    @SuppressWarnings("java:S5738")
+    @SuppressWarnings({ "java:S5738", "removal" })
     void shouldRejectBothFiltersAndFilterDefinitions() {
         List<NamedFilterDefinition> filterDefinitions = List.of(new NamedFilterDefinition("foo", "", ""));
         List<FilterDefinition> filters = List.of(new FilterDefinition("", ""));
@@ -579,7 +596,7 @@ class ConfigurationTest {
     }
 
     @Test
-    @SuppressWarnings("java:S5738")
+    @SuppressWarnings({ "java:S5738", "removal" })
     void shouldRejectFilterDefinitionsWithSameName() {
         List<NamedFilterDefinition> filterDefinitions = List.of(
                 new NamedFilterDefinition("foo", "", ""),
@@ -616,7 +633,9 @@ class ConfigurationTest {
         Optional<Map<String, Object>> development = Optional.empty();
         List<NamedFilterDefinition> filterDefinitions = List.of();
         List<VirtualClusterGateway> defaultGateway = List.of(VIRTUAL_CLUSTER_GATEWAY);
-        Map<String, VirtualCluster> virtualClusters = Map.of("vc1", new VirtualCluster(null, null, Optional.empty(), defaultGateway, false, false, List.of("missing")));
+        TargetCluster targetCluster = new TargetCluster("unused:9082", Optional.empty());
+        List<VirtualCluster> virtualClusters = List
+                .of(new VirtualCluster("vc1", targetCluster, null, Optional.empty(), defaultGateway, false, false, List.of("missing")));
         assertThatThrownBy(() -> new Configuration(
                 null, filterDefinitions,
                 null,
@@ -639,7 +658,8 @@ class ConfigurationTest {
 
         List<String> defaultFilters = List.of("used1");
         List<VirtualClusterGateway> defaultGateway = List.of(VIRTUAL_CLUSTER_GATEWAY);
-        Map<String, VirtualCluster> virtualClusters = Map.of("vc1", new VirtualCluster(null, null, Optional.empty(), defaultGateway, false, false, List.of("used2")));
+        TargetCluster targetCluster = new TargetCluster("unused:9082", Optional.empty());
+        List<VirtualCluster> virtualClusters = List.of(new VirtualCluster("vc1", targetCluster, null, Optional.empty(), defaultGateway, false, false, List.of("used2")));
         assertThatThrownBy(() -> new Configuration(null, filterDefinitions,
                 defaultFilters,
                 virtualClusters,
@@ -650,11 +670,12 @@ class ConfigurationTest {
     }
 
     @Test
-    @SuppressWarnings("java:S5738")
+    @SuppressWarnings({ "java:S5738", "removal" })
     void shouldRejectVirtualClusterFiltersWhenTopLevelFilters() {
         Optional<Map<String, Object>> development = Optional.empty();
         List<VirtualClusterGateway> defaultGateway = List.of(VIRTUAL_CLUSTER_GATEWAY);
-        Map<String, VirtualCluster> virtualClusters = Map.of("vc1", new VirtualCluster(null, null, Optional.empty(), defaultGateway, false, false, List.of()));
+        TargetCluster targetCluster = new TargetCluster("unused:9082", Optional.empty());
+        List<VirtualCluster> virtualClusters = List.of(new VirtualCluster("vc1", targetCluster, null, Optional.empty(), defaultGateway, false, false, List.of()));
         assertThatThrownBy(() -> new Configuration(
                 null,
                 null,
@@ -673,7 +694,7 @@ class ConfigurationTest {
         List<NamedFilterDefinition> filterDefinitions = List.of(
                 new NamedFilterDefinition("foo", "Foo", ""),
                 new NamedFilterDefinition("bar", "Bar", ""));
-        VirtualCluster direct = new VirtualCluster(new TargetCluster("y:9092", Optional.empty()),
+        VirtualCluster direct = new VirtualCluster("direct", new TargetCluster("y:9092", Optional.empty()),
                 null, Optional.empty(),
                 List.of(new VirtualClusterGateway("mygateway",
                         new PortIdentifiesNodeIdentificationStrategy(new HostPort("example.com", 3), null, null, null),
@@ -683,7 +704,7 @@ class ConfigurationTest {
                 false,
                 List.of("foo")); // filters defined on cluster
 
-        VirtualCluster defaulted = new VirtualCluster(new TargetCluster("x:9092", Optional.empty()),
+        VirtualCluster defaulted = new VirtualCluster("defaulted", new TargetCluster("x:9092", Optional.empty()),
                 null,
                 Optional.empty(),
                 List.of(new VirtualClusterGateway("mygateway",
@@ -697,8 +718,7 @@ class ConfigurationTest {
         Configuration configuration = new Configuration(
                 null, filterDefinitions,
                 List.of("bar"),
-                Map.of("direct", direct,
-                        "defaulted", defaulted),
+                List.of(direct, defaulted),
                 null, false,
                 Optional.empty());
 
@@ -720,7 +740,7 @@ class ConfigurationTest {
 
         var targetCluster = new TargetCluster("y:9092", Optional.empty());
         var bootstrapAddress = new HostPort("example.com", 3);
-        var cluster = new VirtualCluster(targetCluster,
+        var cluster = new VirtualCluster("myvc", targetCluster,
                 new ClusterNetworkAddressConfigProviderDefinition("PortPerBrokerClusterNetworkAddressConfigProvider",
                         new PortPerBrokerClusterNetworkAddressConfigProvider.PortPerBrokerClusterNetworkAddressConfigProviderConfig(bootstrapAddress, null,
                                 null, null, null)),
@@ -733,7 +753,7 @@ class ConfigurationTest {
         Configuration configuration = new Configuration(
                 null, filterDefinitions,
                 List.of("foo"),
-                Map.of("myvc", cluster),
+                List.of(cluster),
                 null, false,
                 Optional.empty());
 

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/DefaultKroxyliciousTesterTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/DefaultKroxyliciousTesterTest.java
@@ -430,13 +430,14 @@ class DefaultKroxyliciousTesterTest {
         when(createTopicsResult.all()).thenReturn(KafkaFuture.completedFuture(null));
 
         var vcb = new VirtualClusterBuilder()
+                .withName(DEFAULT_CLUSTER)
                 .withNewTargetCluster()
                 .withBootstrapServers(backingCluster)
                 .endTargetCluster()
                 .withClusterNetworkAddressConfigProvider(
                         bootstrapAddress);
         var configurationBuilder = new ConfigurationBuilder()
-                .addToVirtualClusters(DEFAULT_CLUSTER, vcb.build());
+                .addToVirtualClusters(vcb.build());
 
         try (KroxyliciousTester tester = new KroxyliciousTesterBuilder().setConfigurationBuilder(configurationBuilder)
                 .setKroxyliciousFactory(DefaultKroxyliciousTester::spawnProxy)
@@ -667,8 +668,8 @@ class DefaultKroxyliciousTesterTest {
     @NonNull
     private KroxyliciousTester buildMultiGatewayTester() {
         final ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
-        String virtualClusterName = DEFAULT_VIRTUAL_CLUSTER;
         var vcb = new VirtualClusterBuilder()
+                .withName(DEFAULT_VIRTUAL_CLUSTER)
                 .withNewTargetCluster()
                 .withBootstrapServers(backingCluster)
                 .endTargetCluster()
@@ -680,7 +681,7 @@ class DefaultKroxyliciousTesterTest {
                         .endPortIdentifiesNode()
                         .build());
         configurationBuilder
-                .addToVirtualClusters(virtualClusterName, vcb.build());
+                .addToVirtualClusters(vcb.build());
         return new KroxyliciousTesterBuilder().setConfigurationBuilder(configurationBuilder)
                 .setKroxyliciousFactory(DefaultKroxyliciousTester::spawnProxy)
                 .setClientFactory(clientFactory)
@@ -692,6 +693,7 @@ class DefaultKroxyliciousTesterTest {
         generateSecurityCert(keytoolCertificateGenerator);
         final ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
         var vcb = new VirtualClusterBuilder()
+                .withName(TLS_CLUSTER)
                 .withNewTargetCluster()
                 .withBootstrapServers(backingCluster)
                 .endTargetCluster()
@@ -704,7 +706,7 @@ class DefaultKroxyliciousTesterTest {
                         .endTls()
                         .build());
         configurationBuilder
-                .addToVirtualClusters(TLS_CLUSTER, vcb.build());
+                .addToVirtualClusters(vcb.build());
 
         return new KroxyliciousTesterBuilder().setConfigurationBuilder(configurationBuilder)
                 .setTrustStoreLocation(keytoolCertificateGenerator.getTrustStoreLocation())

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
@@ -315,7 +315,8 @@ class KroxyliciousTestersTest {
 
     private static ConfigurationBuilder addVirtualCluster(String clusterBootstrapServers, ConfigurationBuilder builder, String clusterName,
                                                           String defaultProxyBootstrap) {
-        return builder.addToVirtualClusters(clusterName, new VirtualClusterBuilder()
+        return builder.addToVirtualClusters(new VirtualClusterBuilder()
+                .withName(clusterName)
                 .withNewTargetCluster()
                 .withBootstrapServers(clusterBootstrapServers)
                 .endTargetCluster()

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/DeprecatedConfigurationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/DeprecatedConfigurationIT.java
@@ -103,7 +103,8 @@ public class DeprecatedConfigurationIT extends BaseIT {
     void shouldSupportDeprecatedClusterNetworkAddressConfigProvider(ClusterNetworkAddressConfigProviderDefinition provider, KafkaCluster cluster) {
 
         var builder = new ConfigurationBuilder()
-                .addToVirtualClusters("demo", new VirtualClusterBuilder()
+                .addToVirtualClusters(new VirtualClusterBuilder()
+                        .withName("demo")
                         .withNewTargetCluster()
                         .withBootstrapServers(cluster.getBootstrapServers())
                         .endTargetCluster()

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/FilterIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/FilterIT.java
@@ -17,10 +17,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLHandshakeException;
-import javax.net.ssl.SSLSocket;
-
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -83,7 +79,6 @@ import static org.apache.kafka.common.protocol.ApiKeys.METADATA;
 import static org.apache.kafka.common.protocol.ApiKeys.PRODUCE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 @ExtendWith(KafkaClusterExtension.class)
@@ -165,20 +160,6 @@ class FilterIT {
                     .containsExactly(PLAINTEXT);
 
         }
-    }
-
-    @Test
-    void shouldFailFastWhenConnectWithSSLToPlainListener(KafkaCluster cluster) {
-        assertThatThrownBy(() -> {
-            try (var tester = kroxyliciousTester(proxy(cluster))) {
-                String bootstrap = tester.getBootstrapAddress();
-                String[] split = bootstrap.split(":");
-                try (SSLSocket socket = (SSLSocket) SSLContext.getDefault().getSocketFactory().createSocket(split[0], Integer.parseInt(split[1]))) {
-                    socket.setSoTimeout(5000);
-                    socket.startHandshake();
-                }
-            }
-        }).isInstanceOf(SSLHandshakeException.class).hasMessageContaining("Remote host terminated the handshake");
     }
 
     @Test

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/TlsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/TlsIT.java
@@ -62,6 +62,7 @@ import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.baseVirtualClusterBuilder;
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.defaultPortIdentifiesNodeGatewayBuilder;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -109,7 +110,8 @@ class TlsIT extends BaseIT {
         assertThat(brokerTruststorePassword).isNotEmpty();
 
         var builder = new ConfigurationBuilder()
-                .addToVirtualClusters("demo", new VirtualClusterBuilder()
+                .addToVirtualClusters(new VirtualClusterBuilder()
+                        .withName("demo")
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .withNewTls()
@@ -139,7 +141,8 @@ class TlsIT extends BaseIT {
         assertThat(brokerTruststorePassword).isNotEmpty();
 
         var builder = new ConfigurationBuilder()
-                .addToVirtualClusters("demo", new VirtualClusterBuilder()
+                .addToVirtualClusters(new VirtualClusterBuilder()
+                        .withName("demo")
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers.replace("localhost", "127.0.0.1"))
                         // 127.0.0.1 is not included as Subject Alternate Name (SAN) so hostname validation will fail.
@@ -184,7 +187,8 @@ class TlsIT extends BaseIT {
         var file = writeTrustToTemporaryFile(certificates);
 
         var builder = new ConfigurationBuilder()
-                .addToVirtualClusters("demo", new VirtualClusterBuilder()
+                .addToVirtualClusters(new VirtualClusterBuilder()
+                        .withName("demo")
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .withNewTls()
@@ -210,7 +214,8 @@ class TlsIT extends BaseIT {
         var bootstrapServers = cluster.getBootstrapServers();
 
         var builder = new ConfigurationBuilder()
-                .addToVirtualClusters("demo", new VirtualClusterBuilder()
+                .addToVirtualClusters(new VirtualClusterBuilder()
+                        .withName("demo")
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .withNewTls()
@@ -262,7 +267,8 @@ class TlsIT extends BaseIT {
             assertUnsuccessfulDirectClientAuthConnectionWithoutClientCert(cluster);
 
             var builder = new ConfigurationBuilder()
-                    .addToVirtualClusters("demo", new VirtualClusterBuilder()
+                    .addToVirtualClusters(new VirtualClusterBuilder()
+                            .withName("demo")
                             .withNewTargetCluster()
                             .withBootstrapServers(cluster.getBootstrapServers())
                             .withNewTls()
@@ -324,7 +330,8 @@ class TlsIT extends BaseIT {
         var proxyKeystorePasswordProvider = constructPasswordProvider(providerClazz, proxyKeystorePassword);
 
         var builder = new ConfigurationBuilder()
-                .addToVirtualClusters("demo", new VirtualClusterBuilder()
+                .addToVirtualClusters(new VirtualClusterBuilder()
+                        .withName("demo")
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .withNewTls()
@@ -356,17 +363,12 @@ class TlsIT extends BaseIT {
     }
 
     @Test
-    void downstream_SuccessfulTlsWithProtocolsAllowed(KafkaCluster cluster) throws Exception {
-        var bootstrapServers = cluster.getBootstrapServers();
-
+    void downstream_SuccessfulTlsWithProtocolsAllowed(KafkaCluster cluster) {
         // Protocol we want to use
         AllowDeny<String> protocols = new AllowDeny<>(List.of("TLSv1.2"), null);
 
         var builder = new ConfigurationBuilder()
-                .addToVirtualClusters("demo", new VirtualClusterBuilder()
-                        .withNewTargetCluster()
-                        .withBootstrapServers(bootstrapServers)
-                        .endTargetCluster()
+                .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .withNewTls()
                                 .withNewKeyStoreKey()
@@ -410,17 +412,12 @@ class TlsIT extends BaseIT {
     }
 
     @Test
-    void downstream_UnsuccessfulTlsWithProtocolsAllowed(KafkaCluster cluster) throws Exception {
-        var bootstrapServers = cluster.getBootstrapServers();
-
+    void downstream_UnsuccessfulTlsWithProtocolsAllowed(KafkaCluster cluster) {
         // Protocol we want to use
         AllowDeny<String> protocols = new AllowDeny<>(List.of("TLSv1.2"), null);
 
         var builder = new ConfigurationBuilder()
-                .addToVirtualClusters("demo", new VirtualClusterBuilder()
-                        .withNewTargetCluster()
-                        .withBootstrapServers(bootstrapServers)
-                        .endTargetCluster()
+                .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .withNewTls()
                                 .withNewKeyStoreKey()
@@ -447,17 +444,12 @@ class TlsIT extends BaseIT {
     }
 
     @Test
-    void downstream_SuccessfulTlsWithProtocolsDenied(KafkaCluster cluster) throws Exception {
-        var bootstrapServers = cluster.getBootstrapServers();
-
+    void downstream_SuccessfulTlsWithProtocolsDenied(KafkaCluster cluster) {
         // Protocol we want to use
         AllowDeny<String> protocols = new AllowDeny<>(null, Set.of("TLSv1.2"));
 
         var builder = new ConfigurationBuilder()
-                .addToVirtualClusters("demo", new VirtualClusterBuilder()
-                        .withNewTargetCluster()
-                        .withBootstrapServers(bootstrapServers)
-                        .endTargetCluster()
+                .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .withNewTls()
                                 .withNewKeyStoreKey()
@@ -497,7 +489,8 @@ class TlsIT extends BaseIT {
         AllowDeny<String> protocols = new AllowDeny<>(List.of("TLSv1.2"), null);
 
         var builder = new ConfigurationBuilder()
-                .addToVirtualClusters("demo", new VirtualClusterBuilder()
+                .addToVirtualClusters(new VirtualClusterBuilder()
+                        .withName("demo")
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .withNewTls()
@@ -533,7 +526,8 @@ class TlsIT extends BaseIT {
         AllowDeny<String> protocols = new AllowDeny<>(List.of("TLSv1.1"), null);
 
         var builder = new ConfigurationBuilder()
-                .addToVirtualClusters("demo", new VirtualClusterBuilder()
+                .addToVirtualClusters(new VirtualClusterBuilder()
+                        .withName("demo")
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .withNewTls()
@@ -560,17 +554,12 @@ class TlsIT extends BaseIT {
     }
 
     @Test
-    void downstream_SuccessfulTlsWithCipherSuitesAllowed(KafkaCluster cluster) throws Exception {
-        var bootstrapServers = cluster.getBootstrapServers();
-
+    void downstream_SuccessfulTlsWithCipherSuitesAllowed(KafkaCluster cluster) {
         // Cipher we want to use
         AllowDeny<String> cipherSuites = new AllowDeny<>(List.of("TLS_CHACHA20_POLY1305_SHA256"), null);
 
         var builder = new ConfigurationBuilder()
-                .addToVirtualClusters("demo", new VirtualClusterBuilder()
-                        .withNewTargetCluster()
-                        .withBootstrapServers(bootstrapServers)
-                        .endTargetCluster()
+                .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .withNewTls()
                                 .withNewKeyStoreKey()
@@ -613,17 +602,12 @@ class TlsIT extends BaseIT {
     }
 
     @Test
-    void downstream_UnsuccessfulTlsWithCipherSuitesAllowed(KafkaCluster cluster) throws Exception {
-        var bootstrapServers = cluster.getBootstrapServers();
-
+    void downstream_UnsuccessfulTlsWithCipherSuitesAllowed(KafkaCluster cluster) {
         // Cipher we want to use
         AllowDeny<String> cipherSuites = new AllowDeny<>(List.of("TLS_AES_128_GCM_SHA256"), null);
 
         var builder = new ConfigurationBuilder()
-                .addToVirtualClusters("demo", new VirtualClusterBuilder()
-                        .withNewTargetCluster()
-                        .withBootstrapServers(bootstrapServers)
-                        .endTargetCluster()
+                .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .withNewTls()
                                 .withNewKeyStoreKey()
@@ -650,17 +634,12 @@ class TlsIT extends BaseIT {
     }
 
     @Test
-    void downstream_SuccessfulTlsWithCipherSuitesAllowedAndDenied(KafkaCluster cluster) throws Exception {
-        var bootstrapServers = cluster.getBootstrapServers();
-
+    void downstream_SuccessfulTlsWithCipherSuitesAllowedAndDenied(KafkaCluster cluster) {
         // Cipher we want to use
         AllowDeny<String> cipherSuites = new AllowDeny<>(List.of("TLS_CHACHA20_POLY1305_SHA256"), Set.of("TLS_AES_128_GCM_SHA256"));
 
         var builder = new ConfigurationBuilder()
-                .addToVirtualClusters("demo", new VirtualClusterBuilder()
-                        .withNewTargetCluster()
-                        .withBootstrapServers(bootstrapServers)
-                        .endTargetCluster()
+                .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .withNewTls()
                                 .withNewKeyStoreKey()
@@ -700,7 +679,8 @@ class TlsIT extends BaseIT {
         AllowDeny<String> cipherSuites = new AllowDeny<>(List.of("TLS_CHACHA20_POLY1305_SHA256"), null);
 
         var builder = new ConfigurationBuilder()
-                .addToVirtualClusters("demo", new VirtualClusterBuilder()
+                .addToVirtualClusters(new VirtualClusterBuilder()
+                        .withName("demo")
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .withNewTls()
@@ -736,7 +716,8 @@ class TlsIT extends BaseIT {
         AllowDeny<String> upstreamCipherSuites = new AllowDeny<>(List.of("TLS_AES_128_WRONG_CIPHER"), null);
 
         var builder = new ConfigurationBuilder()
-                .addToVirtualClusters("demo", new VirtualClusterBuilder()
+                .addToVirtualClusters(new VirtualClusterBuilder()
+                        .withName("demo")
                         .withNewTargetCluster()
                         .withBootstrapServers(bootstrapServers)
                         .withNewTls()
@@ -809,7 +790,7 @@ class TlsIT extends BaseIT {
     }
 
     @Test
-    void downstreamMutualTls_SuccessfulTlsClientAuthRequestedAndNotProvided(KafkaCluster cluster) throws Exception {
+    void downstreamMutualTls_SuccessfulTlsClientAuthRequestedAndNotProvided(KafkaCluster cluster) {
         try (var tester = kroxyliciousTester(constructMutualTlsBuilder(cluster, TlsClientAuth.REQUESTED));
                 var admin = tester.admin("demo",
                         Map.of(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG,
@@ -852,14 +833,10 @@ class TlsIT extends BaseIT {
         }
     }
 
-    private ConfigurationBuilder constructMutualTlsBuilder(KafkaCluster cluster, TlsClientAuth tlsClientAuth) throws Exception {
-        var bootstrapServers = cluster.getBootstrapServers();
+    private ConfigurationBuilder constructMutualTlsBuilder(KafkaCluster cluster, TlsClientAuth tlsClientAuth) {
 
         return new ConfigurationBuilder()
-                .addToVirtualClusters("demo", new VirtualClusterBuilder()
-                        .withNewTargetCluster()
-                        .withBootstrapServers(bootstrapServers)
-                        .endTargetCluster()
+                .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .withNewTls()
                                 .withNewKeyStoreKey()

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/multitenant/BaseMultiTenantIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/multitenant/BaseMultiTenantIT.java
@@ -100,7 +100,8 @@ public abstract class BaseMultiTenantIT extends BaseIT {
 
     static ConfigurationBuilder getConfig(KafkaCluster cluster, KeytoolCertificateGenerator certificateGenerator, NamedFilterDefinitionBuilder filterBuilder) {
         return new ConfigurationBuilder()
-                .addToVirtualClusters(TENANT_1_CLUSTER, new VirtualClusterBuilder()
+                .addToVirtualClusters(new VirtualClusterBuilder()
+                        .withName(TENANT_1_CLUSTER)
                         .withNewTargetCluster()
                         .withBootstrapServers(cluster.getBootstrapServers())
                         .endTargetCluster()
@@ -113,7 +114,8 @@ public abstract class BaseMultiTenantIT extends BaseIT {
                                 .endTls()
                                 .build())
                         .build())
-                .addToVirtualClusters(TENANT_2_CLUSTER, new VirtualClusterBuilder()
+                .addToVirtualClusters(new VirtualClusterBuilder()
+                        .withName(TENANT_2_CLUSTER)
                         .withNewTargetCluster()
                         .withBootstrapServers(cluster.getBootstrapServers())
                         .endTargetCluster()

--- a/kroxylicious-kms-provider-aws-kms/DEV_GUIDE.md
+++ b/kroxylicious-kms-provider-aws-kms/DEV_GUIDE.md
@@ -38,7 +38,7 @@ your Kafka client off-EC2.
 10. Create a config file for Kroxylicious updating the virtual clusters bootstrap address to the public address of the EC2 instance.
     ```yaml
      virtualClusters:
-       demo:
+       - name: demo
          targetCluster:
            bootstrapServers: localhost:9092
          gateways:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Secret-example.yaml
@@ -48,15 +48,15 @@ stringData:
         interpolation7: "/opt/kroxylicious/secure/configmap/bar/secret1"
         interpolation8: "/opt/kroxylicious/secure/configmap/bar/secret1"
     virtualClusters:
-      foo:
-        targetCluster:
-          bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
-        gateways:
-        - name: "default"
-          portIdentifiesNode:
-            bootstrapAddress: "localhost:9292"
-            advertisedBrokerAddressPattern: "foo.proxy-ns.svc.cluster.local"
-        filters:
-        - "filter-one.KafkaProtocolFilter.filter.kroxylicious.io"
-        - "filter-two.KafkaProtocolFilter.filter.kroxylicious.io"
-        - "filter-one.KafkaProtocolFilter.filter.kroxylicious.io"
+    - name: "foo"
+      targetCluster:
+        bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
+      gateways:
+      - name: "default"
+        portIdentifiesNode:
+          bootstrapAddress: "localhost:9292"
+          advertisedBrokerAddressPattern: "foo.proxy-ns.svc.cluster.local"
+      filters:
+      - "filter-one.KafkaProtocolFilter.filter.kroxylicious.io"
+      - "filter-two.KafkaProtocolFilter.filter.kroxylicious.io"
+      - "filter-one.KafkaProtocolFilter.filter.kroxylicious.io"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Secret-example.yaml
@@ -38,14 +38,14 @@ stringData:
       config:
         filterTwoConfig: 42
     virtualClusters:
-      bar:
-        targetCluster:
-          bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
-        gateways:
-        - name: "default"
-          portIdentifiesNode:
-            bootstrapAddress: "localhost:9292"
-            advertisedBrokerAddressPattern: "bar.proxy-ns.svc.cluster.local"
-        filters:
-        - "filter-one.KafkaProtocolFilter.filter.kroxylicious.io"
-        - "filter-two.KafkaProtocolFilter.filter.kroxylicious.io"
+    - name: "bar"
+      targetCluster:
+        bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
+      gateways:
+      - name: "default"
+        portIdentifiesNode:
+          bootstrapAddress: "localhost:9292"
+          advertisedBrokerAddressPattern: "bar.proxy-ns.svc.cluster.local"
+      filters:
+      - "filter-one.KafkaProtocolFilter.filter.kroxylicious.io"
+      - "filter-two.KafkaProtocolFilter.filter.kroxylicious.io"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Secret-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Secret-minimal.yaml
@@ -29,11 +29,11 @@ stringData:
       endpoints:
         prometheus: {}
     virtualClusters:
-      one:
-        targetCluster:
-          bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
-        gateways:
-        - name: "default"
-          portIdentifiesNode:
-            bootstrapAddress: "localhost:9292"
-            advertisedBrokerAddressPattern: "one.proxy-ns.svc.cluster.local"
+    - name: "one"
+      targetCluster:
+        bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
+      gateways:
+      - name: "default"
+        portIdentifiesNode:
+          bootstrapAddress: "localhost:9292"
+          advertisedBrokerAddressPattern: "one.proxy-ns.svc.cluster.local"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Secret-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Secret-twocluster.yaml
@@ -29,19 +29,19 @@ stringData:
       endpoints:
         prometheus: {}
     virtualClusters:
-      bar:
-        targetCluster:
-          bootstrapServers: "first-kafka.kafka1.svc.cluster.local:9092"
-        gateways:
-        - name: "default"
-          portIdentifiesNode:
-            bootstrapAddress: "localhost:9292"
-            advertisedBrokerAddressPattern: "bar.proxy-ns.svc.cluster.local"
-      foo:
-        targetCluster:
-          bootstrapServers: "second-kafka.kafka2.svc.cluster.local:9092"
-        gateways:
-        - name: "default"
-          portIdentifiesNode:
-            bootstrapAddress: "localhost:9392"
-            advertisedBrokerAddressPattern: "foo.proxy-ns.svc.cluster.local"
+    - name: "bar"
+      targetCluster:
+        bootstrapServers: "first-kafka.kafka1.svc.cluster.local:9092"
+      gateways:
+      - name: "default"
+        portIdentifiesNode:
+          bootstrapAddress: "localhost:9292"
+          advertisedBrokerAddressPattern: "bar.proxy-ns.svc.cluster.local"
+    - name: "foo"
+      targetCluster:
+        bootstrapServers: "second-kafka.kafka2.svc.cluster.local:9092"
+      gateways:
+      - name: "default"
+        portIdentifiesNode:
+          bootstrapAddress: "localhost:9392"
+          advertisedBrokerAddressPattern: "foo.proxy-ns.svc.cluster.local"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Secret-example.yaml
@@ -40,14 +40,14 @@ stringData:
         filterTwoConfig: 42
         password: "/opt/kroxylicious/secure/secret/my-secret/filter-two"
     virtualClusters:
-      foo:
-        targetCluster:
-          bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
-        gateways:
-        - name: "default"
-          portIdentifiesNode:
-            bootstrapAddress: "localhost:9292"
-            advertisedBrokerAddressPattern: "foo.proxy-ns.svc.cluster.local"
-        filters:
-        - "filter-one.KafkaProtocolFilter.filter.kroxylicious.io"
-        - "filter-two.KafkaProtocolFilter.filter.kroxylicious.io"
+    - name: "foo"
+      targetCluster:
+        bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
+      gateways:
+      - name: "default"
+        portIdentifiesNode:
+          bootstrapAddress: "localhost:9292"
+          advertisedBrokerAddressPattern: "foo.proxy-ns.svc.cluster.local"
+      filters:
+      - "filter-one.KafkaProtocolFilter.filter.kroxylicious.io"
+      - "filter-two.KafkaProtocolFilter.filter.kroxylicious.io"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Secret-use-pod-template-spec.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Secret-use-pod-template-spec.yaml
@@ -29,11 +29,11 @@ stringData:
       endpoints:
         prometheus: {}
     virtualClusters:
-      one:
-        targetCluster:
-          bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
-        gateways:
-        - name: "default"
-          portIdentifiesNode:
-            bootstrapAddress: "localhost:9292"
-            advertisedBrokerAddressPattern: "one.proxy-ns.svc.cluster.local"
+    - name: "one"
+      targetCluster:
+        bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
+      gateways:
+      - name: "default"
+        portIdentifiesNode:
+          bootstrapAddress: "localhost:9292"
+          advertisedBrokerAddressPattern: "one.proxy-ns.svc.cluster.local"

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
@@ -18,11 +18,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.kroxylicious.proxy.config.tls.Tls;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * A virtual cluster.
  *
+ * @param name virtual cluster name
  * @param targetCluster the cluster being proxied
  * @param clusterNetworkAddressConfigProvider virtual cluster network config - deprecated - use a named gateway
  * @param tls deprecated - tls settings for the virtual cluster - deprecated - use a named gateway
@@ -32,7 +34,8 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * @param filters filers.
  */
 @SuppressWarnings("java:S1123") // suppressing the spurious warning about missing @deprecated in javadoc. It is the field that is deprecated, not the class.
-public record VirtualCluster(TargetCluster targetCluster,
+public record VirtualCluster(@NonNull @JsonProperty(required = true) String name,
+                             @NonNull @JsonProperty(required = true) TargetCluster targetCluster,
                              @Deprecated(forRemoval = true, since = "0.11.0") ClusterNetworkAddressConfigProviderDefinition clusterNetworkAddressConfigProvider,
                              @Deprecated(forRemoval = true, since = "0.11.0") @JsonProperty() Optional<Tls> tls,
 
@@ -51,6 +54,9 @@ public record VirtualCluster(TargetCluster targetCluster,
 
     @SuppressWarnings({ "removal", "java:S2789" }) // S2789 - checking for null tls is the intent
     public VirtualCluster {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(targetCluster);
+
         if (clusterNetworkAddressConfigProvider != null || (tls != null && tls.isPresent())) {
             if (clusterNetworkAddressConfigProvider == null) {
                 throw new IllegalConfigurationException("Deprecated virtualCluster property 'tls' supplied, but 'clusterNetworkAddressConfigProvider' is null");
@@ -100,4 +106,5 @@ public record VirtualCluster(TargetCluster targetCluster,
     public Optional<Tls> tls() {
         return tls;
     }
+
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
@@ -34,7 +34,7 @@ class KafkaProxyTest {
     void shouldFailToStartIfRequireFilterConfigIsMissing() throws Exception {
         var config = """
                    virtualClusters:
-                     demo1:
+                     - name: demo1
                        targetCluster:
                          bootstrapServers: kafka.example:1234
                        gateways:
@@ -55,14 +55,14 @@ class KafkaProxyTest {
     static Stream<Arguments> detectsConflictingPorts() {
         return Stream.of(Arguments.of("bootstrap port conflict", """
                 virtualClusters:
-                  demo1:
+                  - name: demo1
                     targetCluster:
                       bootstrapServers: kafka.example:1234
                     gateways:
                     - name: default
                       portIdentifiesNode:
                         bootstrapAddress: localhost:9192
-                  demo2:
+                  - name: demo2
                     targetCluster:
                       bootstrapServers: kafka.example:1234
                     gateways:
@@ -73,7 +73,7 @@ class KafkaProxyTest {
                 "exclusive TCP bind of <any>:9192 for gateway 'default' of virtual cluster 'demo1' conflicts with exclusive TCP bind of <any>:9192 for gateway 'default' of virtual cluster 'demo2': exclusive port collision"),
                 Arguments.of("broker port conflict", """
                         virtualClusters:
-                          demo1:
+                          - name: demo1
                             targetCluster:
                               bootstrapServers: kafka.example:1234
                             gateways:
@@ -81,7 +81,7 @@ class KafkaProxyTest {
                               portIdentifiesNode:
                                 bootstrapAddress: localhost:9192
                                 nodeStartPort: 9193
-                          demo2:
+                          - name: demo2
                             targetCluster:
                               bootstrapServers: kafka.example:1234
                             gateways:
@@ -105,7 +105,7 @@ class KafkaProxyTest {
     static Stream<Arguments> missingTls() {
         return Stream.of(Arguments.of("tls mismatch", """
                 virtualClusters:
-                  demo1:
+                  - name: demo1
                     gateways:
                     - name: default
                       sniHostIdentifiesNode:

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/VirtualClusterTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/VirtualClusterTest.java
@@ -38,7 +38,7 @@ class VirtualClusterTest {
     @SuppressWarnings("removal")
     void supportsDeprecatedConfigProvider() {
         // Given/When
-        var vc = new VirtualCluster(targetCluster, provider, Optional.empty(), null, false, false, NO_FILTERS);
+        var vc = new VirtualCluster("mycluster", targetCluster, provider, Optional.empty(), null, false, false, NO_FILTERS);
 
         // Then
         assertThat(vc.clusterNetworkAddressConfigProvider()).isEqualTo(provider);
@@ -51,7 +51,7 @@ class VirtualClusterTest {
                 new VirtualClusterGateway("mygateway2", portIdentifiesNode2, null, Optional.empty()));
 
         // When
-        var vc = new VirtualCluster(targetCluster, null, null, gateways, false, false, NO_FILTERS);
+        var vc = new VirtualCluster("mycluster", targetCluster, null, null, gateways, false, false, NO_FILTERS);
 
         // Then
         assertThat(vc.gateways())
@@ -65,7 +65,7 @@ class VirtualClusterTest {
         var gateways = List.of(new VirtualClusterGateway("mygateway", portIdentifiesNode1, null, Optional.empty()));
 
         // When/Then
-        assertThatThrownBy(() -> new VirtualCluster(targetCluster, provider, null, gateways, false, false, NO_FILTERS))
+        assertThatThrownBy(() -> new VirtualCluster("mycluster", targetCluster, provider, null, gateways, false, false, NO_FILTERS))
                 .isInstanceOf(IllegalConfigurationException.class);
     }
 
@@ -76,14 +76,14 @@ class VirtualClusterTest {
         var tls = Optional.of(new Tls(null, null, null, null));
 
         // When/Then
-        assertThatThrownBy(() -> new VirtualCluster(targetCluster, null, tls, gateways, false, false, NO_FILTERS))
+        assertThatThrownBy(() -> new VirtualCluster("mycluster", targetCluster, null, tls, gateways, false, false, NO_FILTERS))
                 .isInstanceOf(IllegalConfigurationException.class);
     }
 
     @Test
     void disallowMissingGateways() {
         // Given/When/Then
-        assertThatThrownBy(() -> new VirtualCluster(targetCluster, null, null, null, false, false, NO_FILTERS))
+        assertThatThrownBy(() -> new VirtualCluster("mycluster", targetCluster, null, null, null, false, false, NO_FILTERS))
                 .isInstanceOf(IllegalConfigurationException.class);
     }
 
@@ -92,7 +92,7 @@ class VirtualClusterTest {
         // Given
         var noGateways = List.<VirtualClusterGateway> of();
         // When/Then
-        assertThatThrownBy(() -> new VirtualCluster(targetCluster, null, null, noGateways, false, false, NO_FILTERS))
+        assertThatThrownBy(() -> new VirtualCluster("mycluster", targetCluster, null, null, noGateways, false, false, NO_FILTERS))
                 .isInstanceOf(IllegalConfigurationException.class);
     }
 
@@ -102,7 +102,7 @@ class VirtualClusterTest {
         var gateways = List.of(new VirtualClusterGateway("dup", portIdentifiesNode1, null, Optional.empty()),
                 new VirtualClusterGateway("dup", portIdentifiesNode2, null, Optional.empty()));
         // When/Then
-        assertThatThrownBy(() -> new VirtualCluster(targetCluster, null, null, gateways, false, false, NO_FILTERS))
+        assertThatThrownBy(() -> new VirtualCluster("mycluster", targetCluster, null, null, gateways, false, false, NO_FILTERS))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("Gateway names for a virtual cluster must be unique. The following gateway names are duplicated: [dup]");
     }

--- a/kroxylicious-runtime/src/test/resources/config.yaml
+++ b/kroxylicious-runtime/src/test/resources/config.yaml
@@ -12,7 +12,7 @@ adminHttp:
   endpoints:
     prometheus: {}
 virtualClusters:
-  demo:
+  - name: demo
     targetCluster:
       bootstrapServers: localhost:9092
     gateways:

--- a/kroxylicious-sample/sample-proxy-config.yaml
+++ b/kroxylicious-sample/sample-proxy-config.yaml
@@ -9,7 +9,7 @@ adminHttp:
   endpoints:
     prometheus: {}
 virtualClusters:
-  demo:
+  - name: demo
     targetCluster:
       bootstrapServers: localhost:9092
     gateways:

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/kroxylicious/KroxyliciousConfigMapTemplates.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/kroxylicious/KroxyliciousConfigMapTemplates.java
@@ -105,7 +105,7 @@ public final class KroxyliciousConfigMapTemplates {
                   endpoints:
                     prometheus: {}
                 virtualClusters:
-                  my-cluster-proxy:
+                  - name: my-cluster-proxy
                     gateways:
                     - name: default
                       portIdentifiesNode:
@@ -128,7 +128,7 @@ public final class KroxyliciousConfigMapTemplates {
                   endpoints:
                     prometheus: {}
                 virtualClusters:
-                  demo:
+                  - name: demo
                     targetCluster:
                       bootstrapServers: %s-kafka-bootstrap.%s.svc.cluster.local:9092
                     gateways:
@@ -154,7 +154,7 @@ public final class KroxyliciousConfigMapTemplates {
                   endpoints:
                     prometheus: {}
                 virtualClusters:
-                  demo:
+                  - name: demo
                     targetCluster:
                       bootstrapServers: %s:9094
                     gateways:

--- a/kubernetes-examples/filters/multi-tenant/base/kroxylicious/kroxylicious-config.yaml
+++ b/kubernetes-examples/filters/multi-tenant/base/kroxylicious/kroxylicious-config.yaml
@@ -20,7 +20,7 @@ data:
       endpoints:
         prometheus: {}
     virtualClusters:
-      devenv1:
+      - name: devenv1
         targetCluster:
           bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
         gateways:
@@ -29,7 +29,7 @@ data:
               bootstrapAddress: minikube:30192
         logNetwork: false
         logFrames: false
-      devenv2:
+      - name: devenv2
         targetCluster:
           bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
         gateways:

--- a/kubernetes-examples/filters/record-encryption/base/kroxylicious/kroxylicious-config.yaml
+++ b/kubernetes-examples/filters/record-encryption/base/kroxylicious/kroxylicious-config.yaml
@@ -15,7 +15,7 @@ data:
       endpoints:
         prometheus: {}
     virtualClusters:
-      my-cluster-proxy:
+      - name: my-cluster-proxy
         # the virtual cluster is kafka proxy that sits between kafka clients and the real kafka cluster.  clients
         # connect to the virtual cluster rather than real cluster.
         gateways:

--- a/kubernetes-examples/network-topologies/portidentifiesnode_plain/base/kroxylicious/kroxylicious-config.yaml
+++ b/kubernetes-examples/network-topologies/portidentifiesnode_plain/base/kroxylicious/kroxylicious-config.yaml
@@ -15,7 +15,7 @@ data:
       endpoints:
         prometheus: {}
     virtualClusters:
-      demo:
+      - name: demo
         targetCluster:
           bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
         gateways:

--- a/kubernetes-examples/network-topologies/snihostidentifiesnode_tls/base/kroxylicious/kroxylicious-config.yaml
+++ b/kubernetes-examples/network-topologies/snihostidentifiesnode_tls/base/kroxylicious/kroxylicious-config.yaml
@@ -15,7 +15,7 @@ data:
       endpoints:
         prometheus: {}
     virtualClusters:
-      my-cluster-proxy:
+      - name: my-cluster-proxy
         targetCluster:
           bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
           tls:

--- a/kubernetes-examples/network-topologies/snihostidentifiesnode_tls_in_cluster/base/kroxylicious/kroxylicious-config.yaml
+++ b/kubernetes-examples/network-topologies/snihostidentifiesnode_tls_in_cluster/base/kroxylicious/kroxylicious-config.yaml
@@ -15,7 +15,7 @@ data:
       endpoints:
         prometheus: {}
     virtualClusters:
-      my-cluster-proxy:
+      - name: my-cluster-proxy
         targetCluster:
           bootstrap_servers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
           tls:

--- a/performance-tests/02-no-filters/config.yaml
+++ b/performance-tests/02-no-filters/config.yaml
@@ -9,7 +9,7 @@ adminHttp:
   endpoints:
     prometheus: { }
 virtualClusters:
-  demo:
+  - name: demo
     targetCluster:
       bootstrapServers: broker1:9092
     gateways:

--- a/performance-tests/03-transform-filter/config.yaml
+++ b/performance-tests/03-transform-filter/config.yaml
@@ -9,7 +9,7 @@ adminHttp:
   endpoints:
     prometheus: {}
 virtualClusters:
-  demo:
+  - name: demo
     targetCluster:
       bootstrapServers: broker1:9092
     gateways:

--- a/performance-tests/04-record-encryption-filter/config.yaml
+++ b/performance-tests/04-record-encryption-filter/config.yaml
@@ -9,7 +9,7 @@ adminHttp:
   endpoints:
     prometheus: {}
 virtualClusters:
-  demo:
+  - name: demo
     targetCluster:
       bootstrapServers: broker1:9092
     gateways:


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Refactoring

### Description

Fix #1847: Change virtual cluster map into a list

why: consistency of approach - elsewhere in the model we already use arrays of objects.  virtual cluster map is the
odd one out.

so change from this:

```yaml:
virtualClusters:
  demo1:
    targetCluster:
      bootstrap_servers: kafka.example:1234
    gateways:
       ...
```

to:

```yaml:
virtualClusters:
  - name: demo1:
    targetCluster:
      bootstrap_servers: kafka.example:1234
    gateways:
       ...
```


ability to parse the old format (map) will be retained, but it's use will be deprecated.  Any use of it will cause a warning to be written to the logs.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [x] Update documentation
- [x] Make sure all unit/integration tests pass
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [x] Ensure the PR references relevant issue(s) so they are closed on merging.
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
