### PR TITLE
Testcontainers uses docker mirror

### DIFF
--- a/kroxylicious-integration-test-support/pom.xml
+++ b/kroxylicious-integration-test-support/pom.xml
@@ -128,6 +128,10 @@
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+        </dependency>
 
         <!-- third party dependencies - test -->
 

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/MirrorImageNameSubstitutor.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/MirrorImageNameSubstitutor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test;
+
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.ImageNameSubstitutor;
+
+public class MirrorImageNameSubstitutor extends ImageNameSubstitutor {
+    private static final Set<String> DOMAIN_ALLOW_LIST = Set.of("quay.io", "ghcr.io", "gcr.io");
+    private static final String MIRROR_REPOSITORY = "mirror.gcr.io";
+    private static final Logger LOGGER = LoggerFactory.getLogger(MirrorImageNameSubstitutor.class);
+
+    @Override
+    public DockerImageName apply(DockerImageName dockerImageName) {
+        if (DOMAIN_ALLOW_LIST.stream().anyMatch(domain -> dockerImageName.getRegistry().endsWith(domain))) {
+            return dockerImageName;
+        }
+        else {
+            DockerImageName substituted = dockerImageName.withRegistry(MIRROR_REPOSITORY);
+            LOGGER.warn("replacing image repository for {} with mirror registry: {}", dockerImageName, substituted);
+            return substituted;
+        }
+    }
+
+    @Override
+    protected String getDescription() {
+        return "replaces image repository with mirror: " + MIRROR_REPOSITORY;
+    }
+}

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/MirrorImageNameSubstitutorTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/MirrorImageNameSubstitutorTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MirrorImageNameSubstitutorTest {
+
+    @ParameterizedTest
+    @CsvSource({ "x/y:1.0, mirror.gcr.io/x/y:1.0",
+            "docker.io/x/y:1.0, mirror.gcr.io/x/y:1.0",
+            "arbitrary.io/x/y:1.0, mirror.gcr.io/x/y:1.0",
+            "quay.io/x/y:1.0, quay.io/x/y:1.0",
+            "kroxylicious.quay.io/x/y:1.0, kroxylicious.quay.io/x/y:1.0",
+            "ghcr.io/x/y:1.0, ghcr.io/x/y:1.0",
+            "thing.ghcr.io/x/y:1.0, thing.ghcr.io/x/y:1.0",
+            "gcr.io/x/y:1.0, gcr.io/x/y:1.0",
+            "thing.gcr.io/x/y:1.0, thing.gcr.io/x/y:1.0" })
+    void substitutes(String input, String output) {
+        DockerImageName inputImageName = DockerImageName.parse(input);
+        DockerImageName substituted = new MirrorImageNameSubstitutor().apply(inputImageName);
+        String substitutedCanonical = substituted.asCanonicalNameString();
+        assertThat(substitutedCanonical).isEqualTo(output);
+    }
+
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ApiVersionsDowngradeIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ApiVersionsDowngradeIT.java
@@ -74,7 +74,7 @@ public class ApiVersionsDowngradeIT {
     public static final short API_VERSIONS_ID = ApiKeys.API_VERSIONS.id;
     public static final String SASL_USER = "alice";
     public static final String SASL_PASSWORD = "foo";
-    private static final DockerImageName OLD_REDPANDA_USING_API_VER0_2 = DockerImageName.parse("docker.redpanda.com/redpandadata/redpanda:v22.1.11");
+    private static final DockerImageName OLD_REDPANDA_USING_API_VER0_2 = DockerImageName.parse("redpandadata/redpanda:v22.1.11");
 
     @Test
     void clientAheadOfProxy() {

--- a/kroxylicious-integration-tests/src/test/resources/testcontainers.properties
+++ b/kroxylicious-integration-tests/src/test/resources/testcontainers.properties
@@ -1,0 +1,7 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+image.substitutor=io.kroxylicious.test.MirrorImageNameSubstitutor


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Dockerhub rate limits [kill our integration tests](https://github.com/kroxylicious/kroxylicious/actions/runs/13619770481). Lets default to using a mirror with exceptions for registries that we know are unlimited.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
