### PR TITLE
Implementing basic KafkaClusterRef

### DIFF
--- a/kroxylicious-operator/examples/record-encryption/03.KafkaClusterRef.my-cluster.yaml
+++ b/kroxylicious-operator/examples/record-encryption/03.KafkaClusterRef.my-cluster.yaml
@@ -5,14 +5,10 @@
 #
 
 ---
-kind: VirtualKafkaCluster
+kind: KafkaClusterRef
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
   name: my-cluster
   namespace: my-proxy
 spec:
-  proxyRef:
-    name: simple
-  targetCluster:
-    bootstrapping:
-      bootstrapAddress: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092

--- a/kroxylicious-operator/examples/record-encryption/04.VirtualKafkaCluster.my-cluster.yaml
+++ b/kroxylicious-operator/examples/record-encryption/04.VirtualKafkaCluster.my-cluster.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: VirtualKafkaCluster
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: my-cluster
+  namespace: my-proxy
+spec:
+  proxyRef:
+    name: simple
+  targetCluster:
+    clusterRef:
+      name: my-cluster
+  filters:
+    - group: filter.kroxylicious.io
+      kind: KafkaProtocolFilter
+      name: encryption

--- a/kroxylicious-operator/examples/record-validation/03.KafkaClusterRef.my-cluster.yaml
+++ b/kroxylicious-operator/examples/record-validation/03.KafkaClusterRef.my-cluster.yaml
@@ -1,0 +1,14 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaClusterRef
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: my-cluster
+  namespace: my-proxy
+spec:
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092

--- a/kroxylicious-operator/examples/record-validation/04.VirtualKafkaCluster.my-cluster.yaml
+++ b/kroxylicious-operator/examples/record-validation/04.VirtualKafkaCluster.my-cluster.yaml
@@ -14,10 +14,9 @@ spec:
   proxyRef:
     name: simple
   targetCluster:
-    bootstrapping:
-      bootstrapAddress:
-        my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+    clusterRef:
+      name: my-cluster
   filters:
     - group: filter.kroxylicious.io
-      kind: KafkaProtocolFilter
-      name: encryption
+      kind: RecordValidation
+      name: validation

--- a/kroxylicious-operator/examples/simple/02.KafkaClusterRef.my-cluster.yaml
+++ b/kroxylicious-operator/examples/simple/02.KafkaClusterRef.my-cluster.yaml
@@ -1,0 +1,14 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaClusterRef
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: my-cluster
+  namespace: my-proxy
+spec:
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092

--- a/kroxylicious-operator/examples/simple/03.VirtualKafkaCluster.my-cluster.yaml
+++ b/kroxylicious-operator/examples/simple/03.VirtualKafkaCluster.my-cluster.yaml
@@ -14,9 +14,5 @@ spec:
   proxyRef:
     name: simple
   targetCluster:
-    bootstrapping:
-      bootstrapAddress: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
-  filters:
-    - group: filter.kroxylicious.io
-      kind: RecordValidation
-      name: validation
+    clusterRef:
+      name: my-cluster

--- a/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-watched.yaml
+++ b/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-watched.yaml
@@ -19,6 +19,7 @@ rules:
     resources:
       - kafkaproxies
       - virtualkafkaclusters
+      - kafkaclusterrefs
     verbs:
       - get
       - list

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyReconciler.java
@@ -332,7 +332,7 @@ public class ProxyReconciler implements EventSourceInitializer<KafkaProxy>,
             var proxyNames = resourcesInSameNamespace(context, kafkaClusterRef, VirtualKafkaCluster.class)
                     .filter(vkc -> vkc.getSpec().getTargetCluster().getClusterRef().getName().equals(kafkaClusterRef.getMetadata().getName()))
                     .map(VirtualKafkaCluster::getSpec)
-                    .map(VirtualKafkaClusterSpec::getProxyRef) // TODO be picky about group, kind etc
+                    .map(VirtualKafkaClusterSpec::getProxyRef)
                     .map(ProxyRef::getName)
                     .collect(Collectors.toSet());
 
@@ -356,7 +356,7 @@ public class ProxyReconciler implements EventSourceInitializer<KafkaProxy>,
                     .map(VirtualKafkaCluster::getSpec)
                     .map(VirtualKafkaClusterSpec::getTargetCluster)
                     .map(TargetCluster::getClusterRef)
-                    .map(ClusterRef::getName) // TODO be picky about group, kind etc
+                    .map(ClusterRef::getName)
                     .collect(Collectors.toSet());
 
             Set<ResourceID> kafkaClusterRefs = filteredResourceIdsInSameNamespace(context, primary, KafkaClusterRef.class,

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyReconciler.java
@@ -41,11 +41,16 @@ import io.javaoperatorsdk.operator.processing.event.source.PrimaryToSecondaryMap
 import io.javaoperatorsdk.operator.processing.event.source.SecondaryToPrimaryMapper;
 import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource;
 
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterSpec;
 import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Conditions;
 import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.ConditionsBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ProxyRef;
+import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.TargetCluster;
+import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.targetcluster.ClusterRef;
 import io.kroxylicious.kubernetes.operator.config.FilterApiDecl;
 import io.kroxylicious.kubernetes.operator.config.RuntimeDecl;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
@@ -299,6 +304,7 @@ public class ProxyReconciler implements EventSourceInitializer<KafkaProxy>,
             }
         }
         eventSources.add(buildVirtualKafkaClusterInformer(context));
+        eventSources.add(buildKafkaClusterRefInformer(context));
         return EventSourceInitializer.nameEventSources(eventSources.toArray(new EventSource[0]));
     }
 
@@ -308,6 +314,56 @@ public class ProxyReconciler implements EventSourceInitializer<KafkaProxy>,
                 .withPrimaryToSecondaryMapper(proxyToClusterMapper(context))
                 .build();
         return new InformerEventSource<>(configuration, context);
+    }
+
+    private static InformerEventSource<?, KafkaProxy> buildKafkaClusterRefInformer(EventSourceContext<KafkaProxy> context) {
+        InformerConfiguration<KafkaClusterRef> configuration = InformerConfiguration.from(KafkaClusterRef.class)
+                .withSecondaryToPrimaryMapper(kafkaClusterRefToProxyMapper(context))
+                .withPrimaryToSecondaryMapper(proxyToKafkaClusterRefMapper(context))
+                .build();
+        return new InformerEventSource<>(configuration, context);
+    }
+
+    @VisibleForTesting
+    static @NonNull SecondaryToPrimaryMapper<KafkaClusterRef> kafkaClusterRefToProxyMapper(EventSourceContext<KafkaProxy> context) {
+        return kafkaClusterRef -> {
+            // find all virtual clusters that reference this kafkaClusterRef
+
+            var proxyNames = resourcesInSameNamespace(context, kafkaClusterRef, VirtualKafkaCluster.class)
+                    .filter(vkc -> vkc.getSpec().getTargetCluster().getClusterRef().getName().equals(kafkaClusterRef.getMetadata().getName()))
+                    .map(VirtualKafkaCluster::getSpec)
+                    .map(VirtualKafkaClusterSpec::getProxyRef) // TODO be picky about group, kind etc
+                    .map(ProxyRef::getName)
+                    .collect(Collectors.toSet());
+
+            Set<ResourceID> proxyIds = filteredResourceIdsInSameNamespace(context, kafkaClusterRef, KafkaProxy.class,
+                    proxy -> proxyNames.contains(proxy.getMetadata().getName()));
+            LOGGER.debug("Event source KafkaClusterRef SecondaryToPrimaryMapper got {}", proxyIds);
+            return proxyIds;
+        };
+    }
+
+    /**
+     * @param context context
+     * @return mapper
+     */
+    @VisibleForTesting
+    static @NonNull PrimaryToSecondaryMapper<HasMetadata> proxyToKafkaClusterRefMapper(EventSourceContext<KafkaProxy> context) {
+        return primary -> {
+            // Load all the virtual clusters for the KafkaProxy, then extract all the referenced KafkaClusterRef resource ids.
+            var clusterRefNames = resourcesInSameNamespace(context, primary, VirtualKafkaCluster.class)
+                    .filter(vkc -> vkc.getSpec().getProxyRef().getName().equals(primary.getMetadata().getName()))
+                    .map(VirtualKafkaCluster::getSpec)
+                    .map(VirtualKafkaClusterSpec::getTargetCluster)
+                    .map(TargetCluster::getClusterRef)
+                    .map(ClusterRef::getName) // TODO be picky about group, kind etc
+                    .collect(Collectors.toSet());
+
+            Set<ResourceID> kafkaClusterRefs = filteredResourceIdsInSameNamespace(context, primary, KafkaClusterRef.class,
+                    cluster -> clusterRefNames.contains(cluster.getMetadata().getName()));
+            LOGGER.debug("Event source KafkaClusterRef PrimaryToSecondaryMapper got {}", kafkaClusterRefs);
+            return kafkaClusterRefs;
+        };
     }
 
     @NonNull

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
@@ -7,13 +7,18 @@
 package io.kroxylicious.kubernetes.operator;
 
 import java.util.Comparator;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
 
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 
@@ -76,7 +81,14 @@ public class ResourcesUtil {
 
     static Stream<VirtualKafkaCluster> clustersInNameOrder(Context<KafkaProxy> context) {
         return context.getSecondaryResources(VirtualKafkaCluster.class)
-                .stream().sorted(Comparator.comparing(virtualKafkaCluster -> virtualKafkaCluster.getMetadata().getName()));
+                .stream()
+                .sorted(Comparator.comparing(virtualKafkaCluster -> virtualKafkaCluster.getMetadata().getName()));
+    }
+
+    static Map<ResourceID, KafkaClusterRef> clusterRefs(Context<KafkaProxy> context) {
+        return context.getSecondaryResources(KafkaClusterRef.class)
+                .stream()
+                .collect(Collectors.toMap(ResourceID::fromResource, Function.identity()));
     }
 
 }

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaclusterrefs.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaclusterrefs.kroxylicious.io-v1.yml
@@ -1,0 +1,46 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# Note the v1 in the filename refers to the version of the CustomResourceDefinition
+# not any of the versions of API being defined.
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: kafkaclusterrefs.kroxylicious.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: kroxylicious.io
+  scope: Namespaced
+  names:
+    plural: kafkaclusterrefs
+    singular: kafkaclusterref
+    kind: KafkaClusterRef
+    shortNames:
+      - kcr
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: { }
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            metadata:
+              type: object
+            spec:
+              type: object
+              required: ["bootstrapServers"]
+              properties:
+                bootstrapServers:
+                  description: Bootstrap servers of the Kafka cluster.
+                  type: string
+                  minLength: 1
+                  pattern: ^(([^:]+:[0-9]{1,5}),)*([^:]+:[0-9]{1,5})$

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
@@ -58,15 +58,27 @@ spec:
                       type: string
                 targetCluster:
                   type: object
-                  required: [ "bootstrapping" ]
+                  required: ["clusterRef"]
                   properties:
-                    bootstrapping:
+                    clusterRef:
                       type: object
-                      required: [ "bootstrapAddress" ]
+                      required: [ "name" ]
                       properties:
-                        bootstrapAddress:
+                        group:
                           type: string
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          default: kroxylicious.io
+                        kind:
+                          type: string
+                          maxLength: 63
                           minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          default: KafkaClusterRef
+                        name:
+                          maxLength: 253
+                          minLength: 1
+                          type: string
                 filters:
                   description: The filters to be used for this cluster. Each filter is a separate resource.
                   type: array

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/DerivedResourcesTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/DerivedResourcesTest.java
@@ -329,8 +329,8 @@ class DerivedResourcesTest {
     @NonNull
     private static Context<KafkaProxy> buildContext(Path testDir, List<VirtualKafkaCluster> virtualKafkaClusters, List<KafkaClusterRef> kafkaClusterRefs)
             throws IOException {
-        Answer throwOnUnmockedInvocation = invocation -> {
-            var stringifiedArgs = Arrays.stream(invocation.getArguments()).map(a -> String.valueOf(a)).collect(
+        Answer<?> throwOnUnmockedInvocation = invocation -> {
+            var stringifiedArgs = Arrays.stream(invocation.getArguments()).map(String::valueOf).collect(
                     Collectors.joining(", "));
             throw new RuntimeException("Unmocked method: " + invocation.getMethod() + "(" + stringifiedArgs + ")");
         };

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/DerivedResourcesTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/DerivedResourcesTest.java
@@ -12,6 +12,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -42,6 +43,7 @@ import io.javaoperatorsdk.operator.api.reconciler.dependent.managed.DefaultManag
 import io.javaoperatorsdk.operator.processing.dependent.BulkDependentResource;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResource;
 
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.clusters.Conditions;
@@ -71,21 +73,23 @@ class DerivedResourcesTest {
         }
     }
 
-    public static List<VirtualKafkaCluster> virtualKafkaClustersFromFiles(Set<Path> paths) {
+    private static <T extends HasMetadata> List<T> resourcesFromFiles(Set<Path> paths, Class<T> valueType) {
         // TODO should validate against the CRD schema, because the DependentResource
         // should never see an invalid resource in production
-        List<VirtualKafkaCluster> clusters = paths.stream().map(path -> {
+        List<T> resources = paths.stream().map(path -> {
             try {
-                return YAML_MAPPER.readValue(path.toFile(), VirtualKafkaCluster.class);
+                return YAML_MAPPER.readValue(path.toFile(), valueType);
             }
             catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
         }).sorted(Comparator.comparing(virtualKafkaCluster -> virtualKafkaCluster.getMetadata().getName())).toList();
-        long uniqueResources = clusters.stream().map(s -> s.getMetadata().getNamespace() + ":" + s.getMetadata().getName()).distinct().count();
+        long uniqueResources = resources.stream().map(s -> s.getMetadata().getNamespace() + ":" + s.getMetadata().getName()).distinct().count();
         // sanity check that the identifiers are unique
-        assertThat(uniqueResources).isEqualTo(paths.size());
-        return clusters;
+        assertThat(uniqueResources)
+                .overridingErrorMessage("unexpected number of unique resources from files: %s", paths)
+                .isEqualTo(paths.size());
+        return resources;
     }
 
     public static RuntimeDecl configFromFile(Path path) {
@@ -222,7 +226,8 @@ class DerivedResourcesTest {
             String inFileName = "in-KafkaProxy.yaml";
             Path input = testDir.resolve(inFileName);
             KafkaProxy kafkaProxy = kafkaProxyFromFile(input);
-            List<VirtualKafkaCluster> virtualKafkaClusters = virtualKafkaClustersFromFiles(childFilesMatching(testDir, "in-VirtualKafkaCluster-*"));
+            List<VirtualKafkaCluster> virtualKafkaClusters = resourcesFromFiles(childFilesMatching(testDir, "in-VirtualKafkaCluster-*"), VirtualKafkaCluster.class);
+            List<KafkaClusterRef> kafkaClusterRefs = resourcesFromFiles(childFilesMatching(testDir, "in-KafkaClusterRef-*"), KafkaClusterRef.class);
             assertMinimalMetadata(kafkaProxy.getMetadata(), inFileName);
 
             unusedFiles.remove(input);
@@ -230,7 +235,7 @@ class DerivedResourcesTest {
 
             Context<KafkaProxy> context;
             try {
-                context = buildContext(testDir, virtualKafkaClusters);
+                context = buildContext(testDir, virtualKafkaClusters, kafkaClusterRefs);
             }
             catch (IOException e) {
                 throw new UncheckedIOException(e);
@@ -322,9 +327,12 @@ class DerivedResourcesTest {
     }
 
     @NonNull
-    private static Context<KafkaProxy> buildContext(Path testDir, List<VirtualKafkaCluster> virtualKafkaClusters) throws IOException {
+    private static Context<KafkaProxy> buildContext(Path testDir, List<VirtualKafkaCluster> virtualKafkaClusters, List<KafkaClusterRef> kafkaClusterRefs)
+            throws IOException {
         Answer throwOnUnmockedInvocation = invocation -> {
-            throw new RuntimeException("Unmocked method: " + invocation.getMethod());
+            var stringifiedArgs = Arrays.stream(invocation.getArguments()).map(a -> String.valueOf(a)).collect(
+                    Collectors.joining(", "));
+            throw new RuntimeException("Unmocked method: " + invocation.getMethod() + "(" + stringifiedArgs + ")");
         };
         Context<KafkaProxy> context = mock(Context.class, throwOnUnmockedInvocation);
 
@@ -346,6 +354,7 @@ class DerivedResourcesTest {
         }
         doReturn(filterInstances).when(context).getSecondaryResources(GenericKubernetesResource.class);
         doReturn(Set.copyOf(virtualKafkaClusters)).when(context).getSecondaryResources(VirtualKafkaCluster.class);
+        doReturn(Set.copyOf(kafkaClusterRefs)).when(context).getSecondaryResources(KafkaClusterRef.class);
         SharedKafkaProxyContext.runtimeDecl(context, runtimeDecl);
         return context;
     }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerIT.java
@@ -31,10 +31,13 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRefBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.targetcluster.ClusterRefBuilder;
 import io.kroxylicious.kubernetes.operator.config.RuntimeDecl;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,12 +49,15 @@ class ProxyReconcilerIT {
 
     public static final String PROXY_A = "proxy-a";
     public static final String PROXY_B = "proxy-b";
+    public static final String CLUSTER_FOO_REF = "fooref";
     public static final String CLUSTER_FOO = "foo";
     public static final String CLUSTER_FOO_BOOTSTRAP = "my-cluster-kafka-bootstrap.foo.svc.cluster.local:9092";
+    public static final String CLUSTER_BAR_REF = "barref";
     public static final String CLUSTER_BAR = "bar";
     public static final String CLUSTER_BAR_BOOTSTRAP = "my-cluster-kafka-bootstrap.bar.svc.cluster.local:9092";
     public static final String NEW_BOOTSTRAP = "new-bootstrap:9092";
     public static final String CLUSTER_BAZ = "baz";
+    public static final String CLUSTER_BAZ_REF = "bazref";
     public static final String CLUSTER_BAZ_BOOTSTRAP = "my-cluster-kafka-bootstrap.baz.svc.cluster.local:9092";
 
     static KubernetesClient client;
@@ -82,6 +88,7 @@ class ProxyReconcilerIT {
             ))))
             .withKubernetesClient(client)
             .withAdditionalCustomResourceDefinition(VirtualKafkaCluster.class)
+            .withAdditionalCustomResourceDefinition(KafkaClusterRef.class)
             .waitForNamespaceDeletion(true)
             .withConfigurationService(x -> x.withCloseClientOnStop(false))
             .build();
@@ -96,23 +103,31 @@ class ProxyReconcilerIT {
         doCreate();
     }
 
-    private record CreatedResources(KafkaProxy proxy, Set<VirtualKafkaCluster> clusters) {
+    private record CreatedResources(KafkaProxy proxy, Set<VirtualKafkaCluster> clusters, Set<KafkaClusterRef> clusterRefs) {
         public VirtualKafkaCluster cluster(String name) {
             return clusters.stream().filter(c -> c.getMetadata().getName().equals(name)).findFirst().orElseThrow();
+        }
+
+        public KafkaClusterRef clusterRef(String name) {
+            return clusterRefs.stream().filter(c -> c.getMetadata().getName().equals(name)).findFirst().orElseThrow();
         }
     }
 
     CreatedResources doCreate() {
         KafkaProxy proxy = extension.create(kafkaProxy(PROXY_A));
-        VirtualKafkaCluster clusterFoo = extension.create(virtualKafkaCluster(CLUSTER_FOO, CLUSTER_FOO_BOOTSTRAP, proxy));
-        VirtualKafkaCluster clusterBar = extension.create(virtualKafkaCluster(CLUSTER_BAR, CLUSTER_BAR_BOOTSTRAP, proxy));
+        KafkaClusterRef fooClusterRef = extension.create(clusterRef(CLUSTER_FOO_REF, CLUSTER_FOO_BOOTSTRAP));
+        KafkaClusterRef barClusterRef = extension.create(clusterRef(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP));
+        Set<KafkaClusterRef> clusterRefs = Set.of(fooClusterRef, barClusterRef);
+
+        VirtualKafkaCluster clusterFoo = extension.create(virtualKafkaCluster(CLUSTER_FOO, proxy, fooClusterRef));
+        VirtualKafkaCluster clusterBar = extension.create(virtualKafkaCluster(CLUSTER_BAR, proxy, barClusterRef));
         Set<VirtualKafkaCluster> clusters = Set.of(clusterFoo, clusterBar);
 
         assertProxyConfigContents(proxy, Set.of(CLUSTER_FOO_BOOTSTRAP, CLUSTER_BAR_BOOTSTRAP), Set.of());
         assertDeploymentMountsConfigSecret(proxy);
         assertDeploymentBecomesReady(proxy);
         assertServiceTargetsProxyInstances(proxy, clusters);
-        return new CreatedResources(proxy, clusters);
+        return new CreatedResources(proxy, clusters, clusterRefs);
     }
 
     private void assertDeploymentBecomesReady(KafkaProxy proxy) {
@@ -193,12 +208,12 @@ class ProxyReconcilerIT {
     }
 
     @Test
-    void testUpdateVirtualCluster() {
+    void testUpdateVirtualClusterTargetBootstrap() {
         final var createdResources = doCreate();
         KafkaProxy proxy = createdResources.proxy;
-        VirtualKafkaCluster cluster = createdResources.cluster(CLUSTER_FOO).edit().editSpec().editTargetCluster().editBootstrapping().withBootstrapAddress(NEW_BOOTSTRAP)
-                .endBootstrapping().endTargetCluster().endSpec().build();
-        extension.replace(cluster);
+        var clusterRef = createdResources.clusterRef(CLUSTER_FOO_REF).edit().editSpec().withBootstrapServers(NEW_BOOTSTRAP).endSpec().build();
+        extension.replace(clusterRef);
+
         assertDeploymentBecomesReady(proxy);
         await().untilAsserted(() -> {
             var secret = extension.get(Secret.class, ProxyConfigSecret.secretName(proxy));
@@ -223,7 +238,8 @@ class ProxyReconcilerIT {
     void testAddVirtualCluster() {
         final var createdResources = doCreate();
         KafkaProxy proxy = createdResources.proxy;
-        extension.create(virtualKafkaCluster(CLUSTER_BAZ, CLUSTER_BAZ_BOOTSTRAP, proxy));
+        KafkaClusterRef bazClusterRef = extension.create(clusterRef(CLUSTER_BAZ_REF, CLUSTER_BAZ_BOOTSTRAP));
+        extension.create(virtualKafkaCluster(CLUSTER_BAZ, proxy, bazClusterRef));
         await().untilAsserted(() -> {
             var secret = extension.get(Secret.class, ProxyConfigSecret.secretName(proxy));
             assertThat(secret)
@@ -279,16 +295,26 @@ class ProxyReconcilerIT {
         // given
         KafkaProxy proxyA = extension.create(kafkaProxy(PROXY_A));
         KafkaProxy proxyB = extension.create(kafkaProxy(PROXY_B));
-        extension.create(virtualKafkaCluster(CLUSTER_FOO, CLUSTER_FOO_BOOTSTRAP, proxyA));
-        extension.create(virtualKafkaCluster(CLUSTER_BAR, CLUSTER_BAR_BOOTSTRAP, proxyA));
-        extension.create(virtualKafkaCluster(CLUSTER_BAZ, CLUSTER_BAZ_BOOTSTRAP, proxyB));
+
+        KafkaClusterRef fooClusterRef = extension.create(clusterRef(CLUSTER_FOO_REF, CLUSTER_FOO_BOOTSTRAP));
+        KafkaClusterRef barClusterRef = extension.create(clusterRef(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP));
+        KafkaClusterRef bazClusterRef = extension.create(clusterRef(CLUSTER_BAZ_REF, CLUSTER_BAZ_BOOTSTRAP));
+
+        extension.create(virtualKafkaCluster(CLUSTER_FOO, proxyA, fooClusterRef));
+        extension.create(virtualKafkaCluster(CLUSTER_BAZ, proxyB, bazClusterRef));
+        VirtualKafkaCluster barCluster = extension.create(virtualKafkaCluster(CLUSTER_BAR, proxyA, barClusterRef));
+
         assertProxyConfigContents(proxyA, Set.of(CLUSTER_FOO_BOOTSTRAP, CLUSTER_BAR_BOOTSTRAP), Set.of());
         assertProxyConfigContents(proxyB, Set.of(CLUSTER_BAZ_BOOTSTRAP), Set.of());
         assertClusterServiceExists(proxyA, CLUSTER_FOO);
         assertClusterServiceExists(proxyA, CLUSTER_BAR);
         assertClusterServiceExists(proxyB, CLUSTER_BAZ);
+
         // when
-        extension.replace(virtualKafkaCluster(CLUSTER_BAR, CLUSTER_BAR_BOOTSTRAP, proxyB));
+        var updatedBarCluster = new VirtualKafkaClusterBuilder(barCluster).editSpec().editProxyRef().withName(proxyB.getMetadata().getName()).endProxyRef().endSpec()
+                .build();
+        extension.replace(updatedBarCluster);
+
         // then
         assertDeploymentBecomesReady(proxyA);
         assertDeploymentBecomesReady(proxyB);
@@ -300,14 +326,21 @@ class ProxyReconcilerIT {
         assertClusterServiceExists(proxyB, CLUSTER_BAZ);
     }
 
-    private static VirtualKafkaCluster virtualKafkaCluster(String clusterName, String clusterBootstrap, KafkaProxy proxy) {
+    private static VirtualKafkaCluster virtualKafkaCluster(String clusterName, KafkaProxy proxy, KafkaClusterRef clusterRef) {
         return new VirtualKafkaClusterBuilder().withNewMetadata().withName(clusterName).endMetadata()
                 .withNewSpec()
                 .withNewTargetCluster()
-                .withNewBootstrapping().withBootstrapAddress(clusterBootstrap).endBootstrapping()
+                .withClusterRef(new ClusterRefBuilder().withName(clusterRef.getMetadata().getName()).build())
                 .endTargetCluster()
                 .withNewProxyRef().withName(proxy.getMetadata().getName()).endProxyRef()
                 .withFilters()
+                .endSpec().build();
+    }
+
+    private static KafkaClusterRef clusterRef(String clusterRefName, String clusterBootstrap) {
+        return new KafkaClusterRefBuilder().withNewMetadata().withName(clusterRefName).endMetadata()
+                .withNewSpec()
+                .withBootstrapServers(clusterBootstrap)
                 .endSpec().build();
     }
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerTest.java
@@ -35,6 +35,8 @@ import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.PrimaryToSecondaryMapper;
 import io.javaoperatorsdk.operator.processing.event.source.SecondaryToPrimaryMapper;
 
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRefBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyStatus;
@@ -371,7 +373,7 @@ class ProxyReconcilerTest {
                 .endProxyRef().endSpec().build();
         when(mockList.getItems()).thenReturn(List.of(cluster, clusterForAnotherProxy));
         PrimaryToSecondaryMapper<HasMetadata> mapper = ProxyReconciler.proxyToClusterMapper(context);
-        KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName("proxy").endMetadata().build();
+        KafkaProxy proxy = buildProxy("proxy");
         Set<ResourceID> secondaryResourceIDs = mapper.toSecondaryResourceIDs(proxy);
         assertThat(secondaryResourceIDs).containsExactly(ResourceID.fromResource(cluster));
     }
@@ -391,7 +393,7 @@ class ProxyReconcilerTest {
                 .endProxyRef().endSpec().build();
         when(mockList.getItems()).thenReturn(List.of(clusterForAnotherProxy));
         PrimaryToSecondaryMapper<HasMetadata> mapper = ProxyReconciler.proxyToClusterMapper(context);
-        KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName("proxy").endMetadata().build();
+        KafkaProxy proxy = buildProxy("proxy");
         Set<ResourceID> secondaryResourceIDs = mapper.toSecondaryResourceIDs(proxy);
         assertThat(secondaryResourceIDs).isEmpty();
     }
@@ -406,7 +408,7 @@ class ProxyReconcilerTest {
         KubernetesResourceList<KafkaProxy> mockList = mock();
         when(mockOperation.list()).thenReturn(mockList);
         when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
-        KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName("proxy").endMetadata().build();
+        KafkaProxy proxy = buildProxy("proxy");
         when(mockList.getItems()).thenReturn(List.of(proxy));
         SecondaryToPrimaryMapper<VirtualKafkaCluster> mapper = ProxyReconciler.clusterToProxyMapper(context);
         VirtualKafkaCluster cluster = new VirtualKafkaClusterBuilder().withNewMetadata().withName("cluster").endMetadata().withNewSpec().withNewProxyRef()
@@ -426,7 +428,7 @@ class ProxyReconcilerTest {
         KubernetesResourceList<KafkaProxy> mockList = mock();
         when(mockOperation.list()).thenReturn(mockList);
         when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
-        KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName("proxy").endMetadata().build();
+        KafkaProxy proxy = buildProxy("proxy");
         when(mockList.getItems()).thenReturn(List.of(proxy));
         SecondaryToPrimaryMapper<GenericKubernetesResource> mapper = ProxyReconciler.filterToProxy(context);
         String namespace = "test";
@@ -458,6 +460,223 @@ class ProxyReconcilerTest {
         Set<ResourceID> secondaryResourceIDs = mapper.toSecondaryResourceIDs(proxy);
         assertThat(secondaryResourceIDs).containsExactly(new ResourceID(filterName, proxyNamespace));
         verify(mockOperation).inNamespace(proxyNamespace);
+    }
+
+    @Test
+    void proxyToKafkaClusterRefMapper() {
+        EventSourceContext<KafkaProxy> context = mock();
+        KubernetesClient client = mock();
+        when(context.getClient()).thenReturn(client);
+
+        KafkaProxy proxy = buildProxy("proxy");
+
+        KubernetesResourceList<VirtualKafkaCluster> clusterListMock = mockVirtualKafkaClusterListOperation(client);
+
+        KubernetesResourceList<KafkaClusterRef> clusterRefListMock = mockKafkaClusterRefListOperation(client);
+
+        KafkaClusterRef kafkaClusterRef = buildKafkaClusterRef("ref");
+
+        when(clusterRefListMock.getItems()).thenReturn(List.of(kafkaClusterRef));
+
+        VirtualKafkaCluster cluster = buildVirtualKafkaCluster(proxy, "cluster", kafkaClusterRef);
+
+        when(clusterListMock.getItems()).thenReturn(List.of(cluster));
+
+        PrimaryToSecondaryMapper<HasMetadata> mapper = ProxyReconciler.proxyToKafkaClusterRefMapper(context);
+        Set<ResourceID> secondaryResourceIDs = mapper.toSecondaryResourceIDs(proxy);
+        assertThat(secondaryResourceIDs).containsExactly(ResourceID.fromResource(kafkaClusterRef));
+    }
+
+    @Test
+    void proxyToKafkaClusterRefMapperDistinguishesByProxy() {
+        EventSourceContext<KafkaProxy> context = mock();
+        KubernetesClient client = mock();
+        when(context.getClient()).thenReturn(client);
+
+        KafkaProxy proxy1 = buildProxy("proxy1");
+        KafkaProxy proxy2 = buildProxy("proxy2");
+
+        KubernetesResourceList<VirtualKafkaCluster> clusterListMock = mockVirtualKafkaClusterListOperation(client);
+
+        KubernetesResourceList<KafkaClusterRef> clusterRefListMock = mockKafkaClusterRefListOperation(client);
+
+        KafkaClusterRef kafkaClusterRefProxy1 = buildKafkaClusterRef("proxy1ref");
+        KafkaClusterRef kafkaClusterRefProxy2 = buildKafkaClusterRef("proxy2ref");
+
+        when(clusterRefListMock.getItems()).thenReturn(List.of(kafkaClusterRefProxy1, kafkaClusterRefProxy2));
+
+        VirtualKafkaCluster clusterProxy1 = buildVirtualKafkaCluster(proxy1, "proxy1cluster", kafkaClusterRefProxy1);
+        VirtualKafkaCluster clusterProxy2 = buildVirtualKafkaCluster(proxy2, "proxy2cluster", kafkaClusterRefProxy2);
+
+        when(clusterListMock.getItems()).thenReturn(List.of(clusterProxy1, clusterProxy2));
+
+        PrimaryToSecondaryMapper<HasMetadata> mapper = ProxyReconciler.proxyToKafkaClusterRefMapper(context);
+
+        assertThat(mapper.toSecondaryResourceIDs(proxy1)).containsExactly(ResourceID.fromResource(kafkaClusterRefProxy1));
+        assertThat(mapper.toSecondaryResourceIDs(proxy2)).containsExactly(ResourceID.fromResource(kafkaClusterRefProxy2));
+    }
+
+    @Test
+    void proxyToKafkaClusterRefMapperHandlesProxyWithMultipleRefs() {
+        EventSourceContext<KafkaProxy> context = mock();
+        KubernetesClient client = mock();
+        when(context.getClient()).thenReturn(client);
+
+        KafkaProxy proxy1 = buildProxy("proxy1");
+        KafkaProxy proxy2 = buildProxy("proxy2");
+
+        KubernetesResourceList<VirtualKafkaCluster> clusterListMock = mockVirtualKafkaClusterListOperation(client);
+
+        KubernetesResourceList<KafkaClusterRef> clusterRefListMock = mockKafkaClusterRefListOperation(client);
+
+        KafkaClusterRef kafkaClusterRefProxy1 = buildKafkaClusterRef("proxy1ref");
+
+        KafkaClusterRef kafkaClusterRefProxy2a = buildKafkaClusterRef("proxy2refa");
+        KafkaClusterRef kafkaClusterRefProxy2b = buildKafkaClusterRef("proxy2refb");
+
+        when(clusterRefListMock.getItems()).thenReturn(List.of(kafkaClusterRefProxy1, kafkaClusterRefProxy2a, kafkaClusterRefProxy2b));
+
+        VirtualKafkaCluster clusterProxy1 = buildVirtualKafkaCluster(proxy1, "proxy1cluster", kafkaClusterRefProxy1);
+        VirtualKafkaCluster clusterProxy2a = buildVirtualKafkaCluster(proxy2, "proxy2clustera", kafkaClusterRefProxy2a);
+        VirtualKafkaCluster clusterProxy2b = buildVirtualKafkaCluster(proxy2, "proxy2clusterb", kafkaClusterRefProxy2b);
+
+        when(clusterListMock.getItems()).thenReturn(List.of(clusterProxy1, clusterProxy2a, clusterProxy2b));
+
+        PrimaryToSecondaryMapper<HasMetadata> mapper = ProxyReconciler.proxyToKafkaClusterRefMapper(context);
+
+        assertThat(mapper.toSecondaryResourceIDs(proxy1))
+                .containsExactly(ResourceID.fromResource(kafkaClusterRefProxy1));
+
+        assertThat(mapper.toSecondaryResourceIDs(proxy2))
+                .containsExactly(ResourceID.fromResource(kafkaClusterRefProxy2a), ResourceID.fromResource(kafkaClusterRefProxy2b));
+    }
+
+    @Test
+    void kafkaClusterRefToProxyMapper() {
+        EventSourceContext<KafkaProxy> context = mock();
+        KubernetesClient client = mock();
+        when(context.getClient()).thenReturn(client);
+
+        KafkaClusterRef kafkaClusterRef = buildKafkaClusterRef("ref");
+        KafkaProxy proxy = buildProxy("proxy");
+        VirtualKafkaCluster cluster = buildVirtualKafkaCluster(proxy, "cluster", kafkaClusterRef);
+
+        KubernetesResourceList<KafkaProxy> mockProxyList = mockKafkaProxyListOperation(client);
+        when(mockProxyList.getItems()).thenReturn(List.of(proxy));
+
+        KubernetesResourceList<VirtualKafkaCluster> mockClusterList = mockVirtualKafkaClusterListOperation(client);
+        when(mockClusterList.getItems()).thenReturn(List.of(cluster));
+
+        SecondaryToPrimaryMapper<KafkaClusterRef> mapper = ProxyReconciler.kafkaClusterRefToProxyMapper(context);
+
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(kafkaClusterRef);
+        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(proxy));
+    }
+
+    @Test
+    void kafkaClusterRefToProxyMapperHandlesSharedKafkaClusterRef() {
+        EventSourceContext<KafkaProxy> context = mock();
+        KubernetesClient client = mock();
+        when(context.getClient()).thenReturn(client);
+
+        KafkaClusterRef kafkaClusterRef = buildKafkaClusterRef("ref");
+        KafkaProxy proxy1 = buildProxy("proxy1");
+        KafkaProxy proxy2 = buildProxy("proxy2");
+        VirtualKafkaCluster proxy1cluster = buildVirtualKafkaCluster(proxy1, "proxy1cluster", kafkaClusterRef);
+        VirtualKafkaCluster proxy2cluster = buildVirtualKafkaCluster(proxy2, "proxy2cluster", kafkaClusterRef);
+
+        KubernetesResourceList<KafkaProxy> mockProxyList = mockKafkaProxyListOperation(client);
+        when(mockProxyList.getItems()).thenReturn(List.of(proxy1, proxy2));
+
+        KubernetesResourceList<VirtualKafkaCluster> mockClusterList = mockVirtualKafkaClusterListOperation(client);
+        when(mockClusterList.getItems()).thenReturn(List.of(proxy1cluster, proxy2cluster));
+
+        SecondaryToPrimaryMapper<KafkaClusterRef> mapper = ProxyReconciler.kafkaClusterRefToProxyMapper(context);
+
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(kafkaClusterRef);
+        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(proxy1), ResourceID.fromResource(proxy2));
+    }
+
+    @Test
+    void kafkaClusterRefToProxyMapperHandlesOrphanKafkaClusterRef() {
+        EventSourceContext<KafkaProxy> context = mock();
+        KubernetesClient client = mock();
+        when(context.getClient()).thenReturn(client);
+
+        KafkaClusterRef orphanKafkaClusterRed = buildKafkaClusterRef("orphan");
+        KafkaProxy proxy = buildProxy("proxy");
+        VirtualKafkaCluster cluster = buildVirtualKafkaCluster(proxy, "cluster", buildKafkaClusterRef("ref"));
+
+        KubernetesResourceList<KafkaProxy> mockProxyList = mockKafkaProxyListOperation(client);
+        when(mockProxyList.getItems()).thenReturn(List.of(proxy));
+
+        KubernetesResourceList<VirtualKafkaCluster> mockClusterList = mockVirtualKafkaClusterListOperation(client);
+        when(mockClusterList.getItems()).thenReturn(List.of(cluster));
+
+        SecondaryToPrimaryMapper<KafkaClusterRef> mapper = ProxyReconciler.kafkaClusterRefToProxyMapper(context);
+
+        Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(orphanKafkaClusterRed);
+        assertThat(primaryResourceIDs).isEmpty();
+    }
+
+    private KafkaProxy buildProxy(String name) {
+        return new KafkaProxyBuilder().withNewMetadata().withName(name).endMetadata().build();
+    }
+
+    private KafkaClusterRef buildKafkaClusterRef(String name) {
+        return new KafkaClusterRefBuilder()
+                .withNewMetadata()
+                .withName(name)
+                .endMetadata()
+                .build();
+    }
+
+    private VirtualKafkaCluster buildVirtualKafkaCluster(KafkaProxy kafkaProxy, String name, KafkaClusterRef clusterRef) {
+        return new VirtualKafkaClusterBuilder()
+                .withNewMetadata()
+                .withName(name)
+                .endMetadata()
+                .withNewSpec()
+                .withNewProxyRef()
+                .withName(kafkaProxy.getMetadata().getName())
+                .endProxyRef()
+                .withNewTargetCluster()
+                .withNewClusterRef()
+                .withName(clusterRef.getMetadata().getName())
+                .endClusterRef()
+                .endTargetCluster()
+                .endSpec()
+                .build();
+    }
+
+    private KubernetesResourceList<KafkaProxy> mockKafkaProxyListOperation(KubernetesClient client) {
+        MixedOperation<KafkaProxy, KubernetesResourceList<KafkaProxy>, Resource<KafkaProxy>> mockOperation = mock();
+        when(client.resources(KafkaProxy.class)).thenReturn(mockOperation);
+
+        KubernetesResourceList<KafkaProxy> mockList = mock();
+        when(mockOperation.list()).thenReturn(mockList);
+        when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
+        return mockList;
+    }
+
+    private KubernetesResourceList<VirtualKafkaCluster> mockVirtualKafkaClusterListOperation(KubernetesClient client) {
+        MixedOperation<VirtualKafkaCluster, KubernetesResourceList<VirtualKafkaCluster>, Resource<VirtualKafkaCluster>> clusterOperation = mock();
+        when(client.resources(VirtualKafkaCluster.class)).thenReturn(clusterOperation);
+
+        KubernetesResourceList<VirtualKafkaCluster> clusterList = mock();
+        when(clusterOperation.list()).thenReturn(clusterList);
+        when(clusterOperation.inNamespace(any())).thenReturn(clusterOperation);
+        return clusterList;
+    }
+
+    private KubernetesResourceList<KafkaClusterRef> mockKafkaClusterRefListOperation(KubernetesClient client) {
+        MixedOperation<KafkaClusterRef, KubernetesResourceList<KafkaClusterRef>, Resource<KafkaClusterRef>> clusterRefOperation = mock();
+        when(client.resources(KafkaClusterRef.class)).thenReturn(clusterRefOperation);
+
+        KubernetesResourceList<KafkaClusterRef> clusterRefList = mock();
+        when(clusterRefOperation.list()).thenReturn(clusterRefList);
+        when(clusterRefOperation.inNamespace(any())).thenReturn(clusterRefOperation);
+        return clusterRefList;
     }
 
 }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerTest.java
@@ -357,42 +357,36 @@ class ProxyReconcilerTest {
 
     @Test
     void proxyToClusterMapper() {
-        EventSourceContext<KafkaProxy> context = mock();
+        EventSourceContext<KafkaProxy> eventSourceContext = mock();
         KubernetesClient client = mock();
-        when(context.getClient()).thenReturn(client);
+        when(eventSourceContext.getClient()).thenReturn(client);
         MixedOperation<VirtualKafkaCluster, KubernetesResourceList<VirtualKafkaCluster>, Resource<VirtualKafkaCluster>> mockOperation = mock();
         when(client.resources(VirtualKafkaCluster.class)).thenReturn(mockOperation);
         KubernetesResourceList<VirtualKafkaCluster> mockList = mock();
         when(mockOperation.list()).thenReturn(mockList);
         when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
-        VirtualKafkaCluster cluster = new VirtualKafkaClusterBuilder().withNewMetadata().withName("cluster").endMetadata().withNewSpec().withNewProxyRef()
-                .withName("proxy")
-                .endProxyRef().endSpec().build();
-        VirtualKafkaCluster clusterForAnotherProxy = new VirtualKafkaClusterBuilder().withNewMetadata().withName("cluster").endMetadata().withNewSpec().withNewProxyRef()
-                .withName("anotherProxy")
-                .endProxyRef().endSpec().build();
-        when(mockList.getItems()).thenReturn(List.of(cluster, clusterForAnotherProxy));
-        PrimaryToSecondaryMapper<HasMetadata> mapper = ProxyReconciler.proxyToClusterMapper(context);
         KafkaProxy proxy = buildProxy("proxy");
+        VirtualKafkaCluster cluster = baseVirtualKafkaClusterBuilder(proxy, "cluster").build();
+        VirtualKafkaCluster clusterForAnotherProxy = baseVirtualKafkaClusterBuilder(buildProxy("anotherproxy"), "anothercluster").build();
+        when(mockList.getItems()).thenReturn(List.of(cluster, clusterForAnotherProxy));
+        PrimaryToSecondaryMapper<HasMetadata> mapper = ProxyReconciler.proxyToClusterMapper(eventSourceContext);
         Set<ResourceID> secondaryResourceIDs = mapper.toSecondaryResourceIDs(proxy);
         assertThat(secondaryResourceIDs).containsExactly(ResourceID.fromResource(cluster));
     }
 
     @Test
     void proxyToClusterMapper_NoMatchedClusters() {
-        EventSourceContext<KafkaProxy> context = mock();
+        EventSourceContext<KafkaProxy> eventSourceContext = mock();
         KubernetesClient client = mock();
-        when(context.getClient()).thenReturn(client);
+        when(eventSourceContext.getClient()).thenReturn(client);
         MixedOperation<VirtualKafkaCluster, KubernetesResourceList<VirtualKafkaCluster>, Resource<VirtualKafkaCluster>> mockOperation = mock();
         when(client.resources(VirtualKafkaCluster.class)).thenReturn(mockOperation);
         KubernetesResourceList<VirtualKafkaCluster> mockList = mock();
         when(mockOperation.list()).thenReturn(mockList);
         when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
-        VirtualKafkaCluster clusterForAnotherProxy = new VirtualKafkaClusterBuilder().withNewMetadata().withName("cluster").endMetadata().withNewSpec().withNewProxyRef()
-                .withName("anotherProxy")
-                .endProxyRef().endSpec().build();
+        VirtualKafkaCluster clusterForAnotherProxy = baseVirtualKafkaClusterBuilder(buildProxy("anotherProxy"), "cluster").build();
         when(mockList.getItems()).thenReturn(List.of(clusterForAnotherProxy));
-        PrimaryToSecondaryMapper<HasMetadata> mapper = ProxyReconciler.proxyToClusterMapper(context);
+        PrimaryToSecondaryMapper<HasMetadata> mapper = ProxyReconciler.proxyToClusterMapper(eventSourceContext);
         KafkaProxy proxy = buildProxy("proxy");
         Set<ResourceID> secondaryResourceIDs = mapper.toSecondaryResourceIDs(proxy);
         assertThat(secondaryResourceIDs).isEmpty();
@@ -400,9 +394,9 @@ class ProxyReconcilerTest {
 
     @Test
     void clusterToProxyMapper() {
-        EventSourceContext<KafkaProxy> context = mock();
+        EventSourceContext<KafkaProxy> eventSourceContext = mock();
         KubernetesClient client = mock();
-        when(context.getClient()).thenReturn(client);
+        when(eventSourceContext.getClient()).thenReturn(client);
         MixedOperation<KafkaProxy, KubernetesResourceList<KafkaProxy>, Resource<KafkaProxy>> mockOperation = mock();
         when(client.resources(KafkaProxy.class)).thenReturn(mockOperation);
         KubernetesResourceList<KafkaProxy> mockList = mock();
@@ -410,19 +404,17 @@ class ProxyReconcilerTest {
         when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
         KafkaProxy proxy = buildProxy("proxy");
         when(mockList.getItems()).thenReturn(List.of(proxy));
-        SecondaryToPrimaryMapper<VirtualKafkaCluster> mapper = ProxyReconciler.clusterToProxyMapper(context);
-        VirtualKafkaCluster cluster = new VirtualKafkaClusterBuilder().withNewMetadata().withName("cluster").endMetadata().withNewSpec().withNewProxyRef()
-                .withName("proxy")
-                .endProxyRef().endSpec().build();
+        SecondaryToPrimaryMapper<VirtualKafkaCluster> mapper = ProxyReconciler.clusterToProxyMapper(eventSourceContext);
+        VirtualKafkaCluster cluster = baseVirtualKafkaClusterBuilder(proxy, "cluster").build();
         Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(cluster);
         assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(proxy));
     }
 
     @Test
     void filterToProxyMapper() {
-        EventSourceContext<KafkaProxy> context = mock();
+        EventSourceContext<KafkaProxy> eventSourceContext = mock();
         KubernetesClient client = mock();
-        when(context.getClient()).thenReturn(client);
+        when(eventSourceContext.getClient()).thenReturn(client);
         MixedOperation<KafkaProxy, KubernetesResourceList<KafkaProxy>, Resource<KafkaProxy>> mockOperation = mock();
         when(client.resources(KafkaProxy.class)).thenReturn(mockOperation);
         KubernetesResourceList<KafkaProxy> mockList = mock();
@@ -430,7 +422,7 @@ class ProxyReconcilerTest {
         when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
         KafkaProxy proxy = buildProxy("proxy");
         when(mockList.getItems()).thenReturn(List.of(proxy));
-        SecondaryToPrimaryMapper<GenericKubernetesResource> mapper = ProxyReconciler.filterToProxy(context);
+        SecondaryToPrimaryMapper<GenericKubernetesResource> mapper = ProxyReconciler.filterToProxy(eventSourceContext);
         String namespace = "test";
         GenericKubernetesResource filter = new GenericKubernetesResourceBuilder().withNewMetadata().withName("filter").withNamespace(namespace).endMetadata().build();
         Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(filter);
@@ -440,9 +432,9 @@ class ProxyReconcilerTest {
 
     @Test
     void proxyToFilterMapping() {
-        EventSourceContext<KafkaProxy> context = mock();
+        EventSourceContext<KafkaProxy> eventSourceContext = mock();
         KubernetesClient client = mock();
-        when(context.getClient()).thenReturn(client);
+        when(eventSourceContext.getClient()).thenReturn(client);
         MixedOperation<VirtualKafkaCluster, KubernetesResourceList<VirtualKafkaCluster>, Resource<VirtualKafkaCluster>> mockOperation = mock();
         when(client.resources(VirtualKafkaCluster.class)).thenReturn(mockOperation);
         KubernetesResourceList<VirtualKafkaCluster> mockList = mock();
@@ -451,12 +443,11 @@ class ProxyReconcilerTest {
         String proxyName = "proxy";
         String proxyNamespace = "test";
         String filterName = "filter";
-        VirtualKafkaCluster clusterForAnotherProxy = new VirtualKafkaClusterBuilder().withNewMetadata().withName("cluster").endMetadata().withNewSpec().withNewProxyRef()
-                .withName(proxyName)
-                .endProxyRef().addNewFilter().withName(filterName).endFilter().endSpec().build();
-        when(mockList.getItems()).thenReturn(List.of(clusterForAnotherProxy));
         KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName(proxyName).withNamespace(proxyNamespace).endMetadata().build();
-        PrimaryToSecondaryMapper<KafkaProxy> mapper = ProxyReconciler.proxyToFilters(context);
+        VirtualKafkaCluster clusterForAnotherProxy = baseVirtualKafkaClusterBuilder(proxy, "cluster").editOrNewSpec()
+                .addNewFilter().withName(filterName).endFilter().endSpec().build();
+        when(mockList.getItems()).thenReturn(List.of(clusterForAnotherProxy));
+        PrimaryToSecondaryMapper<KafkaProxy> mapper = ProxyReconciler.proxyToFilters(eventSourceContext);
         Set<ResourceID> secondaryResourceIDs = mapper.toSecondaryResourceIDs(proxy);
         assertThat(secondaryResourceIDs).containsExactly(new ResourceID(filterName, proxyNamespace));
         verify(mockOperation).inNamespace(proxyNamespace);
@@ -464,9 +455,9 @@ class ProxyReconcilerTest {
 
     @Test
     void proxyToKafkaClusterRefMapper() {
-        EventSourceContext<KafkaProxy> context = mock();
+        EventSourceContext<KafkaProxy> eventSourceContext = mock();
         KubernetesClient client = mock();
-        when(context.getClient()).thenReturn(client);
+        when(eventSourceContext.getClient()).thenReturn(client);
 
         KafkaProxy proxy = buildProxy("proxy");
 
@@ -482,16 +473,16 @@ class ProxyReconcilerTest {
 
         when(clusterListMock.getItems()).thenReturn(List.of(cluster));
 
-        PrimaryToSecondaryMapper<HasMetadata> mapper = ProxyReconciler.proxyToKafkaClusterRefMapper(context);
+        PrimaryToSecondaryMapper<HasMetadata> mapper = ProxyReconciler.proxyToKafkaClusterRefMapper(eventSourceContext);
         Set<ResourceID> secondaryResourceIDs = mapper.toSecondaryResourceIDs(proxy);
         assertThat(secondaryResourceIDs).containsExactly(ResourceID.fromResource(kafkaClusterRef));
     }
 
     @Test
     void proxyToKafkaClusterRefMapperDistinguishesByProxy() {
-        EventSourceContext<KafkaProxy> context = mock();
+        EventSourceContext<KafkaProxy> eventSourceContext = mock();
         KubernetesClient client = mock();
-        when(context.getClient()).thenReturn(client);
+        when(eventSourceContext.getClient()).thenReturn(client);
 
         KafkaProxy proxy1 = buildProxy("proxy1");
         KafkaProxy proxy2 = buildProxy("proxy2");
@@ -510,7 +501,7 @@ class ProxyReconcilerTest {
 
         when(clusterListMock.getItems()).thenReturn(List.of(clusterProxy1, clusterProxy2));
 
-        PrimaryToSecondaryMapper<HasMetadata> mapper = ProxyReconciler.proxyToKafkaClusterRefMapper(context);
+        PrimaryToSecondaryMapper<HasMetadata> mapper = ProxyReconciler.proxyToKafkaClusterRefMapper(eventSourceContext);
 
         assertThat(mapper.toSecondaryResourceIDs(proxy1)).containsExactly(ResourceID.fromResource(kafkaClusterRefProxy1));
         assertThat(mapper.toSecondaryResourceIDs(proxy2)).containsExactly(ResourceID.fromResource(kafkaClusterRefProxy2));
@@ -518,9 +509,9 @@ class ProxyReconcilerTest {
 
     @Test
     void proxyToKafkaClusterRefMapperHandlesProxyWithMultipleRefs() {
-        EventSourceContext<KafkaProxy> context = mock();
+        EventSourceContext<KafkaProxy> eventSourceContext = mock();
         KubernetesClient client = mock();
-        when(context.getClient()).thenReturn(client);
+        when(eventSourceContext.getClient()).thenReturn(client);
 
         KafkaProxy proxy1 = buildProxy("proxy1");
         KafkaProxy proxy2 = buildProxy("proxy2");
@@ -542,7 +533,7 @@ class ProxyReconcilerTest {
 
         when(clusterListMock.getItems()).thenReturn(List.of(clusterProxy1, clusterProxy2a, clusterProxy2b));
 
-        PrimaryToSecondaryMapper<HasMetadata> mapper = ProxyReconciler.proxyToKafkaClusterRefMapper(context);
+        PrimaryToSecondaryMapper<HasMetadata> mapper = ProxyReconciler.proxyToKafkaClusterRefMapper(eventSourceContext);
 
         assertThat(mapper.toSecondaryResourceIDs(proxy1))
                 .containsExactly(ResourceID.fromResource(kafkaClusterRefProxy1));
@@ -552,10 +543,30 @@ class ProxyReconcilerTest {
     }
 
     @Test
-    void kafkaClusterRefToProxyMapper() {
-        EventSourceContext<KafkaProxy> context = mock();
+    void proxyToKafkaClusterRefMapperIgnoresDanglingKafkaClusterRef() {
+        EventSourceContext<KafkaProxy> eventSourceContext = mock();
         KubernetesClient client = mock();
-        when(context.getClient()).thenReturn(client);
+        when(eventSourceContext.getClient()).thenReturn(client);
+
+        KafkaProxy proxy = buildProxy("proxy");
+
+        KubernetesResourceList<VirtualKafkaCluster> clusterListMock = mockVirtualKafkaClusterListOperation(client);
+        mockKafkaClusterRefListOperation(client);
+
+        VirtualKafkaCluster cluster = buildVirtualKafkaCluster(proxy, "cluster", buildKafkaClusterRef("dangle"));
+
+        when(clusterListMock.getItems()).thenReturn(List.of(cluster));
+
+        PrimaryToSecondaryMapper<HasMetadata> mapper = ProxyReconciler.proxyToKafkaClusterRefMapper(eventSourceContext);
+        Set<ResourceID> secondaryResourceIDs = mapper.toSecondaryResourceIDs(proxy);
+        assertThat(secondaryResourceIDs).isEmpty();
+    }
+
+    @Test
+    void kafkaClusterRefToProxyMapper() {
+        EventSourceContext<KafkaProxy> eventSourceContext = mock();
+        KubernetesClient client = mock();
+        when(eventSourceContext.getClient()).thenReturn(client);
 
         KafkaClusterRef kafkaClusterRef = buildKafkaClusterRef("ref");
         KafkaProxy proxy = buildProxy("proxy");
@@ -567,7 +578,7 @@ class ProxyReconcilerTest {
         KubernetesResourceList<VirtualKafkaCluster> mockClusterList = mockVirtualKafkaClusterListOperation(client);
         when(mockClusterList.getItems()).thenReturn(List.of(cluster));
 
-        SecondaryToPrimaryMapper<KafkaClusterRef> mapper = ProxyReconciler.kafkaClusterRefToProxyMapper(context);
+        SecondaryToPrimaryMapper<KafkaClusterRef> mapper = ProxyReconciler.kafkaClusterRefToProxyMapper(eventSourceContext);
 
         Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(kafkaClusterRef);
         assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(proxy));
@@ -575,9 +586,9 @@ class ProxyReconcilerTest {
 
     @Test
     void kafkaClusterRefToProxyMapperHandlesSharedKafkaClusterRef() {
-        EventSourceContext<KafkaProxy> context = mock();
+        EventSourceContext<KafkaProxy> eventSourceContext = mock();
         KubernetesClient client = mock();
-        when(context.getClient()).thenReturn(client);
+        when(eventSourceContext.getClient()).thenReturn(client);
 
         KafkaClusterRef kafkaClusterRef = buildKafkaClusterRef("ref");
         KafkaProxy proxy1 = buildProxy("proxy1");
@@ -591,7 +602,7 @@ class ProxyReconcilerTest {
         KubernetesResourceList<VirtualKafkaCluster> mockClusterList = mockVirtualKafkaClusterListOperation(client);
         when(mockClusterList.getItems()).thenReturn(List.of(proxy1cluster, proxy2cluster));
 
-        SecondaryToPrimaryMapper<KafkaClusterRef> mapper = ProxyReconciler.kafkaClusterRefToProxyMapper(context);
+        SecondaryToPrimaryMapper<KafkaClusterRef> mapper = ProxyReconciler.kafkaClusterRefToProxyMapper(eventSourceContext);
 
         Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(kafkaClusterRef);
         assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(proxy1), ResourceID.fromResource(proxy2));
@@ -599,9 +610,9 @@ class ProxyReconcilerTest {
 
     @Test
     void kafkaClusterRefToProxyMapperHandlesOrphanKafkaClusterRef() {
-        EventSourceContext<KafkaProxy> context = mock();
+        EventSourceContext<KafkaProxy> eventSourceContext = mock();
         KubernetesClient client = mock();
-        when(context.getClient()).thenReturn(client);
+        when(eventSourceContext.getClient()).thenReturn(client);
 
         KafkaClusterRef orphanKafkaClusterRed = buildKafkaClusterRef("orphan");
         KafkaProxy proxy = buildProxy("proxy");
@@ -613,7 +624,7 @@ class ProxyReconcilerTest {
         KubernetesResourceList<VirtualKafkaCluster> mockClusterList = mockVirtualKafkaClusterListOperation(client);
         when(mockClusterList.getItems()).thenReturn(List.of(cluster));
 
-        SecondaryToPrimaryMapper<KafkaClusterRef> mapper = ProxyReconciler.kafkaClusterRefToProxyMapper(context);
+        SecondaryToPrimaryMapper<KafkaClusterRef> mapper = ProxyReconciler.kafkaClusterRefToProxyMapper(eventSourceContext);
 
         Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(orphanKafkaClusterRed);
         assertThat(primaryResourceIDs).isEmpty();
@@ -632,14 +643,8 @@ class ProxyReconcilerTest {
     }
 
     private VirtualKafkaCluster buildVirtualKafkaCluster(KafkaProxy kafkaProxy, String name, KafkaClusterRef clusterRef) {
-        return new VirtualKafkaClusterBuilder()
-                .withNewMetadata()
-                .withName(name)
-                .endMetadata()
-                .withNewSpec()
-                .withNewProxyRef()
-                .withName(kafkaProxy.getMetadata().getName())
-                .endProxyRef()
+        return baseVirtualKafkaClusterBuilder(kafkaProxy, name)
+                .editOrNewSpec()
                 .withNewTargetCluster()
                 .withNewClusterRef()
                 .withName(clusterRef.getMetadata().getName())
@@ -647,6 +652,17 @@ class ProxyReconcilerTest {
                 .endTargetCluster()
                 .endSpec()
                 .build();
+    }
+
+    private VirtualKafkaClusterBuilder baseVirtualKafkaClusterBuilder(KafkaProxy kafkaProxy, String name) {
+        return new VirtualKafkaClusterBuilder()
+                .withNewMetadata()
+                .withName(name)
+                .endMetadata()
+                .withNewSpec()
+                .withNewProxyRef()
+                .withName(kafkaProxy.getMetadata().getName())
+                .endProxyRef().endSpec();
     }
 
     private KubernetesResourceList<KafkaProxy> mockKafkaProxyListOperation(KubernetesClient client) {

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/in-KafkaClusterRef-fooref.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/in-KafkaClusterRef-fooref.yaml
@@ -5,14 +5,10 @@
 #
 
 ---
-kind: VirtualKafkaCluster
+kind: KafkaClusterRef
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
-  name: bar
+  name: fooref
   namespace: proxy-ns
 spec:
-  proxyRef:
-    name: twocluster
-  targetCluster:
-    clusterRef:
-      name: barref
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/in-VirtualKafkaCluster-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/in-VirtualKafkaCluster-foo.yaml
@@ -14,8 +14,8 @@ spec:
   proxyRef:
     name: example
   targetCluster:
-    bootstrapping:
-      bootstrapAddress: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+    clusterRef:
+      name: fooref
   filters:
     - group: filter.kroxylicious.io
       kind: KafkaProtocolFilter

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-KafkaClusterRef-myref.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-KafkaClusterRef-myref.yaml
@@ -5,14 +5,10 @@
 #
 
 ---
-kind: VirtualKafkaCluster
+kind: KafkaClusterRef
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
-  name: bar
+  name: myref
   namespace: proxy-ns
 spec:
-  proxyRef:
-    name: twocluster
-  targetCluster:
-    clusterRef:
-      name: barref
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-VirtualKafkaCluster-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-VirtualKafkaCluster-bar.yaml
@@ -14,8 +14,8 @@ spec:
   proxyRef:
     name: example
   targetCluster:
-    bootstrapping:
-      bootstrapAddress: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+    clusterRef:
+      name: myref
   filters:
     - group: filter.kroxylicious.io
       kind: KafkaProtocolFilter

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-VirtualKafkaCluster-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-VirtualKafkaCluster-foo.yaml
@@ -14,9 +14,9 @@ spec:
   proxyRef:
     name: example
   targetCluster:
-      # This cluster should be absent from the output proxy-operator-operator-operator-config.yaml, because there is no Two with name missing
-    bootstrapping:
-      bootstrapAddress: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+    # This cluster should be absent from the output proxy-operator-operator-operator-config.yaml, because there is no Two with name missing
+    clusterRef:
+      name: myref
   filters:
     - group: filter.kroxylicious.io
       kind: KafkaProtocolFilter

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/in-KafkaClusterRef-myref.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/in-KafkaClusterRef-myref.yaml
@@ -5,14 +5,10 @@
 #
 
 ---
-kind: VirtualKafkaCluster
+kind: KafkaClusterRef
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
-  name: bar
+  name: myref
   namespace: proxy-ns
 spec:
-  proxyRef:
-    name: twocluster
-  targetCluster:
-    clusterRef:
-      name: barref
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/in-VirtualKafkaCluster-one.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/in-VirtualKafkaCluster-one.yaml
@@ -14,5 +14,5 @@ spec:
   proxyRef:
     name: minimal
   targetCluster:
-    bootstrapping:
-      bootstrapAddress: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+    clusterRef:
+      name: myref

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/in-KafkaClusterRef-barref.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/in-KafkaClusterRef-barref.yaml
@@ -5,14 +5,10 @@
 #
 
 ---
-kind: VirtualKafkaCluster
+kind: KafkaClusterRef
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
-  name: bar
+  name: barref
   namespace: proxy-ns
 spec:
-  proxyRef:
-    name: twocluster
-  targetCluster:
-    clusterRef:
-      name: barref
+  bootstrapServers: first-kafka.kafka1.svc.cluster.local:9092

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/in-KafkaClusterRef-fooref.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/in-KafkaClusterRef-fooref.yaml
@@ -5,14 +5,10 @@
 #
 
 ---
-kind: VirtualKafkaCluster
+kind: KafkaClusterRef
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
-  name: bar
+  name: fooref
   namespace: proxy-ns
 spec:
-  proxyRef:
-    name: twocluster
-  targetCluster:
-    clusterRef:
-      name: barref
+  bootstrapServers: second-kafka.kafka2.svc.cluster.local:9092

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/in-VirtualKafkaCluster-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/in-VirtualKafkaCluster-foo.yaml
@@ -14,5 +14,5 @@ spec:
   proxyRef:
     name: twocluster
   targetCluster:
-    bootstrapping:
-      bootstrapAddress: second-kafka.kafka2.svc.cluster.local:9092
+    clusterRef:
+      name: fooref

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/in-KafkaClusterRef-myref.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/in-KafkaClusterRef-myref.yaml
@@ -5,14 +5,10 @@
 #
 
 ---
-kind: VirtualKafkaCluster
+kind: KafkaClusterRef
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
-  name: bar
+  name: myref
   namespace: proxy-ns
 spec:
-  proxyRef:
-    name: twocluster
-  targetCluster:
-    clusterRef:
-      name: barref
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/in-VirtualKafkaCluster-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/in-VirtualKafkaCluster-foo.yaml
@@ -14,8 +14,8 @@ spec:
   proxyRef:
     name: example
   targetCluster:
-    bootstrapping:
-      bootstrapAddress: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+    clusterRef:
+      name: myref
   filters:
     - group: filter.kroxylicious.io
       kind: KafkaProtocolFilter

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/in-KafkaClusterRef-myref.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/in-KafkaClusterRef-myref.yaml
@@ -5,14 +5,10 @@
 #
 
 ---
-kind: VirtualKafkaCluster
+kind: KafkaClusterRef
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
-  name: bar
+  name: myref
   namespace: proxy-ns
 spec:
-  proxyRef:
-    name: twocluster
-  targetCluster:
-    clusterRef:
-      name: barref
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/in-VirtualKafkaCluster-one.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/in-VirtualKafkaCluster-one.yaml
@@ -14,5 +14,5 @@ spec:
   proxyRef:
     name: use-pod-template-spec
   targetCluster:
-    bootstrapping:
-      bootstrapAddress: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+    clusterRef:
+      name: myref


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Replacing inline bootstrap property in the KVC with a KCR.

I haven't used the Java Operator SDK before, so I'm using this as a way in.  Feedback welcome.

Contributes towards #1824 


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
