### PR TITLE
Report absence of KCR at the Proxy level

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ClusterCondition.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ClusterCondition.java
@@ -6,6 +6,13 @@
 
 package io.kroxylicious.kubernetes.operator;
 
+import java.util.Locale;
+import java.util.Optional;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.TargetCluster;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import static io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.clusters.Conditions.Status;
 
 public record ClusterCondition(String cluster, ConditionType type, Status status, String reason, String message) {
@@ -29,6 +36,18 @@ public record ClusterCondition(String cluster, ConditionType type, Status status
     static ClusterCondition filterKindNotKnown(String cluster, String filterName, String kind) {
         return new ClusterCondition(cluster, ConditionType.Accepted, Status.FALSE, INVALID,
                 String.format("Filter \"%s\" has a kind %s that is not known to this operator.", filterName, kind));
+    }
+
+    static ClusterCondition targetClusterRefNotExists(String cluster, TargetCluster targetCluster) {
+        return new ClusterCondition(cluster, ConditionType.Accepted, Status.FALSE, INVALID,
+                String.format("Target Cluster \"%s\" does not exist.", kubeName(targetCluster).orElse("<unknown>")));
+    }
+
+    @NonNull
+    private static Optional<String> kubeName(TargetCluster targetCluster) {
+        return Optional.ofNullable(targetCluster.getClusterRef())
+                .map(r -> "%s%s/%s".formatted(r.getKind().toLowerCase(Locale.ROOT), Optional.ofNullable(r.getGroup()).map(
+                        ".%s"::formatted).orElse(""), r.getName()));
     }
 
 }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigSecret.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigSecret.java
@@ -259,12 +259,12 @@ public class ProxyConfigSecret
 
     @NonNull
     private static InvalidClusterException filterResourceNotFound(VirtualKafkaCluster cluster, Filters filterRef) {
-        return new InvalidClusterException(ClusterCondition.filterNotExists(name(cluster), filterRef.getName()));
+        return new InvalidClusterException(ClusterCondition.filterNotFound(name(cluster), filterRef.getName()));
     }
 
     @NonNull
     private static InvalidClusterException targetClusterResourceNotFound(VirtualKafkaCluster cluster) {
-        return new InvalidClusterException(ClusterCondition.targetClusterRefNotExists(cluster.getMetadata().getName(), cluster.getSpec().getTargetCluster()));
+        return new InvalidClusterException(ClusterCondition.targetClusterRefNotFound(cluster.getMetadata().getName(), cluster.getSpec().getTargetCluster()));
     }
 
     /**

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigSecret.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigSecret.java
@@ -264,7 +264,7 @@ public class ProxyConfigSecret
 
     @NonNull
     private static InvalidClusterException targetClusterResourceNotFound(VirtualKafkaCluster cluster) {
-        return new InvalidClusterException(ClusterCondition.targetClusterRefNotFound(cluster.getMetadata().getName(), cluster.getSpec().getTargetCluster()));
+        return new InvalidClusterException(ClusterCondition.targetClusterRefNotFound(name(cluster), cluster.getSpec().getTargetCluster()));
     }
 
     /**

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigSecret.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigSecret.java
@@ -16,6 +16,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -156,9 +158,22 @@ public class ProxyConfigSecret
     private static List<VirtualCluster> buildVirtualClusters(KafkaProxy primary, Context<KafkaProxy> context, List<VirtualKafkaCluster> clusters,
                                                              Map<ResourceID, KafkaClusterRef> clusterRefs) {
         AtomicInteger clusterNum = new AtomicInteger(0);
+
+        Map<VirtualKafkaCluster, Optional<KafkaClusterRef>> clusterToRefMap = clusters.stream()
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        cluster -> clusterTargetClusterResourceID(cluster).map(clusterRefs::get)));
+
+        clusterToRefMap.entrySet().stream()
+                .filter(e -> e.getValue().isEmpty())
+                .forEach(e -> {
+                    var cluster = e.getKey();
+                    SharedKafkaProxyContext.addClusterCondition(context, cluster, targetClusterResourceNotFound(cluster).accepted());
+                });
+
         return clusters.stream()
                 .filter(cluster -> !SharedKafkaProxyContext.isBroken(context, cluster))
-                .map(cluster -> getVirtualCluster(primary, cluster, clusterNum.getAndIncrement(), clusterRefs))
+                .map(cluster -> getVirtualCluster(primary, cluster, clusterToRefMap.get(cluster).get(), clusterNum.getAndIncrement()))
                 .toList();
     }
 
@@ -243,8 +258,13 @@ public class ProxyConfigSecret
     }
 
     @NonNull
-    private static InvalidClusterException resourceNotFound(VirtualKafkaCluster cluster, Filters filterRef) {
+    private static InvalidClusterException filterResourceNotFound(VirtualKafkaCluster cluster, Filters filterRef) {
         return new InvalidClusterException(ClusterCondition.filterNotExists(name(cluster), filterRef.getName()));
+    }
+
+    @NonNull
+    private static InvalidClusterException targetClusterResourceNotFound(VirtualKafkaCluster cluster) {
+        return new InvalidClusterException(ClusterCondition.targetClusterRefNotExists(cluster.getMetadata().getName(), cluster.getSpec().getTargetCluster()));
     }
 
     /**
@@ -262,21 +282,14 @@ public class ProxyConfigSecret
                             && name(filterResource).equals(filterRef.getName());
                 })
                 .findFirst()
-                .orElseThrow(() -> resourceNotFound(cluster, filterRef));
+                .orElseThrow(() -> filterResourceNotFound(cluster, filterRef));
     }
 
     private static VirtualCluster getVirtualCluster(KafkaProxy primary,
                                                     VirtualKafkaCluster cluster,
-                                                    int clusterNum, Map<ResourceID, KafkaClusterRef> clusterRefs) {
+                                                    KafkaClusterRef kafkaClusterRef, int clusterNum) {
 
-        var kafkaClusterRef = clusterTargetClusterResourceID(cluster).map(clusterRefs::get);
-
-        if (kafkaClusterRef.isEmpty()) {
-            // I should be a condition
-            throw new IllegalStateException("boom!");
-        }
-
-        String bootstrap = kafkaClusterRef.get().getSpec().getBootstrapServers();
+        String bootstrap = kafkaClusterRef.getSpec().getBootstrapServers();
         return new VirtualCluster(
                 name(cluster), new TargetCluster(bootstrap, Optional.empty()),
                 null,

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerTest.java
@@ -329,7 +329,7 @@ class ProxyReconcilerTest {
         doReturn(mdrc).when(context).managedDependentResourceContext();
         doReturn(Set.of(new VirtualKafkaClusterBuilder().withNewMetadata().withName("my-cluster").withNamespace("my-ns").endMetadata().withNewSpec().withNewProxyRef()
                 .withName("my-proxy").endProxyRef().endSpec().build())).when(context).getSecondaryResources(VirtualKafkaCluster.class);
-        doReturn(Optional.of(Map.of("my-cluster", ClusterCondition.filterNotExists("my-cluster", "MissingFilter")))).when(mdrc).get(
+        doReturn(Optional.of(Map.of("my-cluster", ClusterCondition.filterNotFound("my-cluster", "MissingFilter")))).when(mdrc).get(
                 SharedKafkaProxyContext.CLUSTER_CONDITIONS_KEY,
                 Map.class);
         doReturn(new RuntimeDecl(List.of())).when(mdrc).getMandatory(SharedKafkaProxyContext.RUNTIME_DECL_KEY, Map.class);

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/cond-Accepted-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/cond-Accepted-bar.yaml
@@ -1,0 +1,12 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+cluster: "bar"
+type: "Accepted"
+status: "False"
+reason: "Invalid"
+message: "Target Cluster \"kafkaclusterref.kroxylicious.io/barref\" does not exist."

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-KafkaClusterRef-fooref.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-KafkaClusterRef-fooref.yaml
@@ -1,0 +1,14 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaClusterRef
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: fooref
+  namespace: proxy-ns
+spec:
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-KafkaProtocolFilter-filter-one.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-KafkaProtocolFilter-filter-one.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProtocolFilter
+apiVersion: filter.kroxylicious.io/v1alpha1
+metadata:
+  name: filter-one
+  namespace: proxy-ns
+spec:
+  type: org.example.some.java.Class
+  configTemplate:
+    filterOneConfig: true

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-KafkaProxy.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-KafkaProxy.yaml
@@ -1,0 +1,12 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: example
+  namespace: proxy-ns

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-VirtualKafkaCluster-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-VirtualKafkaCluster-bar.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: VirtualKafkaCluster
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: bar
+  namespace: proxy-ns
+spec:
+  proxyRef:
+    name: example
+  targetCluster:
+    clusterRef:
+      name: barref
+  filters:
+    - group: filter.kroxylicious.io
+      kind: KafkaProtocolFilter
+      name: filter-one

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-VirtualKafkaCluster-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-VirtualKafkaCluster-foo.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: VirtualKafkaCluster
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: foo
+  namespace: proxy-ns
+spec:
+  proxyRef:
+    name: example
+  targetCluster:
+    clusterRef:
+      name: fooref
+  filters:
+    - group: filter.kroxylicious.io
+      kind: KafkaProtocolFilter
+      name: filter-one

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-Deployment-example.yaml
@@ -10,9 +10,9 @@ kind: "Deployment"
 metadata:
   labels:
     app: "kroxylicious"
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example"
@@ -26,30 +26,38 @@ spec:
   selector:
     matchLabels:
       app: "kroxylicious"
+      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
       app.kubernetes.io/name: "kroxylicious-proxy"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/instance: "example"
       app.kubernetes.io/component: "proxy"
   template:
     metadata:
       labels:
         app: "kroxylicious"
+        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
         app.kubernetes.io/name: "kroxylicious-proxy"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/instance: "example"
         app.kubernetes.io/component: "proxy"
     spec:
       containers:
-        - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
-          args:
+        - args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"
+          image: "quay.io/kroxylicious/kroxylicious:test"
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: "/livez"
+              port: "management"
+            initialDelaySeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          name: "proxy"
           ports:
             - containerPort: 9190
-              name: "metrics"
+              name: "management"
             - containerPort: 9392
             - containerPort: 9393
             - containerPort: 9394

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-Deployment-example.yaml
@@ -1,0 +1,64 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  labels:
+    app: "kroxylicious"
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/instance: "example"
+    app.kubernetes.io/component: "proxy"
+  name: "example"
+  namespace: "proxy-ns"
+  ownerReferences:
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxy"
+      name: "example"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: "kroxylicious"
+      app.kubernetes.io/managed-by: "kroxylicious-operator"
+      app.kubernetes.io/name: "kroxylicious-proxy"
+      app.kubernetes.io/part-of: "kafka"
+      app.kubernetes.io/instance: "example"
+      app.kubernetes.io/component: "proxy"
+  template:
+    metadata:
+      labels:
+        app: "kroxylicious"
+        app.kubernetes.io/managed-by: "kroxylicious-operator"
+        app.kubernetes.io/name: "kroxylicious-proxy"
+        app.kubernetes.io/part-of: "kafka"
+        app.kubernetes.io/instance: "example"
+        app.kubernetes.io/component: "proxy"
+    spec:
+      containers:
+        - name: "proxy"
+          image: "quay.io/kroxylicious/kroxylicious:test"
+          args:
+            - "--config"
+            - "/opt/kroxylicious/config/proxy-config.yaml"
+          ports:
+            - containerPort: 9190
+              name: "metrics"
+            - containerPort: 9392
+            - containerPort: 9393
+            - containerPort: 9394
+            - containerPort: 9395
+          volumeMounts:
+            - mountPath: "/opt/kroxylicious/config/proxy-config.yaml"
+              name: "config-volume"
+              subPath: "proxy-config.yaml"
+      volumes:
+        - name: "config-volume"
+          secret:
+            secretName: "example"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-Secret-example.yaml
@@ -1,0 +1,46 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: "v1"
+kind: "Secret"
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/instance: "example"
+    app.kubernetes.io/component: "proxy"
+  name: "example"
+  namespace: "proxy-ns"
+  ownerReferences:
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxy"
+      name: "example"
+stringData:
+  proxy-config.yaml: |
+    ---
+    adminHttp:
+      host: "0.0.0.0"
+      port: 9190
+      endpoints:
+        prometheus: {}
+    filterDefinitions:
+    - name: "filter-one.KafkaProtocolFilter.filter.kroxylicious.io"
+      type: "org.example.some.java.Class"
+      config:
+        filterOneConfig: true
+    virtualClusters:
+    - name: "foo"
+      targetCluster:
+        bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
+      gateways:
+      - name: "default"
+        portIdentifiesNode:
+          bootstrapAddress: "localhost:9292"
+          advertisedBrokerAddressPattern: "foo.proxy-ns.svc.cluster.local"
+      filters:
+      - "filter-one.KafkaProtocolFilter.filter.kroxylicious.io"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-Secret-example.yaml
@@ -9,9 +9,9 @@ apiVersion: "v1"
 kind: "Secret"
 metadata:
   labels:
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-Service-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-Service-foo.yaml
@@ -1,0 +1,47 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/instance: "example"
+    app.kubernetes.io/component: "proxy"
+  name: "foo"
+  namespace: "proxy-ns"
+  ownerReferences:
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxy"
+      name: "example"
+spec:
+  ports:
+    - name: "foo-9392"
+      port: 9392
+      protocol: "TCP"
+      targetPort: 9392
+    - name: "foo-9393"
+      port: 9393
+      protocol: "TCP"
+      targetPort: 9393
+    - name: "foo-9394"
+      port: 9394
+      protocol: "TCP"
+      targetPort: 9394
+    - name: "foo-9395"
+      port: 9395
+      protocol: "TCP"
+      targetPort: 9395
+  selector:
+    app: "kroxylicious"
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/instance: "example"
+    app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-Service-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-Service-foo.yaml
@@ -9,9 +9,9 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "foo"
@@ -40,8 +40,8 @@ spec:
       targetPort: 9395
   selector:
     app: "kroxylicious"
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Follow on to #1889, this PR reports absence of KCR at the KafkaProxy level.  This follows the same approach as is already taken for reporting of errors on KPF.

Contributes towards https://github.com/kroxylicious/kroxylicious/issues/1824

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
