### PR TITLE
Fix #1573: Minimal proxy health probe (livez only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#1573](https://github.com/kroxylicious/kroxylicious/issues/1573) Minimal proxy health probe (livez)
 * [#1847](https://github.com/kroxylicious/kroxylicious/pull/1847) Remodel virtual cluster map as a list (with explicit names).
 * [#1840](https://github.com/kroxylicious/kroxylicious/pull/1840) Refactor virtual cluster configuration model
 * [#1823](https://github.com/kroxylicious/kroxylicious/pull/1823) Allow VirtualClusters to express more than one listener

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
@@ -287,12 +287,7 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
 
     static KafkaProxy spawnProxy(Configuration config, Features features) {
         KafkaProxy kafkaProxy = new KafkaProxy(new ServiceBasedPluginFactoryRegistry(), config, features);
-        try {
-            kafkaProxy.startup();
-        }
-        catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
+        kafkaProxy.startup();
         return kafkaProxy;
     }
 

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeployment.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeployment.java
@@ -40,11 +40,11 @@ public class ProxyDeployment
         extends CRUDKubernetesDependentResource<Deployment, KafkaProxy> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProxyDeployment.class);
-    public static final String CONFIG_VOLUME = "config-volume";
-    public static final String CONFIG_PATH_IN_CONTAINER = "/opt/kroxylicious/config/" + ProxyConfigSecret.CONFIG_YAML_KEY;
-    public static final Map<String, String> APP_KROXY = Map.of("app", "kroxylicious");
-    public static final int MANAGEMENT_PORT = 9190;
-    public static final String MANAGEMENT_PORT_NAME = "management";
+    private static final String CONFIG_VOLUME = "config-volume";
+    private static final String CONFIG_PATH_IN_CONTAINER = "/opt/kroxylicious/config/" + ProxyConfigSecret.CONFIG_YAML_KEY;
+    private static final Map<String, String> APP_KROXY = Map.of("app", "kroxylicious");
+    private static final int MANAGEMENT_PORT = 9190;
+    private static final String MANAGEMENT_PORT_NAME = "management";
     private final String kroxyliciousImage = getOperandImage();
     static final String KROXYLICIOUS_IMAGE_ENV_VAR = "KROXYLICIOUS_IMAGE";
 
@@ -141,7 +141,7 @@ public class ProxyDeployment
                     .withSubPath(ProxyConfigSecret.CONFIG_YAML_KEY)
                 .endVolumeMount()
                 .addAllToVolumeMounts(ProxyConfigSecret.secureVolumeMounts(context.managedDependentResourceContext()))
-                // metrics port
+                // management port
                 .addNewPort()
                     .withContainerPort(MANAGEMENT_PORT)
                     .withName(MANAGEMENT_PORT_NAME)

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeployment.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeployment.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.PodTemplateSpecBuilder;
@@ -42,7 +43,8 @@ public class ProxyDeployment
     public static final String CONFIG_VOLUME = "config-volume";
     public static final String CONFIG_PATH_IN_CONTAINER = "/opt/kroxylicious/config/" + ProxyConfigSecret.CONFIG_YAML_KEY;
     public static final Map<String, String> APP_KROXY = Map.of("app", "kroxylicious");
-    public static final int METRICS_PORT = 9190;
+    public static final int MANAGEMENT_PORT = 9190;
+    public static final String MANAGEMENT_PORT_NAME = "management";
     private final String kroxyliciousImage = getOperandImage();
     static final String KROXYLICIOUS_IMAGE_ENV_VAR = "KROXYLICIOUS_IMAGE";
 
@@ -120,6 +122,16 @@ public class ProxyDeployment
         // @formatter:off
         var containerBuilder = new ContainerBuilder()
                 .withName("proxy")
+                .withNewLivenessProbe()
+                .withNewHttpGet()
+                .withPath("/livez")
+                .withPort(new IntOrString(MANAGEMENT_PORT_NAME))
+                .endHttpGet()
+                .withInitialDelaySeconds(10)
+                .withSuccessThreshold(1)
+                .withTimeoutSeconds(1)
+                .withFailureThreshold(3)
+                .endLivenessProbe()
                 .withImage(kroxyliciousImage)
                 .withArgs("--config", ProxyDeployment.CONFIG_PATH_IN_CONTAINER)
                 // volume mount
@@ -131,8 +143,8 @@ public class ProxyDeployment
                 .addAllToVolumeMounts(ProxyConfigSecret.secureVolumeMounts(context.managedDependentResourceContext()))
                 // metrics port
                 .addNewPort()
-                    .withContainerPort(METRICS_PORT)
-                    .withName("metrics")
+                    .withContainerPort(MANAGEMENT_PORT)
+                    .withName(MANAGEMENT_PORT_NAME)
                 .endPort();
         // broker ports
         ResourcesUtil.clustersInNameOrder(context).forEach(virtualKafkaCluster -> {

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Deployment-example.yaml
@@ -46,10 +46,18 @@ spec:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"
           image: "quay.io/kroxylicious/kroxylicious:test"
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: "/livez"
+              port: "management"
+            initialDelaySeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           name: "proxy"
           ports:
             - containerPort: 9190
-              name: "metrics"
+              name: "management"
             - containerPort: 9292
             - containerPort: 9293
             - containerPort: 9294

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Deployment-example.yaml
@@ -44,12 +44,20 @@ spec:
       containers:
         - name: "proxy"
           image: "quay.io/kroxylicious/kroxylicious:test"
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: "/livez"
+              port: "management"
+            initialDelaySeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"
           ports:
             - containerPort: 9190
-              name: "metrics"
+              name: "management"
             - containerPort: 9292
             - containerPort: 9293
             - containerPort: 9294

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Deployment-minimal.yaml
@@ -47,9 +47,17 @@ spec:
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: "/livez"
+              port: "management"
+            initialDelaySeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           ports:
             - containerPort: 9190
-              name: "metrics"
+              name: "management"
             - containerPort: 9292
             - containerPort: 9293
             - containerPort: 9294

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Deployment-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Deployment-twocluster.yaml
@@ -47,9 +47,17 @@ spec:
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: "/livez"
+              port: "management"
+            initialDelaySeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           ports:
             - containerPort: 9190
-              name: "metrics"
+              name: "management"
             - containerPort: 9292
             - containerPort: 9293
             - containerPort: 9294

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Deployment-example.yaml
@@ -47,9 +47,17 @@ spec:
             - "/opt/kroxylicious/config/proxy-config.yaml"
           image: "quay.io/kroxylicious/kroxylicious:test"
           name: "proxy"
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: "/livez"
+              port: "management"
+            initialDelaySeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           ports:
             - containerPort: 9190
-              name: "metrics"
+              name: "management"
             - containerPort: 9292
             - containerPort: 9293
             - containerPort: 9294

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Deployment-use-pod-template-spec.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Deployment-use-pod-template-spec.yaml
@@ -49,9 +49,17 @@ spec:
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: "/livez"
+              port: "management"
+            initialDelaySeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           ports:
             - containerPort: 9190
-              name: "metrics"
+              name: "management"
             - containerPort: 9292
             - containerPort: 9293
             - containerPort: 9294

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -243,9 +243,8 @@ public final class KafkaProxy implements AutoCloseable {
     /**
      * Blocks while this proxy is running.
      * This should only be called after a successful call to {@link #startup()}.
-     * @throws InterruptedException
      */
-    public void block() throws Exception {
+    public void block() {
         if (!running.get()) {
             throw new IllegalStateException("This proxy is not running");
         }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/admin/AdminHttpInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/admin/AdminHttpInitializer.java
@@ -8,6 +8,7 @@ package io.kroxylicious.proxy.internal.admin;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpServerCodec;
 import io.netty.handler.codec.http.HttpServerExpectContinueHandler;
 
@@ -16,6 +17,7 @@ import io.kroxylicious.proxy.internal.MeterRegistries;
 
 public class AdminHttpInitializer extends ChannelInitializer<SocketChannel> {
 
+    private static final String LIVEZ = "/livez";
     private final MeterRegistries registries;
     private final AdminHttpConfiguration adminHttpConfiguration;
 
@@ -30,6 +32,7 @@ public class AdminHttpInitializer extends ChannelInitializer<SocketChannel> {
         p.addLast(new HttpServerCodec());
         p.addLast(new HttpServerExpectContinueHandler());
         RoutingHttpServer.RoutingHttpServerBuilder builder = RoutingHttpServer.builder();
+        builder.withRoute(LIVEZ, httpRequest -> RoutingHttpServer.responseWithStatus(httpRequest, HttpResponseStatus.OK));
         adminHttpConfiguration.endpoints().maybePrometheus().ifPresent(prometheusMetricsConfig -> {
             builder.withRoute(PrometheusMetricsEndpoint.PATH, new PrometheusMetricsEndpoint(registries));
         });


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Minimal proxy health probe which gives some assurance that the JVM is minimally live.   This ought to be good enough to detect a JVM in a GC death spiral.

I decided not to implement 'ready' probes at the moment as I don't think it'd bring much benefit.  Proxy is a stateless component to there is no possible for long protracted startup times where the component is live but not ready to serve.

Finally I decided not to make the liveness endpoint configurable.  If you enable management, it will be enabled unconditionally.   The extra cost of a switch didn't really seem worthwhile.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [x] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [x] Ensure the PR references relevant issue(s) so they are closed on merging.
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
