### PR TITLE
Operator Refactor: add utils for accessing common metadata

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/Labels.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/Labels.java
@@ -19,7 +19,7 @@ public class Labels {
         labels.put("app.kubernetes.io/part-of", "kafka");
         labels.put("app.kubernetes.io/managed-by", "kroxylicious-operator");
         labels.put("app.kubernetes.io/name", "kroxylicious-proxy");
-        labels.put("app.kubernetes.io/instance", proxy.getMetadata().getName());
+        labels.put("app.kubernetes.io/instance", ResourcesUtil.name(proxy));
         labels.put("app.kubernetes.io/component", "proxy");
         return labels;
     }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeployment.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeployment.java
@@ -31,6 +31,8 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxySpec;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import static io.kroxylicious.kubernetes.operator.Labels.standardLabels;
+import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
+import static io.kroxylicious.kubernetes.operator.ResourcesUtil.namespace;
 
 /**
  * Generates the Kube {@code Deployment} for the proxy
@@ -56,7 +58,7 @@ public class ProxyDeployment
      * @return The {@code metadata.name} of the desired {@code Deployment}.
      */
     static String deploymentName(KafkaProxy primary) {
-        return primary.getMetadata().getName();
+        return name(primary);
     }
 
     @Override
@@ -66,7 +68,7 @@ public class ProxyDeployment
         return new DeploymentBuilder()
                 .editOrNewMetadata()
                     .withName(deploymentName(primary))
-                    .withNamespace(primary.getMetadata().getNamespace())
+                    .withNamespace(namespace(primary))
                     .addNewOwnerReferenceLike(ResourcesUtil.ownerReferenceTo(primary)).endOwnerReference()
                     .addToLabels(APP_KROXY)
                     .addToLabels(standardLabels(primary))

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/SharedKafkaProxyContext.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/SharedKafkaProxyContext.java
@@ -17,6 +17,8 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.operator.config.RuntimeDecl;
 
+import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
+
 /**
  * Encapsulates access to the mutable state in the {@link Context<KafkaProxy>} shared between
  * {@link ProxyReconciler} its dependent resources.
@@ -52,12 +54,12 @@ public class SharedKafkaProxyContext {
             map = Collections.synchronizedMap(new HashMap<>());
             context.managedDependentResourceContext().put(CLUSTER_CONDITIONS_KEY, map);
         }
-        map.put(cluster.getMetadata().getName(), clusterCondition);
+        map.put(name(cluster), clusterCondition);
     }
 
     static boolean isBroken(Context<KafkaProxy> context, VirtualKafkaCluster cluster) {
         Map<String, ClusterCondition> map = context.managedDependentResourceContext().get(CLUSTER_CONDITIONS_KEY, Map.class).orElse(Map.of());
-        return map.containsKey(cluster.getMetadata().getName());
+        return map.containsKey(name(cluster));
     }
 
     /**
@@ -68,7 +70,7 @@ public class SharedKafkaProxyContext {
      */
     static ClusterCondition clusterCondition(Context<KafkaProxy> context, VirtualKafkaCluster cluster) {
         Optional<Map<String, ClusterCondition>> map = (Optional) context.managedDependentResourceContext().get(CLUSTER_CONDITIONS_KEY, Map.class);
-        return map.orElse(Map.of()).getOrDefault(cluster.getMetadata().getName(), ClusterCondition.accepted(cluster.getMetadata().getName()));
+        return map.orElse(Map.of()).getOrDefault(name(cluster), ClusterCondition.accepted(name(cluster)));
     }
 
 }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerIT.java
@@ -41,6 +41,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.targetclu
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.targetcluster.ClusterRefBuilder;
 import io.kroxylicious.kubernetes.operator.config.RuntimeDecl;
 
+import static io.kroxylicious.kubernetes.operator.ResourcesUtil.findOnlyResourceNamed;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -106,11 +107,11 @@ class ProxyReconcilerIT {
 
     private record CreatedResources(KafkaProxy proxy, Set<VirtualKafkaCluster> clusters, Set<KafkaClusterRef> clusterRefs) {
         public VirtualKafkaCluster cluster(String name) {
-            return clusters.stream().filter(c -> c.getMetadata().getName().equals(name)).findFirst().orElseThrow();
+            return findOnlyResourceNamed(name, clusters).orElseThrow();
         }
 
         public KafkaClusterRef clusterRef(String name) {
-            return clusterRefs.stream().filter(c -> c.getMetadata().getName().equals(name)).findFirst().orElseThrow();
+            return findOnlyResourceNamed(name, clusterRefs).orElseThrow();
         }
     }
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerTest.java
@@ -46,6 +46,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Conditions;
 import io.kroxylicious.kubernetes.operator.assertj.AssertFactory;
 import io.kroxylicious.kubernetes.operator.config.RuntimeDecl;
 
+import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -647,7 +648,7 @@ class ProxyReconcilerTest {
                 .editOrNewSpec()
                 .withNewTargetCluster()
                 .withNewClusterRef()
-                .withName(clusterRef.getMetadata().getName())
+                .withName(name(clusterRef))
                 .endClusterRef()
                 .endTargetCluster()
                 .endSpec()
@@ -661,7 +662,7 @@ class ProxyReconcilerTest {
                 .endMetadata()
                 .withNewSpec()
                 .withNewProxyRef()
-                .withName(kafkaProxy.getMetadata().getName())
+                .withName(name(kafkaProxy))
                 .endProxyRef().endSpec();
     }
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

We can replace some lambdas with method references and generally reduce repetition in extracting name/namespace from classes with metadata.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
