### PR TITLE
Operator Refactor: deterministically order labels

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/Labels.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/Labels.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.kubernetes.operator;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
@@ -14,7 +15,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 public class Labels {
 
     public static Map<String, String> standardLabels(KafkaProxy proxy) {
-        HashMap<String, String> labels = new HashMap<>();
+        HashMap<String, String> labels = new LinkedHashMap<>();
         labels.put("app.kubernetes.io/part-of", "kafka");
         labels.put("app.kubernetes.io/managed-by", "kroxylicious-operator");
         labels.put("app.kubernetes.io/name", "kroxylicious-proxy");

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeployment.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeployment.java
@@ -6,7 +6,7 @@
 package io.kroxylicious.kubernetes.operator;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -91,7 +91,7 @@ public class ProxyDeployment
                 .map(PodTemplateSpec::getMetadata)
                 .map(ObjectMeta::getLabels)
                 .orElse(Map.of());
-        HashMap<String, String> result = new HashMap<>(APP_KROXY);
+        Map<String, String> result = new LinkedHashMap<>(APP_KROXY);
         result.putAll(labelsFromSpec);
         result.putAll(standardLabels(primary));
         return result;

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/LabelsTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/LabelsTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LabelsTest {
+
+    public static final String PROXY_NAME = "kproxy";
+
+    // labels don't technically need to be ordered, but deterministic output reduces noise when comparing output YAML
+    @Test
+    void standardLabelsAreDeterministicallyOrdered() {
+        KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName(PROXY_NAME).endMetadata().build();
+        Map<String, String> labels = Labels.standardLabels(proxy);
+        LinkedHashMap<String, String> expected = new LinkedHashMap<>();
+        expected.put("app.kubernetes.io/part-of", "kafka");
+        expected.put("app.kubernetes.io/managed-by", "kroxylicious-operator");
+        expected.put("app.kubernetes.io/name", "kroxylicious-proxy");
+        expected.put("app.kubernetes.io/instance", PROXY_NAME);
+        expected.put("app.kubernetes.io/component", "proxy");
+        assertThat(labels).containsExactlyEntriesOf(expected);
+    }
+
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyDeploymentTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyDeploymentTest.java
@@ -6,14 +6,25 @@
 
 package io.kroxylicious.kubernetes.operator;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.ClearEnvironmentVariable;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
+
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.PodTemplateSpecBuilder;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
 
 import static io.kroxylicious.kubernetes.operator.ProxyDeployment.KROXYLICIOUS_IMAGE_ENV_VAR;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ProxyDeploymentTest {
+
+    public static final String PROXY_NAME = "kproxy";
 
     @Test
     @ClearEnvironmentVariable(key = KROXYLICIOUS_IMAGE_ENV_VAR)
@@ -27,5 +38,24 @@ class ProxyDeploymentTest {
     void operandImageOverrideFromEnvironment() {
         assertThat(ProxyDeployment.getOperandImage())
                 .isEqualTo("quay.io/myorg/kroxylicious:1");
+    }
+
+    // labels don't technically need to be ordered, but deterministic output reduces noise when comparing output YAML
+    @Test
+    void podLabelsDeterministicallyOrdered() {
+        PodTemplateSpec podTemplate = new PodTemplateSpecBuilder().withNewMetadata().addToLabels("c", "d").addToLabels("a", "b").endMetadata().build();
+        KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName(PROXY_NAME).endMetadata()
+                .withNewSpec().withPodTemplate(podTemplate).endSpec().build();
+        Map<String, String> labels = ProxyDeployment.podLabels(proxy);
+        LinkedHashMap<String, String> expected = new LinkedHashMap<>();
+        expected.put("app", "kroxylicious");
+        expected.put("c", "d");
+        expected.put("a", "b");
+        expected.put("app.kubernetes.io/part-of", "kafka");
+        expected.put("app.kubernetes.io/managed-by", "kroxylicious-operator");
+        expected.put("app.kubernetes.io/name", "kroxylicious-proxy");
+        expected.put("app.kubernetes.io/instance", PROXY_NAME);
+        expected.put("app.kubernetes.io/component", "proxy");
+        assertThat(labels).containsExactlyEntriesOf(expected);
     }
 }

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Deployment-example.yaml
@@ -10,9 +10,9 @@ kind: "Deployment"
 metadata:
   labels:
     app: "kroxylicious"
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Secret-example.yaml
@@ -9,9 +9,9 @@ apiVersion: "v1"
 kind: "Secret"
 metadata:
   labels:
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Service-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Service-foo.yaml
@@ -9,9 +9,9 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "foo"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Deployment-example.yaml
@@ -10,9 +10,9 @@ kind: "Deployment"
 metadata:
   labels:
     app: "kroxylicious"
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example"
@@ -26,18 +26,18 @@ spec:
   selector:
     matchLabels:
       app: "kroxylicious"
+      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
       app.kubernetes.io/name: "kroxylicious-proxy"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/instance: "example"
       app.kubernetes.io/component: "proxy"
   template:
     metadata:
       labels:
         app: "kroxylicious"
+        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
         app.kubernetes.io/name: "kroxylicious-proxy"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/instance: "example"
         app.kubernetes.io/component: "proxy"
     spec:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Secret-example.yaml
@@ -9,9 +9,9 @@ apiVersion: "v1"
 kind: "Secret"
 metadata:
   labels:
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Service-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Service-bar.yaml
@@ -9,9 +9,9 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "bar"
@@ -40,8 +40,8 @@ spec:
       targetPort: 9295
   selector:
     app: "kroxylicious"
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Deployment-minimal.yaml
@@ -10,9 +10,9 @@ kind: "Deployment"
 metadata:
   labels:
     app: "kroxylicious"
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal"
@@ -26,18 +26,18 @@ spec:
   selector:
     matchLabels:
       app: "kroxylicious"
+      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
       app.kubernetes.io/name: "kroxylicious-proxy"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/instance: "minimal"
       app.kubernetes.io/component: "proxy"
   template:
     metadata:
       labels:
         app: "kroxylicious"
+        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
         app.kubernetes.io/name: "kroxylicious-proxy"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/instance: "minimal"
         app.kubernetes.io/component: "proxy"
     spec:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Secret-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Secret-minimal.yaml
@@ -9,9 +9,9 @@ apiVersion: "v1"
 kind: "Secret"
 metadata:
   labels:
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Service-one.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Service-one.yaml
@@ -9,9 +9,9 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one"
@@ -40,8 +40,8 @@ spec:
       targetPort: 9295
   selector:
     app: "kroxylicious"
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Deployment-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Deployment-twocluster.yaml
@@ -10,9 +10,9 @@ kind: "Deployment"
 metadata:
   labels:
     app: "kroxylicious"
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "twocluster"
@@ -26,18 +26,18 @@ spec:
   selector:
     matchLabels:
       app: "kroxylicious"
+      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
       app.kubernetes.io/name: "kroxylicious-proxy"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/instance: "twocluster"
       app.kubernetes.io/component: "proxy"
   template:
     metadata:
       labels:
         app: "kroxylicious"
+        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
         app.kubernetes.io/name: "kroxylicious-proxy"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/instance: "twocluster"
         app.kubernetes.io/component: "proxy"
     spec:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Secret-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Secret-twocluster.yaml
@@ -9,9 +9,9 @@ apiVersion: "v1"
 kind: "Secret"
 metadata:
   labels:
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "twocluster"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Service-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Service-bar.yaml
@@ -9,9 +9,9 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "bar"
@@ -40,8 +40,8 @@ spec:
       targetPort: 9295
   selector:
     app: "kroxylicious"
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Service-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters/out-Service-foo.yaml
@@ -9,9 +9,9 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "foo"
@@ -40,8 +40,8 @@ spec:
       targetPort: 9395
   selector:
     app: "kroxylicious"
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Deployment-example.yaml
@@ -10,9 +10,9 @@ kind: "Deployment"
 metadata:
   labels:
     app: "kroxylicious"
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example"
@@ -26,18 +26,18 @@ spec:
   selector:
     matchLabels:
       app: "kroxylicious"
+      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
       app.kubernetes.io/name: "kroxylicious-proxy"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/instance: "example"
       app.kubernetes.io/component: "proxy"
   template:
     metadata:
       labels:
         app: "kroxylicious"
+        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
         app.kubernetes.io/name: "kroxylicious-proxy"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/instance: "example"
         app.kubernetes.io/component: "proxy"
     spec:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Secret-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Secret-example.yaml
@@ -9,9 +9,9 @@ apiVersion: "v1"
 kind: "Secret"
 metadata:
   labels:
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Service-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Service-foo.yaml
@@ -9,9 +9,9 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "foo"
@@ -40,8 +40,8 @@ spec:
       targetPort: 9295
   selector:
     app: "kroxylicious"
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Deployment-use-pod-template-spec.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Deployment-use-pod-template-spec.yaml
@@ -10,9 +10,9 @@ kind: "Deployment"
 metadata:
   labels:
     app: "kroxylicious"
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "use-pod-template-spec"
     app.kubernetes.io/component: "proxy"
   name: "use-pod-template-spec"
@@ -27,19 +27,19 @@ spec:
     matchLabels:
       app: "kroxylicious"
       environment: "production-from-podTemplate"
+      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
       app.kubernetes.io/name: "kroxylicious-proxy"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/instance: "use-pod-template-spec"
       app.kubernetes.io/component: "proxy"
   template:
     metadata:
       labels:
-        environment: "production-from-podTemplate"
         app: "kroxylicious"
+        environment: "production-from-podTemplate"
+        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
         app.kubernetes.io/name: "kroxylicious-proxy"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/instance: "use-pod-template-spec"
         app.kubernetes.io/component: "proxy"
     spec:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Secret-use-pod-template-spec.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Secret-use-pod-template-spec.yaml
@@ -9,9 +9,9 @@ apiVersion: "v1"
 kind: "Secret"
 metadata:
   labels:
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "use-pod-template-spec"
     app.kubernetes.io/component: "proxy"
   name: "use-pod-template-spec"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Service-one.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Service-one.yaml
@@ -9,9 +9,9 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "use-pod-template-spec"
     app.kubernetes.io/component: "proxy"
   name: "one"
@@ -41,8 +41,8 @@ spec:
   selector:
     app: "kroxylicious"
     environment: "production-from-podTemplate"
+    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
     app.kubernetes.io/name: "kroxylicious-proxy"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/instance: "use-pod-template-spec"
     app.kubernetes.io/component: "proxy"


### PR DESCRIPTION

### Type of change

- Refactoring

### Description

Technically the labels don't need to be ordered, it doesn't matter to kubernetes if the order changes. But in our DerivedResourcesTest we convert to YAML when the reconciled resources are not equal to our expectation, and then compare the YAML strings to produce a more useful output for humans.

These strings currently will often have labels reported as mismatched, which is highlighted by the IDE and distracts from the other real differences between the resources that caused the failure.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
