### PR TITLE
fix: avoid spurious deprecation warning 'ClusterNetworkAddressConfigProvider is deprecated' during startup with new config

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -392,10 +392,10 @@ public class VirtualClusterModel {
         @Override
         public String toString() {
             return "VirtualClusterGatewayModel[" +
-                    "virtualCluster=" + virtualCluster + ", " +
                     "name=" + name + ", " +
+                    "virtualCluster=" + virtualCluster.getClusterName() + ", " +
                     "provider=" + provider + ", " +
-                    "tls=" + tls + ']';
+                    "tls=" + isUseTls() + ']';
         }
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/TlsTestConstants.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/TlsTestConstants.java
@@ -17,7 +17,7 @@ public class TlsTestConstants {
     public static final String PKCS_12 = "PKCS12";
     public static final String PEM = Tls.PEM;
 
-    static final PasswordProvider STOREPASS = new InlinePassword("storepass");
+    public static final PasswordProvider STOREPASS = new InlinePassword("storepass");
     static final PasswordProvider KEYPASS = new InlinePassword("keypass");
     static final PasswordProvider BADPASS = new InlinePassword("badpass");
     static final PasswordProvider KEYSTORE_FILE_PASSWORD = new FilePassword(getResourceLocationOnFilesystem("storepass.password"));


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Bugfix

### Description

Bug fix: Kroxylicious was issuing a spurious configuration deprecation warning even when starting with un-deprecated config.


_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
