### PR TITLE
Remove deprecated `filePath` config property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#1918](https://github.com/kroxylicious/kroxylicious/pull/1918)  Removes support for the deprecated config property `filePath`.
 * [#1573](https://github.com/kroxylicious/kroxylicious/issues/1573) Minimal proxy health probe (livez)
 * [#1847](https://github.com/kroxylicious/kroxylicious/pull/1847) Remodel virtual cluster map as a list (with explicit names).
 * [#1840](https://github.com/kroxylicious/kroxylicious/pull/1840) Refactor virtual cluster configuration model
@@ -28,6 +29,8 @@ Format `<github issue/pr number>: <short description>`.
 * The `virtualClusters` configuration property now expects a list of `virtualCluster` objects (rather than a mapping
   of `name` to `virtualCluster`).  Furthermore, the `virtualCluster` object now requires a `name` configuration property.
   For backward compatibility, support for the map (and values without `name`) continues, but this will be removed in a future release.
+* As announced at 0.5.0, when configuring TLS, the property `passwordFile` should be used for specifying location of a
+  file providing the password. Support for the deprecated alias `filePath` is now removed.
 
 ## 0.10.0
 

--- a/kroxylicious-api/pom.xml
+++ b/kroxylicious-api/pom.xml
@@ -161,7 +161,6 @@
                         <breakBuildOnBinaryIncompatibleModifications>false</breakBuildOnBinaryIncompatibleModifications>
                         <breakBuildBasedOnSemanticVersioningForMajorVersionZero>${ApiCompatability.EnforceForMajorVersionZero}</breakBuildBasedOnSemanticVersioningForMajorVersionZero>
                         <excludes>
-                            <exclude>io.kroxylicious.proxy.config.secret.FilePasswordFilePath</exclude>  <!-- used purely in config files and the name still exists (as a JSON alias) -->
                             <exclude>io.kroxylicious.proxy.filter.FilterFactoryContext#eventLoop()</exclude> <!-- https://github.com/kroxylicious/kroxylicious/issues/1380 scheduled removal of deprecated API method -->
                         </excludes>
                         <!-- see documentation -->

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/secret/FilePassword.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/secret/FilePassword.java
@@ -13,7 +13,6 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -22,12 +21,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * A reference to the file containing a plain text password in UTF-8 encoding.  If the password file
  * contains more than one line, only the characters of the first line are taken to be the password,
  * excluding the line ending.  Subsequent lines are ignored.
- * <br>
- * Note that the {@code filePath} alias was deprecated at 0.5.0.
  *
  * @param passwordFile file containing the password.
  */
-public record FilePassword(@JsonProperty(required = true) @JsonAlias("filePath") String passwordFile) implements PasswordProvider {
+public record FilePassword(@JsonProperty(required = true) String passwordFile) implements PasswordProvider {
 
     public FilePassword {
         Objects.requireNonNull(passwordFile);

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/config/tls/TlsParseTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/config/tls/TlsParseTest.java
@@ -168,7 +168,7 @@ class TlsParseTest {
                         "trust": {
                             "storeFile": "/tmp/file",
                             "storePassword": {
-                                "filePath": null
+                                "passwordFile": null
                             }
                         }
                     }
@@ -194,29 +194,13 @@ class TlsParseTest {
     }
 
     @Test
-    void testTrustStoreStoreFilePathPassword() throws IOException {
-        String json = """
-                {
-                    "trust": {
-                        "storeFile": "/tmp/file",
-                        "storePassword": {
-                            "filePath": "/tmp/pass"
-                        }
-                    }
-                }
-                """;
-        Tls tls = readTls(json);
-        assertThat(tls).isEqualTo(new Tls(null, new TrustStore("/tmp/file", new FilePassword("/tmp/pass"), null), null, null));
-    }
-
-    @Test
     void testTrustStoreStoreWithClientAuth() throws IOException {
         String json = """
                 {
                     "trust": {
                         "storeFile": "/tmp/file",
                         "storePassword": {
-                            "filePath": "/tmp/pass"
+                            "passwordFile": "/tmp/pass"
                         },
                         "trustOptions": {
                             "clientAuth": "REQUIRED"


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

The `filePath` config property was deprecated back at 0.5.0.  It is time to remove it.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
