### PR TITLE
Update JOSDK dependency to 4.9.x to 5.0.x and Fabric8 client to match

### DIFF
--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -19,9 +19,9 @@
     <artifactId>kroxylicious-operator</artifactId>
 
     <properties>
-        <josdk.version>4.9.7</josdk.version>
+        <josdk.version>5.0.3</josdk.version>
         <log4j.version>2.20.0</log4j.version>
-        <fabric8-client.version>6.13.5</fabric8-client.version>
+        <fabric8-client.version>7.1.0</fabric8-client.version>
         <sundrio.version>0.200.0</sundrio.version>
         <lombok.version>1.18.36</lombok.version>
     </properties>

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ClusterService.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ClusterService.java
@@ -23,7 +23,6 @@ import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.operator.ingress.IngressAllocator;
 import io.kroxylicious.kubernetes.operator.ingress.ProxyIngressModel;
 
-import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.toByNameMap;
 
 /**
@@ -45,7 +44,7 @@ public class ClusterService
      */
     static String serviceName(VirtualKafkaCluster cluster) {
         Objects.requireNonNull(cluster);
-        return name(cluster);
+        return ResourcesUtil.name(cluster);
     }
 
     @Override
@@ -65,7 +64,7 @@ public class ClusterService
     public Map<String, Service> getSecondaryResources(
                                                       KafkaProxy primary,
                                                       Context<KafkaProxy> context) {
-        Set<Service> secondaryResources = context.eventSourceRetriever().getResourceEventSourceFor(Service.class)
+        Set<Service> secondaryResources = context.eventSourceRetriever().getEventSourceFor(Service.class)
                 .getSecondaryResources(primary);
         return secondaryResources.stream().collect(toByNameMap());
     }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeployment.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeployment.java
@@ -65,7 +65,7 @@ public class ProxyDeployment
      * @return The {@code metadata.name} of the desired {@code Deployment}.
      */
     static String deploymentName(KafkaProxy primary) {
-        return name(primary);
+        return ResourcesUtil.name(primary);
     }
 
     @Override
@@ -124,7 +124,7 @@ public class ProxyDeployment
                             .withSecretName(ProxyConfigSecret.secretName(primary))
                         .endSecret()
                     .endVolume()
-                    .addAllToVolumes(ProxyConfigSecret.secureVolumes(context.managedDependentResourceContext()))
+                    .addAllToVolumes(ProxyConfigSecret.secureVolumes(context.managedWorkflowAndDependentResourceContext()))
                 .endSpec()
                 .build();
         // @formatter:on
@@ -152,7 +152,7 @@ public class ProxyDeployment
                     .withMountPath(ProxyDeployment.CONFIG_PATH_IN_CONTAINER)
                     .withSubPath(ProxyConfigSecret.CONFIG_YAML_KEY)
                 .endVolumeMount()
-                .addAllToVolumeMounts(ProxyConfigSecret.secureVolumeMounts(context.managedDependentResourceContext()))
+                .addAllToVolumeMounts(ProxyConfigSecret.secureVolumeMounts(context.managedWorkflowAndDependentResourceContext()))
                 // management port
                 .addNewPort()
                     .withContainerPort(MANAGEMENT_PORT)

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/SharedKafkaProxyContext.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/SharedKafkaProxyContext.java
@@ -35,30 +35,30 @@ public class SharedKafkaProxyContext {
      * Set the RuntimeDecl
      */
     static void runtimeDecl(Context<KafkaProxy> context, RuntimeDecl runtimeDecl) {
-        context.managedDependentResourceContext().put(RUNTIME_DECL_KEY, runtimeDecl);
+        context.managedWorkflowAndDependentResourceContext().put(RUNTIME_DECL_KEY, runtimeDecl);
     }
 
     /**
      * Get the RuntimeDecl
      */
     static RuntimeDecl runtimeDecl(Context<KafkaProxy> context) {
-        return context.managedDependentResourceContext().getMandatory(RUNTIME_DECL_KEY, RuntimeDecl.class);
+        return context.managedWorkflowAndDependentResourceContext().getMandatory(RUNTIME_DECL_KEY, RuntimeDecl.class);
     }
 
     /**
      * Associate a condition with a specific cluster.
      */
     static void addClusterCondition(Context<KafkaProxy> context, VirtualKafkaCluster cluster, ClusterCondition clusterCondition) {
-        Map<String, ClusterCondition> map = context.managedDependentResourceContext().get(CLUSTER_CONDITIONS_KEY, Map.class).orElse(null);
+        Map<String, ClusterCondition> map = context.managedWorkflowAndDependentResourceContext().get(CLUSTER_CONDITIONS_KEY, Map.class).orElse(null);
         if (map == null) {
             map = Collections.synchronizedMap(new HashMap<>());
-            context.managedDependentResourceContext().put(CLUSTER_CONDITIONS_KEY, map);
+            context.managedWorkflowAndDependentResourceContext().put(CLUSTER_CONDITIONS_KEY, map);
         }
         map.put(name(cluster), clusterCondition);
     }
 
     static boolean isBroken(Context<KafkaProxy> context, VirtualKafkaCluster cluster) {
-        Map<String, ClusterCondition> map = context.managedDependentResourceContext().get(CLUSTER_CONDITIONS_KEY, Map.class).orElse(Map.of());
+        Map<String, ClusterCondition> map = context.managedWorkflowAndDependentResourceContext().get(CLUSTER_CONDITIONS_KEY, Map.class).orElse(Map.of());
         return map.containsKey(name(cluster));
     }
 
@@ -69,7 +69,7 @@ public class SharedKafkaProxyContext {
      * @return The conditions specific to the given cluster; or empty if there were none.
      */
     static ClusterCondition clusterCondition(Context<KafkaProxy> context, VirtualKafkaCluster cluster) {
-        Optional<Map<String, ClusterCondition>> map = (Optional) context.managedDependentResourceContext().get(CLUSTER_CONDITIONS_KEY, Map.class);
+        Optional<Map<String, ClusterCondition>> map = (Optional) context.managedWorkflowAndDependentResourceContext().get(CLUSTER_CONDITIONS_KEY, Map.class);
         return map.orElse(Map.of()).getOrDefault(name(cluster), ClusterCondition.accepted(name(cluster)));
     }
 }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/DerivedResourcesTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/DerivedResourcesTest.java
@@ -39,7 +39,7 @@ import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
-import io.javaoperatorsdk.operator.api.reconciler.dependent.managed.DefaultManagedDependentResourceContext;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.managed.DefaultManagedWorkflowAndDependentResourceContext;
 import io.javaoperatorsdk.operator.processing.dependent.BulkDependentResource;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResource;
 
@@ -358,9 +358,9 @@ class DerivedResourcesTest {
         };
         Context<KafkaProxy> context = mock(Context.class, throwOnUnmockedInvocation);
 
-        var resourceContext = new DefaultManagedDependentResourceContext();
+        var resourceContext = new DefaultManagedWorkflowAndDependentResourceContext(null, null, context);
 
-        doReturn(resourceContext).when(context).managedDependentResourceContext();
+        doReturn(resourceContext).when(context).managedWorkflowAndDependentResourceContext();
 
         var runtimeDecl = OperatorMain.runtimeDecl();
         Set<GenericKubernetesResource> filterInstances = new HashSet<>();

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerIT.java
@@ -19,7 +19,7 @@ import org.assertj.core.api.Assumptions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
@@ -68,18 +68,18 @@ class ProxyReconcilerIT {
     private static final String CLUSTER_BAR_BOOTSTRAP = "my-cluster-kafka-bootstrap.bar.svc.cluster.local:9092";
     private static final String NEW_BOOTSTRAP = "new-bootstrap:9092";
 
-    private static KubernetesClient client;
+    private KubernetesClient client;
     private final ConditionFactory AWAIT = await().timeout(Duration.ofSeconds(20));
 
-    @BeforeAll
-    static void checkKubeAvailable() {
+    @BeforeEach
+    void checkKubeAvailable() {
         client = OperatorTestUtils.kubeClientIfAvailable();
         Assumptions.assumeThat(client).describedAs("Test requires a viable kube client").isNotNull();
         preloadOperatorImage();
     }
 
     // the initial operator image pull can take a long time and interfere with the tests
-    private static void preloadOperatorImage() {
+    private void preloadOperatorImage() {
         String operandImage = ProxyDeployment.getOperandImage();
         Pod pod = client.run().withName("preload-operator-image")
                 .withNewRunConfig()

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerIT.java
@@ -69,7 +69,7 @@ class ProxyReconcilerIT {
     private static final String NEW_BOOTSTRAP = "new-bootstrap:9092";
 
     private KubernetesClient client;
-    private final ConditionFactory AWAIT = await().timeout(Duration.ofSeconds(20));
+    private final ConditionFactory AWAIT = await().timeout(Duration.ofSeconds(60));
 
     @BeforeEach
     void checkKubeAvailable() {

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerTest.java
@@ -94,7 +94,8 @@ class ProxyReconcilerTest {
 
         // Then
         assertThat(updateControl.isPatchStatus()).isTrue();
-        var statusAssert = assertThat(updateControl.getResource()).get()
+        var statusAssert = assertThat(updateControl.getResource())
+                .isNotEmpty().get()
                 .extracting(KafkaProxy::getStatus);
         statusAssert.extracting(KafkaProxyStatus::getObservedGeneration).isEqualTo(generation);
         ObjectAssert<Conditions> first = statusAssert.extracting(KafkaProxyStatus::getConditions, InstanceOfAssertFactories.list(Conditions.class))
@@ -124,8 +125,8 @@ class ProxyReconcilerTest {
         var updateControl = new ProxyReconciler(new RuntimeDecl(List.of())).updateErrorStatus(primary, context, new InvalidResourceException("Resource was terrible"));
 
         // Then
-        var statusAssert = assertThat(updateControl.getResource()).isNotNull()
-                .isPresent().get()
+        var statusAssert = assertThat(updateControl.getResource())
+                .isNotEmpty().get()
                 .extracting(KafkaProxy::getStatus);
         statusAssert.extracting(KafkaProxyStatus::getObservedGeneration).isEqualTo(generation);
         ObjectAssert<Conditions> first = statusAssert.extracting(KafkaProxyStatus::getConditions, InstanceOfAssertFactories.list(Conditions.class))
@@ -166,7 +167,8 @@ class ProxyReconcilerTest {
 
         // Then
         assertThat(updateControl.isPatchStatus()).isTrue();
-        var statusAssert = assertThat(updateControl.getResource()).get()
+        var statusAssert = assertThat(updateControl.getResource())
+                .isNotEmpty().get()
                 .extracting(KafkaProxy::getStatus);
         statusAssert.extracting(KafkaProxyStatus::getObservedGeneration).isEqualTo(generation);
         ObjectAssert<Conditions> first = statusAssert.extracting(KafkaProxyStatus::getConditions, InstanceOfAssertFactories.list(Conditions.class))
@@ -206,7 +208,8 @@ class ProxyReconcilerTest {
         var updateControl = new ProxyReconciler(new RuntimeDecl(List.of())).updateErrorStatus(primary, context, new InvalidResourceException("Resource was terrible"));
 
         // Then
-        var statusAssert = assertThat(updateControl.getResource()).isNotNull().isPresent().get()
+        var statusAssert = assertThat(updateControl.getResource())
+                .isNotEmpty().get()
                 .extracting(KafkaProxy::getStatus);
         statusAssert.extracting(KafkaProxyStatus::getObservedGeneration).isEqualTo(generation);
         ObjectAssert<Conditions> first = statusAssert.extracting(KafkaProxyStatus::getConditions, InstanceOfAssertFactories.list(Conditions.class))
@@ -246,7 +249,8 @@ class ProxyReconcilerTest {
         var updateControl = new ProxyReconciler(new RuntimeDecl(List.of())).updateErrorStatus(primary, context, new InvalidResourceException("Resource was terrible"));
 
         // Then
-        var statusAssert = assertThat(updateControl.getResource()).isNotNull().isPresent().get()
+        var statusAssert = assertThat(updateControl.getResource())
+                .isNotEmpty().get()
                 .extracting(KafkaProxy::getStatus);
         statusAssert.extracting(KafkaProxyStatus::getObservedGeneration).isEqualTo(generation);
         ObjectAssert<Conditions> first = statusAssert.extracting(KafkaProxyStatus::getConditions, InstanceOfAssertFactories.list(Conditions.class))
@@ -287,7 +291,8 @@ class ProxyReconcilerTest {
 
         // Then
         assertThat(updateControl.isPatchStatus()).isTrue();
-        var statusAssert = assertThat(updateControl.getResource()).get()
+        var statusAssert = assertThat(updateControl.getResource())
+                .isNotEmpty().get()
                 .extracting(KafkaProxy::getStatus);
         statusAssert.extracting(KafkaProxyStatus::getObservedGeneration).isEqualTo(generation);
         ObjectAssert<Conditions> first = statusAssert.extracting(KafkaProxyStatus::getConditions, InstanceOfAssertFactories.list(Conditions.class))
@@ -339,7 +344,7 @@ class ProxyReconcilerTest {
         // Then
         assertThat(updateControl.isPatchStatus()).isTrue();
         var statusAssert = assertThat(updateControl.getResource())
-                .get()
+                .isNotEmpty().get()
                 .extracting(KafkaProxy::getStatus, AssertFactory.status());
         statusAssert.observedGeneration().isEqualTo(generation);
         statusAssert.singleCondition()

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerTest.java
@@ -30,7 +30,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
-import io.javaoperatorsdk.operator.api.reconciler.dependent.managed.ManagedDependentResourceContext;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.managed.ManagedWorkflowAndDependentResourceContext;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.PrimaryToSecondaryMapper;
 import io.javaoperatorsdk.operator.processing.event.source.SecondaryToPrimaryMapper;
@@ -62,7 +62,7 @@ class ProxyReconcilerTest {
     Context<KafkaProxy> context;
 
     @Mock
-    ManagedDependentResourceContext mdrc;
+    ManagedWorkflowAndDependentResourceContext mdrc;
 
     private AutoCloseable closeable;
 
@@ -94,7 +94,7 @@ class ProxyReconcilerTest {
 
         // Then
         assertThat(updateControl.isPatchStatus()).isTrue();
-        var statusAssert = assertThat(updateControl.getResource()).isNotNull()
+        var statusAssert = assertThat(updateControl.getResource()).get()
                 .extracting(KafkaProxy::getStatus);
         statusAssert.extracting(KafkaProxyStatus::getObservedGeneration).isEqualTo(generation);
         ObjectAssert<Conditions> first = statusAssert.extracting(KafkaProxyStatus::getConditions, InstanceOfAssertFactories.list(Conditions.class))
@@ -124,7 +124,6 @@ class ProxyReconcilerTest {
         var updateControl = new ProxyReconciler(new RuntimeDecl(List.of())).updateErrorStatus(primary, context, new InvalidResourceException("Resource was terrible"));
 
         // Then
-        assertThat(updateControl.isPatch()).isTrue();
         var statusAssert = assertThat(updateControl.getResource()).isNotNull()
                 .isPresent().get()
                 .extracting(KafkaProxy::getStatus);
@@ -167,7 +166,7 @@ class ProxyReconcilerTest {
 
         // Then
         assertThat(updateControl.isPatchStatus()).isTrue();
-        var statusAssert = assertThat(updateControl.getResource()).isNotNull()
+        var statusAssert = assertThat(updateControl.getResource()).get()
                 .extracting(KafkaProxy::getStatus);
         statusAssert.extracting(KafkaProxyStatus::getObservedGeneration).isEqualTo(generation);
         ObjectAssert<Conditions> first = statusAssert.extracting(KafkaProxyStatus::getConditions, InstanceOfAssertFactories.list(Conditions.class))
@@ -207,7 +206,6 @@ class ProxyReconcilerTest {
         var updateControl = new ProxyReconciler(new RuntimeDecl(List.of())).updateErrorStatus(primary, context, new InvalidResourceException("Resource was terrible"));
 
         // Then
-        assertThat(updateControl.isPatch()).isTrue();
         var statusAssert = assertThat(updateControl.getResource()).isNotNull().isPresent().get()
                 .extracting(KafkaProxy::getStatus);
         statusAssert.extracting(KafkaProxyStatus::getObservedGeneration).isEqualTo(generation);
@@ -248,7 +246,6 @@ class ProxyReconcilerTest {
         var updateControl = new ProxyReconciler(new RuntimeDecl(List.of())).updateErrorStatus(primary, context, new InvalidResourceException("Resource was terrible"));
 
         // Then
-        assertThat(updateControl.isPatch()).isTrue();
         var statusAssert = assertThat(updateControl.getResource()).isNotNull().isPresent().get()
                 .extracting(KafkaProxy::getStatus);
         statusAssert.extracting(KafkaProxyStatus::getObservedGeneration).isEqualTo(generation);
@@ -290,7 +287,7 @@ class ProxyReconcilerTest {
 
         // Then
         assertThat(updateControl.isPatchStatus()).isTrue();
-        var statusAssert = assertThat(updateControl.getResource()).isNotNull()
+        var statusAssert = assertThat(updateControl.getResource()).get()
                 .extracting(KafkaProxy::getStatus);
         statusAssert.extracting(KafkaProxyStatus::getObservedGeneration).isEqualTo(generation);
         ObjectAssert<Conditions> first = statusAssert.extracting(KafkaProxyStatus::getConditions, InstanceOfAssertFactories.list(Conditions.class))
@@ -328,7 +325,7 @@ class ProxyReconcilerTest {
                 .endStatus()
                 .build();
         // @formatter:on
-        doReturn(mdrc).when(context).managedDependentResourceContext();
+        doReturn(mdrc).when(context).managedWorkflowAndDependentResourceContext();
         doReturn(Set.of(new VirtualKafkaClusterBuilder().withNewMetadata().withName("my-cluster").withNamespace("my-ns").endMetadata().withNewSpec().withNewProxyRef()
                 .withName("my-proxy").endProxyRef().endSpec().build())).when(context).getSecondaryResources(VirtualKafkaCluster.class);
         doReturn(Optional.of(Map.of("my-cluster", ClusterCondition.filterNotFound("my-cluster", "MissingFilter")))).when(mdrc).get(
@@ -342,7 +339,7 @@ class ProxyReconcilerTest {
         // Then
         assertThat(updateControl.isPatchStatus()).isTrue();
         var statusAssert = assertThat(updateControl.getResource())
-                .isNotNull()
+                .get()
                 .extracting(KafkaProxy::getStatus, AssertFactory.status());
         statusAssert.observedGeneration().isEqualTo(generation);
         statusAssert.singleCondition()


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Updates our dependency on JOSDK to 5.0. Also updates the fabric8 client version to match the version that JOSDK 5 uses. Most of the changes in this PR are due to API changes described at https://javaoperatorsdk.io/blog/2025/01/06/version-5-released/. 


