### PR TITLE
draft refactor: operator reconciler components reduce co-ordination

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ClusterCondition.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ClusterCondition.java
@@ -36,9 +36,14 @@ public record ClusterCondition(@NonNull String cluster,
                 String.format("Filter \"%s\" is invalid: %s", filterName, detail));
     }
 
-    static ClusterCondition filterNotFound(String cluster, String filterName) {
+    public static ClusterCondition filterNotFound(String cluster, String filterName) {
         return new ClusterCondition(cluster, ConditionType.Accepted, Status.FALSE, INVALID,
                 String.format("Filter \"%s\" does not exist.", filterName));
+    }
+
+    public static ClusterCondition ingressNotFound(String cluster, String ingressName) {
+        return new ClusterCondition(cluster, ConditionType.Accepted, Status.FALSE, INVALID,
+                String.format("KafkaProxyIngress \"%s\" does not exist.", ingressName));
     }
 
     public static ClusterCondition ingressConflict(String cluster, Set<IngressConflictException> ingressConflictExceptions) {
@@ -49,7 +54,7 @@ public record ClusterCondition(@NonNull String cluster,
                 String.format("Ingress(es) [%s] of cluster conflicts with another ingress", ingresses));
     }
 
-    static ClusterCondition targetClusterRefNotFound(String cluster, TargetCluster targetCluster) {
+    public static ClusterCondition targetClusterRefNotFound(String cluster, TargetCluster targetCluster) {
         return new ClusterCondition(cluster, ConditionType.Accepted, Status.FALSE, INVALID,
                 String.format("Target Cluster \"%s\" does not exist.", kubeName(targetCluster).orElse("<unknown>")));
     }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
@@ -21,9 +21,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
-import io.javaoperatorsdk.operator.processing.event.ResourceID;
 
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 
@@ -86,12 +84,6 @@ public class ResourcesUtil {
         return context.getSecondaryResources(VirtualKafkaCluster.class)
                 .stream()
                 .sorted(Comparator.comparing(ResourcesUtil::name));
-    }
-
-    static Map<ResourceID, KafkaClusterRef> clusterRefs(Context<KafkaProxy> context) {
-        return context.getSecondaryResources(KafkaClusterRef.class)
-                .stream()
-                .collect(Collectors.toMap(ResourceID::fromResource, Function.identity()));
     }
 
     public static String name(@NonNull HasMetadata resource) {

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/SharedKafkaProxyContext.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/SharedKafkaProxyContext.java
@@ -48,18 +48,13 @@ public class SharedKafkaProxyContext {
     /**
      * Associate a condition with a specific cluster.
      */
-    static void addClusterCondition(Context<KafkaProxy> context, VirtualKafkaCluster cluster, ClusterCondition clusterCondition) {
+    public static void addClusterCondition(Context<KafkaProxy> context, VirtualKafkaCluster cluster, ClusterCondition clusterCondition) {
         Map<String, ClusterCondition> map = context.managedDependentResourceContext().get(CLUSTER_CONDITIONS_KEY, Map.class).orElse(null);
         if (map == null) {
             map = Collections.synchronizedMap(new HashMap<>());
             context.managedDependentResourceContext().put(CLUSTER_CONDITIONS_KEY, map);
         }
         map.put(name(cluster), clusterCondition);
-    }
-
-    static boolean isBroken(Context<KafkaProxy> context, VirtualKafkaCluster cluster) {
-        Map<String, ClusterCondition> map = context.managedDependentResourceContext().get(CLUSTER_CONDITIONS_KEY, Map.class).orElse(Map.of());
-        return map.containsKey(name(cluster));
     }
 
     /**
@@ -72,4 +67,5 @@ public class SharedKafkaProxyContext {
         Optional<Map<String, ClusterCondition>> map = (Optional) context.managedDependentResourceContext().get(CLUSTER_CONDITIONS_KEY, Map.class);
         return map.orElse(Map.of()).getOrDefault(name(cluster), ClusterCondition.accepted(name(cluster)));
     }
+
 }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/Dependency.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/Dependency.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator.resolver;
+
+public enum Dependency {
+    KAFKA_PROXY_INGRESS,
+    FILTER,
+    KAFKA_CLUSTER_REF
+}

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolver.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolver.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator.resolver;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterSpec;
+import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.Filters;
+import io.kroxylicious.kubernetes.operator.ClusterCondition;
+import io.kroxylicious.kubernetes.operator.ResourcesUtil;
+import io.kroxylicious.kubernetes.operator.SharedKafkaProxyContext;
+import io.kroxylicious.kubernetes.operator.resolver.ResolutionResult.UnresolvedDependency;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static io.kroxylicious.kubernetes.operator.ClusterCondition.ingressNotFound;
+import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
+import static io.kroxylicious.kubernetes.operator.ResourcesUtil.toByNameMap;
+import static io.kroxylicious.kubernetes.operator.resolver.Dependency.FILTER;
+import static io.kroxylicious.kubernetes.operator.resolver.Dependency.KAFKA_CLUSTER_REF;
+import static io.kroxylicious.kubernetes.operator.resolver.Dependency.KAFKA_PROXY_INGRESS;
+
+public class DependencyResolver {
+
+    public static final ResolutionResult EMPTY_RESOLUTION_RESULT = new ResolutionResult(Map.of(), Map.of(), Map.of(), Map.of());
+
+    public static ResolutionResult deepResolve(@NonNull Context<KafkaProxy> context) {
+        Objects.requireNonNull(context);
+        Set<VirtualKafkaCluster> virtualKafkaClusters = context.getSecondaryResources(VirtualKafkaCluster.class);
+        if (virtualKafkaClusters.isEmpty()) {
+            return EMPTY_RESOLUTION_RESULT;
+        }
+        Map<String, KafkaProxyIngress> ingresses = context.getSecondaryResources(KafkaProxyIngress.class).stream().collect(toByNameMap());
+        Map<String, KafkaClusterRef> clusterRefs = context.getSecondaryResources(KafkaClusterRef.class).stream().collect(toByNameMap());
+        Map<String, GenericKubernetesResource> filters = context.getSecondaryResources(GenericKubernetesResource.class).stream().collect(toByNameMap());
+        var resolutionResult = virtualKafkaClusters.stream().map(cluster -> {
+            VirtualKafkaClusterSpec spec = cluster.getSpec();
+            Set<UnresolvedDependency> unresolvedDependencies = new HashSet<>();
+            spec.getIngressRefs().stream()
+                    .filter(ref -> !ingresses.containsKey(ref.getName()))
+                    .map(ref -> new UnresolvedDependency(KAFKA_PROXY_INGRESS, ref.getName())).forEach(unresolvedDependencies::add);
+            String clusterRef = spec.getTargetCluster().getClusterRef().getName();
+            if (!clusterRefs.containsKey(clusterRef)) {
+                unresolvedDependencies.add(new UnresolvedDependency(KAFKA_CLUSTER_REF, clusterRef));
+            }
+            List<Filters> filtersList = spec.getFilters();
+            if (filtersList != null) {
+                filtersList.stream()
+                        .filter(filterRef -> filters.values().stream().noneMatch(filterResource -> filterResourceMatchesRef(filterRef, filterResource)))
+                        .map(ref -> new UnresolvedDependency(FILTER, ref.getName())).forEach(unresolvedDependencies::add);
+            }
+            return new ResolutionResult.ClusterResolutionResult(cluster, unresolvedDependencies);
+        }).collect(Collectors.toMap(result -> ResourcesUtil.name(result.cluster()), r -> r));
+        ResolutionResult result = new ResolutionResult(filters, ingresses, clusterRefs, resolutionResult);
+        reportClustersThatDidNotFullyResolve(context, result);
+        return result;
+    }
+
+    private static boolean filterResourceMatchesRef(Filters filterRef, GenericKubernetesResource filterResource) {
+        String apiVersion = filterResource.getApiVersion();
+        var filterResourceGroup = apiVersion.substring(0, apiVersion.indexOf("/"));
+        return filterResourceGroup.equals(filterRef.getGroup())
+                && filterResource.getKind().equals(filterRef.getKind())
+                && name(filterResource).equals(filterRef.getName());
+    }
+
+    public static void reportClustersThatDidNotFullyResolve(Context<KafkaProxy> context, ResolutionResult resolutionResult) {
+        resolutionResult.clusterResult()
+                .filter(ResolutionResult.ClusterResolutionResult::isAnyDependencyUnresolved)
+                .forEach(clusterResolutionResult -> {
+                    clusterResolutionResult.firstUnresolvedDependency().ifPresent(unresolved -> {
+                        VirtualKafkaCluster cluster = clusterResolutionResult.cluster();
+                        switch (unresolved.type()) {
+                            case KAFKA_PROXY_INGRESS -> {
+                                SharedKafkaProxyContext.addClusterCondition(context, cluster, ingressNotFound(name(cluster), unresolved.name()));
+                            }
+                            case FILTER -> {
+                                SharedKafkaProxyContext.addClusterCondition(context, cluster, ClusterCondition.filterNotFound(name(cluster), unresolved.name()));
+                            }
+                            case KAFKA_CLUSTER_REF -> {
+                                SharedKafkaProxyContext.addClusterCondition(context, cluster,
+                                        ClusterCondition.targetClusterRefNotFound(name(cluster), cluster.getSpec().getTargetCluster()));
+                            }
+                        }
+                    });
+                });
+    }
+}

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ResolutionResult.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ResolutionResult.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator.resolver;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
+import io.kroxylicious.kubernetes.operator.ResourcesUtil;
+
+import static java.util.Comparator.comparing;
+
+public class ResolutionResult {
+    private final Map<String, GenericKubernetesResource> filters;
+    private final Map<String, KafkaProxyIngress> kafkaProxyIngresses;
+    private final Map<String, KafkaClusterRef> kafkaClusterRefs;
+    private final Map<String, ClusterResolutionResult> clusterResolutionResults;
+
+    ResolutionResult(Map<String, GenericKubernetesResource> filters,
+                     Map<String, KafkaProxyIngress> kafkaProxyIngresses,
+                     Map<String, KafkaClusterRef> kafkaClusterRefs,
+                     Map<String, ClusterResolutionResult> clusterResolutionResults) {
+
+        this.filters = filters;
+        this.kafkaProxyIngresses = kafkaProxyIngresses;
+        this.kafkaClusterRefs = kafkaClusterRefs;
+        this.clusterResolutionResults = clusterResolutionResults;
+    }
+
+    public Set<KafkaProxyIngress> getIngresses() {
+        return new HashSet<>(kafkaProxyIngresses.values());
+    }
+
+    public Stream<ClusterResolutionResult> clusterResult() {
+        return clusterResolutionResults.values().stream();
+    }
+
+    public List<VirtualKafkaCluster> allClustersInNameOrder() {
+        return clusterResolutionResults.values().stream().map(ClusterResolutionResult::cluster).sorted(comparing(ResourcesUtil::name)).toList();
+    }
+
+    public Collection<GenericKubernetesResource> filters() {
+        return filters.values();
+    }
+
+    public record UnresolvedDependency(Dependency type, String name) {}
+
+    public record ClusterResolutionResult(VirtualKafkaCluster cluster, Set<UnresolvedDependency> unresolvedDependencySet) {
+        public boolean isAnyDependencyUnresolved() {
+            return !unresolvedDependencySet.isEmpty();
+        }
+
+        public Optional<UnresolvedDependency> firstUnresolvedDependency() {
+            return unresolvedDependencySet.stream().findFirst();
+        }
+    }
+
+    public Optional<KafkaClusterRef> kafkaClusterRef(String name) {
+        return Optional.ofNullable(kafkaClusterRefs.get(name));
+    }
+
+    public Optional<KafkaClusterRef> kafkaClusterRefFor(VirtualKafkaCluster cluster) {
+        return kafkaClusterRef(cluster.getSpec().getTargetCluster().getClusterRef().getName());
+    }
+
+    public Optional<GenericKubernetesResource> filter(String name) {
+        return Optional.ofNullable(filters.get(name));
+    }
+
+    public List<VirtualKafkaCluster> fullyResolvedClustersInNameOrder() {
+        return clusterResolutionResults.values().stream().filter(v -> !v.isAnyDependencyUnresolved()).map(ClusterResolutionResult::cluster)
+                .sorted(comparing(ResourcesUtil::name)).toList();
+    }
+
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/DerivedResourcesTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/DerivedResourcesTest.java
@@ -281,7 +281,7 @@ class DerivedResourcesTest {
                     var expectedFile = testDir.resolve("out-" + kind + "-" + name + ".yaml");
                     tests.add(DynamicTest.dynamicTest(kind + " '" + name + "' should have the same content as " + testDir.relativize(expectedFile),
                             () -> {
-                                assertThat(Files.exists(expectedFile)).isTrue();
+                                assertThat(Files.exists(expectedFile)).describedAs("file " + expectedFile + " should exist").isTrue();
                                 var expected = loadExpected(expectedFile, resourceType);
                                 assertSameYaml(actualResource, expected);
                                 unusedFiles.remove(expectedFile);


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Each dependent resource reconciler should reconcile as much as it can. That means that they do not need to account for reasons another component may be unable to reconcile some virtual clusters. So broken filter definitions that cannot be built for some reason should not impact reconciliation of the Deployment/Service.

They still report cluster conditions to the context, the last reported condition will be the one presented as cluster status.

Each component constructs it own set of resolved dependencies. Even though the dependencies may vary throughout a single reconciliation of a KafkaProxy, they should become eventually consistent.

This tidies up the workaround for #1916 by resolving all dependencies early. So now we only work with fully resolved virtual clusters where appropriate. The logic within `ProxyConfigSecret` is self-contained and does not rely on calling in and out of the context to check which VCs are accepted.

Note that there is still an interdependency around Filter secrets that are passed throught the context, so we cannot run the dependent resource reconcilers in parallel yet.

### Additional Context

#1916 showed up the brittleness of our technique of using the Context to share whether each Virtual Cluster is accepted (at least within the context of a single dependent resource, it was painful to go in and out of the Context to check and recheck what is not broken).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
