### PR TITLE
Make minikube detection fail more quickly if minikube (etc) isn't available

### DIFF
--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorTestUtils.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorTestUtils.java
@@ -13,8 +13,23 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 public class OperatorTestUtils {
+
+    /**
+     * The timeouts etc of this client build are tuned to handle the case where Kubernetes isn't present.
+     * As might be the case on a developer's machine where minikube isn't running.
+     */
+    private static final KubernetesClientBuilder PRESENCE_PROBING_KUBE_CLIENT_BUILD = new KubernetesClientBuilder()
+            .editOrNewConfig()
+            .withRequestRetryBackoffLimit(2)
+            .withConnectionTimeout(500)
+            .endConfig();
+
     static @Nullable KubernetesClient kubeClientIfAvailable() {
-        var client = new KubernetesClientBuilder().build();
+        return kubeClientIfAvailable(new KubernetesClientBuilder());
+    }
+
+    static @Nullable KubernetesClient kubeClientIfAvailable(KubernetesClientBuilder kubernetesClientBuilder) {
+        var client = kubernetesClientBuilder.build();
         try {
             client.namespaces().list();
             return client;
@@ -26,7 +41,7 @@ public class OperatorTestUtils {
     }
 
     static boolean isKubeClientAvailable() {
-        try (var client = kubeClientIfAvailable()) {
+        try (var client = kubeClientIfAvailable(PRESENCE_PROBING_KUBE_CLIENT_BUILD)) {
             return client != null;
         }
     }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Tune Kube Client timeouts so that it gives up more quickly if Kubernetes cannot be reached.

why: Operator IT tests were hanging excessively (60s) if minikube wasn't running on my box.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
