### PR TITLE
Fix #1810: Run operator/operand image as non-root user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#1810](https://github.com/kroxylicious/kroxylicious/issues/1810) Run operator/operand image as non-root user
 * [#1903](https://github.com/kroxylicious/kroxylicious/issues/1903) Rename `adminHttp` to `management` in the config model.
 * [#1918](https://github.com/kroxylicious/kroxylicious/pull/1918)  Removes support for the deprecated config property `filePath`.
 * [#1573](https://github.com/kroxylicious/kroxylicious/issues/1573) Minimal proxy health probe (livez)

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,54 +6,62 @@
 
 FROM registry.access.redhat.com/ubi9/openjdk-17:1.20 AS builder
 
+ARG TARGETOS
+ARG TARGETARCH
+
 USER root
 WORKDIR /opt/kroxylicious
 COPY . .
 RUN mvn -q -B clean package -Pdist -Dquick
-USER 185
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
 
-ARG JAVA_VERSION=17
-ARG TARGETOS
-ARG TARGETARCH
-ARG KROXYLICIOUS_VERSION
-ARG CURRENT_USER
-ARG CURRENT_USER_UID
-
-RUN microdnf -y update \
-    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
-    && microdnf clean all
-
-ENV JAVA_HOME=/usr/lib/jvm/jre-17
-
-#####
-# Add Tini
-#####
+# Download Tini
 ENV TINI_VERSION=v0.19.0
 ENV TINI_SHA256_AMD64=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c
 ENV TINI_SHA256_ARM64=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81
 ENV TINI_SHA256_PPC64LE=3f658420974768e40810001a038c29d003728c5fe86da211cff5059e48cfdfde
 ENV TINI_SHA256_S390X=931b70a182af879ca249ae9de87ef68423121b38d235c78997fafc680ceab32d
+ENV TINI_DEST=/opt/tini/bin/tini
+
 RUN set -ex; \
+    mkdir -p /opt/tini/bin/; \
     if [[ "${TARGETOS}/${TARGETARCH}" = "linux/ppc64le" ]]; then \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-ppc64le -o /usr/bin/tini; \
-        echo "${TINI_SHA256_PPC64LE} */usr/bin/tini" | sha256sum -c; \
-        chmod +x /usr/bin/tini; \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-ppc64le -o ${TINI_DEST}; \
+        echo "${TINI_SHA256_PPC64LE} *${TINI_DEST}" | sha256sum -c; \
     elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/arm64" ]]; then \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 -o /usr/bin/tini; \
-        echo "${TINI_SHA256_ARM64} */usr/bin/tini" | sha256sum -c; \
-        chmod +x /usr/bin/tini; \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 -o ${TINI_DEST}; \
+        echo "${TINI_SHA256_ARM64} *${TINI_DEST}" | sha256sum -c; \
     elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/s390x" ]]; then \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x -o /usr/bin/tini; \
-        echo "${TINI_SHA256_S390X} */usr/bin/tini" | sha256sum -c; \
-        chmod +x /usr/bin/tini; \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x -o ${TINI_DEST}; \
+        echo "${TINI_SHA256_S390X} *${TINI_DEST}" | sha256sum -c; \
     else \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o /usr/bin/tini; \
-        echo "${TINI_SHA256_AMD64} */usr/bin/tini" | sha256sum -c; \
-        chmod +x /usr/bin/tini; \
-    fi
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o ${TINI_DEST}; \
+        echo "${TINI_SHA256_AMD64} *${TINI_DEST}" | sha256sum -c; \
+    fi; \
+    chmod +x ${TINI_DEST}
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+
+ARG JAVA_VERSION=17
+ARG KROXYLICIOUS_VERSION
+ARG CONTAINER_USER=kroxylicious
+ARG CONTAINER_USER_UID=185
+
+USER root
+
+RUN microdnf -y update \
+    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
+                java-${JAVA_VERSION}-openjdk-headless \
+                openssl \
+                shadow-utils \
+    && if [[ -n "${CONTAINER_USER}" && "${CONTAINER_USER}" != "root" ]] ; then groupadd -r -g "${CONTAINER_USER_UID}" "${CONTAINER_USER}" && useradd -m -r -u "${CONTAINER_USER_UID}" -g "${CONTAINER_USER}" "${CONTAINER_USER}"; fi \
+    && microdnf remove -y shadow-utils \
+    && microdnf clean all
+
+ENV JAVA_HOME=/usr/lib/jvm/jre-17
+
+COPY --from=builder /opt/tini/bin/tini /usr/bin/tini
 COPY --from=builder /opt/kroxylicious/kroxylicious-app/target/kroxylicious-app-${KROXYLICIOUS_VERSION}-bin/kroxylicious-app-${KROXYLICIOUS_VERSION}/ /opt/kroxylicious/
 
-RUN if [[ -n "${CURRENT_USER}" && "${CURRENT_USER}" != "root" ]] ; then groupadd -r -g "${CURRENT_USER_UID}" "${CURRENT_USER}" && useradd -m -r -u "${CURRENT_USER_UID}" -g "${CURRENT_USER}" "${CURRENT_USER}"; fi
+USER ${CONTAINER_USER_UID}
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/opt/kroxylicious/bin/kroxylicious-start.sh" ]

--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -6,56 +6,62 @@
 
 FROM registry.access.redhat.com/ubi9/openjdk-17:1.20 AS builder
 
+ARG TARGETOS
+ARG TARGETARCH
+
 USER root
 WORKDIR /opt/kroxylicious
 COPY . .
 RUN mvn -q -B clean package -Pdist -Dquick
-USER 185
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
-
-ARG JAVA_VERSION=17
-ARG TARGETOS
-ARG TARGETARCH
-ARG KROXYLICIOUS_VERSION
-ARG CURRENT_USER
-ARG CURRENT_USER_UID
-
-RUN microdnf -y update \
-    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y java-${JAVA_VERSION}-openjdk-headless openssl shadow-utils \
-    && microdnf clean all
-
-ENV JAVA_HOME=/usr/lib/jvm/jre-17
-
-#####
-# Add Tini
-#####
+# Download Tini
 ENV TINI_VERSION=v0.19.0
 ENV TINI_SHA256_AMD64=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c
 ENV TINI_SHA256_ARM64=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81
 ENV TINI_SHA256_PPC64LE=3f658420974768e40810001a038c29d003728c5fe86da211cff5059e48cfdfde
 ENV TINI_SHA256_S390X=931b70a182af879ca249ae9de87ef68423121b38d235c78997fafc680ceab32d
-RUN set -ex; \
-    if [[ "${TARGETOS}/${TARGETARCH}" = "linux/ppc64le" ]]; then \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-ppc64le -o /usr/bin/tini; \
-        echo "${TINI_SHA256_PPC64LE} */usr/bin/tini" | sha256sum -c; \
-        chmod +x /usr/bin/tini; \
-    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/arm64" ]]; then \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 -o /usr/bin/tini; \
-        echo "${TINI_SHA256_ARM64} */usr/bin/tini" | sha256sum -c; \
-        chmod +x /usr/bin/tini; \
-    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/s390x" ]]; then \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x -o /usr/bin/tini; \
-        echo "${TINI_SHA256_S390X} */usr/bin/tini" | sha256sum -c; \
-        chmod +x /usr/bin/tini; \
-    else \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o /usr/bin/tini; \
-        echo "${TINI_SHA256_AMD64} */usr/bin/tini" | sha256sum -c; \
-        chmod +x /usr/bin/tini; \
-    fi
+ENV TINI_DEST=/opt/tini/bin/tini
 
+RUN set -ex; \
+    mkdir -p /opt/tini/bin/; \
+    if [[ "${TARGETOS}/${TARGETARCH}" = "linux/ppc64le" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-ppc64le -o ${TINI_DEST}; \
+        echo "${TINI_SHA256_PPC64LE} *${TINI_DEST}" | sha256sum -c; \
+    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/arm64" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 -o ${TINI_DEST}; \
+        echo "${TINI_SHA256_ARM64} *${TINI_DEST}" | sha256sum -c; \
+    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/s390x" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x -o ${TINI_DEST}; \
+        echo "${TINI_SHA256_S390X} *${TINI_DEST}" | sha256sum -c; \
+    else \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o ${TINI_DEST}; \
+        echo "${TINI_SHA256_AMD64} *${TINI_DEST}" | sha256sum -c; \
+    fi; \
+    chmod +x ${TINI_DEST}
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+
+ARG JAVA_VERSION=17
+ARG KROXYLICIOUS_VERSION
+ARG CONTAINER_USER=kroxylicious
+ARG CONTAINER_USER_UID=185
+
+USER root
+
+RUN microdnf -y update \
+    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
+                java-${JAVA_VERSION}-openjdk-headless \
+                openssl \
+                shadow-utils \
+    && if [[ -n "${CONTAINER_USER}" && "${CONTAINER_USER}" != "root" ]] ; then groupadd -r -g "${CONTAINER_USER_UID}" "${CONTAINER_USER}" && useradd -m -r -u "${CONTAINER_USER_UID}" -g "${CONTAINER_USER}" "${CONTAINER_USER}"; fi \
+    && microdnf remove -y shadow-utils \
+    && microdnf clean all
+
+ENV JAVA_HOME=/usr/lib/jvm/jre-17
+
+COPY --from=builder /opt/tini/bin/tini /usr/bin/tini
 COPY --from=builder /opt/kroxylicious/kroxylicious-operator/target/kroxylicious-operator-${KROXYLICIOUS_VERSION}-bin/kroxylicious-operator-${KROXYLICIOUS_VERSION} /opt/kroxylicious-operator
 
-RUN if [[ -n "${CURRENT_USER}" && "${CURRENT_USER}" != "root" ]] ; then groupadd -r -g "${CURRENT_USER_UID}" "${CURRENT_USER}" && useradd -m -r -u "${CURRENT_USER_UID}" -g "${CURRENT_USER}" "${CURRENT_USER}"; fi
+USER ${CONTAINER_USER_UID}
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/opt/kroxylicious-operator/bin/operator-start.sh" ]

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -70,8 +70,8 @@ TAG_ARGS=$(array_to_arg_line "tag" "${IMAGE_TAGS[@]:""}")
 # shellcheck disable=SC2086 #we are passing additional arguments here so word splitting is intended
 ${CONTAINER_ENGINE} build -f "${CONTAINERFILE}" -t "${IMAGE}" ${LABEL_ARGS} ${TAG_ARGS} \
                                         --build-arg "KROXYLICIOUS_VERSION=${KROXYLICIOUS_VERSION}" \
-                                        --build-arg "CURRENT_USER=${USER}" \
-                                        --build-arg "CURRENT_USER_UID=$(id -u)" \
+                                        --build-arg "CONTAINER_USER=${USER}" \
+                                        --build-arg "CONTAINER_USER_UID=$(id -u)" \
                                         .
 if [[ -n ${PUSH_IMAGE:-} ]]; then
   REGISTRY_SERVER=${REGISTRY_SERVER:-$(extractRegistryServer "${REGISTRY_DESTINATION}")}


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

 Run operator/operand image as non-root user.

* correctly sets the `USER`, respecting any username/uid passed in from the user. 
* avoids polluting environment with TINI variables (tini download moved to the builder stage).
* uninstall shadow-utils from in the final layer to keep the dependencies small.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [x] Ensure the PR references relevant issue(s) so they are closed on merging.
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
