### PR TITLE
Abstract the java types used for references between CRs

### DIFF
--- a/kroxylicious-operator/examples/record-encryption/04.VirtualKafkaCluster.my-cluster.yaml
+++ b/kroxylicious-operator/examples/record-encryption/04.VirtualKafkaCluster.my-cluster.yaml
@@ -16,9 +16,7 @@ spec:
   targetCluster:
     clusterRef:
       name: my-cluster
-  filters:
-    - group: filter.kroxylicious.io
-      kind: KafkaProtocolFilter
-      name: encryption
+  filterRefs:
+    - name: encryption
   ingressRefs:
     - name: cluster-ip

--- a/kroxylicious-operator/examples/record-validation/04.VirtualKafkaCluster.my-cluster.yaml
+++ b/kroxylicious-operator/examples/record-validation/04.VirtualKafkaCluster.my-cluster.yaml
@@ -16,9 +16,7 @@ spec:
   targetCluster:
     clusterRef:
       name: my-cluster
-  filters:
-    - group: filter.kroxylicious.io
-      kind: RecordValidation
-      name: validation
+  filterRef:
+    - name: validation
   ingressRefs:
     - name: cluster-ip

--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -301,9 +301,23 @@
                     <source>src/main/resources/META-INF/fabric8</source>
                     <extraAnnotations>true</extraAnnotations>
                     <existingJavaTypes>
+                        <!-- From the kubernetes API -->
                         <io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyspec.PodTemplate>
                             io.fabric8.kubernetes.api.model.PodTemplateSpec
                         </io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyspec.PodTemplate>
+                        <!-- Common types used across our own CRDs -->
+                        <io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyingressspec.ProxyRef>
+                            io.kroxylicious.kubernetes.api.common.ProxyRef
+                        </io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyingressspec.ProxyRef>
+                        <io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ProxyRef>
+                            io.kroxylicious.kubernetes.api.common.ProxyRef
+                        </io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ProxyRef>
+                        <io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.targetcluster.ClusterRef>
+                            io.kroxylicious.kubernetes.api.common.KafkaCRef
+                        </io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.targetcluster.ClusterRef>
+                        <io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressRefs>
+                            io.kroxylicious.kubernetes.api.common.IngressRef
+                        </io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressRefs>
                     </existingJavaTypes>
                     <packageOverrides>
                         <!-- the default package name ($apiGroup.$apiVersion) doesn't work for us -->

--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -318,6 +318,9 @@
                         <io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressRefs>
                             io.kroxylicious.kubernetes.api.common.IngressRef
                         </io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressRefs>
+                        <io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.FilterRefs>
+                            io.kroxylicious.kubernetes.api.common.FilterRef
+                        </io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.FilterRefs>
                     </existingJavaTypes>
                     <packageOverrides>
                         <!-- the default package name ($apiGroup.$apiVersion) doesn't work for us -->

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/AnyLocalRef.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/AnyLocalRef.java
@@ -12,7 +12,6 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @javax.annotation.processing.Generated("io.fabric8.java.generator.CRGeneratorRunner")
 @lombok.ToString()
-@lombok.EqualsAndHashCode()
 @io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
         @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
         @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
@@ -23,9 +22,9 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
         @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
         @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
 })
-public class AnyLocalRef implements
-        LocalRef<HasMetadata>,
-        io.fabric8.kubernetes.api.builder.Editable<AnyLocalRefBuilder>,
+public class AnyLocalRef
+        extends LocalRef<HasMetadata>
+        implements io.fabric8.kubernetes.api.builder.Editable<AnyLocalRefBuilder>,
         io.fabric8.kubernetes.api.model.KubernetesResource {
 
     @java.lang.Override

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/AnyLocalRef.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/AnyLocalRef.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 package io.kroxylicious.kubernetes.api.common;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/AnyLocalRef.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/AnyLocalRef.java
@@ -1,0 +1,77 @@
+package io.kroxylicious.kubernetes.api.common;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+
+/**
+ * A reference, used in a kubernetes resource, to some kubernetes resource in the same namespace.
+ * This is used for references where the kind and group are not known statically.
+ */
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({ "group", "kind", "name" })
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@javax.annotation.processing.Generated("io.fabric8.java.generator.CRGeneratorRunner")
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class AnyLocalRef implements
+        LocalRef<HasMetadata>,
+        io.fabric8.kubernetes.api.builder.Editable<AnyLocalRefBuilder>,
+        io.fabric8.kubernetes.api.model.KubernetesResource {
+
+    @java.lang.Override
+    public AnyLocalRefBuilder edit() {
+        return new AnyLocalRefBuilder(this);
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("group")
+    @io.fabric8.generator.annotation.Pattern("^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private String group;
+
+    @Override
+    public String getGroup() {
+        return group;
+    }
+
+    public void setGroup(String group) {
+        this.group = group;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("kind")
+    @io.fabric8.generator.annotation.Pattern("^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private String kind;
+
+    @Override
+    public String getKind() {
+        return kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @io.fabric8.generator.annotation.Required()
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private String name;
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/FilterRef.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/FilterRef.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.api.common;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+
+/**
+ * A reference, used in a kubernetes resource, to a KafkaProxy resource in the same namespace.
+ */
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({ "name" })
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@javax.annotation.processing.Generated("io.fabric8.java.generator.CRGeneratorRunner")
+@lombok.ToString()
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class FilterRef
+        extends LocalRef<KafkaProxy>
+        implements io.fabric8.kubernetes.api.builder.Editable<FilterRefBuilder>,
+        KubernetesResource {
+
+    @Override
+    public FilterRefBuilder edit() {
+        return new FilterRefBuilder(this);
+    }
+
+    @JsonIgnore
+    @Override
+    public String getGroup() {
+        return "filter.kroxylicious.io";
+    }
+
+    @JsonIgnore
+    @Override
+    public String getKind() {
+        return "KafkaProtocolFilter";
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @io.fabric8.generator.annotation.Required()
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/IngressRef.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/IngressRef.java
@@ -14,7 +14,6 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @javax.annotation.processing.Generated("io.fabric8.java.generator.CRGeneratorRunner")
 @lombok.ToString()
-@lombok.EqualsAndHashCode()
 @io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
         @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
         @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
@@ -25,9 +24,9 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
         @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
         @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
 })
-public class IngressRef implements
-        LocalRef<KafkaProxyIngress>,
-        io.fabric8.kubernetes.api.builder.Editable<IngressRefBuilder>,
+public class IngressRef
+        extends LocalRef<KafkaProxyIngress>
+        implements io.fabric8.kubernetes.api.builder.Editable<IngressRefBuilder>,
         KubernetesResource {
 
     @Override

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/IngressRef.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/IngressRef.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 package io.kroxylicious.kubernetes.api.common;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/IngressRef.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/IngressRef.java
@@ -1,0 +1,62 @@
+package io.kroxylicious.kubernetes.api.common;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
+
+/**
+ * A reference, used in a kubernetes resource, to a KafkaProxyIngress resource in the same namespace.
+ */
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({ "group", "kind", "name" })
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@javax.annotation.processing.Generated("io.fabric8.java.generator.CRGeneratorRunner")
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class IngressRef implements
+        LocalRef<KafkaProxyIngress>,
+        io.fabric8.kubernetes.api.builder.Editable<IngressRefBuilder>,
+        KubernetesResource {
+
+    @Override
+    public IngressRefBuilder edit() {
+        return new IngressRefBuilder(this);
+    }
+
+    @JsonIgnore
+    @Override
+    public String getGroup() {
+        return "kroxylicious.io";
+    }
+
+    @JsonIgnore
+    @Override
+    public String getKind() {
+        return "KafkaProxyIngress";
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @io.fabric8.generator.annotation.Required()
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/IngressRef.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/IngressRef.java
@@ -16,7 +16,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
  * A reference, used in a kubernetes resource, to a KafkaProxyIngress resource in the same namespace.
  */
 @com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
-@com.fasterxml.jackson.annotation.JsonPropertyOrder({ "group", "kind", "name" })
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({ "name" })
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @javax.annotation.processing.Generated("io.fabric8.java.generator.CRGeneratorRunner")
 @lombok.ToString()

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/KafkaCRef.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/KafkaCRef.java
@@ -1,0 +1,62 @@
+package io.kroxylicious.kubernetes.api.common;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
+
+/**
+ * A reference, used in a kubernetes resource, to a KafkaClusterRef resource in the same namespace.
+ */
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({ "group", "kind", "name" })
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@javax.annotation.processing.Generated("io.fabric8.java.generator.CRGeneratorRunner")
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class KafkaCRef implements
+        LocalRef<KafkaClusterRef>,
+        io.fabric8.kubernetes.api.builder.Editable<KafkaCRefBuilder>,
+        KubernetesResource {
+
+    @Override
+    public KafkaCRefBuilder edit() {
+        return new KafkaCRefBuilder(this);
+    }
+
+    @JsonIgnore
+    @Override
+    public String getGroup() {
+        return "kroxylicious.io";
+    }
+
+    @JsonIgnore
+    @Override
+    public String getKind() {
+        return "KafkaClusterRef";
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @io.fabric8.generator.annotation.Required()
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/KafkaCRef.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/KafkaCRef.java
@@ -14,7 +14,6 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @javax.annotation.processing.Generated("io.fabric8.java.generator.CRGeneratorRunner")
 @lombok.ToString()
-@lombok.EqualsAndHashCode()
 @io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
         @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
         @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
@@ -25,9 +24,9 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
         @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
         @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
 })
-public class KafkaCRef implements
-        LocalRef<KafkaClusterRef>,
-        io.fabric8.kubernetes.api.builder.Editable<KafkaCRefBuilder>,
+public class KafkaCRef
+        extends LocalRef<KafkaClusterRef>
+        implements io.fabric8.kubernetes.api.builder.Editable<KafkaCRefBuilder>,
         KubernetesResource {
 
     @Override

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/KafkaCRef.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/KafkaCRef.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 package io.kroxylicious.kubernetes.api.common;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/KafkaCRef.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/KafkaCRef.java
@@ -16,7 +16,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
  * A reference, used in a kubernetes resource, to a KafkaClusterRef resource in the same namespace.
  */
 @com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
-@com.fasterxml.jackson.annotation.JsonPropertyOrder({ "group", "kind", "name" })
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({ "name" })
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @javax.annotation.processing.Generated("io.fabric8.java.generator.CRGeneratorRunner")
 @lombok.ToString()

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/LocalRef.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/LocalRef.java
@@ -6,16 +6,36 @@
 
 package io.kroxylicious.kubernetes.api.common;
 
+import java.util.Objects;
+
 /**
- * Abstraction for references in one kubernetes resource to some kubernetes resource in the same namespace
+ * Abstraction for references in one kubernetes resource to some kubernetes resource in the same namespace.
+ * Two LocalRefs are equal iff they have the same group, kind and name (they don't need to have the same class)
  * @param <T> The Java type of the resource
  */
-public interface LocalRef<T> {
+public abstract class LocalRef<T> {
 
-    public String getGroup();
+    public abstract String getGroup();
 
-    public String getKind();
+    public abstract String getKind();
 
-    public String getName();
+    public abstract String getName();
 
+    @Override
+    public final int hashCode() {
+        return Objects.hash(getGroup(), getKind(), getName());
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof LocalRef)) {
+            return false;
+        }
+        return Objects.equals(getGroup(), ((LocalRef<?>) obj).getGroup())
+                && Objects.equals(getKind(), ((LocalRef<?>) obj).getKind())
+                && Objects.equals(getName(), ((LocalRef<?>) obj).getName());
+    }
 }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/LocalRef.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/LocalRef.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.api.common;
+
+/**
+ * Abstraction for references in one kubernetes resource to some kubernetes resource in the same namespace
+ * @param <T> The Java type of the resource
+ */
+public interface LocalRef<T> {
+
+    public String getGroup();
+
+    public String getKind();
+
+    public String getName();
+
+}

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/ProxyRef.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/ProxyRef.java
@@ -1,0 +1,62 @@
+package io.kroxylicious.kubernetes.api.common;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+
+/**
+ * A reference, used in a kubernetes resource, to a KafkaProxy resource in the same namespace.
+ */
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({ "group", "kind", "name" })
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@javax.annotation.processing.Generated("io.fabric8.java.generator.CRGeneratorRunner")
+@lombok.ToString()
+@lombok.EqualsAndHashCode()
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class ProxyRef implements
+        LocalRef<KafkaProxy>,
+        io.fabric8.kubernetes.api.builder.Editable<ProxyRefBuilder>,
+        KubernetesResource {
+
+    @Override
+    public ProxyRefBuilder edit() {
+        return new ProxyRefBuilder(this);
+    }
+
+    @JsonIgnore
+    @Override
+    public String getGroup() {
+        return "kroxylicious.io";
+    }
+
+    @JsonIgnore
+    @Override
+    public String getKind() {
+        return "KafkaProxy";
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @io.fabric8.generator.annotation.Required()
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/ProxyRef.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/ProxyRef.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 package io.kroxylicious.kubernetes.api.common;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/ProxyRef.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/ProxyRef.java
@@ -14,7 +14,6 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @javax.annotation.processing.Generated("io.fabric8.java.generator.CRGeneratorRunner")
 @lombok.ToString()
-@lombok.EqualsAndHashCode()
 @io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
         @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
         @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
@@ -25,9 +24,9 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
         @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
         @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
 })
-public class ProxyRef implements
-        LocalRef<KafkaProxy>,
-        io.fabric8.kubernetes.api.builder.Editable<ProxyRefBuilder>,
+public class ProxyRef
+        extends LocalRef<KafkaProxy>
+        implements io.fabric8.kubernetes.api.builder.Editable<ProxyRefBuilder>,
         KubernetesResource {
 
     @Override

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/ProxyRef.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/ProxyRef.java
@@ -16,7 +16,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
  * A reference, used in a kubernetes resource, to a KafkaProxy resource in the same namespace.
  */
 @com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
-@com.fasterxml.jackson.annotation.JsonPropertyOrder({ "group", "kind", "name" })
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({ "name" })
 @com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
 @javax.annotation.processing.Generated("io.fabric8.java.generator.CRGeneratorRunner")
 @lombok.ToString()

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyReconciler.java
@@ -344,7 +344,6 @@ public class ProxyReconciler implements
                     .filter(vkc -> vkc.getSpec().getTargetCluster().getClusterRef().getName().equals(name(kafkaClusterRef)))
                     .map(VirtualKafkaCluster::getSpec)
                     .map(VirtualKafkaClusterSpec::getProxyRef)
-                    // .filter(ResourcesUtil::isKafkaProxy)
                     .map(ProxyRef::getName)
                     .collect(Collectors.toSet());
 

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyReconciler.java
@@ -396,7 +396,7 @@ public class ProxyReconciler implements
         return (KafkaProxy proxy) -> {
             Set<ResourceID> filterReferences = resourcesInSameNamespace(context, proxy, VirtualKafkaCluster.class)
                     .filter(clusterReferences(proxy))
-                    .flatMap(cluster -> Optional.ofNullable(cluster.getSpec().getFilters()).orElse(List.of()).stream())
+                    .flatMap(cluster -> Optional.ofNullable(cluster.getSpec().getFilterRefs()).orElse(List.of()).stream())
                     .map(filter -> new ResourceID(filter.getName(), namespace(proxy)))
                     .collect(Collectors.toSet());
             LOGGER.debug("KafkaProxy {} has references to filters {}", ResourceID.fromResource(proxy), filterReferences);

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyReconciler.java
@@ -39,6 +39,8 @@ import io.javaoperatorsdk.operator.processing.event.source.PrimaryToSecondaryMap
 import io.javaoperatorsdk.operator.processing.event.source.SecondaryToPrimaryMapper;
 import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource;
 
+import io.kroxylicious.kubernetes.api.common.KafkaCRef;
+import io.kroxylicious.kubernetes.api.common.ProxyRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
@@ -47,9 +49,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterSpec;
 import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Conditions;
 import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.ConditionsBuilder;
-import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ProxyRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.TargetCluster;
-import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.targetcluster.ClusterRef;
 import io.kroxylicious.kubernetes.operator.config.FilterApiDecl;
 import io.kroxylicious.kubernetes.operator.config.RuntimeDecl;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
@@ -344,6 +344,7 @@ public class ProxyReconciler implements
                     .filter(vkc -> vkc.getSpec().getTargetCluster().getClusterRef().getName().equals(name(kafkaClusterRef)))
                     .map(VirtualKafkaCluster::getSpec)
                     .map(VirtualKafkaClusterSpec::getProxyRef)
+                    // .filter(ResourcesUtil::isKafkaProxy)
                     .map(ProxyRef::getName)
                     .collect(Collectors.toSet());
 
@@ -367,7 +368,7 @@ public class ProxyReconciler implements
                     .map(VirtualKafkaCluster::getSpec)
                     .map(VirtualKafkaClusterSpec::getTargetCluster)
                     .map(TargetCluster::getClusterRef)
-                    .map(ClusterRef::getName)
+                    .map(KafkaCRef::getName)
                     .collect(Collectors.toSet());
 
             Set<ResourceID> kafkaClusterRefs = filteredResourceIdsInSameNamespace(context, primary, KafkaClusterRef.class,

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
@@ -139,39 +139,15 @@ public class ResourcesUtil {
      * @param <T> resource type
      * @return a Collector that collects a Map from element name to element
      */
-    public static <T extends HasMetadata> @NonNull Collector<T, ?, Map<LocalRef<?>, T>> toByLocalRefMap() {
+    public static <T extends HasMetadata> @NonNull Collector<T, ?, Map<LocalRef<T>, T>> toByLocalRefMap() {
         return Collectors.toMap(ResourcesUtil::toLocalRef, Function.identity());
     }
 
-    public static boolean isKafkaProxy(AnyLocalRef ref) {
-        return "kroxylicious.io".equals(ref.getGroup())
-                && "KafkaProxy".equals(ref.getKind());
-    }
-
-    public static AnyLocalRef checkIsKafkaProxy(AnyLocalRef ref) {
-        if (!isKafkaProxy(ref)) {
-            throw new InvalidResourceException("Referenced resource is not a KafkaProxy");
-        }
-        return ref;
-    }
-
-    public static boolean isKafkaCluster(AnyLocalRef ref) {
-        return "kroxylicious.io".equals(ref.getGroup())
-                && "KafkaClusterRef".equals(ref.getKind());
-    }
-
-    public static AnyLocalRef checkIsKafkaCluster(AnyLocalRef ref) {
-        if (!isKafkaCluster(ref)) {
-            throw new InvalidResourceException("Referenced resource is not a KafkaClusterRef");
-        }
-        return ref;
-    }
-
-    public static LocalRef<?> toLocalRef(HasMetadata ref) {
-        return new AnyLocalRefBuilder()
+    public static <T extends HasMetadata> LocalRef<T> toLocalRef(T ref) {
+        return (LocalRef) new AnyLocalRefBuilder()
                 .withKind(ref.getKind())
                 .withGroup(group(ref))
-                .withName(ref.getMetadata().getName())
+                .withName(name(ref))
                 .build();
     }
 

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
@@ -22,7 +22,6 @@ import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 
-import io.kroxylicious.kubernetes.api.common.AnyLocalRef;
 import io.kroxylicious.kubernetes.api.common.AnyLocalRefBuilder;
 import io.kroxylicious.kubernetes.api.common.LocalRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 
+import io.kroxylicious.kubernetes.api.common.AnyLocalRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 
@@ -129,5 +130,29 @@ public class ResourcesUtil {
      */
     public static <T extends HasMetadata> @NonNull Collector<T, ?, Map<String, T>> toByNameMap() {
         return Collectors.toMap(ResourcesUtil::name, Function.identity());
+    }
+
+    public static boolean isKafkaProxy(AnyLocalRef ref) {
+        return "kroxylicious.io".equals(ref.getGroup())
+                && "KafkaProxy".equals(ref.getKind());
+    }
+
+    public static AnyLocalRef checkIsKafkaProxy(AnyLocalRef ref) {
+        if (!isKafkaProxy(ref)) {
+            throw new InvalidResourceException("Referenced resource is not a KafkaProxy");
+        }
+        return ref;
+    }
+
+    public static boolean isKafkaCluster(AnyLocalRef ref) {
+        return "kroxylicious.io".equals(ref.getGroup())
+                && "KafkaClusterRef".equals(ref.getKind());
+    }
+
+    public static AnyLocalRef checkIsKafkaCluster(AnyLocalRef ref) {
+        if (!isKafkaCluster(ref)) {
+            throw new InvalidResourceException("Referenced resource is not a KafkaClusterRef");
+        }
+        return ref;
     }
 }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/ProxyModelBuilder.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/ProxyModelBuilder.java
@@ -46,7 +46,7 @@ public class ProxyModelBuilder {
         // to try and produce the most stable allocation of ports we can, we attempt to consider all clusters in the ingress allocation, even those
         // that we know are unacceptable due to unresolved dependencies.
         List<VirtualKafkaCluster> allClusters = resolutionResult.allClustersInNameOrder();
-        ProxyIngressModel ingressModel = IngressAllocator.allocateProxyIngressModel(primary, allClusters, ingresses, context);
+        ProxyIngressModel ingressModel = IngressAllocator.allocateProxyIngressModel(primary, context, resolutionResult);
         List<VirtualKafkaCluster> clustersWithValidIngresses = resolutionResult.fullyResolvedClustersInNameOrder().stream()
                 .filter(cluster -> ingressModel.clusterIngressModel(cluster).map(i -> i.ingressExceptions().isEmpty()).orElse(false)).toList();
         return new ProxyModel(resolutionResult, ingressModel, clustersWithValidIngresses);

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/ingress/Ingresses.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/ingress/Ingresses.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import io.kroxylicious.kubernetes.api.common.IngressRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
@@ -23,15 +24,17 @@ class Ingresses {
 
     public static Stream<IngressDefinition> ingressesFor(KafkaProxy primary, VirtualKafkaCluster cluster, Set<KafkaProxyIngress> ingressResources) {
         Map<String, KafkaProxyIngress> namedIngresses = ingressResources.stream().collect(toByNameMap());
-        return cluster.getSpec().getIngressRefs().stream().map(io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressRefs::getName).flatMap(
-                ingressName -> {
-                    if (namedIngresses.containsKey(ingressName)) {
-                        return Stream.of(toIngress(primary, cluster, namedIngresses.get(ingressName)));
-                    }
-                    else {
-                        return Stream.empty();
-                    }
-                });
+        return cluster.getSpec().getIngressRefs().stream()
+                .map(IngressRef::getName)
+                .flatMap(
+                        ingressName -> {
+                            if (namedIngresses.containsKey(ingressName)) {
+                                return Stream.of(toIngress(primary, cluster, namedIngresses.get(ingressName)));
+                            }
+                            else {
+                                return Stream.empty();
+                            }
+                        });
     }
 
     private static IngressDefinition toIngress(KafkaProxy primary, VirtualKafkaCluster cluster, KafkaProxyIngress ingress) {

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolverImpl.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolverImpl.java
@@ -30,7 +30,6 @@ import io.kroxylicious.kubernetes.operator.resolver.ResolutionResult.ClusterReso
 import io.kroxylicious.kubernetes.operator.resolver.ResolutionResult.UnresolvedDependency;
 
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
-import static io.kroxylicious.kubernetes.operator.ResourcesUtil.toByNameMap;
 import static io.kroxylicious.kubernetes.operator.resolver.Dependency.FILTER;
 import static io.kroxylicious.kubernetes.operator.resolver.Dependency.KAFKA_CLUSTER_REF;
 import static io.kroxylicious.kubernetes.operator.resolver.Dependency.KAFKA_PROXY_INGRESS;
@@ -53,10 +52,12 @@ public class DependencyResolverImpl implements DependencyResolver {
         if (virtualKafkaClusters.isEmpty()) {
             return EMPTY_RESOLUTION_RESULT;
         }
-        Map<LocalRef<?>, KafkaProxyIngress> ingresses = context.getSecondaryResources(KafkaProxyIngress.class).stream()
+        Map<LocalRef<KafkaProxyIngress>, KafkaProxyIngress> ingresses = context.getSecondaryResources(KafkaProxyIngress.class).stream()
                 .collect(ResourcesUtil.toByLocalRefMap());
-        Map<String, KafkaClusterRef> clusterRefs = context.getSecondaryResources(KafkaClusterRef.class).stream().collect(toByNameMap());
-        Map<String, GenericKubernetesResource> filters = context.getSecondaryResources(GenericKubernetesResource.class).stream().collect(toByNameMap());
+        Map<LocalRef<KafkaClusterRef>, KafkaClusterRef> clusterRefs = context.getSecondaryResources(KafkaClusterRef.class).stream()
+                .collect(ResourcesUtil.toByLocalRefMap());
+        Map<LocalRef<GenericKubernetesResource>, GenericKubernetesResource> filters = context.getSecondaryResources(GenericKubernetesResource.class).stream()
+                .collect(ResourcesUtil.toByLocalRefMap());
         var resolutionResult = virtualKafkaClusters.stream().map(cluster -> determineUnresolvedDependencies(cluster, ingresses, clusterRefs, filters))
                 .collect(Collectors.toMap(result -> ResourcesUtil.name(result.cluster()), r -> r));
         ResolutionResult result = new ResolutionResult(filters, ingresses, clusterRefs, resolutionResult);
@@ -65,9 +66,9 @@ public class DependencyResolverImpl implements DependencyResolver {
     }
 
     private ClusterResolutionResult determineUnresolvedDependencies(VirtualKafkaCluster cluster,
-                                                                    Map<LocalRef<?>, KafkaProxyIngress> ingresses,
-                                                                    Map<String, KafkaClusterRef> clusterRefs,
-                                                                    Map<String, GenericKubernetesResource> filters) {
+                                                                    Map<LocalRef<KafkaProxyIngress>, KafkaProxyIngress> ingresses,
+                                                                    Map<LocalRef<KafkaClusterRef>, KafkaClusterRef> clusterRefs,
+                                                                    Map<LocalRef<GenericKubernetesResource>, GenericKubernetesResource> filters) {
         VirtualKafkaClusterSpec spec = cluster.getSpec();
         Set<UnresolvedDependency> unresolvedDependencies = new HashSet<>();
         determineUnresolvedIngresses(spec, ingresses).forEach(unresolvedDependencies::add);
@@ -76,7 +77,8 @@ public class DependencyResolverImpl implements DependencyResolver {
         return new ClusterResolutionResult(cluster, unresolvedDependencies);
     }
 
-    private Stream<UnresolvedDependency> determineUnresolvedFilters(VirtualKafkaClusterSpec spec, Map<String, GenericKubernetesResource> filters) {
+    private Stream<UnresolvedDependency> determineUnresolvedFilters(VirtualKafkaClusterSpec spec,
+                                                                    Map<LocalRef<GenericKubernetesResource>, GenericKubernetesResource> filters) {
         List<FilterRef> filtersList = spec.getFilterRefs();
         if (filtersList == null) {
             return Stream.empty();
@@ -88,17 +90,19 @@ public class DependencyResolverImpl implements DependencyResolver {
         }
     }
 
-    private Optional<UnresolvedDependency> determineUnresolvedKafkaClusterRef(VirtualKafkaClusterSpec spec, Map<String, KafkaClusterRef> clusterRefs) {
-        String clusterRef = spec.getTargetCluster().getClusterRef().getName();
+    private Optional<UnresolvedDependency> determineUnresolvedKafkaClusterRef(VirtualKafkaClusterSpec spec,
+                                                                              Map<LocalRef<KafkaClusterRef>, KafkaClusterRef> clusterRefs) {
+        var clusterRef = spec.getTargetCluster().getClusterRef();
         if (!clusterRefs.containsKey(clusterRef)) {
-            return Optional.of(new UnresolvedDependency(KAFKA_CLUSTER_REF, clusterRef));
+            return Optional.of(new UnresolvedDependency(KAFKA_CLUSTER_REF, clusterRef.getName()));
         }
         else {
             return Optional.empty();
         }
     }
 
-    private static Stream<UnresolvedDependency> determineUnresolvedIngresses(VirtualKafkaClusterSpec spec, Map<LocalRef<?>, KafkaProxyIngress> ingresses) {
+    private static Stream<UnresolvedDependency> determineUnresolvedIngresses(VirtualKafkaClusterSpec spec,
+                                                                             Map<LocalRef<KafkaProxyIngress>, KafkaProxyIngress> ingresses) {
         return spec.getIngressRefs().stream()
                 .filter(ref -> !ingresses.containsKey(ref))
                 .map(ref -> new UnresolvedDependency(KAFKA_PROXY_INGRESS, ref.getName()));

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolverImpl.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolverImpl.java
@@ -54,7 +54,7 @@ public class DependencyResolverImpl implements DependencyResolver {
             return EMPTY_RESOLUTION_RESULT;
         }
         Map<LocalRef<?>, KafkaProxyIngress> ingresses = context.getSecondaryResources(KafkaProxyIngress.class).stream()
-                .collect(Collectors.toMap(ResourcesUtil::toLocalRef, i -> i));
+                .collect(ResourcesUtil.toByLocalRefMap());
         Map<String, KafkaClusterRef> clusterRefs = context.getSecondaryResources(KafkaClusterRef.class).stream().collect(toByNameMap());
         Map<String, GenericKubernetesResource> filters = context.getSecondaryResources(GenericKubernetesResource.class).stream().collect(toByNameMap());
         var resolutionResult = virtualKafkaClusters.stream().map(cluster -> determineUnresolvedDependencies(cluster, ingresses, clusterRefs, filters))

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolverImpl.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolverImpl.java
@@ -18,13 +18,13 @@ import java.util.stream.Stream;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 
+import io.kroxylicious.kubernetes.api.common.FilterRef;
 import io.kroxylicious.kubernetes.api.common.LocalRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterSpec;
-import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.Filters;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.resolver.ResolutionResult.ClusterResolutionResult;
 import io.kroxylicious.kubernetes.operator.resolver.ResolutionResult.UnresolvedDependency;
@@ -77,7 +77,7 @@ public class DependencyResolverImpl implements DependencyResolver {
     }
 
     private Stream<UnresolvedDependency> determineUnresolvedFilters(VirtualKafkaClusterSpec spec, Map<String, GenericKubernetesResource> filters) {
-        List<Filters> filtersList = spec.getFilters();
+        List<FilterRef> filtersList = spec.getFilterRefs();
         if (filtersList == null) {
             return Stream.empty();
         }
@@ -104,7 +104,7 @@ public class DependencyResolverImpl implements DependencyResolver {
                 .map(ref -> new UnresolvedDependency(KAFKA_PROXY_INGRESS, ref.getName()));
     }
 
-    private static boolean filterResourceMatchesRef(Filters filterRef, GenericKubernetesResource filterResource) {
+    private static boolean filterResourceMatchesRef(FilterRef filterRef, GenericKubernetesResource filterResource) {
         String apiVersion = filterResource.getApiVersion();
         var filterResourceGroup = apiVersion.substring(0, apiVersion.indexOf("/"));
         return filterResourceGroup.equals(filterRef.getGroup())

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ResolutionResult.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ResolutionResult.java
@@ -17,11 +17,11 @@ import java.util.function.Predicate;
 
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 
+import io.kroxylicious.kubernetes.api.common.FilterRef;
 import io.kroxylicious.kubernetes.api.common.LocalRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
-import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.Filters;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 
 import static java.util.Comparator.comparing;
@@ -142,7 +142,7 @@ public class ResolutionResult {
      * Get the resolved GenericKubernetesResource for a filterRef
      * @return optional containing the resource if resolved, else empty
      */
-    public Optional<GenericKubernetesResource> filter(Filters filterRef) {
+    public Optional<GenericKubernetesResource> filter(FilterRef filterRef) {
         return filters().stream()
                 .filter(filterResource -> {
                     String apiVersion = filterResource.getApiVersion();

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ResolutionResult.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ResolutionResult.java
@@ -17,6 +17,7 @@ import java.util.function.Predicate;
 
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 
+import io.kroxylicious.kubernetes.api.common.LocalRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
@@ -32,7 +33,7 @@ import static java.util.Comparator.comparing;
  */
 public class ResolutionResult {
     private final Map<String, GenericKubernetesResource> filters;
-    private final Map<String, KafkaProxyIngress> kafkaProxyIngresses;
+    private final Map<LocalRef<?>, KafkaProxyIngress> kafkaProxyIngresses;
     private final Map<String, KafkaClusterRef> kafkaClusterRefs;
     private final Map<String, ClusterResolutionResult> clusterResolutionResults;
 
@@ -60,7 +61,7 @@ public class ResolutionResult {
     }
 
     ResolutionResult(Map<String, GenericKubernetesResource> filters,
-                     Map<String, KafkaProxyIngress> kafkaProxyIngresses,
+                     Map<LocalRef<?>, KafkaProxyIngress> kafkaProxyIngresses,
                      Map<String, KafkaClusterRef> kafkaClusterRefs,
                      Map<String, ClusterResolutionResult> clusterResolutionResults) {
         Objects.requireNonNull(filters);
@@ -108,6 +109,16 @@ public class ResolutionResult {
      */
     public Set<KafkaProxyIngress> ingresses() {
         return new HashSet<>(kafkaProxyIngresses.values());
+    }
+
+    /**
+     * Get KafkaProxyIngress for this reference
+     * @param localRef reference
+     * @return optional containing ingress if present, else empty
+     */
+    public Optional<KafkaProxyIngress> ingress(LocalRef<?> localRef) {
+        Objects.requireNonNull(localRef);
+        return Optional.ofNullable(kafkaProxyIngresses.get(localRef));
     }
 
     /**

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ResolutionResult.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ResolutionResult.java
@@ -32,9 +32,9 @@ import static java.util.Comparator.comparing;
  * describes which dependencies could not be resolved per VirtualKafkaCluster.
  */
 public class ResolutionResult {
-    private final Map<String, GenericKubernetesResource> filters;
-    private final Map<LocalRef<?>, KafkaProxyIngress> kafkaProxyIngresses;
-    private final Map<String, KafkaClusterRef> kafkaClusterRefs;
+    private final Map<LocalRef<GenericKubernetesResource>, GenericKubernetesResource> filters;
+    private final Map<LocalRef<KafkaProxyIngress>, KafkaProxyIngress> kafkaProxyIngresses;
+    private final Map<LocalRef<KafkaClusterRef>, KafkaClusterRef> kafkaClusterRefs;
     private final Map<String, ClusterResolutionResult> clusterResolutionResults;
 
     public record UnresolvedDependency(Dependency type, String name) {
@@ -60,9 +60,9 @@ public class ResolutionResult {
 
     }
 
-    ResolutionResult(Map<String, GenericKubernetesResource> filters,
-                     Map<LocalRef<?>, KafkaProxyIngress> kafkaProxyIngresses,
-                     Map<String, KafkaClusterRef> kafkaClusterRefs,
+    ResolutionResult(Map<LocalRef<GenericKubernetesResource>, GenericKubernetesResource> filters,
+                     Map<LocalRef<KafkaProxyIngress>, KafkaProxyIngress> kafkaProxyIngresses,
+                     Map<LocalRef<KafkaClusterRef>, KafkaClusterRef> kafkaClusterRefs,
                      Map<String, ClusterResolutionResult> clusterResolutionResults) {
         Objects.requireNonNull(filters);
         Objects.requireNonNull(kafkaProxyIngresses);
@@ -116,7 +116,7 @@ public class ResolutionResult {
      * @param localRef reference
      * @return optional containing ingress if present, else empty
      */
-    public Optional<KafkaProxyIngress> ingress(LocalRef<?> localRef) {
+    public Optional<KafkaProxyIngress> ingress(LocalRef<KafkaProxyIngress> localRef) {
         Objects.requireNonNull(localRef);
         return Optional.ofNullable(kafkaProxyIngresses.get(localRef));
     }
@@ -126,8 +126,8 @@ public class ResolutionResult {
      * @return optional containing the cluster ref if resolved, else empty
      */
     public Optional<KafkaClusterRef> kafkaClusterRef(VirtualKafkaCluster cluster) {
-        String name = cluster.getSpec().getTargetCluster().getClusterRef().getName();
-        return Optional.ofNullable(kafkaClusterRefs.get(name));
+        var ref = cluster.getSpec().getTargetCluster().getClusterRef();
+        return Optional.ofNullable(kafkaClusterRefs.get(ref));
     }
 
     /**

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
@@ -43,15 +43,6 @@ spec:
                   type: object
                   required: [ "name" ]
                   properties:
-                    group:
-                      type: string
-                      maxLength: 253
-                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                    kind:
-                      type: string
-                      maxLength: 63
-                      minLength: 1
-                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                     name:
                       maxLength: 253
                       minLength: 1
@@ -66,15 +57,10 @@ spec:
                       properties:
                         group:
                           type: string
-                          maxLength: 253
-                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                          default: kroxylicious.io
+                          pattern: ^kroxylicious[.]io$
                         kind:
                           type: string
-                          maxLength: 63
-                          minLength: 1
-                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
-                          default: KafkaClusterRef
+                          pattern: ^KafkaClusterRef$
                         name:
                           maxLength: 253
                           minLength: 1

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
@@ -80,22 +80,13 @@ spec:
                         maxLength: 253
                         minLength: 1
                         type: string
-                filters:
+                filterRefs:
                   description: The filters to be used for this cluster. Each filter is a separate resource.
                   type: array
                   items:
                     type: object
                     required: [ "name" ]
                     properties:
-                      group:
-                        type: string
-                        maxLength: 253
-                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                      kind:
-                        type: string
-                        maxLength: 63
-                        minLength: 1
-                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
                       name:
                         maxLength: 253
                         minLength: 1

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/api/common/AnyLocalRefTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/api/common/AnyLocalRefTest.java
@@ -17,6 +17,10 @@ class AnyLocalRefTest {
         var secretRefFoo = new AnyLocalRefBuilder().withName("foo").withKind("Secret").withGroup("").build();
         var secretRefFoo2 = new AnyLocalRefBuilder().withName("foo").withKind("Secret").withGroup("").build();
         var cmRefFoo = new AnyLocalRefBuilder().withName("foo").withKind("ConfigMap").withGroup("").build();
+        var diffGroupSecretFoo = new AnyLocalRefBuilder().withName("foo").withKind("Secret").withGroup("not.the.usual.group").build();
+        assertThat(secretRefFoo).isEqualTo(secretRefFoo);
+        assertThat(secretRefFoo).isNotEqualTo("salami");
+        assertThat(secretRefFoo).isNotEqualTo(diffGroupSecretFoo);
         assertThat(secretRefFoo).isEqualTo(secretRefFoo2);
         assertThat(secretRefFoo2).isEqualTo(secretRefFoo);
         assertThat(secretRefFoo).hasSameHashCodeAs(secretRefFoo2);

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/api/common/AnyLocalRefTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/api/common/AnyLocalRefTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.api.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AnyLocalRefTest {
+
+    @Test
+    void shouldRespectEqualsAndHashCode() {
+        var secretRefFoo = new AnyLocalRefBuilder().withName("foo").withKind("Secret").withGroup("").build();
+        var secretRefFoo2 = new AnyLocalRefBuilder().withName("foo").withKind("Secret").withGroup("").build();
+        var cmRefFoo = new AnyLocalRefBuilder().withName("foo").withKind("ConfigMap").withGroup("").build();
+        assertThat(secretRefFoo).isEqualTo(secretRefFoo2);
+        assertThat(secretRefFoo2).isEqualTo(secretRefFoo);
+        assertThat(secretRefFoo).hasSameHashCodeAs(secretRefFoo2);
+
+        assertThat(secretRefFoo).isNotEqualTo(cmRefFoo);
+    }
+
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/api/common/FilterRefTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/api/common/FilterRefTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.api.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FilterRefTest {
+
+    @Test
+    void shouldEqualAKafkaKindedAnyRef() {
+        var proxyRef = new FilterRefBuilder().withName("foo").build();
+        var anyFoo = new AnyLocalRefBuilder().withName("foo").withKind(proxyRef.getKind()).withGroup(proxyRef.getGroup()).build();
+        assertThat(proxyRef).isEqualTo(anyFoo);
+        assertThat(anyFoo).isEqualTo(proxyRef);
+        assertThat(proxyRef).hasSameHashCodeAs(anyFoo);
+    }
+
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/api/common/IngressRefTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/api/common/IngressRefTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.api.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IngressRefTest {
+
+    @Test
+    void shouldEqualAKafkaKindedAnyRef() {
+        var ingressRefFoo = new IngressRefBuilder().withName("foo").build();
+        var anyFoo = new AnyLocalRefBuilder().withName("foo").withKind(ingressRefFoo.getKind()).withGroup(ingressRefFoo.getGroup()).build();
+        assertThat(ingressRefFoo).isEqualTo(anyFoo);
+        assertThat(anyFoo).isEqualTo(ingressRefFoo);
+        assertThat(ingressRefFoo).hasSameHashCodeAs(anyFoo);
+    }
+
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/api/common/KafkaCRefTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/api/common/KafkaCRefTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.api.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KafkaCRefTest {
+
+    @Test
+    void shouldEqualAKafkaKindedAnyRef() {
+        var kafkaCRefFoo = new KafkaCRefBuilder().withName("foo").build();
+        var anyFoo = new AnyLocalRefBuilder().withName("foo").withKind(kafkaCRefFoo.getKind()).withGroup(kafkaCRefFoo.getGroup()).build();
+        assertThat(kafkaCRefFoo).isEqualTo(anyFoo);
+        assertThat(anyFoo).isEqualTo(kafkaCRefFoo);
+        assertThat(kafkaCRefFoo).hasSameHashCodeAs(anyFoo);
+    }
+
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/api/common/ProxyRefTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/api/common/ProxyRefTest.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.api.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProxyRefTest {
+
+    @Test
+    void shouldEqualAKafkaKindedAnyRef() {
+        var proxyRef = new ProxyRefBuilder().withName("foo").build();
+        var anyFoo = new AnyLocalRefBuilder().withName("foo").withKind(proxyRef.getKind()).withGroup(proxyRef.getGroup()).build();
+        assertThat(proxyRef).isEqualTo(anyFoo);
+        assertThat(anyFoo).isEqualTo(proxyRef);
+        assertThat(proxyRef).hasSameHashCodeAs(anyFoo);
+    }
+
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerIT.java
@@ -328,7 +328,7 @@ class ProxyReconcilerIT {
                 .endTargetCluster()
                 .withNewProxyRef().withName(name(proxy)).endProxyRef()
                 .addNewIngressRef().withName(name(ingress)).endIngressRef()
-                .withFilters()
+                .withFilterRefs()
                 .endSpec().build();
     }
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerIT.java
@@ -31,6 +31,8 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.readiness.Readiness;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 
+import io.kroxylicious.kubernetes.api.common.KafkaCRef;
+import io.kroxylicious.kubernetes.api.common.KafkaCRefBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRefBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
@@ -39,8 +41,6 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngressBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
-import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.targetcluster.ClusterRef;
-import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.targetcluster.ClusterRefBuilder;
 import io.kroxylicious.kubernetes.operator.config.RuntimeDecl;
 
 import static io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyingressspec.ClusterIP.Protocol.TCP;
@@ -242,7 +242,7 @@ class ProxyReconcilerIT {
         String newClusterRefName = "new-cluster-ref";
         extension.create(clusterRef(newClusterRefName, NEW_BOOTSTRAP));
 
-        ClusterRef newClusterRef = new ClusterRefBuilder().withName(newClusterRefName).build();
+        KafkaCRef newClusterRef = new KafkaCRefBuilder().withName(newClusterRefName).build();
         var cluster = createdResources.cluster(CLUSTER_BAR).edit().editSpec().editTargetCluster().withClusterRef(newClusterRef).endTargetCluster().endSpec().build();
 
         // when
@@ -324,7 +324,7 @@ class ProxyReconcilerIT {
         return new VirtualKafkaClusterBuilder().withNewMetadata().withName(clusterName).endMetadata()
                 .withNewSpec()
                 .withNewTargetCluster()
-                .withClusterRef(new ClusterRefBuilder().withName(name(clusterRef)).build())
+                .withClusterRef(new KafkaCRefBuilder().withName(name(clusterRef)).build())
                 .endTargetCluster()
                 .withNewProxyRef().withName(name(proxy)).endProxyRef()
                 .addNewIngressRef().withName(name(ingress)).endIngressRef()

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerTest.java
@@ -35,6 +35,7 @@ import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.PrimaryToSecondaryMapper;
 import io.javaoperatorsdk.operator.processing.event.source.SecondaryToPrimaryMapper;
 
+import io.kroxylicious.kubernetes.api.common.FilterRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRefBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
@@ -45,7 +46,6 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyStatus;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Conditions;
-import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.Filters;
 import io.kroxylicious.kubernetes.operator.assertj.AssertFactory;
 import io.kroxylicious.kubernetes.operator.config.RuntimeDecl;
 
@@ -494,7 +494,7 @@ class ProxyReconcilerTest {
         String filterName = "filter";
         KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName(proxyName).withNamespace(proxyNamespace).endMetadata().build();
         VirtualKafkaCluster clusterForAnotherProxy = baseVirtualKafkaClusterBuilder(proxy, "cluster").editOrNewSpec()
-                .addNewFilter().withName(filterName).endFilter().endSpec().build();
+                .addNewFilterRef().withName(filterName).endFilterRef().endSpec().build();
         when(mockList.getItems()).thenReturn(List.of(clusterForAnotherProxy));
         PrimaryToSecondaryMapper<KafkaProxy> mapper = ProxyReconciler.proxyToFilters(eventSourceContext);
         Set<ResourceID> secondaryResourceIDs = mapper.toSecondaryResourceIDs(proxy);
@@ -511,7 +511,7 @@ class ProxyReconcilerTest {
         KafkaProxy proxy = buildProxy("proxy");
         VirtualKafkaCluster clusterWithoutFilters = baseVirtualKafkaClusterBuilder(proxy, "cluster")
                 .editOrNewSpec()
-                .withFilters((List<Filters>) null)
+                .withFilterRefs((List<FilterRef>) null)
                 .endSpec()
                 .build();
         when(mockList.getItems()).thenReturn(List.of(clusterWithoutFilters));

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ResourcesUtilTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ResourcesUtilTest.java
@@ -14,9 +14,18 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
+import io.fabric8.kubernetes.api.model.GenericKubernetesResourceBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
+
+import io.kroxylicious.kubernetes.api.common.FilterRefBuilder;
+import io.kroxylicious.kubernetes.api.common.IngressRefBuilder;
+import io.kroxylicious.kubernetes.api.common.KafkaCRefBuilder;
+import io.kroxylicious.kubernetes.api.common.ProxyRefBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRefBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngressBuilder;
 
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.findOnlyResourceNamed;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.toByNameMap;
@@ -144,6 +153,24 @@ class ResourcesUtilTest {
         long generation = 123L;
         Secret secret = new SecretBuilder().withNewMetadata().withGeneration(generation).endMetadata().build();
         assertThat(ResourcesUtil.generation(secret)).isEqualTo(generation);
+    }
+
+    @Test
+    void toLocalRef() {
+        assertThat(ResourcesUtil.toLocalRef(new KafkaProxyBuilder().withNewMetadata().withName("foo").endMetadata().build()))
+                .isEqualTo(new ProxyRefBuilder().withName("foo").build());
+
+        assertThat(ResourcesUtil.toLocalRef(new KafkaClusterRefBuilder().withNewMetadata().withName("foo").endMetadata().build()))
+                .isEqualTo(new KafkaCRefBuilder().withName("foo").build());
+
+        assertThat(ResourcesUtil.toLocalRef(new KafkaProxyIngressBuilder().withNewMetadata().withName("foo").endMetadata().build()))
+                .isEqualTo(new IngressRefBuilder().withName("foo").build());
+
+        assertThat(ResourcesUtil.toLocalRef(new GenericKubernetesResourceBuilder()
+                .withKind("KafkaProtocolFilter")
+                .withApiVersion("filter.kroxylicious.io/v1alpha1")
+                .withNewMetadata().withName("foo").endMetadata().build()))
+                .isEqualTo(new FilterRefBuilder().withName("foo").build());
     }
 
 }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/resolver/ClusterConditionUnresolvedDependencyReporterTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/resolver/ClusterConditionUnresolvedDependencyReporterTest.java
@@ -94,7 +94,7 @@ class ClusterConditionUnresolvedDependencyReporterTest {
         UnresolvedDependency unresolved = new UnresolvedDependency(KAFKA_CLUSTER_REF, "a");
         Set<UnresolvedDependency> unresolvedDependencies = Set.of(unresolved);
         VirtualKafkaCluster cluster = new VirtualKafkaClusterBuilder().editMetadata().withName("cluster").endMetadata()
-                .withNewSpec().withNewTargetCluster().withNewClusterRef().withName("name").withKind("kind").withGroup("group").endClusterRef().endTargetCluster()
+                .withNewSpec().withNewTargetCluster().withNewClusterRef().withName("name").endClusterRef().endTargetCluster()
                 .endSpec().build();
 
         // when
@@ -104,7 +104,7 @@ class ClusterConditionUnresolvedDependencyReporterTest {
         verify(mockResourceContext).put(eq("cluster_conditions"), assertArg(a -> {
             assertThat(a).isInstanceOfSatisfying(Map.class, map -> {
                 assertThat(map).containsExactlyEntriesOf(Map.of("cluster", new ClusterCondition("cluster", ConditionType.Accepted, Conditions.Status.FALSE, "Invalid",
-                        "Target Cluster \"kind.group/name\" does not exist.")));
+                        "Target Cluster \"kafkaclusterref.kroxylicious.io/name\" does not exist.")));
             });
         }));
     }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolverImplTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolverImplTest.java
@@ -22,6 +22,8 @@ import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResourceBuilder;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 
+import io.kroxylicious.kubernetes.api.common.IngressRef;
+import io.kroxylicious.kubernetes.api.common.IngressRefBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRefBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
@@ -31,8 +33,6 @@ import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.Filters;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.FiltersBuilder;
-import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressRefs;
-import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressRefsBuilder;
 import io.kroxylicious.kubernetes.operator.resolver.ResolutionResult.ClusterResolutionResult;
 import io.kroxylicious.kubernetes.operator.resolver.ResolutionResult.UnresolvedDependency;
 
@@ -338,8 +338,8 @@ class DependencyResolverImplTest {
         verify(unresolvedDependencyReporter).reportUnresolvedDependencies(cluster, onlyResult.unresolvedDependencySet());
     }
 
-    private IngressRefs ingressRef(String name) {
-        return new IngressRefsBuilder().withName(name).build();
+    private IngressRef ingressRef(String name) {
+        return new IngressRefBuilder().withName(name).build();
     }
 
     private static KafkaProxyIngress ingress(String name) {
@@ -399,7 +399,7 @@ class DependencyResolverImplTest {
         return when(mockContext.getSecondaryResources(type)).thenReturn(Arrays.stream(resources).collect(Collectors.toSet()));
     }
 
-    private static VirtualKafkaCluster virtualCluster(List<Filters> filterRefs, String clusterRef, List<IngressRefs> ingressRefs) {
+    private static VirtualKafkaCluster virtualCluster(List<Filters> filterRefs, String clusterRef, List<IngressRef> ingressRefs) {
         return new VirtualKafkaClusterBuilder()
                 .withNewSpec()
                 .withIngressRefs(ingressRefs)

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolverImplTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolverImplTest.java
@@ -22,6 +22,8 @@ import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResourceBuilder;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 
+import io.kroxylicious.kubernetes.api.common.FilterRef;
+import io.kroxylicious.kubernetes.api.common.FilterRefBuilder;
 import io.kroxylicious.kubernetes.api.common.IngressRef;
 import io.kroxylicious.kubernetes.api.common.IngressRefBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
@@ -31,8 +33,6 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngressBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
-import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.Filters;
-import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.FiltersBuilder;
 import io.kroxylicious.kubernetes.operator.resolver.ResolutionResult.ClusterResolutionResult;
 import io.kroxylicious.kubernetes.operator.resolver.ResolutionResult.UnresolvedDependency;
 
@@ -66,7 +66,7 @@ class DependencyResolverImplTest {
         assertThat(resolutionResult.clusterResults()).isEmpty();
         assertThat(resolutionResult.ingresses()).isEmpty();
         assertThat(resolutionResult.fullyResolvedClustersInNameOrder()).isEmpty();
-        assertThat(resolutionResult.filter(filterRef("a", "b", "c"))).isEmpty();
+        assertThat(resolutionResult.filter(filterRef("c"))).isEmpty();
         assertThat(resolutionResult.filters()).isEmpty();
         verifyNoInteractions(unresolvedDependencyReporter);
     }
@@ -109,48 +109,6 @@ class DependencyResolverImplTest {
         assertThat(onlyResult.isFullyResolved()).isTrue();
         assertThat(onlyResult.unresolvedDependencySet()).isEmpty();
         verifyNoInteractions(unresolvedDependencyReporter);
-    }
-
-    @Test
-    void testSingleFilterUnreferencedBecauseOfKindMismatch() {
-        GenericKubernetesResource filter = protocolFilter("filterName", "kroxylicious.io", "Kind1");
-        givenFiltersInContext(filter);
-        givenClusterRefsInContext(kafkaClusterRef("cluster"));
-        givenIngressesInContext();
-        VirtualKafkaCluster cluster = virtualCluster(List.of(filterRef("filterName", "kroxylicious.io", "Kind2")), "cluster", List.of());
-        givenVirtualKafkaClustersInContext(cluster);
-
-        // when
-        ResolutionResult resolutionResult = DependencyResolverImpl.create().deepResolve(mockContext, unresolvedDependencyReporter);
-
-        // then
-        assertThat(resolutionResult.filter(filterRef("filterName", "kroxylicious.io", "Kind1"))).contains(filter);
-        assertThat(resolutionResult.filters()).containsExactly(filter);
-        ClusterResolutionResult onlyResult = assertSingleResult(resolutionResult, cluster);
-        assertThat(onlyResult.isFullyResolved()).isFalse();
-        assertThat(onlyResult.unresolvedDependencySet()).containsExactly(new UnresolvedDependency(Dependency.FILTER, "filterName"));
-        verify(unresolvedDependencyReporter).reportUnresolvedDependencies(cluster, onlyResult.unresolvedDependencySet());
-    }
-
-    @Test
-    void testSingleFilterUnreferencedBecauseOfGroupMismatch() {
-        GenericKubernetesResource filter = protocolFilter("filterName", "kroxylicious.io", "Kind");
-        givenFiltersInContext(filter);
-        givenClusterRefsInContext(kafkaClusterRef("cluster"));
-        givenIngressesInContext();
-        VirtualKafkaCluster cluster = virtualCluster(List.of(filterRef("filterName", "banana.io", "Kind")), "cluster", List.of());
-        givenVirtualKafkaClustersInContext(cluster);
-
-        // when
-        ResolutionResult resolutionResult = DependencyResolverImpl.create().deepResolve(mockContext, unresolvedDependencyReporter);
-
-        // then
-        assertThat(resolutionResult.filter(filterRef("filterName", "kroxylicious.io", "Kind"))).contains(filter);
-        assertThat(resolutionResult.filters()).containsExactly(filter);
-        ClusterResolutionResult onlyResult = assertSingleResult(resolutionResult, cluster);
-        assertThat(onlyResult.isFullyResolved()).isFalse();
-        assertThat(onlyResult.unresolvedDependencySet()).containsExactly(new UnresolvedDependency(Dependency.FILTER, "filterName"));
-        verify(unresolvedDependencyReporter).reportUnresolvedDependencies(cluster, onlyResult.unresolvedDependencySet());
     }
 
     @Test
@@ -358,23 +316,14 @@ class DependencyResolverImplTest {
         return new KafkaClusterRefBuilder().withNewMetadata().withName(clusterRef).endMetadata().build();
     }
 
-    private static Filters filterRef(String name) {
-        return filterRef(name, "kroxylicious.io", "KafkaProtocolFilter");
-    }
-
-    private static Filters filterRef(String name, String group, String kind) {
-        return new FiltersBuilder().withName(name).withGroup(group).withKind(kind).build();
+    private static FilterRef filterRef(String name) {
+        return new FilterRefBuilder().withName(name).build();
     }
 
     private static GenericKubernetesResource protocolFilter(String name) {
-        // should we build up a typed KafkaProtocolFilter and convert it to a generic resource somehow?
-        return protocolFilter(name, "kroxylicious.io", "KafkaProtocolFilter");
-    }
-
-    private static GenericKubernetesResource protocolFilter(String name, String groupId, String kind) {
         return new GenericKubernetesResourceBuilder()
-                .withApiVersion(groupId + "/v1alpha")
-                .withKind(kind)
+                .withApiVersion("filter.kroxylicious.io/v1alpha")
+                .withKind("KafkaProtocolFilter")
                 .withNewMetadata().withName(name)
                 .endMetadata().build();
     }
@@ -399,12 +348,12 @@ class DependencyResolverImplTest {
         return when(mockContext.getSecondaryResources(type)).thenReturn(Arrays.stream(resources).collect(Collectors.toSet()));
     }
 
-    private static VirtualKafkaCluster virtualCluster(List<Filters> filterRefs, String clusterRef, List<IngressRef> ingressRefs) {
+    private static VirtualKafkaCluster virtualCluster(List<FilterRef> filterRefs, String clusterRef, List<IngressRef> ingressRefs) {
         return new VirtualKafkaClusterBuilder()
                 .withNewSpec()
                 .withIngressRefs(ingressRefs)
                 .withNewTargetCluster().withNewClusterRef().withName(clusterRef).endClusterRef().endTargetCluster()
-                .withFilters(filterRefs)
+                .withFilterRefs(filterRefs)
                 .endSpec()
                 .build();
     }

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-VirtualKafkaCluster-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-VirtualKafkaCluster-bar.yaml
@@ -16,9 +16,7 @@ spec:
   targetCluster:
     clusterRef:
       name: barref
-  filters:
-    - group: filter.kroxylicious.io
-      kind: KafkaProtocolFilter
-      name: filter-one
+  filterRefs:
+    - name: filter-one
   ingressRefs:
     - name: cluster-ip

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-VirtualKafkaCluster-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-VirtualKafkaCluster-foo.yaml
@@ -16,9 +16,7 @@ spec:
   targetCluster:
     clusterRef:
       name: fooref
-  filters:
-    - group: filter.kroxylicious.io
-      kind: KafkaProtocolFilter
-      name: filter-one
+  filterRefs:
+    - name: filter-one
   ingressRefs:
     - name: cluster-ip

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/in-VirtualKafkaCluster-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/in-VirtualKafkaCluster-foo.yaml
@@ -16,15 +16,9 @@ spec:
   targetCluster:
     clusterRef:
       name: fooref
-  filters:
-    - group: filter.kroxylicious.io
-      kind: KafkaProtocolFilter
-      name: filter-one
-    - group: filter.kroxylicious.io
-      kind: KafkaProtocolFilter
-      name: filter-two
-    - group: filter.kroxylicious.io
-      kind: KafkaProtocolFilter
-      name: filter-one
+  filterRefs:
+    - name: filter-one
+    - name: filter-two
+    - name: filter-one
   ingressRefs:
     - name: cluster-ip

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-VirtualKafkaCluster-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-VirtualKafkaCluster-bar.yaml
@@ -16,12 +16,8 @@ spec:
   targetCluster:
     clusterRef:
       name: myref
-  filters:
-    - group: filter.kroxylicious.io
-      kind: KafkaProtocolFilter
-      name: filter-one
-    - group: filter.kroxylicious.io
-      kind: KafkaProtocolFilter
-      name: missing # this does not exist
+  filterRefs:
+    - name: filter-one
+    - name: missing # this does not exist
   ingressRefs:
     - name: cluster-ip-bar

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-VirtualKafkaCluster-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-VirtualKafkaCluster-foo.yaml
@@ -17,12 +17,8 @@ spec:
     # This cluster should be absent from the output proxy-operator-operator-operator-config.yaml, because there is no Two with name missing
     clusterRef:
       name: myref
-  filters:
-    - group: filter.kroxylicious.io
-      kind: KafkaProtocolFilter
-      name: filter-one
-    - group: filter.kroxylicious.io
-      kind: KafkaProtocolFilter
-      name: filter-two
+  filterRefs:
+    - name: filter-one
+    - name: filter-two
   ingressRefs:
     - name: cluster-ip-foo

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/in-VirtualKafkaCluster-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/in-VirtualKafkaCluster-foo.yaml
@@ -16,12 +16,8 @@ spec:
   targetCluster:
     clusterRef:
       name: myref
-  filters:
-    - group: filter.kroxylicious.io
-      kind: KafkaProtocolFilter
-      name: filter-one
-    - group: filter.kroxylicious.io
-      kind: KafkaProtocolFilter
-      name: filter-two
+  filterRefs:
+    - name: filter-one
+    - name: filter-two
   ingressRefs:
     - name: cluster-ip


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

The Java Generator is currently transpiling each schema object that functions as a reference to another kube resource into a new Java class, i.e. there is a class-per-ref pattern going on.

The idea of this PR is to a introduce an abstraction (`LocalRef`) to represent references to kube resources in the same namespace as the referrer. Why? To enable building common APIs around `LocalRef`. 

For example I thought it might be useful for @robobario's `Resolver` idea. While Resolver is OK for now I think it will start to get a bit more hairy later on when we have references which support multiple kinds, for example. Or multiple places which refer to the same kind of object. For example adding TLS support with the current class-per-ref pattern will mean we'd end up with lots of secret-ref like things, each their own java type. With this approach we end up with one SecretRef class, which is also an subtype of LocalRef<Secret> , which feels a lot more flexible.
