### PR TITLE
Add minikube to the release workflow

### DIFF
--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -111,6 +111,13 @@ jobs:
           gpg-private-key: ${{ secrets.KROXYLICIOUS_RELEASE_PRIVATE_KEY }} # Value of the GPG private key to import
           overwrite-settings: true
 
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.13.1
+        with:
+          minikube version: 'v1.35.0'
+          kubernetes version: 'v1.32.0'
+          github token: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
+
       - name: 'Verify no existing staging repository exists'
         if: ${{ github.event.inputs.dry-run == 'false' }}
         env:


### PR DESCRIPTION
…s can be run

### Type of change

_Select the type of your PR_

- Bugfix

### Description

The release workflow runs the tests, so as we've now introduce a reliance on Minikube, this needs to be setup too.
This takes the same approach we have on the main CI workflow (`maven`).

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
