### PR TITLE
Operator ITs - log pod status if operand image preload fails

### DIFF
--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorTestUtils.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorTestUtils.java
@@ -6,13 +6,27 @@
 
 package io.kroxylicious.kubernetes.operator;
 
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.readiness.Readiness;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class OperatorTestUtils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OperatorTestUtils.class);
 
     /**
      * The timeouts etc of this client build are tuned to handle the case where Kubernetes isn't present.
@@ -26,6 +40,12 @@ public class OperatorTestUtils {
 
     static @Nullable KubernetesClient kubeClientIfAvailable() {
         return kubeClientIfAvailable(new KubernetesClientBuilder());
+    }
+
+    static @NonNull KubernetesClient kubeClient() {
+        KubernetesClient kubernetesClient = kubeClientIfAvailable(new KubernetesClientBuilder());
+        assertThat(kubernetesClient).isNotNull();
+        return kubernetesClient;
     }
 
     static @Nullable KubernetesClient kubeClientIfAvailable(KubernetesClientBuilder kubernetesClientBuilder) {
@@ -43,6 +63,29 @@ public class OperatorTestUtils {
     static boolean isKubeClientAvailable() {
         try (var client = kubeClientIfAvailable(PRESENCE_PROBING_KUBE_CLIENT_BUILD)) {
             return client != null;
+        }
+    }
+
+    public static void preloadOperandImage() {
+        try (var client = kubeClient()) {
+            String operandImage = ProxyDeployment.getOperandImage();
+            var pod = client.run().withName("preload-operand-image")
+                    .withNewRunConfig()
+                    .withImage(operandImage)
+                    .withRestartPolicy("Never")
+                    .withCommand("ls").done();
+            try {
+                client.resource(pod).waitUntilCondition(Readiness::isPodSucceeded, 2, TimeUnit.MINUTES);
+            }
+            finally {
+                var reread = client.resource(pod).get();
+                if (!Readiness.isPodSucceeded(reread)) {
+                    var reasons = reread.getStatus().getContainerStatuses().stream().map(ContainerStatus::getState).map(Objects::toString)
+                            .collect(Collectors.joining(","));
+                    LOGGER.error("Preloading operand image failed, phase: {}, container state: {}", reread.getStatus().getPhase(), reasons);
+                }
+                client.resource(pod).delete();
+            }
         }
     }
 }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Contributes towards #1952.

In #1952 the fact that the IT was failing to pull the operand image was not apparent.  Change the test code so it is obvious in the log.s


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
