### PR TITLE
Rename KafkaClusterRef to KafkaService

### DIFF
--- a/kroxylicious-operator/examples/record-encryption/03.KafkaClusterRef.my-cluster.yaml
+++ b/kroxylicious-operator/examples/record-encryption/03.KafkaClusterRef.my-cluster.yaml
@@ -5,7 +5,7 @@
 #
 
 ---
-kind: KafkaClusterRef
+kind: KafkaService
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
   name: my-cluster

--- a/kroxylicious-operator/examples/record-validation/03.KafkaClusterRef.my-cluster.yaml
+++ b/kroxylicious-operator/examples/record-validation/03.KafkaClusterRef.my-cluster.yaml
@@ -5,7 +5,7 @@
 #
 
 ---
-kind: KafkaClusterRef
+kind: KafkaService
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
   name: my-cluster

--- a/kroxylicious-operator/examples/simple/02.KafkaClusterRef.my-cluster.yaml
+++ b/kroxylicious-operator/examples/simple/02.KafkaClusterRef.my-cluster.yaml
@@ -5,7 +5,7 @@
 #
 
 ---
-kind: KafkaClusterRef
+kind: KafkaService
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
   name: my-cluster

--- a/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-watched.yaml
+++ b/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-watched.yaml
@@ -19,7 +19,7 @@ rules:
     resources:
       - kafkaproxies
       - virtualkafkaclusters
-      - kafkaclusterrefs
+      - kafkaservices
       - kafkaproxyingresses
     verbs:
       - get

--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -342,7 +342,7 @@
                             io.kroxylicious.kubernetes.api.common.ProxyRef
                         </io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ProxyRef>
                         <io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.targetcluster.ClusterRef>
-                            io.kroxylicious.kubernetes.api.common.KafkaCRef
+                            io.kroxylicious.kubernetes.api.common.KafkaServiceRef
                         </io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.targetcluster.ClusterRef>
                         <io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressRefs>
                             io.kroxylicious.kubernetes.api.common.IngressRef

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/KafkaServiceRef.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/KafkaServiceRef.java
@@ -10,10 +10,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 
 /**
- * A reference, used in a kubernetes resource, to a KafkaClusterRef resource in the same namespace.
+ * A reference, used in a kubernetes resource, to a KafkaService resource in the same namespace.
  */
 @com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
 @com.fasterxml.jackson.annotation.JsonPropertyOrder({ "name" })
@@ -30,14 +30,14 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
         @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
         @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
 })
-public class KafkaCRef
-        extends LocalRef<KafkaClusterRef>
-        implements io.fabric8.kubernetes.api.builder.Editable<KafkaCRefBuilder>,
+public class KafkaServiceRef
+        extends LocalRef<KafkaService>
+        implements io.fabric8.kubernetes.api.builder.Editable<KafkaServiceRefBuilder>,
         KubernetesResource {
 
     @Override
-    public KafkaCRefBuilder edit() {
-        return new KafkaCRefBuilder(this);
+    public KafkaServiceRefBuilder edit() {
+        return new KafkaServiceRefBuilder(this);
     }
 
     @JsonIgnore
@@ -49,7 +49,7 @@ public class KafkaCRef
     @JsonIgnore
     @Override
     public String getKind() {
-        return "KafkaClusterRef";
+        return "KafkaService";
     }
 
     @com.fasterxml.jackson.annotation.JsonProperty("name")

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigConfigMap.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigConfigMap.java
@@ -30,8 +30,8 @@ import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernete
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
 
 import io.kroxylicious.kubernetes.api.common.FilterRef;
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.operator.model.ProxyModel;
 import io.kroxylicious.kubernetes.operator.model.ProxyModelBuilder;
@@ -155,7 +155,7 @@ public class ProxyConfigConfigMap
         return model.clustersWithValidIngresses().stream()
                 .filter(cluster -> Optional.ofNullable(cluster.getSpec().getFilterRefs()).stream().flatMap(Collection::stream).allMatch(
                         filters -> successfullyBuiltFilterNames.contains(filterDefinitionName(filters))))
-                .map(cluster -> getVirtualCluster(cluster, model.resolutionResult().kafkaClusterRef(cluster).orElseThrow(), model.ingressModel()))
+                .map(cluster -> getVirtualCluster(cluster, model.resolutionResult().kafkaServiceRef(cluster).orElseThrow(), model.ingressModel()))
                 .toList();
     }
 
@@ -241,11 +241,11 @@ public class ProxyConfigConfigMap
     }
 
     private static VirtualCluster getVirtualCluster(VirtualKafkaCluster cluster,
-                                                    KafkaClusterRef kafkaClusterRef,
+                                                    KafkaService kafkaServiceRef,
                                                     ProxyIngressModel ingressModel) {
 
         ProxyIngressModel.VirtualClusterIngressModel virtualClusterIngressModel = ingressModel.clusterIngressModel(cluster).orElseThrow();
-        String bootstrap = kafkaClusterRef.getSpec().getBootstrapServers();
+        String bootstrap = kafkaServiceRef.getSpec().getBootstrapServers();
         return new VirtualCluster(
                 ResourcesUtil.name(cluster), new TargetCluster(bootstrap, Optional.empty()),
                 null,

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolverImpl.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolverImpl.java
@@ -20,9 +20,9 @@ import io.javaoperatorsdk.operator.api.reconciler.Context;
 
 import io.kroxylicious.kubernetes.api.common.FilterRef;
 import io.kroxylicious.kubernetes.api.common.LocalRef;
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterSpec;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
@@ -50,7 +50,7 @@ public class DependencyResolverImpl implements DependencyResolver {
         }
         Map<LocalRef<KafkaProxyIngress>, KafkaProxyIngress> ingresses = context.getSecondaryResources(KafkaProxyIngress.class).stream()
                 .collect(ResourcesUtil.toByLocalRefMap());
-        Map<LocalRef<KafkaClusterRef>, KafkaClusterRef> clusterRefs = context.getSecondaryResources(KafkaClusterRef.class).stream()
+        Map<LocalRef<KafkaService>, KafkaService> clusterRefs = context.getSecondaryResources(KafkaService.class).stream()
                 .collect(ResourcesUtil.toByLocalRefMap());
         Map<LocalRef<GenericKubernetesResource>, GenericKubernetesResource> filters = context.getSecondaryResources(GenericKubernetesResource.class).stream()
                 .collect(ResourcesUtil.toByLocalRefMap());
@@ -63,12 +63,12 @@ public class DependencyResolverImpl implements DependencyResolver {
 
     private ClusterResolutionResult determineUnresolvedDependencies(VirtualKafkaCluster cluster,
                                                                     Map<LocalRef<KafkaProxyIngress>, KafkaProxyIngress> ingresses,
-                                                                    Map<LocalRef<KafkaClusterRef>, KafkaClusterRef> clusterRefs,
+                                                                    Map<LocalRef<KafkaService>, KafkaService> clusterRefs,
                                                                     Map<LocalRef<GenericKubernetesResource>, GenericKubernetesResource> filters) {
         VirtualKafkaClusterSpec spec = cluster.getSpec();
         Set<LocalRef<?>> unresolvedDependencies = new HashSet<>();
         determineUnresolvedIngresses(spec, ingresses).forEach(unresolvedDependencies::add);
-        determineUnresolvedKafkaClusterRef(spec, clusterRefs).ifPresent(unresolvedDependencies::add);
+        determineUnresolvedKafkaService(spec, clusterRefs).ifPresent(unresolvedDependencies::add);
         determineUnresolvedFilters(spec, filters).forEach(unresolvedDependencies::add);
         return new ClusterResolutionResult(cluster, unresolvedDependencies);
     }
@@ -85,8 +85,8 @@ public class DependencyResolverImpl implements DependencyResolver {
         }
     }
 
-    private Optional<LocalRef<?>> determineUnresolvedKafkaClusterRef(VirtualKafkaClusterSpec spec,
-                                                                     Map<LocalRef<KafkaClusterRef>, KafkaClusterRef> clusterRefs) {
+    private Optional<LocalRef<?>> determineUnresolvedKafkaService(VirtualKafkaClusterSpec spec,
+                                                                  Map<LocalRef<KafkaService>, KafkaService> clusterRefs) {
         var clusterRef = spec.getTargetCluster().getClusterRef();
         if (!clusterRefs.containsKey(clusterRef)) {
             return Optional.of(clusterRef);

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ResolutionResult.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ResolutionResult.java
@@ -19,8 +19,8 @@ import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 
 import io.kroxylicious.kubernetes.api.common.FilterRef;
 import io.kroxylicious.kubernetes.api.common.LocalRef;
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 
@@ -28,13 +28,13 @@ import static java.util.Comparator.comparing;
 
 /**
  * The result of a deep resolution of the dependencies of a single KafkaProxy. Contains all
- * Filters, KafkaProxyIngresses and KafkaClusterRefs that were successfully resolved. It also
+ * Filters, KafkaProxyIngresses and KafkaServices that were successfully resolved. It also
  * describes which dependencies could not be resolved per VirtualKafkaCluster.
  */
 public class ResolutionResult {
     private final Map<LocalRef<GenericKubernetesResource>, GenericKubernetesResource> filters;
     private final Map<LocalRef<KafkaProxyIngress>, KafkaProxyIngress> kafkaProxyIngresses;
-    private final Map<LocalRef<KafkaClusterRef>, KafkaClusterRef> kafkaClusterRefs;
+    private final Map<LocalRef<KafkaService>, KafkaService> kafkaServiceRefs;
     private final Map<String, ClusterResolutionResult> clusterResolutionResults;
 
     public record ClusterResolutionResult(VirtualKafkaCluster cluster, Set<LocalRef<?>> unresolvedDependencySet) {
@@ -55,15 +55,15 @@ public class ResolutionResult {
 
     ResolutionResult(Map<LocalRef<GenericKubernetesResource>, GenericKubernetesResource> filters,
                      Map<LocalRef<KafkaProxyIngress>, KafkaProxyIngress> kafkaProxyIngresses,
-                     Map<LocalRef<KafkaClusterRef>, KafkaClusterRef> kafkaClusterRefs,
+                     Map<LocalRef<KafkaService>, KafkaService> kafkaServiceRefs,
                      Map<String, ClusterResolutionResult> clusterResolutionResults) {
         Objects.requireNonNull(filters);
         Objects.requireNonNull(kafkaProxyIngresses);
-        Objects.requireNonNull(kafkaClusterRefs);
+        Objects.requireNonNull(kafkaServiceRefs);
         Objects.requireNonNull(clusterResolutionResults);
         this.filters = filters;
         this.kafkaProxyIngresses = kafkaProxyIngresses;
-        this.kafkaClusterRefs = kafkaClusterRefs;
+        this.kafkaServiceRefs = kafkaServiceRefs;
         this.clusterResolutionResults = clusterResolutionResults;
     }
 
@@ -115,12 +115,12 @@ public class ResolutionResult {
     }
 
     /**
-     * Get the resolved KafkaClusterRef for a cluster
+     * Get the resolved KafkaService for a cluster
      * @return optional containing the cluster ref if resolved, else empty
      */
-    public Optional<KafkaClusterRef> kafkaClusterRef(VirtualKafkaCluster cluster) {
+    public Optional<KafkaService> kafkaServiceRef(VirtualKafkaCluster cluster) {
         var ref = cluster.getSpec().getTargetCluster().getClusterRef();
-        return Optional.ofNullable(kafkaClusterRefs.get(ref));
+        return Optional.ofNullable(kafkaServiceRefs.get(ref));
     }
 
     /**

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
@@ -11,15 +11,15 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
-  name: kafkaclusterrefs.kroxylicious.io
+  name: kafkaservices.kroxylicious.io
 spec:
   # group name to use for REST API: /apis/<group>/<version>
   group: kroxylicious.io
   scope: Namespaced
   names:
-    plural: kafkaclusterrefs
-    singular: kafkaclusterref
-    kind: KafkaClusterRef
+    plural: kafkaservices
+    singular: kafkaservice
+    kind: KafkaService
     shortNames:
       - kcr
   # list of versions supported by this CustomResourceDefinition

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
@@ -60,7 +60,7 @@ spec:
                           pattern: ^kroxylicious[.]io$
                         kind:
                           type: string
-                          pattern: ^KafkaClusterRef$
+                          pattern: ^KafkaService$
                         name:
                           maxLength: 253
                           minLength: 1

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/api/common/KafkaServiceRefTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/api/common/KafkaServiceRefTest.java
@@ -12,6 +12,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class KafkaServiceRefTest {
 
+    // we knowingly use equals across types because we want the property that specific LocalRef types are equal to any other LocalRef
+    // with the same group, kind and name.
+    @SuppressWarnings("java:S5845")
     @Test
     void shouldEqualAKafkaKindedAnyRef() {
         var kafkaCRefFoo = new KafkaServiceRefBuilder().withName("foo").build();

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/api/common/KafkaServiceRefTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/api/common/KafkaServiceRefTest.java
@@ -10,11 +10,11 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class KafkaCRefTest {
+class KafkaServiceRefTest {
 
     @Test
     void shouldEqualAKafkaKindedAnyRef() {
-        var kafkaCRefFoo = new KafkaCRefBuilder().withName("foo").build();
+        var kafkaCRefFoo = new KafkaServiceRefBuilder().withName("foo").build();
         var anyFoo = new AnyLocalRefBuilder().withName("foo").withKind(kafkaCRefFoo.getKind()).withGroup(kafkaCRefFoo.getGroup()).build();
         assertThat(kafkaCRefFoo).isEqualTo(anyFoo);
         assertThat(anyFoo).isEqualTo(kafkaCRefFoo);

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/DerivedResourcesTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/DerivedResourcesTest.java
@@ -43,9 +43,9 @@ import io.javaoperatorsdk.operator.api.reconciler.dependent.managed.DefaultManag
 import io.javaoperatorsdk.operator.processing.dependent.BulkDependentResource;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResource;
 
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.clusters.Conditions;
 import io.kroxylicious.kubernetes.operator.config.RuntimeDecl;
@@ -247,7 +247,7 @@ class DerivedResourcesTest {
             Path input = testDir.resolve(inFileName);
             KafkaProxy kafkaProxy = kafkaProxyFromFile(input);
             List<VirtualKafkaCluster> virtualKafkaClusters = resourcesFromFiles(childFilesMatching(testDir, "in-VirtualKafkaCluster-*"), VirtualKafkaCluster.class);
-            List<KafkaClusterRef> kafkaClusterRefs = resourcesFromFiles(childFilesMatching(testDir, "in-KafkaClusterRef-*"), KafkaClusterRef.class);
+            List<KafkaService> kafkaServiceRefs = resourcesFromFiles(childFilesMatching(testDir, "in-KafkaService-*"), KafkaService.class);
             assertMinimalMetadata(kafkaProxy.getMetadata(), inFileName);
             List<KafkaProxyIngress> ingresses = kafkaProxyIngressesFromFiles(childFilesMatching(testDir, "in-KafkaProxyIngress-*"));
 
@@ -256,7 +256,7 @@ class DerivedResourcesTest {
 
             Context<KafkaProxy> context;
             try {
-                context = buildContext(testDir, virtualKafkaClusters, kafkaClusterRefs, ingresses);
+                context = buildContext(testDir, virtualKafkaClusters, kafkaServiceRefs, ingresses);
             }
             catch (IOException e) {
                 throw new UncheckedIOException(e);
@@ -348,7 +348,7 @@ class DerivedResourcesTest {
     }
 
     @NonNull
-    private static Context<KafkaProxy> buildContext(Path testDir, List<VirtualKafkaCluster> virtualKafkaClusters, List<KafkaClusterRef> kafkaClusterRefs,
+    private static Context<KafkaProxy> buildContext(Path testDir, List<VirtualKafkaCluster> virtualKafkaClusters, List<KafkaService> kafkaServiceRefs,
                                                     List<KafkaProxyIngress> ingresses)
             throws IOException {
         Answer<?> throwOnUnmockedInvocation = invocation -> {
@@ -376,7 +376,7 @@ class DerivedResourcesTest {
         }
         doReturn(filterInstances).when(context).getSecondaryResources(GenericKubernetesResource.class);
         doReturn(Set.copyOf(virtualKafkaClusters)).when(context).getSecondaryResources(VirtualKafkaCluster.class);
-        doReturn(Set.copyOf(kafkaClusterRefs)).when(context).getSecondaryResources(KafkaClusterRef.class);
+        doReturn(Set.copyOf(kafkaServiceRefs)).when(context).getSecondaryResources(KafkaService.class);
         doReturn(Set.copyOf(ingresses)).when(context).getSecondaryResources(KafkaProxyIngress.class);
         SharedKafkaProxyContext.runtimeDecl(context, runtimeDecl);
         return context;

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
@@ -33,11 +33,11 @@ import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRefBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.filter.api.v1alpha1.KafkaProtocolFilter;
 
@@ -62,7 +62,7 @@ class OperatorMainIT {
         LocallyRunOperatorExtension.applyCrd(KafkaProtocolFilter.class, OperatorTestUtils.kubeClientIfAvailable());
         LocallyRunOperatorExtension.applyCrd(KafkaProxy.class, OperatorTestUtils.kubeClientIfAvailable());
         LocallyRunOperatorExtension.applyCrd(VirtualKafkaCluster.class, OperatorTestUtils.kubeClientIfAvailable());
-        LocallyRunOperatorExtension.applyCrd(KafkaClusterRef.class, OperatorTestUtils.kubeClientIfAvailable());
+        LocallyRunOperatorExtension.applyCrd(KafkaService.class, OperatorTestUtils.kubeClientIfAvailable());
         LocallyRunOperatorExtension.applyCrd(KafkaProxyIngress.class, OperatorTestUtils.kubeClientIfAvailable());
     }
 
@@ -74,7 +74,7 @@ class OperatorMainIT {
                 kubernetesClient.resources(KafkaProxyIngress.class).delete();
                 kubernetesClient.resources(KafkaProxy.class).delete();
                 kubernetesClient.resources(VirtualKafkaCluster.class).delete();
-                kubernetesClient.resources(KafkaClusterRef.class).delete();
+                kubernetesClient.resources(KafkaService.class).delete();
             }
         }
     }
@@ -241,8 +241,8 @@ class OperatorMainIT {
         return kubernetesClient.resource(proxyBuilder.build()).create();
     }
 
-    private KafkaClusterRef clusterRef(String clusterRefName, String clusterBootstrap) {
-        return new KafkaClusterRefBuilder().withNewMetadata().withName(clusterRefName).endMetadata()
+    private KafkaService clusterRef(String clusterRefName, String clusterBootstrap) {
+        return new KafkaServiceBuilder().withNewMetadata().withName(clusterRefName).endMetadata()
                 .withNewSpec()
                 .withBootstrapServers(clusterBootstrap)
                 .endSpec()

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
@@ -35,9 +35,9 @@ import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.filter.api.v1alpha1.KafkaProtocolFilter;
 import io.kroxylicious.kubernetes.operator.management.UnsupportedHttpMethodFilter;
@@ -176,7 +176,7 @@ class OperatorMainTest {
         expectCrd(KafkaProtocolFilter.class);
         expectCrd(KafkaProxy.class);
         expectCrd(VirtualKafkaCluster.class);
-        expectCrd(KafkaClusterRef.class);
+        expectCrd(KafkaService.class);
     }
 
     private void expectCrd(Class<? extends CustomResource<?, ?>> crdClass) {

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerIT.java
@@ -30,14 +30,14 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.readiness.Readiness;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 
-import io.kroxylicious.kubernetes.api.common.KafkaCRef;
-import io.kroxylicious.kubernetes.api.common.KafkaCRefBuilder;
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRefBuilder;
+import io.kroxylicious.kubernetes.api.common.KafkaServiceRef;
+import io.kroxylicious.kubernetes.api.common.KafkaServiceRefBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngressBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
 import io.kroxylicious.kubernetes.operator.config.RuntimeDecl;
@@ -86,7 +86,7 @@ class ProxyReconcilerIT {
             ))))
             .withKubernetesClient(client)
             .withAdditionalCustomResourceDefinition(VirtualKafkaCluster.class)
-            .withAdditionalCustomResourceDefinition(KafkaClusterRef.class)
+            .withAdditionalCustomResourceDefinition(KafkaService.class)
             .withAdditionalCustomResourceDefinition(KafkaProxyIngress.class)
             .waitForNamespaceDeletion(true)
             .withConfigurationService(x -> x.withCloseClientOnStop(false))
@@ -103,12 +103,12 @@ class ProxyReconcilerIT {
         doCreate();
     }
 
-    private record CreatedResources(KafkaProxy proxy, Set<VirtualKafkaCluster> clusters, Set<KafkaClusterRef> clusterRefs, Set<KafkaProxyIngress> ingresses) {
+    private record CreatedResources(KafkaProxy proxy, Set<VirtualKafkaCluster> clusters, Set<KafkaService> clusterRefs, Set<KafkaProxyIngress> ingresses) {
         public VirtualKafkaCluster cluster(String name) {
             return findOnlyResourceNamed(name, clusters).orElseThrow();
         }
 
-        public KafkaClusterRef clusterRef(String name) {
+        public KafkaService clusterRef(String name) {
             return findOnlyResourceNamed(name, clusterRefs).orElseThrow();
         }
 
@@ -119,9 +119,9 @@ class ProxyReconcilerIT {
 
     CreatedResources doCreate() {
         KafkaProxy proxy = extension.create(kafkaProxy(PROXY_A));
-        KafkaClusterRef barClusterRef = extension.create(clusterRef(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP));
+        KafkaService barClusterRef = extension.create(clusterRef(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP));
         KafkaProxyIngress ingressBar = extension.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy));
-        Set<KafkaClusterRef> clusterRefs = Set.of(barClusterRef);
+        Set<KafkaService> clusterRefs = Set.of(barClusterRef);
         VirtualKafkaCluster clusterBar = extension.create(virtualKafkaCluster(CLUSTER_BAR, proxy, barClusterRef, ingressBar));
         Set<VirtualKafkaCluster> clusters = Set.of(clusterBar);
         assertProxyConfigContents(proxy, Set.of(CLUSTER_BAR_BOOTSTRAP), Set.of());
@@ -234,7 +234,7 @@ class ProxyReconcilerIT {
         String newClusterRefName = "new-cluster-ref";
         extension.create(clusterRef(newClusterRefName, NEW_BOOTSTRAP));
 
-        KafkaCRef newClusterRef = new KafkaCRefBuilder().withName(newClusterRefName).build();
+        KafkaServiceRef newClusterRef = new KafkaServiceRefBuilder().withName(newClusterRefName).build();
         var cluster = createdResources.cluster(CLUSTER_BAR).edit().editSpec().editTargetCluster().withClusterRef(newClusterRef).endTargetCluster().endSpec().build();
 
         // when
@@ -272,8 +272,8 @@ class ProxyReconcilerIT {
         KafkaProxyIngress ingressFoo = extension.create(clusterIpIngress(CLUSTER_FOO_CLUSTERIP_INGRESS, proxyA));
         KafkaProxyIngress ingressBar = extension.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxyB));
 
-        KafkaClusterRef fooClusterRef = extension.create(clusterRef(CLUSTER_FOO_REF, CLUSTER_FOO_BOOTSTRAP));
-        KafkaClusterRef barClusterRef = extension.create(clusterRef(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP));
+        KafkaService fooClusterRef = extension.create(clusterRef(CLUSTER_FOO_REF, CLUSTER_FOO_BOOTSTRAP));
+        KafkaService barClusterRef = extension.create(clusterRef(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP));
 
         VirtualKafkaCluster clusterFoo = extension.create(virtualKafkaCluster(CLUSTER_FOO, proxyA, fooClusterRef, ingressFoo));
         VirtualKafkaCluster barCluster = extension.create(virtualKafkaCluster(CLUSTER_BAR, proxyB, barClusterRef, ingressBar));
@@ -311,12 +311,12 @@ class ProxyReconcilerIT {
                 .extracting(map -> map.get(ProxyConfigConfigMap.CONFIG_YAML_KEY), InstanceOfAssertFactories.STRING);
     }
 
-    private static VirtualKafkaCluster virtualKafkaCluster(String clusterName, KafkaProxy proxy, KafkaClusterRef clusterRef,
+    private static VirtualKafkaCluster virtualKafkaCluster(String clusterName, KafkaProxy proxy, KafkaService clusterRef,
                                                            KafkaProxyIngress ingress) {
         return new VirtualKafkaClusterBuilder().withNewMetadata().withName(clusterName).endMetadata()
                 .withNewSpec()
                 .withNewTargetCluster()
-                .withClusterRef(new KafkaCRefBuilder().withName(name(clusterRef)).build())
+                .withClusterRef(new KafkaServiceRefBuilder().withName(name(clusterRef)).build())
                 .endTargetCluster()
                 .withNewProxyRef().withName(name(proxy)).endProxyRef()
                 .addNewIngressRef().withName(name(ingress)).endIngressRef()
@@ -324,8 +324,8 @@ class ProxyReconcilerIT {
                 .endSpec().build();
     }
 
-    private static KafkaClusterRef clusterRef(String clusterRefName, String clusterBootstrap) {
-        return new KafkaClusterRefBuilder().withNewMetadata().withName(clusterRefName).endMetadata()
+    private static KafkaService clusterRef(String clusterRefName, String clusterBootstrap) {
+        return new KafkaServiceBuilder().withNewMetadata().withName(clusterRefName).endMetadata()
                 .withNewSpec()
                 .withBootstrapServers(clusterBootstrap)
                 .endSpec().build();

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ResourcesUtilTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ResourcesUtilTest.java
@@ -21,11 +21,11 @@ import io.fabric8.kubernetes.api.model.SecretBuilder;
 
 import io.kroxylicious.kubernetes.api.common.FilterRefBuilder;
 import io.kroxylicious.kubernetes.api.common.IngressRefBuilder;
-import io.kroxylicious.kubernetes.api.common.KafkaCRefBuilder;
+import io.kroxylicious.kubernetes.api.common.KafkaServiceRefBuilder;
 import io.kroxylicious.kubernetes.api.common.ProxyRefBuilder;
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRefBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngressBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceBuilder;
 
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.findOnlyResourceNamed;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.toByNameMap;
@@ -160,8 +160,8 @@ class ResourcesUtilTest {
         assertThat(ResourcesUtil.toLocalRef(new KafkaProxyBuilder().withNewMetadata().withName("foo").endMetadata().build()))
                 .isEqualTo(new ProxyRefBuilder().withName("foo").build());
 
-        assertThat(ResourcesUtil.toLocalRef(new KafkaClusterRefBuilder().withNewMetadata().withName("foo").endMetadata().build()))
-                .isEqualTo(new KafkaCRefBuilder().withName("foo").build());
+        assertThat(ResourcesUtil.toLocalRef(new KafkaServiceBuilder().withNewMetadata().withName("foo").endMetadata().build()))
+                .isEqualTo(new KafkaServiceRefBuilder().withName("foo").build());
 
         assertThat(ResourcesUtil.toLocalRef(new KafkaProxyIngressBuilder().withNewMetadata().withName("foo").endMetadata().build()))
                 .isEqualTo(new IngressRefBuilder().withName("foo").build());

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/resolver/ClusterConditionUnresolvedDependencyReporterTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/resolver/ClusterConditionUnresolvedDependencyReporterTest.java
@@ -23,7 +23,7 @@ import io.javaoperatorsdk.operator.api.reconciler.dependent.managed.ManagedWorkf
 
 import io.kroxylicious.kubernetes.api.common.FilterRefBuilder;
 import io.kroxylicious.kubernetes.api.common.IngressRefBuilder;
-import io.kroxylicious.kubernetes.api.common.KafkaCRefBuilder;
+import io.kroxylicious.kubernetes.api.common.KafkaServiceRefBuilder;
 import io.kroxylicious.kubernetes.api.common.LocalRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
@@ -70,8 +70,8 @@ class ClusterConditionUnresolvedDependencyReporterTest {
     @Test
     void deterministicallyReportsOneUnresolvedDependency() {
         HashSet<LocalRef<?>> unresolvedDependencies = new HashSet<>();
-        unresolvedDependencies.add(new KafkaCRefBuilder().withName("a").build());
-        unresolvedDependencies.add(new KafkaCRefBuilder().withName("b").build());
+        unresolvedDependencies.add(new KafkaServiceRefBuilder().withName("a").build());
+        unresolvedDependencies.add(new KafkaServiceRefBuilder().withName("b").build());
         unresolvedDependencies.add(new FilterRefBuilder().withName("a").build());
         unresolvedDependencies.add(new FilterRefBuilder().withName("b").build());
         unresolvedDependencies.add(new IngressRefBuilder().withName("a").build());
@@ -91,7 +91,7 @@ class ClusterConditionUnresolvedDependencyReporterTest {
 
     @Test
     void clusterRefUnresolved() {
-        var unresolved = new KafkaCRefBuilder().withName("a").build();
+        var unresolved = new KafkaServiceRefBuilder().withName("a").build();
         Set<LocalRef<?>> unresolvedDependencies = Set.of(unresolved);
         VirtualKafkaCluster cluster = new VirtualKafkaClusterBuilder().editMetadata().withName("cluster").endMetadata()
                 .withNewSpec().withNewTargetCluster().withNewClusterRef().withName("name").endClusterRef().endTargetCluster()
@@ -104,7 +104,7 @@ class ClusterConditionUnresolvedDependencyReporterTest {
         verify(mockResourceContext).put(eq("cluster_conditions"), assertArg(a -> {
             assertThat(a).isInstanceOfSatisfying(Map.class, map -> {
                 assertThat(map).containsExactlyEntriesOf(Map.of("cluster", new ClusterCondition("cluster", ConditionType.Accepted, Conditions.Status.FALSE, "Invalid",
-                        "Resource of kind \"KafkaClusterRef\" in group \"kroxylicious.io\" named \"a\" does not exist.")));
+                        "Resource of kind \"KafkaService\" in group \"kroxylicious.io\" named \"a\" does not exist.")));
             });
         }));
     }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolverImplTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolverImplTest.java
@@ -26,12 +26,12 @@ import io.kroxylicious.kubernetes.api.common.FilterRef;
 import io.kroxylicious.kubernetes.api.common.FilterRefBuilder;
 import io.kroxylicious.kubernetes.api.common.IngressRef;
 import io.kroxylicious.kubernetes.api.common.IngressRefBuilder;
-import io.kroxylicious.kubernetes.api.common.KafkaCRefBuilder;
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRef;
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaClusterRefBuilder;
+import io.kroxylicious.kubernetes.api.common.KafkaServiceRefBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngressBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
 import io.kroxylicious.kubernetes.operator.resolver.ResolutionResult.ClusterResolutionResult;
@@ -74,7 +74,7 @@ class DependencyResolverImplTest {
     @Test
     void testNullFiltersOnVirtualClusterTolerated() {
         givenFiltersInContext();
-        givenClusterRefsInContext(kafkaClusterRef("cluster"));
+        givenClusterRefsInContext(kafkaServiceRef("cluster"));
         givenIngressesInContext();
         VirtualKafkaCluster cluster = virtualCluster(null, "cluster", List.of());
         givenVirtualKafkaClustersInContext(cluster);
@@ -94,7 +94,7 @@ class DependencyResolverImplTest {
     void testSingleFilterUnreferenced() {
         GenericKubernetesResource filter = protocolFilter("filterName");
         givenFiltersInContext(filter);
-        givenClusterRefsInContext(kafkaClusterRef("cluster"));
+        givenClusterRefsInContext(kafkaServiceRef("cluster"));
         givenIngressesInContext();
         VirtualKafkaCluster cluster = virtualCluster(List.of(), "cluster", List.of());
         givenVirtualKafkaClustersInContext(cluster);
@@ -115,7 +115,7 @@ class DependencyResolverImplTest {
     void testSingleFilterReferenced() {
         GenericKubernetesResource filter = protocolFilter("filterName");
         givenFiltersInContext(filter);
-        givenClusterRefsInContext(kafkaClusterRef("cluster"));
+        givenClusterRefsInContext(kafkaServiceRef("cluster"));
         givenIngressesInContext();
         VirtualKafkaCluster cluster = virtualCluster(List.of(filterRef("filterName")), "cluster", List.of());
         givenVirtualKafkaClustersInContext(cluster);
@@ -137,7 +137,7 @@ class DependencyResolverImplTest {
         GenericKubernetesResource filter = protocolFilter("filterName");
         GenericKubernetesResource filter2 = protocolFilter("filterName2");
         givenFiltersInContext(filter, filter2);
-        givenClusterRefsInContext(kafkaClusterRef("cluster"));
+        givenClusterRefsInContext(kafkaServiceRef("cluster"));
         givenIngressesInContext();
         VirtualKafkaCluster cluster = virtualCluster(List.of(filterRef("filterName"), filterRef("filterName2")), "cluster", List.of());
         givenVirtualKafkaClustersInContext(cluster);
@@ -159,7 +159,7 @@ class DependencyResolverImplTest {
     void testSubsetOfFiltersReferenced() {
         GenericKubernetesResource filter = protocolFilter("filterName");
         givenFiltersInContext(filter);
-        givenClusterRefsInContext(kafkaClusterRef("cluster"));
+        givenClusterRefsInContext(kafkaServiceRef("cluster"));
         givenIngressesInContext();
         VirtualKafkaCluster cluster = virtualCluster(List.of(filterRef("filterName"), filterRef("filterName2")), "cluster", List.of());
         givenVirtualKafkaClustersInContext(cluster);
@@ -181,7 +181,7 @@ class DependencyResolverImplTest {
     void testUnresolvedFilter() {
         GenericKubernetesResource filter = protocolFilter("filterName");
         givenFiltersInContext(filter);
-        givenClusterRefsInContext(kafkaClusterRef("clusterRef"));
+        givenClusterRefsInContext(kafkaServiceRef("clusterRef"));
         givenIngressesInContext();
         VirtualKafkaCluster cluster = virtualCluster(List.of(filterRef("other")), "clusterRef", List.of());
         givenVirtualKafkaClustersInContext(cluster);
@@ -200,7 +200,7 @@ class DependencyResolverImplTest {
     @Test
     void testUnresolvedIngress() {
         givenFiltersInContext();
-        givenClusterRefsInContext(kafkaClusterRef("clusterRef"));
+        givenClusterRefsInContext(kafkaServiceRef("clusterRef"));
         givenIngressesInContext();
         VirtualKafkaCluster cluster = virtualCluster(List.of(), "clusterRef", List.of(ingressRef("ingressMissing")));
         givenVirtualKafkaClustersInContext(cluster);
@@ -217,7 +217,7 @@ class DependencyResolverImplTest {
     }
 
     @Test
-    void testUnresolvedKafkaClusterRef() {
+    void testUnresolvedKafkaService() {
         givenFiltersInContext();
         givenClusterRefsInContext();
         givenIngressesInContext();
@@ -231,14 +231,14 @@ class DependencyResolverImplTest {
         assertThat(resolutionResult.ingresses()).isEmpty();
         ClusterResolutionResult onlyResult = assertSingleResult(resolutionResult, cluster);
         assertThat(onlyResult.isFullyResolved()).isFalse();
-        assertThat(onlyResult.unresolvedDependencySet()).containsExactly(new KafkaCRefBuilder().withName("missing").build());
+        assertThat(onlyResult.unresolvedDependencySet()).containsExactly(new KafkaServiceRefBuilder().withName("missing").build());
         verify(unresolvedDependencyReporter).reportUnresolvedDependencies(cluster, onlyResult.unresolvedDependencySet());
     }
 
     @Test
     void testSingleResolvedIngress() {
         givenFiltersInContext();
-        givenClusterRefsInContext(kafkaClusterRef("clusterRef"));
+        givenClusterRefsInContext(kafkaServiceRef("clusterRef"));
         KafkaProxyIngress ingress = ingress("ingress");
         givenIngressesInContext(ingress);
         VirtualKafkaCluster cluster = virtualCluster(List.of(), "clusterRef", List.of(ingressRef("ingress")));
@@ -258,7 +258,7 @@ class DependencyResolverImplTest {
     @Test
     void testMultipleResolvedIngresses() {
         givenFiltersInContext();
-        givenClusterRefsInContext(kafkaClusterRef("clusterRef"));
+        givenClusterRefsInContext(kafkaServiceRef("clusterRef"));
         KafkaProxyIngress ingress = ingress("ingress");
         KafkaProxyIngress ingress2 = ingress("ingress2");
         givenIngressesInContext(ingress, ingress2);
@@ -279,7 +279,7 @@ class DependencyResolverImplTest {
     @Test
     void testSubsetOfIngressesResolved() {
         givenFiltersInContext();
-        givenClusterRefsInContext(kafkaClusterRef("clusterRef"));
+        givenClusterRefsInContext(kafkaServiceRef("clusterRef"));
         KafkaProxyIngress ingress = ingress("ingress");
         givenIngressesInContext(ingress);
         VirtualKafkaCluster cluster = virtualCluster(List.of(), "clusterRef", List.of(ingressRef("ingress"), ingressRef("ingress2")));
@@ -312,8 +312,8 @@ class DependencyResolverImplTest {
         return onlyResult;
     }
 
-    private static KafkaClusterRef kafkaClusterRef(String clusterRef) {
-        return new KafkaClusterRefBuilder().withNewMetadata().withName(clusterRef).endMetadata().build();
+    private static KafkaService kafkaServiceRef(String clusterRef) {
+        return new KafkaServiceBuilder().withNewMetadata().withName(clusterRef).endMetadata().build();
     }
 
     private static FilterRef filterRef(String name) {
@@ -340,8 +340,8 @@ class DependencyResolverImplTest {
         givenSecondaryResourcesInContext(VirtualKafkaCluster.class, virtualKafkaClusters);
     }
 
-    private void givenClusterRefsInContext(KafkaClusterRef... clusterRefs) {
-        givenSecondaryResourcesInContext(KafkaClusterRef.class, clusterRefs);
+    private void givenClusterRefsInContext(KafkaService... clusterRefs) {
+        givenSecondaryResourcesInContext(KafkaService.class, clusterRefs);
     }
 
     private <T> OngoingStubbing<Set<T>> givenSecondaryResourcesInContext(Class<T> type, T... resources) {

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/cond-Accepted-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/cond-Accepted-bar.yaml
@@ -9,5 +9,5 @@ cluster: "bar"
 type: "Accepted"
 status: "False"
 reason: "Invalid"
-message: "Resource of kind \"KafkaClusterRef\" in group \"kroxylicious.io\" named\
+message: "Resource of kind \"KafkaService\" in group \"kroxylicious.io\" named\
     \ \"barref\" does not exist."

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-KafkaService-fooref.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-KafkaService-fooref.yaml
@@ -5,10 +5,10 @@
 #
 
 ---
-kind: KafkaClusterRef
+kind: KafkaService
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
-  name: barref
+  name: fooref
   namespace: proxy-ns
 spec:
-  bootstrapServers: first-kafka.kafka1.svc.cluster.local:9092
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/in-KafkaService-fooref.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/in-KafkaService-fooref.yaml
@@ -5,10 +5,10 @@
 #
 
 ---
-kind: KafkaClusterRef
+kind: KafkaService
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
-  name: barref
+  name: fooref
   namespace: proxy-ns
 spec:
-  bootstrapServers: first-kafka.kafka1.svc.cluster.local:9092
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-KafkaService-myref.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-KafkaService-myref.yaml
@@ -5,7 +5,7 @@
 #
 
 ---
-kind: KafkaClusterRef
+kind: KafkaService
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
   name: myref

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/in-KafkaService-myref.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/in-KafkaService-myref.yaml
@@ -5,10 +5,10 @@
 #
 
 ---
-kind: KafkaClusterRef
+kind: KafkaService
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
-  name: fooref
+  name: myref
   namespace: proxy-ns
 spec:
-  bootstrapServers: second-kafka.kafka2.svc.cluster.local:9092
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/in-KafkaService-barref.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/in-KafkaService-barref.yaml
@@ -5,10 +5,10 @@
 #
 
 ---
-kind: KafkaClusterRef
+kind: KafkaService
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
-  name: myref
+  name: barref
   namespace: proxy-ns
 spec:
-  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+  bootstrapServers: first-kafka.kafka1.svc.cluster.local:9092

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/in-KafkaService-fooref.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/in-KafkaService-fooref.yaml
@@ -5,10 +5,10 @@
 #
 
 ---
-kind: KafkaClusterRef
+kind: KafkaService
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
   name: fooref
   namespace: proxy-ns
 spec:
-  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+  bootstrapServers: second-kafka.kafka2.svc.cluster.local:9092

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/in-KafkaService-barref.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/in-KafkaService-barref.yaml
@@ -5,10 +5,10 @@
 #
 
 ---
-kind: KafkaClusterRef
+kind: KafkaService
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
-  name: myref
+  name: barref
   namespace: proxy-ns
 spec:
-  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+  bootstrapServers: first-kafka.kafka1.svc.cluster.local:9092

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/in-KafkaService-fooref.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/in-KafkaService-fooref.yaml
@@ -5,10 +5,10 @@
 #
 
 ---
-kind: KafkaClusterRef
+kind: KafkaService
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
   name: fooref
   namespace: proxy-ns
 spec:
-  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+  bootstrapServers: second-kafka.kafka2.svc.cluster.local:9092

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/cond-Accepted-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/cond-Accepted-bar.yaml
@@ -9,5 +9,5 @@ cluster: bar
 type: Accepted
 status: 'False'
 reason: Invalid
-message: "Resource of kind \"KafkaClusterRef\" in group \"kroxylicious.io\" named\
+message: "Resource of kind \"KafkaService\" in group \"kroxylicious.io\" named\
     \ \"barref\" does not exist."

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/in-KafkaService-fooref.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/in-KafkaService-fooref.yaml
@@ -5,10 +5,10 @@
 #
 
 ---
-kind: KafkaClusterRef
+kind: KafkaService
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
-  name: myref
+  name: fooref
   namespace: proxy-ns
 spec:
-  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+  bootstrapServers: second-kafka.kafka2.svc.cluster.local:9092

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/in-KafkaService-myref.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/in-KafkaService-myref.yaml
@@ -5,10 +5,10 @@
 #
 
 ---
-kind: KafkaClusterRef
+kind: KafkaService
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
-  name: fooref
+  name: myref
   namespace: proxy-ns
 spec:
-  bootstrapServers: second-kafka.kafka2.svc.cluster.local:9092
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/in-KafkaService-myref.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/in-KafkaService-myref.yaml
@@ -5,10 +5,10 @@
 #
 
 ---
-kind: KafkaClusterRef
+kind: KafkaService
 apiVersion: kroxylicious.io/v1alpha1
 metadata:
-  name: fooref
+  name: myref
   namespace: proxy-ns
 spec:
-  bootstrapServers: second-kafka.kafka2.svc.cluster.local:9092
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Implements part of the changes from https://github.com/kroxylicious/design/pull/61

KafkaClusterRef's naming causes some pain. Our Custom Resources often reference other Custom Resources, and our naming convention for these reference properties is *Ref, like `proxyRef` or `filterRefs`. This means we would awkwardly have `clusterRefRef` to reference this CR. Also with the arrival of the `LocalRef` family of classes, Ref now has a stronger meaning in our codebase that would make this confusing for devs. We landed on KafkaService as a better name for this abstraction.

Note that this doesn't change the VirtualKafkaCluster side, which will be done in following PR

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
