### PR TITLE
refactor: replace targetCluster with targetKafkaServiceRef

### DIFF
--- a/kroxylicious-operator/examples/record-encryption/04.VirtualKafkaCluster.my-cluster.yaml
+++ b/kroxylicious-operator/examples/record-encryption/04.VirtualKafkaCluster.my-cluster.yaml
@@ -13,9 +13,8 @@ metadata:
 spec:
   proxyRef:
     name: simple
-  targetCluster:
-    clusterRef:
-      name: my-cluster
+  targetKafkaServiceRef:
+    name: my-cluster
   filterRefs:
     - name: encryption
   ingressRefs:

--- a/kroxylicious-operator/examples/record-validation/04.VirtualKafkaCluster.my-cluster.yaml
+++ b/kroxylicious-operator/examples/record-validation/04.VirtualKafkaCluster.my-cluster.yaml
@@ -13,9 +13,8 @@ metadata:
 spec:
   proxyRef:
     name: simple
-  targetCluster:
-    clusterRef:
-      name: my-cluster
+  targetKafkaServiceRef:
+    name: my-cluster
   filterRef:
     - name: validation
   ingressRefs:

--- a/kroxylicious-operator/examples/simple/03.VirtualKafkaCluster.my-cluster.yaml
+++ b/kroxylicious-operator/examples/simple/03.VirtualKafkaCluster.my-cluster.yaml
@@ -13,8 +13,7 @@ metadata:
 spec:
   proxyRef:
     name: simple
-  targetCluster:
-    clusterRef:
-      name: my-cluster
+  targetKafkaServiceRef:
+    name: my-cluster
   ingressRefs:
     - name: cluster-ip

--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -341,9 +341,9 @@
                         <io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ProxyRef>
                             io.kroxylicious.kubernetes.api.common.ProxyRef
                         </io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ProxyRef>
-                        <io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.targetcluster.ClusterRef>
+                        <io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.TargetKafkaServiceRef>
                             io.kroxylicious.kubernetes.api.common.KafkaServiceRef
-                        </io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.targetcluster.ClusterRef>
+                        </io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.TargetKafkaServiceRef>
                         <io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressRefs>
                             io.kroxylicious.kubernetes.api.common.IngressRef
                         </io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressRefs>

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolverImpl.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolverImpl.java
@@ -87,7 +87,7 @@ public class DependencyResolverImpl implements DependencyResolver {
 
     private Optional<LocalRef<?>> determineUnresolvedKafkaService(VirtualKafkaClusterSpec spec,
                                                                   Map<LocalRef<KafkaService>, KafkaService> clusterRefs) {
-        var clusterRef = spec.getTargetCluster().getClusterRef();
+        var clusterRef = spec.getTargetKafkaServiceRef();
         if (!clusterRefs.containsKey(clusterRef)) {
             return Optional.of(clusterRef);
         }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ResolutionResult.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ResolutionResult.java
@@ -119,7 +119,7 @@ public class ResolutionResult {
      * @return optional containing the cluster ref if resolved, else empty
      */
     public Optional<KafkaService> kafkaServiceRef(VirtualKafkaCluster cluster) {
-        var ref = cluster.getSpec().getTargetCluster().getClusterRef();
+        var ref = cluster.getSpec().getTargetKafkaServiceRef();
         return Optional.ofNullable(kafkaServiceRefs.get(ref));
     }
 

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
@@ -37,7 +37,7 @@ spec:
               type: object
             spec:
               type: object
-              required: ["proxyRef", "targetCluster", "ingressRefs"]
+              required: ["proxyRef", "targetKafkaServiceRef", "ingressRefs"]
               properties:
                 proxyRef:
                   type: object
@@ -47,24 +47,20 @@ spec:
                       maxLength: 253
                       minLength: 1
                       type: string
-                targetCluster:
+                targetKafkaServiceRef:
                   type: object
-                  required: ["clusterRef"]
+                  required: [ "name" ]
                   properties:
-                    clusterRef:
-                      type: object
-                      required: [ "name" ]
-                      properties:
-                        group:
-                          type: string
-                          pattern: ^kroxylicious[.]io$
-                        kind:
-                          type: string
-                          pattern: ^KafkaService$
-                        name:
-                          maxLength: 253
-                          minLength: 1
-                          type: string
+                    group:
+                      type: string
+                      pattern: ^kroxylicious[.]io$
+                    kind:
+                      type: string
+                      pattern: ^KafkaService$
+                    name:
+                      maxLength: 253
+                      minLength: 1
+                      type: string
                 ingressRefs:
                   type: array
                   minItems: 1

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerIT.java
@@ -235,7 +235,7 @@ class ProxyReconcilerIT {
         extension.create(clusterRef(newClusterRefName, NEW_BOOTSTRAP));
 
         KafkaServiceRef newClusterRef = new KafkaServiceRefBuilder().withName(newClusterRefName).build();
-        var cluster = createdResources.cluster(CLUSTER_BAR).edit().editSpec().editTargetCluster().withClusterRef(newClusterRef).endTargetCluster().endSpec().build();
+        var cluster = createdResources.cluster(CLUSTER_BAR).edit().editSpec().withTargetKafkaServiceRef(newClusterRef).endSpec().build();
 
         // when
         extension.replace(cluster);
@@ -315,9 +315,7 @@ class ProxyReconcilerIT {
                                                            KafkaProxyIngress ingress) {
         return new VirtualKafkaClusterBuilder().withNewMetadata().withName(clusterName).endMetadata()
                 .withNewSpec()
-                .withNewTargetCluster()
-                .withClusterRef(new KafkaServiceRefBuilder().withName(name(clusterRef)).build())
-                .endTargetCluster()
+                .withTargetKafkaServiceRef(new KafkaServiceRefBuilder().withName(name(clusterRef)).build())
                 .withNewProxyRef().withName(name(proxy)).endProxyRef()
                 .addNewIngressRef().withName(name(ingress)).endIngressRef()
                 .withFilterRefs()

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyReconcilerTest.java
@@ -713,11 +713,9 @@ class ProxyReconcilerTest {
     private VirtualKafkaCluster buildVirtualKafkaCluster(KafkaProxy kafkaProxy, String name, KafkaService clusterRef) {
         return baseVirtualKafkaClusterBuilder(kafkaProxy, name)
                 .editOrNewSpec()
-                .withNewTargetCluster()
-                .withNewClusterRef()
+                .withNewTargetKafkaServiceRef()
                 .withName(name(clusterRef))
-                .endClusterRef()
-                .endTargetCluster()
+                .endTargetKafkaServiceRef()
                 .endSpec()
                 .build();
     }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/resolver/ClusterConditionUnresolvedDependencyReporterTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/resolver/ClusterConditionUnresolvedDependencyReporterTest.java
@@ -94,7 +94,7 @@ class ClusterConditionUnresolvedDependencyReporterTest {
         var unresolved = new KafkaServiceRefBuilder().withName("a").build();
         Set<LocalRef<?>> unresolvedDependencies = Set.of(unresolved);
         VirtualKafkaCluster cluster = new VirtualKafkaClusterBuilder().editMetadata().withName("cluster").endMetadata()
-                .withNewSpec().withNewTargetCluster().withNewClusterRef().withName("name").endClusterRef().endTargetCluster()
+                .withNewSpec().withNewTargetKafkaServiceRef().withName("name").endTargetKafkaServiceRef()
                 .endSpec().build();
 
         // when

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolverImplTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolverImplTest.java
@@ -352,7 +352,7 @@ class DependencyResolverImplTest {
         return new VirtualKafkaClusterBuilder()
                 .withNewSpec()
                 .withIngressRefs(ingressRefs)
-                .withNewTargetCluster().withNewClusterRef().withName(clusterRef).endClusterRef().endTargetCluster()
+                .withNewTargetKafkaServiceRef().withName(clusterRef).endTargetKafkaServiceRef()
                 .withFilterRefs(filterRefs)
                 .endSpec()
                 .build();

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-VirtualKafkaCluster-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-VirtualKafkaCluster-bar.yaml
@@ -13,9 +13,8 @@ metadata:
 spec:
   proxyRef:
     name: example
-  targetCluster:
-    clusterRef:
-      name: barref
+  targetKafkaServiceRef:
+    name: barref
   filterRefs:
     - name: filter-one
   ingressRefs:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-VirtualKafkaCluster-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-VirtualKafkaCluster-foo.yaml
@@ -13,9 +13,8 @@ metadata:
 spec:
   proxyRef:
     name: example
-  targetCluster:
-    clusterRef:
-      name: fooref
+  targetKafkaServiceRef:
+    name: fooref
   filterRefs:
     - name: filter-one
   ingressRefs:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/in-VirtualKafkaCluster-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/in-VirtualKafkaCluster-foo.yaml
@@ -13,9 +13,8 @@ metadata:
 spec:
   proxyRef:
     name: example
-  targetCluster:
-    clusterRef:
-      name: fooref
+  targetKafkaServiceRef:
+    name: fooref
   filterRefs:
     - name: filter-one
     - name: filter-two

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-VirtualKafkaCluster-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-VirtualKafkaCluster-bar.yaml
@@ -13,9 +13,8 @@ metadata:
 spec:
   proxyRef:
     name: example
-  targetCluster:
-    clusterRef:
-      name: myref
+  targetKafkaServiceRef:
+    name: myref
   filterRefs:
     - name: filter-one
     - name: missing # this does not exist

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-VirtualKafkaCluster-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-VirtualKafkaCluster-foo.yaml
@@ -13,10 +13,9 @@ metadata:
 spec:
   proxyRef:
     name: example
-  targetCluster:
     # This cluster should be absent from the output proxy-operator-operator-operator-config.yaml, because there is no Two with name missing
-    clusterRef:
-      name: myref
+  targetKafkaServiceRef:
+    name: myref
   filterRefs:
     - name: filter-one
     - name: filter-two

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/in-VirtualKafkaCluster-one.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/in-VirtualKafkaCluster-one.yaml
@@ -13,8 +13,7 @@ metadata:
 spec:
   proxyRef:
     name: minimal
-  targetCluster:
-    clusterRef:
-      name: myref
+  targetKafkaServiceRef:
+    name: myref
   ingressRefs:
     - name: cluster-ip

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/in-VirtualKafkaCluster-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/in-VirtualKafkaCluster-bar.yaml
@@ -13,8 +13,7 @@ metadata:
 spec:
   proxyRef:
     name: twocluster
-  targetCluster:
-    clusterRef:
-      name: barref
+  targetKafkaServiceRef:
+    name: barref
   ingressRefs:
     - name: cluster-ip-bar

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/in-VirtualKafkaCluster-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/in-VirtualKafkaCluster-foo.yaml
@@ -13,8 +13,7 @@ metadata:
 spec:
   proxyRef:
     name: twocluster
-  targetCluster:
-    clusterRef:
-      name: fooref
+  targetKafkaServiceRef:
+    name: fooref
   ingressRefs:
     - name: MISSING

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/in-VirtualKafkaCluster-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/in-VirtualKafkaCluster-bar.yaml
@@ -13,8 +13,7 @@ metadata:
 spec:
   proxyRef:
     name: twocluster
-  targetCluster:
-    clusterRef:
-      name: barref
+  targetKafkaServiceRef:
+    name: barref
   ingressRefs:
     - name: cluster-ip-bar

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/in-VirtualKafkaCluster-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/in-VirtualKafkaCluster-foo.yaml
@@ -13,8 +13,7 @@ metadata:
 spec:
   proxyRef:
     name: twocluster
-  targetCluster:
-    clusterRef:
-      name: fooref
+  targetKafkaServiceRef:
+    name: fooref
   ingressRefs:
     - name: cluster-ip-foo

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/in-VirtualKafkaCluster-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/in-VirtualKafkaCluster-bar.yaml
@@ -13,8 +13,7 @@ metadata:
 spec:
   proxyRef:
     name: twocluster
-  targetCluster:
-    clusterRef:
-      name: barref
+  targetKafkaServiceRef:
+    name: barref
   ingressRefs:
     - name: cluster-ip-bar

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/in-VirtualKafkaCluster-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/in-VirtualKafkaCluster-foo.yaml
@@ -13,8 +13,7 @@ metadata:
 spec:
   proxyRef:
     name: twocluster
-  targetCluster:
-    clusterRef:
-      name: fooref
+  targetKafkaServiceRef:
+    name: fooref
   ingressRefs:
     - name: cluster-ip-foo

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/in-VirtualKafkaCluster-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/in-VirtualKafkaCluster-foo.yaml
@@ -13,9 +13,8 @@ metadata:
 spec:
   proxyRef:
     name: example
-  targetCluster:
-    clusterRef:
-      name: myref
+  targetKafkaServiceRef:
+    name: myref
   filterRefs:
     - name: filter-one
     - name: filter-two

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/in-VirtualKafkaCluster-one.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/in-VirtualKafkaCluster-one.yaml
@@ -13,8 +13,7 @@ metadata:
 spec:
   proxyRef:
     name: use-pod-template-spec
-  targetCluster:
-    clusterRef:
-      name: myref
+  targetKafkaServiceRef:
+    name: myref
   ingressRefs:
     - name: cluster-ip


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

We've decided that VirtualKafkaCluster should always have a reference to a KafkaService and it will be the KafkaService that will contain a bootstrap or a reference to some other CRD like a Strimzi Kafka resource. This means the targetCluster object isn't required any more.

See: https://github.com/kroxylicious/design/pull/61

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
