### PR TITLE
Stub `KafkaServiceReconciler`

### DIFF
--- a/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-watched.yaml
+++ b/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-watched.yaml
@@ -32,6 +32,7 @@ rules:
       - "kroxylicious.io"
     resources:
       - kafkaproxies/status
+      - kafkaservices/status
       - kafkaproxyingresses/status
     verbs:
       - get

--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -355,6 +355,9 @@
                         <io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyingressstatus.Conditions>
                             io.kroxylicious.kubernetes.api.common.Condition
                         </io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyingressstatus.Conditions>
+                        <io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicestatus.Conditions>
+                            io.kroxylicious.kubernetes.api.common.Condition
+                        </io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicestatus.Conditions>
                         <io.kroxylicious.kubernetes.filter.api.v1alpha1.kafkaprotocolfilterspec.ConfigTemplate>
                             java.lang.Object
                         </io.kroxylicious.kubernetes.filter.api.v1alpha1.kafkaprotocolfilterspec.ConfigTemplate>

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
@@ -27,6 +27,7 @@ import io.micrometer.prometheusmetrics.PrometheusConfig;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import io.prometheus.metrics.exporter.httpserver.MetricsHandler;
 
+import io.kroxylicious.kubernetes.operator.kafkaservice.KafkaServiceReconciler;
 import io.kroxylicious.kubernetes.operator.management.UnsupportedHttpMethodFilter;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
@@ -81,6 +82,7 @@ public class OperatorMain {
         operator.installShutdownHook(Duration.ofSeconds(10));
         operator.register(new KafkaProxyReconciler());
         operator.register(new KafkaProxyIngressReconciler(Clock.systemUTC()));
+        operator.register(new KafkaServiceReconciler());
         addHttpGetHandler("/", () -> 404);
         managementServer.start();
         operator.start();

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
@@ -82,7 +82,7 @@ public class OperatorMain {
         operator.installShutdownHook(Duration.ofSeconds(10));
         operator.register(new KafkaProxyReconciler());
         operator.register(new KafkaProxyIngressReconciler(Clock.systemUTC()));
-        operator.register(new KafkaServiceReconciler());
+        operator.register(new KafkaServiceReconciler(Clock.systemUTC()));
         addHttpGetHandler("/", () -> 404);
         managementServer.start();
         operator.start();

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/kafkaservice/KafkaServiceReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/kafkaservice/KafkaServiceReconciler.java
@@ -29,9 +29,10 @@ public final class KafkaServiceReconciler implements
     }
 
     @Override
-    public UpdateControl<KafkaService> reconcile(KafkaService resource, Context<KafkaService> context) throws Exception {
+    public UpdateControl<KafkaService> reconcile(KafkaService resource, Context<KafkaService> context) {
         final Condition acceptedCondition = new ConditionBuilder()
                 .withType(Condition.Type.Accepted)
+                .withLastTransitionTime(clock.instant().atZone(clock.getZone()))
                 .withObservedGeneration(resource.getMetadata().getGeneration())
                 .withStatus(Condition.Status.TRUE)
                 .build();

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/kafkaservice/KafkaServiceReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/kafkaservice/KafkaServiceReconciler.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.kubernetes.operator.kafkaservice;
 
+import java.time.Clock;
 import java.util.List;
 
 import io.javaoperatorsdk.operator.api.reconciler.Context;
@@ -21,11 +22,17 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 public final class KafkaServiceReconciler implements
         io.javaoperatorsdk.operator.api.reconciler.Reconciler<KafkaService> {
 
+    private final Clock clock;
+
+    public KafkaServiceReconciler(Clock clock) {
+        this.clock = clock;
+    }
+
     @Override
     public UpdateControl<KafkaService> reconcile(KafkaService resource, Context<KafkaService> context) throws Exception {
         final Condition acceptedCondition = new ConditionBuilder()
                 .withType(Condition.Type.Accepted)
-                .withObservedGeneration(resource.getStatus().getObservedGeneration())
+                .withObservedGeneration(resource.getMetadata().getGeneration())
                 .withReason("")
                 .withMessage("")
                 .withStatus(Condition.Status.TRUE)

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/kafkaservice/KafkaServiceReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/kafkaservice/KafkaServiceReconciler.java
@@ -38,9 +38,8 @@ public final class KafkaServiceReconciler implements
                 .build();
         final KafkaService amended = resource
                 .edit()
-                .editOrNewStatus()
-                .addNewConditionLike(acceptedCondition)
-                .endCondition()
+                .withNewStatus()
+                .withConditions(acceptedCondition)
                 .endStatus()
                 .build();
         return UpdateControl.patchStatus(amended);

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/kafkaservice/KafkaServiceReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/kafkaservice/KafkaServiceReconciler.java
@@ -33,8 +33,6 @@ public final class KafkaServiceReconciler implements
         final Condition acceptedCondition = new ConditionBuilder()
                 .withType(Condition.Type.Accepted)
                 .withObservedGeneration(resource.getMetadata().getGeneration())
-                .withReason("")
-                .withMessage("")
                 .withStatus(Condition.Status.TRUE)
                 .build();
         final KafkaService amended = resource

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/kafkaservice/KafkaServiceReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/kafkaservice/KafkaServiceReconciler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator.kafkaservice;
+
+import java.util.List;
+
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusUpdateControl;
+import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import io.javaoperatorsdk.operator.processing.event.source.EventSource;
+
+import io.kroxylicious.kubernetes.api.common.Condition;
+import io.kroxylicious.kubernetes.api.common.ConditionBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
+
+public final class KafkaServiceReconciler implements
+        io.javaoperatorsdk.operator.api.reconciler.Reconciler<KafkaService> {
+
+    @Override
+    public UpdateControl<KafkaService> reconcile(KafkaService resource, Context<KafkaService> context) throws Exception {
+        final Condition acceptedCondition = new ConditionBuilder()
+                .withType(Condition.Type.Accepted)
+                .withObservedGeneration(resource.getStatus().getObservedGeneration())
+                .withReason("")
+                .withMessage("")
+                .withStatus(Condition.Status.TRUE)
+                .build();
+        final KafkaService amended = resource
+                .edit()
+                .editOrNewStatus()
+                .addNewConditionLike(acceptedCondition)
+                .endCondition()
+                .endStatus()
+                .build();
+        return UpdateControl.patchStatus(amended);
+    }
+
+    @Override
+    public List<EventSource<?, KafkaService>> prepareEventSources(EventSourceContext<KafkaService> context) {
+        return io.javaoperatorsdk.operator.api.reconciler.Reconciler.super.prepareEventSources(context);
+    }
+
+    @Override
+    public ErrorStatusUpdateControl<KafkaService> updateErrorStatus(KafkaService resource, Context<KafkaService> context, Exception e) {
+        return io.javaoperatorsdk.operator.api.reconciler.Reconciler.super.updateErrorStatus(resource, context, e);
+    }
+}

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/kafkaservice/KafkaServiceReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/kafkaservice/KafkaServiceReconciler.java
@@ -6,14 +6,14 @@
 
 package io.kroxylicious.kubernetes.operator.kafkaservice;
 
-import java.time.Clock;
-import java.util.List;
-
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusUpdateControl;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.processing.event.source.EventSource;
+
+import java.time.Clock;
+import java.util.List;
 
 import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.common.ConditionBuilder;
@@ -39,6 +39,7 @@ public final class KafkaServiceReconciler implements
         final KafkaService amended = resource
                 .edit()
                 .withNewStatus()
+                .withObservedGeneration(resource.getMetadata().getGeneration())
                 .withConditions(acceptedCondition)
                 .endStatus()
                 .build();

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/kafkaservice/KafkaServiceReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/kafkaservice/KafkaServiceReconciler.java
@@ -6,14 +6,14 @@
 
 package io.kroxylicious.kubernetes.operator.kafkaservice;
 
+import java.time.Clock;
+import java.util.List;
+
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusUpdateControl;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.processing.event.source.EventSource;
-
-import java.time.Clock;
-import java.util.List;
 
 import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.common.ConditionBuilder;

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
@@ -44,3 +44,49 @@ spec:
                   type: string
                   minLength: 1
                   pattern: ^(([^:]+:[0-9]{1,5}),)*([^:]+:[0-9]{1,5})$
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  description: |
+                    The metadata.generation that was observed during the last reconciliation by the operator.
+                  type: integer
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      lastTransitionTime:
+                        description: |
+                          lastTransitionTime is the last time the condition transitioned from one status to another. 
+                          This should be when the underlying condition changed. 
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: |
+                          message is a human readable message indicating details about the transition. 
+                          This may be an empty string.
+                        type: string
+                      observedGeneration:
+                        description: |
+                          observedGeneration represents the .metadata.generation that the condition was set based upon. 
+                          For instance, if .metadata.generation is currently 12, but the 
+                          .status.conditions[x].observedGeneration is 9, the condition is out of date with 
+                          respect to the current state of the instance.
+                        type: integer
+                      reason:
+                        description: |
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition. 
+                          Producers of specific condition types may define expected values and meanings for this field, 
+                          and whether the values are considered a guaranteed API. 
+                          The value should be a CamelCase string. 
+                          This field may not be empty.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum: [ "True", "False", "Unknown" ]
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        type: string

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
@@ -21,7 +21,7 @@ spec:
     singular: kafkaservice
     kind: KafkaService
     shortNames:
-      - kcr
+      - ks
   # list of versions supported by this CustomResourceDefinition
   versions:
     - name: v1alpha1

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaServiceReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaServiceReconcilerIT.java
@@ -23,9 +23,9 @@ import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceBuilder;
-import io.kroxylicious.kubernetes.operator.assertj.OperatorAssertions;
 import io.kroxylicious.kubernetes.operator.kafkaservice.KafkaServiceReconciler;
 
+import static io.kroxylicious.kubernetes.operator.assertj.OperatorAssertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 @EnabledIf(value = "io.kroxylicious.kubernetes.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
@@ -66,9 +66,10 @@ class KafkaServiceReconcilerIT {
         // Then
         AWAIT.untilAsserted(() -> {
             final KafkaService mycoolkafkaservice = extension.get(KafkaService.class, "mycoolkafkaservice");
-            OperatorAssertions.assertThat(mycoolkafkaservice.getStatus())
+            assertThat(mycoolkafkaservice.getStatus())
                     .isNotNull()
                     .singleCondition()
+                    .hasObservedGenerationInSyncWithMetadataOf(mycoolkafkaservice)
                     .isAcceptedTrue();
         });
     }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaServiceReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaServiceReconcilerIT.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.time.Clock;
+import java.time.Duration;
+
+import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceBuilder;
+import io.kroxylicious.kubernetes.operator.assertj.OperatorAssertions;
+import io.kroxylicious.kubernetes.operator.kafkaservice.KafkaServiceReconciler;
+
+import static org.awaitility.Awaitility.await;
+
+@EnabledIf(value = "io.kroxylicious.kubernetes.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
+class KafkaServiceReconcilerIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KafkaServiceReconcilerIT.class);
+
+    private KubernetesClient client;
+    private static final ConditionFactory AWAIT = await().timeout(Duration.ofSeconds(60));
+
+    @BeforeEach
+    void beforeEach() {
+        client = OperatorTestUtils.kubeClient();
+    }
+
+    @SuppressWarnings("JUnitMalformedDeclaration")
+    @RegisterExtension
+    LocallyRunOperatorExtension extension = LocallyRunOperatorExtension.builder()
+            .withReconciler(new KafkaServiceReconciler(Clock.systemUTC()))
+            .withKubernetesClient(client)
+            .waitForNamespaceDeletion(true)
+            .withConfigurationService(x -> x.withCloseClientOnStop(false))
+            .build();
+
+    @AfterEach
+    void stopOperator() {
+        extension.getOperator().stop();
+        LOGGER.atInfo().log("Test finished");
+    }
+
+    @Test
+    void shouldAcceptKafkaService() {
+        // Given
+
+        // When
+        extension.create(new KafkaServiceBuilder().withNewMetadata().withName("mycoolkafkaservice").endMetadata().build());
+
+        // Then
+        AWAIT.untilAsserted(() -> {
+                    final KafkaService mycoolkafkaservice = extension.get(KafkaService.class, "mycoolkafkaservice");
+                    OperatorAssertions.assertThat(mycoolkafkaservice.getStatus())
+                            .isNotNull()
+                            .singleCondition()
+                            .isAcceptedTrue();
+                }
+        );
+    }
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaServiceReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaServiceReconcilerIT.java
@@ -61,7 +61,8 @@ class KafkaServiceReconcilerIT {
     @Test
     void shouldAcceptKafkaService() {
         // Given
-        final KafkaService kafkaService = extension.create(new KafkaServiceBuilder().withNewMetadata().withName("mycoolkafkaservice").endMetadata().editOrNewSpec().withBootstrapServers("foo.bootstrap:9090").endSpec().build());
+        final KafkaService kafkaService = extension.create(new KafkaServiceBuilder().withNewMetadata().withName("mycoolkafkaservice").endMetadata().editOrNewSpec()
+                .withBootstrapServers("foo.bootstrap:9090").endSpec().build());
         final KafkaService updated = kafkaService.edit().editSpec().withBootstrapServers(UPDATED_BOOTSTRAP).endSpec().build();
 
         // When

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaServiceReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaServiceReconcilerIT.java
@@ -65,12 +65,11 @@ class KafkaServiceReconcilerIT {
 
         // Then
         AWAIT.untilAsserted(() -> {
-                    final KafkaService mycoolkafkaservice = extension.get(KafkaService.class, "mycoolkafkaservice");
-                    OperatorAssertions.assertThat(mycoolkafkaservice.getStatus())
-                            .isNotNull()
-                            .singleCondition()
-                            .isAcceptedTrue();
-                }
-        );
+            final KafkaService mycoolkafkaservice = extension.get(KafkaService.class, "mycoolkafkaservice");
+            OperatorAssertions.assertThat(mycoolkafkaservice.getStatus())
+                    .isNotNull()
+                    .singleCondition()
+                    .isAcceptedTrue();
+        });
     }
 }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/KafkaProxyStatusAssert.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/KafkaProxyStatusAssert.java
@@ -6,10 +6,12 @@
 
 package io.kroxylicious.kubernetes.operator.assertj;
 
+import org.assertj.core.api.AbstractLongAssert;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.ListAssert;
 
+import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyStatus;
 import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Clusters;
 
@@ -23,6 +25,19 @@ public class KafkaProxyStatusAssert extends AbstractStatusAssert<KafkaProxyStatu
 
     public static KafkaProxyStatusAssert assertThat(KafkaProxyStatus actual) {
         return new KafkaProxyStatusAssert(actual);
+    }
+
+    public AbstractLongAssert<?> observedGeneration() {
+        return Assertions.assertThat(actual.getObservedGeneration());
+    }
+
+    public ListAssert<Condition.Status> conditions() {
+        return Assertions.assertThat(actual.getConditions())
+                .asInstanceOf(InstanceOfAssertFactories.list(Condition.Status.class));
+    }
+
+    public ConditionAssert singleCondition() {
+        return conditions().singleElement(AssertFactory.condition());
     }
 
     public ListAssert<Clusters> clusters() {

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/KafkaProxyStatusAssert.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/KafkaProxyStatusAssert.java
@@ -27,15 +27,18 @@ public class KafkaProxyStatusAssert extends AbstractStatusAssert<KafkaProxyStatu
         return new KafkaProxyStatusAssert(actual);
     }
 
+    @Override
     public AbstractLongAssert<?> observedGeneration() {
         return Assertions.assertThat(actual.getObservedGeneration());
     }
 
+    @Override
     public ListAssert<Condition.Status> conditions() {
         return Assertions.assertThat(actual.getConditions())
                 .asInstanceOf(InstanceOfAssertFactories.list(Condition.Status.class));
     }
 
+    @Override
     public ConditionAssert singleCondition() {
         return conditions().singleElement(AssertFactory.condition());
     }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/KafkaServiceStatusAssert.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/KafkaServiceStatusAssert.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator.assertj;
+
+import org.assertj.core.api.AbstractLongAssert;
+import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.assertj.core.api.ListAssert;
+
+import io.kroxylicious.kubernetes.api.common.Condition;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceStatus;
+
+public class KafkaServiceStatusAssert extends AbstractObjectAssert<KafkaServiceStatusAssert, KafkaServiceStatus> {
+    protected KafkaServiceStatusAssert(
+                                       KafkaServiceStatus o) {
+        super(o, KafkaServiceStatusAssert.class);
+    }
+
+    public static KafkaServiceStatusAssert assertThat(KafkaServiceStatus actual) {
+        return new KafkaServiceStatusAssert(actual);
+    }
+
+    public AbstractLongAssert<?> observedGeneration() {
+        return Assertions.assertThat(actual.getObservedGeneration());
+    }
+
+    public ListAssert<Condition.Status> conditions() {
+        return Assertions.assertThat(actual.getConditions())
+                .asInstanceOf(InstanceOfAssertFactories.list(Condition.Status.class));
+    }
+
+    public ConditionAssert singleCondition() {
+        return conditions().singleElement(AssertFactory.condition());
+    }
+
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/OperatorAssertions.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/OperatorAssertions.java
@@ -8,11 +8,16 @@ package io.kroxylicious.kubernetes.operator.assertj;
 
 import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyStatus;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceStatus;
 import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Clusters;
 
 public class OperatorAssertions {
     public static KafkaProxyStatusAssert assertThat(KafkaProxyStatus actual) {
         return KafkaProxyStatusAssert.assertThat(actual);
+    }
+
+    public static KafkaServiceStatusAssert assertThat(KafkaServiceStatus actual) {
+        return KafkaServiceStatusAssert.assertThat(actual);
     }
 
     public static ClusterAssert assertThat(Clusters actual) {

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/protocolfilter/KafkaServiceReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/protocolfilter/KafkaServiceReconcilerTest.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.kubernetes.operator.protocolfilter;
 
+import java.time.Clock;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,8 +19,6 @@ import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
-
-import java.time.Clock;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceBuilder;

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/protocolfilter/KafkaServiceReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/protocolfilter/KafkaServiceReconcilerTest.java
@@ -6,8 +6,6 @@
 
 package io.kroxylicious.kubernetes.operator.protocolfilter;
 
-import java.time.Clock;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,6 +17,8 @@ import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+
+import java.time.Clock;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceBuilder;
@@ -46,9 +46,9 @@ class KafkaServiceReconcilerTest {
     }
 
     @Test
-    void shouldMarkFilterAccepted() throws Exception {
+    void shouldMarkFilterAccepted() {
         // Given
-        final KafkaService kafkaService = new KafkaServiceBuilder().withNewStatus().withObservedGeneration(OBSERVED_GENERATION).endStatus().build();
+        final KafkaService kafkaService = new KafkaServiceBuilder().withNewMetadata().withGeneration(OBSERVED_GENERATION).endMetadata().build();
 
         // When
         final UpdateControl<KafkaService> updateControl = kafkaProtocolFilterReconciler.reconcile(kafkaService, context);

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/protocolfilter/KafkaServiceReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/protocolfilter/KafkaServiceReconcilerTest.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.kubernetes.operator.protocolfilter;
 
+import java.time.Clock;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,7 +42,7 @@ class KafkaServiceReconcilerTest {
 
     @BeforeEach
     void setUp() {
-        kafkaProtocolFilterReconciler = new KafkaServiceReconciler();
+        kafkaProtocolFilterReconciler = new KafkaServiceReconciler(Clock.systemUTC());
     }
 
     @Test

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/protocolfilter/KafkaServiceReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/protocolfilter/KafkaServiceReconcilerTest.java
@@ -70,6 +70,7 @@ class KafkaServiceReconcilerTest {
                                                 .isEqualTo(OBSERVED_GENERATION);
                                         assertThat(kafkaServiceStatus)
                                                 .singleCondition()
+                                                .hasObservedGenerationInSyncWithMetadataOf(input.getResource().get())
                                                 .isAcceptedTrue();
                                     }
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/protocolfilter/KafkaServiceReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/protocolfilter/KafkaServiceReconcilerTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator.protocolfilter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceBuilder;
+import io.kroxylicious.kubernetes.operator.kafkaservice.KafkaServiceReconciler;
+
+import static io.kroxylicious.kubernetes.operator.assertj.OperatorAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnableKubernetesMockClient(crud = true)
+@ExtendWith(MockitoExtension.class)
+class KafkaServiceReconcilerTest {
+
+    public static final long OBSERVED_GENERATION = 1345L;
+    KubernetesClient kubeClient;
+    KubernetesMockServer mockServer;
+
+    @Mock
+    Context<KafkaService> context;
+
+    private KafkaServiceReconciler kafkaProtocolFilterReconciler;
+
+    @BeforeEach
+    void setUp() {
+        kafkaProtocolFilterReconciler = new KafkaServiceReconciler();
+    }
+
+    @Test
+    void shouldMarkFilterAccepted() throws Exception {
+        // Given
+        final KafkaService kafkaService = new KafkaServiceBuilder().withNewStatus().withObservedGeneration(OBSERVED_GENERATION).endStatus().build();
+
+        // When
+        final UpdateControl<KafkaService> updateControl = kafkaProtocolFilterReconciler.reconcile(kafkaService, context);
+
+        // Then
+        assertThat(updateControl)
+                .isNotNull()
+                .satisfies(
+                        input -> {
+                            assertThat(input.isPatchStatus())
+                                    .isTrue();
+                            assertThat(input.getResource())
+                                    .isNotEmpty()
+                                    .get()
+                                    .extracting(KafkaService::getStatus)
+                                    .satisfies(kafkaServiceStatus -> {
+                                        assertThat(kafkaServiceStatus)
+                                                .observedGeneration()
+                                                .isEqualTo(OBSERVED_GENERATION);
+                                        assertThat(kafkaServiceStatus)
+                                                .singleCondition()
+                                                .isAcceptedTrue();
+                                    }
+
+                                    );
+                        });
+    }
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Following the second strategy outlined in https://github.com/kroxylicious/kroxylicious/issues/1948#issuecomment-2738083691 this PR adds a status to KafkaService and populates it.

### Additional Context

Probably mergeable as is, we will look at failing acceptance cases tomorrow (those could be added in a follow up PR).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
