### PR TITLE
Rename ProxyReconciler to KafkaProxyReconciler

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconciler.java
@@ -57,32 +57,32 @@ import static io.kroxylicious.kubernetes.operator.ResourcesUtil.toLocalRef;
 // @formatter:off
 @Workflow(dependents = {
         @Dependent(
-                name = ProxyReconciler.CONFIG_DEP,
+                name = KafkaProxyReconciler.CONFIG_DEP,
                 type = ProxyConfigConfigMap.class
         ),
         @Dependent(
-                name = ProxyReconciler.DEPLOYMENT_DEP,
+                name = KafkaProxyReconciler.DEPLOYMENT_DEP,
                 type = ProxyDeployment.class,
-                dependsOn = { ProxyReconciler.CONFIG_DEP },
+                dependsOn = { KafkaProxyReconciler.CONFIG_DEP },
                 readyPostcondition = DeploymentReadyCondition.class
         ),
         @Dependent(
-                name = ProxyReconciler.CLUSTERS_DEP,
+                name = KafkaProxyReconciler.CLUSTERS_DEP,
                 type = ClusterService.class,
-                dependsOn = { ProxyReconciler.DEPLOYMENT_DEP }
+                dependsOn = { KafkaProxyReconciler.DEPLOYMENT_DEP }
         )
 })
 // @formatter:on
-public class ProxyReconciler implements
+public class KafkaProxyReconciler implements
         Reconciler<KafkaProxy> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ProxyReconciler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProxyReconciler.class);
 
     public static final String CONFIG_DEP = "config";
     public static final String DEPLOYMENT_DEP = "deployment";
     public static final String CLUSTERS_DEP = "clusters";
 
-    public ProxyReconciler() {
+    public KafkaProxyReconciler() {
     }
 
     /**

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
@@ -79,7 +79,7 @@ public class OperatorMain {
      */
     void start() {
         operator.installShutdownHook(Duration.ofSeconds(10));
-        operator.register(new ProxyReconciler());
+        operator.register(new KafkaProxyReconciler());
         operator.register(new KafkaProxyIngressReconciler(Clock.systemUTC()));
         addHttpGetHandler("/", () -> 404);
         managementServer.start();

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/SharedKafkaProxyContext.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/SharedKafkaProxyContext.java
@@ -20,7 +20,7 @@ import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
 
 /**
  * Encapsulates access to the mutable state in the {@link Context<KafkaProxy>} shared between
- * {@link ProxyReconciler} its dependent resources.
+ * {@link KafkaProxyReconciler} its dependent resources.
  */
 public class SharedKafkaProxyContext {
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconcilerIT.java
@@ -36,7 +36,7 @@ import static org.awaitility.Awaitility.await;
 @EnabledIf(value = "io.kroxylicious.kubernetes.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
 class KafkaProxyIngressReconcilerIT {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ProxyReconcilerIT.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProxyReconcilerIT.class);
 
     private static final String PROXY_A = "proxy-a";
     private static final String PROXY_B = "proxy-b";

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
@@ -51,9 +51,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 @EnabledIf(value = "io.kroxylicious.kubernetes.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
-class ProxyReconcilerIT {
+class KafkaProxyReconcilerIT {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ProxyReconcilerIT.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProxyReconcilerIT.class);
 
     private static final String PROXY_A = "proxy-a";
     private static final String PROXY_B = "proxy-b";
@@ -84,7 +84,7 @@ class ProxyReconcilerIT {
 
     @RegisterExtension
     LocallyRunOperatorExtension extension = LocallyRunOperatorExtension.builder()
-            .withReconciler(new ProxyReconciler())
+            .withReconciler(new KafkaProxyReconciler())
             .withKubernetesClient(client)
             .withAdditionalCustomResourceDefinition(VirtualKafkaCluster.class)
             .withAdditionalCustomResourceDefinition(KafkaService.class)

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerTest.java
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-class ProxyReconcilerTest {
+class KafkaProxyReconcilerTest {
 
     @Mock
     Context<KafkaProxy> context;
@@ -88,7 +88,7 @@ class ProxyReconcilerTest {
         // @formatter:on
 
         // When
-        var updateControl = new ProxyReconciler().reconcile(primary, context);
+        var updateControl = new KafkaProxyReconciler().reconcile(primary, context);
 
         // Then
         assertThat(updateControl.isPatchStatus()).isTrue();
@@ -119,7 +119,7 @@ class ProxyReconcilerTest {
         // @formatter:on
 
         // When
-        var updateControl = new ProxyReconciler().updateErrorStatus(primary, context, new InvalidResourceException("Resource was terrible"));
+        var updateControl = new KafkaProxyReconciler().updateErrorStatus(primary, context, new InvalidResourceException("Resource was terrible"));
 
         // Then
         var statusAssert = assertThat(updateControl.getResource())
@@ -159,7 +159,7 @@ class ProxyReconcilerTest {
         // @formatter:on
 
         // When
-        var updateControl = new ProxyReconciler().reconcile(primary, context);
+        var updateControl = new KafkaProxyReconciler().reconcile(primary, context);
 
         // Then
         assertThat(updateControl.isPatchStatus()).isTrue();
@@ -200,7 +200,7 @@ class ProxyReconcilerTest {
         // @formatter:on
 
         // When
-        var updateControl = new ProxyReconciler().updateErrorStatus(primary, context, new InvalidResourceException("Resource was terrible"));
+        var updateControl = new KafkaProxyReconciler().updateErrorStatus(primary, context, new InvalidResourceException("Resource was terrible"));
 
         // Then
         var statusAssert = assertThat(updateControl.getResource())
@@ -240,7 +240,7 @@ class ProxyReconcilerTest {
         // @formatter:on
 
         // When
-        var updateControl = new ProxyReconciler().updateErrorStatus(primary, context, new InvalidResourceException("Resource was terrible"));
+        var updateControl = new KafkaProxyReconciler().updateErrorStatus(primary, context, new InvalidResourceException("Resource was terrible"));
 
         // Then
         var statusAssert = assertThat(updateControl.getResource())
@@ -281,7 +281,7 @@ class ProxyReconcilerTest {
         // @formatter:on
 
         // When
-        var updateControl = new ProxyReconciler().reconcile(primary, context);
+        var updateControl = new KafkaProxyReconciler().reconcile(primary, context);
 
         // Then
         assertThat(updateControl.isPatchStatus()).isTrue();
@@ -331,7 +331,7 @@ class ProxyReconcilerTest {
                 Map.class);
 
         // When
-        var updateControl = new ProxyReconciler().reconcile(primary, context);
+        var updateControl = new KafkaProxyReconciler().reconcile(primary, context);
 
         // Then
         assertThat(updateControl.isPatchStatus()).isTrue();
@@ -366,7 +366,7 @@ class ProxyReconcilerTest {
         VirtualKafkaCluster cluster = baseVirtualKafkaClusterBuilder(proxy, "cluster").build();
         VirtualKafkaCluster clusterForAnotherProxy = baseVirtualKafkaClusterBuilder(buildProxy("anotherproxy"), "anothercluster").build();
         when(mockList.getItems()).thenReturn(List.of(cluster, clusterForAnotherProxy));
-        PrimaryToSecondaryMapper<HasMetadata> mapper = ProxyReconciler.proxyToClusterMapper(eventSourceContext);
+        PrimaryToSecondaryMapper<HasMetadata> mapper = KafkaProxyReconciler.proxyToClusterMapper(eventSourceContext);
         Set<ResourceID> secondaryResourceIDs = mapper.toSecondaryResourceIDs(proxy);
         assertThat(secondaryResourceIDs).containsExactly(ResourceID.fromResource(cluster));
     }
@@ -388,7 +388,7 @@ class ProxyReconcilerTest {
                 .withName("anotherProxy")
                 .endProxyRef().endSpec().build();
         when(mockList.getItems()).thenReturn(List.of(ingress, ingressForAnotherProxy));
-        PrimaryToSecondaryMapper<KafkaProxy> mapper = ProxyReconciler.proxyToIngressMapper(eventSourceContext);
+        PrimaryToSecondaryMapper<KafkaProxy> mapper = KafkaProxyReconciler.proxyToIngressMapper(eventSourceContext);
         KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName("proxy").endMetadata().build();
         Set<ResourceID> secondaryResourceIDs = mapper.toSecondaryResourceIDs(proxy);
         assertThat(secondaryResourceIDs).containsExactly(ResourceID.fromResource(ingress));
@@ -406,7 +406,7 @@ class ProxyReconcilerTest {
         when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
         VirtualKafkaCluster clusterForAnotherProxy = baseVirtualKafkaClusterBuilder(buildProxy("anotherProxy"), "cluster").build();
         when(mockList.getItems()).thenReturn(List.of(clusterForAnotherProxy));
-        PrimaryToSecondaryMapper<HasMetadata> mapper = ProxyReconciler.proxyToClusterMapper(eventSourceContext);
+        PrimaryToSecondaryMapper<HasMetadata> mapper = KafkaProxyReconciler.proxyToClusterMapper(eventSourceContext);
         KafkaProxy proxy = buildProxy("proxy");
         Set<ResourceID> secondaryResourceIDs = mapper.toSecondaryResourceIDs(proxy);
         assertThat(secondaryResourceIDs).isEmpty();
@@ -424,7 +424,7 @@ class ProxyReconcilerTest {
         when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
         KafkaProxy proxy = buildProxy("proxy");
         when(mockList.getItems()).thenReturn(List.of(proxy));
-        SecondaryToPrimaryMapper<VirtualKafkaCluster> mapper = ProxyReconciler.clusterToProxyMapper(eventSourceContext);
+        SecondaryToPrimaryMapper<VirtualKafkaCluster> mapper = KafkaProxyReconciler.clusterToProxyMapper(eventSourceContext);
         VirtualKafkaCluster cluster = baseVirtualKafkaClusterBuilder(proxy, "cluster").build();
         Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(cluster);
         assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(proxy));
@@ -442,7 +442,7 @@ class ProxyReconcilerTest {
         when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
         KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName("proxy").endMetadata().build();
         when(mockList.getItems()).thenReturn(List.of(proxy));
-        SecondaryToPrimaryMapper<KafkaProxyIngress> mapper = ProxyReconciler.ingressToProxyMapper(eventSourceContext);
+        SecondaryToPrimaryMapper<KafkaProxyIngress> mapper = KafkaProxyReconciler.ingressToProxyMapper(eventSourceContext);
         KafkaProxyIngress cluster = new KafkaProxyIngressBuilder().withNewMetadata().withName("ingress").endMetadata().withNewSpec().withNewProxyRef()
                 .withName("proxy")
                 .endProxyRef().endSpec().build();
@@ -462,7 +462,7 @@ class ProxyReconcilerTest {
         when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
         KafkaProxy proxy = buildProxy("proxy");
         when(mockList.getItems()).thenReturn(List.of(proxy));
-        SecondaryToPrimaryMapper<KafkaProtocolFilter> mapper = ProxyReconciler.filterToProxy(eventSourceContext);
+        SecondaryToPrimaryMapper<KafkaProtocolFilter> mapper = KafkaProxyReconciler.filterToProxy(eventSourceContext);
         String namespace = "test";
         KafkaProtocolFilter filter = new KafkaProtocolFilterBuilder().withNewMetadata().withName("filter").withNamespace(namespace).endMetadata().build();
         Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(filter);
@@ -487,7 +487,7 @@ class ProxyReconcilerTest {
         VirtualKafkaCluster clusterForAnotherProxy = baseVirtualKafkaClusterBuilder(proxy, "cluster").editOrNewSpec()
                 .addNewFilterRef().withName(filterName).endFilterRef().endSpec().build();
         when(mockList.getItems()).thenReturn(List.of(clusterForAnotherProxy));
-        PrimaryToSecondaryMapper<KafkaProxy> mapper = ProxyReconciler.proxyToFilters(eventSourceContext);
+        PrimaryToSecondaryMapper<KafkaProxy> mapper = KafkaProxyReconciler.proxyToFilters(eventSourceContext);
         Set<ResourceID> secondaryResourceIDs = mapper.toSecondaryResourceIDs(proxy);
         assertThat(secondaryResourceIDs).containsExactly(new ResourceID(filterName, proxyNamespace));
         verify(mockOperation).inNamespace(proxyNamespace);
@@ -507,7 +507,7 @@ class ProxyReconcilerTest {
                 .build();
         when(mockList.getItems()).thenReturn(List.of(clusterWithoutFilters));
 
-        PrimaryToSecondaryMapper<KafkaProxy> mapper = ProxyReconciler.proxyToFilters(eventSourceContext);
+        PrimaryToSecondaryMapper<KafkaProxy> mapper = KafkaProxyReconciler.proxyToFilters(eventSourceContext);
         Set<ResourceID> secondaryResourceIDs = mapper.toSecondaryResourceIDs(proxy);
         assertThat(secondaryResourceIDs).isEmpty();
     }
@@ -532,7 +532,7 @@ class ProxyReconcilerTest {
 
         when(clusterListMock.getItems()).thenReturn(List.of(cluster));
 
-        PrimaryToSecondaryMapper<HasMetadata> mapper = ProxyReconciler.proxyToKafkaServiceMapper(eventSourceContext);
+        PrimaryToSecondaryMapper<HasMetadata> mapper = KafkaProxyReconciler.proxyToKafkaServiceMapper(eventSourceContext);
         Set<ResourceID> secondaryResourceIDs = mapper.toSecondaryResourceIDs(proxy);
         assertThat(secondaryResourceIDs).containsExactly(ResourceID.fromResource(kafkaServiceRef));
     }
@@ -560,7 +560,7 @@ class ProxyReconcilerTest {
 
         when(clusterListMock.getItems()).thenReturn(List.of(clusterProxy1, clusterProxy2));
 
-        PrimaryToSecondaryMapper<HasMetadata> mapper = ProxyReconciler.proxyToKafkaServiceMapper(eventSourceContext);
+        PrimaryToSecondaryMapper<HasMetadata> mapper = KafkaProxyReconciler.proxyToKafkaServiceMapper(eventSourceContext);
 
         assertThat(mapper.toSecondaryResourceIDs(proxy1)).containsExactly(ResourceID.fromResource(kafkaServiceRefProxy1));
         assertThat(mapper.toSecondaryResourceIDs(proxy2)).containsExactly(ResourceID.fromResource(kafkaServiceRefProxy2));
@@ -592,7 +592,7 @@ class ProxyReconcilerTest {
 
         when(clusterListMock.getItems()).thenReturn(List.of(clusterProxy1, clusterProxy2a, clusterProxy2b));
 
-        PrimaryToSecondaryMapper<HasMetadata> mapper = ProxyReconciler.proxyToKafkaServiceMapper(eventSourceContext);
+        PrimaryToSecondaryMapper<HasMetadata> mapper = KafkaProxyReconciler.proxyToKafkaServiceMapper(eventSourceContext);
 
         assertThat(mapper.toSecondaryResourceIDs(proxy1))
                 .containsExactly(ResourceID.fromResource(kafkaServiceRefProxy1));
@@ -616,7 +616,7 @@ class ProxyReconcilerTest {
 
         when(clusterListMock.getItems()).thenReturn(List.of(cluster));
 
-        PrimaryToSecondaryMapper<HasMetadata> mapper = ProxyReconciler.proxyToKafkaServiceMapper(eventSourceContext);
+        PrimaryToSecondaryMapper<HasMetadata> mapper = KafkaProxyReconciler.proxyToKafkaServiceMapper(eventSourceContext);
         Set<ResourceID> secondaryResourceIDs = mapper.toSecondaryResourceIDs(proxy);
         assertThat(secondaryResourceIDs).isEmpty();
     }
@@ -637,7 +637,7 @@ class ProxyReconcilerTest {
         KubernetesResourceList<VirtualKafkaCluster> mockClusterList = mockVirtualKafkaClusterListOperation(client);
         when(mockClusterList.getItems()).thenReturn(List.of(cluster));
 
-        SecondaryToPrimaryMapper<KafkaService> mapper = ProxyReconciler.kafkaServiceRefToProxyMapper(eventSourceContext);
+        SecondaryToPrimaryMapper<KafkaService> mapper = KafkaProxyReconciler.kafkaServiceRefToProxyMapper(eventSourceContext);
 
         Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(kafkaServiceRef);
         assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(proxy));
@@ -661,7 +661,7 @@ class ProxyReconcilerTest {
         KubernetesResourceList<VirtualKafkaCluster> mockClusterList = mockVirtualKafkaClusterListOperation(client);
         when(mockClusterList.getItems()).thenReturn(List.of(proxy1cluster, proxy2cluster));
 
-        SecondaryToPrimaryMapper<KafkaService> mapper = ProxyReconciler.kafkaServiceRefToProxyMapper(eventSourceContext);
+        SecondaryToPrimaryMapper<KafkaService> mapper = KafkaProxyReconciler.kafkaServiceRefToProxyMapper(eventSourceContext);
 
         Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(kafkaServiceRef);
         assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(proxy1), ResourceID.fromResource(proxy2));
@@ -683,7 +683,7 @@ class ProxyReconcilerTest {
         KubernetesResourceList<VirtualKafkaCluster> mockClusterList = mockVirtualKafkaClusterListOperation(client);
         when(mockClusterList.getItems()).thenReturn(List.of(cluster));
 
-        SecondaryToPrimaryMapper<KafkaService> mapper = ProxyReconciler.kafkaServiceRefToProxyMapper(eventSourceContext);
+        SecondaryToPrimaryMapper<KafkaService> mapper = KafkaProxyReconciler.kafkaServiceRefToProxyMapper(eventSourceContext);
 
         Set<ResourceID> primaryResourceIDs = mapper.toPrimaryResourceIDs(orphanKafkaClusterRed);
         assertThat(primaryResourceIDs).isEmpty();

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
@@ -145,7 +145,7 @@ class OperatorMainIT {
         operatorMain.start();
 
         // Then
-        assertThat(Metrics.globalRegistry.get("operator.sdk.reconciliations.executions.proxyreconciler").meter().getId()).isNotNull();
+        assertThat(Metrics.globalRegistry.get("operator.sdk.reconciliations.executions.kafkaproxyreconciler").meter().getId()).isNotNull();
     }
 
     @SuppressWarnings("resource")
@@ -175,7 +175,7 @@ class OperatorMainIT {
                     assertThat(response.statusCode()).isEqualTo(200);
                     assertThat(response.body())
                             .isNotEmpty()
-                            .anySatisfy(line -> assertThat(line).contains("operator_sdk_reconciliations_executions_proxyreconciler"))
+                            .anySatisfy(line -> assertThat(line).contains("operator_sdk_reconciliations_executions_kafkaproxyreconciler"))
                             .anySatisfy(line -> assertThat(line).contains("operator_sdk_events_received"));
                 });
     }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
@@ -125,7 +125,7 @@ class OperatorMainTest {
         operatorMain.start();
 
         // Then
-        assertThat(Metrics.globalRegistry.get("operator.sdk.reconciliations.executions.proxyreconciler").meter().getId()).isNotNull();
+        assertThat(Metrics.globalRegistry.get("operator.sdk.reconciliations.executions.kafkaproxyreconciler").meter().getId()).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

We decided to have the class names of the reconcilers match the Kind

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
