### PR TITLE
Wrap clock so we always get ZonedDateTime

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconciler.java
@@ -7,9 +7,9 @@
 package io.kroxylicious.kubernetes.operator;
 
 import java.time.Clock;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Objects;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,10 +41,10 @@ public class KafkaProxyIngressReconciler implements
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProxyIngressReconciler.class);
     public static final String PROXY_EVENT_SOURCE_NAME = "proxy";
-    private final Clock clock;
+    private final UtcClock clock;
 
-    KafkaProxyIngressReconciler(Clock clock) {
-        this.clock = clock;
+    KafkaProxyIngressReconciler(@NonNull Clock clock) {
+        this.clock = UtcClock.of(Objects.requireNonNull(clock));
     }
 
     @Override
@@ -68,7 +68,7 @@ public class KafkaProxyIngressReconciler implements
                                                       Context<KafkaProxyIngress> context)
             throws Exception {
 
-        var now = ZonedDateTime.ofInstant(clock.instant(), ZoneId.of("Z"));
+        var now = clock.now();
 
         ConditionBuilder conditionBuilder = newResolvedRefsCondition(ingress, now);
 
@@ -111,7 +111,7 @@ public class KafkaProxyIngressReconciler implements
                                                                          KafkaProxyIngress ingress,
                                                                          Context<KafkaProxyIngress> context,
                                                                          Exception e) {
-        var now = ZonedDateTime.ofInstant(clock.instant(), ZoneId.of("Z"));
+        var now = clock.now();
         // ResolvedRefs to UNKNOWN
         Condition condition = newResolvedRefsCondition(ingress, now)
                 .withStatus(Condition.Status.UNKNOWN)

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconciler.java
@@ -65,8 +65,7 @@ public class KafkaProxyIngressReconciler implements
     @Override
     public UpdateControl<KafkaProxyIngress> reconcile(
                                                       KafkaProxyIngress ingress,
-                                                      Context<KafkaProxyIngress> context)
-            throws Exception {
+                                                      Context<KafkaProxyIngress> context) {
 
         var now = clock.now();
 

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
@@ -80,7 +80,7 @@ public class OperatorMain {
      */
     void start() {
         operator.installShutdownHook(Duration.ofSeconds(10));
-        operator.register(new KafkaProxyReconciler(SecureConfigInterpolator.DEFAULT_INTERPOLATOR));
+        operator.register(new KafkaProxyReconciler(SecureConfigInterpolator.DEFAULT_INTERPOLATOR, Clock.systemUTC()));
         operator.register(new KafkaProxyIngressReconciler(Clock.systemUTC()));
         operator.register(new KafkaServiceReconciler(Clock.systemUTC()));
         operator.register(new KafkaProtocolFilterReconciler(Clock.systemUTC(), SecureConfigInterpolator.DEFAULT_INTERPOLATOR));

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/UtcClock.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/UtcClock.java
@@ -17,6 +17,6 @@ public record UtcClock(Clock clock) {
     }
 
     public ZonedDateTime now() {
-        return ZonedDateTime.ofInstant(clock.instant(), ZoneId.of(ZoneOffset.UTC.getId()));
+        return ZonedDateTime.ofInstant(clock.instant(), ZoneOffset.UTC);
     }
 }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/UtcClock.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/UtcClock.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.time.Clock;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+public record UtcClock(Clock clock) {
+    public static UtcClock of(Clock clock) {
+        return new UtcClock(clock);
+    }
+
+    public ZonedDateTime now() {
+        return ZonedDateTime.ofInstant(clock.instant(), ZoneId.of(ZoneOffset.UTC.getId()));
+    }
+}

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/kafkaservice/KafkaServiceReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/kafkaservice/KafkaServiceReconciler.java
@@ -8,6 +8,7 @@ package io.kroxylicious.kubernetes.operator.kafkaservice;
 
 import java.time.Clock;
 import java.util.List;
+import java.util.Objects;
 
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusUpdateControl;
@@ -18,21 +19,24 @@ import io.javaoperatorsdk.operator.processing.event.source.EventSource;
 import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.common.ConditionBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
+import io.kroxylicious.kubernetes.operator.UtcClock;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 public final class KafkaServiceReconciler implements
         io.javaoperatorsdk.operator.api.reconciler.Reconciler<KafkaService> {
 
-    private final Clock clock;
+    private final UtcClock clock;
 
-    public KafkaServiceReconciler(Clock clock) {
-        this.clock = clock;
+    public KafkaServiceReconciler(@NonNull Clock clock) {
+        this.clock = UtcClock.of(Objects.requireNonNull(clock));
     }
 
     @Override
     public UpdateControl<KafkaService> reconcile(KafkaService resource, Context<KafkaService> context) {
         final Condition acceptedCondition = new ConditionBuilder()
                 .withType(Condition.Type.Accepted)
-                .withLastTransitionTime(clock.instant().atZone(clock.getZone()))
+                .withLastTransitionTime(clock.now())
                 .withObservedGeneration(resource.getMetadata().getGeneration())
                 .withStatus(Condition.Status.TRUE)
                 .build();

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.kubernetes.operator;
 
+import java.time.Clock;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -82,9 +83,10 @@ class KafkaProxyReconcilerIT {
         client = OperatorTestUtils.kubeClient();
     }
 
+    @SuppressWarnings("JUnitMalformedDeclaration")
     @RegisterExtension
     LocallyRunOperatorExtension extension = LocallyRunOperatorExtension.builder()
-            .withReconciler(new KafkaProxyReconciler(SecureConfigInterpolator.DEFAULT_INTERPOLATOR))
+            .withReconciler(new KafkaProxyReconciler(SecureConfigInterpolator.DEFAULT_INTERPOLATOR, Clock.systemUTC()))
             .withKubernetesClient(client)
             .withAdditionalCustomResourceDefinition(VirtualKafkaCluster.class)
             .withAdditionalCustomResourceDefinition(KafkaService.class)

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
@@ -74,7 +74,7 @@ class KafkaProxyReconcilerIT {
 
     // the initial operator image pull can take a long time and interfere with the tests
     @BeforeAll
-    public static void preloadOperandImage() {
+    static void preloadOperandImage() {
         OperatorTestUtils.preloadOperandImage();
     }
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerTest.java
@@ -68,12 +68,12 @@ class KafkaProxyReconcilerTest {
     private AutoCloseable closeable;
 
     @BeforeEach
-    public void openMocks() {
+    void openMocks() {
         closeable = MockitoAnnotations.openMocks(this);
     }
 
     @AfterEach
-    public void releaseMocks() throws Exception {
+    void releaseMocks() throws Exception {
         closeable.close();
     }
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerTest.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.kubernetes.operator;
 
+import java.time.Clock;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -359,7 +360,7 @@ class KafkaProxyReconcilerTest {
 
     @NonNull
     private static KafkaProxyReconciler newKafkaProxyReconciler() {
-        return new KafkaProxyReconciler(SecureConfigInterpolator.DEFAULT_INTERPOLATOR);
+        return new KafkaProxyReconciler(SecureConfigInterpolator.DEFAULT_INTERPOLATOR, Clock.systemUTC());
     }
 
     @Test


### PR DESCRIPTION
### Type of change


- Refactoring

### Description

Rather than having to remember to convert things to UTC standardise on our own clock wrapper. 

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
