### PR TITLE
Add `VirtualKafkaClusterReconciler`

### DIFF
--- a/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-watched.yaml
+++ b/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-watched.yaml
@@ -31,6 +31,7 @@ rules:
       - "kroxylicious.io"
     resources:
       - kafkaproxies/status
+      - virtualkafkaclusters/status
       - kafkaservices/status
       - kafkaproxyingresses/status
     verbs:

--- a/kroxylicious-operator/install/03.Deployment.kroxylicious-operator.yaml
+++ b/kroxylicious-operator/install/03.Deployment.kroxylicious-operator.yaml
@@ -32,10 +32,10 @@ spec:
           args: [ ]
           resources:
             limits:
-              memory: 300M
+              memory: 400M
               cpu: "1"
             requests:
-              memory: 300M
+              memory: 400M
               cpu: "1"
           ports:
             - containerPort: 8080

--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -349,6 +349,9 @@
                         <io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Conditions>
                             io.kroxylicious.kubernetes.api.common.Condition
                         </io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Conditions>
+                        <io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterstatus.Conditions>
+                            io.kroxylicious.kubernetes.api.common.Condition
+                        </io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterstatus.Conditions>
                         <io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.clusters.Conditions>
                             io.kroxylicious.kubernetes.api.common.Condition
                         </io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.clusters.Conditions>

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
@@ -80,6 +80,7 @@ public class OperatorMain {
     void start() {
         operator.installShutdownHook(Duration.ofSeconds(10));
         operator.register(new KafkaProxyReconciler(SecureConfigInterpolator.DEFAULT_INTERPOLATOR));
+        operator.register(new VirtualKafkaClusterReconciler(Clock.systemUTC()));
         operator.register(new KafkaProxyIngressReconciler(Clock.systemUTC()));
         operator.register(new KafkaServiceReconciler(Clock.systemUTC()));
         operator.register(new KafkaProtocolFilterReconciler(Clock.systemUTC(), SecureConfigInterpolator.DEFAULT_INTERPOLATOR));

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
@@ -45,6 +45,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngressStatus;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceStatus;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterStatus;
 import io.kroxylicious.kubernetes.filter.api.v1alpha1.KafkaProtocolFilter;
 import io.kroxylicious.kubernetes.filter.api.v1alpha1.KafkaProtocolFilterStatus;
 
@@ -299,6 +300,22 @@ public class ResourcesUtil {
         observedGenerationSetter.accept(status, ingress.getMetadata().getGeneration());
         result.setStatus(status);
         return result;
+    }
+
+    @NonNull
+    static VirtualKafkaCluster patchWithCondition(VirtualKafkaCluster cluster, Condition condition) {
+        return newStatus(
+                cluster,
+                VirtualKafkaCluster::new,
+                VirtualKafkaClusterStatus::new,
+                VirtualKafkaClusterStatus::setConditions,
+                VirtualKafkaClusterStatus::setObservedGeneration,
+                maybeAddOrUpdateCondition(
+                        Optional.of(cluster)
+                                .map(VirtualKafkaCluster::getStatus)
+                                .map(VirtualKafkaClusterStatus::getConditions)
+                                .orElse(List.of()),
+                        condition));
     }
 
     @NonNull

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconciler.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.time.Clock;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.javaoperatorsdk.operator.api.config.informer.InformerEventSourceConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusUpdateControl;
+import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import io.javaoperatorsdk.operator.processing.event.source.EventSource;
+import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource;
+
+import io.kroxylicious.kubernetes.api.common.Condition;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
+
+import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
+import static io.kroxylicious.kubernetes.operator.ResourcesUtil.namespace;
+
+public final class VirtualKafkaClusterReconciler implements
+        Reconciler<VirtualKafkaCluster> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(VirtualKafkaClusterReconciler.class);
+    public static final String PROXY_EVENT_SOURCE_NAME = "proxy";
+
+    private final Clock clock;
+
+    public VirtualKafkaClusterReconciler(Clock clock) {
+        this.clock = clock;
+    }
+
+    @Override
+    public UpdateControl<VirtualKafkaCluster> reconcile(VirtualKafkaCluster cluster, Context<VirtualKafkaCluster> context) {
+        var proxyOpt = context.getSecondaryResource(KafkaProxy.class, PROXY_EVENT_SOURCE_NAME);
+        LOGGER.debug("spec.proxyRef.name resolves to: {}", proxyOpt);
+
+        Condition condition;
+        if (proxyOpt.isPresent()) {
+            condition = ResourcesUtil.newResolvedRefsTrue(clock, cluster);
+        }
+        else {
+            condition = ResourcesUtil.newResolvedRefsFalse(clock,
+                    cluster,
+                    "spec.proxyRef.name",
+                    "KafkaProxy not found");
+        }
+
+        UpdateControl<VirtualKafkaCluster> uc = UpdateControl.patchStatus(ResourcesUtil.patchWithCondition(cluster, condition));
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("Completed reconciliation of {}/{}", namespace(cluster), name(cluster));
+        }
+        return uc;
+    }
+
+    @Override
+    public List<EventSource<?, VirtualKafkaCluster>> prepareEventSources(EventSourceContext<VirtualKafkaCluster> context) {
+        InformerEventSourceConfiguration<KafkaProxy> configuration = InformerEventSourceConfiguration.from(
+                KafkaProxy.class,
+                VirtualKafkaCluster.class)
+                .withName(PROXY_EVENT_SOURCE_NAME)
+                .withPrimaryToSecondaryMapper((VirtualKafkaCluster cluster) -> ResourcesUtil.localRefAsResourceId(cluster, cluster.getSpec().getProxyRef()))
+                .withSecondaryToPrimaryMapper(proxy -> ResourcesUtil.findReferrers(context,
+                        proxy,
+                        VirtualKafkaCluster.class,
+                        cluster -> cluster.getSpec().getProxyRef()))
+                .build();
+        return List.of(new InformerEventSource<>(configuration, context));
+    }
+
+    @Override
+    public ErrorStatusUpdateControl<VirtualKafkaCluster> updateErrorStatus(VirtualKafkaCluster cluster, Context<VirtualKafkaCluster> context, Exception e) {
+        // ResolvedRefs to UNKNOWN
+        Condition condition = ResourcesUtil.newUnknownCondition(clock, cluster, Condition.Type.ResolvedRefs, e);
+        ErrorStatusUpdateControl<VirtualKafkaCluster> uc = ErrorStatusUpdateControl.patchStatus(ResourcesUtil.patchWithCondition(cluster, condition));
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("Completed reconciliation of {}/{} for error {}", namespace(cluster), name(cluster), e.toString());
+        }
+        return uc;
+    }
+}

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
@@ -87,3 +87,50 @@ spec:
                         maxLength: 253
                         minLength: 1
                         type: string
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  description: |
+                    The metadata.generation that was observed during the last reconciliation by the operator.
+                  type: integer
+                conditions:
+                  # Mapped to Java type io.kroxylicious.kubernetes.api.common.Condition
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      lastTransitionTime:
+                        description: |
+                          lastTransitionTime is the last time the condition transitioned from one status to another. 
+                          This should be when the underlying condition changed. 
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: |
+                          message is a human readable message indicating details about the transition. 
+                          This may be an empty string.
+                        type: string
+                      observedGeneration:
+                        description: |
+                          observedGeneration represents the .metadata.generation that the condition was set based upon. 
+                          For instance, if .metadata.generation is currently 12, but the 
+                          .status.conditions[x].observedGeneration is 9, the condition is out of date with 
+                          respect to the current state of the instance.
+                        type: integer
+                      reason:
+                        description: |
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition. 
+                          Producers of specific condition types may define expected values and meanings for this field, 
+                          and whether the values are considered a guaranteed API. 
+                          The value should be a CamelCase string. 
+                          This field may not be empty.
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum: [ "True", "False", "Unknown" ]
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        type: string

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerIT.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.time.Clock;
+import java.time.Duration;
+
+import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
+
+import io.kroxylicious.kubernetes.api.common.Condition;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngressBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
+import io.kroxylicious.kubernetes.operator.assertj.VirtualKafkaClusterStatusAssert;
+
+import static io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyingressspec.ClusterIP.Protocol.TCP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@EnabledIf(value = "io.kroxylicious.kubernetes.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
+class VirtualKafkaClusterReconcilerIT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProxyIngressReconcilerIT.class);
+
+    private static final String PROXY_A = "proxy-a";
+    private static final String PROXY_B = "proxy-b";
+    private static final String CLUSTER_BAR = "bar-cluster";
+    private static final String INGRESS_D = "ingress-d";
+    private static final String SERVICE_H = "service-h";
+
+    private KubernetesClient client;
+    private static final ConditionFactory AWAIT = await().timeout(Duration.ofSeconds(60));
+
+    // the initial operator image pull can take a long time and interfere with the tests
+    @BeforeAll
+    static void preloadOperandImage() {
+        OperatorTestUtils.preloadOperandImage();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        client = OperatorTestUtils.kubeClient();
+    }
+
+    @RegisterExtension
+    LocallyRunOperatorExtension extension = LocallyRunOperatorExtension.builder()
+            .withReconciler(new VirtualKafkaClusterReconciler(Clock.systemUTC()))
+            .withKubernetesClient(client)
+            .withAdditionalCustomResourceDefinition(KafkaProxy.class)
+            .withAdditionalCustomResourceDefinition(KafkaProxyIngress.class)
+            .withAdditionalCustomResourceDefinition(KafkaService.class)
+            .waitForNamespaceDeletion(true)
+            .withConfigurationService(x -> x.withCloseClientOnStop(false))
+            .build();
+
+    @AfterEach
+    void stopOperator() {
+        extension.getOperator().stop();
+        LOGGER.atInfo().log("Test finished");
+    }
+
+    @Test
+    void shouldNotResolveWhileProxyInitiallyAbsent() {
+        // Given
+        extension.create(clusterIpIngress(INGRESS_D, PROXY_A));
+        extension.create(kafkaService(SERVICE_H));
+
+        // When
+        VirtualKafkaCluster clusterBar = extension.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H));
+
+        // Then
+        assertClusterStatusResolvedRefs(clusterBar, Condition.Status.FALSE);
+
+        // And When
+        extension.create(kafkaProxy(PROXY_A));
+
+        // Then
+        assertClusterStatusResolvedRefs(clusterBar, Condition.Status.TRUE);
+    }
+
+    @Test
+    void shouldResolveWhenProxyInitiallyPresent() {
+        // Given
+        extension.create(kafkaProxy(PROXY_A));
+        extension.create(clusterIpIngress(INGRESS_D, PROXY_A));
+        extension.create(kafkaService(SERVICE_H));
+
+        // When
+        VirtualKafkaCluster clusterBar = extension.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H));
+
+        // Then
+        assertClusterStatusResolvedRefs(clusterBar, Condition.Status.TRUE);
+    }
+
+    @Test
+    void shouldNotResolveWhenProxyDeleted() {
+        // Given
+        KafkaProxy proxy = extension.create(kafkaProxy(PROXY_A));
+        extension.create(clusterIpIngress(INGRESS_D, PROXY_A));
+        extension.create(kafkaService(SERVICE_H));
+        VirtualKafkaCluster clusterBar = extension.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H));
+        assertClusterStatusResolvedRefs(clusterBar, Condition.Status.TRUE);
+
+        // When
+        extension.delete(proxy);
+
+        // Then
+        assertClusterStatusResolvedRefs(clusterBar, Condition.Status.FALSE);
+    }
+
+    private VirtualKafkaCluster cluster(String clusterName, String proxyName, String ingressName, String serviceName) {
+        // @formatter:off
+        return new VirtualKafkaClusterBuilder()
+                .withNewMetadata()
+                    .withName(clusterName)
+                .endMetadata()
+                .withNewSpec()
+                    .withNewProxyRef()
+                        .withName(proxyName)
+                    .endProxyRef()
+                    .addNewIngressRef()
+                        .withName(ingressName)
+                    .endIngressRef()
+                    .withNewTargetKafkaServiceRef()
+                        .withName(serviceName)
+                    .endTargetKafkaServiceRef()
+                .endSpec()
+                .build();
+        // @formatter:on
+    }
+
+    private void assertClusterStatusResolvedRefs(VirtualKafkaCluster cr, Condition.Status conditionStatus) {
+        AWAIT.alias("ClusterStatusResolvedRefs").untilAsserted(() -> {
+            var vkc = extension.resources(VirtualKafkaCluster.class)
+                    .withName(ResourcesUtil.name(cr)).get();
+            assertThat(vkc.getStatus()).isNotNull();
+            VirtualKafkaClusterStatusAssert
+                    .assertThat(vkc.getStatus())
+                    .hasObservedGenerationInSyncWithMetadataOf(vkc)
+                    .singleCondition()
+                    .hasType(Condition.Type.ResolvedRefs)
+                    .hasStatus(conditionStatus)
+                    .hasObservedGenerationInSyncWithMetadataOf(vkc);
+        });
+    }
+
+    KafkaProxy kafkaProxy(String name) {
+        // @formatter:off
+        return new KafkaProxyBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                .endMetadata()
+                .build();
+        // @formatter:on
+    }
+
+    private KafkaProxyIngress clusterIpIngress(String ingressName, String proxyName) {
+        // @formatter:off
+        return new KafkaProxyIngressBuilder()
+                .withNewMetadata()
+                    .withName(ingressName)
+                .endMetadata()
+                .withNewSpec()
+                    .withNewClusterIP()
+                        .withProtocol(TCP)
+                    .endClusterIP()
+                    .withNewProxyRef()
+                        .withName(proxyName)
+                    .endProxyRef()
+                .endSpec()
+                .build();
+        // @formatter:on
+    }
+
+    private static KafkaService kafkaService(String name) {
+        // @formatter:off
+        return new KafkaServiceBuilder()
+                .withNewMetadata()
+                .withName(name)
+                .endMetadata()
+                .editOrNewSpec()
+                .withBootstrapServers("foo.bootstrap:9090")
+                .endSpec()
+                .build();
+        // @formatter:on
+    }
+
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerIT.java
@@ -43,7 +43,6 @@ class VirtualKafkaClusterReconcilerIT {
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProxyIngressReconcilerIT.class);
 
     private static final String PROXY_A = "proxy-a";
-    private static final String PROXY_B = "proxy-b";
     private static final String CLUSTER_BAR = "bar-cluster";
     private static final String INGRESS_D = "ingress-d";
     private static final String SERVICE_H = "service-h";

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerTest.java
@@ -58,7 +58,7 @@ class VirtualKafkaClusterReconcilerTest {
     // @formatter:on
 
     @Test
-    void shouldSetResolvedRefsToFalseWhenProxyNotFound() throws Exception {
+    void shouldSetResolvedRefsToFalseWhenProxyNotFound() {
         // given
         Clock z = Clock.fixed(Instant.EPOCH, ZoneId.of("Z"));
         var reconciler = new VirtualKafkaClusterReconciler(z);
@@ -83,7 +83,7 @@ class VirtualKafkaClusterReconcilerTest {
     }
 
     @Test
-    void shouldSetResolvedRefsToTrueWhenProxyFound() throws Exception {
+    void shouldSetResolvedRefsToTrueWhenProxyFound() {
         // given
         Clock z = Clock.fixed(Instant.EPOCH, ZoneId.of("Z"));
         var reconciler = new VirtualKafkaClusterReconciler(z);

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
+import io.kroxylicious.kubernetes.operator.assertj.VirtualKafkaClusterStatusAssert;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class VirtualKafkaClusterReconcilerTest {
+
+    // @formatter:off
+    public static final VirtualKafkaCluster CLUSTER = new VirtualKafkaClusterBuilder()
+            .withNewMetadata()
+                .withName("foo")
+                .withGeneration(42L)
+            .endMetadata()
+            .withNewSpec()
+                .withNewProxyRef()
+                    .withName("my-proxy")
+                .endProxyRef()
+                .addNewIngressRef()
+                    .withName("my-ingress")
+                .endIngressRef()
+                .withNewTargetKafkaServiceRef()
+                    .withName("my-kafka")
+                .endTargetKafkaServiceRef()
+            .endSpec()
+            .build();
+
+    public static final KafkaProxy PROXY = new KafkaProxyBuilder()
+            .withNewMetadata()
+                .withName("my-proxy")
+                .withGeneration(101L)
+            .endMetadata()
+            .withNewSpec()
+            .endSpec()
+            .build();
+    // @formatter:on
+
+    @Test
+    void shouldSetResolvedRefsToFalseWhenProxyNotFound() throws Exception {
+        // given
+        Clock z = Clock.fixed(Instant.EPOCH, ZoneId.of("Z"));
+        var reconciler = new VirtualKafkaClusterReconciler(z);
+
+        Context<VirtualKafkaCluster> context = mock(Context.class);
+        when(context.getSecondaryResource(KafkaProxy.class, VirtualKafkaClusterReconciler.PROXY_EVENT_SOURCE_NAME)).thenReturn(Optional.empty());
+
+        // when
+        var update = reconciler.reconcile(CLUSTER, context);
+
+        // then
+        assertThat(update).isNotNull();
+        assertThat(update.isPatchStatus()).isTrue();
+        assertThat(update.getResource()).isPresent();
+        VirtualKafkaClusterStatusAssert.assertThat(update.getResource().get().getStatus())
+                .hasObservedGenerationInSyncWithMetadataOf(CLUSTER)
+                .singleCondition()
+                .hasObservedGenerationInSyncWithMetadataOf(CLUSTER)
+                .isResolvedRefsFalse("spec.proxyRef.name", "KafkaProxy not found")
+                .hasLastTransitionTime(ZonedDateTime.ofInstant(z.instant(), z.getZone()));
+
+    }
+
+    @Test
+    void shouldSetResolvedRefsToTrueWhenProxyFound() throws Exception {
+        // given
+        Clock z = Clock.fixed(Instant.EPOCH, ZoneId.of("Z"));
+        var reconciler = new VirtualKafkaClusterReconciler(z);
+
+        Context<VirtualKafkaCluster> context = mock(Context.class);
+        when(context.getSecondaryResource(KafkaProxy.class, VirtualKafkaClusterReconciler.PROXY_EVENT_SOURCE_NAME)).thenReturn(Optional.of(PROXY));
+
+        // when
+        var update = reconciler.reconcile(CLUSTER, context);
+
+        // then
+        assertThat(update).isNotNull();
+        assertThat(update.isPatchStatus()).isTrue();
+        assertThat(update.getResource()).isPresent();
+        VirtualKafkaClusterStatusAssert.assertThat(update.getResource().get().getStatus())
+                .hasObservedGenerationInSyncWithMetadataOf(CLUSTER)
+                .singleCondition()
+                .hasObservedGenerationInSyncWithMetadataOf(CLUSTER)
+                .isResolvedRefsTrue()
+                .hasLastTransitionTime(ZonedDateTime.ofInstant(z.instant(), z.getZone()));
+
+    }
+
+    @Test
+    void shouldSetResolvedRefsToUnknown() {
+        // given
+        Clock z = Clock.fixed(Instant.EPOCH, ZoneId.of("Z"));
+        var reconciler = new VirtualKafkaClusterReconciler(z);
+
+        Context<VirtualKafkaCluster> context = mock(Context.class);
+
+        // when
+        var update = reconciler.updateErrorStatus(CLUSTER, context, new RuntimeException("Boom!"));
+
+        // then
+        assertThat(update).isNotNull();
+        assertThat(update.getResource()).isPresent();
+        VirtualKafkaClusterStatusAssert.assertThat(update.getResource().get().getStatus())
+                .hasObservedGenerationInSyncWithMetadataOf(CLUSTER)
+                .singleCondition()
+                .hasObservedGenerationInSyncWithMetadataOf(CLUSTER)
+                .isResolvedRefsUnknown("java.lang.RuntimeException", "Boom!")
+                .hasLastTransitionTime(ZonedDateTime.ofInstant(z.instant(), z.getZone()));
+
+    }
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/VirtualKafkaClusterStatusAssert.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/VirtualKafkaClusterStatusAssert.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator.assertj;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterStatus;
+
+public class VirtualKafkaClusterStatusAssert extends AbstractStatusAssert<VirtualKafkaClusterStatus, VirtualKafkaClusterStatusAssert> {
+    protected VirtualKafkaClusterStatusAssert(
+                                              VirtualKafkaClusterStatus o) {
+        super(o, VirtualKafkaClusterStatusAssert.class,
+                VirtualKafkaClusterStatus::getObservedGeneration,
+                VirtualKafkaClusterStatus::getConditions);
+    }
+
+    public static VirtualKafkaClusterStatusAssert assertThat(VirtualKafkaClusterStatus actual) {
+        return new VirtualKafkaClusterStatusAssert(actual);
+    }
+
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Add `VirtualKafkaClusterReconciler`. Currently this just sets `ResolvedRefs` in response to the existence, or not, of the `KafkaProxy`. To help keep review manageable I propose that we take account of ingress and service ref resolution in a later PR, though I don't think either should be difficult to add.

