### PR TITLE
[Operator Reconciliation ITs] Run Operator under RBAC restrictions.

### DIFF
--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -245,6 +245,11 @@
             <artifactId>kubernetes-model-apiextensions</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-rbac</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProtocolFilterReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProtocolFilterReconcilerIT.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.kubernetes.operator;
 
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.Base64;
@@ -54,7 +55,8 @@ class KafkaProtocolFilterReconcilerIT {
     }
 
     @RegisterExtension
-    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler();
+    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler(Path.of("install"), "*.ClusterRole.kroxylicious-operator-filter-generic.yaml",
+            "*.ClusterRole.kroxylicious-operator-watched.yaml");
 
     @RegisterExtension
     @SuppressWarnings("JUnitMalformedDeclaration") // The beforeAll and beforeEach have the same effect so we can use it as an instance field.

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProtocolFilterReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProtocolFilterReconcilerIT.java
@@ -54,7 +54,7 @@ class KafkaProtocolFilterReconcilerIT {
     }
 
     @RegisterExtension
-    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler("install", "*.ClusterRole.kroxylicious-operator-watched.yaml");
+    static LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler("install", "*.ClusterRole.kroxylicious-operator-watched.yaml");
 
     @RegisterExtension
     @SuppressWarnings("JUnitMalformedDeclaration") // The beforeAll and beforeEach have the same effect so we can use it as an instance field.

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProtocolFilterReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProtocolFilterReconcilerIT.java
@@ -7,7 +7,6 @@
 package io.kroxylicious.kubernetes.operator;
 
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.Base64;
@@ -55,7 +54,7 @@ class KafkaProtocolFilterReconcilerIT {
     }
 
     @RegisterExtension
-    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler(Path.of("install"), "*.ClusterRole.kroxylicious-operator-watched.yaml");
+    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler("install", "*.ClusterRole.kroxylicious-operator-watched.yaml");
 
     @RegisterExtension
     @SuppressWarnings("JUnitMalformedDeclaration") // The beforeAll and beforeEach have the same effect so we can use it as an instance field.

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProtocolFilterReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProtocolFilterReconcilerIT.java
@@ -55,8 +55,7 @@ class KafkaProtocolFilterReconcilerIT {
     }
 
     @RegisterExtension
-    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler(Path.of("install"), "*.ClusterRole.kroxylicious-operator-filter-generic.yaml",
-            "*.ClusterRole.kroxylicious-operator-watched.yaml");
+    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler(Path.of("install"), "*.ClusterRole.kroxylicious-operator-watched.yaml");
 
     @RegisterExtension
     @SuppressWarnings("JUnitMalformedDeclaration") // The beforeAll and beforeEach have the same effect so we can use it as an instance field.

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconcilerIT.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.kubernetes.operator;
 
+import java.nio.file.Path;
 import java.time.Clock;
 import java.time.Duration;
 
@@ -49,7 +50,7 @@ class KafkaProxyIngressReconcilerIT {
     }
 
     @RegisterExtension
-    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler();
+    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler(Path.of("install"), "*.ClusterRole.kroxylicious-operator-watched.yaml");
 
     @RegisterExtension
     @SuppressWarnings("JUnitMalformedDeclaration") // The beforeAll and beforeEach have the same effect so we can use it as an instance field.

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconcilerIT.java
@@ -6,7 +6,6 @@
 
 package io.kroxylicious.kubernetes.operator;
 
-import java.nio.file.Path;
 import java.time.Clock;
 import java.time.Duration;
 
@@ -50,7 +49,7 @@ class KafkaProxyIngressReconcilerIT {
     }
 
     @RegisterExtension
-    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler(Path.of("install"), "*.ClusterRole.kroxylicious-operator-watched.yaml");
+    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler("install", "*.ClusterRole.kroxylicious-operator-watched.yaml");
 
     @RegisterExtension
     @SuppressWarnings("JUnitMalformedDeclaration") // The beforeAll and beforeEach have the same effect so we can use it as an instance field.

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconcilerIT.java
@@ -49,7 +49,7 @@ class KafkaProxyIngressReconcilerIT {
     }
 
     @RegisterExtension
-    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler("install", "*.ClusterRole.kroxylicious-operator-watched.yaml");
+    static LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler("install", "*.ClusterRole.kroxylicious-operator-watched.yaml");
 
     @RegisterExtension
     @SuppressWarnings("JUnitMalformedDeclaration") // The beforeAll and beforeEach have the same effect so we can use it as an instance field.

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconcilerIT.java
@@ -12,14 +12,12 @@ import java.time.Duration;
 import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 
 import io.kroxylicious.kubernetes.api.common.Condition;
@@ -42,7 +40,6 @@ class KafkaProxyIngressReconcilerIT {
     private static final String PROXY_B = "proxy-b";
     private static final String CLUSTER_BAR_CLUSTERIP_INGRESS = "bar-cluster-ip";
 
-    private KubernetesClient client;
     private static final ConditionFactory AWAIT = await().timeout(Duration.ofSeconds(60));
 
     // the initial operator image pull can take a long time and interfere with the tests
@@ -51,19 +48,19 @@ class KafkaProxyIngressReconcilerIT {
         OperatorTestUtils.preloadOperandImage();
     }
 
-    @BeforeEach
-    void beforeEach() {
-        client = OperatorTestUtils.kubeClient();
-    }
+    @RegisterExtension
+    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler();
 
     @RegisterExtension
+    @SuppressWarnings("JUnitMalformedDeclaration") // The beforeAll and beforeEach have the same effect so we can use it as an instance field.
     LocallyRunOperatorExtension extension = LocallyRunOperatorExtension.builder()
             .withReconciler(new KafkaProxyIngressReconciler(Clock.systemUTC()))
-            .withKubernetesClient(client)
+            .withKubernetesClient(rbacHandler.operatorClient())
             .withAdditionalCustomResourceDefinition(KafkaProxy.class)
             .waitForNamespaceDeletion(true)
             .withConfigurationService(x -> x.withCloseClientOnStop(false))
             .build();
+    private final LocallyRunningOperatorRbacHandler.TestActor testActor = rbacHandler.testActor(extension);
 
     @AfterEach
     void stopOperator() {
@@ -73,37 +70,37 @@ class KafkaProxyIngressReconcilerIT {
 
     @Test
     void testCreateIngressFirst() {
-        KafkaProxyIngress ingressBar = extension.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
+        KafkaProxyIngress ingressBar = testActor.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
         assertIngressStatusResolvedRefs(ingressBar, Condition.Status.FALSE);
-        extension.create(kafkaProxy(PROXY_A));
+        testActor.create(kafkaProxy(PROXY_A));
         assertIngressStatusResolvedRefs(ingressBar, Condition.Status.TRUE);
     }
 
     @Test
     void testCreateProxyFirst() {
-        extension.create(kafkaProxy(PROXY_A));
-        KafkaProxyIngress ingressBar = extension.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
+        testActor.create(kafkaProxy(PROXY_A));
+        KafkaProxyIngress ingressBar = testActor.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
         assertIngressStatusResolvedRefs(ingressBar, Condition.Status.TRUE);
     }
 
     @Test
     void testDeleteProxy() {
-        KafkaProxy proxy = extension.create(kafkaProxy(PROXY_A));
-        KafkaProxyIngress ingressBar = extension.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
+        KafkaProxy proxy = testActor.create(kafkaProxy(PROXY_A));
+        KafkaProxyIngress ingressBar = testActor.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
         assertIngressStatusResolvedRefs(ingressBar, Condition.Status.TRUE);
 
-        extension.delete(proxy);
+        testActor.delete(proxy);
         assertIngressStatusResolvedRefs(ingressBar, Condition.Status.FALSE);
     }
 
     @Test
     void testSwitchProxy() {
-        extension.create(kafkaProxy(PROXY_A));
-        extension.create(kafkaProxy(PROXY_B));
-        KafkaProxyIngress ingressBar = extension.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
+        testActor.create(kafkaProxy(PROXY_A));
+        testActor.create(kafkaProxy(PROXY_B));
+        KafkaProxyIngress ingressBar = testActor.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
         assertIngressStatusResolvedRefs(ingressBar, Condition.Status.TRUE);
 
-        extension.replace(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_B));
+        testActor.replace(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_B));
         assertIngressStatusResolvedRefs(ingressBar, Condition.Status.TRUE);
     }
 
@@ -115,7 +112,7 @@ class KafkaProxyIngressReconcilerIT {
 
     private void assertIngressStatusResolvedRefs(KafkaProxyIngress cr, Condition.Status conditionStatus) {
         AWAIT.alias("IngressStatusResolvedRefs").untilAsserted(() -> {
-            var kpi = extension.resources(KafkaProxyIngress.class)
+            var kpi = testActor.resources(KafkaProxyIngress.class)
                     .withName(ResourcesUtil.name(cr)).get();
             assertThat(kpi.getStatus()).isNotNull();
             KafkaProxyIngressStatusAssert

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.kubernetes.operator;
 
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -75,7 +76,7 @@ class KafkaProxyReconcilerIT {
     }
 
     @RegisterExtension
-    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler();
+    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler(Path.of("install"), "*.ClusterRole.*.yaml");
 
     @RegisterExtension
     @SuppressWarnings("JUnitMalformedDeclaration") // The beforeAll and beforeEach have the same effect so we can use it as an instance field.

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
@@ -75,7 +75,7 @@ class KafkaProxyReconcilerIT {
     }
 
     @RegisterExtension
-    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler("install", "*.ClusterRole.*.yaml");
+    static LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler("install", "*.ClusterRole.*.yaml");
 
     @RegisterExtension
     @SuppressWarnings("JUnitMalformedDeclaration") // The beforeAll and beforeEach have the same effect so we can use it as an instance field.

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
@@ -6,7 +6,6 @@
 
 package io.kroxylicious.kubernetes.operator;
 
-import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -76,7 +75,7 @@ class KafkaProxyReconcilerIT {
     }
 
     @RegisterExtension
-    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler(Path.of("install"), "*.ClusterRole.*.yaml");
+    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler("install", "*.ClusterRole.*.yaml");
 
     @RegisterExtension
     @SuppressWarnings("JUnitMalformedDeclaration") // The beforeAll and beforeEach have the same effect so we can use it as an instance field.

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaServiceReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaServiceReconcilerIT.java
@@ -6,7 +6,6 @@
 
 package io.kroxylicious.kubernetes.operator;
 
-import java.nio.file.Path;
 import java.time.Clock;
 import java.time.Duration;
 
@@ -37,7 +36,7 @@ class KafkaServiceReconcilerIT {
     private static final ConditionFactory AWAIT = await().timeout(Duration.ofSeconds(60));
 
     @RegisterExtension
-    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler(Path.of("install"), "*.ClusterRole.kroxylicious-operator-watched.yaml");
+    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler("install", "*.ClusterRole.kroxylicious-operator-watched.yaml");
 
     @SuppressWarnings("JUnitMalformedDeclaration") // The beforeAll and beforeEach have the same effect so we can use it as an instance field.
     @RegisterExtension

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaServiceReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaServiceReconcilerIT.java
@@ -12,14 +12,12 @@ import java.time.Duration;
 import org.assertj.core.api.Assertions;
 import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
@@ -35,22 +33,21 @@ class KafkaServiceReconcilerIT {
     private static final String UPDATED_BOOTSTRAP = "bar.bootstrap:9090";
     public static final String SERVICE_A = "service-a";
 
-    private KubernetesClient client;
     private static final ConditionFactory AWAIT = await().timeout(Duration.ofSeconds(60));
 
-    @BeforeEach
-    void beforeEach() {
-        client = OperatorTestUtils.kubeClient();
-    }
+    @RegisterExtension
+    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler();
 
     @SuppressWarnings("JUnitMalformedDeclaration") // The beforeAll and beforeEach have the same effect so we can use it as an instance field.
     @RegisterExtension
     LocallyRunOperatorExtension extension = LocallyRunOperatorExtension.builder()
             .withReconciler(new KafkaServiceReconciler(Clock.systemUTC()))
-            .withKubernetesClient(client)
+            .withKubernetesClient(rbacHandler.operatorClient())
             .waitForNamespaceDeletion(true)
             .withConfigurationService(x -> x.withCloseClientOnStop(false))
             .build();
+
+    private final LocallyRunningOperatorRbacHandler.TestActor testActor = rbacHandler.testActor(extension);
 
     @AfterEach
     void stopOperator() {
@@ -61,15 +58,15 @@ class KafkaServiceReconcilerIT {
     @Test
     void shouldAcceptKafkaService() {
         // Given
-        final KafkaService kafkaService = extension.create(kafkaService(SERVICE_A));
+        final KafkaService kafkaService = testActor.create(kafkaService(SERVICE_A));
         final KafkaService updated = kafkaService.edit().editSpec().withBootstrapServers(UPDATED_BOOTSTRAP).endSpec().build();
 
         // When
-        extension.replace(updated);
+        testActor.replace(updated);
 
         // Then
         AWAIT.untilAsserted(() -> {
-            final KafkaService mycoolkafkaservice = extension.get(KafkaService.class, SERVICE_A);
+            final KafkaService mycoolkafkaservice = testActor.get(KafkaService.class, SERVICE_A);
             Assertions.assertThat(mycoolkafkaservice.getSpec().getBootstrapServers()).isEqualTo(UPDATED_BOOTSTRAP);
             assertThat(mycoolkafkaservice.getStatus())
                     .isNotNull()
@@ -84,11 +81,11 @@ class KafkaServiceReconcilerIT {
         // Given
 
         // When
-        extension.create(new KafkaServiceBuilder().withNewMetadata().withName(SERVICE_A).endMetadata().build());
+        testActor.create(new KafkaServiceBuilder().withNewMetadata().withName(SERVICE_A).endMetadata().build());
 
         // Then
         AWAIT.untilAsserted(() -> {
-            final KafkaService mycoolkafkaservice = extension.get(KafkaService.class, SERVICE_A);
+            final KafkaService mycoolkafkaservice = testActor.get(KafkaService.class, SERVICE_A);
             assertThat(mycoolkafkaservice.getStatus())
                     .isNotNull()
                     .singleCondition()

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaServiceReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaServiceReconcilerIT.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.kubernetes.operator;
 
+import java.nio.file.Path;
 import java.time.Clock;
 import java.time.Duration;
 
@@ -36,7 +37,7 @@ class KafkaServiceReconcilerIT {
     private static final ConditionFactory AWAIT = await().timeout(Duration.ofSeconds(60));
 
     @RegisterExtension
-    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler();
+    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler(Path.of("install"), "*.ClusterRole.kroxylicious-operator-watched.yaml");
 
     @SuppressWarnings("JUnitMalformedDeclaration") // The beforeAll and beforeEach have the same effect so we can use it as an instance field.
     @RegisterExtension

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaServiceReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaServiceReconcilerIT.java
@@ -36,7 +36,7 @@ class KafkaServiceReconcilerIT {
     private static final ConditionFactory AWAIT = await().timeout(Duration.ofSeconds(60));
 
     @RegisterExtension
-    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler("install", "*.ClusterRole.kroxylicious-operator-watched.yaml");
+    static LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler("install", "*.ClusterRole.kroxylicious-operator-watched.yaml");
 
     @SuppressWarnings("JUnitMalformedDeclaration") // The beforeAll and beforeEach have the same effect so we can use it as an instance field.
     @RegisterExtension

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/LocallyRunningOperatorRbacHandler.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/LocallyRunningOperatorRbacHandler.java
@@ -67,7 +67,7 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
     // @formatter:off
     private final ClusterRole frameworkClusterRole = new ClusterRoleBuilder()
             .withNewMetadata()
-                .withName("frameowork-cluster-role")
+                .withName("framework-cluster-role")
             .endMetadata()
             .addNewRule()
                 .addToApiGroups("")
@@ -85,7 +85,7 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
     // @formatter:off
     private final ClusterRoleBinding frameworkClusterRoleBinding = new ClusterRoleBindingBuilder()
             .withNewMetadata()
-                .withName("frameowork-cluster-role-binding")
+                .withName("framework-cluster-role-binding")
             .endMetadata()
             .withNewRoleRef()
                 .withName(frameworkClusterRole.getMetadata().getName())

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/LocallyRunningOperatorRbacHandler.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/LocallyRunningOperatorRbacHandler.java
@@ -105,8 +105,8 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
         try (var adminClient = OperatorTestUtils.kubeClient();
                 var files = Files.list(Path.of("install"))) {
             files.sorted().forEach(resourceFile -> {
-                try {
-                    var list = adminClient.load(new FileInputStream(resourceFile.toString())).items();
+                try (var resourceInputStream = new FileInputStream(resourceFile.toString())) {
+                    var list = adminClient.load(resourceInputStream).items();
                     list.stream()
                             .filter(this::isClusterRoleOrRoleBindingResource)
                             .map(r -> {
@@ -132,7 +132,7 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
                                 adminClient.resource(r).createOr(EditReplacePatchable::patch);
                             });
                 }
-                catch (FileNotFoundException e) {
+                catch (IOException e) {
                     throw new UncheckedIOException("failed to install cluster resources " + resourceFile, e);
                 }
             });

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/LocallyRunningOperatorRbacHandler.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/LocallyRunningOperatorRbacHandler.java
@@ -201,7 +201,7 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
 
             @NonNull
             public <T extends HasMetadata> T replace(@NonNull T resource) {
-                return testActorClient.resource(resource).inNamespace(operatorExtension.getNamespace()).replace();
+                return testActorClient.resource(resource).inNamespace(operatorExtension.getNamespace()).update();
             }
 
             @Override

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/LocallyRunningOperatorRbacHandler.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/LocallyRunningOperatorRbacHandler.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBindingBuilder;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.dsl.EditReplacePatchable;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.javaoperatorsdk.operator.junit.AbstractOperatorExtension;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Designed to cooperate with {@link io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension}
+ * so that the operator runs locally with role based access restrictions as close to that it will
+ * have when deployed to Kubernetes for real.
+ * <br/>
+ * Register this extension before LocallyRunOperatorExtension, passing LocallyRunOperatorExtension
+ * the kubernetes client returned by {@link #operatorClient}.  This client will use a principal
+ * which has been configured in Kubernetes to have the same RBAC rights as the operator will use
+ * in production.
+ * <br/>
+ * For the test's interactions with Kubernetes, where more privileges are required, use the operations
+ * exposed by {@link #testActor(AbstractOperatorExtension)}.
+ *
+ */
+public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, AfterEachCallback {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LocallyRunningOperatorRbacHandler.class);
+
+    private final String impersonatedUser = UUID.randomUUID().toString();
+
+    @AutoClose
+    private final KubernetesClient operatorClient = OperatorTestUtils.kubeClient(
+            new KubernetesClientBuilder().editOrNewConfig().withImpersonateUsername(impersonatedUser).endConfig());
+
+    @AutoClose
+    private final KubernetesClient testActorClient = OperatorTestUtils.kubeClient();
+
+    // @formatter:off
+    private final ClusterRole frameworkClusterRole = new ClusterRoleBuilder()
+            .withNewMetadata()
+                .withName("frameowork-cluster-role")
+            .endMetadata()
+            .addNewRule()
+                .addToApiGroups("")
+                .addToVerbs("get", "create", "delete", "patch")
+                .addToResources("namespaces")
+            .endRule()
+            .addNewRule()
+                .addToApiGroups("apiextensions.k8s.io")
+                .addToVerbs("get", "list", "watch", "create", "delete", "patch", "delete")
+                .addToResources("customresourcedefinitions")
+                .endRule()
+            .build();
+    // @formatter:on
+
+    // @formatter:off
+    private final ClusterRoleBinding frameworkClusterRoleBinding = new ClusterRoleBindingBuilder()
+            .withNewMetadata()
+                .withName("frameowork-cluster-role-binding")
+            .endMetadata()
+            .withNewRoleRef()
+                .withName(frameworkClusterRole.getMetadata().getName())
+                .withKind(frameworkClusterRole.getKind())
+                .withApiGroup("rbac.authorization.k8s.io")
+            .endRoleRef()
+            .addNewSubject()
+                .withName(impersonatedUser)
+                .withKind("User")
+                .withApiGroup("rbac.authorization.k8s.io")
+            .endSubject()
+            .build();
+    // @formatter:on
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        try (var adminClient = OperatorTestUtils.kubeClient();
+                var files = Files.list(Path.of("install"))) {
+            files.sorted().forEach(resourceFile -> {
+                try {
+                    var list = adminClient.load(new FileInputStream(resourceFile.toString())).items();
+                    list.stream()
+                            .filter(this::isClusterRoleOrRoleBindingResource)
+                            .map(r -> {
+                                // We need to rewrite the RBAC so that rather than being in terms
+                                // of a ServiceAccount, they are in terms of our impersonating user.
+                                if (r instanceof ClusterRoleBinding crb) {
+                                    crb.getSubjects().stream()
+                                            .filter(s -> s.getKind().equals("ServiceAccount"))
+                                            .forEach(s -> {
+                                                var originalUser = s.getName();
+                                                s.setKind("User");
+                                                s.setNamespace(null);
+                                                s.setName(impersonatedUser);
+                                                s.setApiGroup("rbac.authorization.k8s.io");
+                                                LOGGER.trace("Updated cluster role binding for {} to match impersonated user {}", originalUser,
+                                                        impersonatedUser);
+                                            });
+                                }
+                                return r;
+                            })
+                            .forEach(r -> {
+                                LOGGER.trace("Creating/patching: {} from {}", r.getMetadata().getName(), resourceFile);
+                                adminClient.resource(r).createOr(EditReplacePatchable::patch);
+                            });
+                }
+                catch (FileNotFoundException e) {
+                    throw new UncheckedIOException("failed to install cluster resources " + resourceFile, e);
+                }
+            });
+
+            // The test framework itself needs these roles.
+            adminClient.resource(frameworkClusterRole).createOr(EditReplacePatchable::patch);
+            adminClient.resource(frameworkClusterRoleBinding).createOr(EditReplacePatchable::patch);
+
+            LOGGER.info("Applied Operator RBAC rules rewritten in terms of user {}.", impersonatedUser);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        try (var adminClient = OperatorTestUtils.kubeClient();
+                var files = Files.list(Path.of("install"))) {
+            files.forEach(resourceFile -> {
+                try {
+                    adminClient.load(new FileInputStream(resourceFile.toString())).items()
+                            .stream().filter(this::isClusterRoleOrRoleBindingResource)
+                            .forEach(r -> {
+                                LOGGER.trace("Deleting: {} from {}", r.getMetadata().getName(), resourceFile);
+                                adminClient.resource(r).delete();
+                            });
+                }
+                catch (FileNotFoundException e) {
+                    throw new UncheckedIOException("failed to uninstall cluster resource: " + resourceFile, e);
+                }
+            });
+
+            adminClient.resource(frameworkClusterRole).delete();
+            adminClient.resource(frameworkClusterRoleBinding).delete();
+        }
+
+    }
+
+    @NonNull
+    public KubernetesClient operatorClient() {
+        return operatorClient;
+    }
+
+    @NonNull
+    public KubernetesClient testActorClient() {
+        return testActorClient;
+    }
+
+    @NonNull
+    public TestActor testActor(@NonNull AbstractOperatorExtension operatorExtension) {
+        return new TestActor() {
+
+            @NonNull
+            @Override
+            public <T extends HasMetadata> T create(@NonNull T resource) {
+                return testActorClient.resource(resource).inNamespace(operatorExtension.getNamespace()).create();
+            }
+
+            @Nullable
+            @Override
+            public <T extends HasMetadata> T get(@NonNull Class<T> type, @NonNull String name) {
+                return testActorClient.resources(type).inNamespace(operatorExtension.getNamespace()).withName(name).get();
+            }
+
+            @NonNull
+            public <T extends HasMetadata> T replace(@NonNull T resource) {
+                return testActorClient.resource(resource).inNamespace(operatorExtension.getNamespace()).replace();
+            }
+
+            @Override
+            public <T extends HasMetadata> boolean delete(@NonNull T resource) {
+                var res = testActorClient.resource(resource).inNamespace(operatorExtension.getNamespace()).delete();
+                return res.size() == 1 && res.get(0).getCauses().isEmpty();
+            }
+
+            @NonNull
+            @Override
+            public <T extends HasMetadata> NonNamespaceOperation<T, KubernetesResourceList<T>, Resource<T>> resources(
+                                                                                                                      Class<T> type) {
+                return testActorClient.resources(type).inNamespace(operatorExtension.getNamespace());
+            }
+
+        };
+    }
+
+    private boolean isClusterRoleOrRoleBindingResource(HasMetadata r) {
+        return r instanceof ClusterRoleBinding || r instanceof ClusterRole;
+    }
+
+    public interface TestActor {
+        @NonNull
+        <T extends HasMetadata> T create(@NonNull T resource);
+
+        @Nullable
+        <T extends HasMetadata> T get(@NonNull Class<T> type, @NonNull String name);
+
+        @NonNull
+        <T extends HasMetadata> T replace(@NonNull T resource);
+
+        <T extends HasMetadata> boolean delete(@NonNull T resource);
+
+        @NonNull
+        <T extends HasMetadata> NonNamespaceOperation<T, KubernetesResourceList<T>, Resource<T>> resources(@NonNull Class<T> type);
+    }
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
@@ -59,23 +59,21 @@ class OperatorMainIT {
 
     @BeforeAll
     static void beforeAll() {
-        LocallyRunOperatorExtension.applyCrd(KafkaProtocolFilter.class, OperatorTestUtils.kubeClientIfAvailable());
-        LocallyRunOperatorExtension.applyCrd(KafkaProxy.class, OperatorTestUtils.kubeClientIfAvailable());
-        LocallyRunOperatorExtension.applyCrd(VirtualKafkaCluster.class, OperatorTestUtils.kubeClientIfAvailable());
-        LocallyRunOperatorExtension.applyCrd(KafkaService.class, OperatorTestUtils.kubeClientIfAvailable());
-        LocallyRunOperatorExtension.applyCrd(KafkaProxyIngress.class, OperatorTestUtils.kubeClientIfAvailable());
+        LocallyRunOperatorExtension.applyCrd(KafkaProtocolFilter.class, OperatorTestUtils.kubeClient());
+        LocallyRunOperatorExtension.applyCrd(KafkaProxy.class, OperatorTestUtils.kubeClient());
+        LocallyRunOperatorExtension.applyCrd(VirtualKafkaCluster.class, OperatorTestUtils.kubeClient());
+        LocallyRunOperatorExtension.applyCrd(KafkaService.class, OperatorTestUtils.kubeClient());
+        LocallyRunOperatorExtension.applyCrd(KafkaProxyIngress.class, OperatorTestUtils.kubeClient());
     }
 
     @AfterAll
     static void afterAll() {
-        try (KubernetesClient kubernetesClient = OperatorTestUtils.kubeClientIfAvailable()) {
-            if (kubernetesClient != null) {
-                kubernetesClient.resources(KafkaProtocolFilter.class).delete();
-                kubernetesClient.resources(KafkaProxyIngress.class).delete();
-                kubernetesClient.resources(KafkaProxy.class).delete();
-                kubernetesClient.resources(VirtualKafkaCluster.class).delete();
-                kubernetesClient.resources(KafkaService.class).delete();
-            }
+        try (KubernetesClient kubernetesClient = OperatorTestUtils.kubeClient()) {
+            kubernetesClient.resources(KafkaProtocolFilter.class).delete();
+            kubernetesClient.resources(KafkaProxyIngress.class).delete();
+            kubernetesClient.resources(KafkaProxy.class).delete();
+            kubernetesClient.resources(VirtualKafkaCluster.class).delete();
+            kubernetesClient.resources(KafkaService.class).delete();
         }
     }
 
@@ -88,7 +86,7 @@ class OperatorMainIT {
     @AfterEach
     void afterEach() {
         if (kafkaProxy != null) {
-            final KubernetesClient kubernetesClient = Objects.requireNonNull(OperatorTestUtils.kubeClientIfAvailable());
+            final KubernetesClient kubernetesClient = Objects.requireNonNull(OperatorTestUtils.kubeClient());
             kubernetesClient.resource(kafkaProxy).delete();
             kubernetesClient.resource(clusterRef(CLUSTER_FOO_REF, CLUSTER_FOO_BOOTSTRAP)).delete();
             kubernetesClient.resource(clusterRef(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)).delete();
@@ -235,7 +233,7 @@ class OperatorMainIT {
     }
 
     private KafkaProxy createProxyInstance(KafkaProxyBuilder proxyBuilder) {
-        final KubernetesClient kubernetesClient = Objects.requireNonNull(OperatorTestUtils.kubeClientIfAvailable());
+        final KubernetesClient kubernetesClient = Objects.requireNonNull(OperatorTestUtils.kubeClient());
         kubernetesClient.resource(clusterRef(CLUSTER_FOO_REF, CLUSTER_FOO_BOOTSTRAP)).create();
         kubernetesClient.resource(clusterRef(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)).create();
         return kubernetesClient.resource(proxyBuilder.build()).create();

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorTestUtils.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorTestUtils.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.readiness.Readiness;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,31 +37,26 @@ public class OperatorTestUtils {
             .withConnectionTimeout(500)
             .endConfig();
 
-    static @Nullable KubernetesClient kubeClientIfAvailable() {
-        return kubeClientIfAvailable(new KubernetesClientBuilder());
+    static @NonNull KubernetesClient kubeClient() {
+        return kubeClient(new KubernetesClientBuilder());
     }
 
-    static @NonNull KubernetesClient kubeClient() {
-        KubernetesClient kubernetesClient = kubeClientIfAvailable(new KubernetesClientBuilder());
+    static @NonNull KubernetesClient kubeClient(KubernetesClientBuilder kubernetesClientBuilder) {
+        KubernetesClient kubernetesClient = kubernetesClientBuilder.build();
         assertThat(kubernetesClient).isNotNull();
         return kubernetesClient;
     }
 
-    static @Nullable KubernetesClient kubeClientIfAvailable(KubernetesClientBuilder kubernetesClientBuilder) {
-        var client = kubernetesClientBuilder.build();
+    static boolean isKubeClientAvailable() {
+        KubernetesClient result;
+        var client1 = PRESENCE_PROBING_KUBE_CLIENT_BUILD.build();
         try {
-            client.namespaces().list();
-            return client;
+            client1.namespaces().list();
+            return true;
         }
         catch (KubernetesClientException e) {
-            client.close();
-            return null;
-        }
-    }
-
-    static boolean isKubeClientAvailable() {
-        try (var client = kubeClientIfAvailable(PRESENCE_PROBING_KUBE_CLIENT_BUILD)) {
-            return client != null;
+            client1.close();
+            return false;
         }
     }
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorTestUtils.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorTestUtils.java
@@ -48,14 +48,13 @@ public class OperatorTestUtils {
     }
 
     static boolean isKubeClientAvailable() {
-        KubernetesClient result;
-        var client1 = PRESENCE_PROBING_KUBE_CLIENT_BUILD.build();
+        var client = PRESENCE_PROBING_KUBE_CLIENT_BUILD.build();
         try {
-            client1.namespaces().list();
+            client.namespaces().list();
             return true;
         }
         catch (KubernetesClientException e) {
-            client1.close();
+            client.close();
             return false;
         }
     }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerIT.java
@@ -6,7 +6,6 @@
 
 package io.kroxylicious.kubernetes.operator;
 
-import java.nio.file.Path;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.Map;
@@ -56,7 +55,7 @@ class VirtualKafkaClusterReconcilerIT {
     private static final ConditionFactory AWAIT = await().timeout(Duration.ofSeconds(60));
 
     @RegisterExtension
-    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler(Path.of("install"), "*.ClusterRole*.yaml");
+    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler("install", "*.ClusterRole*.yaml");
 
     @RegisterExtension
     LocallyRunOperatorExtension extension = LocallyRunOperatorExtension.builder()

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerIT.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.kubernetes.operator;
 
+import java.nio.file.Path;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.Map;
@@ -55,7 +56,7 @@ class VirtualKafkaClusterReconcilerIT {
     private static final ConditionFactory AWAIT = await().timeout(Duration.ofSeconds(60));
 
     @RegisterExtension
-    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler();
+    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler(Path.of("install"), "*.ClusterRole*.yaml");
 
     @RegisterExtension
     LocallyRunOperatorExtension extension = LocallyRunOperatorExtension.builder()

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerIT.java
@@ -55,7 +55,7 @@ class VirtualKafkaClusterReconcilerIT {
     private static final ConditionFactory AWAIT = await().timeout(Duration.ofSeconds(60));
 
     @RegisterExtension
-    LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler("install", "*.ClusterRole*.yaml");
+    static LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler("install", "*.ClusterRole*.yaml");
 
     @RegisterExtension
     LocallyRunOperatorExtension extension = LocallyRunOperatorExtension.builder()


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Change Reconciliation IT tests so that they run under the same RBAC restrictions as it will ultimately run
under when deployed to Kubernetes.

why: it was too easy for us to refactor the operator, without adjusting the RBAC rules.  This would have got to be an irritating waste of time. 

With this change, if the RBAC's wrong the tests fail in an obvious way.

<img width="2436" alt="image" src="https://github.com/user-attachments/assets/cc107baa-ce09-4964-83e8-0ec8a8f0cd8b" />


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
