### PR TITLE
Simplify ProxyRpcTest

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="SubjectBodySeparation" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="SubjectBodySeparation" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="SubjectLimit" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="SubjectLimit" enabled="true" level="WARNING" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
   </component>

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ProxyRpcTest.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ProxyRpcTest.java
@@ -47,6 +47,7 @@ import static org.apache.kafka.common.protocol.ApiKeys.METADATA;
 import static org.apache.kafka.common.protocol.ApiKeys.SHARE_ACKNOWLEDGE;
 import static org.apache.kafka.common.protocol.ApiKeys.SHARE_FETCH;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 @ExtendWith(NettyLeakDetectorExtension.class)
 public class ProxyRpcTest {
@@ -117,7 +118,7 @@ public class ProxyRpcTest {
             }
             Request expectedAtMock = createRequestDefinition(apiAndVersion, expected, request);
             ResponsePayload responseJson = createResponseDefinition(apiAndVersion, response);
-            return Arguments.argumentSet(apiKeys.name, responseJson, clientRequest, expectedAtMock, responseJson);
+            return argumentSet(apiAndVersion.keys().name() + "@v" + apiAndVersion.apiVersion(), responseJson, clientRequest, expectedAtMock, responseJson);
         });
     }
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Simplify the wiring of ProxyRpcTest

### Additional Context

I noticed that ProxyRpcTest took 180s to run on my new laptop. So started digging into the test so I simplified the wiring of the test. The slow test run is actually down to https://github.com/nettyplus/netty-leak-detector-junit-extension/issues/32 so this ends up being a small refactor to the test wiring.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
