### PR TITLE
Use maven arch detection.

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
     Copyright Kroxylicious Authors.

--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -101,10 +101,6 @@
             <groupId>io.fabric8</groupId>
             <artifactId>generator-annotations</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.kroxylicious</groupId>
-            <artifactId>kroxylicious-annotations</artifactId>
-        </dependency>
 
         <!-- extraAnnotations requires these additional dependencies -->
         <dependency>

--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -101,6 +101,10 @@
             <groupId>io.fabric8</groupId>
             <artifactId>generator-annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-annotations</artifactId>
+        </dependency>
 
         <!-- extraAnnotations requires these additional dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,9 @@
         <picocli.version>4.7.6</picocli.version>
         <netty.version>4.1.119.Final</netty.version>
         <netty.io_uring.version>0.0.26.Final</netty.io_uring.version>
-        <netty.epoll.classifier>linux-${os.detected.arch}</netty.epoll.classifier>
-        <netty.io_uring.classifier>linux-${os.detected.arch}</netty.io_uring.classifier>
-        <netty.kqueue.classifier>osx-${os.detected.arch}</netty.kqueue.classifier>
+        <netty.epoll.classifier>linux-x86_64</netty.epoll.classifier>
+        <netty.io_uring.classifier>linux-x86_64</netty.io_uring.classifier>
+        <netty.kqueue.classifier>osx-x86_64</netty.kqueue.classifier>
         <assertj-core.version>3.27.3</assertj-core.version>
         <mockito.version>5.16.1</mockito.version>
         <micrometer.version>1.14.5</micrometer.version>
@@ -926,6 +926,19 @@
     </distributionManagement>
 
     <profiles>
+        <profile>
+            <id>aarch64</id>
+            <activation>
+                <os>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <properties>
+                <netty.epoll.classifier>linux-aarch_64</netty.epoll.classifier>
+                <netty.io_uring.classifier>linux-aarch_64</netty.io_uring.classifier>
+                <netty.kqueue.classifier>osx-aarch_64</netty.kqueue.classifier>
+            </properties>
+        </profile>
         <profile>
             <id>qa</id>
             <activation>


### PR DESCRIPTION
Using properties to determine arch seems to be broken in intellij.

### Type of change

- Bugfix

### Description

Fix arch detection when importing into intellij

### Additional Context

Intellij seems to have a boot strapping problem when using properties to determine the arch. 

Note I've left the extension enabled as I think we need it to produce arch specific images.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
