### PR TITLE
Operator: Upstream Node id declaration

### DIFF
--- a/kroxylicious-operator/examples/record-encryption/04.KafkaClusterRef.my-cluster.yaml
+++ b/kroxylicious-operator/examples/record-encryption/04.KafkaClusterRef.my-cluster.yaml
@@ -12,3 +12,6 @@ metadata:
   namespace: my-proxy
 spec:
   bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+  nodeIdRanges:
+    - start: 0
+      end: 2

--- a/kroxylicious-operator/examples/record-transforming/04.KafkaClusterRef.my-cluster.yaml
+++ b/kroxylicious-operator/examples/record-transforming/04.KafkaClusterRef.my-cluster.yaml
@@ -12,3 +12,6 @@ metadata:
   namespace: my-proxy
 spec:
   bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+  nodeIdRanges:
+    - start: 0
+      end: 2

--- a/kroxylicious-operator/examples/record-validation/04.KafkaClusterRef.my-cluster.yaml
+++ b/kroxylicious-operator/examples/record-validation/04.KafkaClusterRef.my-cluster.yaml
@@ -12,3 +12,6 @@ metadata:
   namespace: my-proxy
 spec:
   bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+  nodeIdRanges:
+    - start: 0
+      end: 2

--- a/kroxylicious-operator/examples/simple/03.KafkaClusterRef.my-cluster.yaml
+++ b/kroxylicious-operator/examples/simple/03.KafkaClusterRef.my-cluster.yaml
@@ -12,3 +12,6 @@ metadata:
   namespace: my-proxy
 spec:
   bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+  nodeIdRanges:
+    - start: 0
+      end: 2

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/ingress/Ingresses.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/ingress/Ingresses.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.kubernetes.operator.model.ingress;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -13,9 +14,14 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyingressspec.ClusterIP;
+import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.NodeIdRanges;
+import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.NodeIdRangesBuilder;
 import io.kroxylicious.kubernetes.operator.resolver.ProxyResolutionResult;
 
 class Ingresses {
+
+    public static final List<NodeIdRanges> DEFAULT_NODE_ID_RANGES = List.of(new NodeIdRangesBuilder().withName("default").withStart(0L).withEnd(2L).build());
+
     private Ingresses() {
     }
 
@@ -25,14 +31,16 @@ class Ingresses {
                         ingressRef -> {
                             // skip unresolved ingresses, we are working with VirtualClusters that may have dangling references
                             Optional<KafkaProxyIngress> ingress = resolutionResult.ingress(ingressRef);
-                            return ingress.stream().map(kafkaProxyIngress -> toIngress(primary, cluster, kafkaProxyIngress));
+                            List<NodeIdRanges> nodeIdRanges = resolutionResult.kafkaServiceRef(cluster).map(s -> s.getSpec().getNodeIdRanges())
+                                    .orElse(DEFAULT_NODE_ID_RANGES);
+                            return ingress.stream().map(kafkaProxyIngress -> toIngress(primary, cluster, kafkaProxyIngress, nodeIdRanges));
                         });
     }
 
-    private static IngressDefinition toIngress(KafkaProxy primary, VirtualKafkaCluster cluster, KafkaProxyIngress ingress) {
+    private static IngressDefinition toIngress(KafkaProxy primary, VirtualKafkaCluster cluster, KafkaProxyIngress ingress, List<NodeIdRanges> nodeIdRanges) {
         ClusterIP clusterIP = ingress.getSpec().getClusterIP();
         if (clusterIP != null) {
-            return new ClusterIPIngressDefinition(ingress, cluster, primary);
+            return new ClusterIPIngressDefinition(ingress, cluster, primary, nodeIdRanges);
         }
         else {
             throw new IllegalStateException("ingress must have clusterIP specified");

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
@@ -37,13 +37,39 @@ spec:
               type: object
             spec:
               type: object
-              required: ["bootstrapServers"]
+              required: [ "bootstrapServers" ]
               properties:
                 bootstrapServers:
                   description: Bootstrap servers of the Kafka cluster.
                   type: string
                   minLength: 1
                   pattern: ^(([^:]+:[0-9]{1,5}),)*([^:]+:[0-9]{1,5})$
+                nodeIdRanges:
+                  type: array
+                  minItems: 1
+                  description: |
+                    Declares the ranges of node ids present in the Kafka Cluster this KafkaService refers to. Default 
+                    value is a single range starting with node id 0 and ending with 2 inclusive. Note that if you wish
+                    to expose this cluster using plain (non-TLS) connections it is desirable to use a compact set of
+                    node id ranges, as every node id in every range requires a distinct listening port.
+                    See also: https://kafka.apache.org/documentation/#brokerconfigs_node.id
+                  items:
+                    type: object
+                    required: [ "start", "end" ]
+                    x-kubernetes-validations:
+                      - rule: "self.start <= self.end"
+                        message: "end should be greater than or equal to start"
+                    properties:
+                      name:
+                        description: "the name of this node id range"
+                        type: string
+                        minLength: 1
+                      start:
+                        description: "The first node id in the range"
+                        type: integer
+                      end:
+                        description: "The last node id in the range, inclusive"
+                        type: integer
             status:
               type: object
               properties:

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/OperatorAssertions.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/OperatorAssertions.java
@@ -6,12 +6,18 @@
 
 package io.kroxylicious.kubernetes.operator.assertj;
 
+import org.assertj.core.api.InstanceOfAssertFactory;
+
 import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyStatus;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceStatus;
 import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Clusters;
+import io.kroxylicious.proxy.config.Configuration;
 
 public class OperatorAssertions {
+    public static final InstanceOfAssertFactory<?, ? extends ProxyConfigAssert> CONFIGURATION = new InstanceOfAssertFactory<>(Configuration.class,
+            OperatorAssertions::assertThat);
+
     public static KafkaProxyStatusAssert assertThat(KafkaProxyStatus actual) {
         return KafkaProxyStatusAssert.assertThat(actual);
     }
@@ -26,5 +32,9 @@ public class OperatorAssertions {
 
     public static ConditionAssert assertThat(Condition actual) {
         return ConditionAssert.assertThat(actual);
+    }
+
+    public static ProxyConfigAssert assertThat(Configuration actual) {
+        return ProxyConfigAssert.assertThat(actual);
     }
 }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/ProxyConfigAssert.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/ProxyConfigAssert.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator.assertj;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.Assertions;
+
+import io.kroxylicious.proxy.config.Configuration;
+import io.kroxylicious.proxy.config.NamedRange;
+import io.kroxylicious.proxy.config.PortIdentifiesNodeIdentificationStrategy;
+import io.kroxylicious.proxy.config.VirtualCluster;
+import io.kroxylicious.proxy.config.VirtualClusterGateway;
+import io.kroxylicious.proxy.service.HostPort;
+
+import static java.util.stream.Collectors.toSet;
+
+public class ProxyConfigAssert extends AbstractObjectAssert<ProxyConfigAssert, Configuration> {
+    public ProxyConfigAssert(Configuration config) {
+        super(config, ProxyConfigAssert.class);
+    }
+
+    public static ProxyConfigAssert assertThat(Configuration actual) {
+        return new ProxyConfigAssert(actual);
+    }
+
+    public ProxyConfigClusterAssert cluster(String clusterName) {
+        Set<String> names = Optional.ofNullable(this.actual.virtualClusters()).orElse(List.of()).stream().map(VirtualCluster::name).collect(toSet());
+        Assertions.assertThat(names).withFailMessage("proxy config contains no virtual clusters").isNotEmpty()
+                .withFailMessage("proxy config does not contain a virtual cluster named '" + clusterName + "', clusters in config: " + names).contains(clusterName);
+        List<VirtualCluster> list = this.actual.virtualClusters().stream().filter(x -> x.name().equals(clusterName)).toList();
+        Assertions.assertThat(list).hasSize(1);
+        VirtualCluster virtualCluster = list.get(0);
+        return new ProxyConfigClusterAssert(virtualCluster);
+    }
+
+    public static class ProxyConfigClusterAssert extends AbstractObjectAssert<ProxyConfigClusterAssert, VirtualCluster> {
+        public ProxyConfigClusterAssert(VirtualCluster virtualCluster) {
+            super(virtualCluster, ProxyConfigClusterAssert.class);
+        }
+
+        public ProxyConfigGatewayAssert gateway(String gateway) {
+            Set<String> names = this.actual.gateways().stream().map(VirtualClusterGateway::name).collect(toSet());
+            Assertions.assertThat(names).withFailMessage(
+                    "gateways for cluster '" + this.actual.name() + "' does not contain a gateway named '" + gateway + "', gateways in cluster: " + names)
+                    .contains(gateway);
+            List<VirtualClusterGateway> list = this.actual.gateways().stream().filter(x -> x.name().equals(gateway)).toList();
+            Assertions.assertThat(list).hasSize(1);
+            VirtualClusterGateway virtualCluster = list.get(0);
+            return new ProxyConfigGatewayAssert(virtualCluster);
+        }
+    }
+
+    public static class ProxyConfigGatewayAssert extends AbstractObjectAssert<ProxyConfigGatewayAssert, VirtualClusterGateway> {
+
+        public ProxyConfigGatewayAssert(VirtualClusterGateway virtualClusterGateway) {
+            super(virtualClusterGateway, ProxyConfigGatewayAssert.class);
+        }
+
+        public ProxyConfigPortIdentifiesNodeGatewayAssert portIdentifiesNode() {
+            Assertions.assertThat(actual.portIdentifiesNode()).isNotNull();
+            return new ProxyConfigPortIdentifiesNodeGatewayAssert(actual.portIdentifiesNode());
+        }
+
+    }
+
+    public static class ProxyConfigPortIdentifiesNodeGatewayAssert
+            extends AbstractObjectAssert<ProxyConfigPortIdentifiesNodeGatewayAssert, PortIdentifiesNodeIdentificationStrategy> {
+
+        public ProxyConfigPortIdentifiesNodeGatewayAssert(PortIdentifiesNodeIdentificationStrategy virtualClusterGateway) {
+            super(virtualClusterGateway, ProxyConfigPortIdentifiesNodeGatewayAssert.class);
+        }
+
+        public NamedRangeAssert namedRange(String name) {
+            Set<String> names = Optional.ofNullable(this.actual.nodeIdRanges()).orElse(List.of()).stream().map(NamedRange::name).collect(toSet());
+            Assertions.assertThat(names)
+                    .withFailMessage("gateway has no node id ranges configured").isNotEmpty()
+                    .withFailMessage("node id ranges for gateway does not contain range named '" + name + "', ranges in gateway config: " + names)
+                    .contains(name);
+            List<NamedRange> namedRanges = Optional.ofNullable(actual.nodeIdRanges()).orElse(List.of());
+            List<NamedRange> ranges = namedRanges.stream().filter(r -> r.name().equals(name)).toList();
+            Assertions.assertThat(ranges).hasSize(1);
+            NamedRange namedRange = ranges.get(0);
+            return new NamedRangeAssert(namedRange);
+        }
+
+        public ProxyConfigPortIdentifiesNodeGatewayAssert hasBootstrapAddress(HostPort expected) {
+            Assertions.assertThat(actual.bootstrapAddress())
+                    .withFailMessage("expected bootstrap address for gateway: '" + expected + "' but was '" + actual.bootstrapAddress() + "'")
+                    .isEqualTo(expected);
+            return this;
+        }
+
+        public ProxyConfigPortIdentifiesNodeGatewayAssert hasNullNodeStartPort() {
+            Assertions.assertThat(actual.nodeStartPort()).describedAs("node start port").isNull();
+            return this;
+        }
+    }
+
+    public static class NamedRangeAssert extends AbstractObjectAssert<NamedRangeAssert, NamedRange> {
+
+        public NamedRangeAssert(NamedRange namedRange) {
+            super(namedRange, NamedRangeAssert.class);
+        }
+
+        public NamedRangeAssert hasStart(int expected) {
+            Assertions.assertThat(actual.start()).withFailMessage("expected node id range start to be " + expected + " but was " + actual.start()).isEqualTo(expected);
+            return this;
+        }
+
+        public NamedRangeAssert hasEnd(int expected) {
+            Assertions.assertThat(actual.end()).withFailMessage("expected node id range end to be " + expected + " but was " + actual.end()).isEqualTo(expected);
+            return this;
+        }
+
+    }
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/ProxyConfigAssertTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/ProxyConfigAssertTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator.assertj;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.config.Configuration;
+import io.kroxylicious.proxy.config.NamedRange;
+import io.kroxylicious.proxy.config.PortIdentifiesNodeIdentificationStrategy;
+import io.kroxylicious.proxy.config.TargetCluster;
+import io.kroxylicious.proxy.config.VirtualCluster;
+import io.kroxylicious.proxy.config.VirtualClusterGateway;
+import io.kroxylicious.proxy.service.HostPort;
+
+class ProxyConfigAssertTest {
+
+    @Test
+    void virtualClusterWhenNotContainedInConfig() {
+        VirtualClusterGateway virtualClusterGateway = new VirtualClusterGateway("default",
+                new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 9292), null, null, null), null, Optional.empty());
+        VirtualCluster virtualCluster = new VirtualCluster("cluster", new TargetCluster("localhost:9092", Optional.empty()), null, Optional.empty(),
+                List.of(virtualClusterGateway), false,
+                false, List.of());
+        Configuration config = new Configuration(null, null, null, List.of(virtualCluster), List.of(), false, Optional.empty());
+
+        Assertions.assertThatThrownBy(() -> {
+            OperatorAssertions.assertThat(config).cluster("arbitrary");
+        }).hasMessage("proxy config does not contain a virtual cluster named 'arbitrary', clusters in config: [cluster]");
+    }
+
+    @Test
+    void virtualClusterWhenContainedInConfig() {
+        VirtualClusterGateway virtualClusterGateway = new VirtualClusterGateway("default",
+                new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 9292), null, null, null), null, Optional.empty());
+        String clusterName = "cluster";
+        VirtualCluster virtualCluster = new VirtualCluster(clusterName, new TargetCluster("localhost:9092", Optional.empty()), null, Optional.empty(),
+                List.of(virtualClusterGateway), false,
+                false, List.of());
+        Configuration config = new Configuration(null, null, null, List.of(virtualCluster), List.of(), false, Optional.empty());
+
+        ProxyConfigAssert.ProxyConfigClusterAssert cluster = OperatorAssertions.assertThat(config).cluster(clusterName);
+        Assertions.assertThat(cluster.actual()).isNotNull().isSameAs(virtualCluster);
+    }
+
+    @Test
+    void virtualClusterWhenGatewayNotContainedInConfig() {
+        VirtualClusterGateway virtualClusterGateway = new VirtualClusterGateway("default",
+                new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 9292), null, null, null), null, Optional.empty());
+        VirtualCluster virtualCluster = new VirtualCluster("cluster", new TargetCluster("localhost:9092", Optional.empty()), null, Optional.empty(),
+                List.of(virtualClusterGateway), false,
+                false, List.of());
+        ProxyConfigAssert.ProxyConfigClusterAssert proxyConfigClusterAssert = new ProxyConfigAssert.ProxyConfigClusterAssert(virtualCluster);
+        Assertions.assertThatThrownBy(() -> {
+            proxyConfigClusterAssert.gateway("anything");
+        }).hasMessage("gateways for cluster 'cluster' does not contain a gateway named 'anything', gateways in cluster: [default]");
+    }
+
+    @Test
+    void virtualClusterWhenGatewayContainedInConfig() {
+        String gatewayName = "default";
+        VirtualClusterGateway virtualClusterGateway = new VirtualClusterGateway(gatewayName,
+                new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 9292), null, null, null), null, Optional.empty());
+        VirtualCluster virtualCluster = new VirtualCluster("cluster", new TargetCluster("localhost:9092", Optional.empty()), null, Optional.empty(),
+                List.of(virtualClusterGateway), false,
+                false, List.of());
+        ProxyConfigAssert.ProxyConfigClusterAssert proxyConfigClusterAssert = new ProxyConfigAssert.ProxyConfigClusterAssert(virtualCluster);
+        ProxyConfigAssert.ProxyConfigGatewayAssert gatewayAssert = proxyConfigClusterAssert.gateway(gatewayName);
+        Assertions.assertThat(gatewayAssert.actual()).isNotNull().isSameAs(virtualClusterGateway);
+    }
+
+    @Test
+    void portIdentifiesNodeGateway() {
+        PortIdentifiesNodeIdentificationStrategy strategy = new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 9292), null, null, null);
+        VirtualClusterGateway virtualClusterGateway = new VirtualClusterGateway("default",
+                strategy, null, Optional.empty());
+        ProxyConfigAssert.ProxyConfigGatewayAssert gatewayAssert = new ProxyConfigAssert.ProxyConfigGatewayAssert(virtualClusterGateway);
+        ProxyConfigAssert.ProxyConfigPortIdentifiesNodeGatewayAssert portIdentifiesNodeGatewayAssert = gatewayAssert.portIdentifiesNode();
+        Assertions.assertThat(portIdentifiesNodeGatewayAssert.actual()).isNotNull().isSameAs(strategy);
+    }
+
+    @Test
+    void portIdentifiesNodeGatewayBootstrap() {
+        PortIdentifiesNodeIdentificationStrategy strategy = new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 9292), null, null, null);
+        ProxyConfigAssert.ProxyConfigPortIdentifiesNodeGatewayAssert portIdentifiesNodeGatewayAssert = new ProxyConfigAssert.ProxyConfigPortIdentifiesNodeGatewayAssert(
+                strategy);
+        portIdentifiesNodeGatewayAssert.hasBootstrapAddress(new HostPort("localhost", 9292));
+        Assertions.assertThatThrownBy(() -> {
+            portIdentifiesNodeGatewayAssert.hasBootstrapAddress(new HostPort("another", 9392));
+        }).hasMessage("expected bootstrap address for gateway: 'another:9392' but was 'localhost:9292'");
+    }
+
+    @Test
+    void portIdentifiesNodeGatewayNamedRangeNotExist() {
+        PortIdentifiesNodeIdentificationStrategy strategy = new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 9292), null, null, null);
+        ProxyConfigAssert.ProxyConfigPortIdentifiesNodeGatewayAssert portIdentifiesNodeGatewayAssert = new ProxyConfigAssert.ProxyConfigPortIdentifiesNodeGatewayAssert(
+                strategy);
+        Assertions.assertThatThrownBy(() -> {
+            portIdentifiesNodeGatewayAssert.namedRange("notfound");
+        }).hasMessage("gateway has no node id ranges configured");
+    }
+
+    @Test
+    void portIdentifiesNodeGatewayNamedRangeNotFound() {
+        NamedRange range = new NamedRange("range", 1, 3);
+        PortIdentifiesNodeIdentificationStrategy strategy = new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 9292), null, null, List.of(range));
+        ProxyConfigAssert.ProxyConfigPortIdentifiesNodeGatewayAssert portIdentifiesNodeGatewayAssert = new ProxyConfigAssert.ProxyConfigPortIdentifiesNodeGatewayAssert(
+                strategy);
+        Assertions.assertThatThrownBy(() -> {
+            portIdentifiesNodeGatewayAssert.namedRange("notfound");
+        }).hasMessage("node id ranges for gateway does not contain range named 'notfound', ranges in gateway config: [range]");
+    }
+
+    @Test
+    void portIdentifiesNodeGatewayNamedRangeFound() {
+        String rangeName = "range";
+        NamedRange range = new NamedRange(rangeName, 1, 3);
+        PortIdentifiesNodeIdentificationStrategy strategy = new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 9292), null, null, List.of(range));
+        ProxyConfigAssert.ProxyConfigPortIdentifiesNodeGatewayAssert portIdentifiesNodeGatewayAssert = new ProxyConfigAssert.ProxyConfigPortIdentifiesNodeGatewayAssert(
+                strategy);
+        ProxyConfigAssert.NamedRangeAssert namedRangeAssert = portIdentifiesNodeGatewayAssert.namedRange(rangeName);
+        Assertions.assertThat(namedRangeAssert.actual()).isNotNull().isSameAs(range);
+    }
+
+    @Test
+    void namedRangeStart() {
+        NamedRange range = new NamedRange("range", 1, 3);
+        ProxyConfigAssert.NamedRangeAssert namedRangeAssert = new ProxyConfigAssert.NamedRangeAssert(range);
+        namedRangeAssert.hasStart(1);
+        Assertions.assertThatThrownBy(() -> {
+            namedRangeAssert.hasStart(2);
+        }).hasMessage("expected node id range start to be 2 but was 1");
+    }
+
+    @Test
+    void namedRangeEnd() {
+        NamedRange range = new NamedRange("range", 1, 3);
+        ProxyConfigAssert.NamedRangeAssert namedRangeAssert = new ProxyConfigAssert.NamedRangeAssert(range);
+        namedRangeAssert.hasEnd(3);
+        Assertions.assertThatThrownBy(() -> {
+            namedRangeAssert.hasEnd(2);
+        }).hasMessage("expected node id range end to be 2 but was 3");
+    }
+
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/model/ingress/ClusterIPIngressDefinitionTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/model/ingress/ClusterIPIngressDefinitionTest.java
@@ -1,0 +1,397 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator.model.ingress;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.api.model.ServicePortBuilder;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngressBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.NodeIdRanges;
+import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.NodeIdRangesBuilder;
+import io.kroxylicious.proxy.config.NamedRange;
+import io.kroxylicious.proxy.config.VirtualClusterGateway;
+import io.kroxylicious.proxy.service.HostPort;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+class ClusterIPIngressDefinitionTest {
+
+    private static final String INGRESS_NAME = "my-ingress";
+    public static final String CLUSTER_NAME = "my-cluster";
+    public static final String PROXY_NAME = "my-proxy";
+    public static final String NAMESPACE = "my-namespace";
+    private static final KafkaProxyIngress INGRESS = new KafkaProxyIngressBuilder().withNewMetadata().withName(INGRESS_NAME).withNamespace(NAMESPACE).endMetadata()
+            .build();
+    private static final VirtualKafkaCluster VIRTUAL_KAFKA_CLUSTER = new VirtualKafkaClusterBuilder().withNewMetadata().withName(CLUSTER_NAME).withNamespace(
+            NAMESPACE).endMetadata().build();
+    public static final String PROXY_UID = "my-proxy-uid";
+    public static final KafkaProxy PROXY = new KafkaProxyBuilder().withNewMetadata().withName(PROXY_NAME).withUid(PROXY_UID).withNamespace(NAMESPACE).endMetadata()
+            .build();
+    public static final NodeIdRanges NODE_ID_RANGE = createNodeIdRange("a", 1L, 3L);
+
+    @Test
+    void numIdentifyingPortsRequiredSingleRange() {
+        ClusterIPIngressDefinition definition = new ClusterIPIngressDefinition(INGRESS, VIRTUAL_KAFKA_CLUSTER, PROXY,
+                List.of(NODE_ID_RANGE));
+        // 3 ports for the nodeId range + 1 for bootstrap
+        assertThat(definition.numIdentifyingPortsRequired()).isEqualTo(4);
+    }
+
+    @Test
+    void createInstancesWithExpectedNumber() {
+        // given
+        ClusterIPIngressDefinition definition = new ClusterIPIngressDefinition(INGRESS, VIRTUAL_KAFKA_CLUSTER, PROXY,
+                List.of(createNodeIdRange("a", 1L, 3L)));
+        // when
+        // then
+        // expect to be allocated 4 ports total, 3 ports for the nodeId range + 1 for bootstrap
+        assertThat(definition.createInstance(1, 4)).isNotNull();
+    }
+
+    @Test
+    void createInstancesWithTooManyPorts() {
+        // given
+        ClusterIPIngressDefinition definition = new ClusterIPIngressDefinition(INGRESS, VIRTUAL_KAFKA_CLUSTER, PROXY,
+                List.of(createNodeIdRange("a", 1L, 3L)));
+        // when
+        // then
+        // more ports than the 4 required by the node id range + 1 for bootstrap
+        assertThatThrownBy(() -> definition.createInstance(1, 5)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void createInstancesWithNotEnoughPorts() {
+        // given
+        ClusterIPIngressDefinition definition = new ClusterIPIngressDefinition(INGRESS, VIRTUAL_KAFKA_CLUSTER, PROXY,
+                List.of(createNodeIdRange("a", 1L, 3L)));
+
+        // when
+        // then
+        // more ports than the 4 required by the node id range + 1 for bootstrap
+        assertThatThrownBy(() -> definition.createInstance(1, 3)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void gatewayConfigSingleRange() {
+        // given
+        String rangeName = "a";
+        int rangeStart = 1;
+        int rangeEnd = 3;
+        ClusterIPIngressDefinition definition = new ClusterIPIngressDefinition(INGRESS, VIRTUAL_KAFKA_CLUSTER, PROXY,
+                List.of(createNodeIdRange(rangeName, rangeStart, rangeEnd)));
+        // 3 ports for the nodeId range + 1 for bootstrap
+        IngressInstance instance = definition.createInstance(1, 4);
+        assertThat(instance).isNotNull();
+
+        // when
+        VirtualClusterGateway gateway = instance.gatewayConfig();
+
+        // then
+        assertThat(gateway).isNotNull();
+        assertThat(gateway.name()).isEqualTo("default");
+        assertThat(gateway.tls()).isEmpty();
+        assertThat(gateway.sniHostIdentifiesNode()).isNull();
+        assertThat(gateway.portIdentifiesNode()).isNotNull().satisfies(portIdentifiesNode -> {
+            assertThat(portIdentifiesNode.bootstrapAddress()).isEqualTo(new HostPort("localhost", 1));
+            assertThat(portIdentifiesNode.nodeStartPort()).isNull(); // we use the default of bootstrap port + 1
+            String expectedAdvertisedAddress = CLUSTER_NAME + "-" + INGRESS_NAME + "." + NAMESPACE + ".svc.cluster.local";
+            assertThat(portIdentifiesNode.advertisedBrokerAddressPattern()).isEqualTo(expectedAdvertisedAddress);
+            NamedRange expectedRange = new NamedRange(rangeName, rangeStart, rangeEnd);
+            assertThat(portIdentifiesNode.nodeIdRanges()).containsExactly(expectedRange);
+        });
+    }
+
+    @Test
+    void serviceMetadata() {
+        // given
+        ClusterIPIngressDefinition definition = new ClusterIPIngressDefinition(INGRESS, VIRTUAL_KAFKA_CLUSTER, PROXY,
+                List.of(createNodeIdRange("a", 1, 3)));
+        // 3 ports for the nodeId range + 1 for bootstrap
+        IngressInstance instance = definition.createInstance(1, 4);
+        assertThat(instance).isNotNull();
+
+        // when
+        List<ServiceBuilder> serviceBuilders = instance.services().toList();
+
+        // then
+        assertThat(serviceBuilders).isNotNull().isNotEmpty().singleElement().satisfies(serviceBuild -> {
+            Service build = serviceBuild.build();
+            Map<String, String> orderedServiceLabels = commonLabels(PROXY_NAME);
+            assertThat(build.getMetadata()).isNotNull().satisfies(metadata -> {
+                assertThat(metadata.getNamespace()).isEqualTo(NAMESPACE);
+                assertThat(metadata.getName()).isEqualTo(CLUSTER_NAME + "-" + INGRESS_NAME);
+                assertThat(metadata.getLabels()).containsExactlyEntriesOf(orderedServiceLabels);
+                assertThat(metadata.getOwnerReferences()).hasSize(1).singleElement().satisfies(ownerRef -> {
+                    assertThat(ownerRef.getKind()).isEqualTo("KafkaProxy");
+                    assertThat(ownerRef.getApiVersion()).isEqualTo("kroxylicious.io/v1alpha1");
+                    assertThat(ownerRef.getName()).isEqualTo(PROXY_NAME);
+                    assertThat(ownerRef.getUid()).isEqualTo(PROXY_UID);
+                });
+            });
+        });
+    }
+
+    @Test
+    void serviceCommonSpec() {
+        // given
+        ClusterIPIngressDefinition definition = new ClusterIPIngressDefinition(INGRESS, VIRTUAL_KAFKA_CLUSTER, PROXY,
+                List.of(createNodeIdRange("a", 1, 3)));
+        // 3 ports for the nodeId range + 1 for bootstrap
+        IngressInstance instance = definition.createInstance(1, 4);
+        assertThat(instance).isNotNull();
+
+        // when
+        List<ServiceBuilder> serviceBuilders = instance.services().toList();
+
+        // then
+        assertThat(serviceBuilders).isNotNull().isNotEmpty().singleElement().satisfies(serviceBuild -> {
+            Service build = serviceBuild.build();
+            assertThat(build.getSpec()).isNotNull().satisfies(serviceSpec -> {
+                LinkedHashMap<String, String> orderedSelectorLabels = new LinkedHashMap<>();
+                orderedSelectorLabels.put("app", "kroxylicious");
+                orderedSelectorLabels.putAll(commonLabels(PROXY_NAME));
+                assertThat(serviceSpec.getSelector()).containsExactlyEntriesOf(orderedSelectorLabels);
+            });
+        });
+    }
+
+    @Test
+    void servicesSingleRangePorts() {
+        // given
+        ClusterIPIngressDefinition definition = new ClusterIPIngressDefinition(INGRESS, VIRTUAL_KAFKA_CLUSTER, PROXY,
+                List.of(createNodeIdRange("a", 1, 3)));
+        // 3 ports for the nodeId range + 1 for bootstrap
+        IngressInstance instance = definition.createInstance(1, 4);
+        assertThat(instance).isNotNull();
+
+        // when
+        List<ServiceBuilder> serviceBuilders = instance.services().toList();
+
+        // then
+        assertThat(serviceBuilders).isNotNull().isNotEmpty().singleElement().satisfies(serviceBuild -> {
+            Service build = serviceBuild.build();
+            assertThat(build.getSpec()).isNotNull().satisfies(serviceSpec -> {
+                ServicePort port1 = createTcpServicePort(CLUSTER_NAME + "-" + 1, 1);
+                ServicePort port2 = createTcpServicePort(CLUSTER_NAME + "-" + 2, 2);
+                ServicePort port3 = createTcpServicePort(CLUSTER_NAME + "-" + 3, 3);
+                ServicePort port4 = createTcpServicePort(CLUSTER_NAME + "-" + 4, 4);
+                assertThat(serviceSpec.getPorts())
+                        .isNotNull()
+                        .isNotEmpty()
+                        .containsExactlyInAnyOrder(port1, port2, port3, port4);
+            });
+        });
+    }
+
+    @Test
+    void servicesMultipleRangesPorts() {
+        // given
+        ClusterIPIngressDefinition definition = new ClusterIPIngressDefinition(INGRESS, VIRTUAL_KAFKA_CLUSTER, PROXY,
+                List.of(createNodeIdRange("a", 1, 1), createNodeIdRange("b", 3, 3)));
+        // 2 ports for the nodeId ranges + 1 for bootstrap
+        IngressInstance instance = definition.createInstance(1, 3);
+        assertThat(instance).isNotNull();
+
+        // when
+        List<ServiceBuilder> serviceBuilders = instance.services().toList();
+
+        // then
+        assertThat(serviceBuilders).isNotNull().isNotEmpty().singleElement().satisfies(serviceBuild -> {
+            Service build = serviceBuild.build();
+            assertThat(build.getSpec()).isNotNull().satisfies(serviceSpec -> {
+                ServicePort port1 = createTcpServicePort(CLUSTER_NAME + "-" + 1, 1);
+                ServicePort port2 = createTcpServicePort(CLUSTER_NAME + "-" + 2, 2);
+                ServicePort port3 = createTcpServicePort(CLUSTER_NAME + "-" + 3, 3);
+                assertThat(serviceSpec.getPorts())
+                        .isNotNull()
+                        .isNotEmpty()
+                        .containsExactlyInAnyOrder(port1, port2, port3);
+            });
+        });
+    }
+
+    @Test
+    void gatewayConfigNameDefault() {
+        // given
+        int rangeStart = 1;
+        int rangeEnd = 3;
+
+        int rangeStart2 = 5;
+        int rangeEnd2 = 6;
+        ClusterIPIngressDefinition definition = new ClusterIPIngressDefinition(INGRESS, VIRTUAL_KAFKA_CLUSTER, PROXY,
+                List.of(createNodeIdRange(null, rangeStart, rangeEnd), createNodeIdRange(null, rangeStart2, rangeEnd2)));
+        // 5 ports for the nodeId ranges + 1 for bootstrap
+        IngressInstance instance = definition.createInstance(2, 7);
+        assertThat(instance).isNotNull();
+
+        // when
+        VirtualClusterGateway gateway = instance.gatewayConfig();
+
+        // then
+        assertThat(gateway).isNotNull();
+        assertThat(gateway.name()).isEqualTo("default");
+        assertThat(gateway.tls()).isEmpty();
+        assertThat(gateway.sniHostIdentifiesNode()).isNull();
+        assertThat(gateway.portIdentifiesNode()).isNotNull().satisfies(portIdentifiesNode -> {
+            assertThat(portIdentifiesNode.bootstrapAddress()).isEqualTo(new HostPort("localhost", 2));
+            assertThat(portIdentifiesNode.nodeStartPort()).isNull(); // we use the default of bootstrap port + 1
+            String expectedAdvertisedAddress = CLUSTER_NAME + "-" + INGRESS_NAME + "." + NAMESPACE + ".svc.cluster.local";
+            assertThat(portIdentifiesNode.advertisedBrokerAddressPattern()).isEqualTo(expectedAdvertisedAddress);
+            NamedRange expectedRange = new NamedRange("range-0", rangeStart, rangeEnd);
+            NamedRange expectedRange2 = new NamedRange("range-1", rangeStart2, rangeEnd2);
+            assertThat(portIdentifiesNode.nodeIdRanges()).containsExactly(expectedRange, expectedRange2);
+        });
+    }
+
+    @Test
+    void gatewayConfigMultipleRange() {
+        // given
+        String rangeName = "a";
+        int rangeStart = 1;
+        int rangeEnd = 3;
+
+        String rangeName2 = "b";
+        int rangeStart2 = 5;
+        int rangeEnd2 = 6;
+        ClusterIPIngressDefinition definition = new ClusterIPIngressDefinition(INGRESS, VIRTUAL_KAFKA_CLUSTER, PROXY,
+                List.of(createNodeIdRange(rangeName, rangeStart, rangeEnd), createNodeIdRange(rangeName2, rangeStart2, rangeEnd2)));
+        // 5 ports for the nodeId ranges + 1 for bootstrap
+        IngressInstance instance = definition.createInstance(2, 7);
+        assertThat(instance).isNotNull();
+
+        // when
+        VirtualClusterGateway gateway = instance.gatewayConfig();
+
+        // then
+        assertThat(gateway).isNotNull();
+        assertThat(gateway.name()).isEqualTo("default");
+        assertThat(gateway.tls()).isEmpty();
+        assertThat(gateway.sniHostIdentifiesNode()).isNull();
+        assertThat(gateway.portIdentifiesNode()).isNotNull().satisfies(portIdentifiesNode -> {
+            assertThat(portIdentifiesNode.bootstrapAddress()).isEqualTo(new HostPort("localhost", 2));
+            assertThat(portIdentifiesNode.nodeStartPort()).isNull(); // we use the default of bootstrap port + 1
+            String expectedAdvertisedAddress = CLUSTER_NAME + "-" + INGRESS_NAME + "." + NAMESPACE + ".svc.cluster.local";
+            assertThat(portIdentifiesNode.advertisedBrokerAddressPattern()).isEqualTo(expectedAdvertisedAddress);
+            NamedRange expectedRange = new NamedRange(rangeName, rangeStart, rangeEnd);
+            NamedRange expectedRange2 = new NamedRange(rangeName2, rangeStart2, rangeEnd2);
+            assertThat(portIdentifiesNode.nodeIdRanges()).containsExactly(expectedRange, expectedRange2);
+        });
+    }
+
+    @Test
+    void numIdentifyingPortsRequiredMultipleRanges() {
+        ClusterIPIngressDefinition definition = new ClusterIPIngressDefinition(INGRESS, VIRTUAL_KAFKA_CLUSTER, PROXY,
+                List.of(NODE_ID_RANGE, createNodeIdRange("a", 5L, 6L)));
+        // 5 ports for the nodeId ranges + 1 for bootstrap
+        assertThat(definition.numIdentifyingPortsRequired()).isEqualTo(6);
+    }
+
+    @Test
+    void rangesMustBeNonEmpty() {
+        List<NodeIdRanges> nodeIdRanges = List.of();
+        assertThatThrownBy(() -> new ClusterIPIngressDefinition(INGRESS, VIRTUAL_KAFKA_CLUSTER, PROXY, nodeIdRanges))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void proxyContainerPortsSingleRange() {
+        ClusterIPIngressDefinition definition = new ClusterIPIngressDefinition(INGRESS, VIRTUAL_KAFKA_CLUSTER, PROXY,
+                List.of(createNodeIdRange("a", 1L, 3L)));
+        IngressInstance instance = definition.createInstance(1, 4);
+        assertThat(instance).isNotNull();
+        assertThat(instance.proxyContainerPorts())
+                .containsExactly(createContainerPort(1 + "-bootstrap", 1),
+                        createContainerPort(2 + "-node", 2),
+                        createContainerPort(3 + "-node", 3),
+                        createContainerPort(4 + "-node", 4));
+    }
+
+    @Test
+    void proxyContainerPortsMultipleRanges() {
+        ClusterIPIngressDefinition definition = new ClusterIPIngressDefinition(INGRESS, VIRTUAL_KAFKA_CLUSTER, PROXY,
+                List.of(createNodeIdRange("a", 1L, 1L), createNodeIdRange("b", 3L, 4L)));
+        IngressInstance instance = definition.createInstance(1, 4);
+        assertThat(instance).isNotNull();
+        assertThat(instance.proxyContainerPorts())
+                .containsExactly(createContainerPort(1 + "-bootstrap", 1),
+                        createContainerPort(2 + "-node", 2),
+                        createContainerPort(3 + "-node", 3),
+                        createContainerPort(4 + "-node", 4));
+    }
+
+    public static Stream<Arguments> constructorArgsMustBeNonNull() {
+        List<NodeIdRanges> nodeIdRanges = List.of(NODE_ID_RANGE);
+        ThrowingCallable nullIngress = () -> new ClusterIPIngressDefinition(null, VIRTUAL_KAFKA_CLUSTER, PROXY, nodeIdRanges);
+        ThrowingCallable nullVirtualCluster = () -> new ClusterIPIngressDefinition(INGRESS, null, PROXY, nodeIdRanges);
+        ThrowingCallable nullProxy = () -> new ClusterIPIngressDefinition(INGRESS, VIRTUAL_KAFKA_CLUSTER, null, nodeIdRanges);
+        ThrowingCallable nullRanges = () -> new ClusterIPIngressDefinition(INGRESS, VIRTUAL_KAFKA_CLUSTER, PROXY, null);
+        return Stream.of(argumentSet("ingress", nullIngress),
+                argumentSet("virtualCluster", nullVirtualCluster),
+                argumentSet("proxy", nullProxy),
+                argumentSet("ranges", nullRanges));
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void constructorArgsMustBeNonNull(ThrowingCallable callable) {
+        assertThatThrownBy(callable).isInstanceOf(NullPointerException.class);
+    }
+
+    private ServicePort createTcpServicePort(String portName, int port) {
+        return new ServicePortBuilder()
+                .withName(portName)
+                .withTargetPort(new IntOrString(port))
+                .withPort(port)
+                .withProtocol("TCP")
+                .build();
+    }
+
+    private static @NonNull Map<String, String> commonLabels(String proxyName) {
+        Map<String, String> orderedLabels = new java.util.LinkedHashMap<>();
+        orderedLabels.put("app.kubernetes.io/part-of", "kafka");
+        orderedLabels.put("app.kubernetes.io/managed-by", "kroxylicious-operator");
+        orderedLabels.put("app.kubernetes.io/name", "kroxylicious-proxy");
+        orderedLabels.put("app.kubernetes.io/instance", proxyName);
+        orderedLabels.put("app.kubernetes.io/component", "proxy");
+        return orderedLabels;
+    }
+
+    private static NodeIdRanges createNodeIdRange(@Nullable String name, long start, long endInclusive) {
+        return new NodeIdRangesBuilder().withName(name).withStart(start).withEnd(endInclusive).build();
+    }
+
+    private static ContainerPort createContainerPort(String name, int containerPort) {
+        return new ContainerPortBuilder().withName(name).withContainerPort(containerPort).build();
+    }
+
+}

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-empty.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-empty.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaService
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: fooref
+    namespace: proxy-ns
+  spec:
+    bootstrapServers: 'localhost:9092'
+    nodeIdRanges: []
+expectFailureMessageToContain: |
+  spec.nodeIdRanges: Invalid value: 0

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-end-contains-decimal-point.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-end-contains-decimal-point.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaService
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: fooref
+    namespace: proxy-ns
+  spec:
+    bootstrapServers: 'localhost:9092'
+    nodeIdRanges:
+      - name: 'abc'
+        start: 1
+        end: 2.2
+expectFailureMessageToContain: |
+  spec.nodeIdRanges[0].end: Invalid value: "number"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-end-less-than-start.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-end-less-than-start.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaService
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: fooref
+    namespace: proxy-ns
+  spec:
+    bootstrapServers: 'localhost:9092'
+    nodeIdRanges:
+      - name: 'abc'
+        start: 2
+        end: 1
+expectFailureMessageToContain: |
+  spec.nodeIdRanges[0]: Invalid value: "object"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-end-missing.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-end-missing.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaService
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: fooref
+    namespace: proxy-ns
+  spec:
+    bootstrapServers: 'localhost:9092'
+    nodeIdRanges:
+      - name: 'abc'
+        start: 2
+expectFailureMessageToContain: |
+  spec.nodeIdRanges[0].end: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-end-not-integer.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-end-not-integer.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaService
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: fooref
+    namespace: proxy-ns
+  spec:
+    bootstrapServers: 'localhost:9092'
+    nodeIdRanges:
+      - name: 'abc'
+        start: 2
+        end: "whoops"
+expectFailureMessageToContain: |
+  spec.nodeIdRanges[0].end: Invalid value: "string"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-end-null.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-end-null.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaService
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: fooref
+    namespace: proxy-ns
+  spec:
+    bootstrapServers: 'localhost:9092'
+    nodeIdRanges:
+      - name: 'abc'
+        start: 2
+        end: null
+expectFailureMessageToContain: |
+  spec.nodeIdRanges[0].end: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-name-empty.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-name-empty.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaService
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: fooref
+    namespace: proxy-ns
+  spec:
+    bootstrapServers: 'localhost:9092'
+    nodeIdRanges:
+      - name: ''
+        start: 2
+        end: 1
+expectFailureMessageToContain: |
+  spec.nodeIdRanges[0].name: Invalid value: ""

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-name-not-string.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-name-not-string.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaService
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: fooref
+    namespace: proxy-ns
+  spec:
+    bootstrapServers: 'localhost:9092'
+    nodeIdRanges:
+      - name: []
+        start: 2
+        end: 1
+expectFailureMessageToContain: |
+  spec.nodeIdRanges[0].name: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-not-array.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-not-array.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaService
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: fooref
+    namespace: proxy-ns
+  spec:
+    bootstrapServers: 'localhost:9092'
+    nodeIdRanges: {}
+expectFailureMessageToContain: |
+  spec.nodeIdRanges: Invalid value: "object"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-start-contains-decimal-point.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-start-contains-decimal-point.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaService
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: fooref
+    namespace: proxy-ns
+  spec:
+    bootstrapServers: 'localhost:9092'
+    nodeIdRanges:
+      - name: 'abc'
+        start: 2.2
+        end: 1
+expectFailureMessageToContain: |
+  spec.nodeIdRanges[0].start: Invalid value: "number"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-start-missing.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-start-missing.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaService
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: fooref
+    namespace: proxy-ns
+  spec:
+    bootstrapServers: 'localhost:9092'
+    nodeIdRanges:
+      - name: 'abc'
+        end: 1
+expectFailureMessageToContain: |
+  spec.nodeIdRanges[0].start: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-start-not-integer.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-start-not-integer.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaService
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: fooref
+    namespace: proxy-ns
+  spec:
+    bootstrapServers: 'localhost:9092'
+    nodeIdRanges:
+      - name: 'abc'
+        start: "banan"
+        end: 1
+expectFailureMessageToContain: |
+  spec.nodeIdRanges[0].start: Invalid value: "string"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-start-null.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/nodeIdRanges/invalid-nodeIdRanges-start-null.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaService
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: fooref
+    namespace: proxy-ns
+  spec:
+    bootstrapServers: 'localhost:9092'
+    nodeIdRanges:
+      - name: 'abc'
+        start: null
+        end: 1
+expectFailureMessageToContain: |
+  spec.nodeIdRanges[0].start: Required value


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds nodeIdRanges to KafkaService and wires them through to clusterip ingress Service ports and the gateway config

For example:
```yaml
kind: KafkaService
apiVersion: kroxylicious.io/v1alpha1
metadata:
  name: my-cluster
  namespace: my-proxy
spec:
  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
  nodeIdRanges:
    - name: brokers
      start: 0
      end: 2
    - name: newBrokers
      start: 4
      end: 5
```

* `nodeIdRanges` is optional and remains defaulted to have start id 0 and end id 2. If it is supplied it must be non-empty.
*  `start` and `end` are required fields of `nodeIdRanges` items. `end` must be greater than or equal to `start`.
* `name` is optional and defaults to `range-${index}` such that:

```yaml
  nodeIdRanges:
    - start: 0
      end: 2
    - name: newBrokers
      start: 4
      end: 5
    - start: 4
      end: 5
```

is equivalent to:

```yaml
  nodeIdRanges:
    - name: range-0
      start: 0
      end: 2
    - name: newBrokers
      start: 4
      end: 5
    - name: range-2
      start: 4
      end: 5
```

Note that we do not verify that the ranges are valid, the proxy requires the names to be unique and for the ranges to be distinct. We will add matching validation to the KafkaServiceReconciler in a subsequent PR.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
