### PR TITLE
Add integration test for apiserver CR validation

### DIFF
--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/CustomResourceValidationIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/CustomResourceValidationIT.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.Status;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.NamespaceableResource;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
+import io.kroxylicious.kubernetes.filter.api.v1alpha1.KafkaProtocolFilter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnabledIf(value = "io.kroxylicious.kubernetes.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
+class CustomResourceValidationIT {
+
+    public static final Namespace NAMESPACE = new NamespaceBuilder().withNewMetadata().withName("proxy-ns").endMetadata().build();
+    public static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
+
+    @BeforeAll
+    static void beforeAll() {
+        KubernetesClient client = OperatorTestUtils.kubeClient();
+        LocallyRunOperatorExtension.applyCrd(KafkaProtocolFilter.class, client);
+        LocallyRunOperatorExtension.applyCrd(KafkaProxy.class, client);
+        LocallyRunOperatorExtension.applyCrd(VirtualKafkaCluster.class, client);
+        LocallyRunOperatorExtension.applyCrd(KafkaService.class, client);
+        LocallyRunOperatorExtension.applyCrd(KafkaProxyIngress.class, client);
+        client.namespaces().resource(NAMESPACE).createOr(NonDeletingOperation::update);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        try (KubernetesClient kubernetesClient = OperatorTestUtils.kubeClient()) {
+            kubernetesClient.namespaces().resource(NAMESPACE).delete();
+            kubernetesClient.resources(KafkaProtocolFilter.class).delete();
+            kubernetesClient.resources(KafkaProxyIngress.class).delete();
+            kubernetesClient.resources(KafkaProxy.class).delete();
+            kubernetesClient.resources(VirtualKafkaCluster.class).delete();
+            kubernetesClient.resources(KafkaService.class).delete();
+        }
+    }
+
+    public static Stream<Path> testDerivedResourceInputsValid() {
+        return TestFiles.recursiveFilesInDirectoryForTest(DerivedResourcesTest.class, "in-*.yaml").stream();
+    }
+
+    public static Stream<Arguments> testResourceInvalid() {
+        return TestFiles.recursiveFilesInDirectoryForTest(CustomResourceValidationIT.class, "invalid-*.yaml").stream().map(p -> {
+            try {
+                return Arguments.argumentSet(p.toString(), YAML_MAPPER.readValue(p.toFile(), InvalidResource.class));
+            }
+            catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void testDerivedResourceInputsValid(Path validYaml) {
+        try (InputStream is = Files.newInputStream(validYaml)) {
+            NamespaceableResource<HasMetadata> resource = OperatorTestUtils.kubeClient().resource(is);
+            Assertions.assertThatCode(resource::create).doesNotThrowAnyException();
+            Assertions.assertThatCode(resource::delete).doesNotThrowAnyException();
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    record InvalidResource(String expectFailureMessageToContain, Object resource) {
+        String resourceAsString() {
+            try {
+                return YAML_MAPPER.writeValueAsString(resource);
+            }
+            catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void testResourceInvalid(InvalidResource invalidYaml) {
+        NamespaceableResource<HasMetadata> resource = OperatorTestUtils.kubeClient().resource(invalidYaml.resourceAsString());
+        try {
+            Assertions.assertThatThrownBy(resource::create).isInstanceOfSatisfying(KubernetesClientException.class, e -> {
+                Status status = e.getStatus();
+                assertThat(status).isNotNull();
+                assertThat(status.getCode()).isEqualTo(422);
+                assertThat(status.getMessage()).contains(invalidYaml.expectFailureMessageToContain);
+            });
+        }
+        finally {
+            try {
+                resource.delete();
+            }
+            catch (KubernetesClientException e) {
+                // ignored, redundantly deleting in case the resource was accidentally valid
+            }
+        }
+    }
+
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/TestFiles.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/TestFiles.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import io.kroxylicious.proxy.tag.VisibleForTesting;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class TestFiles {
+
+    @NonNull
+    static HashSet<Path> childFilesMatching(
+                                            Path testDir,
+                                            String glob)
+            throws IOException {
+        return StreamSupport.stream(Files.newDirectoryStream(testDir, glob).spliterator(), false)
+                .filter(Files::isRegularFile)
+                .collect(Collectors.toCollection(HashSet::new));
+    }
+
+    static List<Path> subDirectoriesForTest(Class<?> testClazz) {
+        var dir = testDir(testClazz);
+        return subDirectories(dir);
+    }
+
+    private static @NonNull Path testDir(Class<?> testClazz) {
+        return Path.of("target", "test-classes", testClazz.getSimpleName());
+    }
+
+    @NonNull
+    static List<Path> subDirectories(Path dir) {
+        var directories = new ArrayList<Path>();
+        try (var expected = Files.newDirectoryStream(dir, Files::isDirectory)) {
+            for (Path f : expected) {
+                directories.add(f);
+            }
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return directories;
+    }
+
+    static List<Path> recursiveFilesInDirectoryForTest(Class<?> testClazz, String filenameGlob) {
+        Path path = testDir(testClazz);
+        return recursiveFilesInDirectory(filenameGlob, path);
+    }
+
+    @VisibleForTesting
+    static @NonNull List<Path> recursiveFilesInDirectory(String filenameGlob, Path path) {
+        PathMatcher globMatcher = FileSystems.getDefault().getPathMatcher("glob:**/" + filenameGlob);
+        List<Path> files = new ArrayList<>();
+        try {
+            Files.walkFileTree(path, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (globMatcher.matches(file)) {
+                        files.add(file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return files;
+    }
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/TestFilesTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/TestFilesTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestFilesTest {
+
+    @Test
+    void testSubDirectories() {
+        List<Path> paths = TestFiles.subDirectoriesForTest(TestFilesTest.class);
+        Path one = Path.of("target", "test-classes", "TestFilesTest", "sub1");
+        Path two = Path.of("target", "test-classes", "TestFilesTest", "sub2");
+        assertThat(paths).containsExactlyInAnyOrder(one, two);
+    }
+
+    @Test
+    void testSubDirectoriesWhenEmpty(@TempDir Path tempDir) {
+        List<Path> paths = TestFiles.subDirectories(tempDir);
+        assertThat(paths).isEmpty();
+    }
+
+    @Test
+    void testSubDirectoriesWhenOnlyContainsFile(@TempDir Path tempDir) throws IOException {
+        Files.writeString(tempDir.resolve("file"), "hello");
+        List<Path> paths = TestFiles.subDirectories(tempDir);
+        assertThat(paths).isEmpty();
+    }
+
+    @Test
+    void testSubDirectoriesWithSingleSubdir(@TempDir Path tempDir) throws IOException {
+        Path subdir = tempDir.resolve("file");
+        Files.createDirectory(subdir);
+        List<Path> paths = TestFiles.subDirectories(tempDir);
+        assertThat(paths).containsExactly(subdir);
+    }
+
+    @Test
+    void childFilesMatchingWithEmptyDir(@TempDir Path tempDir) throws IOException {
+        HashSet<Path> paths = TestFiles.childFilesMatching(tempDir, "any");
+        assertThat(paths).isEmpty();
+    }
+
+    @Test
+    void childFilesExactMatching(@TempDir Path tempDir) throws IOException {
+        Files.writeString(tempDir.resolve("a"), "a");
+        Files.writeString(tempDir.resolve("aa"), "aa");
+        HashSet<Path> paths = TestFiles.childFilesMatching(tempDir, "a");
+        assertThat(paths).containsExactly(tempDir.resolve("a"));
+    }
+
+    static Stream<Arguments> childFilesMatchingGlob() {
+        Arguments all = Arguments.of(Set.of("a", "b"), "*", Set.of("a", "b"));
+        Arguments prefix = Arguments.of(Set.of("aa", "ab"), "*b", Set.of("ab"));
+        Arguments suffix = Arguments.of(Set.of("aa", "ba"), "a*", Set.of("aa"));
+        Arguments extension = Arguments.of(Set.of("a.yaml", "b.yaml"), "*.yaml", Set.of("a.yaml", "b.yaml"));
+        return Stream.of(all, prefix, suffix, extension);
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void childFilesMatchingGlob(Set<String> filenames, String glob, Set<String> expectedToResolve, @TempDir Path tempDir) throws IOException {
+        filenames.forEach(s -> writeFile(tempDir, s));
+        HashSet<Path> paths = TestFiles.childFilesMatching(tempDir, glob);
+        Set<Path> expectedPaths = expectedToResolve.stream().map(tempDir::resolve).collect(toSet());
+        assertThat(paths).containsExactlyInAnyOrderElementsOf(expectedPaths);
+    }
+
+    @Test
+    void recursiveFilesForTestingEmpty(@TempDir Path tempDir) throws IOException {
+        List<Path> paths = TestFiles.recursiveFilesInDirectory("*", tempDir);
+        assertThat(paths).isEmpty();
+    }
+
+    @Test
+    void recursiveFilesForTesting(@TempDir Path tempDir) throws IOException {
+        Path rootFile = tempDir.resolve("fileInRoot");
+        Files.writeString(rootFile, "hello");
+        Path dirA = tempDir.resolve("a");
+        Files.createDirectory(dirA);
+        Path fileA = dirA.resolve("fileA");
+        Files.writeString(fileA, "a");
+        Path dirB = tempDir.resolve("b");
+        Files.createDirectory(dirB);
+        Path fileB = dirB.resolve("fileB");
+        Files.writeString(fileB, "b");
+        List<Path> paths = TestFiles.recursiveFilesInDirectory("*", tempDir);
+        assertThat(paths).containsExactlyInAnyOrder(fileA, fileB, rootFile);
+    }
+
+    @Test
+    void recursiveFilesForTestingGlob(@TempDir Path tempDir) throws IOException {
+        Path rootFile = tempDir.resolve("fileInRoot");
+        Files.writeString(rootFile, "hello");
+        Path dirA = tempDir.resolve("a");
+        Files.createDirectory(dirA);
+        Path fileA = dirA.resolve("fileA");
+        Files.writeString(fileA, "a");
+        Path dirB = tempDir.resolve("b");
+        Files.createDirectory(dirB);
+        Path fileB = dirB.resolve("fileB");
+        Files.writeString(fileB, "b");
+        List<Path> paths = TestFiles.recursiveFilesInDirectory("*A", tempDir);
+        assertThat(paths).containsExactlyInAnyOrder(fileA);
+    }
+
+    private static void writeFile(Path tempDir, String filename) {
+        try {
+            Files.writeString(tempDir.resolve(filename), "arbitrary");
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+}

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaprotocolfilter/invalid-configTemplate-missing.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaprotocolfilter/invalid-configTemplate-missing.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProtocolFilter
+  apiVersion: filter.kroxylicious.io/v1alpha1
+  metadata:
+    name: filter-one
+    namespace: proxy-ns
+  spec:
+    type: "RecordEncryption"
+expectFailureMessageToContain: |
+  spec.configTemplate: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaprotocolfilter/invalid-configTemplate-not-object.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaprotocolfilter/invalid-configTemplate-not-object.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProtocolFilter
+  apiVersion: filter.kroxylicious.io/v1alpha1
+  metadata:
+    name: filter-one
+    namespace: proxy-ns
+  spec:
+    type: "RecordEncryption"
+    configTemplate: [ ]
+expectFailureMessageToContain: |
+  spec.configTemplate: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaprotocolfilter/invalid-configTemplate-null.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaprotocolfilter/invalid-configTemplate-null.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProtocolFilter
+  apiVersion: filter.kroxylicious.io/v1alpha1
+  metadata:
+    name: filter-one
+    namespace: proxy-ns
+  spec:
+    type: "RecordEncryption"
+    configTemplate: null
+expectFailureMessageToContain: |
+  spec.configTemplate: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaprotocolfilter/invalid-type-missing.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaprotocolfilter/invalid-type-missing.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProtocolFilter
+  apiVersion: filter.kroxylicious.io/v1alpha1
+  metadata:
+    name: filter-one
+    namespace: proxy-ns
+  spec:
+    configTemplate:
+      filterOneConfig: true
+expectFailureMessageToContain: |
+  spec.type: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaprotocolfilter/invalid-type-not-string.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaprotocolfilter/invalid-type-not-string.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProtocolFilter
+  apiVersion: filter.kroxylicious.io/v1alpha1
+  metadata:
+    name: filter-one
+    namespace: proxy-ns
+  spec:
+    type: {}
+    configTemplate:
+      filterOneConfig: true
+expectFailureMessageToContain: |
+  spec.type: Invalid value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaprotocolfilter/invalid-type-null.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaprotocolfilter/invalid-type-null.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProtocolFilter
+  apiVersion: filter.kroxylicious.io/v1alpha1
+  metadata:
+    name: filter-one
+    namespace: proxy-ns
+  spec:
+    type: null
+    configTemplate:
+      filterOneConfig: true
+expectFailureMessageToContain: |
+  spec.type: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/invalid-podTemplate-not-object.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/invalid-podTemplate-not-object.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxy
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: use-pod-template-spec
+    namespace: proxy-ns
+  spec:
+    podTemplate: []
+expectFailureMessageToContain: |
+  spec.podTemplate: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/invalid-podTemplate.metadata-not-object.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/invalid-podTemplate.metadata-not-object.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxy
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: use-pod-template-spec
+    namespace: proxy-ns
+  spec:
+    podTemplate:
+      metadata: []
+expectFailureMessageToContain: |
+  spec.podTemplate.metadata: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/invalid-podTemplate.metadata.labels-not-object.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/invalid-podTemplate.metadata.labels-not-object.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxy
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: use-pod-template-spec
+    namespace: proxy-ns
+  spec:
+    podTemplate:
+      metadata:
+        labels: []
+expectFailureMessageToContain: |
+  spec.podTemplate.metadata.labels: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-clusterIP-missing.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-clusterIP-missing.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxyIngress
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: cluster-ip-bar
+    namespace: proxy-ns
+    generation: 2
+  spec:
+    proxyRef:
+      name: "my-proxy"
+expectFailureMessageToContain: |
+  spec.clusterIP: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-clusterIP-not-object.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-clusterIP-not-object.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxyIngress
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: cluster-ip-bar
+    namespace: proxy-ns
+    generation: 2
+  spec:
+    proxyRef:
+      name: "my-proxy"
+    clusterIP: []
+expectFailureMessageToContain: |
+  spec.clusterIP: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-clusterIP-null.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-clusterIP-null.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxyIngress
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: cluster-ip-bar
+    namespace: proxy-ns
+    generation: 2
+  spec:
+    proxyRef:
+      name: "my-proxy"
+    clusterIP: null
+expectFailureMessageToContain: |
+  spec.clusterIP: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-clusterIP.protocol-empty.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-clusterIP.protocol-empty.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxyIngress
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: cluster-ip-bar
+    namespace: proxy-ns
+    generation: 2
+  spec:
+    proxyRef:
+      name: "my-proxy"
+    clusterIP:
+      protocol: ''
+expectFailureMessageToContain: |
+  spec.clusterIP.protocol: Unsupported value: ""

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-clusterIP.protocol-missing.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-clusterIP.protocol-missing.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxyIngress
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: cluster-ip-bar
+    namespace: proxy-ns
+    generation: 2
+  spec:
+    proxyRef:
+      name: "my-proxy"
+    clusterIP: {}
+expectFailureMessageToContain: |
+  spec.clusterIP.protocol: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-clusterIP.protocol-not-string.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-clusterIP.protocol-not-string.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxyIngress
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: cluster-ip-bar
+    namespace: proxy-ns
+    generation: 2
+  spec:
+    proxyRef:
+      name: "my-proxy"
+    clusterIP:
+      protocol: {}
+expectFailureMessageToContain: |
+  spec.clusterIP.protocol: Invalid value: "object"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-clusterIP.protocol-null.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-clusterIP.protocol-null.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxyIngress
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: cluster-ip-bar
+    namespace: proxy-ns
+    generation: 2
+  spec:
+    proxyRef:
+      name: "my-proxy"
+    clusterIP:
+      protocol: null
+expectFailureMessageToContain: |
+  spec.clusterIP.protocol: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-clusterIP.protocol-unknown-value.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-clusterIP.protocol-unknown-value.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxyIngress
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: cluster-ip-bar
+    namespace: proxy-ns
+    generation: 2
+  spec:
+    proxyRef:
+      name: "my-proxy"
+    clusterIP:
+      protocol: "IPoAC"
+expectFailureMessageToContain: |
+  spec.clusterIP.protocol: Unsupported value: "IPoAC"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-proxyRef-missing.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-proxyRef-missing.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxyIngress
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: cluster-ip-bar
+    namespace: proxy-ns
+    generation: 2
+  spec:
+    clusterIP:
+      protocol: TCP
+expectFailureMessageToContain: |
+  spec.proxyRef: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-proxyRef-not-object.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-proxyRef-not-object.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxyIngress
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: cluster-ip-bar
+    namespace: proxy-ns
+    generation: 2
+  spec:
+    proxyRef: []
+    clusterIP:
+      protocol: TCP
+expectFailureMessageToContain: |
+  spec.proxyRef: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-proxyRef-null.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-proxyRef-null.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxyIngress
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: cluster-ip-bar
+    namespace: proxy-ns
+    generation: 2
+  spec:
+    clusterIP:
+      protocol: TCP
+expectFailureMessageToContain: |
+  spec.proxyRef: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-proxyRef.name-empty.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-proxyRef.name-empty.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxyIngress
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: cluster-ip-bar
+    namespace: proxy-ns
+    generation: 2
+  spec:
+    proxyRef:
+      name: ''
+    clusterIP:
+      protocol: TCP
+expectFailureMessageToContain: |
+  spec.proxyRef.name: Invalid value: ""

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-proxyRef.name-missing.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-proxyRef.name-missing.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxyIngress
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: cluster-ip-bar
+    namespace: proxy-ns
+    generation: 2
+  spec:
+    proxyRef: {}
+    clusterIP:
+      protocol: TCP
+expectFailureMessageToContain: |
+  spec.proxyRef.name: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-proxyRef.name-not-string.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-proxyRef.name-not-string.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxyIngress
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: cluster-ip-bar
+    namespace: proxy-ns
+    generation: 2
+  spec:
+    proxyRef:
+      name: {}
+    clusterIP:
+      protocol: TCP
+expectFailureMessageToContain: |
+  spec.proxyRef.name: Invalid value: "object"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-proxyRef.name-null.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-proxyRef.name-null.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxyIngress
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: cluster-ip-bar
+    namespace: proxy-ns
+    generation: 2
+  spec:
+    proxyRef:
+      name: null
+    clusterIP:
+      protocol: TCP
+expectFailureMessageToContain: |
+  spec.proxyRef.name: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-proxyRef.name-too-long.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxyingress/invalid-proxyRef.name-too-long.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxyIngress
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: cluster-ip-bar
+    namespace: proxy-ns
+    generation: 2
+  spec:
+    proxyRef:
+      name: "0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+        50aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+        100aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+        150aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+        200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+        aaaa"
+    clusterIP:
+      protocol: TCP
+expectFailureMessageToContain: |
+  spec.proxyRef.name: Too long

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/invalid-bootstrapServers-empty.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/invalid-bootstrapServers-empty.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaService
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: fooref
+    namespace: proxy-ns
+  spec:
+    bootstrapServers: ''
+expectFailureMessageToContain: |
+  spec.bootstrapServers: Invalid value: ""

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/invalid-bootstrapServers-missing.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/invalid-bootstrapServers-missing.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaService
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: fooref
+    namespace: proxy-ns
+  spec: {}
+expectFailureMessageToContain: |
+  spec.bootstrapServers: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/invalid-bootstrapServers-no-hostname.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/invalid-bootstrapServers-no-hostname.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaService
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: fooref
+    namespace: proxy-ns
+  spec:
+    bootstrapServers: :9092
+expectFailureMessageToContain: |
+  spec.bootstrapServers: Invalid value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/invalid-bootstrapServers-no-port.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/invalid-bootstrapServers-no-port.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaService
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: fooref
+    namespace: proxy-ns
+  spec:
+    bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local
+expectFailureMessageToContain: |
+  spec.bootstrapServers: Invalid value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/invalid-bootstrapServers-null.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaservice/invalid-bootstrapServers-null.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaService
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: fooref
+    namespace: proxy-ns
+  spec:
+    bootstrapServers: null
+expectFailureMessageToContain: |
+  spec.bootstrapServers: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/filterRefs/invalid-filterRefs-not-array.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/filterRefs/invalid-filterRefs-not-array.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: service
+    filterRefs: {}
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.filterRefs: Invalid value: "object"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/filterRefs/invalid-filterRefs.name-empty.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/filterRefs/invalid-filterRefs.name-empty.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: service
+    filterRefs:
+      - name: ''
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.filterRefs[0].name: Invalid value: ""

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/filterRefs/invalid-filterRefs.name-missing.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/filterRefs/invalid-filterRefs.name-missing.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: service
+    filterRefs:
+      - {}
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.filterRefs[0].name: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/filterRefs/invalid-filterRefs.name-not-string.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/filterRefs/invalid-filterRefs.name-not-string.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: service
+    filterRefs:
+      - name: []
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.filterRefs[0].name: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/filterRefs/invalid-filterRefs.name-null.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/filterRefs/invalid-filterRefs.name-null.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: service
+    filterRefs:
+      - name: null
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.filterRefs[0].name: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/filterRefs/invalid-filterRefs.name-too-long.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/filterRefs/invalid-filterRefs.name-too-long.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: service
+    filterRefs:
+      - name: "0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+               50aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+               100aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+               150aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+               200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+               aaaa"
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.filterRefs[0].name: Too long

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/ingressRefs/invalid-ingressRefs-empty.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/ingressRefs/invalid-ingressRefs-empty.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: serviceName
+    filterRefs:
+      - name: filter-one
+    ingressRefs: []
+expectFailureMessageToContain: |
+  spec.ingressRefs: Invalid value: 0

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/ingressRefs/invalid-ingressRefs-missing.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/ingressRefs/invalid-ingressRefs-missing.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: serviceName
+    filterRefs:
+      - name: filter-one
+expectFailureMessageToContain: |
+  spec.ingressRefs: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/ingressRefs/invalid-ingressRefs-not-array.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/ingressRefs/invalid-ingressRefs-not-array.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: serviceName
+    filterRefs:
+      - name: filter-one
+    ingressRefs: {}
+expectFailureMessageToContain: |
+  spec.ingressRefs: Invalid value: "object"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/ingressRefs/invalid-ingressRefs-null.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/ingressRefs/invalid-ingressRefs-null.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: serviceName
+    filterRefs:
+      - name: filter-one
+    ingressRefs: null
+expectFailureMessageToContain: |
+  spec.ingressRefs: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/ingressRefs/invalid-ingressRefs.name-empty.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/ingressRefs/invalid-ingressRefs.name-empty.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: serviceName
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: ''
+expectFailureMessageToContain: |
+  spec.ingressRefs[0].name: Invalid value: ""

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/ingressRefs/invalid-ingressRefs.name-mssing.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/ingressRefs/invalid-ingressRefs.name-mssing.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: serviceName
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - {}
+expectFailureMessageToContain: |
+  spec.ingressRefs[0].name: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/ingressRefs/invalid-ingressRefs.name-not-string.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/ingressRefs/invalid-ingressRefs.name-not-string.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: serviceName
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: []
+expectFailureMessageToContain: |
+  spec.ingressRefs[0].name: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/ingressRefs/invalid-ingressRefs.name-null.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/ingressRefs/invalid-ingressRefs.name-null.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: serviceName
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: null
+expectFailureMessageToContain: |
+  spec.ingressRefs[0].name: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/ingressRefs/invalid-ingressRefs.name-too-long.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/ingressRefs/invalid-ingressRefs.name-too-long.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: serviceName
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: "0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+               50aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+               100aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+               150aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+               200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+               aaaa"
+expectFailureMessageToContain: |
+  spec.ingressRefs[0].name: Too long

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/proxyRef/invalid-proxyRef-missing.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/proxyRef/invalid-proxyRef-missing.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    targetKafkaServiceRef:
+      name: barref
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.proxyRef: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/proxyRef/invalid-proxyRef-not-object.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/proxyRef/invalid-proxyRef-not-object.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef: []
+    targetKafkaServiceRef:
+      name: barref
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.proxyRef: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/proxyRef/invalid-proxyRef-null.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/proxyRef/invalid-proxyRef-null.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef: null
+    targetKafkaServiceRef:
+      name: barref
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.proxyRef: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/proxyRef/invalid-proxyRef.name-empty.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/proxyRef/invalid-proxyRef.name-empty.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: ''
+    targetKafkaServiceRef:
+      name: barref
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.proxyRef.name: Invalid value: ""

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/proxyRef/invalid-proxyRef.name-missing.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/proxyRef/invalid-proxyRef.name-missing.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef: {}
+    targetKafkaServiceRef:
+      name: barref
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.proxyRef.name: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/proxyRef/invalid-proxyRef.name-not-string.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/proxyRef/invalid-proxyRef.name-not-string.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: []
+    targetKafkaServiceRef:
+      name: barref
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.proxyRef.name: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/proxyRef/invalid-proxyRef.name-null.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/proxyRef/invalid-proxyRef.name-null.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: null
+    targetKafkaServiceRef:
+      name: barref
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.proxyRef.name: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/proxyRef/invalid-proxyRef.name-too-long.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/proxyRef/invalid-proxyRef.name-too-long.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: "0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+             50aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+             100aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+             150aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+             200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+             aaaa"
+    targetKafkaServiceRef:
+      name: barref
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.proxyRef.name: Too long

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef-missing.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef-missing.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.targetKafkaServiceRef: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef-not-object.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef-not-object.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef: []
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.targetKafkaServiceRef: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef-null.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef-null.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef: null
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.targetKafkaServiceRef: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef.group-not-kroxylicious.io.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef.group-not-kroxylicious.io.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: serviceName
+      group: "not-kroxylicious.io"
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.targetKafkaServiceRef.group: Invalid value: "not-kroxylicious.io"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef.group-not-string.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef.group-not-string.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: serviceName
+      group: []
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.targetKafkaServiceRef.group: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef.kind-not-KafkaService.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef.kind-not-KafkaService.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: serviceName
+      kind: 'notKafkaService'
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.targetKafkaServiceRef.kind: Invalid value: "notKafkaService"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef.kind-not-string.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef.kind-not-string.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: serviceName
+      kind: []
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.targetKafkaServiceRef.kind: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef.name-empty.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef.name-empty.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: ''
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.targetKafkaServiceRef.name: Invalid value: ""

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef.name-missing.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef.name-missing.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef: {}
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.targetKafkaServiceRef.name: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef.name-not-string.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef.name-not-string.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: []
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.targetKafkaServiceRef.name: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef.name-null.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef.name-null.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: null
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.targetKafkaServiceRef.name: Required value

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef.name-too-long.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/targetKafkaServiceRef/invalid-targetKafkaServiceRef.name-too-long.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: bar
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: "0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+             50aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+             100aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+             150aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+             200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
+             aaaa"
+    filterRefs:
+      - name: filter-one
+    ingressRefs:
+      - name: cluster-ip
+expectFailureMessageToContain: |
+  spec.targetKafkaServiceRef.name: Too long

--- a/kroxylicious-operator/src/test/resources/TestFilesTest/sub1/one.yaml
+++ b/kroxylicious-operator/src/test/resources/TestFilesTest/sub1/one.yaml
@@ -1,0 +1,8 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+hi

--- a/kroxylicious-operator/src/test/resources/TestFilesTest/sub2/two.yaml
+++ b/kroxylicious-operator/src/test/resources/TestFilesTest/sub2/two.yaml
@@ -1,0 +1,8 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+two


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Tests that:
1. myriad invalid custom resources will not be accepted by k8s
2. all the in-* files used by our DerivedResourcesTest are valid, this is handy because it is a crucial test, but since it is mocked it is possible for us to test against different data than would be allowed in via the k8s APIs.

Why:
Our CRDs contain a lot of declared constraints. Required fields, types, length restrictions, patterns. We want some quick feedback that we have specified things correctly. Checking directly with a json schema validation library is a bit tricky since k8s uses an odd standard with their own extensions. Instead we test against minikube to get some real integration with a k8s API server.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
