### PR TITLE
make message, reason and type required

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/Condition.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/Condition.java
@@ -10,6 +10,9 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.Nulls;
 
+import io.fabric8.generator.annotation.Default;
+import io.fabric8.generator.annotation.Required;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -66,17 +69,20 @@ public class Condition implements io.fabric8.kubernetes.api.builder.Editable<Con
      * message is a human readable message indicating details about the transition.
      * This may be an empty string.
      */
-    @com.fasterxml.jackson.annotation.JsonProperty("message")
+    @com.fasterxml.jackson.annotation.JsonProperty(value = "message", defaultValue = "")
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("message is a human readable message indicating details about the transition. \nThis may be an empty string.\n")
-    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = Nulls.FAIL, value = "")
+    @Default("")
+    @NonNull
     private String message;
 
+    @NonNull
     public String getMessage() {
         return message;
     }
 
-    public void setMessage(String message) {
-        this.message = message;
+    public void setMessage(@NonNull String message) {
+        this.message = Objects.requireNonNull(message);
     }
 
     /**
@@ -106,17 +112,20 @@ public class Condition implements io.fabric8.kubernetes.api.builder.Editable<Con
      * The value should be a CamelCase string.
      * This field may not be empty.
      */
-    @com.fasterxml.jackson.annotation.JsonProperty("reason")
+    @com.fasterxml.jackson.annotation.JsonProperty(value = "reason", defaultValue = "")
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("reason contains a programmatic identifier indicating the reason for the condition's last transition. \nProducers of specific condition types may define expected values and meanings for this field, \nand whether the values are considered a guaranteed API. \nThe value should be a CamelCase string. \nThis field may not be empty.\n")
-    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = Nulls.FAIL, value = "")
+    @Default("")
+    @Required
+    @NonNull
     private String reason;
 
     public String getReason() {
         return reason;
     }
 
-    public void setReason(String reason) {
-        this.reason = reason;
+    public void setReason(@NonNull String reason) {
+        this.reason = Objects.requireNonNull(reason);
     }
 
     @Override
@@ -171,9 +180,10 @@ public class Condition implements io.fabric8.kubernetes.api.builder.Editable<Con
     /**
      * type of condition in CamelCase or in foo.example.com/CamelCase.
      */
-    @com.fasterxml.jackson.annotation.JsonProperty("type")
+    @com.fasterxml.jackson.annotation.JsonProperty(value = "type")
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("type of condition in CamelCase or in foo.example.com/CamelCase.")
-    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = Nulls.FAIL)
+    @NonNull
     private Type type;
 
     public Type getType() {
@@ -181,7 +191,7 @@ public class Condition implements io.fabric8.kubernetes.api.builder.Editable<Con
     }
 
     public void setType(Type type) {
-        this.type = type;
+        this.type = Objects.requireNonNull(type);
     }
 
     public enum Type {

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/Condition.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/Condition.java
@@ -13,8 +13,6 @@ import com.fasterxml.jackson.annotation.Nulls;
 import io.fabric8.generator.annotation.Default;
 import io.fabric8.generator.annotation.Required;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-
 /**
  * A common Condition type, used in CR statuses.
  */
@@ -54,14 +52,13 @@ public class Condition implements io.fabric8.kubernetes.api.builder.Editable<Con
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("lastTransitionTime is the last time the condition transitioned from one status to another. \nThis should be when the underlying condition changed. \nIf that is not known, then using the time when the API field changed is acceptable.\n")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = Nulls.FAIL)
     @com.fasterxml.jackson.annotation.JsonFormat(shape = com.fasterxml.jackson.annotation.JsonFormat.Shape.STRING)
-    @NonNull
     private java.time.Instant lastTransitionTime;
 
     public java.time.Instant getLastTransitionTime() {
         return lastTransitionTime;
     }
 
-    public void setLastTransitionTime(@NonNull java.time.Instant lastTransitionTime) {
+    public void setLastTransitionTime(java.time.Instant lastTransitionTime) {
         this.lastTransitionTime = Objects.requireNonNull(lastTransitionTime);
     }
 
@@ -73,15 +70,13 @@ public class Condition implements io.fabric8.kubernetes.api.builder.Editable<Con
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("message is a human readable message indicating details about the transition. \nThis may be an empty string.\n")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = Nulls.FAIL, value = "")
     @Default("")
-    @NonNull
     private String message;
 
-    @NonNull
     public String getMessage() {
         return message;
     }
 
-    public void setMessage(@NonNull String message) {
+    public void setMessage(String message) {
         this.message = Objects.requireNonNull(message);
     }
 
@@ -94,14 +89,13 @@ public class Condition implements io.fabric8.kubernetes.api.builder.Editable<Con
     @com.fasterxml.jackson.annotation.JsonProperty("observedGeneration")
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("observedGeneration represents the .metadata.generation that the condition was set based upon. \nFor instance, if .metadata.generation is currently 12, but the \n.status.conditions[x].observedGeneration is 9, the condition is out of date with \nrespect to the current state of the instance.\n")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = Nulls.FAIL)
-    @NonNull
     private Long observedGeneration;
 
     public Long getObservedGeneration() {
         return observedGeneration;
     }
 
-    public void setObservedGeneration(@NonNull Long observedGeneration) {
+    public void setObservedGeneration(Long observedGeneration) {
         this.observedGeneration = Objects.requireNonNull(observedGeneration);
     }
 
@@ -116,14 +110,13 @@ public class Condition implements io.fabric8.kubernetes.api.builder.Editable<Con
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("reason contains a programmatic identifier indicating the reason for the condition's last transition. \nProducers of specific condition types may define expected values and meanings for this field, \nand whether the values are considered a guaranteed API. \nThe value should be a CamelCase string. \nThis field may not be empty.\n")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = Nulls.FAIL, value = "")
     @Required
-    @NonNull
     private String reason;
 
     public String getReason() {
         return reason;
     }
 
-    public void setReason(@NonNull String reason) {
+    public void setReason(String reason) {
         this.reason = Objects.requireNonNull(reason);
     }
 
@@ -182,7 +175,6 @@ public class Condition implements io.fabric8.kubernetes.api.builder.Editable<Con
     @com.fasterxml.jackson.annotation.JsonProperty(value = "type")
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("type of condition in CamelCase or in foo.example.com/CamelCase.")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = Nulls.FAIL)
-    @NonNull
     private Type type;
 
     public Type getType() {

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/Condition.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/Condition.java
@@ -115,7 +115,6 @@ public class Condition implements io.fabric8.kubernetes.api.builder.Editable<Con
     @com.fasterxml.jackson.annotation.JsonProperty(value = "reason", defaultValue = "")
     @com.fasterxml.jackson.annotation.JsonPropertyDescription("reason contains a programmatic identifier indicating the reason for the condition's last transition. \nProducers of specific condition types may define expected values and meanings for this field, \nand whether the values are considered a guaranteed API. \nThe value should be a CamelCase string. \nThis field may not be empty.\n")
     @com.fasterxml.jackson.annotation.JsonSetter(nulls = Nulls.FAIL, value = "")
-    @Default("")
     @Required
     @NonNull
     private String reason;

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/package-info.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/api/common/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+@ReturnValuesAreNonnullByDefault
+@DefaultAnnotationForParameters(NonNull.class)
+@DefaultAnnotation(NonNull.class)
+package io.kroxylicious.kubernetes.api.common;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotationForParameters;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/StatusFactory.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/StatusFactory.java
@@ -34,7 +34,7 @@ public abstract class StatusFactory<R extends CustomResource<?, ?>> {
                 .withType(type)
                 .withStatus(Condition.Status.TRUE)
                 .withMessage("")
-                .withReason("")
+                .withReason(type.name())
                 .build();
     }
 

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/StatusFactory.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/StatusFactory.java
@@ -33,6 +33,8 @@ public abstract class StatusFactory<R extends CustomResource<?, ?>> {
         return newConditionBuilder(observedGenerationSource)
                 .withType(type)
                 .withStatus(Condition.Status.TRUE)
+                .withMessage("")
+                .withReason("")
                 .build();
     }
 

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaprotocolfilters.filter.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaprotocolfilters.filter.kroxylicious.io-v1.yml
@@ -112,3 +112,4 @@ spec:
                       - observedGeneration
                       - reason
                       - message
+                      - type

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaprotocolfilters.filter.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaprotocolfilters.filter.kroxylicious.io-v1.yml
@@ -98,7 +98,6 @@ spec:
                           The value should be a CamelCase string. 
                           This field may not be empty.
                         type: string
-                        default: ""
                         nullable: false
                       status:
                         description: status of the condition, one of True, False, Unknown.

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaprotocolfilters.filter.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaprotocolfilters.filter.kroxylicious.io-v1.yml
@@ -80,6 +80,8 @@ spec:
                           message is a human readable message indicating details about the transition. 
                           This may be an empty string.
                         type: string
+                        default: ""
+                        nullable: false
                       observedGeneration:
                         description: |
                           observedGeneration represents the .metadata.generation that the condition was set based upon. 
@@ -87,6 +89,7 @@ spec:
                           .status.conditions[x].observedGeneration is 9, the condition is out of date with 
                           respect to the current state of the instance.
                         type: integer
+                        nullable: false
                       reason:
                         description: |
                           reason contains a programmatic identifier indicating the reason for the condition's last transition. 
@@ -95,6 +98,8 @@ spec:
                           The value should be a CamelCase string. 
                           This field may not be empty.
                         type: string
+                        default: ""
+                        nullable: false
                       status:
                         description: status of the condition, one of True, False, Unknown.
                         type: string
@@ -105,3 +110,5 @@ spec:
                     required:
                       - lastTransitionTime
                       - observedGeneration
+                      - reason
+                      - message

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
@@ -77,6 +77,8 @@ spec:
                           message is a human readable message indicating details about the transition. 
                           This may be an empty string.
                         type: string
+                        default: ""
+                        nullable: false
                       observedGeneration:
                         description: |
                           observedGeneration represents the .metadata.generation that the condition was set based upon. 
@@ -84,6 +86,7 @@ spec:
                           .status.conditions[x].observedGeneration is 9, the condition is out of date with 
                           respect to the current state of the instance.
                         type: integer
+                        nullable: false
                       reason:
                         description: |
                           reason contains a programmatic identifier indicating the reason for the condition's last transition. 
@@ -92,6 +95,8 @@ spec:
                           The value should be a CamelCase string. 
                           This field may not be empty.
                         type: string
+                        default: ""
+                        nullable: false
                       status:
                         description: status of the condition, one of True, False, Unknown.
                         type: string
@@ -102,6 +107,8 @@ spec:
                     required:
                       - lastTransitionTime
                       - observedGeneration
+                      - reason
+                      - message
                 clusters:
                   type: array
                   x-kubernetes-list-type: map

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
@@ -109,6 +109,7 @@ spec:
                       - observedGeneration
                       - reason
                       - message
+                      - type
                 clusters:
                   type: array
                   x-kubernetes-list-type: map

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxyingresses.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxyingresses.kroxylicious.io-v1.yml
@@ -104,7 +104,6 @@ spec:
                           The value should be a CamelCase string. 
                           This field may not be empty.
                         type: string
-                        default: ""
                         nullable: false
                       status:
                         description: status of the condition, one of True, False, Unknown.

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxyingresses.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxyingresses.kroxylicious.io-v1.yml
@@ -118,3 +118,4 @@ spec:
                       - observedGeneration
                       - reason
                       - message
+                      - type

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxyingresses.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxyingresses.kroxylicious.io-v1.yml
@@ -86,6 +86,8 @@ spec:
                           message is a human readable message indicating details about the transition. 
                           This may be an empty string.
                         type: string
+                        default: ""
+                        nullable: false
                       observedGeneration:
                         description: |
                           observedGeneration represents the .metadata.generation that the condition was set based upon. 
@@ -93,6 +95,7 @@ spec:
                           .status.conditions[x].observedGeneration is 9, the condition is out of date with 
                           respect to the current state of the instance.
                         type: integer
+                        nullable: false
                       reason:
                         description: |
                           reason contains a programmatic identifier indicating the reason for the condition's last transition. 
@@ -101,6 +104,8 @@ spec:
                           The value should be a CamelCase string. 
                           This field may not be empty.
                         type: string
+                        default: ""
+                        nullable: false
                       status:
                         description: status of the condition, one of True, False, Unknown.
                         type: string
@@ -111,3 +116,5 @@ spec:
                     required:
                       - lastTransitionTime
                       - observedGeneration
+                      - reason
+                      - message

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
@@ -68,6 +68,8 @@ spec:
                           message is a human readable message indicating details about the transition. 
                           This may be an empty string.
                         type: string
+                        default: ""
+                        nullable: false
                       observedGeneration:
                         description: |
                           observedGeneration represents the .metadata.generation that the condition was set based upon. 
@@ -75,6 +77,7 @@ spec:
                           .status.conditions[x].observedGeneration is 9, the condition is out of date with 
                           respect to the current state of the instance.
                         type: integer
+                        nullable: false
                       reason:
                         description: |
                           reason contains a programmatic identifier indicating the reason for the condition's last transition. 
@@ -83,6 +86,8 @@ spec:
                           The value should be a CamelCase string. 
                           This field may not be empty.
                         type: string
+                        default: ""
+                        nullable: false
                       status:
                         description: status of the condition, one of True, False, Unknown.
                         type: string
@@ -93,3 +98,5 @@ spec:
                     required:
                       - lastTransitionTime
                       - observedGeneration
+                      - reason
+                      - message

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
@@ -100,3 +100,4 @@ spec:
                       - observedGeneration
                       - reason
                       - message
+                      - type

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
@@ -86,7 +86,6 @@ spec:
                           The value should be a CamelCase string. 
                           This field may not be empty.
                         type: string
-                        default: ""
                         nullable: false
                       status:
                         description: status of the condition, one of True, False, Unknown.

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
@@ -112,6 +112,8 @@ spec:
                           message is a human readable message indicating details about the transition. 
                           This may be an empty string.
                         type: string
+                        default: ""
+                        nullable: false
                       observedGeneration:
                         description: |
                           observedGeneration represents the .metadata.generation that the condition was set based upon. 
@@ -119,6 +121,7 @@ spec:
                           .status.conditions[x].observedGeneration is 9, the condition is out of date with 
                           respect to the current state of the instance.
                         type: integer
+                        nullable: false
                       reason:
                         description: |
                           reason contains a programmatic identifier indicating the reason for the condition's last transition. 
@@ -127,6 +130,8 @@ spec:
                           The value should be a CamelCase string. 
                           This field may not be empty.
                         type: string
+                        default: ""
+                        nullable: false
                       status:
                         description: status of the condition, one of True, False, Unknown.
                         type: string
@@ -137,3 +142,5 @@ spec:
                     required:
                       - lastTransitionTime
                       - observedGeneration
+                      - reason
+                      - message

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
@@ -144,3 +144,4 @@ spec:
                       - observedGeneration
                       - reason
                       - message
+                      - type

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
@@ -130,7 +130,6 @@ spec:
                           The value should be a CamelCase string. 
                           This field may not be empty.
                         type: string
-                        default: ""
                         nullable: false
                       status:
                         description: status of the condition, one of True, False, Unknown.

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/api/common/ConditionTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/api/common/ConditionTest.java
@@ -8,6 +8,7 @@ package io.kroxylicious.kubernetes.api.common;
 
 import java.time.Instant;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -18,12 +19,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ConditionTest {
 
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+    }
+
     @Test
     void serializedFormShouldUseIso8601() throws JsonProcessingException {
         // Given
-        Condition build = new ConditionBuilder().withLastTransitionTime(Instant.EPOCH).withObservedGeneration(345678L).build();
+        Condition build = new ConditionBuilder()
+                .withLastTransitionTime(Instant.EPOCH)
+                .withObservedGeneration(345678L)
+                .withReason("")
+                .withMessage("")
+                .withType(Condition.Type.Ready)
+                .build();
         // When
-        var conditionWithEpoch = new ObjectMapper().registerModule(new JavaTimeModule()).writeValueAsString(build);
+        var conditionWithEpoch = objectMapper.writeValueAsString(build);
+
         // Then
         assertThat(conditionWithEpoch).contains("\"lastTransitionTime\":\"1970-01-01T00:00:00Z\"");
     }
@@ -31,11 +46,18 @@ class ConditionTest {
     @Test
     void roundTrip() throws JsonProcessingException {
         // Given
-        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
-        Condition wroteCondition = new ConditionBuilder().withLastTransitionTime(Instant.now()).withObservedGeneration(1L).build();
-        // When
+        Condition wroteCondition = new ConditionBuilder()
+                .withLastTransitionTime(Instant.now())
+                .withObservedGeneration(1L)
+                .withReason("")
+                .withMessage("")
+                .withType(Condition.Type.Ready)
+                .build();
         var conditionString = objectMapper.writeValueAsString(wroteCondition);
+
+        // When
         var readCondition = objectMapper.readValue(conditionString, Condition.class);
+
         // Then
         assertThat(readCondition).isEqualTo(wroteCondition);
     }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerTest.java
@@ -323,6 +323,8 @@ class KafkaProxyReconcilerTest {
                         .withType(Condition.Type.Ready)
                         .withStatus(Condition.Status.TRUE)
                         .withObservedGeneration(generation)
+                        .withMessage("")
+                        .withReason("")
                         .withLastTransitionTime(TEST_CLOCK.instant())
                     .endCondition()
                 .endStatus()

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ResourceStateTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ResourceStateTest.java
@@ -38,6 +38,8 @@ class ResourceStateTest {
                 .withType(Condition.Type.ResolvedRefs)
                 .withStatus(Condition.Status.FALSE)
                 .withLastTransitionTime(Instant.EPOCH)
+                .withReason("RESOLVE_FAILURE")
+                .withMessage("failed to resolve")
                 .build();
 
         var c13 = new ConditionBuilder()
@@ -45,6 +47,8 @@ class ResourceStateTest {
                 .withType(Condition.Type.ResolvedRefs)
                 .withStatus(Condition.Status.FALSE)
                 .withLastTransitionTime(Instant.EPOCH)
+                .withReason("RESOLVE_FAILURE")
+                .withMessage("failed to resolve")
                 .build();
 
         var c13True = new ConditionBuilder()
@@ -52,6 +56,8 @@ class ResourceStateTest {
                 .withType(Condition.Type.ResolvedRefs)
                 .withStatus(Condition.Status.TRUE)
                 .withLastTransitionTime(Instant.EPOCH)
+                .withReason("")
+                .withMessage("")
                 .build();
 
         assertThat(ResourceState.newConditions(List.of(c12), ResourceState.fromList(List.of(c13)))).isEqualTo(List.of(c13));
@@ -64,6 +70,9 @@ class ResourceStateTest {
     public static Stream<Arguments> testComparator() {
         Instant now = Instant.now();
         Condition template = new ConditionBuilder().withStatus(Condition.Status.FALSE)
+                .withReason("REASON")
+                .withMessage("message for humans")
+                .withType(Condition.Type.Ready)
                 .withObservedGeneration(1L)
                 .withLastTransitionTime(now).build();
         Condition observedGenerationOne = template.edit().withObservedGeneration(1L).build();
@@ -114,12 +123,16 @@ class ResourceStateTest {
                 .withType(Condition.Type.ResolvedRefs)
                 .withStatus(Condition.Status.FALSE)
                 .withLastTransitionTime(originalTime)
+                .withReason("RESOLVE_FAILURE")
+                .withMessage("failed to resolve")
                 .build();
 
         Condition newCondition = new ConditionBuilder()
                 .withObservedGeneration(12L)
                 .withType(Condition.Type.ResolvedRefs)
                 .withStatus(Condition.Status.FALSE)
+                .withReason("RESOLVE_FAILURE")
+                .withMessage("failed to resolve")
                 .withLastTransitionTime(originalTime.plus(1, ChronoUnit.MINUTES))
                 .build();
 
@@ -137,6 +150,7 @@ class ResourceStateTest {
                 .withObservedGeneration(12L)
                 .withType(Condition.Type.ResolvedRefs)
                 .withStatus(Condition.Status.FALSE)
+                .withReason("ORIGINAL_REASON")
                 .withMessage("original message")
                 .withLastTransitionTime(originalTime)
                 .build();
@@ -145,6 +159,7 @@ class ResourceStateTest {
                 .withObservedGeneration(12L)
                 .withType(Condition.Type.ResolvedRefs)
                 .withStatus(Condition.Status.FALSE)
+                .withReason("ORIGINAL_REASON")
                 .withMessage("new message")
                 .withLastTransitionTime(originalTime.plus(1, ChronoUnit.MINUTES))
                 .build();
@@ -166,6 +181,8 @@ class ResourceStateTest {
                 .withType(Condition.Type.ResolvedRefs)
                 .withStatus(Condition.Status.FALSE)
                 .withLastTransitionTime(originalTime)
+                .withReason("RESOLVE_FAILURE")
+                .withMessage("failed to resolve")
                 .build();
 
         Condition newCondition = new ConditionBuilder()
@@ -173,6 +190,8 @@ class ResourceStateTest {
                 .withType(Condition.Type.ResolvedRefs)
                 .withStatus(Condition.Status.TRUE)
                 .withLastTransitionTime(originalTime.plus(1, ChronoUnit.MINUTES))
+                .withReason("")
+                .withMessage("")
                 .build();
 
         // when
@@ -191,6 +210,8 @@ class ResourceStateTest {
                 .withType(Condition.Type.ResolvedRefs)
                 .withStatus(Condition.Status.FALSE)
                 .withLastTransitionTime(originalTime)
+                .withReason("RESOLVE_FAILURE")
+                .withMessage("failed to resolve")
                 .build();
 
         Condition newCondition = new ConditionBuilder()
@@ -198,6 +219,8 @@ class ResourceStateTest {
                 .withType(Condition.Type.ResolvedRefs)
                 .withStatus(Condition.Status.FALSE)
                 .withLastTransitionTime(originalTime.plus(1, ChronoUnit.MINUTES))
+                .withReason("RESOLVE_FAILURE")
+                .withMessage("failed to resolve")
                 .build();
 
         // when
@@ -216,6 +239,8 @@ class ResourceStateTest {
                 .withObservedGeneration(12L)
                 .withType(Condition.Type.ResolvedRefs)
                 .withStatus(Condition.Status.FALSE)
+                .withReason("RESOLVE_FAILURE")
+                .withMessage("failed to resolve")
                 .withLastTransitionTime(originalTime)
                 .build();
 
@@ -223,6 +248,8 @@ class ResourceStateTest {
                 .withObservedGeneration(13L)
                 .withType(Condition.Type.ResolvedRefs)
                 .withStatus(Condition.Status.TRUE)
+                .withReason("")
+                .withMessage("")
                 .withLastTransitionTime(originalTime.plus(1, ChronoUnit.MINUTES))
                 .build();
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerTest.java
@@ -180,6 +180,8 @@ class VirtualKafkaClusterReconcilerTest {
                                 .withStatus(Condition.Status.FALSE)
                                 .withLastTransitionTime(Instant.now())
                                 .withObservedGeneration(1L)
+                                .withReason("NO_FILTERS")
+                                .withMessage("no filters found")
                                 .endCondition().endStatus().build()),
                         Set.of(INGRESS),
                         Set.of(),
@@ -205,6 +207,8 @@ class VirtualKafkaClusterReconcilerTest {
                                 .withStatus(Condition.Status.FALSE)
                                 .withLastTransitionTime(Instant.now())
                                 .withObservedGeneration(1L)
+                                .withReason("NO_FILTERS")
+                                .withMessage("no filters found")
                                 .endCondition().endStatus().build()),
                         Set.of(),
                         assertResolvedRefsFalse(
@@ -226,9 +230,15 @@ class VirtualKafkaClusterReconcilerTest {
                         Optional.empty(),
                         Optional.of(SERVICE),
                         Set.of(INGRESS),
-                        Set.of(new KafkaProtocolFilterBuilder(FILTER_MY_FILTER).withNewStatus().addNewCondition().withType(Condition.Type.ResolvedRefs)
-                                .withStatus(Condition.Status.FALSE).withLastTransitionTime(Instant.now())
-                                .withObservedGeneration(1L).endCondition().endStatus().build()),
+                        Set.of(new KafkaProtocolFilterBuilder(FILTER_MY_FILTER).withNewStatus()
+                                .addNewCondition()
+                                .withType(Condition.Type.ResolvedRefs)
+                                .withStatus(Condition.Status.FALSE)
+                                .withLastTransitionTime(Instant.now())
+                                .withObservedGeneration(1L)
+                                .withReason("RESOLVE_FAILURE")
+                                .withMessage("failed to resolve")
+                                .endCondition().endStatus().build()),
                         assertResolvedRefsFalse(
                                 VirtualKafkaClusterReconciler.TRANSITIVELY_REFERENCED_RESOURCES_NOT_FOUND,
                                 "spec.filterRefs references kafkaprotocolfilter.filter.kroxylicious.io/my-filter in namespace 'my-namespace'")));
@@ -238,7 +248,7 @@ class VirtualKafkaClusterReconcilerTest {
     private static BiConsumer<VirtualKafkaCluster, ConditionListAssert> assertResolvedRefsFalse(
                                                                                                 String referencedResourcesNotFound,
                                                                                                 String message) {
-        return (BiConsumer<VirtualKafkaCluster, ConditionListAssert>) (cluster, cl) -> cl.singleOfType(Condition.Type.ResolvedRefs)
+        return (cluster, cl) -> cl.singleOfType(Condition.Type.ResolvedRefs)
                 .hasObservedGenerationInSyncWithMetadataOf(cluster)
                 .hasLastTransitionTime(TEST_CLOCK.instant())
                 .isResolvedRefsFalse(

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/ConditionAssert.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/ConditionAssert.java
@@ -72,11 +72,6 @@ public class ConditionAssert extends AbstractObjectAssert<ConditionAssert, Condi
         return Assertions.assertThat(actual.getReason());
     }
 
-    public ConditionAssert hasNoReason() {
-        reason().isEmpty();
-        return this;
-    }
-
     public ConditionAssert hasReason(String expected) {
         reason().isEqualTo(expected);
         return this;
@@ -103,7 +98,7 @@ public class ConditionAssert extends AbstractObjectAssert<ConditionAssert, Condi
     public ConditionAssert isAcceptedTrue() {
         hasType(Condition.Type.Accepted);
         hasStatus(Condition.Status.TRUE);
-        hasNoReason();
+        hasReason(Condition.Type.Accepted.name());
         hasNoMessage();
         return this;
     }
@@ -141,7 +136,7 @@ public class ConditionAssert extends AbstractObjectAssert<ConditionAssert, Condi
     public ConditionAssert isResolvedRefsTrue() {
         hasType(Condition.Type.ResolvedRefs);
         hasStatus(Condition.Status.TRUE);
-        hasNoReason();
+        hasReason(Condition.Type.ResolvedRefs.name());
         hasNoMessage();
         return this;
     }
@@ -171,7 +166,7 @@ public class ConditionAssert extends AbstractObjectAssert<ConditionAssert, Condi
     public ConditionAssert isReadyTrue() {
         hasType(Condition.Type.Ready);
         hasStatus(Condition.Status.TRUE);
-        hasNoReason();
+        hasReason(Condition.Type.Ready.name());
         hasNoMessage();
         return this;
     }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/ConditionAssert.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/assertj/ConditionAssert.java
@@ -59,7 +59,7 @@ public class ConditionAssert extends AbstractObjectAssert<ConditionAssert, Condi
     }
 
     public ConditionAssert hasNoMessage() {
-        message().isNull();
+        message().isEmpty();
         return this;
     }
 
@@ -73,7 +73,7 @@ public class ConditionAssert extends AbstractObjectAssert<ConditionAssert, Condi
     }
 
     public ConditionAssert hasNoReason() {
-        reason().isNull();
+        reason().isEmpty();
         return this;
     }
 

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-ConfigMap-example-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-ConfigMap-example-config-state.yaml
@@ -32,6 +32,6 @@ data:
         type: "Accepted"
         status: "True"
         lastTransitionTime: "1970-01-01T00:00:00Z"
-        reason: ""
+        reason: "Accepted"
         message: ""
       observedGeneration: 2

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-ConfigMap-example-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-ConfigMap-example-config-state.yaml
@@ -32,4 +32,6 @@ data:
         type: "Accepted"
         status: "True"
         lastTransitionTime: "1970-01-01T00:00:00Z"
+        reason: ""
+        message: ""
       observedGeneration: 2

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-ConfigMap-minimal-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-ConfigMap-minimal-config-state.yaml
@@ -32,6 +32,6 @@ data:
         type: "Accepted"
         status: "True"
         lastTransitionTime: "1970-01-01T00:00:00Z"
-        reason: ""
+        reason: "Accepted"
         message: ""
       observedGeneration: 4

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-ConfigMap-minimal-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-ConfigMap-minimal-config-state.yaml
@@ -32,4 +32,6 @@ data:
         type: "Accepted"
         status: "True"
         lastTransitionTime: "1970-01-01T00:00:00Z"
+        reason: ""
+        message: ""
       observedGeneration: 4

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-ConfigMap-twocluster-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-ConfigMap-twocluster-config-state.yaml
@@ -47,4 +47,6 @@ data:
         type: "Accepted"
         status: "True"
         lastTransitionTime: "1970-01-01T00:00:00Z"
+        reason: ""
+        message: ""
       observedGeneration: 3

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-ConfigMap-twocluster-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-ConfigMap-twocluster-config-state.yaml
@@ -47,6 +47,6 @@ data:
         type: "Accepted"
         status: "True"
         lastTransitionTime: "1970-01-01T00:00:00Z"
-        reason: ""
+        reason: "Accepted"
         message: ""
       observedGeneration: 3

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-ConfigMap-twocluster-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-ConfigMap-twocluster-config-state.yaml
@@ -32,7 +32,7 @@ data:
         type: "Accepted"
         status: "True"
         lastTransitionTime: "1970-01-01T00:00:00Z"
-        reason: ""
+        reason: "Accepted"
         message: ""
       observedGeneration: 6
   cluster-foo: |-

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-ConfigMap-twocluster-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-ConfigMap-twocluster-config-state.yaml
@@ -32,6 +32,8 @@ data:
         type: "Accepted"
         status: "True"
         lastTransitionTime: "1970-01-01T00:00:00Z"
+        reason: ""
+        message: ""
       observedGeneration: 6
   cluster-foo: |-
     ---

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-ConfigMap-example-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-ConfigMap-example-config-state.yaml
@@ -32,4 +32,6 @@ data:
         type: "Accepted"
         status: "True"
         lastTransitionTime: "1970-01-01T00:00:00Z"
+        reason: ""
+        message: ""
       observedGeneration: 12

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-ConfigMap-example-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-ConfigMap-example-config-state.yaml
@@ -32,6 +32,6 @@ data:
         type: "Accepted"
         status: "True"
         lastTransitionTime: "1970-01-01T00:00:00Z"
-        reason: ""
+        reason: "Accepted"
         message: ""
       observedGeneration: 12

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-ConfigMap-use-pod-template-spec-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-ConfigMap-use-pod-template-spec-config-state.yaml
@@ -32,4 +32,6 @@ data:
         type: "Accepted"
         status: "True"
         lastTransitionTime: "1970-01-01T00:00:00Z"
+        reason: ""
+        message: ""
       observedGeneration: 5

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-ConfigMap-use-pod-template-spec-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-ConfigMap-use-pod-template-spec-config-state.yaml
@@ -32,6 +32,6 @@ data:
         type: "Accepted"
         status: "True"
         lastTransitionTime: "1970-01-01T00:00:00Z"
-        reason: ""
+        reason: "Accepted"
         message: ""
       observedGeneration: 5


### PR DESCRIPTION
This completes the alignment with KEP-1623

### Type of change


- Enhancement / new feature

### Description

This PR completes our alignment with [KEP-1623](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/1623-standardize-conditions#kep-1623-standardize-condition)

### Additional Context

It was noted during #2032 that we should completely align with KEP-1623 so this PR does that.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
