### PR TITLE
Operator: Proxy reconciler ignores VirtualKafkaCluster with ResolvedRefs: False

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ClusterResolutionResult.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ClusterResolutionResult.java
@@ -8,6 +8,7 @@ package io.kroxylicious.kubernetes.operator.resolver;
 
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import io.kroxylicious.kubernetes.api.common.LocalRef;
@@ -56,6 +57,11 @@ public record ClusterResolutionResult(VirtualKafkaCluster cluster,
 
     public Stream<LocalRef<?>> findResourcesWithResolvedRefsFalse(String kind) {
         return findResourcesWithResolvedRefsFalse().filter(r -> r.getKind().equals(kind));
+    }
+
+    ClusterResolutionResult addAllResourcesHavingResolvedRefsFalse(Set<LocalRef<?>> resolvedRefsFalse) {
+        return new ClusterResolutionResult(cluster, danglingReferences, Stream.concat(resourcesWithResolvedRefsFalse.stream(), resolvedRefsFalse.stream()).collect(
+                Collectors.toSet()));
     }
 
     /**

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolverTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/resolver/DependencyResolverTest.java
@@ -155,8 +155,9 @@ class DependencyResolverTest {
 
     // we want to ensure that when we are reconciling a VirtualKafkaCluster than we do not consider the status of that
     // cluster. Ie if a previous reconciliation sets the cluster to ResolvedRefs: False, we do not want that status to
+    // be considered when calculating a fresh status.
     @Test
-    void resolveClusterWithResolvedRefsFalseCondition() {
+    void resolveClusterShouldIgnoreConditionsForTargetCluster() {
         // given
         givenClusterRefsInContext(kafkaService("cluster"));
         VirtualKafkaCluster cluster = virtualCluster(null, "cluster", List.of(), getProxyRef(PROXY_NAME))


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactor

### Description

The ProxyReconciler did not consider the conditions of the VirtualKafkaCluster. It should not include any VKC with ResolvedRefs: False.

To implement this I've refactored the Resolver

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
