### PR TITLE
Fix #1829: Report downstream bootstrap address via the VirtualKafkaCluster status section.

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="MavenProjectsManager">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="MavenProjectsManager">

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconciler.java
@@ -118,7 +118,7 @@ public final class VirtualKafkaClusterReconciler implements
                     var kubenetesService = existingKubernetesServices.get(ingressRef);
                     var builder = new IngressesBuilder();
                     builder.withName(ingressRef.getName());
-                    builder.withBootstrap(getBootstrap(kubenetesService));
+                    builder.withBootstrapServer(getBootstrapServer(kubenetesService));
                     return builder.build();
                 }).toList();
 
@@ -137,7 +137,7 @@ public final class VirtualKafkaClusterReconciler implements
         return updateControl;
     }
 
-    private String getBootstrap(Service kubenetesService) {
+    private String getBootstrapServer(Service kubenetesService) {
         var metadata = kubenetesService.getMetadata();
         var bootstrapPort = kubenetesService.getSpec().getPorts().stream()
                 .map(ServicePort::getPort)

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterStatusFactory.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterStatusFactory.java
@@ -14,6 +14,7 @@ import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterStatus;
+import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterstatus.Ingresses;
 
 public class VirtualKafkaClusterStatusFactory extends StatusFactory<VirtualKafkaCluster> {
 
@@ -22,7 +23,7 @@ public class VirtualKafkaClusterStatusFactory extends StatusFactory<VirtualKafka
     }
 
     VirtualKafkaCluster clusterStatusPatch(VirtualKafkaCluster observedIngress,
-                                           ResourceState condition) {
+                                           ResourceState condition, List<Ingresses> ingresses) {
         // @formatter:off
         return new VirtualKafkaClusterBuilder()
                 .withNewMetadata()
@@ -33,6 +34,7 @@ public class VirtualKafkaClusterStatusFactory extends StatusFactory<VirtualKafka
                 .withNewStatus()
                     .withObservedGeneration(ResourcesUtil.generation(observedIngress))
                     .withConditions(ResourceState.newConditions(Optional.ofNullable(observedIngress.getStatus()).map(VirtualKafkaClusterStatus::getConditions).orElse(List.of()), condition))
+                    .withIngresses(ingresses)
                 .endStatus()
                 .build();
         // @formatter:on
@@ -43,7 +45,7 @@ public class VirtualKafkaClusterStatusFactory extends StatusFactory<VirtualKafka
                                                        Condition.Type type,
                                                        Exception e) {
         Condition unknownCondition = newUnknownCondition(observedFilter, type, e);
-        return clusterStatusPatch(observedFilter, ResourceState.of(unknownCondition));
+        return clusterStatusPatch(observedFilter, ResourceState.of(unknownCondition), List.of());
     }
 
     @Override
@@ -52,13 +54,13 @@ public class VirtualKafkaClusterStatusFactory extends StatusFactory<VirtualKafka
                                                      String reason,
                                                      String message) {
         Condition falseCondition = newFalseCondition(observedProxy, type, reason, message);
-        return clusterStatusPatch(observedProxy, ResourceState.of(falseCondition));
+        return clusterStatusPatch(observedProxy, ResourceState.of(falseCondition), List.of());
     }
 
     @Override
     VirtualKafkaCluster newTrueConditionStatusPatch(VirtualKafkaCluster observedProxy,
                                                     Condition.Type type) {
         Condition trueCondition = newTrueCondition(observedProxy, type);
-        return clusterStatusPatch(observedProxy, ResourceState.of(trueCondition));
+        return clusterStatusPatch(observedProxy, ResourceState.of(trueCondition), List.of());
     }
 }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/ingress/ClusterIPIngressDefinition.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/ingress/ClusterIPIngressDefinition.java
@@ -34,7 +34,9 @@ import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.namespace;
 import static java.lang.Math.toIntExact;
 
-public record ClusterIPIngressDefinition(KafkaProxyIngress resource, VirtualKafkaCluster cluster, KafkaProxy primary,
+public record ClusterIPIngressDefinition(KafkaProxyIngress resource,
+                                         VirtualKafkaCluster cluster,
+                                         KafkaProxy primary,
                                          List<NodeIdRanges> nodeIdRanges)
         implements IngressDefinition {
 

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
@@ -144,3 +144,23 @@ spec:
                       - reason
                       - message
                       - type
+                ingresses:
+                  type: array
+                  description: -|
+                    Ingresses is a list of ingresses that are associated with the virtual cluster. It reports
+                    the name of each ingress associated with the virtual cluster and the boostrap that
+                    a Kafka client will use to connect to the virtual cluster.
+                  default: []
+                  items:
+                    type: object
+                    required: [ "name" ]
+                    properties:
+                      name:
+                        description: Name is the name of the ingress.
+                        type: string
+                      bootstrap:
+                        description: -|
+                          Bootstrap that a Kafka client would use to connect to the virtual cluster. The boostrap
+                          field will be absent if the address is not yet available. This may mean that work by
+                          another operator to assign the address is still pending.
+                        type: string

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
@@ -145,22 +145,19 @@ spec:
                       - message
                       - type
                 ingresses:
-                  type: array
                   description: -|
-                    Ingresses is a list of ingresses that are associated with the virtual cluster. It reports
-                    the name of each ingress associated with the virtual cluster and the boostrap that
-                    a Kafka client will use to connect to the virtual cluster.
+                    Lists the ingresses that have been associated with the virtual cluster.
+                  type: array
                   default: []
                   items:
                     type: object
                     required: [ "name" ]
                     properties:
                       name:
-                        description: Name is the name of the ingress.
+                        description: The name of the ingress.
                         type: string
-                      bootstrap:
+                      bootstrapServer:
                         description: -|
-                          Bootstrap that a Kafka client would use to connect to the virtual cluster. The boostrap
-                          field will be absent if the address is not yet available. This may mean that work by
-                          another operator to assign the address is still pending.
+                          The address (host and port) that a Kafka client would use make its initial connection to the
+                          virtual cluster. This property will be absent if the address is not yet available.
                         type: string

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerIT.java
@@ -285,7 +285,7 @@ class VirtualKafkaClusterReconcilerIT {
                     .singleElement()
                     .satisfies(i -> {
                         assertThat(i.getName()).isEqualTo(INGRESS_D);
-                        assertThat(i.getBootstrap()).isEqualTo("bar-cluster-ingress-d.%s.svc.cluster.local".formatted(extension.getNamespace()));
+                        assertThat(i.getBootstrap()).isEqualTo("bar-cluster-ingress-d.%s.svc.cluster.local:9292".formatted(extension.getNamespace()));
                     });
         });
     }
@@ -316,14 +316,14 @@ class VirtualKafkaClusterReconcilerIT {
         AWAIT.alias("ClusterStatusBootstrap").untilAsserted(() -> {
             var vkc = testActor.resources(VirtualKafkaCluster.class)
                     .withName(ResourcesUtil.name(clusterBar)).get();
-            VirtualKafkaClusterStatus status = vkc.getStatus();
+            var status = vkc.getStatus();
             assertThat(status)
                     .isNotNull()
                     .extracting(VirtualKafkaClusterStatus::getIngresses, InstanceOfAssertFactories.list(Ingresses.class))
                     .singleElement()
                     .satisfies(i -> {
                         assertThat(i.getName()).isEqualTo(INGRESS_D);
-                        assertThat(i.getBootstrap()).isEqualTo("bar-cluster-ingress-d.%s.svc.cluster.local".formatted(extension.getNamespace()));
+                        assertThat(i.getBootstrap()).isEqualTo("bar-cluster-ingress-d.%s.svc.cluster.local:9292".formatted(extension.getNamespace()));
                     });
         });
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerTest.java
@@ -380,7 +380,7 @@ class VirtualKafkaClusterReconcilerTest {
                         .singleElement()
                         .satisfies(ingress -> {
                             assertThat(ingress.getName()).isEqualTo(INGRESS.getMetadata().getName());
-                            assertThat(ingress.getBootstrap()).isEqualTo("foo-my-ingress.my-namespace.svc.cluster.local:9082");
+                            assertThat(ingress.getBootstrapServer()).isEqualTo("foo-my-ingress.my-namespace.svc.cluster.local:9082");
                         }));
 
     }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/model/ingress/ClusterIPIngressDefinitionTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/model/ingress/ClusterIPIngressDefinitionTest.java
@@ -40,6 +40,8 @@ import io.kroxylicious.proxy.service.HostPort;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+import static io.kroxylicious.kubernetes.operator.model.ingress.ClusterIPIngressDefinition.INGRESS_NAME_ANNOTATION;
+import static io.kroxylicious.kubernetes.operator.model.ingress.ClusterIPIngressDefinition.VIRTUAL_CLUSTER_NAME_ANNOTATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
@@ -151,6 +153,8 @@ class ClusterIPIngressDefinitionTest {
                 assertThat(metadata.getNamespace()).isEqualTo(NAMESPACE);
                 assertThat(metadata.getName()).isEqualTo(CLUSTER_NAME + "-" + INGRESS_NAME);
                 assertThat(metadata.getLabels()).containsExactlyEntriesOf(orderedServiceLabels);
+                assertThat(metadata.getAnnotations())
+                        .containsExactlyInAnyOrderEntriesOf(Map.of(INGRESS_NAME_ANNOTATION, INGRESS_NAME, VIRTUAL_CLUSTER_NAME_ANNOTATION, CLUSTER_NAME));
                 assertThat(metadata.getOwnerReferences()).hasSize(1).singleElement().satisfies(ownerRef -> {
                     assertThat(ownerRef.getKind()).isEqualTo("KafkaProxy");
                     assertThat(ownerRef.getApiVersion()).isEqualTo("kroxylicious.io/v1alpha1");

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-ConfigMap-example-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-ConfigMap-example-config-state.yaml
@@ -35,6 +35,7 @@ data:
         reason: "Invalid"
         message: "Resource kafkaservice.kroxylicious.io/barref in namespace 'proxy-ns'\
           \ was not found."
+      ingresses: []
       observedGeneration: 4
   cluster-foo: |-
     ---
@@ -49,4 +50,5 @@ data:
         lastTransitionTime: "1970-01-01T00:00:00Z"
         reason: "Invalid"
         message: "Ingress(es) [cluster-ip] of cluster conflicts with another ingress"
+      ingresses: []
       observedGeneration: 4

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-ConfigMap-example-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-ConfigMap-example-config-state.yaml
@@ -34,4 +34,5 @@ data:
         lastTransitionTime: "1970-01-01T00:00:00Z"
         reason: "Accepted"
         message: ""
+      ingresses: []
       observedGeneration: 2

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Service-foo-cluster-ip.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Service-foo-cluster-ip.yaml
@@ -8,6 +8,9 @@
 apiVersion: "v1"
 kind: "Service"
 metadata:
+  annotations:
+    io.kroxylicious/operator.ingress.ingress-name: "cluster-ip"
+    io.kroxylicious/operator.ingress.virtualcluster-name: "foo"
   labels:
     app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Service-foo-cluster-ip.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Service-foo-cluster-ip.yaml
@@ -8,9 +8,6 @@
 apiVersion: "v1"
 kind: "Service"
 metadata:
-  annotations:
-    io.kroxylicious/operator.ingress.ingress-name: "cluster-ip"
-    io.kroxylicious/operator.ingress.virtualcluster-name: "foo"
   labels:
     app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
@@ -23,6 +20,12 @@ metadata:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"
       name: "example"
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "VirtualKafkaCluster"
+      name: "foo"
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxyIngress"
+      name: "cluster-ip"
 spec:
   ports:
     - name: "foo-9292"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-ConfigMap-example-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-ConfigMap-example-config-state.yaml
@@ -35,6 +35,7 @@ data:
         reason: "Invalid"
         message: "Resource kafkaprotocolfilter.filter.kroxylicious.io/missing in namespace\
           \ 'proxy-ns' was not found."
+      ingresses: []
       observedGeneration: 4
   cluster-foo: |-
     ---
@@ -49,4 +50,5 @@ data:
         lastTransitionTime: "1970-01-01T00:00:00Z"
         reason: "Invalid"
         message: "Ingress(es) [cluster-ip-foo] of cluster conflicts with another ingress"
+      ingresses: []
       observedGeneration: 1

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-ConfigMap-minimal-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-ConfigMap-minimal-config-state.yaml
@@ -34,4 +34,5 @@ data:
         lastTransitionTime: "1970-01-01T00:00:00Z"
         reason: "Accepted"
         message: ""
+      ingresses: []
       observedGeneration: 4

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Service-one-cluster-ip.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Service-one-cluster-ip.yaml
@@ -8,9 +8,6 @@
 apiVersion: "v1"
 kind: "Service"
 metadata:
-  annotations:
-    io.kroxylicious/operator.ingress.ingress-name: "cluster-ip"
-    io.kroxylicious/operator.ingress.virtualcluster-name: "one"
   labels:
     app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
@@ -23,6 +20,12 @@ metadata:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"
       name: "minimal"
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "VirtualKafkaCluster"
+      name: "one"
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxyIngress"
+      name: "cluster-ip"
 spec:
   ports:
     - name: "one-9292"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Service-one-cluster-ip.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Service-one-cluster-ip.yaml
@@ -8,6 +8,9 @@
 apiVersion: "v1"
 kind: "Service"
 metadata:
+  annotations:
+    io.kroxylicious/operator.ingress.ingress-name: "cluster-ip"
+    io.kroxylicious/operator.ingress.virtualcluster-name: "one"
   labels:
     app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-ConfigMap-twocluster-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-ConfigMap-twocluster-config-state.yaml
@@ -35,6 +35,7 @@ data:
         reason: "Invalid"
         message: "Resource kafkaproxyingress.kroxylicious.io/MISSING in namespace 'proxy-ns'\
           \ was not found."
+      ingresses: []
       observedGeneration: 4
   cluster-bar: |-
     ---
@@ -49,4 +50,5 @@ data:
         lastTransitionTime: "1970-01-01T00:00:00Z"
         reason: "Accepted"
         message: ""
+      ingresses: []
       observedGeneration: 3

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-Service-bar-cluster-ip-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-Service-bar-cluster-ip-bar.yaml
@@ -8,6 +8,9 @@
 apiVersion: "v1"
 kind: "Service"
 metadata:
+  annotations:
+    io.kroxylicious/operator.ingress.ingress-name: "cluster-ip-bar"
+    io.kroxylicious/operator.ingress.virtualcluster-name: "bar"
   labels:
     app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-Service-bar-cluster-ip-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-Service-bar-cluster-ip-bar.yaml
@@ -8,9 +8,6 @@
 apiVersion: "v1"
 kind: "Service"
 metadata:
-  annotations:
-    io.kroxylicious/operator.ingress.ingress-name: "cluster-ip-bar"
-    io.kroxylicious/operator.ingress.virtualcluster-name: "bar"
   labels:
     app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
@@ -23,6 +20,12 @@ metadata:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"
       name: "twocluster"
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "VirtualKafkaCluster"
+      name: "bar"
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxyIngress"
+      name: "cluster-ip-bar"
 spec:
   ports:
     - name: "bar-9292"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-ConfigMap-twocluster-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-ConfigMap-twocluster-config-state.yaml
@@ -34,6 +34,7 @@ data:
         lastTransitionTime: "1970-01-01T00:00:00Z"
         reason: "Accepted"
         message: ""
+      ingresses: []
       observedGeneration: 6
   cluster-foo: |-
     ---
@@ -48,5 +49,6 @@ data:
         lastTransitionTime: "1970-01-01T00:00:00Z"
         reason: "Invalid"
         message: "Ingress(es) [cluster-ip-foo] of cluster conflicts with another ingress"
+      ingresses: []
       observedGeneration: 7
 

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-Service-bar-cluster-ip-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-Service-bar-cluster-ip-bar.yaml
@@ -8,6 +8,9 @@
 apiVersion: "v1"
 kind: "Service"
 metadata:
+  annotations:
+    io.kroxylicious/operator.ingress.ingress-name: "cluster-ip-bar"
+    io.kroxylicious/operator.ingress.virtualcluster-name: "bar"
   labels:
     app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-Service-bar-cluster-ip-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-Service-bar-cluster-ip-bar.yaml
@@ -8,9 +8,6 @@
 apiVersion: "v1"
 kind: "Service"
 metadata:
-  annotations:
-    io.kroxylicious/operator.ingress.ingress-name: "cluster-ip-bar"
-    io.kroxylicious/operator.ingress.virtualcluster-name: "bar"
   labels:
     app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
@@ -23,6 +20,12 @@ metadata:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"
       name: "twocluster"
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "VirtualKafkaCluster"
+      name: "bar"
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxyIngress"
+      name: "cluster-ip-bar"
 spec:
   ports:
     - name: "bar-9292"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/out-ConfigMap-twocluster-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/out-ConfigMap-twocluster-config-state.yaml
@@ -35,6 +35,7 @@ data:
         reason: "Invalid"
         message: "Resource kafkaservice.kroxylicious.io/barref in namespace 'proxy-ns'\
           \ was not found."
+      ingresses: []
       observedGeneration: 1
   cluster-foo: |-
     ---
@@ -49,4 +50,5 @@ data:
         lastTransitionTime: "1970-01-01T00:00:00Z"
         reason: "Invalid"
         message: "Ingress(es) [cluster-ip-foo] of cluster conflicts with another ingress"
+      ingresses: []
       observedGeneration: 2

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-ConfigMap-example-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-ConfigMap-example-config-state.yaml
@@ -34,4 +34,5 @@ data:
         lastTransitionTime: "1970-01-01T00:00:00Z"
         reason: "Accepted"
         message: ""
+      ingresses: []
       observedGeneration: 12

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Service-foo-cluster-ip.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Service-foo-cluster-ip.yaml
@@ -8,6 +8,9 @@
 apiVersion: "v1"
 kind: "Service"
 metadata:
+  annotations:
+    io.kroxylicious/operator.ingress.ingress-name: "cluster-ip"
+    io.kroxylicious/operator.ingress.virtualcluster-name: "foo"
   labels:
     app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Service-foo-cluster-ip.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Service-foo-cluster-ip.yaml
@@ -8,9 +8,6 @@
 apiVersion: "v1"
 kind: "Service"
 metadata:
-  annotations:
-    io.kroxylicious/operator.ingress.ingress-name: "cluster-ip"
-    io.kroxylicious/operator.ingress.virtualcluster-name: "foo"
   labels:
     app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
@@ -23,6 +20,12 @@ metadata:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"
       name: "example"
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "VirtualKafkaCluster"
+      name: "foo"
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxyIngress"
+      name: "cluster-ip"
 spec:
   ports:
     - name: "foo-9292"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-ConfigMap-use-pod-template-spec-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-ConfigMap-use-pod-template-spec-config-state.yaml
@@ -34,4 +34,5 @@ data:
         lastTransitionTime: "1970-01-01T00:00:00Z"
         reason: "Accepted"
         message: ""
+      ingresses: []
       observedGeneration: 5

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Service-one-cluster-ip.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Service-one-cluster-ip.yaml
@@ -8,9 +8,6 @@
 apiVersion: "v1"
 kind: "Service"
 metadata:
-  annotations:
-    io.kroxylicious/operator.ingress.ingress-name: "cluster-ip"
-    io.kroxylicious/operator.ingress.virtualcluster-name: "one"
   labels:
     app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
@@ -23,6 +20,12 @@ metadata:
     - apiVersion: "kroxylicious.io/v1alpha1"
       kind: "KafkaProxy"
       name: "use-pod-template-spec"
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "VirtualKafkaCluster"
+      name: "one"
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxyIngress"
+      name: "cluster-ip"
 spec:
   ports:
     - name: "one-9292"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Service-one-cluster-ip.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Service-one-cluster-ip.yaml
@@ -8,6 +8,9 @@
 apiVersion: "v1"
 kind: "Service"
 metadata:
+  annotations:
+    io.kroxylicious/operator.ingress.ingress-name: "cluster-ip"
+    io.kroxylicious/operator.ingress.virtualcluster-name: "one"
   labels:
     app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

As an application developer I need to know what the bootstrap address of my virtual cluster is so I can enable clients to connect to the cluster.

This changes adds an ingress array to the VKC's status section, giving the user access to the ingress host + bootstrap port for each defined ingress.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
