### PR TITLE
Operator: Proxy reconciler require VirtualKafkaCluster to be reconciled

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
@@ -28,6 +28,8 @@ import io.javaoperatorsdk.operator.processing.event.ResourceID;
 
 import io.kroxylicious.kubernetes.api.common.AnyLocalRefBuilder;
 import io.kroxylicious.kubernetes.api.common.LocalRef;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterStatus;
 
 public class ResourcesUtil {
 
@@ -268,4 +270,19 @@ public class ResourcesUtil {
         return ref.getKind().toLowerCase(Locale.ROOT) + groupString + "/" + name;
     }
 
+    /**
+     * Checks that the status observedGeneration is equal to the metadata generation. Indicating
+     * that the current {@code spec} of the resource has been reconciled.
+     * @param cluster cluster
+     * @return true if status observedGeneration is equal to the metadata generation
+     */
+    public static boolean isStatusFresh(VirtualKafkaCluster cluster) {
+        return isStatusFresh(cluster, c -> Optional.ofNullable(c.getStatus()).map(VirtualKafkaClusterStatus::getObservedGeneration).orElse(null));
+    }
+
+    private static <T extends HasMetadata> boolean isStatusFresh(T resource, Function<T, Long> observedGenerationFunc) {
+        Long observedGeneration = observedGenerationFunc.apply(resource);
+        Long generation = resource.getMetadata().getGeneration();
+        return Objects.equals(generation, observedGeneration);
+    }
 }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/StaleReferentStatusException.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/StaleReferentStatusException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+/**
+ * Indicates that a Referent has not been reconciled, therefore we are operating on incomplete information.
+ * We cannot continue reconciliation as the state of that Referent is undetermined. This should be a transient
+ * state. The Referent should be reconciled, and it's updated status event should prompt the Referencing reconciler
+ * to reconcile again, this time successfully.
+ */
+public class StaleReferentStatusException extends RuntimeException {
+    public StaleReferentStatusException(String message) {
+        super(message);
+    }
+}

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconciler.java
@@ -128,8 +128,8 @@ public final class VirtualKafkaClusterReconciler implements
                 .map(ProxyConfigStateData::new)
                 .flatMap(data -> data.getStatusPatchForCluster(name(cluster)))
                 .map(patch -> {
-                    var acc = ResourceState.fromList(patch.getStatus().getConditions());
-                    return statusFactory.clusterStatusPatch(cluster, resolvedRefsTrueResourceState.replacementFor(acc), ingresses);
+                    var patchResourceState = ResourceState.fromList(patch.getStatus().getConditions());
+                    return statusFactory.clusterStatusPatch(cluster, resolvedRefsTrueResourceState.replacementFor(patchResourceState), ingresses);
                 })
                 .map(UpdateControl::patchStatus)
                 .orElse(UpdateControl.patchStatus(statusFactory.clusterStatusPatch(cluster, resolvedRefsTrueResourceState, ingresses)));

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconciler.java
@@ -121,19 +121,18 @@ public final class VirtualKafkaClusterReconciler implements
                     builder.withBootstrapServer(getBootstrapServer(kubenetesService));
                     return builder.build();
                 }).toList();
-
+        ResourceState resolvedRefsTrueResourceState = ResourceState.of(statusFactory.newTrueCondition(cluster, Condition.Type.ResolvedRefs));
         updateControl = context
                 .getSecondaryResource(ConfigMap.class)
                 .flatMap(cm -> Optional.ofNullable(cm.getData()))
                 .map(ProxyConfigStateData::new)
                 .flatMap(data -> data.getStatusPatchForCluster(name(cluster)))
                 .map(patch -> {
-                    var rr = ResourceState.of(statusFactory.newTrueCondition(cluster, Condition.Type.ResolvedRefs));
                     var acc = ResourceState.fromList(patch.getStatus().getConditions());
-                    return statusFactory.clusterStatusPatch(cluster, rr.replacementFor(acc), ingresses);
+                    return statusFactory.clusterStatusPatch(cluster, resolvedRefsTrueResourceState.replacementFor(acc), ingresses);
                 })
                 .map(UpdateControl::patchStatus)
-                .orElse(UpdateControl.noUpdate());
+                .orElse(UpdateControl.patchStatus(statusFactory.clusterStatusPatch(cluster, resolvedRefsTrueResourceState, ingresses)));
         return updateControl;
     }
 

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ClusterResolutionResult.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ClusterResolutionResult.java
@@ -21,17 +21,22 @@ import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
  */
 public record ClusterResolutionResult(VirtualKafkaCluster cluster,
                                       Set<DanglingReference> danglingReferences,
-                                      Set<LocalRef<?>> resourcesWithResolvedRefsFalse) {
+                                      Set<LocalRef<?>> resourcesWithResolvedRefsFalse,
+                                      Set<LocalRef<?>> referentsWithStaleStatus) {
     public ClusterResolutionResult {
         Objects.requireNonNull(danglingReferences);
     }
 
+    // using wildcards intentionally
+    @SuppressWarnings("java:S1452")
     public Stream<LocalRef<?>> findDanglingReferences(LocalRef<?> from, String kindTo) {
         Objects.requireNonNull(from);
         Objects.requireNonNull(kindTo);
         return danglingReferences.stream().filter(r -> r.from().equals(from) && kindTo.equals(r.to.getKind())).map(DanglingReference::to);
     }
 
+    // using wildcards intentionally
+    @SuppressWarnings("java:S1452")
     public Stream<LocalRef<?>> findDanglingReferences(String fromKind, String toKind) {
         Objects.requireNonNull(fromKind);
         Objects.requireNonNull(toKind);
@@ -39,8 +44,23 @@ public record ClusterResolutionResult(VirtualKafkaCluster cluster,
                 .map(DanglingReference::to);
     }
 
+    /**
+     * A result is fully resolved if:
+     * <ol>
+     *     <li>All references can be retrieved from kubernetes (we have no dangling refs)</li>
+     *     <li>No referent has a ResolvedRefs=False condition, which declares that it has unresolved dependencies</li>
+     * </ol>
+     */
     public boolean isFullyResolved() {
         return danglingReferences.isEmpty() && resourcesWithResolvedRefsFalse.isEmpty();
+    }
+
+    /**
+     * A result is fully reconciled if all referents have been reconciled.
+     * @return true if all referents have been reconciled
+     */
+    public boolean allReferentsHaveFreshStatus() {
+        return referentsWithStaleStatus.isEmpty();
     }
 
     public boolean anyDependenciesNotFoundFor(LocalRef<?> fromResource) {
@@ -51,17 +71,33 @@ public record ClusterResolutionResult(VirtualKafkaCluster cluster,
         return !resourcesWithResolvedRefsFalse.isEmpty();
     }
 
+    // using wildcards intentionally
+    @SuppressWarnings("java:S1452")
     public Stream<LocalRef<?>> findResourcesWithResolvedRefsFalse() {
         return resourcesWithResolvedRefsFalse.stream();
     }
 
+    // using wildcards intentionally
+    @SuppressWarnings("java:S1452")
+    public Stream<LocalRef<?>> findReferentsWithStaleStatus() {
+        return referentsWithStaleStatus.stream();
+    }
+
+    // using wildcards intentionally
+    @SuppressWarnings("java:S1452")
     public Stream<LocalRef<?>> findResourcesWithResolvedRefsFalse(String kind) {
         return findResourcesWithResolvedRefsFalse().filter(r -> kind.equals(r.getKind()));
     }
 
     ClusterResolutionResult addAllResourcesHavingResolvedRefsFalse(Set<LocalRef<?>> resolvedRefsFalse) {
         return new ClusterResolutionResult(cluster, danglingReferences, Stream.concat(resourcesWithResolvedRefsFalse.stream(), resolvedRefsFalse.stream()).collect(
-                Collectors.toSet()));
+                Collectors.toSet()), referentsWithStaleStatus);
+    }
+
+    ClusterResolutionResult addReferentsWithStaleStatus(Set<LocalRef<?>> referentsWithStaleStatus) {
+        return new ClusterResolutionResult(cluster, danglingReferences, resourcesWithResolvedRefsFalse,
+                Stream.concat(this.referentsWithStaleStatus.stream(), referentsWithStaleStatus.stream()).collect(
+                        Collectors.toSet()));
     }
 
     /**

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ProxyResolutionResult.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ProxyResolutionResult.java
@@ -14,6 +14,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import io.kroxylicious.kubernetes.api.common.FilterRef;
 import io.kroxylicious.kubernetes.api.common.LocalRef;
@@ -134,4 +135,13 @@ public class ProxyResolutionResult {
                 .findFirst();
     }
 
+    public boolean allReferentsHaveFreshStatus() {
+        return clusterResolutionResults.stream().allMatch(ClusterResolutionResult::allReferentsHaveFreshStatus);
+    }
+
+    // using wildcards intentionally
+    @SuppressWarnings("java:S1452")
+    public Stream<LocalRef<?>> allReferentsWithStaleStatus() {
+        return clusterResolutionResults.stream().flatMap(ClusterResolutionResult::findReferentsWithStaleStatus);
+    }
 }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/LocallyRunningOperatorRbacHandler.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/LocallyRunningOperatorRbacHandler.java
@@ -214,6 +214,11 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
                 return testActorClient.resource(resource).inNamespace(operatorExtension.getNamespace()).update();
             }
 
+            @NonNull
+            public <T extends HasMetadata> T patchStatus(@NonNull T resource) {
+                return testActorClient.resource(resource).inNamespace(operatorExtension.getNamespace()).patchStatus();
+            }
+
             @Override
             public <T extends HasMetadata> boolean delete(@NonNull T resource) {
                 var res = testActorClient.resource(resource).inNamespace(operatorExtension.getNamespace()).delete();
@@ -244,6 +249,9 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
 
         @NonNull
         <T extends HasMetadata> T replace(@NonNull T resource);
+
+        @NonNull
+        <T extends HasMetadata> T patchStatus(@NonNull T resource);
 
         <T extends HasMetadata> boolean delete(@NonNull T resource);
 

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-VirtualKafkaCluster-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-VirtualKafkaCluster-bar.yaml
@@ -20,3 +20,5 @@ spec:
     - name: filter-one
   ingressRefs:
     - name: cluster-ip
+status:
+  observedGeneration: 4

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-VirtualKafkaCluster-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/in-VirtualKafkaCluster-foo.yaml
@@ -20,3 +20,5 @@ spec:
     - name: filter-one
   ingressRefs:
     - name: cluster-ip
+status:
+  observedGeneration: 4

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/in-VirtualKafkaCluster-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/in-VirtualKafkaCluster-foo.yaml
@@ -22,3 +22,5 @@ spec:
     - name: filter-one
   ingressRefs:
     - name: cluster-ip
+status:
+  observedGeneration: 2

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-VirtualKafkaCluster-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-VirtualKafkaCluster-bar.yaml
@@ -21,3 +21,5 @@ spec:
     - name: missing # this does not exist
   ingressRefs:
     - name: cluster-ip-bar
+status:
+  observedGeneration: 4

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-VirtualKafkaCluster-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/in-VirtualKafkaCluster-foo.yaml
@@ -22,3 +22,5 @@ spec:
     - name: filter-two
   ingressRefs:
     - name: cluster-ip-foo
+status:
+  observedGeneration: 1

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/in-VirtualKafkaCluster-one.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/in-VirtualKafkaCluster-one.yaml
@@ -18,3 +18,5 @@ spec:
     name: myref
   ingressRefs:
     - name: cluster-ip
+status:
+  observedGeneration: 4

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/in-VirtualKafkaCluster-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/in-VirtualKafkaCluster-bar.yaml
@@ -18,3 +18,5 @@ spec:
     name: barref
   ingressRefs:
     - name: cluster-ip-bar
+status:
+  observedGeneration: 3

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/in-VirtualKafkaCluster-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/in-VirtualKafkaCluster-foo.yaml
@@ -18,3 +18,5 @@ spec:
     name: fooref
   ingressRefs:
     - name: MISSING
+status:
+  observedGeneration: 4

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/in-VirtualKafkaCluster-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/in-VirtualKafkaCluster-bar.yaml
@@ -18,3 +18,5 @@ spec:
     name: barref
   ingressRefs:
     - name: cluster-ip-bar
+status:
+  observedGeneration: 6

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/in-VirtualKafkaCluster-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/in-VirtualKafkaCluster-foo.yaml
@@ -18,3 +18,5 @@ spec:
     name: fooref
   ingressRefs:
     - name: cluster-ip-foo
+status:
+  observedGeneration: 7

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/in-VirtualKafkaCluster-bar.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/in-VirtualKafkaCluster-bar.yaml
@@ -18,3 +18,5 @@ spec:
     name: barref
   ingressRefs:
     - name: cluster-ip-bar
+status:
+  observedGeneration: 1

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/in-VirtualKafkaCluster-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/in-VirtualKafkaCluster-foo.yaml
@@ -18,3 +18,5 @@ spec:
     name: fooref
   ingressRefs:
     - name: cluster-ip-foo
+status:
+  observedGeneration: 2

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/in-VirtualKafkaCluster-foo.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/in-VirtualKafkaCluster-foo.yaml
@@ -21,3 +21,5 @@ spec:
     - name: filter-two
   ingressRefs:
     - name: cluster-ip
+status:
+  observedGeneration: 12

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/in-VirtualKafkaCluster-one.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/in-VirtualKafkaCluster-one.yaml
@@ -18,3 +18,5 @@ spec:
     name: myref
   ingressRefs:
     - name: cluster-ip
+status:
+  observedGeneration: 5


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

If the KafkaProxyReconciler encounters and VirtualKafkaClusters where their metadata.generation is higher than their status.observedGeneration, then the KPR reconcilation terminates with exception.

The KafkaProxyReconciler informers ignore events from unreconciled VirtualKafkaClusters. This should prevent this error log in some cases, though there will likely always be cases where the KPR observes a VKC in an unreconciled state.

Some new terminology is introduced for this state:

- **stale status**: a resource has a stale status if `metadata.generation != status.observedGeneration`
- **fresh status**: a resource has a fresh status if `metadata.generation == status.observedGeneration`

When we throw the exception during `KafkaProxyReconciler#initContext`, `KafkaProxyReconciler#updateErrorStatus` is invoked with the exception. This exception does not result in a status update of the KafkaProxy.

```
2025-04-14 01:33:22 <ReconcilerExecutor-kafkaproxyreconciler-184> INFO  io.kroxylicious.kubernetes.operator.KafkaProxyReconciler:129 - Completed reconciliation of my-proxy/simple with error io.javaoperatorsdk.operator.OperatorException: java.lang.IllegalStateException: Dependencies not fully reconciled
2025-04-14 01:33:22 <ReconcilerExecutor-kafkaproxyingressreconciler-186> INFO  io.kroxylicious.kubernetes.operator.KafkaProxyIngressReconciler:87 - Completed reconciliation of my-proxy/cluster-ip
2025-04-14 01:33:22 <ReconcilerExecutor-kafkaproxyreconciler-184> ERROR io.javaoperatorsdk.operator.processing.event.EventProcessor:344 - Error during event processing ExecutionScope{ resource id: ResourceID{name='simple', namespace='my-proxy'}, version: 21089}
io.javaoperatorsdk.operator.OperatorException: java.lang.IllegalStateException: Dependencies not fully reconciled
	at io.javaoperatorsdk.operator.monitoring.micrometer.MicrometerMetrics.lambda$timeControllerExecution$0(MicrometerMetrics.java:151) ~[micrometer-support-5.0.3.jar:?]
	at io.micrometer.core.instrument.composite.CompositeTimer.record(CompositeTimer.java:69) ~[micrometer-core-1.14.5.jar:1.14.5]
	at io.javaoperatorsdk.operator.monitoring.micrometer.MicrometerMetrics.timeControllerExecution(MicrometerMetrics.java:147) ~[micrometer-support-5.0.3.jar:?]
	at io.javaoperatorsdk.operator.processing.Controller.reconcile(Controller.java:114) ~[operator-framework-core-5.0.3.jar:?]
	at io.javaoperatorsdk.operator.processing.event.ReconciliationDispatcher.reconcileExecution(ReconciliationDispatcher.java:144) ~[operator-framework-core-5.0.3.jar:?]
	at io.javaoperatorsdk.operator.processing.event.ReconciliationDispatcher.handleReconcile(ReconciliationDispatcher.java:125) ~[operator-framework-core-5.0.3.jar:?]
	at io.javaoperatorsdk.operator.processing.event.ReconciliationDispatcher.handleDispatch(ReconciliationDispatcher.java:94) ~[operator-framework-core-5.0.3.jar:?]
	at io.javaoperatorsdk.operator.processing.event.ReconciliationDispatcher.handleExecution(ReconciliationDispatcher.java:67) ~[operator-framework-core-5.0.3.jar:?]
	at io.javaoperatorsdk.operator.processing.event.EventProcessor$ReconcilerExecutor.run(EventProcessor.java:444) [operator-framework-core-5.0.3.jar:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at java.lang.Thread.run(Thread.java:840) [?:?]
Caused by: java.lang.IllegalStateException: Dependencies not fully reconciled
	at io.kroxylicious.kubernetes.operator.model.ProxyModelBuilder.build(ProxyModelBuilder.java:40) ~[kroxylicious-operator-0.12.0-SNAPSHOT.jar:?]
	at io.kroxylicious.kubernetes.operator.KafkaProxyReconciler.initContext(KafkaProxyReconciler.java:103) ~[kroxylicious-operator-0.12.0-SNAPSHOT.jar:?]
	at io.kroxylicious.kubernetes.operator.KafkaProxyReconciler.initContext(KafkaProxyReconciler.java:53) ~[kroxylicious-operator-0.12.0-SNAPSHOT.jar:?]
	at io.javaoperatorsdk.operator.processing.Controller.initContextIfNeeded(Controller.java:233) ~[operator-framework-core-5.0.3.jar:?]
	at io.javaoperatorsdk.operator.processing.Controller$1.execute(Controller.java:150) ~[operator-framework-core-5.0.3.jar:?]
	at io.javaoperatorsdk.operator.processing.Controller$1.execute(Controller.java:115) ~[operator-framework-core-5.0.3.jar:?]
	at io.javaoperatorsdk.operator.monitoring.micrometer.MicrometerMetrics.lambda$timeControllerExecution$0(MicrometerMetrics.java:149) ~[micrometer-support-5.0.3.jar:?]
	... 11 more
2025-04-14 01:33:22 <ReconcilerExecutor-virtualkafkaclusterreconciler-185> INFO  io.kroxylicious.kubernetes.operator.VirtualKafkaClusterReconciler:92 - Completed reconciliation of my-proxy/my-cluster
2025-04-14 01:33:22 <ReconcilerExecutor-virtualkafkaclusterreconciler-190> INFO  io.kroxylicious.kubernetes.operator.VirtualKafkaClusterReconciler:92 - Completed reconciliation of my-proxy/my-cluster
2025-04-14 01:33:23 <ReconcilerExecutor-kafkaproxyreconciler-187> INFO  io.kroxylicious.kubernetes.operator.KafkaProxyReconciler:115 - Completed reconciliation of my-proxy/simple
```

We want the aggregating reconcilers to operate on reconciled dependencies. If the KafkaProxyReconciler observes a VirtualKafkaCluster with metadata.generation ahead of it's status.observedGeneration, then we know it hasn't been reconciled, it's in an indeterminate state, maybe it is invalid, we cannot treat it as a valid input to the KafkaProxy.

Ideally we would be able to leave that VKC untouched but incorporate changes from other clusters, but this is quite tricky to do with a single proxy config file and stateless allocation of ingress resources. Maybe in future we could architect things this way and avoid erroring out of the reconciliation, which will create mysterious error messages in the Operator logs.

The expectation is that the VKC reconciliation will run and update the status, and this will drive a fresh reconciliation of the KafkaProxy, the VKC status will now be fresh and proxy reconcilation can proceed.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
