### PR TITLE
Refactor the system tests to use the bootstrapServer from the VKC

### DIFF
--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/KroxyliciousST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/KroxyliciousST.java
@@ -38,7 +38,6 @@ class KroxyliciousST extends AbstractST {
     private static final Logger LOGGER = LoggerFactory.getLogger(KroxyliciousST.class);
     private static Kroxylicious kroxylicious;
     private final String clusterName = "my-cluster";
-    private final String clusterIpServiceName = clusterName + "-" + Constants.KROXYLICIOUS_INGRESS_CLUSTER_IP;
     protected static final String BROKER_NODE_NAME = "kafka";
     private static final String MESSAGE = "Hello-world";
     private KroxyliciousOperator kroxyliciousOperator;
@@ -56,7 +55,7 @@ class KroxyliciousST extends AbstractST {
         LOGGER.atInfo().setMessage("Given Kroxylicious in {} namespace with {} replicas").addArgument(namespace).addArgument(1).log();
         kroxylicious = new Kroxylicious(namespace);
         kroxylicious.deployPortIdentifiesNodeWithNoFilters(clusterName);
-        String bootstrap = kroxylicious.getBootstrap(clusterIpServiceName);
+        String bootstrap = kroxylicious.getBootstrap(clusterName);
 
         LOGGER.atInfo().setMessage("And a kafka Topic named {}").addArgument(topicName).log();
         KafkaSteps.createTopic(namespace, topicName, bootstrap, 1, 2);
@@ -87,7 +86,7 @@ class KroxyliciousST extends AbstractST {
         LOGGER.atInfo().setMessage("Given Kroxylicious in {} namespace with {} replicas").addArgument(namespace).addArgument(1).log();
         kroxylicious = new Kroxylicious(namespace);
         kroxylicious.deployPortIdentifiesNodeWithNoFilters(clusterName);
-        String bootstrap = kroxylicious.getBootstrap(clusterIpServiceName);
+        String bootstrap = kroxylicious.getBootstrap(clusterName);
 
         LOGGER.atInfo().setMessage("And a kafka Topic named {}").addArgument(topicName).log();
         KafkaSteps.createTopic(namespace, topicName, bootstrap, 3, 2);
@@ -122,7 +121,7 @@ class KroxyliciousST extends AbstractST {
         LOGGER.atInfo().setMessage("Given Kroxylicious in {} namespace with {} replicas").addArgument(namespace).addArgument(replicas).log();
         kroxylicious = new Kroxylicious(namespace);
         kroxylicious.deployPortIdentifiesNodeWithNoFilters(clusterName);
-        String bootstrap = kroxylicious.getBootstrap(clusterIpServiceName);
+        String bootstrap = kroxylicious.getBootstrap(clusterName);
         int currentReplicas = kroxylicious.getNumberOfReplicas();
         given(currentReplicas).withFailMessage("unexpected deployed replicas").isEqualTo(replicas);
 
@@ -163,7 +162,7 @@ class KroxyliciousST extends AbstractST {
         LOGGER.atInfo().setMessage("Given Kroxylicious in {} namespace with {} replicas").addArgument(namespace).addArgument(replicas).log();
         kroxylicious = new Kroxylicious(namespace);
         kroxylicious.deployPortIdentifiesNodeWithNoFilters(clusterName);
-        String bootstrap = kroxylicious.getBootstrap(clusterIpServiceName);
+        String bootstrap = kroxylicious.getBootstrap(clusterName);
         int currentReplicas = kroxylicious.getNumberOfReplicas();
         given(currentReplicas).withFailMessage("unexpected deployed replicas").isEqualTo(replicas);
 

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/MetricsST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/MetricsST.java
@@ -42,7 +42,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 class MetricsST extends AbstractST {
     private static final Logger LOGGER = LoggerFactory.getLogger(MetricsST.class);
     private final String clusterName = "my-cluster";
-    private final String clusterIpServiceName = clusterName + "-" + Constants.KROXYLICIOUS_INGRESS_CLUSTER_IP;
     protected static final String BROKER_NODE_NAME = "kafka";
     private static final String MESSAGE = "Hello-world";
     private MetricsCollector kroxyliciousCollector;
@@ -142,7 +141,7 @@ class MetricsST extends AbstractST {
 
         Kroxylicious kroxylicious = new Kroxylicious(namespace);
         kroxylicious.deployPortIdentifiesNodeWithNoFilters(clusterName);
-        bootstrap = kroxylicious.getBootstrap(clusterIpServiceName);
+        bootstrap = kroxylicious.getBootstrap(clusterName);
         kroxyliciousCollector = new MetricsCollector.Builder()
                 .withScraperPodName(scraperPodName)
                 .withNamespaceName(namespace)

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/NonJVMClientsST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/NonJVMClientsST.java
@@ -39,7 +39,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class NonJVMClientsST extends AbstractST {
     private static final Logger LOGGER = LoggerFactory.getLogger(NonJVMClientsST.class);
     private final String clusterName = "my-cluster";
-    private final String clusterIpServiceName = clusterName + "-" + Constants.KROXYLICIOUS_INGRESS_CLUSTER_IP;
     protected static final String BROKER_NODE_NAME = "kafka";
     private static final String MESSAGE = "Hello-world";
     private String bootstrap;
@@ -183,7 +182,7 @@ class NonJVMClientsST extends AbstractST {
 
         Kroxylicious kroxylicious = new Kroxylicious(namespace);
         kroxylicious.deployPortIdentifiesNodeWithNoFilters(clusterName);
-        bootstrap = kroxylicious.getBootstrap(clusterIpServiceName);
+        bootstrap = kroxylicious.getBootstrap(clusterName);
 
         LOGGER.atInfo().setMessage("And a kafka Topic named {}").addArgument(topicName).log();
         KafkaSteps.createTopic(namespace, topicName, bootstrap, 1, 2);

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/RecordEncryptionST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/RecordEncryptionST.java
@@ -46,7 +46,6 @@ class RecordEncryptionST extends AbstractST {
     private static final Logger LOGGER = LoggerFactory.getLogger(RecordEncryptionST.class);
     private static final String MESSAGE = "Hello-world";
     private final String clusterName = "my-cluster";
-    private final String clusterIpServiceName = clusterName + "-" + Constants.KROXYLICIOUS_INGRESS_CLUSTER_IP;
     private String bootstrap;
     private TestKekManager testKekManager;
     private KroxyliciousOperator kroxyliciousOperator;
@@ -111,7 +110,7 @@ class RecordEncryptionST extends AbstractST {
         LOGGER.info("Given Kroxylicious in {} namespace with {} replicas", namespace, 1);
         Kroxylicious kroxylicious = new Kroxylicious(namespace);
         kroxylicious.deployPortPerBrokerPlainWithRecordEncryptionFilter(clusterName, testKmsFacade);
-        bootstrap = kroxylicious.getBootstrap(clusterIpServiceName);
+        bootstrap = kroxylicious.getBootstrap(clusterName);
 
         LOGGER.info("And a kafka Topic named {}", topicName);
         KafkaSteps.createTopic(namespace, topicName, bootstrap, 1, 2);
@@ -143,7 +142,7 @@ class RecordEncryptionST extends AbstractST {
         LOGGER.info("Given Kroxylicious in {} namespace with {} replicas", namespace, 1);
         Kroxylicious kroxylicious = new Kroxylicious(namespace);
         kroxylicious.deployPortPerBrokerPlainWithRecordEncryptionFilter(clusterName, testKmsFacade);
-        bootstrap = kroxylicious.getBootstrap(clusterIpServiceName);
+        bootstrap = kroxylicious.getBootstrap(clusterName);
 
         LOGGER.info("And a kafka Topic named {}", topicName);
         KafkaSteps.createTopic(namespace, topicName, bootstrap, 1, 2);
@@ -175,7 +174,7 @@ class RecordEncryptionST extends AbstractST {
         LOGGER.info("Given Kroxylicious in {} namespace with {} replicas", namespace, 1);
         Kroxylicious kroxylicious = new Kroxylicious(namespace);
         kroxylicious.deployPortPerBrokerPlainWithRecordEncryptionFilter(clusterName, testKmsFacade, experimentalKmsConfig);
-        bootstrap = kroxylicious.getBootstrap(clusterIpServiceName);
+        bootstrap = kroxylicious.getBootstrap(clusterName);
 
         LOGGER.info("And a kafka Topic named {}", topicName);
         KafkaSteps.createTopic(namespace, topicName, bootstrap, 1, 2);
@@ -242,7 +241,7 @@ class RecordEncryptionST extends AbstractST {
         LOGGER.info("Given Kroxylicious in {} namespace with {} replicas", namespace, 1);
         Kroxylicious kroxylicious = new Kroxylicious(namespace);
         kroxylicious.deployPortPerBrokerPlainWithRecordEncryptionFilter(clusterName, testKmsFacade, experimentalKmsConfig);
-        bootstrap = kroxylicious.getBootstrap(clusterIpServiceName);
+        bootstrap = kroxylicious.getBootstrap(clusterName);
 
         LOGGER.info("And a kafka Topic named {}", topicName);
         KafkaSteps.createTopic(namespace, topicName, bootstrap, 1, 2);


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Refactor the system tests to take the Virtual Cluster's bootstrap from the status section of the VKC.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [x] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
