### PR TITLE
docs: Fix link to the kroxylicious-api module in developer's guide

### DIFF
--- a/docs/modules/con-custom-filters.adoc
+++ b/docs/modules/con-custom-filters.adoc
@@ -24,7 +24,7 @@ You can find them {github}/tree/main/kroxylicious-sample[here] for a hands-on in
 == API docs
 
 Custom filters are built by implementing interfaces supplied by the
-{github}/tree/main/api/kroxylicious-api[kroxylicious-api^] module
+{github}/tree/main/kroxylicious-api[kroxylicious-api^] module
 (https://mvnrepository.com/artifact/io.kroxylicious/kroxylicious-api[io.kroxylicious:kroxylicious-api] on
 maven central). You can view the javadoc {api-javadoc}/io/kroxylicious/proxy/filter/package-summary.html[here^].
 


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Fixes a link to the kroxylicious-api module in the developer's guide


