### PR TITLE
Move Configuration construction to KafkaProxyReconciler

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ConfigurationFragment.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ConfigurationFragment.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.util.Set;
+
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+
+/**
+ * A piece of proxy configuration which references files on the proxy container filesystem
+ * @param fragment The piece of proxy configuration
+ * @param volumes The volumes the configuration depends on
+ * @param mounts The mount the configuration depends on
+ * @param <F> The type of fragment
+ */
+public record ConfigurationFragment<F>(F fragment, Set<Volume> volumes, Set<VolumeMount> mounts) {}

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyContext.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyContext.java
@@ -13,7 +13,6 @@ import java.util.stream.Collectors;
 
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
-import io.javaoperatorsdk.operator.OperatorException;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
@@ -27,33 +26,17 @@ public record KafkaProxyContext(VirtualKafkaClusterStatusFactory virtualKafkaClu
                                 ProxyModel model,
                                 Optional<Configuration> configuration,
                                 List<Volume> volumes,
-                                List<VolumeMount> mounts,
-                                @Nullable RuntimeException error) {
+                                List<VolumeMount> mounts) {
 
     private static final String KEY_CTX = KafkaProxyContext.class.getName();
-
-    static void initError(Context<KafkaProxy> context,
-                          VirtualKafkaClusterStatusFactory virtualKafkaClusterStatusFactory,
-                          ProxyModel model,
-                          RuntimeException error) {
-        var rc = context.managedWorkflowAndDependentResourceContext();
-        rc.put(KEY_CTX,
-                new KafkaProxyContext(
-                        virtualKafkaClusterStatusFactory,
-                        model,
-                        Optional.empty(),
-                        List.of(),
-                        List.of(),
-                        error));
-    }
 
     static void init(Context<KafkaProxy> context,
                      VirtualKafkaClusterStatusFactory virtualKafkaClusterStatusFactory,
                      ProxyModel model,
-                     ConfigurationFragment<Configuration> configuration) {
+                     @Nullable ConfigurationFragment<Configuration> configuration) {
         var rc = context.managedWorkflowAndDependentResourceContext();
 
-        var fragmentOpt = Optional.of(configuration);
+        var fragmentOpt = Optional.ofNullable(configuration);
         Set<Volume> volumes = fragmentOpt.map(ConfigurationFragment::volumes).orElse(Set.of());
         if (volumes.stream().map(Volume::getName).distinct().count() != volumes.size()) {
             throw new IllegalStateException("Two volumes with different definitions share the same name");
@@ -68,8 +51,7 @@ public record KafkaProxyContext(VirtualKafkaClusterStatusFactory virtualKafkaClu
                         model,
                         fragmentOpt.map(ConfigurationFragment::fragment),
                         volumes.stream().toList(),
-                        mounts.stream().toList(),
-                        null));
+                        mounts.stream().toList()));
     }
 
     static KafkaProxyContext proxyContext(Context<KafkaProxy> context) {
@@ -84,9 +66,4 @@ public record KafkaProxyContext(VirtualKafkaClusterStatusFactory virtualKafkaClu
 
     }
 
-    public void rethrowInitException() {
-        if (error != null) {
-            throw new OperatorException(error);
-        }
-    }
 }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyContext.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyContext.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.kubernetes.operator;
 
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import io.javaoperatorsdk.operator.api.reconciler.Context;
@@ -13,24 +14,27 @@ import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.operator.model.ProxyModel;
+import io.kroxylicious.proxy.config.Configuration;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 public record KafkaProxyContext(VirtualKafkaClusterStatusFactory virtualKafkaClusterStatusFactory,
-                                SecureConfigInterpolator secureConfigInterpolator,
-                                ProxyModel model) {
+                                ProxyModel model,
+                                Optional<ConfigurationFragment<Configuration>> configuration) {
 
     private static final String KEY_CTX = KafkaProxyContext.class.getName();
 
     static void init(Context<KafkaProxy> context,
                      VirtualKafkaClusterStatusFactory virtualKafkaClusterStatusFactory,
-                     SecureConfigInterpolator secureConfigInterpolator,
-                     ProxyModel model) {
+                     ProxyModel model,
+                     @Nullable ConfigurationFragment<Configuration> configuration) {
         var rc = context.managedWorkflowAndDependentResourceContext();
 
         rc.put(KEY_CTX,
                 new KafkaProxyContext(
                         virtualKafkaClusterStatusFactory,
-                        secureConfigInterpolator,
-                        model));
+                        model,
+                        Optional.ofNullable(configuration)));
     }
 
     static KafkaProxyContext proxyContext(Context<KafkaProxy> context) {

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyContext.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyContext.java
@@ -6,9 +6,13 @@
 
 package io.kroxylicious.kubernetes.operator;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
@@ -20,7 +24,9 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 
 public record KafkaProxyContext(VirtualKafkaClusterStatusFactory virtualKafkaClusterStatusFactory,
                                 ProxyModel model,
-                                Optional<ConfigurationFragment<Configuration>> configuration) {
+                                Optional<Configuration> configuration,
+                                List<Volume> volumes,
+                                List<VolumeMount> mounts) {
 
     private static final String KEY_CTX = KafkaProxyContext.class.getName();
 
@@ -30,11 +36,22 @@ public record KafkaProxyContext(VirtualKafkaClusterStatusFactory virtualKafkaClu
                      @Nullable ConfigurationFragment<Configuration> configuration) {
         var rc = context.managedWorkflowAndDependentResourceContext();
 
+        var fragmentOpt = Optional.ofNullable(configuration);
+        Set<Volume> volumes = fragmentOpt.map(ConfigurationFragment::volumes).orElse(Set.of());
+        if (volumes.stream().map(Volume::getName).distinct().count() != volumes.size()) {
+            throw new IllegalStateException("Two volumes with different definitions share the same name");
+        }
+        Set<VolumeMount> mounts = fragmentOpt.map(ConfigurationFragment::mounts).orElse(Set.of());
+        if (mounts.stream().map(VolumeMount::getMountPath).distinct().count() != mounts.size()) {
+            throw new IllegalStateException("Two volume mounts with different definitions share the same mount path");
+        }
         rc.put(KEY_CTX,
                 new KafkaProxyContext(
                         virtualKafkaClusterStatusFactory,
                         model,
-                        Optional.ofNullable(configuration)));
+                        fragmentOpt.map(ConfigurationFragment::fragment),
+                        volumes.stream().toList(),
+                        mounts.stream().toList()));
     }
 
     static KafkaProxyContext proxyContext(Context<KafkaProxy> context) {

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconciler.java
@@ -121,18 +121,19 @@ public class KafkaProxyReconciler implements
                             Context<KafkaProxy> context) {
         ProxyModelBuilder proxyModelBuilder = ProxyModelBuilder.contextBuilder();
         ProxyModel model = proxyModelBuilder.build(proxy, context);
-        ConfigurationFragment<Configuration> fragment;
         try {
-            fragment = generateProxyConfig(model);
+            var fragment = generateProxyConfig(model);
+            KafkaProxyContext.init(context,
+                    new VirtualKafkaClusterStatusFactory(clock),
+                    model,
+                    fragment);
         }
         catch (IllegalConfigurationException ice) {
-            fragment = null;
+            KafkaProxyContext.initError(context,
+                    new VirtualKafkaClusterStatusFactory(clock),
+                    model,
+                    ice);
         }
-
-        KafkaProxyContext.init(context,
-                new VirtualKafkaClusterStatusFactory(clock),
-                model,
-                fragment);
     }
 
     private ConfigurationFragment<Configuration> generateProxyConfig(ProxyModel model) {
@@ -251,6 +252,10 @@ public class KafkaProxyReconciler implements
     @Override
     public UpdateControl<KafkaProxy> reconcile(KafkaProxy primary,
                                                Context<KafkaProxy> context) {
+        // Any exceptions from the following will propagate to #updateErrorStatus()
+        //KafkaProxyContext.proxyContext(context).rethrowInitException();
+        context.managedWorkflowAndDependentResourceContext().reconcileManagedWorkflow().throwAggregateExceptionIfErrorsPresent();
+
         var uc = UpdateControl.patchStatus(statusFactory.newTrueConditionStatusPatch(primary, Condition.Type.Ready));
         if (LOGGER.isInfoEnabled()) {
             LOGGER.info("Completed reconciliation of {}/{}", namespace(primary), name(primary));

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconciler.java
@@ -23,9 +23,9 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.javaoperatorsdk.operator.OperatorException;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.javaoperatorsdk.operator.OperatorException;
 import io.javaoperatorsdk.operator.api.config.informer.InformerEventSourceConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ContextInitializer;

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigDependentResource.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigDependentResource.java
@@ -7,14 +7,10 @@ package io.kroxylicious.kubernetes.operator;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
-import io.fabric8.kubernetes.api.model.Volume;
-import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
@@ -50,22 +46,6 @@ public class ProxyConfigDependentResource extends CRUDKubernetesDependentResourc
         return ResourcesUtil.name(primary) + PROXY_CONFIG_CONFIG_MAP_SUFFIX;
     }
 
-    public static List<Volume> secureVolumes(Context<KafkaProxy> context) {
-        Set<Volume> volumes = KafkaProxyContext.proxyContext(context).configuration().map(ConfigurationFragment::volumes).orElse(Set.of());
-        if (volumes.stream().map(Volume::getName).distinct().count() != volumes.size()) {
-            throw new IllegalStateException("Two volumes with different definitions share the same name");
-        }
-        return volumes.stream().toList();
-    }
-
-    public static List<VolumeMount> secureVolumeMounts(Context<KafkaProxy> context) {
-        Set<VolumeMount> mounts = KafkaProxyContext.proxyContext(context).configuration().map(ConfigurationFragment::mounts).orElse(Set.of());
-        if (mounts.stream().map(VolumeMount::getMountPath).distinct().count() != mounts.size()) {
-            throw new IllegalStateException("Two volume mounts with different definitions share the same mount path");
-        }
-        return mounts.stream().toList();
-    }
-
     @Override
     protected ConfigMap desired(KafkaProxy primary,
                                 Context<KafkaProxy> context) {
@@ -73,7 +53,6 @@ public class ProxyConfigDependentResource extends CRUDKubernetesDependentResourc
         // this is the case if the dependant resource is to be removed.
         var data = KafkaProxyContext.proxyContext(context)
                 .configuration()
-                .map(ConfigurationFragment::fragment)
                 .map(c -> Map.of(CONFIG_YAML_KEY, toYaml(c)))
                 .orElse(Map.of());
 

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigReconcilePrecondition.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigReconcilePrecondition.java
@@ -6,163 +6,23 @@
 
 package io.kroxylicious.kubernetes.operator;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
-import io.javaoperatorsdk.operator.api.reconciler.dependent.managed.ManagedWorkflowAndDependentResourceContext;
 import io.javaoperatorsdk.operator.processing.dependent.workflow.Condition;
 
-import io.kroxylicious.kubernetes.api.common.FilterRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
-import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
-import io.kroxylicious.kubernetes.filter.api.v1alpha1.KafkaProtocolFilterSpec;
-import io.kroxylicious.kubernetes.operator.model.ProxyModel;
-import io.kroxylicious.kubernetes.operator.model.ingress.ProxyIngressModel;
-import io.kroxylicious.kubernetes.operator.resolver.ProxyResolutionResult;
-import io.kroxylicious.proxy.config.Configuration;
-import io.kroxylicious.proxy.config.IllegalConfigurationException;
-import io.kroxylicious.proxy.config.NamedFilterDefinition;
-import io.kroxylicious.proxy.config.TargetCluster;
-import io.kroxylicious.proxy.config.VirtualCluster;
-import io.kroxylicious.proxy.config.admin.EndpointsConfiguration;
-import io.kroxylicious.proxy.config.admin.ManagementConfiguration;
-import io.kroxylicious.proxy.config.admin.PrometheusMetricsConfig;
 
 /**
- * Tests whether the proxy's config would be a legal state.
+ * Precondition that's met iff there's a well-formed proxy configuration
  */
 public class ProxyConfigReconcilePrecondition implements Condition<ConfigMap, KafkaProxy> {
 
     @Override
-    public boolean isMet(DependentResource<ConfigMap, KafkaProxy> dependentResource, KafkaProxy primary, Context<KafkaProxy> context) {
-        try {
-            var configuration = generateProxyConfig(context);
-            context.managedWorkflowAndDependentResourceContext().put(ProxyConfigDependentResource.CONFIGURATION_DATA_KEY, configuration);
-            return true;
-        }
-        catch (IllegalConfigurationException ice) {
-            context.managedWorkflowAndDependentResourceContext().put(ProxyConfigDependentResource.CONFIGURATION_DATA_KEY, null);
-            return false;
-        }
-    }
-
-    private Configuration generateProxyConfig(Context<KafkaProxy> context) {
-
-        var model = KafkaProxyContext.proxyContext(context).model();
-
-        List<NamedFilterDefinition> allFilterDefinitions = buildFilterDefinitions(context, model);
-        Map<String, NamedFilterDefinition> namedDefinitions = allFilterDefinitions.stream().collect(Collectors.toMap(NamedFilterDefinition::name, f -> f));
-
-        var virtualClusters = buildVirtualClusters(namedDefinitions.keySet(), model);
-
-        List<NamedFilterDefinition> referencedFilters = virtualClusters.stream().flatMap(c -> Optional.ofNullable(c.filters()).stream().flatMap(Collection::stream))
-                .distinct()
-                .map(namedDefinitions::get).toList();
-
-        return new Configuration(
-                new ManagementConfiguration(null, null, new EndpointsConfiguration(new PrometheusMetricsConfig())), referencedFilters,
-                null, // no defaultFilters <= each of the virtualClusters specifies its own
-                virtualClusters,
-                List.of(), false,
-                // micrometer
-                Optional.empty());
-    }
-
-    private static List<VirtualCluster> buildVirtualClusters(Set<String> successfullyBuiltFilterNames, ProxyModel model) {
-        return model.clustersWithValidIngresses().stream()
-                .filter(cluster -> Optional.ofNullable(cluster.getSpec().getFilterRefs()).stream().flatMap(Collection::stream).allMatch(
-                        filters -> successfullyBuiltFilterNames.contains(filterDefinitionName(filters))))
-                .map(cluster -> getVirtualCluster(cluster, model.resolutionResult().kafkaServiceRef(cluster).orElseThrow(), model.ingressModel()))
-                .toList();
-    }
-
-    private List<NamedFilterDefinition> buildFilterDefinitions(Context<KafkaProxy> context,
-                                                               ProxyModel model) {
-        List<NamedFilterDefinition> filterDefinitions = new ArrayList<>();
-        Set<NamedFilterDefinition> uniqueValues = new HashSet<>();
-        for (VirtualKafkaCluster cluster : model.clustersWithValidIngresses()) {
-            for (NamedFilterDefinition namedFilterDefinition : filterDefinitions(context, cluster, model.resolutionResult())) {
-                if (uniqueValues.add(namedFilterDefinition)) {
-                    filterDefinitions.add(namedFilterDefinition);
-                }
-            }
-        }
-        filterDefinitions.sort(Comparator.comparing(NamedFilterDefinition::name));
-        return filterDefinitions;
-    }
-
-    private static List<String> filterNamesForCluster(VirtualKafkaCluster cluster) {
-        return Optional.ofNullable(cluster.getSpec().getFilterRefs())
-                .orElse(List.of())
-                .stream()
-                .map(ProxyConfigReconcilePrecondition::filterDefinitionName)
-                .toList();
-    }
-
-    private static String filterDefinitionName(FilterRef filterCrRef) {
-        return filterCrRef.getName() + "." + filterCrRef.getKind() + "." + filterCrRef.getGroup();
-    }
-
-    private List<NamedFilterDefinition> filterDefinitions(Context<KafkaProxy> context, VirtualKafkaCluster cluster, ProxyResolutionResult resolutionResult) {
-
-        return Optional.ofNullable(cluster.getSpec().getFilterRefs()).orElse(List.of()).stream().map(filterCrRef -> {
-
-            String filterDefinitionName = filterDefinitionName(filterCrRef);
-
-            var filterCr = resolutionResult.filter(filterCrRef).orElseThrow();
-            var spec = filterCr.getSpec();
-            String type = spec.getType();
-            SecureConfigInterpolator.InterpolationResult interpolationResult = interpolateConfig(context, spec);
-            ManagedWorkflowAndDependentResourceContext ctx = context.managedWorkflowAndDependentResourceContext();
-            putOrMerged(ctx, ProxyConfigDependentResource.SECURE_VOLUME_KEY, interpolationResult.volumes());
-            putOrMerged(ctx, ProxyConfigDependentResource.SECURE_VOLUME_MOUNT_KEY, interpolationResult.mounts());
-            return new NamedFilterDefinition(filterDefinitionName, type, interpolationResult.config());
-
-        }).toList();
-    }
-
-    private static <T> void putOrMerged(ManagedWorkflowAndDependentResourceContext ctx, String ctxKey, Set<T> set) {
-        Optional<Set<T>> ctxVolumes = (Optional) ctx.get(ctxKey, Set.class);
-        if (ctxVolumes.isPresent()) {
-            ctxVolumes.get().addAll(set);
-        }
-        else {
-            ctx.put(ctxKey, new LinkedHashSet<>(set));
-        }
-    }
-
-    private SecureConfigInterpolator.InterpolationResult interpolateConfig(Context<KafkaProxy> context, KafkaProtocolFilterSpec spec) {
-        SecureConfigInterpolator secureConfigInterpolator = KafkaProxyContext.proxyContext(context).secureConfigInterpolator();
-        Object configTemplate = Objects.requireNonNull(spec.getConfigTemplate(), "ConfigTemplate is required in the KafkaProtocolFilterSpec");
-        return secureConfigInterpolator.interpolate(configTemplate);
-    }
-
-    private static VirtualCluster getVirtualCluster(VirtualKafkaCluster cluster,
-                                                    KafkaService kafkaServiceRef,
-                                                    ProxyIngressModel ingressModel) {
-
-        ProxyIngressModel.VirtualClusterIngressModel virtualClusterIngressModel = ingressModel.clusterIngressModel(cluster).orElseThrow();
-        String bootstrap = kafkaServiceRef.getSpec().getBootstrapServers();
-        return new VirtualCluster(
-                ResourcesUtil.name(cluster), new TargetCluster(bootstrap, Optional.empty()),
-                null,
-                Optional.empty(),
-                virtualClusterIngressModel.gateways(),
-                false, false,
-                filterNamesForCluster(cluster));
+    public boolean isMet(DependentResource<ConfigMap, KafkaProxy> dependentResource,
+                         KafkaProxy primary,
+                         Context<KafkaProxy> context) {
+        return KafkaProxyContext.proxyContext(context).configuration().isPresent();
     }
 
 }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeploymentDependentResource.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeploymentDependentResource.java
@@ -118,7 +118,7 @@ public class ProxyDeploymentDependentResource
                             .withName(ProxyConfigDependentResource.configMapName(primary))
                         .endConfigMap()
                     .endVolume()
-                    .addAllToVolumes(ProxyConfigDependentResource.secureVolumes(context.managedWorkflowAndDependentResourceContext()))
+                    .addAllToVolumes(ProxyConfigDependentResource.secureVolumes(context))
                 .endSpec()
                 .build();
         // @formatter:on
@@ -146,7 +146,7 @@ public class ProxyDeploymentDependentResource
                     .withMountPath(ProxyDeploymentDependentResource.CONFIG_PATH_IN_CONTAINER)
                     .withSubPath(ProxyConfigDependentResource.CONFIG_YAML_KEY)
                 .endVolumeMount()
-                .addAllToVolumeMounts(ProxyConfigDependentResource.secureVolumeMounts(context.managedWorkflowAndDependentResourceContext()))
+                .addAllToVolumeMounts(ProxyConfigDependentResource.secureVolumeMounts(context))
                 // management port
                 .addNewPort()
                     .withContainerPort(MANAGEMENT_PORT)

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeploymentDependentResource.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeploymentDependentResource.java
@@ -67,7 +67,8 @@ public class ProxyDeploymentDependentResource
     @Override
     protected Deployment desired(KafkaProxy primary,
                                  Context<KafkaProxy> context) {
-        var model = KafkaProxyContext.proxyContext(context).model();
+        KafkaProxyContext kafkaProxyContext = KafkaProxyContext.proxyContext(context);
+        var model = kafkaProxyContext.model();
         // @formatter:off
         return new DeploymentBuilder()
                 .editOrNewMetadata()
@@ -82,7 +83,7 @@ public class ProxyDeploymentDependentResource
                     .editOrNewSelector()
                         .withMatchLabels(deploymentSelector(primary))
                     .endSelector()
-                    .withTemplate(podTemplate(primary, context, model.ingressModel(), model.clustersWithValidIngresses()))
+                    .withTemplate(podTemplate(primary, kafkaProxyContext, model.ingressModel(), model.clustersWithValidIngresses()))
                 .endSpec()
                 .build();
         // @formatter:on
@@ -104,29 +105,33 @@ public class ProxyDeploymentDependentResource
     }
 
     private PodTemplateSpec podTemplate(KafkaProxy primary,
-                                        Context<KafkaProxy> context, ProxyIngressModel ingressModel, List<VirtualKafkaCluster> virtualKafkaClusters) {
+                                        KafkaProxyContext kafkaProxyContext,
+                                        ProxyIngressModel ingressModel,
+                                        List<VirtualKafkaCluster> virtualKafkaClusters) {
         // @formatter:off
         return new PodTemplateSpecBuilder()
                 .editOrNewMetadata()
                     .addToLabels(podLabels(primary))
                 .endMetadata()
                 .editOrNewSpec()
-                    .withContainers(proxyContainer( context, ingressModel, virtualKafkaClusters))
+                    .withContainers(proxyContainer(kafkaProxyContext, ingressModel, virtualKafkaClusters))
                     .addNewVolume()
                         .withName(CONFIG_VOLUME)
                         .withNewConfigMap()
                             .withName(ProxyConfigDependentResource.configMapName(primary))
                         .endConfigMap()
                     .endVolume()
-                    .addAllToVolumes(ProxyConfigDependentResource.secureVolumes(context))
+                    .addAllToVolumes(kafkaProxyContext.volumes())
                 .endSpec()
                 .build();
         // @formatter:on
     }
 
-    private Container proxyContainer(Context<KafkaProxy> context, ProxyIngressModel ingressModel, List<VirtualKafkaCluster> virtualKafkaClusters) {
+    private Container proxyContainer(KafkaProxyContext kafkaProxyContext,
+                                     ProxyIngressModel ingressModel,
+                                     List<VirtualKafkaCluster> virtualKafkaClusters) {
         // @formatter:off
-        var containerBuilder = new ContainerBuilder()
+         var containerBuilder = new ContainerBuilder()
                 .withName("proxy")
                 .withNewLivenessProbe()
                     .withNewHttpGet()
@@ -146,7 +151,7 @@ public class ProxyDeploymentDependentResource
                     .withMountPath(ProxyDeploymentDependentResource.CONFIG_PATH_IN_CONTAINER)
                     .withSubPath(ProxyConfigDependentResource.CONFIG_YAML_KEY)
                 .endVolumeMount()
-                .addAllToVolumeMounts(ProxyConfigDependentResource.secureVolumeMounts(context))
+                .addAllToVolumeMounts(kafkaProxyContext.mounts())
                 // management port
                 .addNewPort()
                     .withContainerPort(MANAGEMENT_PORT)
@@ -154,7 +159,7 @@ public class ProxyDeploymentDependentResource
                 .endPort();
         // broker ports
         virtualKafkaClusters.forEach(virtualKafkaCluster -> {
-            if (!KafkaProxyContext.proxyContext(context).isBroken(virtualKafkaCluster)) {
+            if (!kafkaProxyContext.isBroken(virtualKafkaCluster)) {
                 ProxyIngressModel.VirtualClusterIngressModel virtualClusterIngressModel = ingressModel.clusterIngressModel(virtualKafkaCluster).orElseThrow();
                 for (ProxyIngressModel.IngressModel ingress : virtualClusterIngressModel.ingressModels()) {
                     ingress.proxyContainerPorts().forEach(containerBuilder::addToPorts);

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerTest.java
@@ -13,8 +13,6 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.Set;
 
-import io.javaoperatorsdk.operator.api.reconciler.dependent.managed.DefaultManagedWorkflowAndDependentResourceContext;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -93,8 +91,7 @@ class KafkaProxyReconcilerTest {
         // @formatter:on
 
         // When
-        var updateControl = newKafkaProxyReconciler(TEST_CLOCK, primary, context)
-                .reconcile(primary, context);
+        var updateControl = newKafkaProxyReconciler(TEST_CLOCK).reconcile(primary, context);
 
         // Then
         assertThat(updateControl.isPatchStatus()).isTrue();
@@ -122,7 +119,7 @@ class KafkaProxyReconcilerTest {
         // @formatter:on
 
         // When
-        var updateControl = newKafkaProxyReconciler(TEST_CLOCK, proxy, context)
+        var updateControl = newKafkaProxyReconciler(TEST_CLOCK)
                 .updateErrorStatus(proxy, context, new InvalidResourceException("Resource was terrible"));
 
         // Then
@@ -167,7 +164,7 @@ class KafkaProxyReconcilerTest {
 
         // When
 
-        var updateControl = newKafkaProxyReconciler(reconciliationTime, primary, context).reconcile(primary, context);
+        var updateControl = newKafkaProxyReconciler(reconciliationTime).reconcile(primary, context);
 
         // Then
         assertThat(updateControl.isPatchStatus()).isTrue();
@@ -207,7 +204,7 @@ class KafkaProxyReconcilerTest {
         Clock reconciliationTime = Clock.offset(TEST_CLOCK, Duration.ofSeconds(1));
 
         // When
-        var updateControl = newKafkaProxyReconciler(reconciliationTime, primary, context)
+        var updateControl = newKafkaProxyReconciler(reconciliationTime)
                 .updateErrorStatus(primary, context, new InvalidResourceException("Resource was terrible"));
 
         // Then
@@ -250,7 +247,7 @@ class KafkaProxyReconcilerTest {
         Clock reconciliationTime = Clock.offset(TEST_CLOCK, Duration.ofSeconds(1));
 
         // When
-        var updateControl = newKafkaProxyReconciler(reconciliationTime, primary, context)
+        var updateControl = newKafkaProxyReconciler(reconciliationTime)
                 .updateErrorStatus(primary, context, new InvalidResourceException("Resource was terrible"));
 
         // Then
@@ -359,8 +356,7 @@ class KafkaProxyReconcilerTest {
         Clock reconciliationTime = Clock.offset(TEST_CLOCK, Duration.ofSeconds(1));
 
         // When
-        var updateControl = newKafkaProxyReconciler(reconciliationTime, proxy, context)
-                .reconcile(proxy, context);
+        var updateControl = newKafkaProxyReconciler(reconciliationTime).reconcile(proxy, context);
 
         // Then
         assertThat(updateControl.isPatchStatus()).isTrue();
@@ -406,7 +402,7 @@ class KafkaProxyReconcilerTest {
                 .withName("my-proxy").endProxyRef().endSpec().build())).when(context).getSecondaryResources(VirtualKafkaCluster.class);
 
         // When
-        var updateControl = newKafkaProxyReconciler(reconciliationTime, primary, context).reconcile(primary, context);
+        var updateControl = newKafkaProxyReconciler(reconciliationTime).reconcile(primary, context);
 
         // Then
         assertThat(updateControl.isPatchStatus()).isTrue();
@@ -421,13 +417,8 @@ class KafkaProxyReconcilerTest {
     }
 
     @NonNull
-    private static KafkaProxyReconciler newKafkaProxyReconciler(Clock reconciliationTime,
-                                                                KafkaProxy proxy,
-                                                                Context<KafkaProxy> context) {
-        when(context.managedWorkflowAndDependentResourceContext()).thenReturn(new DefaultManagedWorkflowAndDependentResourceContext<>(null, proxy, context));
-        KafkaProxyReconciler kafkaProxyReconciler = new KafkaProxyReconciler(reconciliationTime, SecureConfigInterpolator.DEFAULT_INTERPOLATOR);
-        kafkaProxyReconciler.initContext(proxy, context);
-        return kafkaProxyReconciler;
+    private static KafkaProxyReconciler newKafkaProxyReconciler(Clock reconciliationTime) {
+        return new KafkaProxyReconciler(reconciliationTime, SecureConfigInterpolator.DEFAULT_INTERPOLATOR);
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

* Makes the precondition side-effect-free.
* Avoids needing mutable maps in the context for volumes and mounts.

