### PR TITLE
Add additionalPrinterColumns and categories to CRDs

### DIFF
--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaprotocolfilters.filter.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaprotocolfilters.filter.kroxylicious.io-v1.yml
@@ -32,10 +32,10 @@ spec:
       subresources:
         status: {}
       additionalPrinterColumns:
-        - jsonPath: ".status.conditions[?(@.type==\"ResolvedRefs\")].status"
-          type: string
-          name: ResolvedRefs
+        - name: ResolvedRefs
           description: Whether the other resources referenced by this protocol filter can be found
+          jsonPath: ".status.conditions[?(@.type==\"ResolvedRefs\")].status"
+          type: string
           priority: 0
       schema:
         openAPIV3Schema:

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaprotocolfilters.filter.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaprotocolfilters.filter.kroxylicious.io-v1.yml
@@ -17,13 +17,13 @@ spec:
   group: filter.kroxylicious.io
   scope: Namespaced
   names:
-    categories:
-      - kroxylicious-plugins
     plural: kafkaprotocolfilters
     singular: kafkaprotocolfilter
     kind: KafkaProtocolFilter
     shortNames:
       - kpf
+    categories:
+      - kroxylicious
   # list of versions supported by this CustomResourceDefinition
   versions:
     - name: v1alpha1
@@ -31,6 +31,12 @@ spec:
       storage: true
       subresources:
         status: {}
+      additionalPrinterColumns:
+        - jsonPath: ".status.conditions[?(@.type==\"ResolvedRefs\")].status"
+          type: string
+          name: ResolvedRefs
+          description: Whether the other resources referenced by this protocol filter can be found
+          priority: 0
       schema:
         openAPIV3Schema:
           type: object

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaprotocolfilters.filter.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaprotocolfilters.filter.kroxylicious.io-v1.yml
@@ -33,7 +33,7 @@ spec:
         status: {}
       additionalPrinterColumns:
         - name: ResolvedRefs
-          description: Whether the other resources referenced by this protocol filter can be found
+          description: Whether the other resources referenced by this protocol filter can be found.
           jsonPath: ".status.conditions[?(@.type==\"ResolvedRefs\")].status"
           type: string
           priority: 0

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
@@ -32,10 +32,10 @@ spec:
       subresources:
         status: { }
       additionalPrinterColumns:
-        - jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
-          type: string
-          name: Ready
+        - name: Ready
           description: Whether the other resources referenced by this proxy can be found
+          jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+          type: string
           priority: 0
       schema:
         openAPIV3Schema:

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
@@ -33,7 +33,7 @@ spec:
         status: { }
       additionalPrinterColumns:
         - name: Ready
-          description: Whether the other resources referenced by this proxy can be found
+          description: Whether the other resources referenced by this proxy can be found.
           jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
           type: string
           priority: 0

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
@@ -22,6 +22,8 @@ spec:
     kind: KafkaProxy
     shortNames:
       - kp
+    categories:
+      - kroxylicious
   # list of versions supported by this CustomResourceDefinition
   versions:
     - name: v1alpha1
@@ -29,6 +31,12 @@ spec:
       storage: true
       subresources:
         status: { }
+      additionalPrinterColumns:
+        - jsonPath: ".status.conditions[?(@.type==\"Ready\")].status"
+          type: string
+          name: Ready
+          description: Whether the other resources referenced by this proxy can be found
+          priority: 0
       schema:
         openAPIV3Schema:
           type: object

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxyingresses.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxyingresses.kroxylicious.io-v1.yml
@@ -32,10 +32,15 @@ spec:
       subresources:
         status: { }
       additionalPrinterColumns:
-        - jsonPath: ".status.conditions[?(@.type==\"ResolvedRefs\")].status"
+        - name: Proxy
+          description: The name of the proxy that this virtual cluster is part of.
+          jsonPath: ".spec.proxyRef.name"
           type: string
-          name: ResolvedRefs
+          priority: 0
+        - name: ResolvedRefs
           description: Whether the other resources referenced by this proxy ingress can be found
+          jsonPath: ".status.conditions[?(@.type==\"ResolvedRefs\")].status"
+          type: string
           priority: 0
       schema:
         openAPIV3Schema:

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxyingresses.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxyingresses.kroxylicious.io-v1.yml
@@ -38,7 +38,7 @@ spec:
           type: string
           priority: 0
         - name: ResolvedRefs
-          description: Whether the other resources referenced by this proxy ingress can be found
+          description: Whether the other resources referenced by this proxy ingress can be found.
           jsonPath: ".status.conditions[?(@.type==\"ResolvedRefs\")].status"
           type: string
           priority: 0

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxyingresses.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaproxyingresses.kroxylicious.io-v1.yml
@@ -22,6 +22,8 @@ spec:
     kind: KafkaProxyIngress
     shortNames:
       - kpi
+    categories:
+      - kroxylicious
   # list of versions supported by this CustomResourceDefinition
   versions:
     - name: v1alpha1
@@ -29,6 +31,12 @@ spec:
       storage: true
       subresources:
         status: { }
+      additionalPrinterColumns:
+        - jsonPath: ".status.conditions[?(@.type==\"ResolvedRefs\")].status"
+          type: string
+          name: ResolvedRefs
+          description: Whether the other resources referenced by this proxy ingress can be found
+          priority: 0
       schema:
         openAPIV3Schema:
           type: object

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
@@ -33,7 +33,7 @@ spec:
         status: { }
       additionalPrinterColumns:
         - jsonPath: ".status.conditions[?(@.type==\"ResolvedRefs\")].status"
-          description: Whether the other resources referenced by this service can be found
+          description: Whether the other resources referenced by this service can be found.
           type: string
           name: ResolvedRefs
           priority: 0
@@ -53,7 +53,7 @@ spec:
                   minLength: 1
                   pattern: ^(([^:]+:[0-9]{1,5}),)*([^:]+:[0-9]{1,5})$
                 tls:
-                  description: Configuration for TLS connections made to the Kafka cluster
+                  description: Configuration for TLS connections made to the Kafka cluster.
                   type: object
                   properties:
                     certificateRef:

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
@@ -33,9 +33,9 @@ spec:
         status: { }
       additionalPrinterColumns:
         - jsonPath: ".status.conditions[?(@.type==\"ResolvedRefs\")].status"
+          description: Whether the other resources referenced by this service can be found
           type: string
           name: ResolvedRefs
-          description: Whether the other resources referenced by this service can be found
           priority: 0
       schema:
         openAPIV3Schema:

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
@@ -22,6 +22,8 @@ spec:
     kind: KafkaService
     shortNames:
       - ks
+    categories:
+      - kroxylicious
   # list of versions supported by this CustomResourceDefinition
   versions:
     - name: v1alpha1
@@ -29,6 +31,12 @@ spec:
       storage: true
       subresources:
         status: { }
+      additionalPrinterColumns:
+        - jsonPath: ".status.conditions[?(@.type==\"ResolvedRefs\")].status"
+          type: string
+          name: ResolvedRefs
+          description: Whether the other resources referenced by this service can be found
+          priority: 0
       schema:
         openAPIV3Schema:
           type: object

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
@@ -22,6 +22,8 @@ spec:
     kind: VirtualKafkaCluster
     shortNames:
       - vkc
+    categories:
+      - kroxylicious
   # list of versions supported by this CustomResourceDefinition
   versions:
     - name: v1alpha1
@@ -29,6 +31,17 @@ spec:
       storage: true
       subresources:
         status: { }
+      additionalPrinterColumns:
+        - jsonPath: ".status.conditions[?(@.type==\"ResolvedRefs\")].status"
+          type: string
+          name: ResolvedRefs
+          description: Whether the other resources referenced by this virtual cluster can be found
+          priority: 0
+        - jsonPath: ".status.conditions[?(@.type==\"Accepted\")].status"
+          type: string
+          name: Accepted
+          description: Whether the virtual cluster has been accepted by the proxy
+          priority: 0
       schema:
         openAPIV3Schema:
           type: object

--- a/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
+++ b/kroxylicious-operator/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
@@ -32,15 +32,25 @@ spec:
       subresources:
         status: { }
       additionalPrinterColumns:
-        - jsonPath: ".status.conditions[?(@.type==\"ResolvedRefs\")].status"
+        - name: Proxy
+          description: The name of the proxy that this virtual cluster is part of.
+          jsonPath: ".spec.proxyRef.name"
           type: string
-          name: ResolvedRefs
-          description: Whether the other resources referenced by this virtual cluster can be found
           priority: 0
-        - jsonPath: ".status.conditions[?(@.type==\"Accepted\")].status"
+        - name: KafkaService
+          description: The name of the kafka service that this virtual cluster exposes.
+          jsonPath: ".spec.targetKafkaServiceRef.name"
           type: string
-          name: Accepted
-          description: Whether the virtual cluster has been accepted by the proxy
+          priority: 0
+        - name: ResolvedRefs
+          description: Whether the other resources referenced by this virtual cluster can be found.
+          jsonPath: ".status.conditions[?(@.type==\"ResolvedRefs\")].status"
+          type: string
+          priority: 0
+        - name: Accepted
+          description: Whether the virtual cluster has been accepted by the proxy.
+          jsonPath: ".status.conditions[?(@.type==\"Accepted\")].status"
+          type: string
           priority: 0
       schema:
         openAPIV3Schema:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

1. Adds the `kroxylicious` category to all the CRDs, allowing for say things like `kubectl get kroxylicious` to get all the kroxylicious recources.
2. Adds [`additionalPrinterColumns`](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#additional-printer-columns) for the relevant condition types to the `v1alpha1` CRD versions. 


As a result of these two changes you can get a quick overview of all the parts of  a proxy like this

```$ kubectl -n my-proxy get kroxylicious 
NAME                                                    RESOLVEDREFS
kafkaprotocolfilter.filter.kroxylicious.io/encryption   True

NAME                                READY
kafkaproxy.kroxylicious.io/simple   True

NAME                                           PROXY    RESOLVEDREFS
kafkaproxyingress.kroxylicious.io/cluster-ip   simple   True

NAME                                      RESOLVEDREFS
kafkaservice.kroxylicious.io/my-cluster   True

NAME                                             PROXY    KAFKASERVICE   RESOLVEDREFS   ACCEPTED
virtualkafkacluster.kroxylicious.io/my-cluster   simple   my-cluster     False          True
```

There are a couple of limitations:

1. I'd have liked to show the filters and ingresses in the output for `virtualkafkacluster.kroxylicious.io`, but `additionalPrinterColumns` don't support lists, so there seems not to be any way to do this.
2. `additionalPrinterColumns` are just given as JsonPaths. In particular there's no way to check whether the resource you're getting them from has `metadata.generation == status.observedGeneration`, so there's always the possibility that a columns that depends on anything from the status is out of date. I wasn't able to find a way of adding a separate `INSYNC` column either, because the apiserver requires that the `jsonPath` begins with `.`.