### PR TITLE
Exposing the port for metrics the Record encryption example

### DIFF
--- a/kubernetes-examples/filters/record-encryption/base/kroxylicious/kroxylicious-service.yaml
+++ b/kubernetes-examples/filters/record-encryption/base/kroxylicious/kroxylicious-service.yaml
@@ -37,3 +37,9 @@ spec:
     port: 30195
     targetPort: 30195
     nodePort: 30195
+
+  - name: metrics
+    protocol: TCP
+    port: 30090
+    targetPort: 9190
+    nodePort: 30090

--- a/kubernetes-examples/filters/record-encryption/base/kroxylicious/kroxylicious-service.yaml
+++ b/kubernetes-examples/filters/record-encryption/base/kroxylicious/kroxylicious-service.yaml
@@ -14,6 +14,12 @@ spec:
   selector:
     app: kroxylicious
   ports:
+  - name: metrics
+    protocol: TCP
+    port: 30090
+    targetPort: 9190
+    nodePort: 30090
+
   - name: port-30192
     protocol: TCP
     port: 30192
@@ -38,8 +44,3 @@ spec:
     targetPort: 30195
     nodePort: 30195
 
-  - name: metrics
-    protocol: TCP
-    port: 30090
-    targetPort: 9190
-    nodePort: 30090


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Currently if we try to do a `curl minikube:30090/metrics` request to obtain the metrics, the command fails with the error `Couldn't connect to server`. this is because the port is not exposed. This PR fixes the issue by exposing the port.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
