### PR TITLE
Fixing KafkaService configmap/secret reconcilation NPEs

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconciler.java
@@ -9,6 +9,7 @@ package io.kroxylicious.kubernetes.operator;
 import java.time.Clock;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,7 +56,7 @@ public class KafkaProxyIngressReconciler implements
                 .withSecondaryToPrimaryMapper(proxy -> ResourcesUtil.findReferrers(context,
                         proxy,
                         KafkaProxyIngress.class,
-                        ingress -> ingress.getSpec().getProxyRef()))
+                        ingress -> Optional.of(ingress.getSpec().getProxyRef())))
                 .build();
         return List.of(new InformerEventSource<>(configuration, context));
     }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
@@ -257,11 +257,11 @@ public class ResourcesUtil {
     static <O extends HasMetadata, R extends HasMetadata> Set<ResourceID> findReferrers(EventSourceContext<?> context,
                                                                                         R referent,
                                                                                         Class<O> owner,
-                                                                                        Function<O, LocalRef<R>> refAccessor) {
+                                                                                        Function<O, Optional<LocalRef<R>>> refAccessor) {
         return ResourcesUtil.filteredResourceIdsInSameNamespace(context,
                 referent,
                 owner,
-                primary -> ResourcesUtil.isReferent(refAccessor.apply(primary), referent));
+                primary -> refAccessor.apply(primary).map(lr -> ResourcesUtil.isReferent(lr, referent)).orElse(false));
     }
 
     /**

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconciler.java
@@ -219,7 +219,7 @@ public final class VirtualKafkaClusterReconciler implements
                 .withSecondaryToPrimaryMapper(proxy -> ResourcesUtil.findReferrers(context,
                         proxy,
                         VirtualKafkaCluster.class,
-                        cluster -> cluster.getSpec().getProxyRef()))
+                        cluster -> Optional.of(cluster.getSpec().getProxyRef())))
                 .build();
 
         InformerEventSourceConfiguration<ConfigMap> clusterToProxyConfigState = InformerEventSourceConfiguration.from(
@@ -230,9 +230,9 @@ public final class VirtualKafkaClusterReconciler implements
                 .withSecondaryToPrimaryMapper(configMap -> ResourcesUtil.findReferrers(context,
                         configMap,
                         VirtualKafkaCluster.class,
-                        cluster -> new AnyLocalRefBuilder().withGroup("").withKind("ConfigMap")
+                        cluster -> Optional.of(new AnyLocalRefBuilder().withGroup("").withKind("ConfigMap")
                                 .withName(cluster.getSpec().getProxyRef().getName() + CONFIG_STATE_CONFIG_MAP_SUFFIX)
-                                .build()))
+                                .build())))
                 .build();
 
         InformerEventSourceConfiguration<KafkaService> clusterToService = InformerEventSourceConfiguration.from(
@@ -244,7 +244,7 @@ public final class VirtualKafkaClusterReconciler implements
                 .withSecondaryToPrimaryMapper(service -> ResourcesUtil.findReferrers(context,
                         service,
                         VirtualKafkaCluster.class,
-                        cluster -> cluster.getSpec().getTargetKafkaServiceRef()))
+                        cluster -> Optional.of(cluster.getSpec().getTargetKafkaServiceRef())))
                 .build();
 
         InformerEventSourceConfiguration<KafkaProxyIngress> clusterToIngresses = InformerEventSourceConfiguration.from(


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

The reconciliation of KafkaService is failing if KafkaService has no trust anchor (or cert) and the namespace contains a configmap (or secret).  

```
java.lang.NullPointerException: Cannot invoke "io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.Tls.getTrustAnchorRef()" because the return value of "io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceSpec.getTls()" is null
	at io.kroxylicious.kubernetes.operator.KafkaServiceReconciler.lambda$prepareEventSources$4(KafkaServiceReconciler.java:89) ~[kroxylicious-operator-0.12.0-SNAPSHOT.jar:?]
	at io.kroxylicious.kubernetes.operator.ResourcesUtil.lambda$findReferrers$2(ResourcesUtil.java:264) ~[kroxylicious-operator-0.12.0-SNAPSHOT.jar:?]
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:178) ~[?:?]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682) ~[?:?]
	at io.kroxylicious.kubernetes.operator.ResourcesUtil.filteredResourceIdsInSameNamespace(ResourcesUtil.java:203) ~[kroxylicious-operator-0.12.0-SNAPSHOT.jar:?]
	at io.kroxylicious.kubernetes.operator.ResourcesUtil.findReferrers(ResourcesUtil.java:261) ~[kroxylicious-operator-0.12.0-SNAPSHOT.jar:?]
	at io.kroxylicious.kubernetes.operator.KafkaServiceReconciler.lambda$prepareEventSources$5(KafkaServiceReconciler.java:86) ~[kroxylicious-operator-0.12.0-SNAPSHOT.jar:?]
	at io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource.propagateEvent(InformerEventSource.java:216) ~[operator-framework-core-5.0.3.jar:?]
	at io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource.onAddOrUpdate(InformerEventSource.java:175) ~[operator-framework-core-5.0.3.jar:?]
	at io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource.onAdd(InformerEventSource.java:125) ~[operator-framework-core-5.0.3.jar:?]
	at io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource.onAdd(InformerEventSource.java:68) ~[operator-framework-core-5.0.3.jar:?]
	at io.fabric8.kubernetes.client.informers.impl.cache.ProcessorListener$AddNotification.handle(ProcessorListener.java:103) ~[kubernetes-client-6.13.5.jar:?]
	at io.fabric8.kubernetes.client.informers.impl.cache.ProcessorListener.add(ProcessorListener.java:50) ~[kubernetes-client-6.13.5.jar:?]
	at io.fabric8.kubernetes.client.informers.impl.cache.SharedProcessor.lambda$distribute$0(SharedProcessor.java:91) ~[kubernetes-client-6.13.5.jar:?]
	at io.fabric8.kubernetes.client.informers.impl.cache.SharedProcessor.lambda$distribute$1(SharedProcessor.java:114) ~[kubernetes-client-6.13.5.jar:?]
	at io.fabric8.kubernetes.client.utils.internal.SerialExecutor.lambda$execute$0(SerialExecutor.java:57) ~[kubernetes-client-6.13.5.jar:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
```

The issue is that the mappers don't consider the possibility that the KafkaService will be without TLS parts.
We need stronger tests.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
