### PR TITLE
operator: VKC reconciler ignores events from stale referents

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
@@ -290,7 +290,13 @@ public class ResourcesUtil {
         return ResourcesUtil.filteredResourceIdsInSameNamespace(context,
                 referent,
                 owner,
-                primary -> refAccessor.apply(primary).stream().anyMatch(ref -> ResourcesUtil.isReferent(ref, referent)));
+                primary -> {
+                    Collection<? extends LocalRef<R>> refs = refAccessor.apply(primary);
+                    if (refs == null) {
+                        return false;
+                    }
+                    return refs.stream().anyMatch(ref -> ResourcesUtil.isReferent(ref, referent));
+                });
     }
 
     public static String namespacedSlug(LocalRef<?> ref, HasMetadata resource) {


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

When deciding if CRUD events should trigger a VirtualKafkaCluster reconcilation, we do not trigger any reconciliations if the resource has a stale status (`status.observedGeneration != metadata.generation`).

Before we run an aggregating reconciler like the VirtualKafkaCluster we want all the referents to be in a reconciled state. The aggregating reconciler can not act on a referent that has not been reconciled because the referent's reconciler may decide that there is some problem.

Closes #2069

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
