### PR TITLE
Only construct configuration if we have at least one cluster

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconciler.java
@@ -68,7 +68,6 @@ import io.kroxylicious.kubernetes.operator.model.ingress.ClusterIPIngressDefinit
 import io.kroxylicious.kubernetes.operator.model.ingress.ProxyIngressModel;
 import io.kroxylicious.kubernetes.operator.resolver.ProxyResolutionResult;
 import io.kroxylicious.proxy.config.Configuration;
-import io.kroxylicious.proxy.config.IllegalConfigurationException;
 import io.kroxylicious.proxy.config.NamedFilterDefinition;
 import io.kroxylicious.proxy.config.NamedRange;
 import io.kroxylicious.proxy.config.PortIdentifiesNodeIdentificationStrategy;
@@ -153,14 +152,11 @@ public class KafkaProxyReconciler implements
                             Context<KafkaProxy> context) {
         ProxyModelBuilder proxyModelBuilder = ProxyModelBuilder.contextBuilder();
         ProxyModel model = proxyModelBuilder.build(proxy, context);
-        ConfigurationFragment<Configuration> fragment;
-        try {
+        boolean hasClusters = !model.clustersWithValidIngresses().isEmpty();
+        ConfigurationFragment<Configuration> fragment = null;
+        if (hasClusters) {
             fragment = generateProxyConfig(model);
         }
-        catch (IllegalConfigurationException ice) {
-            fragment = null;
-        }
-
         KafkaProxyContext.init(context,
                 new VirtualKafkaClusterStatusFactory(clock),
                 model,


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

We do not construct a config in the case where we have zero cluster. If the config generation throws any exceptions it will terminate the reconcilation, log and update the Ready condition to Unknown.

### Additional Context

Currently any IllegalConfigurationExceptions are silently swallowed, resulting in the removal of all the resources for that proxy. We want unhandled exceptions to be visible in the operator logs and cause a change to the status.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
