### PR TITLE
Fix #2091: OauthBearer factory needs to add the JWKS endpoint to the allow-list.

### DIFF
--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/pom.xml
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/pom.xml
@@ -61,6 +61,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
@@ -101,6 +106,10 @@
             <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-filter-test-support</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit-pioneer</groupId>
+            <artifactId>junit-pioneer</artifactId>
         </dependency>
     </dependencies>
     <build>

--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationTest.java
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationTest.java
@@ -160,14 +160,14 @@ class OauthBearerValidationTest {
 
     static Stream<Arguments> closeShouldRestoreOauthAllowList() {
         return Stream.of(
-                Arguments.argumentSet("clears system property after close",
+                Arguments.argumentSet("close clears system property",
                         (Consumer<String>) unused -> System.clearProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG),
                         (BiConsumer<String, String>) (initial, propValue) -> assertThat(propValue).isNull()),
-                Arguments.argumentSet("preserves existing system property value",
-                        (Consumer<String>) initial -> System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG, initial),
+                Arguments.argumentSet("close preserves an existing system property that exactly matches config value",
+                        (Consumer<String>) configValue -> System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG, configValue),
                         (BiConsumer<String, String>) (initial, propValue) -> assertThat(propValue).isEqualTo(initial)),
-                Arguments.argumentSet("other endpoint values preserved",
-                        (Consumer<String>) unused -> System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG, "https://another.invalid"),
+                Arguments.argumentSet("close preserves an existing system property that did not matches config value",
+                        (Consumer<String>) configValue -> System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG, "https://another.invalid"),
                         (BiConsumer<String, String>) (initial, propValue) -> assertThat(propValue).isEqualTo("https://another.invalid")));
     }
 

--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationTest.java
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationTest.java
@@ -8,11 +8,19 @@ package io.kroxylicious.proxy.filter.oauthbearer;
 
 import java.net.URI;
 import java.util.List;
+import java.util.UUID;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junitpioneer.jupiter.RestoreSystemProperties;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -21,7 +29,9 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import io.kroxylicious.proxy.filter.FilterDispatchExecutor;
 import io.kroxylicious.proxy.filter.FilterFactoryContext;
+import io.kroxylicious.proxy.filter.oauthbearer.OauthBearerValidation.Config;
 
+import static io.kroxylicious.proxy.filter.oauthbearer.OauthBearerValidation.ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.assertArg;
@@ -30,6 +40,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@RestoreSystemProperties
 class OauthBearerValidationTest {
 
     @Mock
@@ -51,7 +62,7 @@ class OauthBearerValidationTest {
     @Test
     void mustProvideDefaultValuesForConfig() throws Exception {
         ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
-        OauthBearerValidation.Config yamlConfig = yamlMapper.readerFor(OauthBearerValidation.Config.class).readValue("""
+        Config yamlConfig = yamlMapper.readerFor(Config.class).readValue("""
                 jwksEndpointUrl: https://jwks.endpoint
                 """);
 
@@ -60,14 +71,14 @@ class OauthBearerValidationTest {
 
     @Test
     @SuppressWarnings("java:S5838")
-    void mustInitAndCreateFilterWithDefaultsNull() throws Exception {
+    void mustInitAndCreateFilterWithDefaultsNull() {
         mustInitAndCreateFilter(defaultConfig());
     }
 
     @Test
-    void mustInitAndCreateFilterWithNegativeAndEmptyValues() throws Exception {
-        OauthBearerValidation.Config config = new OauthBearerValidation.Config(
-                new URI("https://jwks.endpoint"),
+    void mustInitAndCreateFilterWithNegativeAndEmptyValues() {
+        Config config = new Config(
+                URI.create("https://jwks.endpoint"),
                 -1L,
                 -1L,
                 -1L,
@@ -86,7 +97,7 @@ class OauthBearerValidationTest {
         // given
         when(ffc.filterDispatchExecutor()).thenReturn(executor);
         OauthBearerValidation oauthBearerValidation = new OauthBearerValidation(callbackHandler);
-        OauthBearerValidation.Config config = new OauthBearerValidation.Config(
+        Config config = new Config(
                 new URI("https://jwks.endpoint"),
                 10000L,
                 20000L,
@@ -132,8 +143,55 @@ class OauthBearerValidationTest {
         verify(callbackHandler).close();
     }
 
+    @Test
+    void initShouldAddJwksEndpointToOauthAllowList() {
+        // given
+        OauthBearerValidation oauthBearerValidation = new OauthBearerValidation(callbackHandler);
+        Config config = defaultConfig(URI.create("https://" + UUID.randomUUID() + ".invalid"));
+
+        // when
+        oauthBearerValidation.initialize(ffc, config);
+
+        // then
+        assertThat(System.getProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG))
+                .isNotEmpty()
+                .contains(config.jwksEndpointUrl().toString());
+    }
+
+    static Stream<Arguments> closeShouldRestoreOauthAllowList() {
+        return Stream.of(
+                Arguments.argumentSet("clears system property after close",
+                        (Consumer<String>) unused -> System.clearProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG),
+                        (BiConsumer<String, String>) (initial, propValue) -> assertThat(propValue).isNull()),
+                Arguments.argumentSet("preserves existing system property value",
+                        (Consumer<String>) initial -> System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG, initial),
+                        (BiConsumer<String, String>) (initial, propValue) -> assertThat(propValue).isEqualTo(initial)),
+                Arguments.argumentSet("other endpoint values preserved",
+                        (Consumer<String>) unused -> System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG, "https://another.invalid"),
+                        (BiConsumer<String, String>) (initial, propValue) -> assertThat(propValue).isEqualTo("https://another.invalid")));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    @SuppressWarnings("java:S6103") // false positive, the consumer does include an assertion.
+    void closeShouldRestoreOauthAllowList(Consumer<String> prepareSysProperties, BiConsumer<String, String> postCloseAssertions) {
+        // given
+        var jwksEndpointUrl = "https://" + UUID.randomUUID() + ".invalid";
+        prepareSysProperties.accept(jwksEndpointUrl);
+        OauthBearerValidation oauthBearerValidation = new OauthBearerValidation(callbackHandler);
+        Config config = defaultConfig(URI.create(jwksEndpointUrl));
+        var context = oauthBearerValidation.initialize(ffc, config);
+
+        // when
+        oauthBearerValidation.close(context);
+
+        // then
+        assertThat(System.getProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG))
+                .satisfies(current -> postCloseAssertions.accept(jwksEndpointUrl, current));
+    }
+
     @SuppressWarnings("java:S5838")
-    void mustInitAndCreateFilter(OauthBearerValidation.Config config) {
+    void mustInitAndCreateFilter(Config config) {
         // given
         OauthBearerValidation oauthBearerValidation = new OauthBearerValidation(callbackHandler);
         when(ffc.filterDispatchExecutor()).thenReturn(executor);
@@ -162,9 +220,13 @@ class OauthBearerValidationTest {
         assertThat(sharedContext.config().authenticateCacheMaxSize()).isEqualTo(1000);
     }
 
-    private OauthBearerValidation.Config defaultConfig() throws Exception {
-        return new OauthBearerValidation.Config(
-                new URI("https://jwks.endpoint"),
+    private Config defaultConfig() {
+        return defaultConfig(URI.create("https://jwks.endpoint"));
+    }
+
+    private Config defaultConfig(URI jwksEndpointUrl) {
+        return new Config(
+                jwksEndpointUrl,
                 null,
                 null,
                 null,

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationIT.java
@@ -94,8 +94,10 @@ class OauthBearerValidationIT {
     private static OauthServerContainer oauthServer;
 
     @BeforeAll
-    public static void beforeAll() {
-        // required to permit Kafka to interact with our endpoint.
+    static void beforeAll() {
+        // Kafka 4.0 requires that the org.apache.kafka.sasl.oauthbearer.allowed.urls sys property is set in order to use Oauth Bearer.
+        // The Kafka Broker and Proxy requires that JWKS_ENDPOINT_URL is in the allow list.
+        // The Kafka Client requires that TOKEN_ENDPOINT_URL is in the allow list.
         System.setProperty(ALLOWED_SASL_OAUTHBEARER_URLS_CONFIG, JWKS_ENDPOINT_URL + "," + TOKEN_ENDPOINT_URL);
 
         oauthServer = new OauthServerContainer(OauthBearerValidationIT.DOCKER_IMAGE_NAME);
@@ -107,14 +109,14 @@ class OauthBearerValidationIT {
     }
 
     @AfterAll
-    public static void afterAll() {
+    static void afterAll() {
         if (oauthServer != null) {
             oauthServer.close();
         }
     }
 
     @AfterEach
-    public void afterEach() throws Exception {
+    void afterEach() throws Exception {
         workaroundKafka17134();
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In Kafka 4.0.0, the OauthBearer server side needs to add the JWKS endpoint URL to an allow list
in order for the Kafka libraries to interact with it.

With this change, the OauthBearer factory will automatically set the Kafka `org.apache.kafka.sasl.oauthbearer.allowed.urls` system property to include the JWKS endpoint (if it does not already include the value).  To support embedded use-cases, the factory will undo the system properties changes on closure (this is a best effort approach).

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
