### PR TITLE
Fix #1831 - adding support for downstream trust

### DIFF
--- a/kroxylicious-kubernetes-api/pom.xml
+++ b/kroxylicious-kubernetes-api/pom.xml
@@ -167,12 +167,18 @@
                         <io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.IngressRef>
                             io.kroxylicious.kubernetes.api.common.IngressRef
                         </io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.IngressRef>
+                        <io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.tls.TrustAnchorRef>
+                            io.kroxylicious.kubernetes.api.common.TrustAnchorRef
+                        </io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.tls.TrustAnchorRef>
                         <io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.tls.CertificateRef>
                             io.kroxylicious.kubernetes.api.common.CertificateRef
                         </io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.tls.CertificateRef>
                         <io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.tls.CertificateRef>
                             io.kroxylicious.kubernetes.api.common.CertificateRef
                         </io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.tls.CertificateRef>
+                        <io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.tls.TrustAnchorRef>
+                            io.kroxylicious.kubernetes.api.common.TrustAnchorRef
+                        </io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.tls.TrustAnchorRef>
                         <io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.FilterRefs>
                             io.kroxylicious.kubernetes.api.common.FilterRef
                         </io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.FilterRefs>

--- a/kroxylicious-kubernetes-api/src/main/java/io/kroxylicious/kubernetes/api/common/AbstractLocalRef.java
+++ b/kroxylicious-kubernetes-api/src/main/java/io/kroxylicious/kubernetes/api/common/AbstractLocalRef.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.api.common;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+abstract class AbstractLocalRef extends LocalRef<HasMetadata> implements KubernetesResource {
+    @com.fasterxml.jackson.annotation.JsonProperty("group")
+    @io.fabric8.generator.annotation.Pattern("^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private String group;
+    @com.fasterxml.jackson.annotation.JsonProperty("kind")
+    @io.fabric8.generator.annotation.Pattern("^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$")
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private String kind;
+    @com.fasterxml.jackson.annotation.JsonProperty("name")
+    @io.fabric8.generator.annotation.Required()
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private String name;
+
+    @Override
+    @Nullable
+    public String getGroup() {
+        return group;
+    }
+
+    public void setGroup(String group) {
+        this.group = group;
+    }
+
+    @Override
+    @Nullable
+    public String getKind() {
+        return kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String toString() {
+        return this.getClass() + "(group=" + this.getGroup() + ", kind=" + this.getKind() + ", name=" + this.getName() + ")";
+    }
+}

--- a/kroxylicious-kubernetes-api/src/main/java/io/kroxylicious/kubernetes/api/common/AnyLocalRef.java
+++ b/kroxylicious-kubernetes-api/src/main/java/io/kroxylicious/kubernetes/api/common/AnyLocalRef.java
@@ -6,11 +6,6 @@
 
 package io.kroxylicious.kubernetes.api.common;
 
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesResource;
-
-import edu.umd.cs.findbugs.annotations.Nullable;
-
 /**
  * A reference, used in a kubernetes resource, to some kubernetes resource in the same namespace.
  * This is used for references where the kind and group are not known statically.
@@ -31,56 +26,12 @@ import edu.umd.cs.findbugs.annotations.Nullable;
         @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
 })
 public class AnyLocalRef
-        extends LocalRef<HasMetadata>
-        implements io.fabric8.kubernetes.api.builder.Editable<AnyLocalRefBuilder>,
-        KubernetesResource {
+        extends AbstractLocalRef
+        implements io.fabric8.kubernetes.api.builder.Editable<AnyLocalRefBuilder> {
 
     @java.lang.Override
     public AnyLocalRefBuilder edit() {
         return new AnyLocalRefBuilder(this);
     }
 
-    @com.fasterxml.jackson.annotation.JsonProperty("group")
-    @io.fabric8.generator.annotation.Pattern("^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
-    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
-    private String group;
-
-    @Override
-    @Nullable
-    public String getGroup() {
-        return group;
-    }
-
-    public void setGroup(String group) {
-        this.group = group;
-    }
-
-    @com.fasterxml.jackson.annotation.JsonProperty("kind")
-    @io.fabric8.generator.annotation.Pattern("^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$")
-    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
-    private String kind;
-
-    @Override
-    @Nullable
-    public String getKind() {
-        return kind;
-    }
-
-    public void setKind(String kind) {
-        this.kind = kind;
-    }
-
-    @com.fasterxml.jackson.annotation.JsonProperty("name")
-    @io.fabric8.generator.annotation.Required()
-    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
-    private String name;
-
-    @Override
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
 }

--- a/kroxylicious-kubernetes-api/src/main/java/io/kroxylicious/kubernetes/api/common/CertificateRef.java
+++ b/kroxylicious-kubernetes-api/src/main/java/io/kroxylicious/kubernetes/api/common/CertificateRef.java
@@ -6,10 +6,7 @@
 
 package io.kroxylicious.kubernetes.api.common;
 
-import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
-
-import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * A reference, used in a kubernetes resource, to a resource containing a private key and certificate.
@@ -30,56 +27,12 @@ import edu.umd.cs.findbugs.annotations.Nullable;
         @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
 })
 public class CertificateRef
-        extends LocalRef<HasMetadata>
+        extends AbstractLocalRef
         implements io.fabric8.kubernetes.api.builder.Editable<CertificateRefBuilder>,
         KubernetesResource {
 
     @Override
     public CertificateRefBuilder edit() {
         return new CertificateRefBuilder(this);
-    }
-
-    @com.fasterxml.jackson.annotation.JsonProperty("group")
-    @io.fabric8.generator.annotation.Pattern("^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
-    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
-    private String group;
-
-    @Override
-    @Nullable
-    public String getGroup() {
-        return group;
-    }
-
-    public void setGroup(String group) {
-        this.group = group;
-    }
-
-    @com.fasterxml.jackson.annotation.JsonProperty("kind")
-    @io.fabric8.generator.annotation.Pattern("^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$")
-    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
-    private String kind;
-
-    @Override
-    @Nullable
-    public String getKind() {
-        return kind;
-    }
-
-    public void setKind(String kind) {
-        this.kind = kind;
-    }
-
-    @com.fasterxml.jackson.annotation.JsonProperty("name")
-    @io.fabric8.generator.annotation.Required()
-    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
-    private String name;
-
-    @Override
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
     }
 }

--- a/kroxylicious-kubernetes-api/src/main/java/io/kroxylicious/kubernetes/api/common/LocalRef.java
+++ b/kroxylicious-kubernetes-api/src/main/java/io/kroxylicious/kubernetes/api/common/LocalRef.java
@@ -18,7 +18,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  */
 public abstract class LocalRef<T> implements Comparable<LocalRef<T>> {
 
-    public static final Comparator<LocalRef<?>> COMPARATOR = Comparator.<LocalRef<?>, String> comparing(LocalRef::getKind, Comparator.nullsLast(String::compareTo))
+    private static final Comparator<LocalRef<?>> COMPARATOR = Comparator.<LocalRef<?>, String> comparing(LocalRef::getKind, Comparator.nullsLast(String::compareTo))
             .thenComparing(LocalRef::getGroup, Comparator.nullsLast(String::compareTo))
             .thenComparing(LocalRef::getName, Comparator.nullsLast(String::compareTo));
 

--- a/kroxylicious-kubernetes-api/src/main/java/io/kroxylicious/kubernetes/api/common/TrustAnchorRef.java
+++ b/kroxylicious-kubernetes-api/src/main/java/io/kroxylicious/kubernetes/api/common/TrustAnchorRef.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.api.common;
+
+import java.util.Comparator;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+
+/**
+ * A reference, used in a kubernetes resource, to a resource containing trust anchor(s).
+ */
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({ "ref", "key" })
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@javax.annotation.processing.Generated("io.fabric8.java.generator.CRGeneratorRunner")
+@lombok.ToString()
+@io.sundr.builder.annotations.Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ObjectReference.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Container.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.EnvVar.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.ContainerPort.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.Volume.class),
+        @io.sundr.builder.annotations.BuildableReference(io.fabric8.kubernetes.api.model.VolumeMount.class)
+})
+public class TrustAnchorRef
+        implements io.fabric8.kubernetes.api.builder.Editable<TrustAnchorRefBuilder>,
+        KubernetesResource, Comparable<TrustAnchorRef> {
+
+    private static final Comparator<TrustAnchorRef> COMPARATOR = Comparator
+            .<TrustAnchorRef, AnyLocalRef> comparing(TrustAnchorRef::getRef, Comparator.nullsLast(AnyLocalRef::compareTo))
+            .thenComparing(TrustAnchorRef::getKey, Comparator.nullsLast(String::compareTo));
+
+    @Override
+    public TrustAnchorRefBuilder edit() {
+        return new TrustAnchorRefBuilder(this);
+    }
+
+    @JsonUnwrapped
+    @io.fabric8.generator.annotation.Required()
+    private AnyLocalRef ref;
+
+    public AnyLocalRef getRef() {
+        return ref;
+    }
+
+    public void setRef(AnyLocalRef ref) {
+        this.ref = ref;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonProperty("key")
+    @io.fabric8.generator.annotation.Required()
+    @com.fasterxml.jackson.annotation.JsonSetter(nulls = com.fasterxml.jackson.annotation.Nulls.SKIP)
+    private String key;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String toString() {
+        return this.getClass() + "(ref=" + this.getRef() + ", key=" + this.getKey() + ")";
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(getRef(), getKey());
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public final boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof TrustAnchorRef)) {
+            return false;
+        }
+        TrustAnchorRef other = (TrustAnchorRef) obj;
+        return Objects.equals(getRef(), other.getRef())
+                && Objects.equals(getKey(), other.getKey());
+
+    }
+
+    @Override
+    public int compareTo(TrustAnchorRef o) {
+        return COMPARATOR.compare(this, o);
+    }
+}

--- a/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
+++ b/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kafkaservices.kroxylicious.io-v1.yml
@@ -81,7 +81,8 @@ spec:
                       description: |
                         A reference to a resource holding the trusted CA certificates for validation of
                         a Kafka broker's TLS server certificate.
-                        If not specified the proxy will use the trust store inherited from the platform.
+                        If not specified the system will use the trust store inherited from the JVM that the
+                        proxy runs on.
                       type: object
                       required: [ "name", "key" ]
                       properties:

--- a/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
+++ b/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
@@ -135,6 +135,31 @@ spec:
                                 type: string
                                 minLength: 1
                                 maxLength: 253
+                          trustAnchorRef:
+                            description: |
+                              A reference to a resource holding the trusted CA certificates for validation of
+                              a Kafka client's TLS client certificate.
+                              If not specified the system will use the trust store inherited from the JVM that the
+                              proxy runs on.
+                            type: object
+                            required: [ "name", "key" ]
+                            properties:
+                              kind:
+                                description: The API kind of the resource containing the TLS trust anchor(s).
+                                type: string
+                                default: ConfigMap
+                              group:
+                                description: The API group of the resource containing the TLS trust anchor(s).
+                                type: string
+                                default: ""
+                              name:
+                                description: The name of the resource containing the TLS trust anchor(s).
+                                type: string
+                              key:
+                                description: |
+                                  The name of the key identifying the certificate bundle within the resource. 
+                                  Supported formats for the bundle are: PEM, PKCS#12 and JKS.
+                                type: string
                 filterRefs:
                   description: The filters to be used for this cluster. Each filter is a separate resource.
                   type: array

--- a/kroxylicious-kubernetes-api/src/test/java/io/kroxylicious/kubernetes/api/common/AnyLocalRefTest.java
+++ b/kroxylicious-kubernetes-api/src/test/java/io/kroxylicious/kubernetes/api/common/AnyLocalRefTest.java
@@ -13,6 +13,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AnyLocalRefTest {
 
     @Test
+    // we knowingly use equals across types because we want the property that specific LocalRef types are equal to any other LocalRef
+    // with the same group, kind and name.
+    @SuppressWarnings("java:S5845")
     void shouldRespectEqualsAndHashCode() {
         var secretRefFoo = new AnyLocalRefBuilder().withName("foo").withKind("Secret").withGroup("").build();
         var secretRefFoo2 = new AnyLocalRefBuilder().withName("foo").withKind("Secret").withGroup("").build();

--- a/kroxylicious-kubernetes-api/src/test/java/io/kroxylicious/kubernetes/api/common/CertificateRefTest.java
+++ b/kroxylicious-kubernetes-api/src/test/java/io/kroxylicious/kubernetes/api/common/CertificateRefTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.api.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CertificateRefTest {
+
+    @Test
+    void shouldRespectEqualsAndHashCode() {
+        var secretRefFoo = new CertificateRefBuilder().withName("foo").withKind("Secret").withGroup("").build();
+        var secretRefFoo2 = new CertificateRefBuilder().withName("foo").withKind("Secret").withGroup("").build();
+        var cmRefFoo = new CertificateRefBuilder().withName("foo").withKind("ConfigMap").withGroup("").build();
+        var diffGroupSecretFoo = new CertificateRefBuilder().withName("foo").withKind("Secret").withGroup("not.the.usual.group").build();
+        assertThat(secretRefFoo).isEqualTo(secretRefFoo);
+        assertThat(secretRefFoo).isNotEqualTo("salami");
+        assertThat(secretRefFoo).isNotEqualTo(diffGroupSecretFoo);
+        assertThat(secretRefFoo).isEqualTo(secretRefFoo2);
+        assertThat(secretRefFoo2).isEqualTo(secretRefFoo);
+        assertThat(secretRefFoo).hasSameHashCodeAs(secretRefFoo2);
+
+        assertThat(secretRefFoo).isNotEqualTo(cmRefFoo);
+    }
+
+    @Test
+    void anyLocalRefEquivalence() {
+        var certRef = new CertificateRefBuilder().withName("foo").withKind("Secret").withGroup("").build();
+        var anyLocalRef = new AnyLocalRefBuilder().withName("foo").withKind("Secret").withGroup("").build();
+        assertThat(certRef).isEqualTo(anyLocalRef);
+        assertThat(certRef).hasSameHashCodeAs(anyLocalRef);
+    }
+
+    @Test
+    void shouldReturnBuilder() {
+        // Given
+        CertificateRefBuilder originalBuilder = new CertificateRefBuilder();
+        var fooRef = originalBuilder.withName("foo").withKind("ConfigMap").withGroup("").build();
+
+        // When
+        CertificateRefBuilder actualBuilder = fooRef.edit();
+
+        // Then
+        assertThat(actualBuilder)
+                .isNotNull()
+                .isInstanceOf(CertificateRefBuilder.class)
+                .isNotSameAs(originalBuilder);
+    }
+}

--- a/kroxylicious-kubernetes-api/src/test/java/io/kroxylicious/kubernetes/api/common/CertificateRefTest.java
+++ b/kroxylicious-kubernetes-api/src/test/java/io/kroxylicious/kubernetes/api/common/CertificateRefTest.java
@@ -13,27 +13,36 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CertificateRefTest {
 
     @Test
+    // we knowingly use equals across types because we want the property that specific LocalRef types are equal to any other LocalRef
+    // with the same group, kind and name.
+    @SuppressWarnings("java:S5845")
     void shouldRespectEqualsAndHashCode() {
         var secretRefFoo = new CertificateRefBuilder().withName("foo").withKind("Secret").withGroup("").build();
         var secretRefFoo2 = new CertificateRefBuilder().withName("foo").withKind("Secret").withGroup("").build();
         var cmRefFoo = new CertificateRefBuilder().withName("foo").withKind("ConfigMap").withGroup("").build();
         var diffGroupSecretFoo = new CertificateRefBuilder().withName("foo").withKind("Secret").withGroup("not.the.usual.group").build();
         assertThat(secretRefFoo).isEqualTo(secretRefFoo);
+
         assertThat(secretRefFoo).isNotEqualTo("salami");
         assertThat(secretRefFoo).isNotEqualTo(diffGroupSecretFoo);
+
         assertThat(secretRefFoo).isEqualTo(secretRefFoo2);
-        assertThat(secretRefFoo2).isEqualTo(secretRefFoo);
         assertThat(secretRefFoo).hasSameHashCodeAs(secretRefFoo2);
+
+        assertThat(secretRefFoo2).isEqualTo(secretRefFoo);
 
         assertThat(secretRefFoo).isNotEqualTo(cmRefFoo);
     }
 
     @Test
+    // we knowingly use equals across types because we want the property that specific LocalRef types are equal to any other LocalRef
+    // with the same group, kind and name.
+    @SuppressWarnings("java:S5845")
     void anyLocalRefEquivalence() {
         var certRef = new CertificateRefBuilder().withName("foo").withKind("Secret").withGroup("").build();
         var anyLocalRef = new AnyLocalRefBuilder().withName("foo").withKind("Secret").withGroup("").build();
-        assertThat(certRef).isEqualTo(anyLocalRef);
-        assertThat(certRef).hasSameHashCodeAs(anyLocalRef);
+        assertThat(certRef).isEqualTo(anyLocalRef)
+                .hasSameHashCodeAs(anyLocalRef);
     }
 
     @Test

--- a/kroxylicious-kubernetes-api/src/test/java/io/kroxylicious/kubernetes/api/common/TrustAnchorRefTest.java
+++ b/kroxylicious-kubernetes-api/src/test/java/io/kroxylicious/kubernetes/api/common/TrustAnchorRefTest.java
@@ -13,6 +13,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 class TrustAnchorRefTest {
 
     @Test
+    // we knowingly use equals across types because we want the property that specific LocalRef types are equal to any other LocalRef
+    // with the same group, kind and name.
+    @SuppressWarnings("java:S5845")
     void shouldRespectEqualsAndHashCode() {
         var secretRefFoo = new TrustAnchorRefBuilder().withRef(new AnyLocalRefBuilder().withName("foo").withKind("Secret").withGroup("").build()).withKey("key").build();
         var secretRefFoo2 = new TrustAnchorRefBuilder().withRef(new AnyLocalRefBuilder().withName("foo").withKind("Secret").withGroup("").build()).withKey("key").build();

--- a/kroxylicious-kubernetes-api/src/test/java/io/kroxylicious/kubernetes/api/common/TrustAnchorRefTest.java
+++ b/kroxylicious-kubernetes-api/src/test/java/io/kroxylicious/kubernetes/api/common/TrustAnchorRefTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.api.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TrustAnchorRefTest {
+
+    @Test
+    void shouldRespectEqualsAndHashCode() {
+        var secretRefFoo = new TrustAnchorRefBuilder().withRef(new AnyLocalRefBuilder().withName("foo").withKind("Secret").withGroup("").build()).withKey("key").build();
+        var secretRefFoo2 = new TrustAnchorRefBuilder().withRef(new AnyLocalRefBuilder().withName("foo").withKind("Secret").withGroup("").build()).withKey("key").build();
+        var cmRefFoo = new TrustAnchorRefBuilder().withRef(new AnyLocalRefBuilder().withName("foo").withKind("ConfigMap").withGroup("").build()).withKey("key").build();
+        var diffGroupSecretFoo = new TrustAnchorRefBuilder().withRef(new AnyLocalRefBuilder().withName("foo").withKind("Secret").withGroup("not.the.usual.group").build())
+                .withKey("key").build();
+        var diffKeySecretFoo = new TrustAnchorRefBuilder().withRef(new AnyLocalRefBuilder().withName("foo").withKind("Secret").withGroup("").build()).withKey("diff.key")
+                .build();
+        assertThat(secretRefFoo).isEqualTo(secretRefFoo);
+        assertThat(secretRefFoo).isNotEqualTo("salami");
+        assertThat(secretRefFoo).isNotEqualTo(diffGroupSecretFoo);
+        assertThat(secretRefFoo).isNotEqualTo(diffKeySecretFoo);
+        assertThat(secretRefFoo).isEqualTo(secretRefFoo2);
+        assertThat(secretRefFoo2).isEqualTo(secretRefFoo);
+        assertThat(secretRefFoo).hasSameHashCodeAs(secretRefFoo2);
+
+        assertThat(secretRefFoo).isNotEqualTo(cmRefFoo);
+    }
+
+    @Test
+    void shouldReturnBuilder() {
+        // Given
+        TrustAnchorRefBuilder originalBuilder = new TrustAnchorRefBuilder();
+        var fooRef = originalBuilder.withRef(new AnyLocalRefBuilder().withName("foo").build()).build();
+
+        // When
+        TrustAnchorRefBuilder actualBuilder = fooRef.edit();
+
+        // Then
+        assertThat(actualBuilder)
+                .isNotNull()
+                .isInstanceOf(TrustAnchorRefBuilder.class)
+                .isNotSameAs(originalBuilder);
+    }
+}

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconciler.java
@@ -50,6 +50,7 @@ import io.kroxylicious.kubernetes.api.common.CertificateRef;
 import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.common.FilterRef;
 import io.kroxylicious.kubernetes.api.common.LocalRef;
+import io.kroxylicious.kubernetes.api.common.TrustAnchorRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
@@ -57,7 +58,6 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceSpec;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterSpec;
 import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.NodeIdRanges;
-import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.tls.TrustAnchorRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.Ingresses;
 import io.kroxylicious.kubernetes.filter.api.v1alpha1.KafkaProtocolFilter;
 import io.kroxylicious.kubernetes.filter.api.v1alpha1.KafkaProtocolFilterSpec;
@@ -135,6 +135,7 @@ public class KafkaProxyReconciler implements
     private static final Path CLIENT_TRUSTED_CERTS_BASE_DIR = TARGET_CLUSTER_MOUNTS_BASE.resolve("trusted-certs");
     private static final Path VIRTUAL_CLUSTER_MOUNTS_BASE = MOUNTS_BASE_DIR.resolve("virtual-cluster");
     private static final Path SERVER_CERTS_BASE_DIR = VIRTUAL_CLUSTER_MOUNTS_BASE.resolve("server-certs");
+    private static final Path SERVER_TRUSTED_CERTS_BASE_DIR = VIRTUAL_CLUSTER_MOUNTS_BASE.resolve("trusted-certs");
 
     private final Clock clock;
     private final SecureConfigInterpolator secureConfigInterpolator;
@@ -291,25 +292,34 @@ public class KafkaProxyReconciler implements
         }).toList();
 
         var ingressName = instance.definition().resource().getMetadata().getName();
-        var clusterWithTls = instance.definition().cluster().getSpec().getIngresses().stream()
+        var tlsConfigFragment = instance.definition().cluster().getSpec().getIngresses().stream()
                 .filter(i -> ingressName.equals(i.getIngressRef().getName()))
                 .map(Ingresses::getTls)
                 .filter(Objects::nonNull)
-                .findFirst();
+                .findFirst()
+                .map(KafkaProxyReconciler::buildTlsFragment)
+                .orElse(ConfigurationFragment.empty());
 
-        var keyCf = clusterWithTls.map(cwt -> buildKeyProvider(cwt.getCertificateRef(), SERVER_CERTS_BASE_DIR));
-
-        var tls = keyCf.flatMap(ConfigurationFragment::fragment)
-                .map(kp -> new Tls(kp, null, null, null));
-        var volumes = keyCf.map(ConfigurationFragment::volumes).orElse(Set.of());
-        var mounts = keyCf.map(ConfigurationFragment::mounts).orElse(Set.of());
+        var volumes = tlsConfigFragment.volumes();
+        var mounts = tlsConfigFragment.mounts();
 
         return new ConfigurationFragment<>(new VirtualClusterGateway("default",
                 new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", instance.firstIdentifyingPort()),
                         qualifiedServiceHost(instance.definition()), null,
                         portRanges),
                 null,
-                tls), volumes, mounts);
+                tlsConfigFragment.fragment()), volumes, mounts);
+    }
+
+    private static ConfigurationFragment<Optional<Tls>> buildTlsFragment(io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls ingressTls) {
+        return ConfigurationFragment.combine(
+                buildKeyProvider(ingressTls.getCertificateRef(), SERVER_CERTS_BASE_DIR),
+                buildTrustProvider(ingressTls.getTrustAnchorRef(), SERVER_TRUSTED_CERTS_BASE_DIR),
+                (keyProviderOpt, trustProvider) -> Optional.of(
+                        new Tls(keyProviderOpt.orElse(null),
+                                trustProvider,
+                                null,
+                                null)));
     }
 
     private static String qualifiedServiceHost(ClusterIPIngressDefinition definition) {
@@ -326,7 +336,7 @@ public class KafkaProxyReconciler implements
                 .map(KafkaServiceSpec::getTls)
                 .map(serviceTls -> ConfigurationFragment.combine(
                         buildKeyProvider(serviceTls.getCertificateRef(), CLIENT_CERTS_BASE_DIR),
-                        buildTrustProvider(serviceTls.getTrustAnchorRef()),
+                        buildTrustProvider(serviceTls.getTrustAnchorRef(), CLIENT_TRUSTED_CERTS_BASE_DIR),
                         (keyProviderOpt, trustProvider) -> Optional.of(
                                 new Tls(keyProviderOpt.orElse(null),
                                         trustProvider,
@@ -364,24 +374,25 @@ public class KafkaProxyReconciler implements
                 }).orElse(ConfigurationFragment.empty());
     }
 
-    private static ConfigurationFragment<TrustProvider> buildTrustProvider(@Nullable TrustAnchorRef trustAnchorRef) {
+    private static ConfigurationFragment<TrustProvider> buildTrustProvider(@Nullable TrustAnchorRef trustAnchorRef, Path parent) {
         return Optional.ofNullable(trustAnchorRef)
-                .filter(ResourcesUtil::isConfigMap)
-                .map(ref -> {
+                .filter(tar -> ResourcesUtil.isConfigMap(tar.getRef()))
+                .map(tar -> {
+                    var ref = tar.getRef();
                     var volume = new VolumeBuilder()
                             .withName(ResourcesUtil.volumeName("", "configmaps", ref.getName()))
                             .withNewConfigMap()
                             .withName(ref.getName())
                             .endConfigMap()
                             .build();
-                    Path mountPath = CLIENT_TRUSTED_CERTS_BASE_DIR.resolve(ref.getName());
+                    Path mountPath = parent.resolve(ref.getName());
                     var mount = new VolumeMountBuilder()
                             .withName(ResourcesUtil.volumeName("", "configmaps", ref.getName()))
                             .withMountPath(mountPath.toString())
                             .withReadOnly(true)
                             .build();
                     TrustProvider trustProvider = new TrustStore(
-                            mountPath.resolve(ref.getKey()).toString(),
+                            mountPath.resolve(tar.getKey()).toString(),
                             null,
                             "PEM");
                     return new ConfigurationFragment<>(trustProvider,
@@ -596,11 +607,11 @@ public class KafkaProxyReconciler implements
     }
 
     private static Predicate<VirtualKafkaCluster> clusterReferences(KafkaProxy proxy) {
-        return cluster -> cluster.getSpec().getProxyRef().getName().equals(name(proxy));
+        return cluster -> name(proxy).equals(cluster.getSpec().getProxyRef().getName());
     }
 
     private static Predicate<KafkaProxyIngress> ingressReferences(KafkaProxy proxy) {
-        return ingress -> ingress.getSpec().getProxyRef().getName().equals(name(proxy));
+        return ingress -> name(proxy).equals(ingress.getSpec().getProxyRef().getName());
     }
 }
 // @formatter:off

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaServiceReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaServiceReconcilerIT.java
@@ -238,7 +238,9 @@ class KafkaServiceReconcilerIT {
                     .editSpec()
                         .editOrNewTls()
                             .withNewTrustAnchorRef()
-                                .withName(trustResourceName)
+                                .withNewRef()
+                                    .withName(trustResourceName)
+                                .endRef()
                                 .withKey("ca-bundle.pem")
                             .endTrustAnchorRef()
                         .endTls()
@@ -292,7 +294,7 @@ class KafkaServiceReconcilerIT {
     private void assertResolvedRefsFalse(KafkaService cr,
                                          String reason,
                                          String message) {
-        AWAIT.alias("FilterStatusResolvedRefs").untilAsserted(() -> {
+        AWAIT.alias("KafkaServiceStatusResolvedRefs").untilAsserted(() -> {
             var kafkaService = testActor.resources(KafkaService.class)
                     .withName(ResourcesUtil.name(cr)).get();
             Assertions.assertThat(kafkaService.getStatus()).isNotNull();

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerIT.java
@@ -326,7 +326,7 @@ class VirtualKafkaClusterReconcilerIT {
                 .withNewProxyRef()
                     .withName(proxyName)
                 .endProxyRef()
-                .addAllToIngresses(ingresses)
+                .withIngresses(ingresses)
                 .withNewTargetKafkaServiceRef()
                     .withName(serviceName)
                 .endTargetKafkaServiceRef();

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerTest.java
@@ -78,7 +78,8 @@ class VirtualKafkaClusterReconcilerTest {
 
     public static final String PROXY_NAME = "my-proxy";
     public static final String NAMESPACE = "my-namespace";
-    public static final String SERVER_CERT_NAME = "server-cert";
+    public static final String SERVER_CERT_SECRET_NAME = "server-cert";
+    public static final String TRUST_ANCHOR_CERT_CONFIGMAP_NAME = "trust-anchor-cert";
 
     // @formatter:off
     public static final VirtualKafkaCluster CLUSTER_NO_FILTERS = new VirtualKafkaClusterBuilder()
@@ -102,23 +103,41 @@ class VirtualKafkaClusterReconcilerTest {
             .endSpec()
             .build();
 
-    private static final VirtualKafkaCluster CLUSTER_NO_FILTERS_WITH_TLS = new VirtualKafkaClusterBuilder(CLUSTER_NO_FILTERS)
+    private static final VirtualKafkaCluster CLUSTER_TLS_NO_FILTERS = new VirtualKafkaClusterBuilder(CLUSTER_NO_FILTERS)
             .editOrNewSpec()
                 .withIngresses(new IngressesBuilder(CLUSTER_NO_FILTERS.getSpec().getIngresses().get(0))
                     .withNewTls()
                         .withNewCertificateRef()
-                            .withName(SERVER_CERT_NAME)
+                            .withName(SERVER_CERT_SECRET_NAME)
                         .endCertificateRef()
                     .endTls()
                 .build())
             .endSpec()
             .build();
-    private static final VirtualKafkaCluster CLUSTER_NO_FILTERS_WITH_TLS_WRONG_RESOURCE_TYPE = new VirtualKafkaClusterBuilder(CLUSTER_NO_FILTERS)
+
+    private static final VirtualKafkaCluster CLUSTER_TLS_NO_FILTERS_WITH_TRUST_ANCHOR = new VirtualKafkaClusterBuilder(CLUSTER_NO_FILTERS)
             .editOrNewSpec()
                 .withIngresses(new IngressesBuilder(CLUSTER_NO_FILTERS.getSpec().getIngresses().get(0))
                     .withNewTls()
                         .withNewCertificateRef()
-                            .withName(SERVER_CERT_NAME)
+                            .withName(SERVER_CERT_SECRET_NAME)
+                        .endCertificateRef()
+                        .withNewTrustAnchorRef()
+                        .withNewRef()
+                            .withName(TRUST_ANCHOR_CERT_CONFIGMAP_NAME)
+                        .endRef()
+                        .withKey("ca-bundle.pem")
+                        .endTrustAnchorRef()
+                    .endTls()
+                .build())
+            .endSpec()
+            .build();
+    private static final VirtualKafkaCluster CLUSTER_TLS_NO_FILTERS_WITH_SECRET_WRONG_RESOURCE_TYPE = new VirtualKafkaClusterBuilder(CLUSTER_NO_FILTERS)
+            .editOrNewSpec()
+                .withIngresses(new IngressesBuilder(CLUSTER_NO_FILTERS.getSpec().getIngresses().get(0))
+                    .withNewTls()
+                        .withNewCertificateRef()
+                            .withName(SERVER_CERT_SECRET_NAME)
                             .withKind("ConfigMap")
                         .endCertificateRef()
                     .endTls()
@@ -190,9 +209,9 @@ class VirtualKafkaClusterReconcilerTest {
 
     private static final Secret KUBE_TLS_CERT_SECRET = new SecretBuilder()
             .withNewMetadata()
-            .withName(SERVER_CERT_NAME)
-            .withNamespace(NAMESPACE)
-            .withGeneration(42L)
+                .withName(SERVER_CERT_SECRET_NAME)
+                .withNamespace(NAMESPACE)
+                .withGeneration(42L)
             .endMetadata()
             .withType("kubernetes.io/tls")
             .addToData("tls.crt", "value")
@@ -200,13 +219,22 @@ class VirtualKafkaClusterReconcilerTest {
             .build();
     private static final Secret NON_KUBE_TLS_CERT_SECRET = new SecretBuilder()
             .withNewMetadata()
-            .withName(SERVER_CERT_NAME)
-            .withNamespace(NAMESPACE)
-            .withGeneration(42L)
+                .withName(SERVER_CERT_SECRET_NAME)
+                .withNamespace(NAMESPACE)
+                .withGeneration(42L)
             .endMetadata()
             .withType("example.com/nottls")  // unexpected type value
             .addToData("tls.crt", "value")
             .addToData("tls.key", "value")
+            .build();
+
+    public static final ConfigMap PEM_CONFIG_MAP = new ConfigMapBuilder()
+            .withNewMetadata()
+                .withName(TRUST_ANCHOR_CERT_CONFIGMAP_NAME)
+                .withNamespace(NAMESPACE)
+                .withGeneration(42L)
+            .endMetadata()
+            .addToData("ca-bundle.pem", "value")
             .build();
 
     // @formatter:on
@@ -423,7 +451,7 @@ class VirtualKafkaClusterReconcilerTest {
             when(context.getSecondaryResources(KafkaProxyIngress.class)).thenReturn(Set.of(INGRESS_WITH_TLS));
             when(context.getSecondaryResources(KafkaService.class)).thenReturn(Set.of(SERVICE));
             result.add(Arguments.argumentSet("cluster with tls",
-                    CLUSTER_NO_FILTERS_WITH_TLS,
+                    CLUSTER_TLS_NO_FILTERS,
                     context,
                     (Consumer<ConditionListAssert>) conditionList -> {
                         conditionList
@@ -439,8 +467,8 @@ class VirtualKafkaClusterReconcilerTest {
             when(context.getSecondaryResources(KafkaProxy.class)).thenReturn(Set.of(PROXY));
             when(context.getSecondaryResources(KafkaProxyIngress.class)).thenReturn(Set.of(INGRESS_WITH_TLS));
             when(context.getSecondaryResources(KafkaService.class)).thenReturn(Set.of(SERVICE));
-            result.add(Arguments.argumentSet("cluster with tls - secret not found",
-                    CLUSTER_NO_FILTERS_WITH_TLS,
+            result.add(Arguments.argumentSet("cluster with tls - server cert secret not found",
+                    CLUSTER_TLS_NO_FILTERS,
                     context,
                     (Consumer<ConditionListAssert>) conditionList -> conditionList
                             .singleElement()
@@ -456,8 +484,8 @@ class VirtualKafkaClusterReconcilerTest {
             when(context.getSecondaryResources(KafkaProxy.class)).thenReturn(Set.of(PROXY));
             when(context.getSecondaryResources(KafkaProxyIngress.class)).thenReturn(Set.of(INGRESS_WITH_TLS));
             when(context.getSecondaryResources(KafkaService.class)).thenReturn(Set.of(SERVICE));
-            result.add(Arguments.argumentSet("cluster with tls - wrong secret type",
-                    CLUSTER_NO_FILTERS_WITH_TLS,
+            result.add(Arguments.argumentSet("cluster with tls -  server cert secret wrong type",
+                    CLUSTER_TLS_NO_FILTERS,
                     context,
                     (Consumer<ConditionListAssert>) conditionList -> conditionList
                             .singleElement()
@@ -473,8 +501,8 @@ class VirtualKafkaClusterReconcilerTest {
             when(context.getSecondaryResources(KafkaProxy.class)).thenReturn(Set.of(PROXY));
             when(context.getSecondaryResources(KafkaProxyIngress.class)).thenReturn(Set.of(INGRESS_WITH_TLS));
             when(context.getSecondaryResources(KafkaService.class)).thenReturn(Set.of(SERVICE));
-            result.add(Arguments.argumentSet("cluster with tls - unsupported resource type",
-                    CLUSTER_NO_FILTERS_WITH_TLS_WRONG_RESOURCE_TYPE,
+            result.add(Arguments.argumentSet("cluster with tls - server cert unsupported resource type",
+                    CLUSTER_TLS_NO_FILTERS_WITH_SECRET_WRONG_RESOURCE_TYPE,
                     context,
                     (Consumer<ConditionListAssert>) conditionList -> conditionList
                             .singleElement()
@@ -485,12 +513,47 @@ class VirtualKafkaClusterReconcilerTest {
 
         {
             Context<? extends CustomResource<?, ?>> context = mock();
+            mockGetSecret(context, Optional.of(KUBE_TLS_CERT_SECRET));
+            mockGetConfigMap(context, Optional.of(PEM_CONFIG_MAP));
+            when(context.getSecondaryResources(KafkaProxy.class)).thenReturn(Set.of(PROXY));
+            when(context.getSecondaryResources(KafkaProxyIngress.class)).thenReturn(Set.of(INGRESS_WITH_TLS));
+            when(context.getSecondaryResources(KafkaService.class)).thenReturn(Set.of(SERVICE));
+            result.add(Arguments.argumentSet("cluster with tls with trust anchor",
+                    CLUSTER_TLS_NO_FILTERS_WITH_TRUST_ANCHOR,
+                    context,
+                    (Consumer<ConditionListAssert>) conditionList -> {
+                        conditionList
+                                .singleElement()
+                                .isResolvedRefsTrue();
+                    }));
+        }
+
+        {
+            Context<? extends CustomResource<?, ?>> context = mock();
+
+            mockGetSecret(context, Optional.of(KUBE_TLS_CERT_SECRET));
+            mockGetConfigMap(context, Optional.empty());
+            when(context.getSecondaryResources(KafkaProxy.class)).thenReturn(Set.of(PROXY));
+            when(context.getSecondaryResources(KafkaProxyIngress.class)).thenReturn(Set.of(INGRESS_WITH_TLS));
+            when(context.getSecondaryResources(KafkaService.class)).thenReturn(Set.of(SERVICE));
+            result.add(Arguments.argumentSet("cluster with tls - trust anchor cert configmap not found",
+                    CLUSTER_TLS_NO_FILTERS_WITH_TRUST_ANCHOR,
+                    context,
+                    (Consumer<ConditionListAssert>) conditionList -> conditionList
+                            .singleElement()
+                            .isResolvedRefsFalse(
+                                    Condition.REASON_REFS_NOT_FOUND,
+                                    "spec.ingresses[].tls.trustAnchor: referenced resource not found")));
+        }
+
+        {
+            Context<? extends CustomResource<?, ?>> context = mock();
 
             when(context.getSecondaryResources(KafkaProxy.class)).thenReturn(Set.of(PROXY));
             when(context.getSecondaryResources(KafkaProxyIngress.class)).thenReturn(Set.of(INGRESS));
             when(context.getSecondaryResources(KafkaService.class)).thenReturn(Set.of(SERVICE));
             result.add(Arguments.argumentSet("cluster defines tls, ingress does not",
-                    CLUSTER_NO_FILTERS_WITH_TLS,
+                    CLUSTER_TLS_NO_FILTERS,
                     context,
                     (Consumer<ConditionListAssert>) conditionList -> conditionList
                             .singleElement()
@@ -638,7 +701,7 @@ class VirtualKafkaClusterReconcilerTest {
         var mapper = VirtualKafkaClusterReconciler.virtualKafkaClusterToSecret();
 
         // When
-        var secondaryResourceIDs = mapper.toSecondaryResourceIDs(CLUSTER_NO_FILTERS_WITH_TLS);
+        var secondaryResourceIDs = mapper.toSecondaryResourceIDs(CLUSTER_TLS_NO_FILTERS);
 
         // Then
         assertThat(secondaryResourceIDs).containsExactly(ResourceID.fromResource(KUBE_TLS_CERT_SECRET));
@@ -657,20 +720,20 @@ class VirtualKafkaClusterReconcilerTest {
     }
 
     @Test
-    void mappingToSecretToVirtualKafkaClusterWithTls() {
+    void canMapFromSecretToVirtualKafkaClusterWithTls() {
         // Given
-        EventSourceContext<VirtualKafkaCluster> eventSourceContext = mockContextContaining(CLUSTER_NO_FILTERS_WITH_TLS);
+        EventSourceContext<VirtualKafkaCluster> eventSourceContext = mockContextContaining(CLUSTER_TLS_NO_FILTERS);
 
         // When
         var mapper = VirtualKafkaClusterReconciler.secretToVirtualKafkaCluster(eventSourceContext);
 
         // Then
         var primaryResourceIDs = mapper.toPrimaryResourceIDs(KUBE_TLS_CERT_SECRET);
-        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(CLUSTER_NO_FILTERS_WITH_TLS));
+        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(CLUSTER_TLS_NO_FILTERS));
     }
 
     @Test
-    void mappingToSecretToVirtualKafkaClusterToleratesVirtualKafkaClusterWithoutTls() {
+    void canMapFromSecretToVirtualKafkaClusterToleratesVirtualKafkaClusterWithoutTls() {
         // Given
         EventSourceContext<VirtualKafkaCluster> eventSourceContext = mockContextContaining(CLUSTER_NO_FILTERS);
 
@@ -682,9 +745,54 @@ class VirtualKafkaClusterReconcilerTest {
         assertThat(primaryResourceIDs).isEmpty();
     }
 
-    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    private static void mockGetSecret(Context<? extends CustomResource<?, ?>> context, Optional<Secret> optional) {
-        when(context.getSecondaryResource(Secret.class, VirtualKafkaClusterReconciler.SECRETS_EVENT_SOURCE_NAME)).thenReturn(optional);
+    @Test
+    void canMapFromVirtualKafkaClusterWithTrustAnchorToConfigMap() {
+        // Given
+        var mapper = VirtualKafkaClusterReconciler.virtualKafkaClusterToConfigMap();
+
+        // When
+        var secondaryResourceIDs = mapper.toSecondaryResourceIDs(CLUSTER_TLS_NO_FILTERS_WITH_TRUST_ANCHOR);
+
+        // Then
+        assertThat(secondaryResourceIDs).containsExactly(ResourceID.fromResource(PEM_CONFIG_MAP));
+    }
+
+    @Test
+    void canMapFromVirtualKafkaClusterWithoutTrustAnchorToConfigMap() {
+        // Given
+        var mapper = VirtualKafkaClusterReconciler.virtualKafkaClusterToConfigMap();
+
+        // When
+        var secondaryResourceIDs = mapper.toSecondaryResourceIDs(CLUSTER_NO_FILTERS);
+
+        // Then
+        assertThat(secondaryResourceIDs).isEmpty();
+    }
+
+    @Test
+    void canMapFromConfigMapToVirtualKafkaClusterWithTls() {
+        // Given
+        EventSourceContext<VirtualKafkaCluster> eventSourceContext = mockContextContaining(CLUSTER_TLS_NO_FILTERS_WITH_TRUST_ANCHOR);
+
+        // When
+        var mapper = VirtualKafkaClusterReconciler.configMapToVirtualKafkaCluster(eventSourceContext);
+
+        // Then
+        var primaryResourceIDs = mapper.toPrimaryResourceIDs(PEM_CONFIG_MAP);
+        assertThat(primaryResourceIDs).containsExactly(ResourceID.fromResource(CLUSTER_TLS_NO_FILTERS_WITH_TRUST_ANCHOR));
+    }
+
+    @Test
+    void canMapFromConfigMapToVirtualKafkaClusterToleratesVirtualKafkaClusterWithoutTls() {
+        // Given
+        EventSourceContext<VirtualKafkaCluster> eventSourceContext = mockContextContaining(CLUSTER_NO_FILTERS);
+
+        // When
+        var mapper = VirtualKafkaClusterReconciler.configMapToVirtualKafkaCluster(eventSourceContext);
+
+        // Then
+        var primaryResourceIDs = mapper.toPrimaryResourceIDs(PEM_CONFIG_MAP);
+        assertThat(primaryResourceIDs).isEmpty();
     }
 
     @Test
@@ -859,4 +967,17 @@ class VirtualKafkaClusterReconcilerTest {
         when(mockOperation.inNamespace(any())).thenReturn(mockOperation);
         return mockList;
     }
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private static void mockGetSecret(Context<? extends CustomResource<?, ?>> context, Optional<Secret> optional) {
+        when(context.getSecondaryResource(Secret.class, VirtualKafkaClusterReconciler.SECRETS_EVENT_SOURCE_NAME)).thenReturn(optional);
+    }
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private static void mockGetConfigMap(
+                                         Context<? extends CustomResource<?, ?>> context,
+                                         Optional<ConfigMap> empty) {
+        when(context.getSecondaryResource(ConfigMap.class, VirtualKafkaClusterReconciler.CONFIGMAPS_EVENT_SOURCE_NAME)).thenReturn(empty);
+    }
+
 }

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-and-trustanchor/in-ConfigMap-downstream-ca.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-and-trustanchor/in-ConfigMap-downstream-ca.yaml
@@ -1,0 +1,12 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: downstream-ca
+data:
+  cas.pem: "whatever"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-and-trustanchor/in-KafkaProxy.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-and-trustanchor/in-KafkaProxy.yaml
@@ -1,0 +1,13 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: minimal
+  namespace: proxy-ns
+  generation: 1

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-and-trustanchor/in-KafkaProxyIngress-cluster-ip.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-and-trustanchor/in-KafkaProxyIngress-cluster-ip.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxyIngress
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: cluster-ip
+  namespace: proxy-ns
+  generation: 2
+spec:
+  proxyRef:
+    name: minimal
+  clusterIP:
+    protocol: TLS
+status:
+  observedGeneration: 2

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-and-trustanchor/in-KafkaService-kafka.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-and-trustanchor/in-KafkaService-kafka.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaService
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: kafka
+  namespace: proxy-ns
+  generation: 3
+spec:
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+status:
+  observedGeneration: 3

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-and-trustanchor/in-Secret-downstream-tls-cert.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-and-trustanchor/in-Secret-downstream-tls-cert.yaml
@@ -1,0 +1,14 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+kind: Secret
+apiVersion: v1
+metadata:
+  name: downstream-tls-cert
+type: kubernetes.io/tls
+data:
+  tls.crt: whatever
+  tls.key: whatever

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-and-trustanchor/in-VirtualKafkaCluster-one.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-and-trustanchor/in-VirtualKafkaCluster-one.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: VirtualKafkaCluster
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: one
+  namespace: proxy-ns
+  generation: 4
+spec:
+  proxyRef:
+    name: minimal
+  targetKafkaServiceRef:
+    name: kafka
+  ingresses:
+    - ingressRef:
+        name: cluster-ip
+      tls:
+        certificateRef:
+          name: downstream-tls-cert
+        trustAnchorRef:
+          name: downstream-ca
+          key: cas.pem
+status:
+  observedGeneration: 4

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-and-trustanchor/out-ConfigMap-minimal-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-and-trustanchor/out-ConfigMap-minimal-config-state.yaml
@@ -1,0 +1,38 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: "v1"
+kind: "ConfigMap"
+metadata:
+  labels:
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/instance: "minimal"
+    app.kubernetes.io/component: "proxy"
+  name: "minimal-config-state"
+  namespace: "proxy-ns"
+  ownerReferences:
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxy"
+      name: "minimal"
+data:
+  cluster-one: |-
+    ---
+    metadata:
+      name: "one"
+      namespace: "proxy-ns"
+    status:
+      conditions:
+      - observedGeneration: 4
+        type: "Accepted"
+        status: "True"
+        lastTransitionTime: "1970-01-01T00:00:00Z"
+        reason: "Accepted"
+        message: ""
+      ingresses: []
+      observedGeneration: 4

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-and-trustanchor/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-and-trustanchor/out-ConfigMap-minimal-proxy-config.yaml
@@ -43,4 +43,6 @@ data:
           key:
             privateKeyFile: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert/tls.key"
             certificateFile: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert/tls.crt"
-          trust: {}
+          trust:
+            storeFile: "/opt/kroxylicious/virtual-cluster/trusted-certs/downstream-ca/cas.pem"
+            storeType: "PEM"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-and-trustanchor/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-and-trustanchor/out-Deployment-minimal.yaml
@@ -1,0 +1,101 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  labels:
+    app: "kroxylicious"
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/instance: "minimal"
+    app.kubernetes.io/component: "proxy"
+  name: "minimal"
+  namespace: "proxy-ns"
+  ownerReferences:
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxy"
+      name: "minimal"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: "kroxylicious"
+      app.kubernetes.io/part-of: "kafka"
+      app.kubernetes.io/managed-by: "kroxylicious-operator"
+      app.kubernetes.io/name: "kroxylicious-proxy"
+      app.kubernetes.io/instance: "minimal"
+      app.kubernetes.io/component: "proxy"
+  template:
+    metadata:
+      annotations:
+        kroxylicious.io/referent-checksum: "AAAAAAAB4wY"
+      labels:
+        app: "kroxylicious"
+        app.kubernetes.io/part-of: "kafka"
+        app.kubernetes.io/managed-by: "kroxylicious-operator"
+        app.kubernetes.io/name: "kroxylicious-proxy"
+        app.kubernetes.io/instance: "minimal"
+        app.kubernetes.io/component: "proxy"
+    spec:
+      containers:
+        - name: "proxy"
+          image: "quay.io/kroxylicious/kroxylicious:test"
+          args:
+            - "--config"
+            - "/opt/kroxylicious/config/proxy-config.yaml"
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: "/livez"
+              port: "management"
+            initialDelaySeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          ports:
+            - containerPort: 9190
+              name: "management"
+            - containerPort: 9292
+              name: "9292-bootstrap"
+            - containerPort: 9293
+              name: "9293-node"
+            - containerPort: 9294
+              name: "9294-node"
+            - containerPort: 9295
+              name: "9295-node"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+            readOnlyRootFilesystem: true
+          terminationMessagePolicy: "FallbackToLogsOnError"
+          volumeMounts:
+            - mountPath: "/opt/kroxylicious/config/proxy-config.yaml"
+              name: "config-volume"
+              subPath: "proxy-config.yaml"
+            - mountPath: "/opt/kroxylicious/virtual-cluster/trusted-certs/downstream-ca"
+              name: "configmaps-downstream-ca"
+              readOnly: true
+            - mountPath: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert"
+              name: "secrets-downstream-tls-cert"
+              readOnly: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: "RuntimeDefault"
+      volumes:
+        - configMap:
+            name: "minimal-proxy-config"
+          name: "config-volume"
+        - name: "secrets-downstream-tls-cert"
+          secret:
+            secretName: "downstream-tls-cert"
+        - configMap:
+            name: "downstream-ca"
+          name: "configmaps-downstream-ca"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-and-trustanchor/out-Service-one-cluster-ip.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-and-trustanchor/out-Service-one-cluster-ip.yaml
@@ -1,0 +1,53 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  labels:
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/instance: "minimal"
+    app.kubernetes.io/component: "proxy"
+  name: "one-cluster-ip"
+  namespace: "proxy-ns"
+  ownerReferences:
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxy"
+      name: "minimal"
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "VirtualKafkaCluster"
+      name: "one"
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxyIngress"
+      name: "cluster-ip"
+spec:
+  ports:
+    - name: "one-9292"
+      port: 9292
+      protocol: "TCP"
+      targetPort: 9292
+    - name: "one-9293"
+      port: 9293
+      protocol: "TCP"
+      targetPort: 9293
+    - name: "one-9294"
+      port: 9294
+      protocol: "TCP"
+      targetPort: 9294
+    - name: "one-9295"
+      port: 9295
+      protocol: "TCP"
+      targetPort: 9295
+  selector:
+    app: "kroxylicious"
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/instance: "minimal"
+    app.kubernetes.io/component: "proxy"


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Adding support for downstream trust. Partially addresses #1831.

* factored as shared `TrustAnchorRef` and refactored `KafkaService` to use the checkTrustAnchor from a shared class.
* fixed up some minor mistakes in the unit tests.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [x] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
