### PR TITLE
Operator: KafkaProtocolFilter add referent checksum annotation

### DIFF
--- a/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-watched.yaml
+++ b/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-watched.yaml
@@ -49,6 +49,8 @@ rules:
       - get
       - list
       - watch
+      - patch
+      - update
   - # The operator needs to update the status on its own CRs
     apiGroups:
       - "filter.kroxylicious.io"

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProtocolFilterReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProtocolFilterReconciler.java
@@ -8,6 +8,7 @@ package io.kroxylicious.kubernetes.operator;
 
 import java.time.Clock;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -37,8 +38,10 @@ import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEven
 import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.filter.api.v1alpha1.KafkaProtocolFilter;
 
+import static io.kroxylicious.kubernetes.operator.MetadataChecksumGenerator.NO_CHECKSUM_SPECIFIED;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.namespace;
+import static io.kroxylicious.kubernetes.operator.ResourcesUtil.toByNameMap;
 
 /**
  * <p>Reconciles a {@link KafkaProtocolFilter} by checking whether the {@link Secret}s
@@ -123,15 +126,11 @@ public class KafkaProtocolFilterReconciler implements
                                                         KafkaProtocolFilter filter,
                                                         Context<KafkaProtocolFilter> context) {
 
-        var existingSecrets = context.getSecondaryResourcesAsStream(Secret.class)
-                .map(ResourcesUtil::name)
-                .collect(Collectors.toSet());
-        LOGGER.debug("Existing secrets: {}", existingSecrets);
+        Map<String, Secret> existingSecretsByName = context.getSecondaryResourcesAsStream(Secret.class).collect(toByNameMap());
+        LOGGER.debug("Existing secrets: {}", existingSecretsByName.keySet());
 
-        var existingConfigMaps = context.getSecondaryResourcesAsStream(ConfigMap.class)
-                .map(ResourcesUtil::name)
-                .collect(Collectors.toSet());
-        LOGGER.debug("Existing configmaps: {}", existingConfigMaps);
+        Map<String, ConfigMap> existingConfigMapsByName = context.getSecondaryResourcesAsStream(ConfigMap.class).collect(toByNameMap());
+        LOGGER.debug("Existing configmaps: {}", existingConfigMapsByName.keySet());
 
         var interpolationResult = secureConfigInterpolator.interpolate(filter.getSpec().getConfigTemplate());
         var referencedSecrets = interpolationResult.volumes().stream()
@@ -149,15 +148,20 @@ public class KafkaProtocolFilterReconciler implements
         LOGGER.debug("Referenced configmaps: {}", referencedConfigMaps);
 
         KafkaProtocolFilter patch;
-        if (existingSecrets.containsAll(referencedSecrets)
-                && existingConfigMaps.containsAll(referencedConfigMaps)) {
+        if (existingSecretsByName.keySet().containsAll(referencedSecrets)
+                && existingConfigMapsByName.keySet().containsAll(referencedConfigMaps)) {
+            Stream<HasMetadata> referents = Stream.concat(referencedSecrets.stream().map(existingSecretsByName::get),
+                    referencedConfigMaps.stream().map(existingConfigMapsByName::get));
+            HasMetadata[] referentsArray = referents.toArray(HasMetadata[]::new);
+            String checksum = referentsArray.length == 0 ? NO_CHECKSUM_SPECIFIED : MetadataChecksumGenerator.checksumFor(referentsArray);
             patch = statusFactory.newTrueConditionStatusPatch(
                     filter,
-                    Condition.Type.ResolvedRefs);
+                    Condition.Type.ResolvedRefs,
+                    checksum);
         }
         else {
-            referencedSecrets.removeAll(existingSecrets);
-            referencedConfigMaps.removeAll(existingConfigMaps);
+            referencedSecrets.removeAll(existingSecretsByName.keySet());
+            referencedConfigMaps.removeAll(existingConfigMapsByName.keySet());
             String message = "Referenced";
             if (!referencedSecrets.isEmpty()) {
                 message += " Secrets [" + String.join(", ", referencedSecrets) + "]";
@@ -176,7 +180,7 @@ public class KafkaProtocolFilterReconciler implements
         if (LOGGER.isInfoEnabled()) {
             LOGGER.info("Completed reconciliation of {}/{}", namespace(filter), name(filter));
         }
-        return UpdateControl.patchStatus(patch);
+        return UpdateControl.patchResourceAndStatus(patch);
     }
 
     @Override

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProtocolFilterStatusFactory.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProtocolFilterStatusFactory.java
@@ -22,13 +22,19 @@ public class KafkaProtocolFilterStatusFactory extends StatusFactory<KafkaProtoco
     }
 
     private KafkaProtocolFilter filterStatusPatch(KafkaProtocolFilter observedProxy,
-                                                  Condition condition) {
+                                                  Condition condition, String checksum) {
         // @formatter:off
-        return new KafkaProtocolFilterBuilder()
+        var metadataBuilder = new KafkaProtocolFilterBuilder()
                 .withNewMetadata()
                     .withUid(ResourcesUtil.uid(observedProxy))
                     .withName(ResourcesUtil.name(observedProxy))
-                    .withNamespace(ResourcesUtil.namespace(observedProxy))
+                    .withNamespace(ResourcesUtil.namespace(observedProxy));
+        if (!checksum.isBlank()) {
+            // In practice this condition means that the existing annotation will be left alone.
+            metadataBuilder
+                    .addToAnnotations(MetadataChecksumGenerator.REFERENT_CHECKSUM_ANNOTATION, checksum);
+        }
+        return metadataBuilder
                 .endMetadata()
                 .withNewStatus()
                     .withObservedGeneration(ResourcesUtil.generation(observedProxy))
@@ -43,7 +49,7 @@ public class KafkaProtocolFilterStatusFactory extends StatusFactory<KafkaProtoco
                                                        Condition.Type type,
                                                        Exception e) {
         Condition unknownCondition = newUnknownCondition(observedFilter, type, e);
-        return filterStatusPatch(observedFilter, unknownCondition);
+        return filterStatusPatch(observedFilter, unknownCondition, MetadataChecksumGenerator.NO_CHECKSUM_SPECIFIED);
     }
 
     @Override
@@ -52,14 +58,14 @@ public class KafkaProtocolFilterStatusFactory extends StatusFactory<KafkaProtoco
                                                      String reason,
                                                      String message) {
         Condition falseCondition = newFalseCondition(observedProxy, type, reason, message);
-        return filterStatusPatch(observedProxy, falseCondition);
+        return filterStatusPatch(observedProxy, falseCondition, MetadataChecksumGenerator.NO_CHECKSUM_SPECIFIED);
     }
 
     @Override
     KafkaProtocolFilter newTrueConditionStatusPatch(KafkaProtocolFilter observedProxy,
                                                     Condition.Type type, String checksum) {
         Condition trueCondition = newTrueCondition(observedProxy, type);
-        return filterStatusPatch(observedProxy, trueCondition);
+        return filterStatusPatch(observedProxy, trueCondition, checksum);
     }
 
     @SuppressWarnings("removal")

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProtocolFilterReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProtocolFilterReconcilerIT.java
@@ -32,6 +32,7 @@ import io.kroxylicious.kubernetes.filter.api.v1alpha1.KafkaProtocolFilter;
 import io.kroxylicious.kubernetes.filter.api.v1alpha1.KafkaProtocolFilterBuilder;
 import io.kroxylicious.kubernetes.operator.assertj.KafkaProtocolFilterStatusAssert;
 
+import static io.kroxylicious.kubernetes.operator.MetadataChecksumGenerator.NO_CHECKSUM_SPECIFIED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -122,6 +123,9 @@ class KafkaProtocolFilterReconcilerIT {
                     .conditionList()
                     .singleElement()
                     .isResolvedRefsTrue(kpf);
+            String checksum = kpf.getMetadata().getAnnotations()
+                    .getOrDefault(MetadataChecksumGenerator.REFERENT_CHECKSUM_ANNOTATION, NO_CHECKSUM_SPECIFIED);
+            assertThat(checksum).isNotEqualTo(NO_CHECKSUM_SPECIFIED);
         });
     }
 
@@ -156,6 +160,44 @@ class KafkaProtocolFilterReconcilerIT {
                 .addToData("baz", Base64.getEncoder().encodeToString("".getBytes(StandardCharsets.UTF_8)))
                 .build());
         assertAllConditionsTrue(filterOne);
+    }
+
+    @Test
+    void shouldUpdateReferentAnnotationOnSecretModify() {
+        // given
+        var filterOne = createFilterFirst();
+        String checksum = testActor.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
+                .getOrDefault(MetadataChecksumGenerator.REFERENT_CHECKSUM_ANNOTATION, NO_CHECKSUM_SPECIFIED);
+
+        // when
+        testActor.resources(Secret.class).withName(A).edit(secret -> secret.edit()
+                .addToData("baz", Base64.getEncoder().encodeToString("".getBytes(StandardCharsets.UTF_8)))
+                .build());
+
+        // then
+        assertAllConditionsTrue(filterOne);
+        String newChecksum = testActor.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
+                .getOrDefault(MetadataChecksumGenerator.REFERENT_CHECKSUM_ANNOTATION, NO_CHECKSUM_SPECIFIED);
+        assertThat(newChecksum).isNotEqualTo(checksum);
+    }
+
+    @Test
+    void shouldUpdateReferentAnnotationOnConfigMapModify() {
+        // given
+        var filterOne = createFilterFirst();
+        String checksum = testActor.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
+                .getOrDefault(MetadataChecksumGenerator.REFERENT_CHECKSUM_ANNOTATION, NO_CHECKSUM_SPECIFIED);
+
+        // when
+        testActor.resources(ConfigMap.class).withName(B).edit(configMap -> configMap.edit()
+                .addToData("baz", Base64.getEncoder().encodeToString("".getBytes(StandardCharsets.UTF_8)))
+                .build());
+
+        // then
+        assertAllConditionsTrue(filterOne);
+        String newChecksum = testActor.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
+                .getOrDefault(MetadataChecksumGenerator.REFERENT_CHECKSUM_ANNOTATION, NO_CHECKSUM_SPECIFIED);
+        assertThat(newChecksum).isNotEqualTo(checksum);
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

When reconciling a KafkaProtocolFilter, if it's references to Secrets/ConfigMaps resolve, we compute a checksum across those referents and update the `metadata` of the resource with a `kroxylicious.io/referent-checksum` annotation with the checksum as the value.

### Additional Context

Implements part of https://github.com/kroxylicious/design/pull/65

When the referents are modified, for example a configmap or secret is updated, then the checksum in the annotation will change. This will eventually  be consumed by the aggregating reconcilers and cause the proxy pods to be rolled.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
