### PR TITLE
Fix: #2113: ensure that filter handler does not leak deferred opaque requests/responses if the upstream or downstream side closes unexpectedly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#2113](https://github.com/kroxylicious/kroxylicious/pull/2113) Ensure that filter handler does not leak deferred opaque requests/responses if the upstream or downstream side closes unexpectedly 
 * [#1928](https://github.com/kroxylicious/kroxylicious/pull/2085) Bump info.picocli:picocli from 4.7.6 to 4.7.7
 * [#1437](https://github.com/kroxylicious/kroxylicious/issues/1437) Remove "zero-ack produce requests" warning
 * [#1900](https://github.com/kroxylicious/kroxylicious/issues/1900) Enforce business rule that a proxy must have at least one virtual cluster

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/RecordEncryptionFilterIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/RecordEncryptionFilterIT.java
@@ -53,6 +53,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
+
 import io.kroxylicious.filter.encryption.RecordEncryption;
 import io.kroxylicious.filter.encryption.TemplateKekSelector;
 import io.kroxylicious.filter.encryption.config.UnresolvedKeyPolicy;
@@ -84,6 +86,7 @@ import static org.hamcrest.Matchers.contains;
 
 @ExtendWith(KafkaClusterExtension.class)
 @ExtendWith(TestKmsFacadeInvocationContextProvider.class)
+@ExtendWith(NettyLeakDetectorExtension.class)
 class RecordEncryptionFilterIT {
 
     private static final String TEMPLATE_KEK_SELECTOR_PATTERN = "$(topicName)";

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/OpaqueFrame.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/OpaqueFrame.java
@@ -5,6 +5,8 @@
  */
 package io.kroxylicious.proxy.frame;
 
+import java.util.Objects;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +38,7 @@ public abstract class OpaqueFrame implements Frame {
      * @param length The length of the frame within {@code buf}.
      */
     OpaqueFrame(ByteBuf buf, int correlationId, int length) {
+        Objects.requireNonNull(buf);
         this.length = length;
         this.correlationId = correlationId;
         this.buf = buf.asReadOnly();
@@ -63,6 +66,16 @@ public abstract class OpaqueFrame implements Frame {
         out.ensureWritable(estimateEncodedSize());
         out.writeInt(length);
         out.writeBytes(buf, length);
+        buf.release();
+    }
+
+    /**
+     * Releases the underlying buffer.  This is used in the situation where the proxy
+     * knows that the frame cannot be forwarded to the upstream or downstream (probably
+     * owing to previous network error) and the proxy needs to release the buffer to
+     * prevent a resource leak.
+     */
+    public void releaseBuffer() {
         buf.release();
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/OpaqueRequestFrame.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/OpaqueRequestFrame.java
@@ -9,17 +9,22 @@ import org.apache.kafka.common.protocol.ApiKeys;
 
 import io.netty.buffer.ByteBuf;
 
+/**
+ * Used to represent Kafka requests that the proxy does not need to decode.
+ */
 public class OpaqueRequestFrame extends OpaqueFrame implements RequestFrame {
 
     private final boolean decodeResponse;
-    private boolean hasResponse;
+    private final boolean hasResponse;
 
     /**
+     * Creates an opaque request.
+     *
      * @param buf The message buffer (excluding the frame size)
-     * @param correlationId
-     * @param decodeResponse
-     * @param length
-     * @param hasResponse
+     * @param correlationId correlation id
+     * @param decodeResponse whether the response will be decoded
+     * @param length length of the request
+     * @param hasResponse true if the request expects a response
      */
     public OpaqueRequestFrame(ByteBuf buf,
                               int correlationId,

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/OpaqueResponseFrame.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/OpaqueResponseFrame.java
@@ -7,7 +7,17 @@ package io.kroxylicious.proxy.frame;
 
 import io.netty.buffer.ByteBuf;
 
+/**
+ * Used to represent Kafka responses that the proxy does not need to decode.
+ */
 public class OpaqueResponseFrame extends OpaqueFrame implements ResponseFrame {
+    /**
+     * Creates an opaque response.
+     *
+     * @param buf The message buffer (excluding the frame size)
+     * @param correlationId correlation id
+     * @param length length of the response
+     */
     public OpaqueResponseFrame(ByteBuf buf, int correlationId, int length) {
         super(buf, correlationId, length);
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -122,7 +122,7 @@ public class FilterHandler extends ChannelDuplexHandler {
                         ctx.fireChannelRead(msg);
                     }
                     else {
-                        orf.buf().release();
+                        orf.releaseBuffer();
                     }
                 });
             }
@@ -160,7 +160,7 @@ public class FilterHandler extends ChannelDuplexHandler {
                         ctx.write(msg, promise);
                     }
                     else if (msg instanceof OpaqueRequestFrame orf) {
-                        orf.buf().release();
+                        orf.releaseBuffer();
                     }
                 });
             }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHandlerTest.java
@@ -79,6 +79,15 @@ class FilterHandlerTest extends FilterHarness {
         assertEquals(frame, propagated, "Expect it to be the frame that was sent");
     }
 
+    // Note: Unpooled.EMPTY_BUFFER is used by KafkaProxyFrontendHandler#closeOnFlush
+    @Test
+    void canForwardEmptyBuffers() {
+        buildChannel();
+        channel.writeOutbound(Unpooled.EMPTY_BUFFER);
+        var propagated = channel.readOutbound();
+        assertThat(propagated).isSameAs(Unpooled.EMPTY_BUFFER);
+    }
+
     @Test
     void testShortCircuitResponse() {
         ApiVersionsResponseData responseData = new ApiVersionsResponseData();

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHandlerTest.java
@@ -37,6 +37,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import io.netty.buffer.Unpooled;
+
 import io.kroxylicious.proxy.filter.ApiVersionsRequestFilter;
 import io.kroxylicious.proxy.filter.ApiVersionsResponseFilter;
 import io.kroxylicious.proxy.filter.FetchRequestFilter;
@@ -58,6 +60,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 class FilterHandlerTest extends FilterHarness {
 
@@ -510,6 +514,30 @@ class FilterHandlerTest extends FilterHarness {
     }
 
     @Test
+    void closedChannelReleasesOpaqueDeferredPendingRequests() {
+        var seen = new ArrayList<ApiMessage>();
+        var filterFuture = new CompletableFuture<RequestFilterResult>();
+        ApiVersionsRequestFilter filter = (apiVersion, header, request, context) -> {
+            seen.add(request);
+            return filterFuture;
+        };
+        buildChannel(filter);
+        var first = writeRequest(new ApiVersionsRequestData());
+        var opaqueBuf = spy(Unpooled.buffer());
+        writeArbitraryOpaqueRequest(opaqueBuf);
+        // the filter handler will have queued up the opaque request, awaiting the completion of the first.
+        filterFuture.complete(new RequestFilterResultBuilderImpl().withCloseConnection().build());
+        channel.runPendingTasks();
+
+        assertThat(channel.isOpen()).isFalse();
+        var propagated = channel.readOutbound();
+        assertThat(propagated).isNull();
+        assertThat(seen).containsExactly(first.body());
+
+        verify(opaqueBuf).release();
+    }
+
+    @Test
     void closedChannelIgnoresDeferredPendingResponse() {
         var seen = new ArrayList<ApiMessage>();
         var filterFuture = new CompletableFuture<ResponseFilterResult>();
@@ -528,6 +556,32 @@ class FilterHandlerTest extends FilterHarness {
         var propagated = channel.readInbound();
         assertThat(propagated).isNull();
         assertThat(seen).containsExactly(frame1.body());
+    }
+
+    @Test
+    void closedChannelReleasesOpaqueDeferredPendingResponses() {
+        var seen = new ArrayList<ApiMessage>();
+        var filterFuture = new CompletableFuture<ResponseFilterResult>();
+        ApiVersionsResponseFilter filter = (apiVersion, header, response, context) -> {
+            seen.add(response);
+            return filterFuture;
+        };
+        buildChannel(filter);
+        var frame1 = writeResponse(new ApiVersionsResponseData().setErrorCode((short) 1));
+        var opaqueBuf = spy(Unpooled.buffer());
+        writeArbitraryOpaqueResponse(opaqueBuf);
+
+        writeResponse(new ApiVersionsResponseData().setErrorCode((short) 2));
+        // the filter handler will have queued up the second response, awaiting the completion of the first.
+        filterFuture.complete(new ResponseFilterResultBuilderImpl().withCloseConnection().build());
+        channel.runPendingTasks();
+
+        assertThat(channel.isOpen()).isFalse();
+        var propagated = channel.readInbound();
+        assertThat(propagated).isNull();
+        assertThat(seen).containsExactly(frame1.body());
+
+        verify(opaqueBuf).release();
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.junit.jupiter.api.AfterEach;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -143,7 +144,12 @@ public abstract class FilterHarness {
      * @return the opaque frame written to the channel
      */
     protected OpaqueRequestFrame writeArbitraryOpaqueRequest() {
-        OpaqueRequestFrame frame = new OpaqueRequestFrame(Unpooled.buffer(), 55, false, 0, false);
+        ByteBuf buffer = Unpooled.buffer();
+        return writeArbitraryOpaqueRequest(buffer);
+    }
+
+    protected OpaqueRequestFrame writeArbitraryOpaqueRequest(ByteBuf buffer) {
+        OpaqueRequestFrame frame = new OpaqueRequestFrame(buffer, 55, false, buffer.readableBytes(), false);
         channel.writeOneOutbound(frame);
         return frame;
     }
@@ -154,7 +160,12 @@ public abstract class FilterHarness {
      * @return the opaque frame written to the channel
      */
     protected OpaqueResponseFrame writeArbitraryOpaqueResponse() {
-        OpaqueResponseFrame frame = new OpaqueResponseFrame(Unpooled.buffer(), 55, 0);
+        ByteBuf buffer = Unpooled.buffer();
+        return writeArbitraryOpaqueResponse(buffer);
+    }
+
+    protected OpaqueResponseFrame writeArbitraryOpaqueResponse(ByteBuf buffer) {
+        OpaqueResponseFrame frame = new OpaqueResponseFrame(buffer, 55, buffer.readableBytes());
         channel.writeOneInbound(frame);
         return frame;
     }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Fix: #2113: ensure that filter handler does not leak opaque requests/responses bytebufs if the upstream or downstream side closes whilst requests/responses are queued-up (auto-read toggled off).

**_I'm not convinced that this is actually the root cause of #2113 (I haven't been able to reproduce the issue), but I think you can reason that the FilterHandler code is leaky/wrong._**

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [x] Ensure the PR references relevant issue(s) so they are closed on merging.
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
