### PR TITLE
Update strimzi example url installed by run-operator.sh

### DIFF
--- a/scripts/run-operator.sh
+++ b/scripts/run-operator.sh
@@ -41,7 +41,7 @@ info "installing kafka (no-op if already installed)"
 kubectl create namespace kafka
 kubectl create -n kafka -f 'https://strimzi.io/install/latest?namespace=kafka'
 kubectl wait -n kafka deployment/strimzi-cluster-operator --for=condition=Available=True --timeout=300s
-kubectl apply -n kafka -f https://strimzi.io/examples/latest/kafka/kraft/kafka-single-node.yaml
+kubectl apply -n kafka -f https://strimzi.io/examples/latest/kafka/kafka-single-node.yaml
 kubectl wait -n kafka kafka/my-cluster --for=condition=Ready --timeout=300s
 
 info "deleting example"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The old example URL is 404, presumably killed off with dropping ZK support.

In future the Kafka CR should probably belong alongside the specific example, but for now keen to take this as a quick fix.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
