### PR TITLE
operator: add referent checksum to KafkaService

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProtocolFilterReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProtocolFilterReconciler.java
@@ -42,7 +42,6 @@ import io.kroxylicious.kubernetes.operator.checksum.MetadataChecksumGenerator;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.namespace;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.toByNameMap;
-import static io.kroxylicious.kubernetes.operator.checksum.MetadataChecksumGenerator.NO_CHECKSUM_SPECIFIED;
 
 /**
  * <p>Reconciles a {@link KafkaProtocolFilter} by checking whether the {@link Secret}s
@@ -153,8 +152,7 @@ public class KafkaProtocolFilterReconciler implements
                 && existingConfigMapsByName.keySet().containsAll(referencedConfigMaps)) {
             Stream<HasMetadata> referents = Stream.concat(referencedSecrets.stream().map(existingSecretsByName::get),
                     referencedConfigMaps.stream().map(existingConfigMapsByName::get));
-            HasMetadata[] referentsArray = referents.toArray(HasMetadata[]::new);
-            String checksum = referentsArray.length == 0 ? NO_CHECKSUM_SPECIFIED : MetadataChecksumGenerator.checksumFor(referentsArray);
+            String checksum = MetadataChecksumGenerator.checksumFor(referents.toList());
             patch = statusFactory.newTrueConditionStatusPatch(
                     filter,
                     Condition.Type.ResolvedRefs,

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyIngressReconciler.java
@@ -73,7 +73,7 @@ public class KafkaProxyIngressReconciler implements
 
         UpdateControl<KafkaProxyIngress> updateControl;
         if (proxyOpt.isPresent()) {
-            String checksum = MetadataChecksumGenerator.checksumFor(proxyOpt.get());
+            String checksum = MetadataChecksumGenerator.checksumFor(List.of(proxyOpt.get()));
             updateControl = UpdateControl.patchResourceAndStatus(
                     statusFactory.newTrueConditionStatusPatch(
                             ingress,

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourceCheckResult.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourceCheckResult.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.util.List;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.CustomResource;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Resource check result
+ *
+ * @param <T> custom resource type
+ * @param resource null if check passed, else a resource with status updated to reflect problems
+ * @param referents contains any referents if check passed and resource had refs
+ */
+public record ResourceCheckResult<T extends CustomResource<?, ?>>(@Nullable T resource, List<? extends HasMetadata> referents) {}

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconciler.java
@@ -145,7 +145,7 @@ public final class VirtualKafkaClusterReconciler implements
             var certRefCheck = certRefs.stream()
                     .map(certRef -> {
                         var path = "spec.ingresses[].tls.certificateRef";
-                        return ResourcesUtil.checkCertRef(cluster, context, SECRETS_EVENT_SOURCE_NAME, certRef, path, statusFactory);
+                        return ResourcesUtil.checkCertRef(cluster, certRef, path, statusFactory, context, SECRETS_EVENT_SOURCE_NAME).resource();
                     })
                     .filter(Objects::nonNull)
                     .findFirst();

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/checksum/MetadataChecksumGenerator.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/checksum/MetadataChecksumGenerator.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.kubernetes.operator.checksum;
 
+import java.util.List;
 import java.util.Map;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -17,9 +18,11 @@ public interface MetadataChecksumGenerator {
     String CHECKSUM_CONTEXT_KEY = "kroxylicious.io/referent-checksum-generator";
     String NO_CHECKSUM_SPECIFIED = "";
 
-    static String checksumFor(HasMetadata... metadataSources) {
+    static String checksumFor(List<? extends HasMetadata> metadataSources) {
+        if (metadataSources.isEmpty()) {
+            return NO_CHECKSUM_SPECIFIED;
+        }
         var checksum = new Crc32ChecksumGenerator();
-
         for (HasMetadata metadataSource : metadataSources) {
             var objectMeta = metadataSource.getMetadata();
             checksum.appendMetadata(objectMeta);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

If a KafkaService resource has a referent certificate secret, or a referent trustAnchor configmap, the KafkaServiceReconciler will add a kroxylicious.io/referent-checksum annotation to the KafkaService's metadata.

The checksum annotation is updated if the configmap or secret are modified.

### Additional Context

We intend to consume this annotation in aggregating reconcilers to drive rolling of the Proxy pods when any config/secret data changes. The proxy has no ability to reload configuration currently so we are making the operator handle rolling it.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
