### PR TITLE
Operator packaging

### DIFF
--- a/.github/workflows/operator-maven.yaml
+++ b/.github/workflows/operator-maven.yaml
@@ -84,30 +84,7 @@ jobs:
           # KROXYLICIOUS_IMAGE env var is used by the Operator ITs
           echo "KROXYLICIOUS_IMAGE=${KROXYLICIOUS_IMAGE}" >> "$GITHUB_ENV"
           # make sure everything is built and compiles
-          mvn -B install -DskipTests -Pci -Djapicmp.skip=${REFERENCE_RELEASE_UNPUBLISHED} -pl ':kroxylicious-operator' -am
-          # now run just the operator unit tests.         
-          mvn -B verify -DskipITs -Pci -Djapicmp.skip=${REFERENCE_RELEASE_UNPUBLISHED} -pl ':kroxylicious-operator'
-      - name: 'Set up Docker Buildx'
-        uses: docker/setup-buildx-action@v3
-      - name: 'Build tagged Docker image'
-        uses: docker/build-push-action@v6
-        with:
-          file: Dockerfile
-          context: .
-          build-args:
-            KROXYLICIOUS_VERSION=${{ env.KROXYLICIOUS_VERSION }}
-          tags: ${{ env.KROXYLICIOUS_IMAGE }}
-          push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,compression=zstd
-          load: 'true'
-      - name: 'Load Kroxylicious Image in Minikube'
-        run: minikube image load  ${{ env.KROXYLICIOUS_IMAGE }}
-      - name: 'Run Kroxylicious operator integration tests'
-        if: github.ref_name != 'main' || env.SONAR_TOKEN_SET != 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -B verify -Pci -Djapicmp.skip=${REFERENCE_RELEASE_UNPUBLISHED} -DskipUTs -pl ':kroxylicious-operator'
+          mvn -B install -Pci -Djapicmp.skip=${REFERENCE_RELEASE_UNPUBLISHED} -pl ':kroxylicious-operator' -am
       - name: 'Build Kroxylicious maven project on main with Sonar'
         if: github.event_name == 'push' && github.ref_name == 'main' && env.SONAR_TOKEN_SET == 'true'
         env:

--- a/kroxylicious-app/pom.xml
+++ b/kroxylicious-app/pom.xml
@@ -175,6 +175,10 @@
     <profiles>
         <profile>
             <id>dist</id>
+            <properties>
+                <io.kroxylicious.proxy.image.name>quay.io/kroxylicious/proxy:${project.version}</io.kroxylicious.proxy.image.name>
+                <io.kroxylicious.proxy.image.archive>target/kroxylicious-proxy.img.tar.gz</io.kroxylicious.proxy.image.archive>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -198,6 +202,35 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>build</goal>
+                                <goal>save</goal>
+                            </goals>
+                            <phase>package</phase>
+                            <configuration>
+                                <images>
+                                    <image>
+                                        <name>${io.kroxylicious.proxy.image.name}</name>
+                                        <alias>pxy</alias>
+                                        <build>
+                                            <dockerFile>src/main/docker/proxy.dockerfile</dockerFile>
+                                            <contextDir>${project.basedir}</contextDir>
+                                            <args>
+                                                <KROXYLICIOUS_VERSION>${project.version}</KROXYLICIOUS_VERSION>
+                                            </args>
+                                        </build>
+                                    </image>
+                                </images>
+                                <saveFile>${io.kroxylicious.proxy.image.archive}</saveFile>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
                 </plugins>
             </build>
         </profile>

--- a/kroxylicious-app/src/main/docker/proxy.dockerfile
+++ b/kroxylicious-app/src/main/docker/proxy.dockerfile
@@ -1,0 +1,59 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1745855087
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG JAVA_VERSION=17
+ARG KROXYLICIOUS_VERSION
+ARG CONTAINER_USER=kroxylicious
+ARG CONTAINER_USER_UID=185
+
+USER root
+WORKDIR /opt/kroxylicious
+
+# Download Tini
+ENV TINI_VERSION=v0.19.0
+ENV TINI_SHA256_AMD64=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c
+ENV TINI_SHA256_ARM64=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81
+ENV TINI_SHA256_PPC64LE=3f658420974768e40810001a038c29d003728c5fe86da211cff5059e48cfdfde
+ENV TINI_SHA256_S390X=931b70a182af879ca249ae9de87ef68423121b38d235c78997fafc680ceab32d
+ENV TINI_DEST=/usr/bin/tini
+
+RUN set -ex; \
+    mkdir -p /opt/tini/bin/; \
+    if [[ "${TARGETOS}/${TARGETARCH}" = "linux/ppc64le" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-ppc64le -o ${TINI_DEST}; \
+        echo "${TINI_SHA256_PPC64LE} *${TINI_DEST}" | sha256sum -c; \
+    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/arm64" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 -o ${TINI_DEST}; \
+        echo "${TINI_SHA256_ARM64} *${TINI_DEST}" | sha256sum -c; \
+    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/s390x" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x -o ${TINI_DEST}; \
+        echo "${TINI_SHA256_S390X} *${TINI_DEST}" | sha256sum -c; \
+    else \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o ${TINI_DEST}; \
+        echo "${TINI_SHA256_AMD64} *${TINI_DEST}" | sha256sum -c; \
+    fi; \
+    chmod +x ${TINI_DEST}
+
+RUN microdnf -y update \
+    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
+                java-${JAVA_VERSION}-openjdk-headless \
+                openssl \
+                shadow-utils \
+    && if [[ -n "${CONTAINER_USER}" && "${CONTAINER_USER}" != "root" ]] ; then groupadd -r -g "${CONTAINER_USER_UID}" "${CONTAINER_USER}" && useradd -m -r -u "${CONTAINER_USER_UID}" -g "${CONTAINER_USER}" "${CONTAINER_USER}"; fi \
+    && microdnf remove -y shadow-utils \
+    && microdnf clean all
+
+ENV JAVA_HOME=/usr/lib/jvm/jre-${JAVA_VERSION}
+
+COPY target/kroxylicious-app-${KROXYLICIOUS_VERSION}-bin/kroxylicious-app-${KROXYLICIOUS_VERSION}/ .
+
+USER ${CONTAINER_USER_UID}
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/opt/kroxylicious/bin/kroxylicious-start.sh" ]

--- a/kroxylicious-operator/packaging/examples/downstream-tls/00.Namespace.my-proxy.yaml
+++ b/kroxylicious-operator/packaging/examples/downstream-tls/00.Namespace.my-proxy.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+# A Namespace for a single KafkaProxy instance
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-proxy
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: proxy

--- a/kroxylicious-operator/packaging/examples/downstream-tls/01.KafkaProxy.simple.yaml
+++ b/kroxylicious-operator/packaging/examples/downstream-tls/01.KafkaProxy.simple.yaml
@@ -1,0 +1,13 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: simple
+  namespace: my-proxy
+spec: {}

--- a/kroxylicious-operator/packaging/examples/downstream-tls/02.KafkaProxyIngress-cluster-ip.yaml
+++ b/kroxylicious-operator/packaging/examples/downstream-tls/02.KafkaProxyIngress-cluster-ip.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxyIngress
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: cluster-ip
+  namespace: my-proxy
+spec:
+  proxyRef:
+    name: simple
+  clusterIP:
+    protocol: TLS

--- a/kroxylicious-operator/packaging/examples/downstream-tls/03.KafkaService.my-cluster.yaml
+++ b/kroxylicious-operator/packaging/examples/downstream-tls/03.KafkaService.my-cluster.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaService
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: my-cluster
+  namespace: my-proxy
+spec:
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+  nodeIdRanges:
+    - start: 0
+      end: 2

--- a/kroxylicious-operator/packaging/examples/downstream-tls/04.VirtualKafkaCluster.my-cluster.yaml
+++ b/kroxylicious-operator/packaging/examples/downstream-tls/04.VirtualKafkaCluster.my-cluster.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: VirtualKafkaCluster
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: my-cluster
+  namespace: my-proxy
+spec:
+  proxyRef:
+    name: simple
+  targetKafkaServiceRef:
+    name: my-cluster
+  ingresses:
+    - ingressRef:
+        name: cluster-ip
+      tls:
+        certificateRef:
+          name: server-certificate
+          kind: Secret

--- a/kroxylicious-operator/packaging/examples/downstream-tls/05.Issuer.self-signed-issuer.yaml
+++ b/kroxylicious-operator/packaging/examples/downstream-tls/05.Issuer.self-signed-issuer.yaml
@@ -1,0 +1,14 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: my-proxy
+spec:
+  selfSigned: {}

--- a/kroxylicious-operator/packaging/examples/downstream-tls/06.Certificate.server-certificate.yaml
+++ b/kroxylicious-operator/packaging/examples/downstream-tls/06.Certificate.server-certificate.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: server-certificate
+  namespace: my-proxy
+spec:
+  commonName: my-cluster-cluster-ip.my-proxy.svc.cluster.local
+  secretName: server-certificate
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS8
+    size: 4096
+  dnsNames:
+    - my-cluster-cluster-ip.my-proxy.svc.cluster.local
+  usages:
+    - server auth
+  issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io

--- a/kroxylicious-operator/packaging/examples/downstream-tls/README.md
+++ b/kroxylicious-operator/packaging/examples/downstream-tls/README.md
@@ -1,0 +1,26 @@
+These manifests declare a minimal proxy which simply forwards all requests to a single backend Apache Kafka cluster without doing anything clever either in terms of networking of protocol filters.
+In this example, the downstream connection (that is, between the Kafka client and the proxy) uses TLS.
+
+For the purposes of this example we use
+* an in-cluster Apache Kafka provided by [Strimzi](https://strimzi.io/)
+* cert manager to create a server certificate which is signed by a self-signed issuer.
+
+To try this example out:
+1. Install kubectl
+2. `cd` to this directory
+3. Apply cert-manager
+   ```shell
+    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml
+    kubectl wait deployment/cert-manager-webhook --for=condition=Available=True --timeout=300s -n cert-manager
+    ```
+4. Apply the example
+   ```shell
+   kubectl apply -f .
+   ```
+5. Try producing and consuming some messages with commands like this:
+   ```
+   CA=$(kubectl get secret -n my-proxy server-certificate -o json | jq -r ".data.\"ca.crt\" | @base64d")
+   kubectl exec -it my-cluster-dual-role-0 -n kafka -- /bin/bash ./bin/kafka-console-producer.sh --bootstrap-server my-cluster-cluster-ip.my-proxy.svc.cluster.local:9292 --topic mytopic --producer-property ssl.truststore.type=PEM --producer-property security.protocol=SSL --producer-property ssl.truststore.certificates="${CA}"
+   kubectl exec -it my-cluster-dual-role-0 -n kafka -- /bin/bash ./bin/kafka-console-consumer.sh --bootstrap-server my-cluster-cluster-ip.my-proxy.svc.cluster.local:9292 --topic mytopic --from-beginning --consumer-property ssl.truststore.type=PEM --consumer-property security.protocol=SSL --consumer-property ssl.truststore.certificates="${CA}"
+   ```
+

--- a/kroxylicious-operator/packaging/examples/record-encryption/00.Namespace.my-proxy.yaml
+++ b/kroxylicious-operator/packaging/examples/record-encryption/00.Namespace.my-proxy.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+# A Namespace for a single KafkaProxy instance
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-proxy
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: proxy

--- a/kroxylicious-operator/packaging/examples/record-encryption/01.KafkaProxy.simple.yaml
+++ b/kroxylicious-operator/packaging/examples/record-encryption/01.KafkaProxy.simple.yaml
@@ -1,0 +1,13 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: simple
+  namespace: my-proxy
+spec: {}

--- a/kroxylicious-operator/packaging/examples/record-encryption/02.KafkaProxyIngress-cluster-ip.yaml
+++ b/kroxylicious-operator/packaging/examples/record-encryption/02.KafkaProxyIngress-cluster-ip.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxyIngress
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: cluster-ip
+  namespace: my-proxy
+spec:
+  proxyRef:
+    name: simple
+  clusterIP:
+    protocol: TCP

--- a/kroxylicious-operator/packaging/examples/record-encryption/03.Filter.encryption.yaml
+++ b/kroxylicious-operator/packaging/examples/record-encryption/03.Filter.encryption.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProtocolFilter
+apiVersion: filter.kroxylicious.io/v1alpha1
+metadata:
+  name: encryption
+  namespace: my-proxy
+spec:
+  type: io.kroxylicious.filter.encryption.RecordEncryption
+  configTemplate:
+    kms: Foo
+    kmsConfig: {}
+    selector: Bar
+    selectorConfig: {}

--- a/kroxylicious-operator/packaging/examples/record-encryption/04.KafkaService.my-cluster.yaml
+++ b/kroxylicious-operator/packaging/examples/record-encryption/04.KafkaService.my-cluster.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaService
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: my-cluster
+  namespace: my-proxy
+spec:
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+  nodeIdRanges:
+    - start: 0
+      end: 2

--- a/kroxylicious-operator/packaging/examples/record-encryption/05.VirtualKafkaCluster.my-cluster.yaml
+++ b/kroxylicious-operator/packaging/examples/record-encryption/05.VirtualKafkaCluster.my-cluster.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: VirtualKafkaCluster
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: my-cluster
+  namespace: my-proxy
+spec:
+  proxyRef:
+    name: simple
+  targetKafkaServiceRef:
+    name: my-cluster
+  filterRefs:
+    - name: encryption
+  ingresses:
+    - ingressRef:
+        name: cluster-ip

--- a/kroxylicious-operator/packaging/examples/record-encryption/README.md
+++ b/kroxylicious-operator/packaging/examples/record-encryption/README.md
@@ -1,0 +1,12 @@
+These manifests declare a Kafka proxy which does record encryption.
+
+For the purposes of this example we use
+* an in-cluster Kafka provided by [Strimzi](https://strimzi.io/)
+* an in-cluster KMS provided by Hashicorp Vault
+
+As such this example should work more-or-less any Kube cluster which is able to pull the necessary images. But note that Kroxylicious also supports other KMSes.
+
+To try this example out:
+1. Install kubectl
+2. `cd` to this directory
+3. `kubectl apply -f .`

--- a/kroxylicious-operator/packaging/examples/record-transforming/00.Namespace.my-proxy.yaml
+++ b/kroxylicious-operator/packaging/examples/record-transforming/00.Namespace.my-proxy.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+# A Namespace for a single KafkaProxy instance
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-proxy
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: proxy

--- a/kroxylicious-operator/packaging/examples/record-transforming/01.KafkaProxy.simple.yaml
+++ b/kroxylicious-operator/packaging/examples/record-transforming/01.KafkaProxy.simple.yaml
@@ -1,0 +1,13 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: simple
+  namespace: my-proxy
+spec: {}

--- a/kroxylicious-operator/packaging/examples/record-transforming/02.KafkaProxyIngress-cluster-ip.yaml
+++ b/kroxylicious-operator/packaging/examples/record-transforming/02.KafkaProxyIngress-cluster-ip.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxyIngress
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: cluster-ip
+  namespace: my-proxy
+spec:
+  proxyRef:
+    name: simple
+  clusterIP:
+    protocol: TCP

--- a/kroxylicious-operator/packaging/examples/record-transforming/03.Filter.transforming.yaml
+++ b/kroxylicious-operator/packaging/examples/record-transforming/03.Filter.transforming.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProtocolFilter
+apiVersion: filter.kroxylicious.io/v1alpha1
+metadata:
+  name: transforming
+  namespace: my-proxy
+spec:
+  type: ProduceRequestTransformation
+  configTemplate:
+    transformation: UpperCasing
+    transformationConfig:
+      charset: UTF-8

--- a/kroxylicious-operator/packaging/examples/record-transforming/04.KafkaService.my-cluster.yaml
+++ b/kroxylicious-operator/packaging/examples/record-transforming/04.KafkaService.my-cluster.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaService
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: my-cluster
+  namespace: my-proxy
+spec:
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+  nodeIdRanges:
+    - start: 0
+      end: 2

--- a/kroxylicious-operator/packaging/examples/record-transforming/05.VirtualKafkaCluster.my-cluster.yaml
+++ b/kroxylicious-operator/packaging/examples/record-transforming/05.VirtualKafkaCluster.my-cluster.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: VirtualKafkaCluster
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: my-cluster
+  namespace: my-proxy
+spec:
+  proxyRef:
+    name: simple
+  targetKafkaServiceRef:
+    name: my-cluster
+  filterRefs:
+    - name: transforming
+  ingresses:
+    - ingressRef:
+        name: cluster-ip

--- a/kroxylicious-operator/packaging/examples/record-transforming/README.md
+++ b/kroxylicious-operator/packaging/examples/record-transforming/README.md
@@ -1,0 +1,14 @@
+These manifests declare a proxy with a simple proxy which simply forwards all requests to a single backend Apache Kafka cluster. It deploys the transforming filter
+that simply transforms (upper-cases) the values of record as they are produced by the client.  Note that this filter is intended for demonstration purposes. It
+is not for use in production.
+
+For the purposes of this example we use
+* an in-cluster Apache Kafka provided by [Strimzi](https://strimzi.io/)
+
+As such this example should work more-or-less any Kube cluster which is able to pull the necessary images.
+But please note that Kroxylicious should work with any Kafka protocol compatible broker.
+
+To try this example out:
+1. Install kubectl
+2. `cd` to this directory
+3. `kubectl apply -f .`

--- a/kroxylicious-operator/packaging/examples/record-validation/00.Namespace.my-proxy.yaml
+++ b/kroxylicious-operator/packaging/examples/record-validation/00.Namespace.my-proxy.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+# A Namespace for a single KafkaProxy instance
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-proxy
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: proxy

--- a/kroxylicious-operator/packaging/examples/record-validation/01.KafkaProxy.simple.yaml
+++ b/kroxylicious-operator/packaging/examples/record-validation/01.KafkaProxy.simple.yaml
@@ -1,0 +1,13 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: simple
+  namespace: my-proxy
+spec: {}

--- a/kroxylicious-operator/packaging/examples/record-validation/02.KafkaProxyIngress-cluster-ip.yaml
+++ b/kroxylicious-operator/packaging/examples/record-validation/02.KafkaProxyIngress-cluster-ip.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxyIngress
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: cluster-ip
+  namespace: my-proxy
+spec:
+  proxyRef:
+    name: simple
+  clusterIP:
+    protocol: TCP

--- a/kroxylicious-operator/packaging/examples/record-validation/03.Filter.validation.yaml
+++ b/kroxylicious-operator/packaging/examples/record-validation/03.Filter.validation.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProtocolFilter
+apiVersion: filter.kroxylicious.io/v1alpha1
+metadata:
+  name: validation
+  namespace: my-proxy
+spec:
+  type: io.kroxylicious.proxy.filter.validation.RecordValidation
+  config:
+    # ...

--- a/kroxylicious-operator/packaging/examples/record-validation/04.KafkaService.my-cluster.yaml
+++ b/kroxylicious-operator/packaging/examples/record-validation/04.KafkaService.my-cluster.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaService
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: my-cluster
+  namespace: my-proxy
+spec:
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+  nodeIdRanges:
+    - start: 0
+      end: 2

--- a/kroxylicious-operator/packaging/examples/record-validation/05.VirtualKafkaCluster.my-cluster.yaml
+++ b/kroxylicious-operator/packaging/examples/record-validation/05.VirtualKafkaCluster.my-cluster.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: VirtualKafkaCluster
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: my-cluster
+  namespace: my-proxy
+spec:
+  proxyRef:
+    name: simple
+  targetKafkaServiceRef:
+    name: my-cluster
+  filterRefs:
+    - name: validation
+  ingresses:
+    - ingressRef:
+        name: cluster-ip

--- a/kroxylicious-operator/packaging/examples/record-validation/README.md
+++ b/kroxylicious-operator/packaging/examples/record-validation/README.md
@@ -1,0 +1,13 @@
+These manifests declare a Kafka proxy which does _record validation_. 
+
+For the purposes of this example we use
+* an in-cluster Kafka provided by [Strimzi](https://strimzi.io/)
+* an in-cluster registry provided by [Apicurio Registry](https://www.apicur.io/registry/)
+
+As such this example should work more-or-less any Kube cluster which is able to pull the necessary images.
+But note that this should work with any API-compatible registry implementation, such as Confluent Registry. 
+
+To try this example out:
+1. Install kubectl
+2. `cd` to this directory
+3. `kubectl apply -f .`

--- a/kroxylicious-operator/packaging/examples/simple/00.Namespace.my-proxy.yaml
+++ b/kroxylicious-operator/packaging/examples/simple/00.Namespace.my-proxy.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+# A Namespace for a single KafkaProxy instance
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-proxy
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: proxy
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest

--- a/kroxylicious-operator/packaging/examples/simple/01.KafkaProxy.simple.yaml
+++ b/kroxylicious-operator/packaging/examples/simple/01.KafkaProxy.simple.yaml
@@ -1,0 +1,13 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: simple
+  namespace: my-proxy
+spec: {}

--- a/kroxylicious-operator/packaging/examples/simple/02.KafkaProxyIngress-cluster-ip.yaml
+++ b/kroxylicious-operator/packaging/examples/simple/02.KafkaProxyIngress-cluster-ip.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxyIngress
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: cluster-ip
+  namespace: my-proxy
+spec:
+  proxyRef:
+    name: simple
+  clusterIP:
+    protocol: TCP

--- a/kroxylicious-operator/packaging/examples/simple/03.KafkaService.my-cluster.yaml
+++ b/kroxylicious-operator/packaging/examples/simple/03.KafkaService.my-cluster.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaService
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: my-cluster
+  namespace: my-proxy
+spec:
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+  nodeIdRanges:
+    - start: 0
+      end: 2

--- a/kroxylicious-operator/packaging/examples/simple/04.VirtualKafkaCluster.my-cluster.yaml
+++ b/kroxylicious-operator/packaging/examples/simple/04.VirtualKafkaCluster.my-cluster.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: VirtualKafkaCluster
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: my-cluster
+  namespace: my-proxy
+spec:
+  proxyRef:
+    name: simple
+  targetKafkaServiceRef:
+    name: my-cluster
+  ingresses:
+    - ingressRef:
+        name: cluster-ip

--- a/kroxylicious-operator/packaging/examples/simple/README.md
+++ b/kroxylicious-operator/packaging/examples/simple/README.md
@@ -1,0 +1,17 @@
+These manifests declare a minimal proxy which simply forwards all requests to a single backend Apache Kafka cluster without doing anything clever either in terms of networking of protocol filters.
+
+For the purposes of this example we use
+* an in-cluster Apache Kafka provided by [Strimzi](https://strimzi.io/)
+
+As such this example should work more-or-less any Kube cluster which is able to pull the necessary images.
+But please note that Kroxylicious should work with any Kafka protocol compatible broker.
+
+To try this example out:
+1. Install kubectl
+2. `cd` to this directory
+3. `kubectl apply -f .`
+4. Try producing and consuming some messages with commands like this:
+   ```
+   kubectl exec -it my-cluster-dual-role-0 -n kafka -- /bin/bash ./bin/kafka-console-producer.sh --bootstrap-server my-cluster-cluster-ip.my-proxy.svc.cluster.local:9292 --topic mytopic
+   kubectl exec -it my-cluster-dual-role-0 -n kafka -- /bin/bash ./bin/kafka-console-consumer.sh --bootstrap-server my-cluster-cluster-ip.my-proxy.svc.cluster.local:9292 --topic mytopic --from-beginning
+   ```

--- a/kroxylicious-operator/packaging/examples/upstream-tls/00.Namespace.my-proxy.yaml
+++ b/kroxylicious-operator/packaging/examples/upstream-tls/00.Namespace.my-proxy.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+# A Namespace for a single KafkaProxy instance
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-proxy
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: proxy

--- a/kroxylicious-operator/packaging/examples/upstream-tls/01.KafkaProxy.simple.yaml
+++ b/kroxylicious-operator/packaging/examples/upstream-tls/01.KafkaProxy.simple.yaml
@@ -1,0 +1,13 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: simple
+  namespace: my-proxy
+spec: {}

--- a/kroxylicious-operator/packaging/examples/upstream-tls/02.KafkaProxyIngress-cluster-ip.yaml
+++ b/kroxylicious-operator/packaging/examples/upstream-tls/02.KafkaProxyIngress-cluster-ip.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxyIngress
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: cluster-ip
+  namespace: my-proxy
+spec:
+  proxyRef:
+    name: simple
+  clusterIP:
+    protocol: TCP

--- a/kroxylicious-operator/packaging/examples/upstream-tls/03.KafkaService.my-cluster.yaml
+++ b/kroxylicious-operator/packaging/examples/upstream-tls/03.KafkaService.my-cluster.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaService
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: my-cluster
+  namespace: my-proxy
+spec:
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
+  nodeIdRanges:
+    - start: 0
+      end: 2
+  tls:
+    trustAnchorRef:
+      name: my-cluster-clients-ca-cert
+      kind: ConfigMap
+      key: ca.pem

--- a/kroxylicious-operator/packaging/examples/upstream-tls/04.VirtualKafkaCluster.my-cluster.yaml
+++ b/kroxylicious-operator/packaging/examples/upstream-tls/04.VirtualKafkaCluster.my-cluster.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: VirtualKafkaCluster
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: my-cluster
+  namespace: my-proxy
+spec:
+  proxyRef:
+    name: simple
+  targetKafkaServiceRef:
+    name: my-cluster
+  ingresses:
+    - ingressRef:
+        name: cluster-ip

--- a/kroxylicious-operator/packaging/examples/upstream-tls/README.md
+++ b/kroxylicious-operator/packaging/examples/upstream-tls/README.md
@@ -1,0 +1,16 @@
+These manifests declare a minimal proxy which simply forwards all requests to a single backend Apache Kafka cluster without doing anything clever either in terms of networking of protocol filters.
+In this example, the upstream connection to Kafka cluster uses TLS.
+
+For the purposes of this example we use
+* an in-cluster Apache Kafka provided by [Strimzi](https://strimzi.io/)
+
+To try this example out:
+1. Install kubectl
+2. `cd` to this directory
+3. `kubectl apply -f .`
+4. ` kubectl create cm my-cluster-clients-ca-cert -n my-proxy --from-literal=ca.pem="$(oc get kafka --namespace kafka my-cluster -o json | jq -r '.status.listeners[1].certificates[0]')"`
+5. Try producing and consuming some messages with commands like this:
+   ```
+   kubectl exec -it my-cluster-dual-role-0 -n kafka -- /bin/bash ./bin/kafka-console-producer.sh --bootstrap-server my-cluster-cluster-ip.my-proxy.svc.cluster.local:9292 --topic mytopic
+   kubectl exec -it my-cluster-dual-role-0 -n kafka -- /bin/bash ./bin/kafka-console-consumer.sh --bootstrap-server my-cluster-cluster-ip.my-proxy.svc.cluster.local:9292 --topic mytopic --from-beginning
+   ```

--- a/kroxylicious-operator/packaging/install/00.Namespace.kroxylicious-operator.yaml
+++ b/kroxylicious-operator/packaging/install/00.Namespace.kroxylicious-operator.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+# A Namespace for the operator
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kroxylicious-operator
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: operator
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest

--- a/kroxylicious-operator/packaging/install/01.ClusterRole.kroxylicious-operator-dependent.yaml
+++ b/kroxylicious-operator/packaging/install/01.ClusterRole.kroxylicious-operator-dependent.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+# The access rules for the resources the Kroxylicious Operator produces
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kroxylicious-operator-dependent
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+      - delete
+  - apiGroups:
+      - "apps"
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+      - delete

--- a/kroxylicious-operator/packaging/install/01.ClusterRole.kroxylicious-operator-watched.yaml
+++ b/kroxylicious-operator/packaging/install/01.ClusterRole.kroxylicious-operator-watched.yaml
@@ -1,0 +1,73 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+# The access rules for the resources the Kroxylicious Operator consumes
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kroxylicious-operator-watched
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: operator
+rules:
+  - # The operator needs to know about its own CRs and be able to patch the annotations
+    apiGroups:
+      - "kroxylicious.io"
+    resources:
+      - kafkaproxies
+      - virtualkafkaclusters
+      - kafkaservices
+      - kafkaproxyingresses
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - # The operator needs to update the status on its own CRs
+    apiGroups:
+      - "kroxylicious.io"
+    resources:
+      - kafkaproxies/status
+      - virtualkafkaclusters/status
+      - kafkaservices/status
+      - kafkaproxyingresses/status
+    verbs:
+      - get
+      - patch
+      - update
+  - # The operator needs to know about its own CRs
+    apiGroups:
+      - "filter.kroxylicious.io"
+    resources:
+      - kafkaprotocolfilters
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - # The operator needs to update the status on its own CRs
+    apiGroups:
+      - "filter.kroxylicious.io"
+    resources:
+      - kafkaprotocolfilters/status
+    verbs:
+      - get
+      - patch
+      - update
+  - # the operator needs get/list/watch on these because they can be referenced
+    # from our CRs, so the operator needs to be able to resolve them.
+    apiGroups:
+      - ""
+    resources:
+      - secrets
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch

--- a/kroxylicious-operator/packaging/install/01.ServiceAccount.kroxylicious-operator.yaml
+++ b/kroxylicious-operator/packaging/install/01.ServiceAccount.kroxylicious-operator.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+# The ServiceAccount used by the Kroxylicious Operator
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kroxylicious-operator
+  namespace: kroxylicious-operator
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: operator

--- a/kroxylicious-operator/packaging/install/02.ClusterRoleBinding.kroxylicious-operator-dependent.yaml
+++ b/kroxylicious-operator/packaging/install/02.ClusterRoleBinding.kroxylicious-operator-dependent.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+# Binds the access rules for the resources the Kroxylicious Operator produces
+# to the operator's service account
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kroxylicious-operator-dependent
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: operator
+subjects:
+  - kind: ServiceAccount
+    name: kroxylicious-operator
+    namespace: kroxylicious-operator
+roleRef:
+  kind: ClusterRole
+  name: kroxylicious-operator-dependent
+  apiGroup: rbac.authorization.k8s.io

--- a/kroxylicious-operator/packaging/install/02.ClusterRoleBinding.kroxylicious-operator-watched.yaml
+++ b/kroxylicious-operator/packaging/install/02.ClusterRoleBinding.kroxylicious-operator-watched.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+# Binds the access rules for the resources the Kroxylicious Operator consumes
+# to the operator's service account
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kroxylicious-operator-watched
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: operator
+subjects:
+  - kind: ServiceAccount
+    name: kroxylicious-operator
+    namespace: kroxylicious-operator
+roleRef:
+  kind: ClusterRole
+  name: kroxylicious-operator-watched
+  apiGroup: rbac.authorization.k8s.io

--- a/kroxylicious-operator/packaging/install/03.Deployment.kroxylicious-operator.yaml
+++ b/kroxylicious-operator/packaging/install/03.Deployment.kroxylicious-operator.yaml
@@ -1,0 +1,60 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+# The Deployment for the operator
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kroxylicious-operator
+  namespace: kroxylicious-operator
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kroxylicious
+  template:
+    metadata:
+      labels:
+        app: kroxylicious
+    spec:
+      serviceAccountName: kroxylicious-operator
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: operator
+          image: $[io.kroxylicious.operator.image.name]
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          terminationMessagePolicy: FallbackToLogsOnError
+          args: [ ]
+          resources:
+            limits:
+              memory: 400M
+              cpu: "1"
+            requests:
+              memory: 400M
+              cpu: "1"
+          ports:
+            - containerPort: 8080
+              name: http
+          livenessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 5
+            httpGet:
+              port: http
+              path: /livez

--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -21,6 +21,8 @@
     <properties>
         <josdk.version>5.0.3</josdk.version>
         <prometheus-metrics.version>1.3.6</prometheus-metrics.version>
+        <io.kroxylicious.operator.image.name>quay.io/kroxylicious/operator:${project.version}</io.kroxylicious.operator.image.name>
+        <io.kroxylicious.operator.image.archive>target/kroxylicious-operator.img.tar.gz</io.kroxylicious.operator.image.archive>
     </properties>
 
     <dependencyManagement>
@@ -278,24 +280,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <configuration>
-                    <descriptors>
-                        <descriptor>src/assembly/binary-distribution.xml</descriptor>
-                    </descriptors>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>make-assembly</id> <!-- this is used for inheritance merges -->
-                        <phase>package</phase> <!-- bind to the packaging phase -->
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <!-- https://junit-pioneer.org/docs/environment-variables/#warnings-for-reflective-access
@@ -321,6 +305,150 @@
             <testResource>
                 <directory>src/test/resources</directory>
             </testResource>
+            <testResource>
+                <directory>src/test/resources-filtered</directory>
+                <filtering>true</filtering>
+            </testResource>
         </testResources>
     </build>
+
+    <profiles>
+        <profile>
+            <id>dist</id>
+            <properties>
+                <skipKTs>false</skipKTs>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/assembly/binary-distribution.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>make-assembly</id> <!-- this is used for inheritance merges -->
+                                <phase>package</phase> <!-- bind to the packaging phase -->
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default</id>
+                                <goals>
+                                    <goal>build</goal>
+                                    <goal>save</goal>
+                                </goals>
+                                <phase>package</phase>
+                                <configuration>
+                                    <images>
+                                        <image>
+                                            <name>${io.kroxylicious.operator.image.name}</name>
+                                            <alias>optr</alias>
+                                            <build>
+                                                <dockerFile>src/main/docker/operator.dockerfile</dockerFile>
+                                                <contextDir>${project.basedir}</contextDir>
+                                                <args>
+                                                    <KROXYLICIOUS_VERSION>${project.version}</KROXYLICIOUS_VERSION>
+                                                </args>
+                                            </build>
+                                        </image>
+                                    </images>
+                                    <saveFile>${io.kroxylicious.operator.image.archive}</saveFile>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <!-- copy from packaging into target/packaged, interpolating $[ ] (e.g. to use the container image) -->
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>3.3.1</version>
+                        <executions>
+                            <execution>
+                                <id>copy-operator-install</id>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <phase>package</phase>
+                                <configuration>
+                                    <delimiters>
+                                        <delimiter>$[*]</delimiter>
+                                    </delimiters>
+                                    <resources>
+                                        <resource>
+                                            <directory>packaging</directory>
+                                            <filtering>true</filtering>
+                                        </resource>
+                                    </resources>
+                                    <outputDirectory>target/packaged</outputDirectory>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>copy-crds</id>
+                                <goals><goal>copy-resources</goal></goals>
+                                <phase>package</phase>
+                                <configuration>
+                                    <resources>
+                                        <resource>
+                                            <directory>../kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8</directory>
+                                            <filtering>false</filtering>
+                                        </resource>
+                                    </resources>
+                                    <outputDirectory>target/packaged/install</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>3.5.3</version>
+                        <executions>
+                            <execution>
+                                <!-- run the tests which depend on having an operator image + install manifests -->
+                                <id>kube-integration-test</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                </goals>
+                                <phase>verify</phase>
+                                <configuration>
+                                    <includes>
+                                        <include>**/KT*.java</include>
+                                        <include>**/*KT.java</include>
+                                        <include>**/*KTCase.java</include>
+                                    </includes>
+                                    <skipITs>${skipKTs}</skipITs>
+                                    <skip>${skipKTs}</skip>
+                                    <skipTests>${skipKTs}</skipTests>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>kube-verify</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <skipITs>${skipKTs}</skipITs>
+                                    <skip>${skipKTs}</skip>
+                                    <skipTests>${skipKTs}</skipTests>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+    </profiles>
 </project>

--- a/kroxylicious-operator/src/main/docker/operator.dockerfile
+++ b/kroxylicious-operator/src/main/docker/operator.dockerfile
@@ -1,0 +1,59 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5-1745855087
+
+ARG TARGETOS=linux
+ARG TARGETARCH
+ARG JAVA_VERSION=17
+ARG KROXYLICIOUS_VERSION
+ARG CONTAINER_USER=kroxylicious
+ARG CONTAINER_USER_UID=185
+
+USER root
+WORKDIR /opt/kroxylicious-operator
+
+# Download Tini
+ENV TINI_VERSION=v0.19.0
+ENV TINI_SHA256_AMD64=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c
+ENV TINI_SHA256_ARM64=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81
+ENV TINI_SHA256_PPC64LE=3f658420974768e40810001a038c29d003728c5fe86da211cff5059e48cfdfde
+ENV TINI_SHA256_S390X=931b70a182af879ca249ae9de87ef68423121b38d235c78997fafc680ceab32d
+ENV TINI_DEST=/usr/bin/tini
+
+RUN set -ex; \
+    mkdir -p /opt/tini/bin/; \
+    if [[ "${TARGETOS}/${TARGETARCH}" = "linux/ppc64le" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-ppc64le -o ${TINI_DEST}; \
+        echo "${TINI_SHA256_PPC64LE} *${TINI_DEST}" | sha256sum -c; \
+    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/arm64" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 -o ${TINI_DEST}; \
+        echo "${TINI_SHA256_ARM64} *${TINI_DEST}" | sha256sum -c; \
+    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/s390x" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x -o ${TINI_DEST}; \
+        echo "${TINI_SHA256_S390X} *${TINI_DEST}" | sha256sum -c; \
+    else \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o ${TINI_DEST}; \
+        echo "${TINI_SHA256_AMD64} *${TINI_DEST}" | sha256sum -c; \
+    fi; \
+    chmod +x ${TINI_DEST}
+
+RUN microdnf -y update \
+    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
+                java-${JAVA_VERSION}-openjdk-headless \
+                openssl \
+                shadow-utils \
+    && if [[ -n "${CONTAINER_USER}" && "${CONTAINER_USER}" != "root" ]] ; then groupadd -r -g "${CONTAINER_USER_UID}" "${CONTAINER_USER}" && useradd -m -r -u "${CONTAINER_USER_UID}" -g "${CONTAINER_USER}" "${CONTAINER_USER}"; fi \
+    && microdnf remove -y shadow-utils \
+    && microdnf clean all
+
+ENV JAVA_HOME=/usr/lib/jvm/jre-${JAVA_VERSION}
+
+COPY target/kroxylicious-operator-${KROXYLICIOUS_VERSION}-bin/kroxylicious-operator-${KROXYLICIOUS_VERSION}/ .
+
+USER ${CONTAINER_USER_UID}
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/opt/kroxylicious-operator/bin/operator-start.sh" ]

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AbstractInstallKT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AbstractInstallKT.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * An abstract test that we can install the operator.
+ * Abstract because this class only depends on kubectl.
+ * It's not defined here how a Kube cluster is provided or how it knows about the images we're testing.
+ */
+abstract class AbstractInstallKT {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractInstallKT.class);
+
+    protected static void exec(String... args) throws IOException, InterruptedException {
+        List<String> argList = List.of(args);
+        LOGGER.info("Executing '{}'", String.join(" ", argList));
+        var out = Files.createTempFile(AbstractInstallKT.class.getSimpleName(), ".out");
+        var err = Files.createTempFile(AbstractInstallKT.class.getSimpleName(), ".err");
+        var process = new ProcessBuilder()
+                .command(argList)
+                .redirectOutput(out.toFile())
+                .redirectError(err.toFile())
+                .start();
+        boolean exited = process.waitFor(5, TimeUnit.MINUTES);
+        if (exited) {
+            String description = ("'%s' exited with value: %d%n"
+                    + "standard error output:%n"
+                    + "---%n"
+                    + "%s---%n"
+                    + "standard output:%n"
+                    + "---%n"
+                    + "%s---").formatted(
+                            argList,
+                            process.exitValue(),
+                            Files.readString(err),
+                            Files.readString(out));
+            LOGGER.info(description);
+            assertThat(process.exitValue()).describedAs(argList + " should have 0 exit code").isZero();
+        }
+        else {
+            process.destroy();
+            boolean killed = process.waitFor(5, TimeUnit.SECONDS);
+            if (!killed) {
+                process.destroyForcibly();
+                process.waitFor(5, TimeUnit.SECONDS);
+            }
+            throw new AssertionError("Process " + argList + " did not complete within timeout");
+        }
+    }
+
+    @Test
+    void shouldInstallFromYamlManifests() throws Exception {
+        try {
+            AbstractInstallKT.exec("kubectl",
+                    "apply",
+                    "-f",
+                    "target/packaged/install");
+
+            AbstractInstallKT.exec("kubectl",
+                    "wait",
+                    "-n",
+                    "kroxylicious-operator",
+                    "--for=jsonpath={.status.readyReplicas}=1",
+                    "--timeout=300s",
+                    "deployment", "kroxylicious-operator");
+            LOGGER.info("Operator deployment became ready");
+        }
+        finally {
+            AbstractInstallKT.exec("kubectl",
+                    "delete",
+                    "-f",
+                    "target/packaged/install");
+        }
+    }
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/MinikubeInstallKT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/MinikubeInstallKT.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.assertj.core.api.Assumptions.assumeThatCode;
+
+/**
+ * An installation test which satisfies the requirements of {@link AbstractInstallKT} using {@code minikube}.
+ * This test:
+ * <ul>
+ * <li>assumes minikube is running, so the test will be skipped if it's not.</li>
+ * <li>loads the image using {@code minikube image load}.</li>
+ * <li>cleans up the image using {@code minikube image rm}.</li>
+ * </ul>
+ */
+class MinikubeInstallKT extends AbstractInstallKT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MinikubeInstallKT.class);
+
+    // These are normally set automatically by mvn
+    private static final String IMAGE_ARCHIVE;
+    private static final String IMAGE_NAME;
+    static {
+        OperatorInfo operatorInfo = OperatorInfo.fromResource();
+        IMAGE_ARCHIVE = operatorInfo.imageArchive();
+        IMAGE_NAME = operatorInfo.imageName();
+    }
+    private static boolean loaded = false;
+
+    @BeforeAll
+    static void beforeAll() throws IOException, InterruptedException {
+        Assertions.setDescriptionConsumer(desc -> {
+            LOGGER.info("Testing assumption: \"{}\"", desc);
+        });
+
+        assumeThat(Path.of(IMAGE_ARCHIVE))
+                .describedAs("Container image archive %s must exist", IMAGE_ARCHIVE)
+                .withFailMessage("Container image archive %s did not exist", IMAGE_ARCHIVE)
+                .exists();
+
+        LOGGER.info("Checking whether minikube is available");
+        assumeThatCode(() -> exec("minikube"))
+                .describedAs("minikube must be available on the path")
+                .doesNotThrowAnyException();
+
+        LOGGER.info("Checking whether minikube is running");
+        assumeThatCode(() -> exec("minikube", "status"))
+                .describedAs("minikube must be running")
+                .doesNotThrowAnyException();
+
+        LOGGER.info("Loading {} into minikube registry", IMAGE_ARCHIVE);
+        exec("minikube", "image", "load", IMAGE_ARCHIVE);
+        loaded = true;
+    }
+
+    @AfterAll
+    static void afterAll() throws IOException, InterruptedException {
+        if (loaded) {
+            LOGGER.info("Removing {} from minikube registry", IMAGE_NAME);
+            exec("minikube", "image", "rm", IMAGE_NAME);
+        }
+    }
+
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OcInstallKT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OcInstallKT.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.io.IOException;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assumptions.assumeThatCode;
+
+/**
+ * An installation test which depends on CRC/{@code oc}.
+ * This test:
+ * <ul>
+ * <li>assumes CRC is running, so the test will be skipped if it's not.</li>
+ * <li>loads the image using {@code oc import-image}.</li>
+ * <li>cleans up the image using {@code oc delete imagestream}.</li>
+ *
+ * </ul>
+ */
+class OcInstallKT extends AbstractInstallKT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OcInstallKT.class);
+
+    // These are normally set automatically by mvn
+    private static final String IMAGE_NAME = OperatorInfo.fromResource().imageName();
+    private static final String IMAGE_STREAM_NAME = "kroxylicious-operator";
+    private static boolean loaded = false;
+
+    @BeforeAll
+    static void beforeAll() throws IOException, InterruptedException {
+        Assertions.setDescriptionConsumer(desc -> {
+            LOGGER.info("Testing assumption: \"{}\"", desc);
+        });
+
+        LOGGER.info("Checking whether oc is available");
+        assumeThatCode(() -> exec("oc"))
+                .describedAs("oc must be available on the path")
+                .doesNotThrowAnyException();
+
+        LOGGER.info("Checking whether oc is logged in");
+        assumeThatCode(() -> exec("oc", "whoami"))
+                .describedAs("oc must be logged in")
+                .doesNotThrowAnyException();
+
+        LOGGER.info("Logging into oc registry");
+        assumeThatCode(() -> exec("oc", "registry", "login", "--insecure=true"))
+                .describedAs("oc registry login")
+                .doesNotThrowAnyException();
+
+        LOGGER.info("Importing {} into oc registry", IMAGE_NAME);
+        exec("oc",
+                "import-image",
+                IMAGE_STREAM_NAME,
+                "--from=" + IMAGE_NAME,
+                "--confirm");
+        loaded = true;
+    }
+
+    @AfterAll
+    static void afterAll() throws IOException, InterruptedException {
+        if (loaded) {
+            LOGGER.info("Deleting imagestream {}", IMAGE_STREAM_NAME);
+            exec("oc", "delete", "imagestream", IMAGE_STREAM_NAME);
+        }
+    }
+
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorInfo.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorInfo.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Properties;
+
+record OperatorInfo(String imageName, String imageArchive) {
+
+    static OperatorInfo fromResource() {
+        try (var is = OperatorInfo.class.getResourceAsStream("/operator-info.properties")) {
+            var properties = new Properties();
+            properties.load(is);
+            String imageName = properties.getProperty("operator.image.name");
+            String imageArchive = properties.getProperty("operator.image.archive");
+            return new OperatorInfo(imageName, imageArchive);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/kroxylicious-operator/src/test/resources-filtered/operator-info.properties
+++ b/kroxylicious-operator/src/test/resources-filtered/operator-info.properties
@@ -1,0 +1,8 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+operator.image.name: ${io.kroxylicious.operator.image.name}
+operator.image.archive: ${io.kroxylicious.operator.image.archive}

--- a/pom.xml
+++ b/pom.xml
@@ -781,6 +781,11 @@
                     <version>0.23.1</version>
                 </plugin>
 
+                <plugin>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>0.46.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION
### Type of change

- Build

### Description

This PR is a prototype which:
* uses the `maven-exec-plugin` to perform an operator build (using `podman`) 
* uses the `maven-exec-plugin` to perform a `minikube image load`
* uses the `maven-resource-plugin` to copy and filter Kube manifests into a single `target/packaged/install` directory (it also copies the examples)
* demonstrates using the `maven-failsafe-plugin`  to execute tests which would depend on running the operator in a real kube environment (unlike our existing operator ITs).

All of these things are dependent on enabling the `kubeTest` maven profile, and also on having `podman` and `minikube` installed and running on the host. 

You can try it using `mvn clean verify -pl kroxylicious-operator -DskipTests -P kubeTest`, but because this PR's only `KT` test makes a failing assertion that `mvn` command is expected to fail, like this:

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.053 s <<< FAILURE! -- in io.kroxylicious.kubernetes.operator.ExampleKT
[ERROR] io.kroxylicious.kubernetes.operator.ExampleKT.example -- Time elapsed: 0.040 s <<< FAILURE!
org.opentest4j.AssertionFailedError: 

Expecting value to be true but was false
	at io.kroxylicious.kubernetes.operator.ExampleKT.example(ExampleKT.java:17)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```

This PR provides:
* a way to test installation of the operator (at least from Kube manifests)
* a way of executing the documentation tests in #2112 (i.e. its `ProcedureIT` could be a `ProcedureKT`). 

It is also relates to some other issues:
* #2096: in that it's gathering together multiple parts of the an operator release artifact (install and examples, and it could probably include docs too if we wanted)
* #1949: in that combined with #2112 we're now expecting to have tested and working operator examples. 
* #1852: the functionality in this PR is currently gated on `-P kubeTest`. The source, unit and integration tests are compiled and execute on the host, then re-built in a container, and the that container is tested. This is less than ideal. Then the release process does its own thing, rebuilding everything all over again.