### PR TITLE
Require client certificates by default if user supplies downstream trust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#2135](https://github.com/kroxylicious/kroxylicious/pull/2135) Require client certificates by default if user supplies downstream trust
 * [#2140](https://github.com/kroxylicious/kroxylicious/pull/2140) Bump Jackson from 2.18.1 to 2.18.3
 * [#2115](https://github.com/kroxylicious/kroxylicious/pull/2115) Ensure request path chains deferred opaque requests correctly
 * [#2113](https://github.com/kroxylicious/kroxylicious/pull/2113) Ensure that filter handler does not leak deferred opaque requests/responses if the upstream or downstream side closes unexpectedly 
@@ -16,6 +17,12 @@ Format `<github issue/pr number>: <short description>`.
 * [#1900](https://github.com/kroxylicious/kroxylicious/issues/1900) Enforce business rule that a proxy must have at least one virtual cluster
 * [#1855](https://github.com/kroxylicious/kroxylicious/issues/1855) Upgrade to Apache Kafka 4.0
 * [#1928](https://github.com/kroxylicious/kroxylicious/pull/1928) Make Kroxylicious Operator metrics available for collection
+
+### Changes, deprecations and removals
+
+* The default behaviour for client authentication has changed, if a Gateway is configured with client trust certificates, then
+by default we will require the client to supply certificates. Previously the user had to also configure the clientAuth mode to
+`REQUIRED` to enable this behaviour, the default was to not check the client certificates.
 
 ## 0.11.0
 

--- a/docs/modules/configuring/con-configuring-vc-client-tls.adoc
+++ b/docs/modules/configuring/con-configuring-vc-client-tls.adoc
@@ -95,10 +95,11 @@ virtualClusters:
 <1> PKCS #12 store containing CA certificate(s) used to verify that the client's certificate is trusted.
 <2> (Optional) Password to protect the PKCS #12 store.
 <3> (Optional) Keystore type. If a keystore type is not specified, the default JKS (Java Keystore) type is used.
-<4> Client authentication mode. 
+<4> (Optional) Client authentication mode. 
 If set to `REQUIRED`, the client must present a valid certificate. 
 If set to `REQUESTED`, the client is requested to present a certificate. If presented, the certificate is validated. If the client chooses not to present a certificate the connection is still allowed. 
 If set to `NONE`, client authentication is disabled.
+If a client authentication mode is not specified, then the default behaviour is `REQUIRED`.
 
 NOTE: The client's identity, as established through TLS client authentication, is currently not relayed to the target cluster. 
 For more information, see the {github-issues}/1637[related issue^].

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/NettyTrustProvider.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/NettyTrustProvider.java
@@ -62,12 +62,13 @@ public class NettyTrustProvider {
             }
 
             private void enableClientAuth(TrustStore trustStore) {
-                Optional.ofNullable(trustStore.trustOptions())
+                ClientAuth clientAuth = Optional.ofNullable(trustStore.trustOptions())
                         .filter(ServerOptions.class::isInstance)
                         .map(ServerOptions.class::cast)
                         .map(ServerOptions::clientAuth)
                         .map(NettyTrustProvider::toNettyClientAuth)
-                        .ifPresent(builder::clientAuth);
+                        .orElse(ClientAuth.REQUIRE);
+                builder.clientAuth(clientAuth);
             }
 
             @Override

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/NettyTrustProviderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/NettyTrustProviderTest.java
@@ -59,7 +59,7 @@ class NettyTrustProviderTest {
         return Stream.of(argumentSet("required", TlsClientAuth.REQUIRED, ClientAuth.REQUIRE),
                 argumentSet("requested", TlsClientAuth.REQUESTED, ClientAuth.OPTIONAL),
                 argumentSet("none", TlsClientAuth.NONE, ClientAuth.NONE),
-                argumentSet("no configuration", null, ClientAuth.NONE));
+                argumentSet("no configuration", null, ClientAuth.REQUIRE));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

If a user is configuring the downstream trust certificates, they will reasonably expect that the default behaviour is to use those certificates. We should default to a secure mode, leaving it up to users to tune it down to REQUESTED or NONE. Also the docs made the option look like a required configuration, where it could be omitted in reality.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
