### PR TITLE
Avoid httpclient duplicate factory warning in system tests too.

### DIFF
--- a/kroxylicious-systemtests/pom.xml
+++ b/kroxylicious-systemtests/pom.xml
@@ -70,6 +70,17 @@
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-httpclient-vertx</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-jdk</artifactId>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
@@ -87,11 +98,6 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>openshift-model-operator</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-httpclient-jdk</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Like #2134 but for the system tests module.

The system test logs are full of:

```
2025-05-07T10:40:23.261Z] 2025-05-07 06:40:19 WARN  io.fabric8.kubernetes.client.utils.HttpClientUtils:188 - The following httpclient factories were detected on your classpath: [io.fabric8.kubernetes.client.vertx.VertxHttpClientFactory, io.fabric8.kubernetes.client.jdkhttp.JdkHttpClientFactory], multiple of which had the same priority (0) so one was chosen randomly. You should exclude dependencies that aren't needed or use an explicit association of the HttpClient.Factory.
```

This change removes the VertxHttpClient leaving only the JdkHttpClient one.

(Also, I want to rule out the Vertx based client from some rather odd failures we've seen pop up when running the system tests on Jenkins (#2129)).


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
