### PR TITLE
Operator CI build needs to skip japicmp if the reference release is not published.

### DIFF
--- a/.github/workflows/operator-maven.yaml
+++ b/.github/workflows/operator-maven.yaml
@@ -55,6 +55,10 @@ jobs:
           "kubernetes version": 'v1.32.0'
           "github token": ${{ secrets.GITHUB_TOKEN }}
           driver: docker
+      - name: 'Test for unpublished reference release (japicmp)'
+        run: |
+          REFERENCE_RELEASE=$(mvn --quiet -pl kroxylicious-api help:evaluate -Dexpression=ApiCompatability.ReferenceVersion -DforceStdout)
+          echo "REFERENCE_RELEASE_UNPUBLISHED=$(mvn --quiet dependency:get -Dartifact=io.kroxylicious:kroxylicious-parent:${REFERENCE_RELEASE}:pom 1>/dev/null && echo false || echo true)" >> $GITHUB_ENV
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
         if: github.ref_name == 'main' || env.SONAR_TOKEN_SET == 'true'


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

In the case where the CI pipeline is processing a release, the release reference won't exist.
The opeator workflow needs the same smarts as `maven.yaml` 

https://github.com/kroxylicious/kroxylicious/blob/main/.github/workflows/maven.yaml#L58

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
