### PR TITLE
Fix promote release to account for the fact we now have several check-runs

### DIFF
--- a/.github/workflows/promote_release.yaml
+++ b/.github/workflows/promote_release.yaml
@@ -130,14 +130,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
         run: |
-          STATUS=$(gh api \
+          UNFINISHED_OR_ERRORED=$(gh api \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               /repos/${{ github.repository }}/commits/${PR_REF}/check-runs \
-              | jq --exit-status -r '.check_runs[] | select(.name=="build") | .status + "/" + .conclusion')
+              | jq --exit-status -r '[.check_runs[] | select( .status != "completed" or .conclusion != "success")] | length')
 
-          if [[ ${STATUS} != "completed/success" ]]; then
-            gh pr comment --body "Build workflow has not completed successfully (${STATUS}). Ask me again later." ${{ inputs.release-pr-issue-number }}
+          if [[ ${UNFINISHED_OR_ERRORED} > 0 ]]; then
+            gh pr comment --body "${UNFINISHED_OR_ERRORED} build check(s) have not completed successfully. If they are still running, you can ask me to promote-release again once they are finished." ${{ inputs.release-pr-issue-number }}
             exit 1
           fi
 


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Bugfix

### Description

why: the prompte script was still expected a build-check called `build`. This got changed by 4cb72e94e22145ac255990cf25686beec921fc96.


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
