### PR TITLE
Default QUAY_ORG to kroxylicious

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -70,7 +70,7 @@ function error {
 
 function buildPullSpec {
   IMAGE_REGISTRY=${IMAGE_REGISTRY:-"quay.io"}
-  IMAGE_REGISTRY_ORG=${IMAGE_REGISTRY_ORG:-${QUAY_ORG}}
+  IMAGE_REGISTRY_ORG=${IMAGE_REGISTRY_ORG:-${QUAY_ORG:-kroxylicious}}
   IMAGE_NAME=${IMAGE_NAME:-${1}}
   echo "${IMAGE_REGISTRY}/${IMAGE_REGISTRY_ORG}/${IMAGE_NAME}:${IMAGE_TAG:-latest}"
 }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Ensure we have a default value for the registry org when building a pull-spec

### Additional Context

`./run-operator.sh` should work out of the box.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
