### PR TITLE
Enable users to inject virtual cluster name into SNI bootstrap address and advertised broker address pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
-
+* [#2185](https://github.com/kroxylicious/kroxylicious/pull/2185) Add $(virtualClusterName) placeholders to SNI bootstrap address and advertised broker address pattern
 * [#2198](https://github.com/kroxylicious/kroxylicious/pull/2198) Require VirtualCluster name to be a valid DNS label
 * [#2188](https://github.com/kroxylicious/kroxylicious/pull/2188) Delete deprecated bootstrapAddressPattern SNI gateway property
 * [#2186](https://github.com/kroxylicious/kroxylicious/pull/2186) Remove deprecated FilterFactory implementations
@@ -29,6 +29,10 @@ Format `<github issue/pr number>: <short description>`.
 * Remove the deprecated configuration property `brokerAddressPattern` from `sniHostIdentifiesNode` gateway configuration. Use
   `advertisedBrokerAddressPattern` instead.
 * VirtualCluster names are now restricted to a maximum length of 63, and must match pattern `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` (case insensitive).
+* `virtualClusters[].gateways[].sniHostIdentifiesNode.bootstrapAddress` can now contain an optional replacement token `$(virtualClusterName)`.
+When this is present, it will be replaced with the name of that gateway's VirtualCluster.
+* `virtualClusters[].gateways[].sniHostIdentifiesNode.advertisedBrokerAddressPattern` can now contain an optional replacement token `$(virtualClusterName)`.
+When this is present, it will be replaced with the name of that gateway's VirtualCluster.
 
 ## 0.12.0
 

--- a/docs/modules/configuring/con-configuring-vc-gateways.adoc
+++ b/docs/modules/configuring/con-configuring-vc-gateways.adoc
@@ -225,6 +225,8 @@ The gateway exposes the following broker addresses:
 
 |===
 
+Both the `advertisedBrokerAddressPattern` and `bootstrapAddress` configuration parameters accept the `$(virtualClusterName)` replacement token, 
+which is optional. If included, `$(virtualClusterName)` is replaced with the name of the gateway's virtual cluster.
 
 .Example SNI Host Identifies Node configuration with customized advertised port
 [source,yaml]

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousConfigUtils.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousConfigUtils.java
@@ -116,7 +116,9 @@ public class KroxyliciousConfigUtils {
             return c.getBootstrapAddress().toString();
         }
         else if (provider.config() instanceof SniRoutingClusterNetworkAddressConfigProviderConfig c) {
-            return new HostPort(c.getBootstrapAddress().host(), c.getAdvertisedPort()).toString();
+            String bootstrapAddressPattern = c.getBootstrapAddressPattern();
+            String replaced = bootstrapAddressPattern.replace("$(virtualClusterName)", virtualCluster);
+            return new HostPort(replaced, c.getAdvertisedPort()).toString();
         }
         else {
             throw new IllegalStateException("I don't know how to handle ClusterEndpointConfigProvider type:" + provider.type());
@@ -141,7 +143,7 @@ public class KroxyliciousConfigUtils {
     public static VirtualClusterGatewayBuilder defaultSniHostIdentifiesNodeGatewayBuilder(HostPort bootstrapAddress, String advertisedBrokerAddressPattern) {
         return defaultGatewayBuilder()
                 .withNewSniHostIdentifiesNode()
-                .withBootstrapAddress(bootstrapAddress)
+                .withBootstrapAddress(bootstrapAddress.toString())
                 .withAdvertisedBrokerAddressPattern(advertisedBrokerAddressPattern)
                 .endSniHostIdentifiesNode();
     }
@@ -183,7 +185,7 @@ public class KroxyliciousConfigUtils {
                     strategy, null, cluster.tls()));
         }
         else if (providerDefinition.config() instanceof SniRoutingClusterNetworkAddressConfigProviderConfig sc) {
-            var strategy = new SniHostIdentifiesNodeIdentificationStrategy(sc.getBootstrapAddress(),
+            var strategy = new SniHostIdentifiesNodeIdentificationStrategy(new HostPort(sc.getBootstrapAddressPattern(), sc.getAdvertisedPort()).toString(),
                     sc.getAdvertisedBrokerAddressPattern());
 
             return Stream.of(new VirtualClusterGateway(DEFAULT_GATEWAY_NAME,

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/SniHostIdentifiesNodeIdentificationStrategy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/SniHostIdentifiesNodeIdentificationStrategy.java
@@ -24,7 +24,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  *        must be resolvable and routable from the client's network).  A port number can be included.  If the port number is not included, the port number assigned
  *        to the bootstrapAddress is used.  One pattern is supported: {@code $(nodeId)} which interpolates the node id into the address (required).
  */
-public record SniHostIdentifiesNodeIdentificationStrategy(@NonNull @JsonProperty(required = true) HostPort bootstrapAddress,
+public record SniHostIdentifiesNodeIdentificationStrategy(@NonNull @JsonProperty(required = true) String bootstrapAddress,
                                                           @NonNull @JsonProperty(required = true) String advertisedBrokerAddressPattern)
         implements NodeIdentificationStrategy {
     public SniHostIdentifiesNodeIdentificationStrategy {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/PortPerBrokerClusterNetworkAddressConfigProvider.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/PortPerBrokerClusterNetworkAddressConfigProvider.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.plugin.Plugin;
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProviderService;
@@ -42,8 +43,8 @@ public class PortPerBrokerClusterNetworkAddressConfigProvider
 
     @NonNull
     @Override
-    public ClusterNetworkAddressConfigProvider build(PortPerBrokerClusterNetworkAddressConfigProviderConfig config) {
-        return new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider().build(config.rangeAwareConfig);
+    public ClusterNetworkAddressConfigProvider build(PortPerBrokerClusterNetworkAddressConfigProviderConfig config, VirtualClusterModel virtualCluster) {
+        return new RangeAwarePortPerNodeClusterNetworkAddressConfigProvider().build(config.rangeAwareConfig, virtualCluster);
     }
 
     /**

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.plugin.Plugin;
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProviderService;
@@ -30,7 +31,7 @@ import io.kroxylicious.proxy.service.HostPort;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-import static io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.BrokerAddressPatternUtils.EXPECTED_TOKEN_SET;
+import static io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.BrokerAddressPatternUtils.LITERAL_NODE_ID;
 import static io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.BrokerAddressPatternUtils.validatePortSpecifier;
 import static io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.BrokerAddressPatternUtils.validateStringContainsOnlyExpectedTokens;
 
@@ -58,7 +59,7 @@ public class RangeAwarePortPerNodeClusterNetworkAddressConfigProvider implements
 
     @NonNull
     @Override
-    public ClusterNetworkAddressConfigProvider build(RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig config) {
+    public ClusterNetworkAddressConfigProvider build(RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig config, VirtualClusterModel virtualCluster) {
         return new Provider(config);
     }
 
@@ -117,6 +118,8 @@ public class RangeAwarePortPerNodeClusterNetworkAddressConfigProvider implements
      * Creates the configuration for this provider.
      */
     public static class RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig {
+        private static final Set<String> ALLOWED_TOKEN_SET = Set.of(LITERAL_NODE_ID);
+
         private final HostPort bootstrapAddress;
         private final String nodeAddressPattern;
         private final int nodeStartPort;
@@ -174,7 +177,7 @@ public class RangeAwarePortPerNodeClusterNetworkAddressConfigProvider implements
             validatePortSpecifier(this.nodeAddressPattern, s -> {
                 throw new IllegalArgumentException("nodeAddressPattern cannot have port specifier.  Found port : " + s + " within " + this.nodeAddressPattern);
             });
-            validateStringContainsOnlyExpectedTokens(this.nodeAddressPattern, EXPECTED_TOKEN_SET, token -> {
+            validateStringContainsOnlyExpectedTokens(this.nodeAddressPattern, ALLOWED_TOKEN_SET, token -> {
                 throw new IllegalArgumentException("nodeAddressPattern contains an unexpected replacement token '" + token + "'");
             });
         }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/service/ClusterNetworkAddressConfigProviderService.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/service/ClusterNetworkAddressConfigProviderService.java
@@ -5,6 +5,8 @@
  */
 package io.kroxylicious.proxy.service;
 
+import io.kroxylicious.proxy.model.VirtualClusterModel;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -17,10 +19,12 @@ public interface ClusterNetworkAddressConfigProviderService<T> {
 
     /**
      * Build a cluster network address config provider
+     *
      * @param config config
+     * @param virtualCluster virtual cluster model
      * @return cluster network address config provider
      */
     @NonNull
-    ClusterNetworkAddressConfigProvider build(T config);
+    ClusterNetworkAddressConfigProvider build(T config, VirtualClusterModel virtualCluster);
 
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/PortIdentifiesNodeIdentificationStrategyTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/PortIdentifiesNodeIdentificationStrategyTest.java
@@ -9,9 +9,11 @@ package io.kroxylicious.proxy.config;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.RangeAwarePortPerNodeClusterNetworkAddressConfigProvider;
 import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.RangeAwarePortPerNodeClusterNetworkAddressConfigProvider.RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
 import io.kroxylicious.proxy.service.HostPort;
 
@@ -79,7 +81,7 @@ class PortIdentifiesNodeIdentificationStrategyTest {
     private ClusterNetworkAddressConfigProvider buildProvider(PortIdentifiesNodeIdentificationStrategy strategy) {
         var definition = strategy.get();
         return service.build(
-                ((RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig) definition.config()));
+                ((RangeAwarePortPerNodeClusterNetworkAddressConfigProviderConfig) definition.config()), Mockito.mock(VirtualClusterModel.class));
     }
 
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/SniHostIdentifiesNodeIdentificationStrategyTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/SniHostIdentifiesNodeIdentificationStrategyTest.java
@@ -7,11 +7,14 @@
 package io.kroxylicious.proxy.config;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.SniRoutingClusterNetworkAddressConfigProvider;
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings("removal")
 class SniHostIdentifiesNodeIdentificationStrategyTest {
@@ -20,7 +23,7 @@ class SniHostIdentifiesNodeIdentificationStrategyTest {
 
     @Test
     void providesDefinition() {
-        var strategy = new SniHostIdentifiesNodeIdentificationStrategy(HostPort.parse("boot:1234"), "mybroker-$(nodeId)");
+        var strategy = new SniHostIdentifiesNodeIdentificationStrategy("boot:1234", "mybroker-$(nodeId)");
         var definition = strategy.get();
         assertThat(definition.type()).isEqualTo(SniRoutingClusterNetworkAddressConfigProvider.class.getSimpleName());
     }
@@ -28,10 +31,33 @@ class SniHostIdentifiesNodeIdentificationStrategyTest {
     @Test
     void canConstructProviderFromDefinition() {
         var bootstrap = HostPort.parse("boot:1234");
-        var strategy = new SniHostIdentifiesNodeIdentificationStrategy(bootstrap, "mybroker-$(nodeId)");
+        var strategy = new SniHostIdentifiesNodeIdentificationStrategy(bootstrap.toString(), "mybroker-$(nodeId)");
         var definition = strategy.get();
 
-        var provider = service.build((SniRoutingClusterNetworkAddressConfigProvider.SniRoutingClusterNetworkAddressConfigProviderConfig) definition.config());
+        VirtualClusterModel mock = Mockito.mock(
+                VirtualClusterModel.class);
+        when(mock.getClusterName()).thenReturn("my-cluster");
+        var provider = service.build((SniRoutingClusterNetworkAddressConfigProvider.SniRoutingClusterNetworkAddressConfigProviderConfig) definition.config(),
+                mock);
         assertThat(provider.getClusterBootstrapAddress()).isEqualTo(bootstrap);
+    }
+
+    @Test
+    void canConstructProviderFromDefinitionWithClusterNameReplacementToken() {
+        String virtualClusterName = "my-cluster";
+        var bootstrap = HostPort.parse("boot:1234");
+        var strategy = new SniHostIdentifiesNodeIdentificationStrategy(bootstrap.toString(), "my-broker-$(virtualClusterName)-$(nodeId)");
+        var definition = strategy.get();
+
+        VirtualClusterModel mock = Mockito.mock(
+                VirtualClusterModel.class);
+        when(mock.getClusterName()).thenReturn(virtualClusterName);
+        var provider = service.build((SniRoutingClusterNetworkAddressConfigProvider.SniRoutingClusterNetworkAddressConfigProviderConfig) definition.config(),
+                mock);
+        assertThat(provider.getClusterBootstrapAddress()).isEqualTo(bootstrap);
+        assertThat(provider.getBrokerAddress(1)).isEqualTo(HostPort.parse("my-broker-my-cluster-1:1234"));
+        assertThat(provider.getBrokerIdFromBrokerAddress(HostPort.parse("my-broker-my-cluster-1:1234"))).isEqualTo(1);
+        assertThat(provider.getBrokerIdFromBrokerAddress(HostPort.parse("my-broker-another-cluster-1:1234"))).isNull();
+        assertThat(provider.getAdvertisedBrokerAddress(1)).isEqualTo(HostPort.parse("my-broker-my-cluster-1:1234"));
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyBackendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyBackendHandlerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.netty.buffer.Unpooled;
@@ -45,7 +46,8 @@ class KafkaProxyBackendHandlerTest {
     @SuppressWarnings("removal")
     private static final ClusterNetworkAddressConfigProvider ADDRESS_CONFIG_PROVIDER = new PortPerBrokerClusterNetworkAddressConfigProvider().build(
             new PortPerBrokerClusterNetworkAddressConfigProvider.PortPerBrokerClusterNetworkAddressConfigProviderConfig(new HostPort("localhost", 9090), "broker-", 9190,
-                    0, 10));
+                    0, 10),
+            Mockito.mock(VirtualClusterModel.class));
     @Mock
     ProxyChannelStateMachine proxyChannelStateMachine;
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/PortPerBrokerClusterNetworkAddressConfigProviderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/clusternetworkaddressconfigprovider/PortPerBrokerClusterNetworkAddressConfigProviderTest.java
@@ -13,7 +13,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
 
+import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.HostPort;
 
 import static io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.PortPerBrokerClusterNetworkAddressConfigProvider.PortPerBrokerClusterNetworkAddressConfigProviderConfig;
@@ -90,7 +92,8 @@ class PortPerBrokerClusterNetworkAddressConfigProviderTest {
     void portsExhausted() {
         var provider = new PortPerBrokerClusterNetworkAddressConfigProvider().build(
                 new PortPerBrokerClusterNetworkAddressConfigProviderConfig(parse("localhost:1235"),
-                        "localhost", 1236, 0, 1));
+                        "localhost", 1236, 0, 1),
+                Mockito.mock(VirtualClusterModel.class));
         assertThat(provider.getBrokerAddress(0)).isEqualTo(parse("localhost:1236"));
         assertThatThrownBy(() -> provider.getBrokerAddress(1))
                 .isInstanceOf(IllegalArgumentException.class);
@@ -99,7 +102,7 @@ class PortPerBrokerClusterNetworkAddressConfigProviderTest {
     @Test
     void defaultsBrokerPatternBasedOnBootstrapHost() {
         var provider = new PortPerBrokerClusterNetworkAddressConfigProvider().build(
-                new PortPerBrokerClusterNetworkAddressConfigProviderConfig(parse("mycluster:1235"), null, 1236, 0, 1237));
+                new PortPerBrokerClusterNetworkAddressConfigProviderConfig(parse("mycluster:1235"), null, 1236, 0, 1237), Mockito.mock(VirtualClusterModel.class));
         assertThat(provider.getClusterBootstrapAddress()).isEqualTo(parse("mycluster:1235"));
         assertThat(provider.getBrokerAddress(0)).isEqualTo(parse("mycluster:1236"));
     }
@@ -107,7 +110,7 @@ class PortPerBrokerClusterNetworkAddressConfigProviderTest {
     @Test
     void defaultsBrokerStartPortBasedOnBootstrapPort() {
         var provider = new PortPerBrokerClusterNetworkAddressConfigProvider().build(
-                new PortPerBrokerClusterNetworkAddressConfigProviderConfig(parse("mycluster:1235"), null, null, 0, 1237));
+                new PortPerBrokerClusterNetworkAddressConfigProviderConfig(parse("mycluster:1235"), null, null, 0, 1237), Mockito.mock(VirtualClusterModel.class));
         assertThat(provider.getClusterBootstrapAddress()).isEqualTo(parse("mycluster:1235"));
         assertThat(provider.getBrokerAddress(0)).isEqualTo(parse("mycluster:1236"));
     }
@@ -115,7 +118,7 @@ class PortPerBrokerClusterNetworkAddressConfigProviderTest {
     @Test
     void defaultsNumberOfBrokerPorts() {
         var provider = new PortPerBrokerClusterNetworkAddressConfigProvider().build(
-                new PortPerBrokerClusterNetworkAddressConfigProviderConfig(parse("mycluster:1235"), null, null, 0, null));
+                new PortPerBrokerClusterNetworkAddressConfigProviderConfig(parse("mycluster:1235"), null, null, 0, null), Mockito.mock(VirtualClusterModel.class));
         assertThat(provider.getClusterBootstrapAddress()).isEqualTo(parse("mycluster:1235"));
         assertThat(provider.getBrokerAddress(0)).isEqualTo(parse("mycluster:1236"));
         assertThat(provider.getBrokerAddress(1)).isEqualTo(parse("mycluster:1237"));
@@ -129,7 +132,7 @@ class PortPerBrokerClusterNetworkAddressConfigProviderTest {
     @Test
     void lowestTargetBrokerIdConfigurable() {
         var provider = new PortPerBrokerClusterNetworkAddressConfigProvider().build(
-                new PortPerBrokerClusterNetworkAddressConfigProviderConfig(parse("mycluster:1235"), null, null, 2, null));
+                new PortPerBrokerClusterNetworkAddressConfigProviderConfig(parse("mycluster:1235"), null, null, 2, null), Mockito.mock(VirtualClusterModel.class));
         assertThat(provider.getClusterBootstrapAddress()).isEqualTo(parse("mycluster:1235"));
         assertThat(provider.getBrokerAddress(2)).isEqualTo(parse("mycluster:1236"));
         assertThat(provider.getBrokerAddress(3)).isEqualTo(parse("mycluster:1237"));
@@ -144,7 +147,8 @@ class PortPerBrokerClusterNetworkAddressConfigProviderTest {
     void definesExclusiveAndSharedCorrectly() {
         var provider = new PortPerBrokerClusterNetworkAddressConfigProvider().build(
                 new PortPerBrokerClusterNetworkAddressConfigProviderConfig(parse("localhost:1235"),
-                        "localhost", 1236, 0, 2));
+                        "localhost", 1236, 0, 2),
+                Mockito.mock(VirtualClusterModel.class));
         assertThat(provider.getExclusivePorts()).containsExactlyInAnyOrder(1235, 1236, 1237);
         assertThat(provider.getSharedPorts()).isEmpty();
     }
@@ -153,7 +157,8 @@ class PortPerBrokerClusterNetworkAddressConfigProviderTest {
     void generatesBrokerAddresses() {
         var provider = new PortPerBrokerClusterNetworkAddressConfigProvider().build(
                 new PortPerBrokerClusterNetworkAddressConfigProviderConfig(parse("localhost:1235"),
-                        "localhost", 1236, 0, 3));
+                        "localhost", 1236, 0, 3),
+                Mockito.mock(VirtualClusterModel.class));
         assertThat(provider.getClusterBootstrapAddress()).isEqualTo(parse("localhost:1235"));
         assertThat(provider.getBrokerAddress(0)).isEqualTo(parse("localhost:1236"));
         assertThat(provider.getBrokerAddress(1)).isEqualTo(parse("localhost:1237"));
@@ -164,7 +169,8 @@ class PortPerBrokerClusterNetworkAddressConfigProviderTest {
         var provider = new PortPerBrokerClusterNetworkAddressConfigProvider().build(
                 new PortPerBrokerClusterNetworkAddressConfigProviderConfig(parse("cluster.kafka.example.com:1235"),
                         "broker.kafka.example.com", 1236,
-                        0, 1238));
+                        0, 1238),
+                Mockito.mock(VirtualClusterModel.class));
         assertThat(provider.getClusterBootstrapAddress()).isEqualTo(parse("cluster.kafka.example.com:1235"));
         assertThat(provider.getBrokerAddress(0)).isEqualTo(parse("broker.kafka.example.com:1236"));
         assertThat(provider.getBrokerAddress(1)).isEqualTo(parse("broker.kafka.example.com:1237"));
@@ -175,7 +181,8 @@ class PortPerBrokerClusterNetworkAddressConfigProviderTest {
         var provider = new PortPerBrokerClusterNetworkAddressConfigProvider().build(
                 new PortPerBrokerClusterNetworkAddressConfigProviderConfig(parse("cluster.kafka.example.com:1235"),
                         "broker$(nodeId).kafka.example.com",
-                        1236, 0, 1238));
+                        1236, 0, 1238),
+                Mockito.mock(VirtualClusterModel.class));
         assertThat(provider.getClusterBootstrapAddress()).isEqualTo(parse("cluster.kafka.example.com:1235"));
         assertThat(provider.getBrokerAddress(0)).isEqualTo(parse("broker0.kafka.example.com:1236"));
         assertThat(provider.getBrokerAddress(1)).isEqualTo(parse("broker1.kafka.example.com:1237"));

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterListenerModelTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterListenerModelTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
 
 import io.netty.buffer.ByteBufAllocator;
 
@@ -286,6 +287,6 @@ class VirtualClusterListenerModelTest {
                 parse("localhost:1235"),
                 "localhost", 19092, 0, 1);
         return new PortPerBrokerClusterNetworkAddressConfigProvider().build(
-                clusterNetworkAddressConfigProviderConfig);
+                clusterNetworkAddressConfigProviderConfig, Mockito.mock(VirtualClusterModel.class));
     }
 }

--- a/kubernetes-examples/network-topologies/snihostidentifiesnode_tls/base/kroxylicious/kroxylicious-config.yaml
+++ b/kubernetes-examples/network-topologies/snihostidentifiesnode_tls/base/kroxylicious/kroxylicious-config.yaml
@@ -15,7 +15,7 @@ data:
       endpoints:
         prometheus: {}
     virtualClusters:
-      - name: my-cluster-proxy
+      - name: mycluster-proxy
         targetCluster:
           bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9093
           tls:
@@ -26,8 +26,8 @@ data:
         gateways:
           - name: mygateway
             sniHostIdentifiesNode:
-              bootstrapAddress: mycluster-proxy.kafka:9092
-              advertisedBrokerAddressPattern: broker$(nodeId).mycluster-proxy.kafka
+              bootstrapAddress: $(virtualClusterName).kafka:9092
+              advertisedBrokerAddressPattern: broker$(nodeId).$(virtualClusterName).kafka
             tls:
               key:
                 storeFile: /opt/kroxylicious/server/key-material/keystore.p12


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

If `$(virtualClusterName)`is present in the `advertisedBrokerAddressPattern` (or deprecated `brokerAddressPattern`), then it is replaced with the nameof the gateway's VirtualCluster.

So if the `advertisedBrokerAddressPattern` is `$(virtualClusterName)-broker-$(nodeId).mycluster.com:443` and the
virtual cluster name is my-cluster, then the advertised address for node 3 will be `my-cluster-broker-3.mycluster.com:443`. The proxy will map `my-cluster-broker-3.mycluster.com` to node 3 for my-cluster when it
receives a connection.

If `$(virtualClusterName)` is present in the SNI `bootstrapAddress`, then it is replaced with the name of the gateway's VirtualCluster.

So if the bootstrapAddress is `$(virtualClusterName)-bootstrap.mycluster.com:9292` and the virtual cluster name is `my-cluster`, then the Proxy will map the SNI host `my-cluster-bootstrap.mycluster.com` to this gateway.

Why:
We want users of the operator to be able to define a single Ingress that defines the bootstrap address with a cluster name placeholder so that we can inject it into multiple virtual cluster's gateway configs. The configuration will be identical and not need the operator to know how to construct different configurations for each cluster.

Contributes towards #1833, as described [here in the design proposal](https://github.com/kroxylicious/design/blob/main/proposals/001-kroxylicious-operator-api-v1alpha.md#off-cluster-traffic-load-balancer).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
