### PR TITLE
Delete deprecated Tls constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Format `<github issue/pr number>: <short description>`.
 * Remove deprecated `SampleFetchResponseFilterFactory`. Use `SampleFetchResponse` instead.
 * Remove deprecated `ProduceRequestTransformationFilterFactory`. Use `ProduceRequestTransformation` instead.
 * Remove deprecated `FetchResponseTransformationFilterFactory`. Use `FetchResponseTransformation` instead.
+* Remove deprecated `io.kroxylicious.proxy.config.tls.Tls(KeyProvider, TrustProvider)` constructor.
 
 ## 0.12.0
 

--- a/kroxylicious-api/pom.xml
+++ b/kroxylicious-api/pom.xml
@@ -162,6 +162,7 @@
                         <breakBuildBasedOnSemanticVersioningForMajorVersionZero>${ApiCompatability.EnforceForMajorVersionZero}</breakBuildBasedOnSemanticVersioningForMajorVersionZero>
                         <excludes>
                             <exclude>io.kroxylicious.proxy.filter.FilterFactoryContext#eventLoop()</exclude> <!-- https://github.com/kroxylicious/kroxylicious/issues/1380 scheduled removal of deprecated API method -->
+                            <exclude>io.kroxylicious.proxy.config.tls.Tls#Tls(io.kroxylicious.proxy.config.tls.KeyProvider, io.kroxylicious.proxy.config.tls.TrustProvider)</exclude>
                             <!-- The following filter exclusions relate to RPCs that were removed at Kafka 4.0 -->
                             <exclude>io.kroxylicious.proxy.filter.ControlledShutdownRequestFilter</exclude>
                             <exclude>io.kroxylicious.proxy.filter.ControlledShutdownResponseFilter</exclude>

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/Tls.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/tls/Tls.java
@@ -22,30 +22,6 @@ public record Tls(KeyProvider key,
                   AllowDeny<String> cipherSuites,
                   AllowDeny<String> protocols) {
 
-    // Sundrio seems to need constructor order to matter, or it won't generate the with* methods for integration tests
-    // This can be removed once the old constructor is deprecated as unnecessary when the record will be generating it
-    public Tls(KeyProvider key, TrustProvider trust, AllowDeny<String> cipherSuites, AllowDeny<String> protocols) {
-        this.key = key;
-        this.trust = trust;
-        this.cipherSuites = cipherSuites;
-        this.protocols = protocols;
-    }
-
-    /**
-     * @deprecated use the all args constructor
-     * {@see io.kroxylicious.proxy.config.tls.Tls#Tls(
-     *      io.kroxylicious.proxy.config.tls.KeyProvider,
-     *      io.kroxylicious.proxy.config.tls.TrustProvider,
-     *      io.kroxylicious.proxy.config.tls.AllowDeny<String>,
-     *      io.kroxylicious.proxy.config.tls.AllowDeny<String>)
-     * }
-     */
-    // This is required for API backwards compatability
-    @Deprecated(forRemoval = true, since = "0.10.0")
-    public Tls(KeyProvider key, TrustProvider trust) {
-        this(key, trust, null, null);
-    }
-
     public static final String PEM = "PEM";
 
     public static String getStoreTypeOrPlatformDefault(String storeType) {


### PR DESCRIPTION
### Type of change

- Refactoring

### Additional Context

Deprecated in 0.10.0 and now eligible for deletion.

I've excluded the whole class from japicmp checking, I couldn't figure out how to just exclude the modified constructor.

I've not added a changelog since it was left there for API backwards compatibility, but the deletion doesn't affect the configuration API

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
