### PR TITLE
Delete deprecated bootstrapAddressPattern SNI gateway property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format `<github issue/pr number>: <short description>`.
 ## SNAPSHOT
 
 
+* [#2188](https://github.com/kroxylicious/kroxylicious/pull/2188) Delete deprecated bootstrapAddressPattern SNI gateway property
 * [#2186](https://github.com/kroxylicious/kroxylicious/pull/2186) Remove deprecated FilterFactory implementations
 * [#2164](https://github.com/kroxylicious/kroxylicious/issues/2164) Remove deprecated top-level configuration property filters
 * [#1871](https://github.com/kroxylicious/kroxylicious/issues/1871) Remove deprecated configuration property bootstrap_servers
@@ -24,6 +25,8 @@ Format `<github issue/pr number>: <short description>`.
 * Remove deprecated `ProduceRequestTransformationFilterFactory`. Use `ProduceRequestTransformation` instead.
 * Remove deprecated `FetchResponseTransformationFilterFactory`. Use `FetchResponseTransformation` instead.
 * Remove deprecated `io.kroxylicious.proxy.config.tls.Tls(KeyProvider, TrustProvider)` constructor.
+* Remove the deprecated configuration property `brokerAddressPattern` from `sniHostIdentifiesNode` gateway configuration. Use
+  `advertisedBrokerAddressPattern` instead.
 
 ## 0.12.0
 

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousConfigUtils.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousConfigUtils.java
@@ -184,7 +184,7 @@ public class KroxyliciousConfigUtils {
         }
         else if (providerDefinition.config() instanceof SniRoutingClusterNetworkAddressConfigProviderConfig sc) {
             var strategy = new SniHostIdentifiesNodeIdentificationStrategy(sc.getBootstrapAddress(),
-                    sc.getBrokerAddressPattern());
+                    sc.getAdvertisedBrokerAddressPattern());
 
             return Stream.of(new VirtualClusterGateway(DEFAULT_GATEWAY_NAME,
                     null, strategy, cluster.tls()));

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/SniHostIdentifiesNodeIdentificationStrategy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/SniHostIdentifiesNodeIdentificationStrategy.java
@@ -37,6 +37,6 @@ public record SniHostIdentifiesNodeIdentificationStrategy(@NonNull @JsonProperty
         // This code is bridging to the old model
         return new ClusterNetworkAddressConfigProviderDefinition(SniRoutingClusterNetworkAddressConfigProvider.class.getSimpleName(),
                 new SniRoutingClusterNetworkAddressConfigProviderConfig(bootstrapAddress(),
-                        null, advertisedBrokerAddressPattern()));
+                        advertisedBrokerAddressPattern()));
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -223,17 +223,6 @@ class ConfigParserTest {
                                     startInclusive: 0
                                     endExclusive: 1
                         """),
-                Arguments.argumentSet("Virtual cluster (SniRouting - deprecated)", """
-                        virtualClusters:
-                          - name: demo1
-                            targetCluster:
-                              bootstrapServers: kafka.example:1234
-                            clusterNetworkAddressConfigProvider:
-                              type: SniRoutingClusterNetworkAddressConfigProvider
-                              config:
-                                bootstrapAddress: cluster1:9192
-                                brokerAddressPattern: broker$(nodeId)
-                        """),
                 Arguments.argumentSet("Filters", """
                         filterDefinitions:
                         - name: myfilter


### PR DESCRIPTION
It was deprecated in 0.10.0 and is eligible for deletion.

### Type of change

- Refactoring

### Description

Delete deprecated bootstrapAddressPattern property on `SniRoutingClusterNetworkAddressConfigProviderConfig`

### Additional Context

It was deprecated in 0.10.0 and is eligible for deletion.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
