### PR TITLE
[System Tests] removed the kroxylicious operand dependency for system tests

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -333,13 +333,9 @@ has been applied ineffectively.
 * [OPTIONAL] aws cli ([install guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)): in case an AWS Cloud account is used for KMS.
 
 ### Environment variables
-* `KROXYLICIOUS_REGISTRY`: url to the registry where the image of kroxylicious is located. Default value: `quay.io`
-* `KROXYLICIOUS_ORG`: name of the organisation in the registry where kroxylicious is located. Default value: `kroxylicious`
-* `KROXYLICIOUS_IMAGE_NAME`: name of the image of kroxylicious to be used. Default value: `kroxylicious`
 * `KROXYLICIOUS_OPERATOR_REGISTRY`: url to the registry where the image of kroxylicious operator is located. Default value: `quay.io`
 * `KROXYLICIOUS_OPERATOR_ORG`: name of the organisation in the registry where kroxylicious operator is located. Default value: `kroxylicious`
 * `KROXYLICIOUS_OPERATOR_IMAGE_NAME`: name of the image of kroxylicious operator to be used. Default value: `operator`
-* `KROXYLICIOUS_VERSION`: version of kroxylicious to be used. Default value: `${project.version}` in pom file
 * `KROXYLICIOUS_OPERATOR_VERSION`: version of kroxylicious operator to be used. Default value: `${project.version}` in pom file
 * `KAFKA_VERSION`: kafka version to be used. Default value: `${kafka.version}` in pom file
 * `STRIMZI_VERSION`: strimzi version to be used. Default value: `${strimzi.version}` in pom file

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
@@ -143,9 +143,7 @@ public final class Constants {
     /**
      * Scraper pod labels
      */
-    public static final String SCRAPER_LABEL_KEY = "user-test-app";
     public static final String SCRAPER_LABEL_VALUE = "scraper";
-    public static final String SCRAPER_NAME = "Scraper";
 
     /**
      * Basic paths to examples

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
@@ -82,7 +82,6 @@ public class Environment {
     /**
      * The url where kroxylicious image lives to be downloaded.
      */
-    private static final String KROXYLICIOUS_IMAGE_REPO_DEFAULT = "quay.io/kroxylicious/kroxylicious";
     private static final String KROXYLICIOUS_OPERATOR_IMAGE_REPO_DEFAULT = "quay.io/kroxylicious/operator";
 
     /**

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
@@ -35,12 +35,8 @@ public class Environment {
      */
     private static final String KAFKA_VERSION_ENV = "KAFKA_VERSION";
     private static final String KROXYLICIOUS_OPERATOR_IMAGE_ENV = "KROXYLICIOUS_OPERATOR_IMAGE_NAME";
-    private static final String KROXYLICIOUS_IMAGE_ENV = "KROXYLICIOUS_IMAGE_NAME";
-    private static final String KROXYLICIOUS_ORG_ENV = "KROXYLICIOUS_ORG";
     private static final String KROXYLICIOUS_OPERATOR_ORG_ENV = "KROXYLICIOUS_OPERATOR_ORG";
-    private static final String KROXYLICIOUS_REGISTRY_ENV = "KROXYLICIOUS_REGISTRY";
     private static final String KROXYLICIOUS_OPERATOR_REGISTRY_ENV = "KROXYLICIOUS_OPERATOR_REGISTRY";
-    private static final String KROXYLICIOUS_VERSION_ENV = "KROXYLICIOUS_VERSION";
     private static final String KROXYLICIOUS_OPERATOR_VERSION_ENV = "KROXYLICIOUS_OPERATOR_VERSION";
     public static final String SKIP_TEARDOWN_ENV = "SKIP_TEARDOWN";
     private static final String CONTAINER_CONFIG_PATH_ENV = "CONTAINER_CONFIG_PATH";
@@ -93,11 +89,8 @@ public class Environment {
      * The default value for skipping the teardown locally.
      */
     private static final boolean SKIP_TEARDOWN_DEFAULT = false;
-    public static final String KROXYLICIOUS_IMAGE_DEFAULT = KROXYLICIOUS_IMAGE_REPO_DEFAULT.split("/")[2];
     public static final String KROXYLICIOUS_OPERATOR_IMAGE_DEFAULT = KROXYLICIOUS_OPERATOR_IMAGE_REPO_DEFAULT.split("/")[2];
-    public static final String KROXYLICIOUS_ORG_DEFAULT = KROXYLICIOUS_IMAGE_REPO_DEFAULT.split("/")[1];
     public static final String KROXYLICIOUS_OPERATOR_ORG_DEFAULT = KROXYLICIOUS_OPERATOR_IMAGE_REPO_DEFAULT.split("/")[1];
-    public static final String KROXYLICIOUS_REGISTRY_DEFAULT = KROXYLICIOUS_IMAGE_REPO_DEFAULT.split("/")[0];
     public static final String KROXYLICIOUS_OPERATOR_REGISTRY_DEFAULT = KROXYLICIOUS_OPERATOR_IMAGE_REPO_DEFAULT.split("/")[0];
     private static final String CONTAINER_CONFIG_PATH_DEFAULT = System.getProperty("user.home") + "/.docker/config.json";
     private static final boolean SKIP_STRIMZI_INSTALL_DEFAULT = false;
@@ -118,7 +111,6 @@ public class Environment {
     /**
      * KROXYLICIOUS_VERSION env variable assignment
      */
-    public static final String KROXYLICIOUS_VERSION = ENVIRONMENT_VARIABLES.getOrDefault(KROXYLICIOUS_VERSION_ENV, KROXYLICIOUS_VERSION_DEFAULT);
     public static final String KROXYLICIOUS_OPERATOR_VERSION = ENVIRONMENT_VARIABLES.getOrDefault(KROXYLICIOUS_OPERATOR_VERSION_ENV, KROXYLICIOUS_VERSION_DEFAULT);
 
     /**
@@ -152,11 +144,8 @@ public class Environment {
 
     public static final String AWS_REGION = ENVIRONMENT_VARIABLES.getOrDefault(AWS_REGION_ENV, AWS_REGION_DEFAULT);
 
-    public static final String KROXYLICIOUS_IMAGE = ENVIRONMENT_VARIABLES.getOrDefault(KROXYLICIOUS_IMAGE_ENV, KROXYLICIOUS_IMAGE_DEFAULT);
     public static final String KROXYLICIOUS_OPERATOR_IMAGE = ENVIRONMENT_VARIABLES.getOrDefault(KROXYLICIOUS_OPERATOR_IMAGE_ENV, KROXYLICIOUS_OPERATOR_IMAGE_DEFAULT);
-    public static final String KROXYLICIOUS_ORG = ENVIRONMENT_VARIABLES.getOrDefault(KROXYLICIOUS_ORG_ENV, KROXYLICIOUS_ORG_DEFAULT);
     public static final String KROXYLICIOUS_OPERATOR_ORG = ENVIRONMENT_VARIABLES.getOrDefault(KROXYLICIOUS_OPERATOR_ORG_ENV, KROXYLICIOUS_OPERATOR_ORG_DEFAULT);
-    public static final String KROXYLICIOUS_REGISTRY = ENVIRONMENT_VARIABLES.getOrDefault(KROXYLICIOUS_REGISTRY_ENV, KROXYLICIOUS_REGISTRY_DEFAULT);
     public static final String KROXYLICIOUS_OPERATOR_REGISTRY = ENVIRONMENT_VARIABLES.getOrDefault(KROXYLICIOUS_OPERATOR_REGISTRY_ENV,
             KROXYLICIOUS_OPERATOR_REGISTRY_DEFAULT);
 

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/MetricsST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/MetricsST.java
@@ -128,8 +128,10 @@ class MetricsST extends AbstractST {
     @SuppressWarnings("java:S2925")
     @BeforeEach
     void beforeEach(String namespace) throws InterruptedException {
-        final String scraperName = namespace + "-" + Constants.SCRAPER_LABEL_VALUE;
-        resourceManager.createResourceFromBuilderWithWait(ScraperTemplates.scraperPod(namespace, scraperName));
+        final String scraperName = Constants.SCRAPER_LABEL_VALUE;
+
+        ScraperTemplates.deployPortIdentifiesNodeWithNoFilters(namespace, scraperName);
+//        resourceManager.createResourceFromBuilderWithWait(ScraperTemplates.scraperPod(namespace, scraperName));
         cluster.setNamespace(namespace);
 
         LOGGER.atInfo().setMessage("Sleeping for {} seconds to give operators and operands some time to stabilize before collecting metrics.")

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/MetricsST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/MetricsST.java
@@ -131,7 +131,6 @@ class MetricsST extends AbstractST {
         final String scraperName = Constants.SCRAPER_LABEL_VALUE;
 
         ScraperTemplates.deployPortIdentifiesNodeWithNoFilters(namespace, scraperName);
-//        resourceManager.createResourceFromBuilderWithWait(ScraperTemplates.scraperPod(namespace, scraperName));
         cluster.setNamespace(namespace);
 
         LOGGER.atInfo().setMessage("Sleeping for {} seconds to give operators and operands some time to stabilize before collecting metrics.")


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

After making system test cases to use the operator, there were `MetricsST` system tests that was dependent of the kroxylicious operand installation.

With this change we get rid of this dependency and make it simpler.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [x] Update documentation
- [x] Make sure all unit/integration tests pass
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [x] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [x] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
