### PR TITLE
Require VirtualCluster name to be a valid DNS label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format `<github issue/pr number>: <short description>`.
 ## SNAPSHOT
 
 
+* [#2198](https://github.com/kroxylicious/kroxylicious/pull/2198) Require VirtualCluster name to be a valid DNS label
 * [#2188](https://github.com/kroxylicious/kroxylicious/pull/2188) Delete deprecated bootstrapAddressPattern SNI gateway property
 * [#2186](https://github.com/kroxylicious/kroxylicious/pull/2186) Remove deprecated FilterFactory implementations
 * [#2164](https://github.com/kroxylicious/kroxylicious/issues/2164) Remove deprecated top-level configuration property filters
@@ -27,6 +28,7 @@ Format `<github issue/pr number>: <short description>`.
 * Remove deprecated `io.kroxylicious.proxy.config.tls.Tls(KeyProvider, TrustProvider)` constructor.
 * Remove the deprecated configuration property `brokerAddressPattern` from `sniHostIdentifiesNode` gateway configuration. Use
   `advertisedBrokerAddressPattern` instead.
+* VirtualCluster names are now restricted to a maximum length of 63, and must match pattern `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` (case insensitive).
 
 ## 0.12.0
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -121,13 +122,14 @@ public record Configuration(
     private void validateNoDuplicatedClusterNames(List<VirtualCluster> clusters) {
         var names = clusters.stream()
                 .map(VirtualCluster::name)
+                .map(name -> name.toLowerCase(Locale.ROOT))
                 .toList();
         var duplicates = names.stream()
                 .filter(i -> Collections.frequency(names, i) > 1)
                 .collect(Collectors.toSet());
         if (!duplicates.isEmpty()) {
             throw new IllegalConfigurationException(
-                    "Virtual cluster must be unique. The following virtual cluster names are duplicated: [%s]".formatted(
+                    "Virtual cluster must be unique (case insensitive). The following virtual cluster names are duplicated: [%s]".formatted(
                             String.join(", ", duplicates)));
         }
     }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -477,7 +477,36 @@ class ConfigParserTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasCauseInstanceOf(JsonMappingException.class) // Debatable to enforce the wrapped JsonMappingException
                 .cause()
-                .hasMessageContaining("Virtual cluster must be unique. The following virtual cluster names are duplicated: [demo1]");
+                .hasMessageContaining("Virtual cluster must be unique (case insensitive). The following virtual cluster names are duplicated: [demo1]");
+    }
+
+    @Test
+    void shouldDetectDuplicateClusterNodeNamesCaseInsensitively() {
+        // Given
+        assertThatThrownBy(() ->
+        // When
+        configParser.parseConfiguration("""
+                virtualClusters:
+                  - name: demo1
+                    targetCluster:
+                      bootstrapServers: kafka.example:1234
+                    gateways:
+                    - name: default
+                      portIdentifiesNode:
+                        bootstrapAddress: cluster1:9192
+                  - name: dEmO1
+                    targetCluster:
+                      bootstrapServers: magic-kafka.example:1234
+                    gateways:
+                    - name: default
+                      portIdentifiesNode:
+                        bootstrapAddress: cluster1:9192
+                """))
+                // Then
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasCauseInstanceOf(JsonMappingException.class) // Debatable to enforce the wrapped JsonMappingException
+                .cause()
+                .hasMessageContaining("Virtual cluster must be unique (case insensitive). The following virtual cluster names are duplicated: [demo1]");
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/VirtualClusterTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/VirtualClusterTest.java
@@ -8,16 +8,24 @@ package io.kroxylicious.proxy.config;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.google.common.base.Strings;
 
 import io.kroxylicious.proxy.config.tls.Tls;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 @ExtendWith(MockitoExtension.class)
 class VirtualClusterTest {
@@ -105,5 +113,50 @@ class VirtualClusterTest {
         assertThatThrownBy(() -> new VirtualCluster("mycluster", targetCluster, null, null, gateways, false, false, NO_FILTERS))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("Gateway names for a virtual cluster must be unique. The following gateway names are duplicated: [dup]");
+    }
+
+    public static Stream<Arguments> rejectVirtualClusterNamesThatArentDnsLabels() {
+        return Stream.of(argumentSet("hyphen at start", "-cluster"),
+                argumentSet("hyphen at end", "cluster-"),
+                argumentSet("hyphen at start and end", "-cluster-"),
+                argumentSet("too long", Strings.repeat("a", 64)));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void rejectVirtualClusterNamesThatArentDnsLabels(String clusterName) {
+        // Given
+        var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
+
+        // When
+        // Then
+        assertThatThrownBy(() -> {
+            new VirtualCluster(clusterName, targetCluster, null, null, gateways, false, false, NO_FILTERS);
+        }).isInstanceOf(IllegalConfigurationException.class)
+                .hasMessageContaining("Virtual cluster name '" + clusterName
+                        + "' is invalid. It must be less than 64 characters long and match pattern ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ (case insensitive)");
+    }
+
+    public static Stream<Arguments> acceptVirtualClusterNamesThatAreDnsLabels() {
+        return Stream.of(argumentSet("start with number", "1a"),
+                argumentSet("start with alpha", "a1"),
+                argumentSet("start with uppercase alpha", "A1"),
+                argumentSet("alphabetical only", "a"),
+                argumentSet("uppercase alphabetical only", "A"),
+                argumentSet("contains hyphen", "a-b"),
+                argumentSet("max length", Strings.repeat("a", 63)));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void acceptVirtualClusterNamesThatAreDnsLabels(String clusterName) {
+        // Given
+        var gateways = List.of(new VirtualClusterGateway("mygateway1", portIdentifiesNode1, null, Optional.empty()));
+
+        // When
+        // Then
+        assertThatCode(() -> {
+            new VirtualCluster(clusterName, targetCluster, null, null, gateways, false, false, NO_FILTERS);
+        }).doesNotThrowAnyException();
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/config/FeaturesTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/config/FeaturesTest.java
@@ -22,6 +22,7 @@ import io.kroxylicious.proxy.config.VirtualCluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class FeaturesTest {
 
@@ -65,7 +66,9 @@ class FeaturesTest {
     @MethodSource
     @SuppressWarnings("java:S5738")
     void supportsValidTestConfiguration(Features features, Map<String, Object> config) {
-        Configuration configuration = new Configuration(null, List.of(), List.of(), List.of(mock(VirtualCluster.class)), null, false, Optional.ofNullable(config));
+        VirtualCluster mockCluster = mock(VirtualCluster.class);
+        when(mockCluster.name()).thenReturn("test");
+        Configuration configuration = new Configuration(null, List.of(), List.of(), List.of(mockCluster), null, false, Optional.ofNullable(config));
         List<String> errorMessages = features.supports(configuration);
         assertThat(errorMessages).isEmpty();
     }
@@ -74,7 +77,9 @@ class FeaturesTest {
     @SuppressWarnings("java:S5738")
     void supportsReturnsErrorOnTestConfigurationPresentWithFeatureDisabled() {
         Optional<Map<String, Object>> a = Optional.of(Map.of("a", "b"));
-        Configuration configuration = new Configuration(null, List.of(), List.of(), List.of(mock(VirtualCluster.class)), null, false, a);
+        VirtualCluster mockCluster = mock(VirtualCluster.class);
+        when(mockCluster.name()).thenReturn("test");
+        Configuration configuration = new Configuration(null, List.of(), List.of(), List.of(mockCluster), null, false, a);
         List<String> errors = Features.defaultFeatures().supports(configuration);
         assertThat(errors).containsExactly("test-only configuration for proxy present, but loading test-only configuration not enabled");
     }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Require that VirtualCluster names are valid DNS labels by [RFC 1123](https://www.rfc-editor.org/rfc/rfc1123) & [RFC 952](https://www.rfc-editor.org/rfc/rfc952.txt)

The cluster name must be:
* at most 63 characters (for maximum compatibility)
* start with a number or letter
* end with a number or letter
* can contain numbers/letters/hyphen

We also require that VirtualCluster names are unique case-insensitively, to prevent any ambiguity. Ie the user cannot have clusters named `my-cluster` and `mY-cLuStEr` in the same proxy configuration.

Why:

Originally suggested by Keith [here](https://github.com/kroxylicious/kroxylicious/pull/2185#discussion_r2094077954) during review.

We want to [support placeholders for SNI](https://github.com/kroxylicious/kroxylicious/pull/2185) where the user can substitute their virtual cluster name into the bootstrap address and advertisedBrokerHostNames config. This could introduce a new class of problems if we can inject virtual cluster names that are not valid DNS labels. Leading to failures in awkward places like in the Kafka client.

By requiring this naming convention in the Proxy we can be sure that it's always safe to inject the cluster name as a DNS label.

For additional comparison, here's the error spat out of k8s when you try to create a namespace with an invalid name:
```
Invalid value: "kafka^#@": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
```
though they require it to be lowercase

Contributes towards https://github.com/kroxylicious/kroxylicious/issues/1833, as described [here in the design proposal](https://github.com/kroxylicious/design/blob/main/proposals/001-kroxylicious-operator-api-v1alpha.md#off-cluster-traffic-load-balancer).

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
