### PR TITLE
operator: require cluster name plus ingress name to be <= 51 chars

### DIFF
--- a/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
+++ b/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/virtualkafkaclusters.kroxylicious.io-v1.yml
@@ -55,6 +55,9 @@ spec:
       schema:
         openAPIV3Schema:
           type: object
+          x-kubernetes-validations:
+            - rule: "self.spec.ingresses.all(ingress, (ingress.ingressRef.name.size() + self.metadata.name.size()) <= 51)"
+              message: "the total length of the virtual cluster name and the ingress name must not exceed 51 characters"
           properties:
             metadata:
               type: object

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/CustomResourceValidationIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/CustomResourceValidationIT.java
@@ -89,6 +89,20 @@ class CustomResourceValidationIT {
     @MethodSource
     @ParameterizedTest
     void testDerivedResourceInputsValid(Path validYaml) {
+        testValid(validYaml);
+    }
+
+    public static Stream<Path> testResourceValid() {
+        return TestFiles.recursiveFilesInDirectoryForTest(CustomResourceValidationIT.class, "valid-*.yaml").stream();
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void testResourceValid(Path validYaml) {
+        testValid(validYaml);
+    }
+
+    private static void testValid(Path validYaml) {
         try (InputStream is = Files.newInputStream(validYaml)) {
             NamespaceableResource<HasMetadata> resource = OperatorTestUtils.kubeClient().resource(is);
             Assertions.assertThatCode(resource::create).doesNotThrowAnyException();

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/ingresses/invalid-ingresses-ingressRef.name-plus-cluster-name-exceeds-51-characters.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/ingresses/invalid-ingresses-ingressRef.name-plus-cluster-name-exceeds-51-characters.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: VirtualKafkaCluster
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: abcdefghijklmnopqrstuvwxyz
+    namespace: proxy-ns
+  spec:
+    proxyRef:
+      name: proxy
+    targetKafkaServiceRef:
+      name: serviceName
+    filterRefs:
+      - name: filter
+    ingresses:
+      - ingressRef:
+          name: 'abcdefghijklmnopqrstuvwxyz'
+expectFailureMessageToContain: |
+  the total length of the virtual cluster name and the ingress name must not exceed 51 characters

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/ingresses/valid-ingresses-ingressRef.name-plus-cluster-name-exactly-51-characters.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/virtualkafkacluster/ingresses/valid-ingresses-ingressRef.name-plus-cluster-name-exactly-51-characters.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: VirtualKafkaCluster
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: abcdefghijklmnopqrstuvwxyz
+  namespace: proxy-ns
+spec:
+  proxyRef:
+    name: proxy
+  targetKafkaServiceRef:
+    name: serviceName
+  filterRefs:
+    - name: filter
+  ingresses:
+    - ingressRef:
+        name: 'abcdefghijklmnopqrstuvwxy'


### PR DESCRIPTION

### Type of change

- Bugfix

### Description

For all VKC ingresses require that `length(ingressRef.name) + length(vkc.metadata.name) <= 51`.

### Additional Context

When constructing a clusterIP ingress we currently use the vkc name plus the kpi name with a hyphen between them. A k8s service name must be 63 characters or less. We want to reserve 11 characters to allow the possibility for injecting node ids up to integer max for clusterIP SNI access, leaving 52 characters available for the names (and a hyphen).

Partially addresses #2205 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
