### PR TITLE
[Fix #2146] operator: only consider fresh referent ResolvedRefs conditions

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigStateDependentResource.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyConfigStateDependentResource.java
@@ -93,7 +93,7 @@ public class ProxyConfigStateDependentResource
 
     private static void addResolvedRefsConditions(VirtualKafkaClusterStatusFactory statusFactory, ProxyModel proxyModel, ProxyConfigStateData data) {
         proxyModel.resolutionResult().clusterResolutionResults().stream()
-                .filter(result -> !result.allReferentsFullyResolved() || ResourcesUtil.hasResolvedRefsFalseCondition(result.cluster()))
+                .filter(result -> !result.allReferentsFullyResolved() || ResourcesUtil.hasFreshResolvedRefsFalseCondition(result.cluster()))
                 .forEach(clusterResolutionResult -> {
                     VirtualKafkaCluster cluster = clusterResolutionResult.cluster();
                     VirtualKafkaCluster patch;
@@ -111,9 +111,9 @@ public class ProxyConfigStateDependentResource
                     }
                     else {
                         Stream<LocalRef<?>> referentsWithResolvedRefsFalse = clusterResolutionResult.allResolvedReferents()
-                                .filter(ResourcesUtil::hasResolvedRefsFalseCondition)
+                                .filter(ResourcesUtil::hasFreshResolvedRefsFalseCondition)
                                 .map(ResourcesUtil::toLocalRef);
-                        Stream<LocalRef<?>> clusterWithResolvedRefsTrue = ResourcesUtil.hasResolvedRefsFalseCondition(clusterResolutionResult.cluster())
+                        Stream<LocalRef<?>> clusterWithResolvedRefsTrue = ResourcesUtil.hasFreshResolvedRefsFalseCondition(clusterResolutionResult.cluster())
                                 ? Stream.of(ResourcesUtil.toLocalRef(
                                         clusterResolutionResult.cluster()))
                                 : Stream.of();

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconciler.java
@@ -66,8 +66,8 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import static io.fabric8.kubernetes.api.model.HasMetadata.getKind;
 import static io.kroxylicious.kubernetes.api.common.Condition.Type.ResolvedRefs;
 import static io.kroxylicious.kubernetes.operator.ProxyConfigStateDependentResource.CONFIG_STATE_CONFIG_MAP_SUFFIX;
+import static io.kroxylicious.kubernetes.operator.ResourcesUtil.hasFreshResolvedRefsFalseCondition;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.hasKind;
-import static io.kroxylicious.kubernetes.operator.ResourcesUtil.hasResolvedRefsFalseCondition;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.namespace;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.toLocalRef;
@@ -295,16 +295,16 @@ public final class VirtualKafkaClusterReconciler implements
             return statusFactory.newFalseConditionStatusPatch(cluster, Condition.Type.ResolvedRefs, Condition.REASON_REFS_NOT_FOUND,
                     joiningMessages(proxyMsg, serviceMsg, ingressMsg, filterMsg));
         }
-        else if (clusterResolutionResult.allResolvedReferents().anyMatch(ResourcesUtil::hasResolvedRefsFalseCondition) || !unresolvedIngressProxies.isEmpty()) {
+        else if (clusterResolutionResult.allResolvedReferents().anyMatch(ResourcesUtil::hasFreshResolvedRefsFalseCondition) || !unresolvedIngressProxies.isEmpty()) {
             Stream<String> serviceMsg = refsMessage("spec.targetKafkaServiceRef references ", cluster,
-                    clusterResolutionResult.allResolvedReferents().filter(hasResolvedRefsFalseCondition().and(hasKind(KAFKA_SERVICE_KIND)))
+                    clusterResolutionResult.allResolvedReferents().filter(hasFreshResolvedRefsFalseCondition().and(hasKind(KAFKA_SERVICE_KIND)))
                             .map(ResourcesUtil::toLocalRef));
             Stream<String> ingressMsg = refsMessage("spec.ingresses[].ingressRef references ", cluster,
                     clusterResolutionResult.allResolvedReferents()
-                            .filter(hasResolvedRefsFalseCondition().and(hasKind(KAFKA_PROXY_INGRESS_KIND))).map(ResourcesUtil::toLocalRef));
+                            .filter(hasFreshResolvedRefsFalseCondition().and(hasKind(KAFKA_PROXY_INGRESS_KIND))).map(ResourcesUtil::toLocalRef));
             Stream<String> filterMsg = refsMessage("spec.filterRefs references ", cluster,
                     clusterResolutionResult.allResolvedReferents()
-                            .filter(hasResolvedRefsFalseCondition().and(hasKind(KAFKA_PROTOCOL_FILTER_KIND)))
+                            .filter(hasFreshResolvedRefsFalseCondition().and(hasKind(KAFKA_PROTOCOL_FILTER_KIND)))
                             .map(ResourcesUtil::toLocalRef));
             Stream<String> ingressProxyMessage = refsMessage("a spec.ingresses[].ingressRef had an inconsistent or missing proxyRef ", cluster,
                     clusterResolutionResult.allDanglingReferences()

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/ProxyModelBuilder.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/ProxyModelBuilder.java
@@ -45,7 +45,7 @@ public class ProxyModelBuilder {
         // that we know are unacceptable due to unresolved dependencies.
         ProxyIngressModel ingressModel = IngressAllocator.allocateProxyIngressModel(primary, resolutionResult);
         List<ClusterResolutionResult> clustersWithValidIngresses = resolutionResult.allResolutionResultsInClusterNameOrder()
-                .filter(clusterResolutionResult -> clusterResolutionResult.allReferentsFullyResolved() && !ResourcesUtil.hasResolvedRefsFalseCondition(
+                .filter(clusterResolutionResult -> clusterResolutionResult.allReferentsFullyResolved() && !ResourcesUtil.hasFreshResolvedRefsFalseCondition(
                         clusterResolutionResult.cluster()))
                 .filter(result -> ingressModel.clusterIngressModel(result.cluster()).map(i -> i.ingressExceptions().isEmpty()).orElse(false))
                 .toList();

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ClusterResolutionResult.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ClusterResolutionResult.java
@@ -50,7 +50,7 @@ public record ClusterResolutionResult(VirtualKafkaCluster cluster,
      */
     public boolean allReferentsFullyResolved() {
         return allDanglingReferences().findAny().isEmpty() && allResolvedReferents()
-                .noneMatch(ResourcesUtil::hasResolvedRefsFalseCondition);
+                .noneMatch(ResourcesUtil::hasFreshResolvedRefsFalseCondition);
     }
 
     /**

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ProxyResolutionResult.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/resolver/ProxyResolutionResult.java
@@ -37,7 +37,7 @@ public class ProxyResolutionResult {
      */
     public List<VirtualKafkaCluster> fullyResolvedClustersInNameOrder() {
         return clustersSatisfying(
-                clusterResolutionResult -> clusterResolutionResult.allReferentsFullyResolved() && !ResourcesUtil.hasResolvedRefsFalseCondition(
+                clusterResolutionResult -> clusterResolutionResult.allReferentsFullyResolved() && !ResourcesUtil.hasFreshResolvedRefsFalseCondition(
                         clusterResolutionResult.cluster()));
     }
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerTest.java
@@ -359,7 +359,7 @@ class VirtualKafkaClusterReconcilerTest {
                     .withType(Condition.Type.ResolvedRefs)
                     .withStatus(Condition.Status.FALSE)
                     .withLastTransitionTime(Instant.now())
-                    .withObservedGeneration(1L)
+                    .withObservedGeneration(SERVICE.getMetadata().getGeneration())
                     .withReason("NO_FILTERS")
                     .withMessage("no filters found")
                     .endCondition().endStatus().build()));
@@ -395,7 +395,7 @@ class VirtualKafkaClusterReconcilerTest {
                     Set.of(new KafkaProxyIngressBuilder(INGRESS).withNewStatus().addNewCondition().withType(Condition.Type.ResolvedRefs)
                             .withStatus(Condition.Status.FALSE)
                             .withLastTransitionTime(Instant.now())
-                            .withObservedGeneration(1L)
+                            .withObservedGeneration(INGRESS.getMetadata().getGeneration())
                             .withReason("NO_FILTERS")
                             .withMessage("no filters found")
                             .endCondition().endStatus().build()));
@@ -435,7 +435,7 @@ class VirtualKafkaClusterReconcilerTest {
                     .withType(Condition.Type.ResolvedRefs)
                     .withStatus(Condition.Status.FALSE)
                     .withLastTransitionTime(Instant.now())
-                    .withObservedGeneration(1L)
+                    .withObservedGeneration(FILTER_MY_FILTER.getMetadata().getGeneration())
                     .withReason("RESOLVE_FAILURE")
                     .withMessage("failed to resolve")
                     .endCondition().endStatus().build()));


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

When we are observing Referent resources to determine if they have a status condition declaring that that referent has unresolved dependencies, we should only consider fresh conditions where the observedGeneration of the condition is the same as the metadata.generation of the referent. A ResolvedRefs condition for an older generation is not material to the decision as it doesn't reflect the current spec.

Note that we have other means to prevent the aggregating reconcilers processing referents with stale statuses, this covers the case where the status is fresh, but it contains a stale condition for whatever reason.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
