### PR TITLE
Push filter names down into logging and exceptions

### DIFF
--- a/kroxylicious-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-multitenant/src/test/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilterTest.java
@@ -37,6 +37,7 @@ import com.flipkart.zjsonpatch.JsonDiff;
 import com.google.common.reflect.ClassPath;
 import com.google.common.reflect.ClassPath.ResourceInfo;
 
+import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
 import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.FilterInvoker;
@@ -87,7 +88,7 @@ class MultiTenantFilterTest {
 
     private final MultiTenantFilter filter = new MultiTenantFilter(new MultiTenantConfig(null));
 
-    private final FilterInvoker invoker = getOnlyElement(FilterAndInvoker.build(filter)).invoker();
+    private final FilterInvoker invoker = getOnlyElement(FilterAndInvoker.build(((Filter) filter).getClass().getSimpleName(), filter)).invoker();
 
     @Mock(strictness = LENIENT)
     private FilterContext context;

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/bootstrap/FilterChainFactory.java
@@ -157,13 +157,17 @@ public class FilterChainFactory implements AutoCloseable {
      *
      * @return the new chain.
      */
-    public List<FilterAndInvoker> createFilters(FilterFactoryContext context, @Nullable List<NamedFilterDefinition> filterChain) {
+    public List<FilterAndInvoker> createFilters(FilterFactoryContext context,
+                                                @Nullable List<NamedFilterDefinition> filterChain) {
         if (filterChain == null) {
             return List.of();
         }
         return filterChain
                 .stream()
-                .flatMap(filterDefinition -> FilterAndInvoker.build(initialized.get(filterDefinition.name()).create(context)).stream())
+                .flatMap(filterDefinition -> FilterAndInvoker.build(
+                        filterDefinition.name(),
+                        initialized.get(filterDefinition.name()).create(context))
+                        .stream())
                 .toList();
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/filter/FilterAndInvoker.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/filter/FilterAndInvoker.java
@@ -12,10 +12,11 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * A Filter and it's respective invoker
- * @param filter filter
- * @param invoker invoker
+ * @param filterName The name of the filter (from the config)
+ * @param filter filter The filter instance
+ * @param invoker invoker The invoker
  */
-public record FilterAndInvoker(Filter filter, FilterInvoker invoker) {
+public record FilterAndInvoker(String filterName, Filter filter, FilterInvoker invoker) {
 
     /**
      * A Filter and it's respective invoker
@@ -32,7 +33,16 @@ public record FilterAndInvoker(Filter filter, FilterInvoker invoker) {
      * @param filter filter
      * @return a filter and its respective invoker
      */
-    public static List<FilterAndInvoker> build(Filter filter) {
-        return FilterInvokers.from(filter);
+    public static List<FilterAndInvoker> build(String filterName, Filter filter) {
+        return FilterInvokers.from(filterName, filter);
+    }
+
+    @Override
+    public String toString() {
+        return "FilterAndInvoker{" +
+                "filter='" + filterName + '\'' +
+                ", filterClass='" + filter.getClass().getSimpleName() + '\'' +
+                ", invoker=" + invoker +
+                '}';
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -489,6 +489,8 @@ public class KafkaProxyFrontendHandler
             pipeline.addFirst("ssl", handler);
         });
 
+        LOGGER.debug("Configured broker channel pipeline: {}", pipeline);
+
         serverTcpConnectFuture.addListener(future -> {
             if (future.isSuccess()) {
                 LOGGER.trace("{}: Outbound connected", clientCtx().channel().id());
@@ -612,10 +614,13 @@ public class KafkaProxyFrontendHandler
                                       List<FilterAndInvoker> filters,
                                       ChannelPipeline pipeline,
                                       Channel inboundChannel) {
+        int num = 0;
         for (var protocolFilter : filters) {
             // TODO configurable timeout
+            // Handler name must be unique, but filters are allowed to appear multiple times
+            String handlerName = "filter-" + (++num) + "-" + protocolFilter.filterName();
             pipeline.addFirst(
-                    protocolFilter.toString(),
+                    handlerName,
                     new FilterHandler(
                             protocolFilter,
                             20000,

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -264,16 +264,16 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
         @Override
         public void selectServer(NetFilter.NetFilterContext context) {
             List<FilterAndInvoker> apiVersionFilters = decodePredicate.isAuthenticationOffloadEnabled() ? List.of()
-                    : FilterAndInvoker.build(apiVersionsIntersectFilter);
+                    : FilterAndInvoker.build("ApiVersionsIntersect (internal)", apiVersionsIntersectFilter);
 
             NettyFilterContext filterContext = new NettyFilterContext(ch.eventLoop(), pfr);
             List<FilterAndInvoker> filterChain = filterChainFactory.createFilters(filterContext, filterDefinitions);
-            List<FilterAndInvoker> brokerAddressFilters = FilterAndInvoker.build(new BrokerAddressFilter(gateway, endpointReconciler));
+            List<FilterAndInvoker> brokerAddressFilters = FilterAndInvoker.build("BrokerAddress (internal)", new BrokerAddressFilter(gateway, endpointReconciler));
             var filters = new ArrayList<>(apiVersionFilters);
-            filters.addAll(FilterAndInvoker.build(apiVersionsDowngradeFilter));
+            filters.addAll(FilterAndInvoker.build("ApiVersionsDowngrade (internal)", apiVersionsDowngradeFilter));
             filters.addAll(filterChain);
             if (binding.restrictUpstreamToMetadataDiscovery()) {
-                filters.addAll(FilterAndInvoker.build(new EagerMetadataLearner()));
+                filters.addAll(FilterAndInvoker.build("EagerMetadataLearner (internal)", new EagerMetadataLearner()));
             }
             filters.addAll(brokerAddressFilters);
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/filter/FilterInvokersTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/filter/FilterInvokersTest.java
@@ -26,13 +26,13 @@ class FilterInvokersTest {
     @ParameterizedTest
     @MethodSource("invalidFilters")
     void testInvalidFilters(Filter invalid) {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> FilterInvokers.from(invalid));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> FilterInvokers.from("invalid", invalid));
     }
 
     @ParameterizedTest
     @MethodSource("validFilters")
     void testValidFilters(Filter invalid) {
-        assertThat(FilterInvokers.from(invalid)).isNotNull();
+        assertThat(FilterInvokers.from("valid", invalid)).isNotNull();
     }
 
     public static Stream<Filter> invalidFilters() {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
@@ -91,7 +91,7 @@ public abstract class FilterHarness {
                     return d2;
                 })) // reverses order
                 .stream()
-                .map(f -> new FilterHandler(getOnlyElement(FilterAndInvoker.build(f)), timeoutMs, null, testVirtualCluster, inboundChannel))
+                .map(f -> new FilterHandler(getOnlyElement(FilterAndInvoker.build(f.getClass().getSimpleName(), f)), timeoutMs, null, testVirtualCluster, inboundChannel))
                 .map(ChannelHandler.class::cast);
         var handlers = Stream.concat(channelProcessors, filterHandlers);
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilterTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilterTest.java
@@ -34,6 +34,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.flipkart.zjsonpatch.JsonDiff;
 import com.google.common.reflect.ClassPath;
 
+import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
 import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.FilterInvoker;
@@ -104,7 +105,7 @@ class BrokerAddressFilterTest {
     @BeforeEach
     public void beforeEach() {
         filter = new BrokerAddressFilter(virtualClusterListenerModel, endpointReconciler);
-        invoker = getOnlyElement(FilterAndInvoker.build(filter)).invoker();
+        invoker = getOnlyElement(FilterAndInvoker.build(((Filter) filter).getClass().getSimpleName(), filter)).invoker();
         lenient().when(virtualClusterListenerModel.getBrokerAddress(0)).thenReturn(HostPort.parse("downstream:19199"));
         lenient().when(virtualClusterListenerModel.getAdvertisedBrokerAddress(0)).thenReturn(HostPort.parse("downstream:19200"));
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

In the proxy, filters are now named explicitly by the user in the configuration file. This PR makes use of those filter names in logging and exception messages. This change should make it easier for users to understand which filter these messages are about if we're referring to filters using their naming.

