### PR TITLE
Operator: Name each gateway in the proxy configuration after the underlying ingress

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconciler.java
@@ -289,7 +289,7 @@ public class KafkaProxyReconciler implements
 
         NodeIdentificationStrategy nodeIdentificationStrategy = gateway.nodeIdentificationStrategy();
         if (nodeIdentificationStrategy instanceof PortIdentifiesNodeIdentificationStrategy port) {
-            return new ConfigurationFragment<>(new VirtualClusterGateway("default",
+            return new ConfigurationFragment<>(new VirtualClusterGateway(name(gateway.ingress()),
                     port,
                     null,
                     tlsConfigFragment.fragment()), volumes, mounts);

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
@@ -290,7 +290,7 @@ class KafkaProxyReconcilerIT {
         AWAIT.alias("proxy config - gateway configured with node id ranges from KafkaService").untilAsserted(() -> {
             ProxyConfigAssert.ProxyConfigPortIdentifiesNodeGatewayAssert portIdentifiesNodeGatewayAssert = assertProxyConfigInConfigMap(proxy)
                     .cluster(clusterBar.getMetadata().getName())
-                    .gateway("default")
+                    .gateway(name(ingressBar))
                     .portIdentifiesNode()
                     .hasBootstrapAddress(new HostPort("localhost", expectedBootstrapPort))
                     .hasNullNodeStartPort();
@@ -364,17 +364,17 @@ class KafkaProxyReconcilerIT {
         clusterBar = updateStatusObservedGeneration(clusterBar);
         Set<VirtualKafkaCluster> clusters = Set.of(clusterBar);
         assertProxyConfigContents(proxy, Set.of(CLUSTER_BAR_BOOTSTRAP, filter.getSpec().getType()), Set.of());
-        assertDefaultVirtualClusterGatewayConfigured(proxy, clusterBar);
+        assertDefaultVirtualClusterGatewayConfigured(proxy, ingressBar, clusterBar);
         assertDeploymentMountsConfigMap(proxy, ProxyConfigDependentResource.configMapName(proxy));
         assertDeploymentBecomesReady(proxy);
         assertServiceTargetsProxyInstances(proxy, clusterBar, ingressBar);
         return new CreatedResources(proxy, clusters, kafkaServices, Set.of(ingressBar));
     }
 
-    private void assertDefaultVirtualClusterGatewayConfigured(KafkaProxy proxy, VirtualKafkaCluster clusterBar) {
+    private void assertDefaultVirtualClusterGatewayConfigured(KafkaProxy proxy, KafkaProxyIngress ingressBar, VirtualKafkaCluster clusterBar) {
         AWAIT.alias("gateway configured as expected").untilAsserted(() -> {
             assertProxyConfigInConfigMap(proxy).cluster(clusterBar.getMetadata().getName())
-                    .gateway("default")
+                    .gateway(name(ingressBar))
                     .portIdentifiesNode()
                     .hasBootstrapAddress(new HostPort("localhost", 9292))
                     .hasNullNodeStartPort()

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/model/networking/ClusterIPClusterIngressNetworkingModelTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/model/networking/ClusterIPClusterIngressNetworkingModelTest.java
@@ -145,7 +145,7 @@ class ClusterIPClusterIngressNetworkingModelTest {
 
         // then
         assertThat(gateway).isNotNull();
-        assertThat(gateway.name()).isEqualTo("default");
+        assertThat(gateway.name()).isEqualTo(INGRESS_NAME);
         assertThat(gateway.tls()).isEmpty();
         assertThat(gateway.sniHostIdentifiesNode()).isNull();
         assertThat(gateway.portIdentifiesNode()).isNotNull().satisfies(portIdentifiesNode -> {
@@ -297,7 +297,7 @@ class ClusterIPClusterIngressNetworkingModelTest {
 
         // then
         assertThat(gateway).isNotNull();
-        assertThat(gateway.name()).isEqualTo("default");
+        assertThat(gateway.name()).isEqualTo(INGRESS_NAME);
         assertThat(gateway.tls()).isEmpty();
         assertThat(gateway.sniHostIdentifiesNode()).isNull();
         assertThat(gateway.portIdentifiesNode()).isNotNull().satisfies(portIdentifiesNode -> {
@@ -332,7 +332,7 @@ class ClusterIPClusterIngressNetworkingModelTest {
 
         // then
         assertThat(gateway).isNotNull();
-        assertThat(gateway.name()).isEqualTo("default");
+        assertThat(gateway.name()).isEqualTo(INGRESS_NAME);
         assertThat(gateway.tls()).isEmpty();
         assertThat(gateway.sniHostIdentifiesNode()).isNull();
         assertThat(gateway.portIdentifiesNode()).isNotNull().satisfies(portIdentifiesNode -> {

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-ConfigMap-example-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-ConfigMap-example-proxy-config.yaml
@@ -50,7 +50,7 @@ data:
       targetCluster:
         bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
       gateways:
-      - name: "default"
+      - name: "cluster-ip"
         portIdentifiesNode:
           bootstrapAddress: "localhost:9292"
           advertisedBrokerAddressPattern: "foo-cluster-ip.proxy-ns.svc.cluster.local"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/kafka-service-with-tls/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/kafka-service-with-tls/out-ConfigMap-minimal-proxy-config.yaml
@@ -51,7 +51,7 @@ data:
             denied:
             - "TLS1.2"
       gateways:
-      - name: "default"
+      - name: "cluster-ip"
         portIdentifiesNode:
           bootstrapAddress: "localhost:9292"
           advertisedBrokerAddressPattern: "one-cluster-ip.proxy-ns.svc.cluster.local"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-ConfigMap-minimal-proxy-config.yaml
@@ -31,7 +31,7 @@ data:
       targetCluster:
         bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
       gateways:
-      - name: "default"
+      - name: "cluster-ip"
         portIdentifiesNode:
           bootstrapAddress: "localhost:9292"
           advertisedBrokerAddressPattern: "one-cluster-ip.proxy-ns.svc.cluster.local"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-ConfigMap-twocluster-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-ConfigMap-twocluster-proxy-config.yaml
@@ -31,7 +31,7 @@ data:
       targetCluster:
         bootstrapServers: "first-kafka.kafka1.svc.cluster.local:9092"
       gateways:
-      - name: "default"
+      - name: "cluster-ip-bar"
         portIdentifiesNode:
           bootstrapAddress: "localhost:9292"
           advertisedBrokerAddressPattern: "bar-cluster-ip-bar.proxy-ns.svc.cluster.local"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-ConfigMap-twocluster-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-ConfigMap-twocluster-proxy-config.yaml
@@ -31,7 +31,7 @@ data:
       targetCluster:
         bootstrapServers: "first-kafka.kafka1.svc.cluster.local:9092"
       gateways:
-      - name: "default"
+      - name: "cluster-ip-bar"
         portIdentifiesNode:
           bootstrapAddress: "localhost:9292"
           advertisedBrokerAddressPattern: "bar-cluster-ip-bar.proxy-ns.svc.cluster.local"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-ConfigMap-example-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-ConfigMap-example-proxy-config.yaml
@@ -42,7 +42,7 @@ data:
       targetCluster:
         bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
       gateways:
-      - name: "default"
+      - name: "cluster-ip"
         portIdentifiesNode:
           bootstrapAddress: "localhost:9292"
           advertisedBrokerAddressPattern: "foo-cluster-ip.proxy-ns.svc.cluster.local"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-ConfigMap-use-pod-template-spec-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-ConfigMap-use-pod-template-spec-proxy-config.yaml
@@ -31,7 +31,7 @@ data:
       targetCluster:
         bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
       gateways:
-      - name: "default"
+      - name: "cluster-ip"
         portIdentifiesNode:
           bootstrapAddress: "localhost:9292"
           advertisedBrokerAddressPattern: "one-cluster-ip.proxy-ns.svc.cluster.local"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-ConfigMap-minimal-proxy-config.yaml
@@ -31,7 +31,7 @@ data:
       targetCluster:
         bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
       gateways:
-      - name: "default"
+      - name: "cluster-ip"
         portIdentifiesNode:
           bootstrapAddress: "localhost:9292"
           advertisedBrokerAddressPattern: "one-cluster-ip.proxy-ns.svc.cluster.local"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-ConfigMap-minimal-proxy-config.yaml
@@ -31,7 +31,7 @@ data:
       targetCluster:
         bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
       gateways:
-      - name: "default"
+      - name: "cluster-ip"
         portIdentifiesNode:
           bootstrapAddress: "localhost:9292"
           advertisedBrokerAddressPattern: "one-cluster-ip.proxy-ns.svc.cluster.local"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-ConfigMap-minimal-proxy-config.yaml
@@ -31,7 +31,7 @@ data:
       targetCluster:
         bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
       gateways:
-      - name: "default"
+      - name: "cluster-ip"
         portIdentifiesNode:
           bootstrapAddress: "localhost:9292"
           advertisedBrokerAddressPattern: "one-cluster-ip.proxy-ns.svc.cluster.local"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-ConfigMap-minimal-proxy-config.yaml
@@ -31,7 +31,7 @@ data:
       targetCluster:
         bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
       gateways:
-      - name: "default"
+      - name: "cluster-ip"
         portIdentifiesNode:
           bootstrapAddress: "localhost:9292"
           advertisedBrokerAddressPattern: "one-cluster-ip.proxy-ns.svc.cluster.local"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-ConfigMap-minimal-proxy-config.yaml
@@ -31,7 +31,7 @@ data:
       targetCluster:
         bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
       gateways:
-      - name: "default"
+      - name: "cluster-ip"
         portIdentifiesNode:
           bootstrapAddress: "localhost:9292"
           advertisedBrokerAddressPattern: "one-cluster-ip.proxy-ns.svc.cluster.local"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-ConfigMap-minimal-proxy-config.yaml
@@ -31,7 +31,7 @@ data:
       targetCluster:
         bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
       gateways:
-      - name: "default"
+      - name: "cluster-ip"
         portIdentifiesNode:
           bootstrapAddress: "localhost:9292"
           advertisedBrokerAddressPattern: "one-cluster-ip.proxy-ns.svc.cluster.local"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Why:
When we add multiple ingresses to a VKC the gateways in the Proxy Configuration configmap all get named "default", which explodes in the Operator when we assemble the proxy config as it's not allowed.

This is preparation for adding further ingress types where we will want to have a clusterIP ingress and a LoadBalancer ingress for the same VKC.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
