### PR TITLE
Edit the ksfkaproxyingress via the same k8s client as created it.

### DIFF
--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/manager/ResourceManager.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/manager/ResourceManager.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.systemtests.resources.manager;
 
 import java.util.Arrays;
+import java.util.function.Consumer;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -128,5 +129,9 @@ public class ResourceManager {
     @SafeVarargs
     public final void createOrUpdateResourceWithWait(Builder<? extends HasMetadata>... resources) {
         KubeResourceManager.get().createOrUpdateResourceWithWait(Arrays.stream(resources).map(Builder::build).toList().toArray(new HasMetadata[0]));
+    }
+
+    public <T extends HasMetadata> void replaceResourceWithRetries(T resource, Consumer<T> editor) {
+        KubeResourceManager.get().replaceResourceWithRetries(resource, editor, 3);
     }
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Another attempt to make the OperatorChangeDetection system test pass reliably.

### Additional Context

After merging #2203 the system test run on main failed. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
