### PR TITLE
Revert "Bump io.javaoperatorsdk:operator-framework-bom from 5.0.4 to 5.1.0"

### DIFF
--- a/kroxylicious-kubernetes-api/pom.xml
+++ b/kroxylicious-kubernetes-api/pom.xml
@@ -27,7 +27,7 @@
     </description>
 
     <properties>
-        <josdk.version>5.1.0</josdk.version>
+        <josdk.version>5.0.4</josdk.version>
         <log4j.version>2.20.0</log4j.version>
         <fabric8-client.version>7.1.0</fabric8-client.version>
         <lombok.version>1.18.38</lombok.version>

--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -19,7 +19,7 @@
     <artifactId>kroxylicious-operator</artifactId>
 
     <properties>
-        <josdk.version>5.1.0</josdk.version>
+        <josdk.version>5.0.4</josdk.version>
         <prometheus-metrics.version>1.3.7</prometheus-metrics.version>
         <io.kroxylicious.operator.image.name>quay.io/kroxylicious/operator:${project.version}</io.kroxylicious.operator.image.name>
         <io.kroxylicious.operator.image.archive>target/kroxylicious-operator.img.tar.gz</io.kroxylicious.operator.image.archive>


### PR DESCRIPTION
Reverts kroxylicious/kroxylicious#2220

We are seeing a lot of system test failures at the moment so reverting this out of an abundance of caution while we finalise the operator for release.