### PR TITLE
Fix #2235: Avoid potential for NPE if virtual cluster defines TLS without trust anchor

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconciler.java
@@ -466,6 +466,7 @@ public final class VirtualKafkaClusterReconciler implements
                 cluster.getSpec().getIngresses().stream()
                         .flatMap(ingress -> Optional.ofNullable(ingress.getTls()).stream())
                         .map(Tls::getTrustAnchorRef)
+                        .filter(Objects::nonNull)
                         .map(TrustAnchorRef::getRef)
                         .toList());
     }
@@ -478,6 +479,7 @@ public final class VirtualKafkaClusterReconciler implements
                 cluster -> cluster.getSpec().getIngresses().stream()
                         .flatMap(ingress -> Optional.ofNullable(ingress.getTls()).stream())
                         .map(Tls::getTrustAnchorRef)
+                        .filter(Objects::nonNull)
                         .map(TrustAnchorRef::getRef)
                         .toList());
     }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerTest.java
@@ -764,12 +764,24 @@ class VirtualKafkaClusterReconcilerTest {
     }
 
     @Test
-    void canMapFromVirtualKafkaClusterWithoutTrustAnchorToConfigMap() {
+    void canMapFromVirtualKafkaClusterWithTlsToConfigMap() {
         // Given
         var mapper = VirtualKafkaClusterReconciler.virtualKafkaClusterToConfigMap();
 
         // When
         var secondaryResourceIDs = mapper.toSecondaryResourceIDs(CLUSTER_NO_FILTERS);
+
+        // Then
+        assertThat(secondaryResourceIDs).isEmpty();
+    }
+
+    @Test
+    void canMapFromVirtualKafkaClusterWithoutTrustAnchorToConfigMap() {
+        // Given
+        var mapper = VirtualKafkaClusterReconciler.virtualKafkaClusterToConfigMap();
+
+        // When
+        var secondaryResourceIDs = mapper.toSecondaryResourceIDs(CLUSTER_TLS_NO_FILTERS);
 
         // Then
         assertThat(secondaryResourceIDs).isEmpty();
@@ -792,6 +804,19 @@ class VirtualKafkaClusterReconcilerTest {
     void canMapFromConfigMapToVirtualKafkaClusterToleratesVirtualKafkaClusterWithoutTls() {
         // Given
         EventSourceContext<VirtualKafkaCluster> eventSourceContext = mockContextContaining(CLUSTER_NO_FILTERS);
+
+        // When
+        var mapper = VirtualKafkaClusterReconciler.configMapToVirtualKafkaCluster(eventSourceContext);
+
+        // Then
+        var primaryResourceIDs = mapper.toPrimaryResourceIDs(PEM_CONFIG_MAP);
+        assertThat(primaryResourceIDs).isEmpty();
+    }
+
+    @Test
+    void canMapFromConfigMapToVirtualKafkaClusterToleratesVirtualKafkaClusterWithoutTrustAnchor() {
+        // Given
+        EventSourceContext<VirtualKafkaCluster> eventSourceContext = mockContextContaining(CLUSTER_TLS_NO_FILTERS);
 
         // When
         var mapper = VirtualKafkaClusterReconciler.configMapToVirtualKafkaCluster(eventSourceContext);


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Avoid potential for NPE if virtual cluster defines TLS without trust anchor.  Fixes issue discovered by #2235.
### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
