### PR TITLE
Revert "Update quay.io/apicurio/apicurio-registry-mem Docker tag to v2.6.9.Final"

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/validation/JsonSchemaRecordValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/validation/JsonSchemaRecordValidationIT.java
@@ -108,7 +108,7 @@ class JsonSchemaRecordValidationIT extends RecordValidationBaseIT {
     @BeforeAll
     public static void init() throws IOException {
         // An Apicurio Registry instance is required for this test to work, so we start one using a Generic Container
-        DockerImageName dockerImageName = DockerImageName.parse("quay.io/apicurio/apicurio-registry-mem:2.6.9.Final");
+        DockerImageName dockerImageName = DockerImageName.parse("quay.io/apicurio/apicurio-registry-mem:2.6.8.Final");
 
         Consumer<CreateContainerCmd> cmd = e -> e.withPortBindings(
                 new PortBinding(Ports.Binding.bindPort(APICURIO_REGISTRY_PORT), new ExposedPort(APICURIO_REGISTRY_PORT)));


### PR DESCRIPTION
Merged in error.   Let's hold this upgrade with #2253 until 0.14.0.
 Reverts kroxylicious/kroxylicious#2248
