### PR TITLE
Simplify mocking in VirtualKafkaClusterReconcilerTest

### DIFF
--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconcilerTest.java
@@ -111,8 +111,6 @@ class VirtualKafkaClusterReconcilerTest {
             .endSpec()
             .build();
 
-    private static final ConfigMap NO_FILTERS_CONFIG_MAP=buildProxyConfigMapWithPatch(CLUSTER_NO_FILTERS);
-
     private static final VirtualKafkaCluster CLUSTER_TLS_NO_FILTERS = new VirtualKafkaClusterBuilder(CLUSTER_NO_FILTERS)
             .editOrNewSpec()
                 .withIngresses(new IngressesBuilder(CLUSTER_NO_FILTERS.getSpec().getIngresses().get(0))
@@ -256,6 +254,8 @@ class VirtualKafkaClusterReconcilerTest {
             .addToData("ca-bundle.pem", "value")
             .build();
     // @formatter:on
+
+    private static final ConfigMap NO_FILTERS_CONFIG_MAP = buildProxyConfigMapWithPatch(CLUSTER_NO_FILTERS);
 
     private static final ManagedWorkflowAndDependentResourceContext workflowContext = mock(ManagedWorkflowAndDependentResourceContext.class);
     private VirtualKafkaClusterReconciler virtualKafkaClusterReconciler;


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Simplify the unit test so its easier to add other references.

### Additional Context

While working on #2234 I noticed there was a lot of boiler plate code, now thats merged I wanted to take a look at what could be simplified so it was easier to look at the strategic fix for #2211.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
