### PR TITLE
Refactor to allow unit test #2266 (SNI hostname mismatch errors don't close connections)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#2268](https://github.com/kroxylicious/kroxylicious/issues/2268) Ensure downstream connection is closed if proxy cannot match SNI hostname against a virtual cluster
 * [#2185](https://github.com/kroxylicious/kroxylicious/pull/2185) Add $(virtualClusterName) placeholders to SNI bootstrap address and advertised broker address pattern
 * [#2198](https://github.com/kroxylicious/kroxylicious/pull/2198) Require VirtualCluster name to be a valid DNS label
 * [#2188](https://github.com/kroxylicious/kroxylicious/pull/2188) Delete deprecated bootstrapAddressPattern SNI gateway property

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -97,7 +97,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
 
         ChannelPipeline pipeline = ch.pipeline();
 
-        var serverSocketChannel = (ServerSocketChannel) ch.parent();
+        var serverSocketChannel = getAcceptingChannel(ch);
         var serverSocketAddress = serverSocketChannel.localAddress();
         int targetPort = serverSocketAddress.getPort();
         var bindingAddress = serverSocketAddress.getAddress().isAnyLocalAddress() ? Optional.<String> empty()
@@ -109,6 +109,11 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
             initPlainChannel(ch, pipeline, bindingAddress, targetPort);
         }
         addLoggingErrorHandler(pipeline);
+    }
+
+    @VisibleForTesting
+    protected ServerSocketChannel getAcceptingChannel(Channel ch) {
+        return (ServerSocketChannel) ch.parent();
     }
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -15,11 +15,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.micrometer.core.instrument.Counter;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
-import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.handler.codec.haproxy.HAProxyMessageDecoder;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
@@ -52,7 +53,7 @@ import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import static io.kroxylicious.proxy.internal.util.Metrics.KROXYLICIOUS_CLIENT_TO_PROXY_ERROR_TOTAL_METER_PROVIDER;
 
-public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
+public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProxyInitializer.class);
 
@@ -90,15 +91,17 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
     }
 
     @Override
-    public void initChannel(SocketChannel ch) {
+    public void initChannel(Channel ch) {
 
         LOGGER.trace("Connection from {} to my address {}", ch.remoteAddress(), ch.localAddress());
 
         ChannelPipeline pipeline = ch.pipeline();
 
-        int targetPort = ch.localAddress().getPort();
-        var bindingAddress = ch.parent().localAddress().getAddress().isAnyLocalAddress() ? Optional.<String> empty()
-                : Optional.of(ch.localAddress().getAddress().getHostAddress());
+        var serverSocketChannel = (ServerSocketChannel) ch.parent();
+        var serverSocketAddress = serverSocketChannel.localAddress();
+        int targetPort = serverSocketAddress.getPort();
+        var bindingAddress = serverSocketAddress.getAddress().isAnyLocalAddress() ? Optional.<String> empty()
+                : Optional.of(serverSocketAddress.getAddress().getHostAddress());
         if (tls) {
             initTlsChannel(ch, pipeline, bindingAddress, targetPort);
         }
@@ -109,7 +112,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
     }
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    private void initPlainChannel(SocketChannel ch, ChannelPipeline pipeline, Optional<String> bindingAddress, int targetPort) {
+    private void initPlainChannel(Channel ch, ChannelPipeline pipeline, Optional<String> bindingAddress, int targetPort) {
         pipeline.addLast("plainResolver", new ChannelInboundHandlerAdapter() {
             @Override
             public void channelActive(ChannelHandlerContext ctx) {
@@ -138,7 +141,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
 
     // deep inheritance tree of SniHandler not something we can fix
     @SuppressWarnings({ "OptionalUsedAsFieldOrParameterType", "java:S110" })
-    private void initTlsChannel(SocketChannel ch, ChannelPipeline pipeline, Optional<String> bindingAddress, int targetPort) {
+    private void initTlsChannel(Channel ch, ChannelPipeline pipeline, Optional<String> bindingAddress, int targetPort) {
         LOGGER.debug("Adding SSL/SNI handler");
         pipeline.addLast("sniResolver", new SniHandler((sniHostname, promise) -> {
             try {
@@ -193,7 +196,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
     }
 
     @VisibleForTesting
-    void addHandlers(SocketChannel ch, EndpointBinding binding) {
+    void addHandlers(Channel ch, EndpointBinding binding) {
         var virtualCluster = binding.endpointGateway().virtualCluster();
         ChannelPipeline pipeline = ch.pipeline();
         pipeline.remove(LOGGING_INBOUND_ERROR_HANDLER_NAME);
@@ -261,7 +264,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
     static class InitalizerNetFilter implements NetFilter {
 
         private final SaslDecodePredicate decodePredicate;
-        private final SocketChannel ch;
+        private final Channel ch;
         private final EndpointGateway gateway;
         private final EndpointBinding binding;
         private final PluginFactoryRegistry pfr;
@@ -272,7 +275,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<SocketChannel> {
         private final ApiVersionsDowngradeFilter apiVersionsDowngradeFilter;
 
         InitalizerNetFilter(SaslDecodePredicate decodePredicate,
-                            SocketChannel ch,
+                            Channel ch,
                             EndpointBinding binding,
                             PluginFactoryRegistry pfr,
                             FilterChainFactory filterChainFactory,

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -26,10 +26,12 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.DefaultChannelId;
 import io.netty.channel.EventLoop;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.socket.ServerSocketChannel;
@@ -38,6 +40,7 @@ import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.MessageToByteEncoder;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SniHandler;
+import io.netty.util.internal.StringUtil;
 
 import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
 import io.kroxylicious.proxy.config.ServiceBasedPluginFactoryRegistry;
@@ -50,6 +53,7 @@ import io.kroxylicious.proxy.internal.filter.ApiVersionsIntersectFilter;
 import io.kroxylicious.proxy.internal.net.Endpoint;
 import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointBindingResolver;
+import io.kroxylicious.proxy.internal.net.EndpointResolutionException;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.service.ClusterNetworkAddressConfigProvider;
 import io.kroxylicious.proxy.service.HostPort;
@@ -57,6 +61,7 @@ import io.kroxylicious.proxy.service.HostPort;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static io.kroxylicious.proxy.internal.KafkaProxyInitializer.LOGGING_INBOUND_ERROR_HANDLER_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -289,6 +294,38 @@ class KafkaProxyInitializerTest {
         // Then
         verify(channelPipeline).addLast(anyString(), isA(SniHandler.class));
         assertErrorHandlerAdded();
+    }
+
+    @Test
+    void shouldCloseConnectionOnUnrecognizedSniHostName() {
+        // Given
+        var endpointBindingResolver = mock(EndpointBindingResolver.class);
+        var embeddedChannel = new EmbeddedChannel(serverSocketChannel, DefaultChannelId.newInstance(), true, false);
+        kafkaProxyInitializer = createKafkaProxyInitializer(true, endpointBindingResolver, Map.of());
+        kafkaProxyInitializer.initChannel(embeddedChannel);
+        when(endpointBindingResolver.resolve(any(), eq("chat4.leancloud.cn"))).thenReturn(CompletableFuture.failedStage(new EndpointResolutionException("not resolved")));
+
+        // lifted from the Netty tests
+        // hex dump of a client hello packet, which contains hostname "CHAT4.LEANCLOUD.CN"
+        String tlsHandshakeMessageHex1 = "16030100";
+        // part 2
+        String tlsHandshakeMessageHex = "c6010000c20303bb0855d66532c05a0ef784f7c384feeafa68b3" +
+                "b655ac7288650d5eed4aa3fb52000038c02cc030009fcca9cca8ccaac02b" +
+                "c02f009ec024c028006bc023c0270067c00ac0140039c009c0130033009d" +
+                "009c003d003c0035002f00ff010000610000001700150000124348415434" +
+                "2e4c45414e434c4f55442e434e000b000403000102000a000a0008001d00" +
+                "170019001800230000000d0020001e060106020603050105020503040104" +
+                "0204030301030203030201020202030016000000170000";
+        assertThat(embeddedChannel.isOpen())
+                .isTrue();
+
+        // When
+        embeddedChannel.writeInbound(Unpooled.wrappedBuffer(StringUtil.decodeHexDump(tlsHandshakeMessageHex1)),
+                Unpooled.wrappedBuffer(StringUtil.decodeHexDump(tlsHandshakeMessageHex)));
+
+        // Then
+        assertThat(embeddedChannel.isOpen())
+                .isFalse();
     }
 
     @Test


### PR DESCRIPTION
### Type of change


- Enhancement / new feature

### Description

Refactored the `KafkaProxyInitializer` to allow it to be unit tested with Netty's `EmbeddedChannel`.
Added new test case testing the case where the SNI hostname in the TLS hello doesn't match a virtual cluster (the bug fixed by #2266).


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
