### PR TITLE
Operator: Change TLS ClusterIP to use SNI  node identification mechanism instead of port-identifies-node

### DIFF
--- a/kroxylicious-operator/examples/downstream-tls/06.Certificate.server-certificate.yaml
+++ b/kroxylicious-operator/examples/downstream-tls/06.Certificate.server-certificate.yaml
@@ -19,6 +19,9 @@ spec:
     size: 4096
   dnsNames:
     - my-cluster-cluster-ip.my-proxy.svc.cluster.local
+    - my-cluster-cluster-ip-0.my-proxy.svc.cluster.local
+    - my-cluster-cluster-ip-1.my-proxy.svc.cluster.local
+    - my-cluster-cluster-ip-2.my-proxy.svc.cluster.local
   usages:
     - server auth
   issuerRef:

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
@@ -531,4 +531,13 @@ public class ResourcesUtil {
                 && !key.endsWith(".p12")
                 && !key.endsWith(".jks");
     }
+
+    /**
+     * @return an address that any pod in the same k8s cluster can use to address the service, regardless of which namespace the pod is in
+     * @param serviceName service name
+     * @param namespacedResource resource in the namespace of the Service
+     */
+    public static String crossNamespaceServiceAddress(String serviceName, HasMetadata namespacedResource) {
+        return serviceName + "." + namespace(namespacedResource) + ".svc.cluster.local";
+    }
 }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconciler.java
@@ -72,7 +72,7 @@ import static io.kroxylicious.kubernetes.operator.ResourcesUtil.hasKind;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.namespace;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.toLocalRef;
-import static io.kroxylicious.kubernetes.operator.model.networking.ClusterIPClusterIngressNetworkingModel.bootstrapServiceName;
+import static io.kroxylicious.kubernetes.operator.model.networking.TcpClusterIPClusterIngressNetworkingModel.bootstrapServiceName;
 
 /**
  * Reconciles a {@link VirtualKafkaCluster} by checking whether the resources

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/TlsClusterIPClusterIngressNetworkingModel.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/TlsClusterIPClusterIngressNetworkingModel.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator.model.networking;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.ServicePortBuilder;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
+import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.NodeIdRanges;
+import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls;
+import io.kroxylicious.kubernetes.operator.ProxyDeploymentDependentResource;
+import io.kroxylicious.kubernetes.operator.ResourcesUtil;
+import io.kroxylicious.proxy.config.NodeIdentificationStrategy;
+import io.kroxylicious.proxy.config.SniHostIdentifiesNodeIdentificationStrategy;
+import io.kroxylicious.proxy.service.HostPort;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static io.kroxylicious.kubernetes.operator.Labels.standardLabels;
+import static io.kroxylicious.kubernetes.operator.ResourcesUtil.crossNamespaceServiceAddress;
+import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
+import static io.kroxylicious.kubernetes.operator.ResourcesUtil.namespace;
+import static java.lang.Math.toIntExact;
+
+public record TlsClusterIPClusterIngressNetworkingModel(KafkaProxy proxy,
+                                                        VirtualKafkaCluster cluster,
+                                                        KafkaProxyIngress ingress,
+                                                        List<NodeIdRanges> nodeIdRanges,
+                                                        Tls tls,
+                                                        int sharedSniPort)
+        implements ClusterIngressNetworkingModel {
+
+    public static final int CLIENT_FACING_PORT = 9292;
+
+    public TlsClusterIPClusterIngressNetworkingModel {
+        Objects.requireNonNull(proxy);
+        Objects.requireNonNull(cluster);
+        Objects.requireNonNull(ingress);
+        Objects.requireNonNull(nodeIdRanges);
+        Objects.requireNonNull(tls);
+        if (nodeIdRanges.isEmpty()) {
+            throw new IllegalArgumentException("nodeIdRanges cannot be empty");
+        }
+    }
+
+    @Override
+    public Stream<ServiceBuilder> services() {
+        String serviceName = bootstrapServiceName();
+        var bootstrapService = createService(serviceName);
+        var nodeServices = nodeIdRanges.stream()
+                .flatMapToInt(nodeIdRange -> IntStream.rangeClosed(toIntExact(nodeIdRange.getStart()), toIntExact(nodeIdRange.getEnd())))
+                .mapToObj(upstreamNodeId -> createService(bootstrapServiceName() + "-" + upstreamNodeId));
+        return Stream.concat(Stream.of(bootstrapService), nodeServices);
+    }
+
+    private ServiceBuilder createService(String serviceName) {
+        return new ServiceBuilder()
+                .withMetadata(serviceMetadata(serviceName))
+                .withNewSpec()
+                .withSelector(ProxyDeploymentDependentResource.podLabels(proxy))
+                .withPorts(new ServicePortBuilder().withProtocol("TCP").withPort(CLIENT_FACING_PORT).withTargetPort(new IntOrString(sharedSniPort)).build())
+                .endSpec();
+    }
+
+    @NonNull
+    private String bootstrapServiceName() {
+        // we want to ensure TLS and TCP have the same service name for the service that will be used to bootstrap
+        // this is because the VKC reconciler loads the Service by name.
+        return TcpClusterIPClusterIngressNetworkingModel.bootstrapServiceName(cluster, name(ingress));
+    }
+
+    ObjectMeta serviceMetadata(String name) {
+        return new ObjectMetaBuilder()
+                .withName(name)
+                .withNamespace(namespace(cluster))
+                .addToLabels(standardLabels(proxy))
+                .addNewOwnerReferenceLike(ResourcesUtil.newOwnerReferenceTo(proxy)).endOwnerReference()
+                .addNewOwnerReferenceLike(ResourcesUtil.newOwnerReferenceTo(cluster)).endOwnerReference()
+                .addNewOwnerReferenceLike(ResourcesUtil.newOwnerReferenceTo(ingress)).endOwnerReference()
+                .build();
+    }
+
+    @Override
+    public Stream<ContainerPort> identifyingProxyContainerPorts() {
+        return Stream.of();
+    }
+
+    @Override
+    public boolean requiresSharedSniContainerPort() {
+        return true;
+    }
+
+    @Override
+    public NodeIdentificationStrategy nodeIdentificationStrategy() {
+        HostPort bootstrapAddress = new HostPort(crossNamespaceServiceAddress(bootstrapServiceName(), proxy), sharedSniPort);
+        HostPort advertisedBrokerAddressPattern = new HostPort(crossNamespaceServiceAddress(bootstrapServiceName() + "-$(nodeId)", proxy), CLIENT_FACING_PORT);
+        return new SniHostIdentifiesNodeIdentificationStrategy(bootstrapAddress.toString(),
+                advertisedBrokerAddressPattern.toString());
+    }
+
+    @Override
+    public Optional<Tls> downstreamTls() {
+        return Optional.of(tls);
+    }
+
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/model/networking/TcpClusterIPClusterIngressNetworkingModelTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/model/networking/TcpClusterIPClusterIngressNetworkingModelTest.java
@@ -46,7 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
-class ClusterIPClusterIngressNetworkingModelTest {
+class TcpClusterIPClusterIngressNetworkingModelTest {
 
     private static final String INGRESS_NAME = "my-ingress";
     public static final String CLUSTER_NAME = "my-cluster";
@@ -90,7 +90,7 @@ class ClusterIPClusterIngressNetworkingModelTest {
     @Test
     void numIdentifyingPortsRequiredSingleRange() {
         // 3 ports for the nodeId range + 1 for bootstrap
-        int numIdentifyingPortsRequired = ClusterIPClusterIngressNetworkingModel.numIdentifyingPortsRequired(List.of(NODE_ID_RANGE));
+        int numIdentifyingPortsRequired = TcpClusterIPClusterIngressNetworkingModel.numIdentifyingPortsRequired(List.of(NODE_ID_RANGE));
         assertThat(numIdentifyingPortsRequired).isEqualTo(4);
     }
 
@@ -99,8 +99,8 @@ class ClusterIPClusterIngressNetworkingModelTest {
         // given
         List<NodeIdRanges> nodeIdRange = List.of(createNodeIdRange("a", 1L, 3L));
         // when
-        ClusterIPClusterIngressNetworkingModel model = new ClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
-                nodeIdRange, null, 1, 4);
+        TcpClusterIPClusterIngressNetworkingModel model = new TcpClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
+                nodeIdRange, 1, 4);
         // then
         assertThat(model).isNotNull();
     }
@@ -112,8 +112,8 @@ class ClusterIPClusterIngressNetworkingModelTest {
         // when
         // then
         // more ports than the 4 required by the node id range + 1 for bootstrap
-        assertThatThrownBy(() -> new ClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
-                nodeIdRange, null, 1, 5)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new TcpClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
+                nodeIdRange, 1, 5)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -124,8 +124,8 @@ class ClusterIPClusterIngressNetworkingModelTest {
         // when
         // then
         // more ports than the 4 required by the node id range + 1 for bootstrap
-        assertThatThrownBy(() -> new ClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
-                nodeIdRange, null, 1, 3)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new TcpClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
+                nodeIdRange, 1, 3)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -136,8 +136,8 @@ class ClusterIPClusterIngressNetworkingModelTest {
         int rangeEnd = 3;
         List<NodeIdRanges> nodeIdRange = List.of(createNodeIdRange(rangeName, rangeStart, rangeEnd));
         // 3 ports for the nodeId range + 1 for bootstrap
-        ClusterIngressNetworkingModel instance = new ClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
-                nodeIdRange, null, 1, 4);
+        ClusterIngressNetworkingModel instance = new TcpClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
+                nodeIdRange, 1, 4);
         assertThat(instance).isNotNull();
 
         // when
@@ -162,9 +162,8 @@ class ClusterIPClusterIngressNetworkingModelTest {
     void serviceMetadata() {
         // given
         // 3 ports for the nodeId range + 1 for bootstrap
-        ClusterIngressNetworkingModel instance = new ClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
-                List.of(createNodeIdRange("a", 1, 3)), null, 1, 4);
-        assertThat(instance).isNotNull();
+        ClusterIngressNetworkingModel instance = new TcpClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
+                List.of(createNodeIdRange("a", 1, 3)), 1, 4);
         assertThat(instance).isNotNull();
 
         // when
@@ -203,8 +202,8 @@ class ClusterIPClusterIngressNetworkingModelTest {
     @Test
     void serviceCommonSpec() {
         // given
-        ClusterIngressNetworkingModel instance = new ClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
-                List.of(createNodeIdRange("a", 1, 3)), null, 1, 4);
+        ClusterIngressNetworkingModel instance = new TcpClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
+                List.of(createNodeIdRange("a", 1, 3)), 1, 4);
 
         // when
         List<ServiceBuilder> serviceBuilders = instance.services().toList();
@@ -225,8 +224,8 @@ class ClusterIPClusterIngressNetworkingModelTest {
     void servicesSingleRangePorts() {
         // given
         // 3 ports for the nodeId range + 1 for bootstrap
-        ClusterIngressNetworkingModel instance = new ClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
-                List.of(createNodeIdRange("a", 1, 3)), null, 1, 4);
+        ClusterIngressNetworkingModel instance = new TcpClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
+                List.of(createNodeIdRange("a", 1, 3)), 1, 4);
 
         assertThat(instance).isNotNull();
 
@@ -253,8 +252,8 @@ class ClusterIPClusterIngressNetworkingModelTest {
     void servicesMultipleRangesPorts() {
         // given
         // 2 ports for the nodeId ranges + 1 for bootstrap
-        ClusterIngressNetworkingModel instance = new ClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
-                List.of(createNodeIdRange("a", 1, 1), createNodeIdRange("b", 3, 3)), null, 1, 3);
+        ClusterIngressNetworkingModel instance = new TcpClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
+                List.of(createNodeIdRange("a", 1, 1), createNodeIdRange("b", 3, 3)), 1, 3);
 
         assertThat(instance).isNotNull();
 
@@ -287,8 +286,8 @@ class ClusterIPClusterIngressNetworkingModelTest {
         List<NodeIdRanges> nodeIdRange = List.of(createNodeIdRange(null, rangeStart, rangeEnd), createNodeIdRange(null, rangeStart2, rangeEnd2));
 
         // 5 ports for the nodeId ranges + 1 for bootstrap
-        ClusterIngressNetworkingModel instance = new ClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
-                nodeIdRange, null, 2, 7);
+        ClusterIngressNetworkingModel instance = new TcpClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
+                nodeIdRange, 2, 7);
 
         assertThat(instance).isNotNull();
 
@@ -322,8 +321,8 @@ class ClusterIPClusterIngressNetworkingModelTest {
         int rangeStart2 = 5;
         int rangeEnd2 = 6;
         // 5 ports for the nodeId ranges + 1 for bootstrap
-        ClusterIngressNetworkingModel instance = new ClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
-                List.of(createNodeIdRange(rangeName, rangeStart, rangeEnd), createNodeIdRange(rangeName2, rangeStart2, rangeEnd2)), null, 2, 7);
+        ClusterIngressNetworkingModel instance = new TcpClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
+                List.of(createNodeIdRange(rangeName, rangeStart, rangeEnd), createNodeIdRange(rangeName2, rangeStart2, rangeEnd2)), 2, 7);
 
         assertThat(instance).isNotNull();
 
@@ -349,20 +348,20 @@ class ClusterIPClusterIngressNetworkingModelTest {
     @Test
     void numIdentifyingPortsRequiredMultipleRanges() {
         // 5 ports for the nodeId ranges + 1 for bootstrap
-        assertThat(ClusterIPClusterIngressNetworkingModel.numIdentifyingPortsRequired(List.of(NODE_ID_RANGE, createNodeIdRange("a", 5L, 6L)))).isEqualTo(6);
+        assertThat(TcpClusterIPClusterIngressNetworkingModel.numIdentifyingPortsRequired(List.of(NODE_ID_RANGE, createNodeIdRange("a", 5L, 6L)))).isEqualTo(6);
     }
 
     @Test
     void rangesMustBeNonEmpty() {
         List<NodeIdRanges> nodeIdRanges = List.of();
-        assertThatThrownBy(() -> new ClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS, nodeIdRanges, null, 1, 3))
+        assertThatThrownBy(() -> new TcpClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS, nodeIdRanges, 1, 3))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void identifyingProxyContainerPortsSingleRange() {
-        ClusterIngressNetworkingModel instance = new ClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
-                List.of(createNodeIdRange("a", 1, 3)), null, 1, 4);
+        ClusterIngressNetworkingModel instance = new TcpClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
+                List.of(createNodeIdRange("a", 1, 3)), 1, 4);
 
         assertThat(instance).isNotNull();
         assertThat(instance.identifyingProxyContainerPorts())
@@ -374,8 +373,8 @@ class ClusterIPClusterIngressNetworkingModelTest {
 
     @Test
     void identifyingProxyContainerPortsMultipleRanges() {
-        ClusterIngressNetworkingModel instance = new ClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
-                List.of(createNodeIdRange("a", 1L, 1L), createNodeIdRange("b", 3L, 4L)), null, 1, 4);
+        ClusterIngressNetworkingModel instance = new TcpClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
+                List.of(createNodeIdRange("a", 1L, 1L), createNodeIdRange("b", 3L, 4L)), 1, 4);
 
         assertThat(instance).isNotNull();
         assertThat(instance.identifyingProxyContainerPorts())
@@ -387,10 +386,10 @@ class ClusterIPClusterIngressNetworkingModelTest {
 
     public static Stream<Arguments> constructorArgsMustBeNonNull() {
         List<NodeIdRanges> nodeIdRanges = List.of(NODE_ID_RANGE);
-        ThrowingCallable nullIngress = () -> new ClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, null, nodeIdRanges, null, 1, 4);
-        ThrowingCallable nullVirtualCluster = () -> new ClusterIPClusterIngressNetworkingModel(PROXY, null, INGRESS, nodeIdRanges, null, 1, 4);
-        ThrowingCallable nullProxy = () -> new ClusterIPClusterIngressNetworkingModel(null, VIRTUAL_KAFKA_CLUSTER, INGRESS, nodeIdRanges, null, 1, 4);
-        ThrowingCallable nullRanges = () -> new ClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS, null, null, 1, 4);
+        ThrowingCallable nullIngress = () -> new TcpClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, null, nodeIdRanges, 1, 4);
+        ThrowingCallable nullVirtualCluster = () -> new TcpClusterIPClusterIngressNetworkingModel(PROXY, null, INGRESS, nodeIdRanges, 1, 4);
+        ThrowingCallable nullProxy = () -> new TcpClusterIPClusterIngressNetworkingModel(null, VIRTUAL_KAFKA_CLUSTER, INGRESS, nodeIdRanges, 1, 4);
+        ThrowingCallable nullRanges = () -> new TcpClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS, null, 1, 4);
         return Stream.of(argumentSet("ingress", nullIngress),
                 argumentSet("virtualCluster", nullVirtualCluster),
                 argumentSet("proxy", nullProxy),

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/model/networking/TlsClusterIPClusterIngressNetworkingModelTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/model/networking/TlsClusterIPClusterIngressNetworkingModelTest.java
@@ -1,0 +1,320 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator.model.networking;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.ServicePortBuilder;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngressBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyingressspec.ClusterIP;
+import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.NodeIdRanges;
+import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.NodeIdRangesBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls;
+import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.TlsBuilder;
+import io.kroxylicious.kubernetes.operator.KafkaProxyReconciler;
+import io.kroxylicious.proxy.config.VirtualClusterGateway;
+import io.kroxylicious.proxy.service.HostPort;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+class TlsClusterIPClusterIngressNetworkingModelTest {
+
+    private static final String INGRESS_NAME = "my-ingress";
+    public static final String CLUSTER_NAME = "my-cluster";
+    public static final String PROXY_NAME = "my-proxy";
+    public static final String NAMESPACE = "my-namespace";
+
+    // @formatter:off
+    private static final KafkaProxyIngress INGRESS = new KafkaProxyIngressBuilder()
+            .withNewMetadata()
+                .withName(INGRESS_NAME)
+                .withNamespace(NAMESPACE)
+            .endMetadata()
+            .withNewSpec()
+                .withNewClusterIP()
+                    .withProtocol(ClusterIP.Protocol.TLS)
+                .endClusterIP()
+            .endSpec()
+            .build();
+    // @formatter:on
+
+    private static final Tls TLS = new TlsBuilder().withNewCertificateRef().withName("server-cert").endCertificateRef().build();
+
+    // @formatter:off
+    private static final VirtualKafkaCluster VIRTUAL_KAFKA_CLUSTER = new VirtualKafkaClusterBuilder()
+            .withNewMetadata()
+                .withName(CLUSTER_NAME)
+                .withNamespace(NAMESPACE)
+            .endMetadata()
+            .withNewSpec()
+                .addNewIngress()
+                    .withNewIngressRef()
+                        .withName(INGRESS_NAME)
+                    .endIngressRef()
+                    .withTls(TLS)
+                .endIngress()
+            .endSpec()
+            .build();
+    // @formatter:on
+    public static final String PROXY_UID = "my-proxy-uid";
+    public static final KafkaProxy PROXY = new KafkaProxyBuilder().withNewMetadata().withName(PROXY_NAME).withUid(PROXY_UID).withNamespace(NAMESPACE).endMetadata()
+            .build();
+    public static final NodeIdRanges NODE_ID_RANGE = createNodeIdRange("a", 1L, 3L);
+
+    @Test
+    void createInstancesWithSharedSniPort() {
+        // given
+        List<NodeIdRanges> nodeIdRange = List.of(createNodeIdRange("a", 1L, 3L));
+        // when
+        TlsClusterIPClusterIngressNetworkingModel model = new TlsClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
+                nodeIdRange, TLS, 1);
+        // then
+        assertThat(model).isNotNull();
+    }
+
+    @Test
+    void gatewayConfig() {
+        // given
+        String rangeName = "a";
+        int rangeStart = 1;
+        int rangeEnd = 3;
+        List<NodeIdRanges> nodeIdRange = List.of(createNodeIdRange(rangeName, rangeStart, rangeEnd));
+
+        int sharedSniPort = 5;
+        ClusterIngressNetworkingModel instance = new TlsClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
+                nodeIdRange, TLS, sharedSniPort);
+        assertThat(instance).isNotNull();
+
+        // when
+        VirtualClusterGateway gateway = KafkaProxyReconciler.buildVirtualClusterGateway(instance).fragment();
+
+        // then
+        assertThat(gateway).isNotNull();
+        assertThat(gateway.name()).isEqualTo(INGRESS_NAME);
+        assertThat(gateway.tls()).isNotNull();
+        assertThat(gateway.sniHostIdentifiesNode()).isNotNull().satisfies(sni -> {
+            assertThat(sni.bootstrapAddress()).isEqualTo(new HostPort("my-cluster-my-ingress." + NAMESPACE + ".svc.cluster.local", sharedSniPort).toString());
+            assertThat(sni.advertisedBrokerAddressPattern()).isEqualTo("my-cluster-my-ingress-$(nodeId)." + NAMESPACE + ".svc.cluster.local:" + 9292);
+        });
+    }
+
+    @Test
+    void serviceMetadata() {
+        // given
+        ClusterIngressNetworkingModel instance = new TlsClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
+                List.of(createNodeIdRange("a", 1, 3)), TLS, 5);
+        assertThat(instance).isNotNull();
+
+        // when
+        List<ServiceBuilder> serviceBuilders = instance.services().toList();
+
+        // then
+        assertThat(serviceBuilders).isNotNull().isNotEmpty().allSatisfy(serviceBuild -> {
+            Service build = serviceBuild.build();
+            Map<String, String> orderedServiceLabels = commonLabels(PROXY_NAME);
+            assertThat(build.getMetadata()).isNotNull().satisfies(metadata -> {
+                assertThat(metadata.getNamespace()).isEqualTo(NAMESPACE);
+                assertThat(metadata.getLabels()).containsExactlyEntriesOf(orderedServiceLabels);
+                assertThat(metadata.getOwnerReferences())
+                        .satisfiesExactlyInAnyOrder(
+                                ownerRef -> {
+                                    assertThat(ownerRef.getKind()).isEqualTo("KafkaProxy");
+                                    assertThat(ownerRef.getApiVersion()).isEqualTo("kroxylicious.io/v1alpha1");
+                                    assertThat(ownerRef.getName()).isEqualTo(PROXY_NAME);
+                                    assertThat(ownerRef.getUid()).isEqualTo(PROXY_UID);
+                                },
+                                ownerRef -> {
+                                    assertThat(ownerRef.getKind()).isEqualTo("VirtualKafkaCluster");
+                                    assertThat(ownerRef.getApiVersion()).isEqualTo("kroxylicious.io/v1alpha1");
+                                    assertThat(ownerRef.getName()).isEqualTo(CLUSTER_NAME);
+                                },
+                                ownerRef -> {
+                                    assertThat(ownerRef.getKind()).isEqualTo("KafkaProxyIngress");
+                                    assertThat(ownerRef.getApiVersion()).isEqualTo("kroxylicious.io/v1alpha1");
+                                    assertThat(ownerRef.getName()).isEqualTo(INGRESS_NAME);
+                                });
+            });
+        });
+    }
+
+    @Test
+    void serviceCommonSpec() {
+        // given
+        ClusterIngressNetworkingModel instance = new TlsClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
+                List.of(createNodeIdRange("a", 1, 3)), TLS, 5);
+
+        // when
+        List<ServiceBuilder> serviceBuilders = instance.services().toList();
+
+        // then
+        assertThat(serviceBuilders).isNotNull().isNotEmpty().allSatisfy(serviceBuild -> {
+            Service build = serviceBuild.build();
+            assertThat(build.getSpec()).isNotNull().satisfies(serviceSpec -> {
+                LinkedHashMap<String, String> orderedSelectorLabels = new LinkedHashMap<>();
+                orderedSelectorLabels.put("app", "kroxylicious");
+                orderedSelectorLabels.putAll(commonLabels(PROXY_NAME));
+                assertThat(serviceSpec.getSelector()).containsExactlyEntriesOf(orderedSelectorLabels);
+            });
+        });
+    }
+
+    @Test
+    void servicesSingleRangeOfNodeIds() {
+        // given
+        int sharedSniPort = 5;
+        ClusterIngressNetworkingModel instance = new TlsClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
+                List.of(createNodeIdRange("a", 1, 2)), TLS, sharedSniPort);
+
+        assertThat(instance).isNotNull();
+
+        // when
+        List<ServiceBuilder> serviceBuilders = instance.services().toList();
+
+        // then
+        var listAssert = assertThat(serviceBuilders).isNotNull().hasSize(3);
+
+        listAssert.element(0).satisfies(serviceBuild -> {
+            assertServiceNameAndPortMapping(serviceBuild, CLUSTER_NAME + "-" + INGRESS_NAME, 9292, sharedSniPort);
+        });
+
+        listAssert.element(1).satisfies(serviceBuild -> {
+            assertServiceNameAndPortMapping(serviceBuild, CLUSTER_NAME + "-" + INGRESS_NAME + "-1", 9292, sharedSniPort);
+        });
+
+        listAssert.element(2).satisfies(serviceBuild -> {
+            assertServiceNameAndPortMapping(serviceBuild, CLUSTER_NAME + "-" + INGRESS_NAME + "-2", 9292, sharedSniPort);
+        });
+    }
+
+    private static void assertServiceNameAndPortMapping(ServiceBuilder serviceBuild, String expectedName, int port, int targetPort) {
+        Service build = serviceBuild.build();
+        assertThat(build.getMetadata()).isNotNull().satisfies(metadata -> {
+            assertThat(metadata.getName()).isEqualTo(expectedName);
+        });
+        assertThat(build.getSpec()).isNotNull().satisfies(serviceSpec -> {
+            assertThat(serviceSpec.getPorts())
+                    .isNotNull()
+                    .isNotEmpty()
+                    .containsExactly(new ServicePortBuilder()
+                            .withTargetPort(new IntOrString(targetPort))
+                            .withPort(port)
+                            .withProtocol("TCP")
+                            .build());
+        });
+    }
+
+    @Test
+    void servicesMultipleRangesOfNodeIds() {
+        // given
+        int sharedSniPort = 5;
+        ClusterIngressNetworkingModel instance = new TlsClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
+                List.of(createNodeIdRange("a", 1, 1), createNodeIdRange("b", 3, 3)), TLS, sharedSniPort);
+
+        assertThat(instance).isNotNull();
+
+        // when
+        List<ServiceBuilder> serviceBuilders = instance.services().toList();
+
+        // then
+        var listAssert = assertThat(serviceBuilders).isNotNull().hasSize(3);
+
+        listAssert.element(0).satisfies(serviceBuild -> {
+            assertServiceNameAndPortMapping(serviceBuild, CLUSTER_NAME + "-" + INGRESS_NAME, 9292, sharedSniPort);
+        });
+
+        listAssert.element(1).satisfies(serviceBuild -> {
+            assertServiceNameAndPortMapping(serviceBuild, CLUSTER_NAME + "-" + INGRESS_NAME + "-1", 9292, sharedSniPort);
+        });
+
+        listAssert.element(2).satisfies(serviceBuild -> {
+            assertServiceNameAndPortMapping(serviceBuild, CLUSTER_NAME + "-" + INGRESS_NAME + "-3", 9292, sharedSniPort);
+        });
+    }
+
+    @Test
+    void nodeIdRangesMustBeNonEmpty() {
+        List<NodeIdRanges> nodeIdRanges = List.of();
+        assertThatThrownBy(() -> new TlsClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS, nodeIdRanges, TLS, 5))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void requiresSharedSniContainerPort() {
+        ClusterIngressNetworkingModel instance = new TlsClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
+                List.of(createNodeIdRange("a", 1, 3)), TLS, 5);
+
+        assertThat(instance.requiresSharedSniContainerPort()).isTrue();
+    }
+
+    @Test
+    void identifyingProxyContainerPortsEmpty() {
+        ClusterIngressNetworkingModel instance = new TlsClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS,
+                List.of(createNodeIdRange("a", 1, 3)), TLS, 5);
+
+        assertThat(instance).isNotNull();
+        assertThat(instance.identifyingProxyContainerPorts())
+                .isEmpty();
+    }
+
+    public static Stream<Arguments> constructorArgsMustBeNonNull() {
+        List<NodeIdRanges> nodeIdRanges = List.of(NODE_ID_RANGE);
+        ThrowingCallable nullIngress = () -> new TlsClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, null, nodeIdRanges, TLS, 5);
+        ThrowingCallable nullVirtualCluster = () -> new TlsClusterIPClusterIngressNetworkingModel(PROXY, null, INGRESS, nodeIdRanges, TLS, 5);
+        ThrowingCallable nullProxy = () -> new TlsClusterIPClusterIngressNetworkingModel(null, VIRTUAL_KAFKA_CLUSTER, INGRESS, nodeIdRanges, TLS, 5);
+        ThrowingCallable nullRanges = () -> new TlsClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS, null, TLS, 5);
+        ThrowingCallable nullTls = () -> new TlsClusterIPClusterIngressNetworkingModel(PROXY, VIRTUAL_KAFKA_CLUSTER, INGRESS, null, null, 5);
+        return Stream.of(argumentSet("ingress", nullIngress),
+                argumentSet("virtualCluster", nullVirtualCluster),
+                argumentSet("proxy", nullProxy),
+                argumentSet("ranges", nullRanges),
+                argumentSet("tls", nullTls));
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void constructorArgsMustBeNonNull(ThrowingCallable callable) {
+        assertThatThrownBy(callable).isInstanceOf(NullPointerException.class);
+    }
+
+    private static @NonNull Map<String, String> commonLabels(String proxyName) {
+        Map<String, String> orderedLabels = new LinkedHashMap<>();
+        orderedLabels.put("app.kubernetes.io/part-of", "kafka");
+        orderedLabels.put("app.kubernetes.io/managed-by", "kroxylicious-operator");
+        orderedLabels.put("app.kubernetes.io/name", "kroxylicious-proxy");
+        orderedLabels.put("app.kubernetes.io/instance", proxyName);
+        orderedLabels.put("app.kubernetes.io/component", "proxy");
+        return orderedLabels;
+    }
+
+    private static NodeIdRanges createNodeIdRange(@Nullable String name, long start, long endInclusive) {
+        return new NodeIdRangesBuilder().withName(name).withStart(start).withEnd(endInclusive).build();
+    }
+
+}

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-ConfigMap-minimal-proxy-config.yaml
@@ -40,13 +40,9 @@ data:
             privateKeyFile: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert/tls.key"
             certificateFile: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert/tls.crt"
       - name: "cluster-ip"
-        portIdentifiesNode:
-          bootstrapAddress: "localhost:9292"
-          advertisedBrokerAddressPattern: "one-cluster-ip.proxy-ns.svc.cluster.local"
-          nodeIdRanges:
-          - name: "default"
-            start: 0
-            end: 2
+        sniHostIdentifiesNode:
+          bootstrapAddress: "one-cluster-ip.proxy-ns.svc.cluster.local:9291"
+          advertisedBrokerAddressPattern: "one-cluster-ip-$(nodeId).proxy-ns.svc.cluster.local:9292"
         tls:
           key:
             privateKeyFile: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert/tls.key"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Deployment-minimal.yaml
@@ -60,14 +60,6 @@ spec:
           ports:
             - containerPort: 9190
               name: "management"
-            - containerPort: 9292
-              name: "9292-bootstrap"
-            - containerPort: 9293
-              name: "9293-node"
-            - containerPort: 9294
-              name: "9294-node"
-            - containerPort: 9295
-              name: "9295-node"
             - containerPort: 9291
               name: "shared-sni-port"
           securityContext:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Service-one-cluster-ip-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Service-one-cluster-ip-0.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
-  name: "one-cluster-ip"
+  name: "one-cluster-ip-0"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Service-one-cluster-ip-1.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Service-one-cluster-ip-1.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
-  name: "one-cluster-ip"
+  name: "one-cluster-ip-1"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Service-one-cluster-ip-2.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Service-one-cluster-ip-2.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
-  name: "one-cluster-ip"
+  name: "one-cluster-ip-2"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-ConfigMap-minimal-proxy-config.yaml
@@ -32,13 +32,9 @@ data:
         bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
       gateways:
       - name: "cluster-ip"
-        portIdentifiesNode:
-          bootstrapAddress: "localhost:9292"
-          advertisedBrokerAddressPattern: "one-cluster-ip.proxy-ns.svc.cluster.local"
-          nodeIdRanges:
-          - name: "default"
-            start: 0
-            end: 2
+        sniHostIdentifiesNode:
+          bootstrapAddress: "one-cluster-ip.proxy-ns.svc.cluster.local:9291"
+          advertisedBrokerAddressPattern: "one-cluster-ip-$(nodeId).proxy-ns.svc.cluster.local:9292"
         tls:
           key:
             privateKeyFile: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert/tls.key"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Deployment-minimal.yaml
@@ -60,14 +60,8 @@ spec:
           ports:
             - containerPort: 9190
               name: "management"
-            - containerPort: 9292
-              name: "9292-bootstrap"
-            - containerPort: 9293
-              name: "9293-node"
-            - containerPort: 9294
-              name: "9294-node"
-            - containerPort: 9295
-              name: "9295-node"
+            - containerPort: 9291
+              name: "shared-sni-port"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Service-one-cluster-ip-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Service-one-cluster-ip-0.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
-  name: "one-cluster-ip"
+  name: "one-cluster-ip-0"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Service-one-cluster-ip-1.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Service-one-cluster-ip-1.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
-  name: "one-cluster-ip"
+  name: "one-cluster-ip-1"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Service-one-cluster-ip-2.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Service-one-cluster-ip-2.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
-  name: "one-cluster-ip"
+  name: "one-cluster-ip-2"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Service-one-cluster-ip.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Service-one-cluster-ip.yaml
@@ -28,22 +28,9 @@ metadata:
       name: "cluster-ip"
 spec:
   ports:
-    - name: "one-9292"
-      port: 9292
+    - port: 9292
       protocol: "TCP"
-      targetPort: 9292
-    - name: "one-9293"
-      port: 9293
-      protocol: "TCP"
-      targetPort: 9293
-    - name: "one-9294"
-      port: 9294
-      protocol: "TCP"
-      targetPort: 9294
-    - name: "one-9295"
-      port: 9295
-      protocol: "TCP"
-      targetPort: 9295
+      targetPort: 9291
   selector:
     app: "kroxylicious"
     app.kubernetes.io/part-of: "kafka"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-ConfigMap-minimal-proxy-config.yaml
@@ -32,13 +32,9 @@ data:
         bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
       gateways:
       - name: "cluster-ip"
-        portIdentifiesNode:
-          bootstrapAddress: "localhost:9292"
-          advertisedBrokerAddressPattern: "one-cluster-ip.proxy-ns.svc.cluster.local"
-          nodeIdRanges:
-          - name: "default"
-            start: 0
-            end: 2
+        sniHostIdentifiesNode:
+          bootstrapAddress: "one-cluster-ip.proxy-ns.svc.cluster.local:9291"
+          advertisedBrokerAddressPattern: "one-cluster-ip-$(nodeId).proxy-ns.svc.cluster.local:9292"
         tls:
           key:
             privateKeyFile: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert/tls.key"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Deployment-minimal.yaml
@@ -60,14 +60,8 @@ spec:
           ports:
             - containerPort: 9190
               name: "management"
-            - containerPort: 9292
-              name: "9292-bootstrap"
-            - containerPort: 9293
-              name: "9293-node"
-            - containerPort: 9294
-              name: "9294-node"
-            - containerPort: 9295
-              name: "9295-node"
+            - containerPort: 9291
+              name: "shared-sni-port"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Service-one-cluster-ip-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Service-one-cluster-ip-0.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
-  name: "one-cluster-ip"
+  name: "one-cluster-ip-0"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Service-one-cluster-ip-1.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Service-one-cluster-ip-1.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
-  name: "one-cluster-ip"
+  name: "one-cluster-ip-1"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Service-one-cluster-ip-2.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Service-one-cluster-ip-2.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
-  name: "one-cluster-ip"
+  name: "one-cluster-ip-2"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Service-one-cluster-ip.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Service-one-cluster-ip.yaml
@@ -28,22 +28,9 @@ metadata:
       name: "cluster-ip"
 spec:
   ports:
-    - name: "one-9292"
-      port: 9292
+    - port: 9292
       protocol: "TCP"
-      targetPort: 9292
-    - name: "one-9293"
-      port: 9293
-      protocol: "TCP"
-      targetPort: 9293
-    - name: "one-9294"
-      port: 9294
-      protocol: "TCP"
-      targetPort: 9294
-    - name: "one-9295"
-      port: 9295
-      protocol: "TCP"
-      targetPort: 9295
+      targetPort: 9291
   selector:
     app: "kroxylicious"
     app.kubernetes.io/part-of: "kafka"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-ConfigMap-minimal-proxy-config.yaml
@@ -32,13 +32,9 @@ data:
         bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
       gateways:
       - name: "cluster-ip"
-        portIdentifiesNode:
-          bootstrapAddress: "localhost:9292"
-          advertisedBrokerAddressPattern: "one-cluster-ip.proxy-ns.svc.cluster.local"
-          nodeIdRanges:
-          - name: "default"
-            start: 0
-            end: 2
+        sniHostIdentifiesNode:
+          bootstrapAddress: "one-cluster-ip.proxy-ns.svc.cluster.local:9291"
+          advertisedBrokerAddressPattern: "one-cluster-ip-$(nodeId).proxy-ns.svc.cluster.local:9292"
         tls:
           key:
             privateKeyFile: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert/tls.key"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Deployment-minimal.yaml
@@ -60,14 +60,8 @@ spec:
           ports:
             - containerPort: 9190
               name: "management"
-            - containerPort: 9292
-              name: "9292-bootstrap"
-            - containerPort: 9293
-              name: "9293-node"
-            - containerPort: 9294
-              name: "9294-node"
-            - containerPort: 9295
-              name: "9295-node"
+            - containerPort: 9291
+              name: "shared-sni-port"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Service-one-cluster-ip-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Service-one-cluster-ip-0.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
-  name: "one-cluster-ip"
+  name: "one-cluster-ip-0"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Service-one-cluster-ip-1.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Service-one-cluster-ip-1.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
-  name: "one-cluster-ip"
+  name: "one-cluster-ip-1"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Service-one-cluster-ip-2.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Service-one-cluster-ip-2.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
-  name: "one-cluster-ip"
+  name: "one-cluster-ip-2"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Service-one-cluster-ip.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Service-one-cluster-ip.yaml
@@ -28,22 +28,9 @@ metadata:
       name: "cluster-ip"
 spec:
   ports:
-    - name: "one-9292"
-      port: 9292
+    - port: 9292
       protocol: "TCP"
-      targetPort: 9292
-    - name: "one-9293"
-      port: 9293
-      protocol: "TCP"
-      targetPort: 9293
-    - name: "one-9294"
-      port: 9294
-      protocol: "TCP"
-      targetPort: 9294
-    - name: "one-9295"
-      port: 9295
-      protocol: "TCP"
-      targetPort: 9295
+      targetPort: 9291
   selector:
     app: "kroxylicious"
     app.kubernetes.io/part-of: "kafka"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-ConfigMap-minimal-proxy-config.yaml
@@ -32,13 +32,9 @@ data:
         bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
       gateways:
       - name: "cluster-ip"
-        portIdentifiesNode:
-          bootstrapAddress: "localhost:9292"
-          advertisedBrokerAddressPattern: "one-cluster-ip.proxy-ns.svc.cluster.local"
-          nodeIdRanges:
-          - name: "default"
-            start: 0
-            end: 2
+        sniHostIdentifiesNode:
+          bootstrapAddress: "one-cluster-ip.proxy-ns.svc.cluster.local:9291"
+          advertisedBrokerAddressPattern: "one-cluster-ip-$(nodeId).proxy-ns.svc.cluster.local:9292"
         tls:
           key:
             privateKeyFile: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert/tls.key"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Deployment-minimal.yaml
@@ -60,14 +60,8 @@ spec:
           ports:
             - containerPort: 9190
               name: "management"
-            - containerPort: 9292
-              name: "9292-bootstrap"
-            - containerPort: 9293
-              name: "9293-node"
-            - containerPort: 9294
-              name: "9294-node"
-            - containerPort: 9295
-              name: "9295-node"
+            - containerPort: 9291
+              name: "shared-sni-port"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Service-one-cluster-ip-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Service-one-cluster-ip-0.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
-  name: "one-cluster-ip"
+  name: "one-cluster-ip-0"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Service-one-cluster-ip-1.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Service-one-cluster-ip-1.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
-  name: "one-cluster-ip"
+  name: "one-cluster-ip-1"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Service-one-cluster-ip-2.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Service-one-cluster-ip-2.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
-  name: "one-cluster-ip"
+  name: "one-cluster-ip-2"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Service-one-cluster-ip.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Service-one-cluster-ip.yaml
@@ -28,22 +28,9 @@ metadata:
       name: "cluster-ip"
 spec:
   ports:
-    - name: "one-9292"
-      port: 9292
+    - port: 9292
       protocol: "TCP"
-      targetPort: 9292
-    - name: "one-9293"
-      port: 9293
-      protocol: "TCP"
-      targetPort: 9293
-    - name: "one-9294"
-      port: 9294
-      protocol: "TCP"
-      targetPort: 9294
-    - name: "one-9295"
-      port: 9295
-      protocol: "TCP"
-      targetPort: 9295
+      targetPort: 9291
   selector:
     app: "kroxylicious"
     app.kubernetes.io/part-of: "kafka"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-ConfigMap-minimal-proxy-config.yaml
@@ -32,13 +32,9 @@ data:
         bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
       gateways:
       - name: "cluster-ip"
-        portIdentifiesNode:
-          bootstrapAddress: "localhost:9292"
-          advertisedBrokerAddressPattern: "one-cluster-ip.proxy-ns.svc.cluster.local"
-          nodeIdRanges:
-          - name: "default"
-            start: 0
-            end: 2
+        sniHostIdentifiesNode:
+          bootstrapAddress: "one-cluster-ip.proxy-ns.svc.cluster.local:9291"
+          advertisedBrokerAddressPattern: "one-cluster-ip-$(nodeId).proxy-ns.svc.cluster.local:9292"
         tls:
           key:
             privateKeyFile: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert/tls.key"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Deployment-minimal.yaml
@@ -60,14 +60,8 @@ spec:
           ports:
             - containerPort: 9190
               name: "management"
-            - containerPort: 9292
-              name: "9292-bootstrap"
-            - containerPort: 9293
-              name: "9293-node"
-            - containerPort: 9294
-              name: "9294-node"
-            - containerPort: 9295
-              name: "9295-node"
+            - containerPort: 9291
+              name: "shared-sni-port"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Service-one-cluster-ip-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Service-one-cluster-ip-0.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
-  name: "one-cluster-ip"
+  name: "one-cluster-ip-0"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Service-one-cluster-ip-1.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Service-one-cluster-ip-1.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
-  name: "one-cluster-ip"
+  name: "one-cluster-ip-1"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Service-one-cluster-ip-2.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Service-one-cluster-ip-2.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
-  name: "one-cluster-ip"
+  name: "one-cluster-ip-2"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Service-one-cluster-ip.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Service-one-cluster-ip.yaml
@@ -28,22 +28,9 @@ metadata:
       name: "cluster-ip"
 spec:
   ports:
-    - name: "one-9292"
-      port: 9292
+    - port: 9292
       protocol: "TCP"
-      targetPort: 9292
-    - name: "one-9293"
-      port: 9293
-      protocol: "TCP"
-      targetPort: 9293
-    - name: "one-9294"
-      port: 9294
-      protocol: "TCP"
-      targetPort: 9294
-    - name: "one-9295"
-      port: 9295
-      protocol: "TCP"
-      targetPort: 9295
+      targetPort: 9291
   selector:
     app: "kroxylicious"
     app.kubernetes.io/part-of: "kafka"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-ConfigMap-minimal-proxy-config.yaml
@@ -32,13 +32,9 @@ data:
         bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
       gateways:
       - name: "cluster-ip"
-        portIdentifiesNode:
-          bootstrapAddress: "localhost:9292"
-          advertisedBrokerAddressPattern: "one-cluster-ip.proxy-ns.svc.cluster.local"
-          nodeIdRanges:
-          - name: "default"
-            start: 0
-            end: 2
+        sniHostIdentifiesNode:
+          bootstrapAddress: "one-cluster-ip.proxy-ns.svc.cluster.local:9291"
+          advertisedBrokerAddressPattern: "one-cluster-ip-$(nodeId).proxy-ns.svc.cluster.local:9292"
         tls:
           key:
             privateKeyFile: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert/tls.key"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Deployment-minimal.yaml
@@ -60,14 +60,8 @@ spec:
           ports:
             - containerPort: 9190
               name: "management"
-            - containerPort: 9292
-              name: "9292-bootstrap"
-            - containerPort: 9293
-              name: "9293-node"
-            - containerPort: 9294
-              name: "9294-node"
-            - containerPort: 9295
-              name: "9295-node"
+            - containerPort: 9291
+              name: "shared-sni-port"
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Service-one-cluster-ip-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Service-one-cluster-ip-0.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
-  name: "one-cluster-ip"
+  name: "one-cluster-ip-0"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Service-one-cluster-ip-1.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Service-one-cluster-ip-1.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
-  name: "one-cluster-ip"
+  name: "one-cluster-ip-1"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Service-one-cluster-ip-2.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Service-one-cluster-ip-2.yaml
@@ -14,7 +14,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious-proxy"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
-  name: "one-cluster-ip"
+  name: "one-cluster-ip-2"
   namespace: "proxy-ns"
   ownerReferences:
     - apiVersion: "kroxylicious.io/v1alpha1"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Service-one-cluster-ip.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Service-one-cluster-ip.yaml
@@ -28,22 +28,9 @@ metadata:
       name: "cluster-ip"
 spec:
   ports:
-    - name: "one-9292"
-      port: 9292
+    - port: 9292
       protocol: "TCP"
-      targetPort: 9292
-    - name: "one-9293"
-      port: 9293
-      protocol: "TCP"
-      targetPort: 9293
-    - name: "one-9294"
-      port: 9294
-      protocol: "TCP"
-      targetPort: 9294
-    - name: "one-9295"
-      port: 9295
-      protocol: "TCP"
-      targetPort: 9295
+      targetPort: 9291
   selector:
     app: "kroxylicious"
     app.kubernetes.io/part-of: "kafka"

--- a/scripts/run-operator.sh
+++ b/scripts/run-operator.sh
@@ -39,11 +39,13 @@ kubectl apply -n kafka -f https://strimzi.io/examples/latest/kafka/kafka-single-
 kubectl wait -n kafka kafka/my-cluster --for=condition=Ready --timeout=300s
 
 info "deleting example"
+set +e
 kubectl delete -f examples/simple/ --ignore-not-found=true --timeout=30s --grace-period=1
 
 info "deleting kroxylicious-operator installation"
 kubectl delete -n kroxylicious-operator all --all --timeout=30s --grace-period=1
 kubectl delete -f install --ignore-not-found=true --timeout=30s --grace-period=1
+set -e
 
 info "deleting all kroxylicious.io resources and crds"
 for crd in $(kubectl get crds -oname | grep kroxylicious.io | awk -F / '{ print $2 }');


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Use SNI node identification for TLS ClusterIP ingress
    
For TLS clusterIP ingress we manifest:
1. a bootstrap service named `${virtualClusterName}-${ingressName}`, the same naming we use for the service carrying the TCP bootstrap port.
2. a service for each upstream node named like `${virtualClusterName}-${ingressName}-${upstreamNodeId}`.
3. we configure the proxy virtual cluster gateway like:
    ```yaml
    sniHostIdentifiesNode:
      bootstrapAddress: "${virtualClusterName}-${ingressName}.${proxyNamespace}.svc.cluster.local:9191"
      advertisedBrokerAddressPattern: "${virtualClusterName}-${ingressName}-$(nodeId).${proxyNamespace}.svc.cluster.local:9292"
    ```
The user must ensure their downstream TLS certificates contain SANs for the bootstrap and each upstream node.
    
### Additional Context

Previously we limited the user to a single VKC+ingress using identifying ports due to the risks of using port for identification. see #1902 (during reconciliation, the identity of a port can change, so clients could connect to an unexpected vcluster/node).
    
By changing to SNI as the mechanism, the identity is unambiguous as VKCs/gateways are added and removed, as the hostnames should be stable and uniquely address a gateway bootstrap or node. So we can safely allow numerous TLS clusterIP ingresses to co-exist within a cluster without implementing a safer port allocation strategy for identifying ports.

Note that the restriction will still be in place for TCP clusterIP ingresses.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
