### PR TITLE
Operator Examples should suggest Strimzi Quickstarts in order to obtain a suitable Kafka Cluster.

### DIFF
--- a/kroxylicious-operator/examples/README.md
+++ b/kroxylicious-operator/examples/README.md
@@ -1,0 +1,20 @@
+# Examples
+
+These examples assume a Kafka cluster running the Kubernetes Cluster.
+
+The [Strimzi Quickstart](https://strimzi.io/quickstarts/) fulfils the requirement:
+
+## Install Strimzi
+
+```
+kubectl create ns kafka
+kubectl apply -f https://strimzi.io/examples/latest/kafka/kafka-single-node.yaml -n kafka
+kubectl wait deployment/strimzi-cluster-operator --for=condition=Available=True --timeout=300s -n kafka
+```
+
+## Deploy the Quickstart
+
+```
+kubectl apply -f https://strimzi.io/examples/latest/kafka/kafka-single-node.yaml -n kafka
+kubectl wait -n kafka kafka my-cluster --for=condition=Ready=True
+```


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

The Operator [examples](https://github.com/kroxylicious/kroxylicious/tree/main/kroxylicious-operator/examples) assume that you have a Kafka cluster running on the cluster.  We fail to tell the developer how to deploy a suitable one.  We can just direct the user to the Strimzi Quickstarts.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
