### PR TITLE
Reduce max length of KafkaProxy metadata.name to 50

### DIFF
--- a/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
+++ b/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
@@ -46,7 +46,7 @@ spec:
               properties:
                 name:
                   type: string
-                  maxLength: 63
+                  maxLength: 50
                   pattern: "[a-z0-9]([a-z0-9-]*[a-z0-9])?"
             spec:
               type: object

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/invalid-metadata.name-over-50-characters.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/invalid-metadata.name-over-50-characters.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxy
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: 123456789012345678901234567890123456789012345678901
+    namespace: proxy-ns
+expectFailureMessageToContain: |
+  metadata.name: Too long

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/valid-metadata.name-50-characters.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/valid-metadata.name-50-characters.yaml
@@ -1,0 +1,12 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: 12345678901234567890123456789012345678901234567890
+  namespace: proxy-ns


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Reduce max length of KafkaProxy metadata.name to 50

### Additional Context

We want to be able to suffix the proxy name to create a shared LoadBalancer service. The max length for the Service name is 63 characters, so currently we could create a 63 character long KafkaProxy name which prevents the Service manifesting. Limiting the KafkaProxy name to 50 gives us some wiggle room for creating resources based on the proxy name.

Closes #2264 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
