### PR TITLE
Fix #2276: Tidy up the Kubernetes Labels applied by the Operator

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/Labels.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/Labels.java
@@ -6,7 +6,6 @@
 
 package io.kroxylicious.kubernetes.operator;
 
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -14,13 +13,16 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 
 public class Labels {
 
+    private Labels() {
+        // singleton
+    }
+
     public static Map<String, String> standardLabels(KafkaProxy proxy) {
-        HashMap<String, String> labels = new LinkedHashMap<>();
-        labels.put("app.kubernetes.io/part-of", "kafka");
+        Map<String, String> labels = new LinkedHashMap<>();
         labels.put("app.kubernetes.io/managed-by", "kroxylicious-operator");
-        labels.put("app.kubernetes.io/name", "kroxylicious-proxy");
-        labels.put("app.kubernetes.io/instance", ResourcesUtil.name(proxy));
+        labels.put("app.kubernetes.io/name", "kroxylicious");
         labels.put("app.kubernetes.io/component", "proxy");
+        labels.put("app.kubernetes.io/instance", ResourcesUtil.name(proxy));
         return labels;
     }
 

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeploymentDependentResource.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeploymentDependentResource.java
@@ -52,7 +52,6 @@ public class ProxyDeploymentDependentResource
     private static final Logger LOGGER = LoggerFactory.getLogger(ProxyDeploymentDependentResource.class);
     public static final String CONFIG_VOLUME = "config-volume";
     public static final String CONFIG_PATH_IN_CONTAINER = "/opt/kroxylicious/config/" + ProxyConfigDependentResource.CONFIG_YAML_KEY;
-    public static final Map<String, String> APP_KROXY = Map.of("app", "kroxylicious");
     private static final int MANAGEMENT_PORT = 9190;
     private static final String MANAGEMENT_PORT_NAME = "management";
     public static final int PROXY_PORT_START = 9292;
@@ -84,7 +83,6 @@ public class ProxyDeploymentDependentResource
                     .withName(deploymentName(primary))
                     .withNamespace(namespace(primary))
                     .addNewOwnerReferenceLike(ResourcesUtil.newOwnerReferenceTo(primary)).endOwnerReference()
-                    .addToLabels(APP_KROXY)
                     .addToLabels(standardLabels(primary))
                 .endMetadata()
                 .editOrNewSpec()
@@ -122,8 +120,7 @@ public class ProxyDeploymentDependentResource
                 .map(PodTemplateSpec::getMetadata)
                 .map(ObjectMeta::getLabels)
                 .orElse(Map.of());
-        Map<String, String> result = new LinkedHashMap<>(APP_KROXY);
-        result.putAll(labelsFromSpec);
+        Map<String, String> result = new LinkedHashMap<>(labelsFromSpec);
         result.putAll(standardLabels(primary));
         return result;
     }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/LabelsTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/LabelsTest.java
@@ -26,11 +26,10 @@ class LabelsTest {
         KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName(PROXY_NAME).endMetadata().build();
         Map<String, String> labels = Labels.standardLabels(proxy);
         LinkedHashMap<String, String> expected = new LinkedHashMap<>();
-        expected.put("app.kubernetes.io/part-of", "kafka");
         expected.put("app.kubernetes.io/managed-by", "kroxylicious-operator");
-        expected.put("app.kubernetes.io/name", "kroxylicious-proxy");
-        expected.put("app.kubernetes.io/instance", PROXY_NAME);
+        expected.put("app.kubernetes.io/name", "kroxylicious");
         expected.put("app.kubernetes.io/component", "proxy");
+        expected.put("app.kubernetes.io/instance", PROXY_NAME);
         assertThat(labels).containsExactlyEntriesOf(expected);
     }
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyDeploymentTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyDeploymentTest.java
@@ -155,14 +155,12 @@ class ProxyDeploymentTest {
     @NonNull
     private static LinkedHashMap<String, String> expectedLabels() {
         LinkedHashMap<String, String> expected = new LinkedHashMap<>();
-        expected.put("app", "kroxylicious");
         expected.put("c", "d");
         expected.put("a", "b");
-        expected.put("app.kubernetes.io/part-of", "kafka");
         expected.put("app.kubernetes.io/managed-by", "kroxylicious-operator");
-        expected.put("app.kubernetes.io/name", "kroxylicious-proxy");
-        expected.put("app.kubernetes.io/instance", PROXY_NAME);
+        expected.put("app.kubernetes.io/name", "kroxylicious");
         expected.put("app.kubernetes.io/component", "proxy");
+        expected.put("app.kubernetes.io/instance", PROXY_NAME);
         return expected;
     }
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/model/networking/TcpClusterIPClusterIngressNetworkingModelTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/model/networking/TcpClusterIPClusterIngressNetworkingModelTest.java
@@ -212,9 +212,7 @@ class TcpClusterIPClusterIngressNetworkingModelTest {
         assertThat(serviceBuilders).isNotNull().isNotEmpty().singleElement().satisfies(serviceBuild -> {
             Service build = serviceBuild.build();
             assertThat(build.getSpec()).isNotNull().satisfies(serviceSpec -> {
-                LinkedHashMap<String, String> orderedSelectorLabels = new LinkedHashMap<>();
-                orderedSelectorLabels.put("app", "kroxylicious");
-                orderedSelectorLabels.putAll(commonLabels(PROXY_NAME));
+                LinkedHashMap<String, String> orderedSelectorLabels = new LinkedHashMap<>(commonLabels(PROXY_NAME));
                 assertThat(serviceSpec.getSelector()).containsExactlyEntriesOf(orderedSelectorLabels);
             });
         });
@@ -413,11 +411,10 @@ class TcpClusterIPClusterIngressNetworkingModelTest {
 
     private static @NonNull Map<String, String> commonLabels(String proxyName) {
         Map<String, String> orderedLabels = new java.util.LinkedHashMap<>();
-        orderedLabels.put("app.kubernetes.io/part-of", "kafka");
         orderedLabels.put("app.kubernetes.io/managed-by", "kroxylicious-operator");
-        orderedLabels.put("app.kubernetes.io/name", "kroxylicious-proxy");
-        orderedLabels.put("app.kubernetes.io/instance", proxyName);
+        orderedLabels.put("app.kubernetes.io/name", "kroxylicious");
         orderedLabels.put("app.kubernetes.io/component", "proxy");
+        orderedLabels.put("app.kubernetes.io/instance", proxyName);
         return orderedLabels;
     }
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/model/networking/TlsClusterIPClusterIngressNetworkingModelTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/model/networking/TlsClusterIPClusterIngressNetworkingModelTest.java
@@ -177,9 +177,7 @@ class TlsClusterIPClusterIngressNetworkingModelTest {
         assertThat(serviceBuilders).isNotNull().isNotEmpty().allSatisfy(serviceBuild -> {
             Service build = serviceBuild.build();
             assertThat(build.getSpec()).isNotNull().satisfies(serviceSpec -> {
-                LinkedHashMap<String, String> orderedSelectorLabels = new LinkedHashMap<>();
-                orderedSelectorLabels.put("app", "kroxylicious");
-                orderedSelectorLabels.putAll(commonLabels(PROXY_NAME));
+                LinkedHashMap<String, String> orderedSelectorLabels = new LinkedHashMap<>(commonLabels(PROXY_NAME));
                 assertThat(serviceSpec.getSelector()).containsExactlyEntriesOf(orderedSelectorLabels);
             });
         });
@@ -305,11 +303,10 @@ class TlsClusterIPClusterIngressNetworkingModelTest {
 
     private static @NonNull Map<String, String> commonLabels(String proxyName) {
         Map<String, String> orderedLabels = new LinkedHashMap<>();
-        orderedLabels.put("app.kubernetes.io/part-of", "kafka");
         orderedLabels.put("app.kubernetes.io/managed-by", "kroxylicious-operator");
-        orderedLabels.put("app.kubernetes.io/name", "kroxylicious-proxy");
-        orderedLabels.put("app.kubernetes.io/instance", proxyName);
+        orderedLabels.put("app.kubernetes.io/name", "kroxylicious");
         orderedLabels.put("app.kubernetes.io/component", "proxy");
+        orderedLabels.put("app.kubernetes.io/instance", proxyName);
         return orderedLabels;
     }
 

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-ConfigMap-example-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-ConfigMap-example-config-state.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example-config-state"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-Deployment-example.yaml
@@ -9,10 +9,8 @@ apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   labels:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example"
@@ -25,19 +23,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: "kroxylicious"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
-      app.kubernetes.io/name: "kroxylicious-proxy"
+      app.kubernetes.io/name: "kroxylicious"
       app.kubernetes.io/instance: "example"
       app.kubernetes.io/component: "proxy"
   template:
     metadata:
       labels:
-        app: "kroxylicious"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
-        app.kubernetes.io/name: "kroxylicious-proxy"
+        app.kubernetes.io/name: "kroxylicious"
         app.kubernetes.io/instance: "example"
         app.kubernetes.io/component: "proxy"
       annotations:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-ConfigMap-example-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-ConfigMap-example-config-state.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example-config-state"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-ConfigMap-example-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-ConfigMap-example-proxy-config.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example-proxy-config"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Deployment-example.yaml
@@ -9,10 +9,8 @@ apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   labels:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example"
@@ -25,19 +23,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: "kroxylicious"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
-      app.kubernetes.io/name: "kroxylicious-proxy"
+      app.kubernetes.io/name: "kroxylicious"
       app.kubernetes.io/instance: "example"
       app.kubernetes.io/component: "proxy"
   template:
     metadata:
       labels:
-        app: "kroxylicious"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
-        app.kubernetes.io/name: "kroxylicious-proxy"
+        app.kubernetes.io/name: "kroxylicious"
         app.kubernetes.io/instance: "example"
         app.kubernetes.io/component: "proxy"
       annotations:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Service-foo-cluster-ip-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Service-foo-cluster-ip-bootstrap.yaml
@@ -13,9 +13,8 @@ metadata:
       :\"cluster-ip\",\"bootstrapServers\":\"foo-cluster-ip-bootstrap.proxy-ns.svc.cluster.local:9292\"\
       }]}"
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "foo-cluster-ip-bootstrap"
@@ -49,9 +48,7 @@ spec:
       protocol: "TCP"
       targetPort: 9295
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-ConfigMap-example-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-ConfigMap-example-config-state.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example-config-state"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Deployment-example.yaml
@@ -9,10 +9,8 @@ apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   labels:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example"
@@ -25,19 +23,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: "kroxylicious"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
-      app.kubernetes.io/name: "kroxylicious-proxy"
+      app.kubernetes.io/name: "kroxylicious"
       app.kubernetes.io/instance: "example"
       app.kubernetes.io/component: "proxy"
   template:
     metadata:
       labels:
-        app: "kroxylicious"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
-        app.kubernetes.io/name: "kroxylicious-proxy"
+        app.kubernetes.io/name: "kroxylicious"
         app.kubernetes.io/instance: "example"
         app.kubernetes.io/component: "proxy"
       annotations:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/kafka-service-with-tls/out-ConfigMap-minimal-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/kafka-service-with-tls/out-ConfigMap-minimal-config-state.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal-config-state"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/kafka-service-with-tls/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/kafka-service-with-tls/out-ConfigMap-minimal-proxy-config.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal-proxy-config"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/kafka-service-with-tls/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/kafka-service-with-tls/out-Deployment-minimal.yaml
@@ -9,10 +9,8 @@ apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   labels:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal"
@@ -25,19 +23,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: "kroxylicious"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
-      app.kubernetes.io/name: "kroxylicious-proxy"
+      app.kubernetes.io/name: "kroxylicious"
       app.kubernetes.io/instance: "minimal"
       app.kubernetes.io/component: "proxy"
   template:
     metadata:
       labels:
-        app: "kroxylicious"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
-        app.kubernetes.io/name: "kroxylicious-proxy"
+        app.kubernetes.io/name: "kroxylicious"
         app.kubernetes.io/instance: "minimal"
         app.kubernetes.io/component: "proxy"
       annotations:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/kafka-service-with-tls/out-Service-one-cluster-ip-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/kafka-service-with-tls/out-Service-one-cluster-ip-bootstrap.yaml
@@ -13,9 +13,8 @@ metadata:
         :\"cluster-ip\",\"bootstrapServers\":\"one-cluster-ip-bootstrap.proxy-ns.svc.cluster.local:9292\"\
         }]}"
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-bootstrap"
@@ -49,9 +48,7 @@ spec:
       protocol: "TCP"
       targetPort: 9295
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-ConfigMap-minimal-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-ConfigMap-minimal-config-state.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal-config-state"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-ConfigMap-minimal-proxy-config.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal-proxy-config"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Deployment-minimal.yaml
@@ -9,10 +9,8 @@ apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   labels:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal"
@@ -25,19 +23,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: "kroxylicious"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
-      app.kubernetes.io/name: "kroxylicious-proxy"
+      app.kubernetes.io/name: "kroxylicious"
       app.kubernetes.io/instance: "minimal"
       app.kubernetes.io/component: "proxy"
   template:
     metadata:
       labels:
-        app: "kroxylicious"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
-        app.kubernetes.io/name: "kroxylicious-proxy"
+        app.kubernetes.io/name: "kroxylicious"
         app.kubernetes.io/instance: "minimal"
         app.kubernetes.io/component: "proxy"
       annotations:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Service-minimal-sni.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Service-minimal-sni.yaml
@@ -12,9 +12,8 @@ metadata:
     kroxylicious.io/bootstrap-servers: "{\"version\":\"0.13.0\",\"bootstrapServers\":[{\"clusterName\":\"one\",\"ingressName\"\
       :\"load-balancer\",\"bootstrapServers\":\"one.kafkaproxy:9083\"}]}"
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal-sni"
@@ -30,10 +29,8 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   type: "LoadBalancer"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Service-one-cluster-ip-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Service-one-cluster-ip-0.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-0"
@@ -32,9 +31,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Service-one-cluster-ip-1.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Service-one-cluster-ip-1.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-1"
@@ -32,9 +31,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Service-one-cluster-ip-2.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Service-one-cluster-ip-2.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-2"
@@ -32,9 +31,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Service-one-cluster-ip-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Service-one-cluster-ip-bootstrap.yaml
@@ -13,9 +13,8 @@ metadata:
         :\"cluster-ip\",\"bootstrapServers\":\"one-cluster-ip-bootstrap.proxy-ns.svc.cluster.local:9292\"\
         }]}"
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-bootstrap"
@@ -36,9 +35,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress-with-no-downstream-tls-on-cluster/out-ConfigMap-twocluster-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress-with-no-downstream-tls-on-cluster/out-ConfigMap-twocluster-config-state.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "twocluster-config-state"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress-with-no-downstream-tls-on-cluster/out-ConfigMap-twocluster-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress-with-no-downstream-tls-on-cluster/out-ConfigMap-twocluster-proxy-config.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "twocluster-proxy-config"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress-with-no-downstream-tls-on-cluster/out-Deployment-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress-with-no-downstream-tls-on-cluster/out-Deployment-twocluster.yaml
@@ -9,10 +9,8 @@ apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   labels:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "twocluster"
@@ -25,19 +23,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: "kroxylicious"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
-      app.kubernetes.io/name: "kroxylicious-proxy"
+      app.kubernetes.io/name: "kroxylicious"
       app.kubernetes.io/instance: "twocluster"
       app.kubernetes.io/component: "proxy"
   template:
     metadata:
       labels:
-        app: "kroxylicious"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
-        app.kubernetes.io/name: "kroxylicious-proxy"
+        app.kubernetes.io/name: "kroxylicious"
         app.kubernetes.io/instance: "twocluster"
         app.kubernetes.io/component: "proxy"
       annotations:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress-with-no-downstream-tls-on-cluster/out-Service-twocluster-sni.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress-with-no-downstream-tls-on-cluster/out-Service-twocluster-sni.yaml
@@ -12,9 +12,8 @@ metadata:
     kroxylicious.io/bootstrap-servers: "{\"version\":\"0.13.0\",\"bootstrapServers\":[{\"clusterName\":\"bar\",\"ingressName\"\
       :\"load-balancer\",\"bootstrapServers\":\"bar.kafkaproxy:9083\"}]}"
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "twocluster-sni"
@@ -30,10 +29,8 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   type: "LoadBalancer"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress/out-ConfigMap-minimal-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress/out-ConfigMap-minimal-config-state.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal-config-state"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress/out-ConfigMap-minimal-proxy-config.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal-proxy-config"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress/out-Deployment-minimal.yaml
@@ -9,10 +9,8 @@ apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   labels:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal"
@@ -25,19 +23,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: "kroxylicious"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
-      app.kubernetes.io/name: "kroxylicious-proxy"
+      app.kubernetes.io/name: "kroxylicious"
       app.kubernetes.io/instance: "minimal"
       app.kubernetes.io/component: "proxy"
   template:
     metadata:
       labels:
-        app: "kroxylicious"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
-        app.kubernetes.io/name: "kroxylicious-proxy"
+        app.kubernetes.io/name: "kroxylicious"
         app.kubernetes.io/instance: "minimal"
         app.kubernetes.io/component: "proxy"
       annotations:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress/out-Service-minimal-sni.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress/out-Service-minimal-sni.yaml
@@ -12,9 +12,8 @@ metadata:
     kroxylicious.io/bootstrap-servers: "{\"version\":\"0.13.0\",\"bootstrapServers\":[{\"clusterName\":\"one\",\"ingressName\"\
       :\"load-balancer\",\"bootstrapServers\":\"one.kafkaproxy:9083\"}]}"
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal-sni"
@@ -30,10 +29,8 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   type: "LoadBalancer"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-ConfigMap-minimal-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-ConfigMap-minimal-config-state.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal-config-state"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-ConfigMap-minimal-proxy-config.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal-proxy-config"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Deployment-minimal.yaml
@@ -9,10 +9,8 @@ apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   labels:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal"
@@ -25,19 +23,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: "kroxylicious"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
-      app.kubernetes.io/name: "kroxylicious-proxy"
+      app.kubernetes.io/name: "kroxylicious"
       app.kubernetes.io/instance: "minimal"
       app.kubernetes.io/component: "proxy"
   template:
     metadata:
       labels:
-        app: "kroxylicious"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
-        app.kubernetes.io/name: "kroxylicious-proxy"
+        app.kubernetes.io/name: "kroxylicious"
         app.kubernetes.io/instance: "minimal"
         app.kubernetes.io/component: "proxy"
       annotations:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Service-one-cluster-ip-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Service-one-cluster-ip-bootstrap.yaml
@@ -13,9 +13,8 @@ metadata:
         :\"cluster-ip\",\"bootstrapServers\":\"one-cluster-ip-bootstrap.proxy-ns.svc.cluster.local:9292\"\
         }]}"
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-bootstrap"
@@ -49,9 +48,7 @@ spec:
       protocol: "TCP"
       targetPort: 9295
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-ConfigMap-twocluster-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-ConfigMap-twocluster-config-state.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "twocluster-config-state"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-ConfigMap-twocluster-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-ConfigMap-twocluster-proxy-config.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "twocluster-proxy-config"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-Deployment-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-Deployment-twocluster.yaml
@@ -9,10 +9,8 @@ apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   labels:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "twocluster"
@@ -25,19 +23,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: "kroxylicious"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
-      app.kubernetes.io/name: "kroxylicious-proxy"
+      app.kubernetes.io/name: "kroxylicious"
       app.kubernetes.io/instance: "twocluster"
       app.kubernetes.io/component: "proxy"
   template:
     metadata:
       labels:
-        app: "kroxylicious"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
-        app.kubernetes.io/name: "kroxylicious-proxy"
+        app.kubernetes.io/name: "kroxylicious"
         app.kubernetes.io/instance: "twocluster"
         app.kubernetes.io/component: "proxy"
       annotations:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-Service-bar-cluster-ip-bar-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-Service-bar-cluster-ip-bar-bootstrap.yaml
@@ -13,9 +13,8 @@ metadata:
       :\"cluster-ip-bar\",\"bootstrapServers\":\"bar-cluster-ip-bar-bootstrap.proxy-ns.svc.cluster.local:9292\"\
       }]}"
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "bar-cluster-ip-bar-bootstrap"
@@ -49,9 +48,7 @@ spec:
       protocol: "TCP"
       targetPort: 9295
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-ConfigMap-twocluster-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-ConfigMap-twocluster-config-state.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "twocluster-config-state"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-ConfigMap-twocluster-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-ConfigMap-twocluster-proxy-config.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "twocluster-proxy-config"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-Deployment-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-Deployment-twocluster.yaml
@@ -9,10 +9,8 @@ apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   labels:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "twocluster"
@@ -25,19 +23,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: "kroxylicious"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
-      app.kubernetes.io/name: "kroxylicious-proxy"
+      app.kubernetes.io/name: "kroxylicious"
       app.kubernetes.io/instance: "twocluster"
       app.kubernetes.io/component: "proxy"
   template:
     metadata:
       labels:
-        app: "kroxylicious"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
-        app.kubernetes.io/name: "kroxylicious-proxy"
+        app.kubernetes.io/name: "kroxylicious"
         app.kubernetes.io/instance: "twocluster"
         app.kubernetes.io/component: "proxy"
       annotations:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-Service-bar-cluster-ip-bar-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-Service-bar-cluster-ip-bar-bootstrap.yaml
@@ -13,9 +13,8 @@ metadata:
       :\"cluster-ip-bar\",\"bootstrapServers\":\"bar-cluster-ip-bar-bootstrap.proxy-ns.svc.cluster.local:9292\"\
       }]}"
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "bar-cluster-ip-bar-bootstrap"
@@ -49,9 +48,7 @@ spec:
       protocol: "TCP"
       targetPort: 9295
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/out-ConfigMap-twocluster-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/out-ConfigMap-twocluster-config-state.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "twocluster-config-state"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/out-Deployment-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/out-Deployment-twocluster.yaml
@@ -9,10 +9,8 @@ apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   labels:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "twocluster"
@@ -25,19 +23,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: "kroxylicious"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
-      app.kubernetes.io/name: "kroxylicious-proxy"
+      app.kubernetes.io/name: "kroxylicious"
       app.kubernetes.io/instance: "twocluster"
       app.kubernetes.io/component: "proxy"
   template:
     metadata:
       labels:
-        app: "kroxylicious"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
-        app.kubernetes.io/name: "kroxylicious-proxy"
+        app.kubernetes.io/name: "kroxylicious"
         app.kubernetes.io/instance: "twocluster"
         app.kubernetes.io/component: "proxy"
       annotations:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-shared-loadbalancer-ingress/out-ConfigMap-twocluster-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-shared-loadbalancer-ingress/out-ConfigMap-twocluster-config-state.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "twocluster-config-state"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-shared-loadbalancer-ingress/out-ConfigMap-twocluster-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-shared-loadbalancer-ingress/out-ConfigMap-twocluster-proxy-config.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "twocluster-proxy-config"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-shared-loadbalancer-ingress/out-Deployment-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-shared-loadbalancer-ingress/out-Deployment-twocluster.yaml
@@ -9,10 +9,8 @@ apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   labels:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "twocluster"
@@ -25,19 +23,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: "kroxylicious"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
-      app.kubernetes.io/name: "kroxylicious-proxy"
+      app.kubernetes.io/name: "kroxylicious"
       app.kubernetes.io/instance: "twocluster"
       app.kubernetes.io/component: "proxy"
   template:
     metadata:
       labels:
-        app: "kroxylicious"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
-        app.kubernetes.io/name: "kroxylicious-proxy"
+        app.kubernetes.io/name: "kroxylicious"
         app.kubernetes.io/instance: "twocluster"
         app.kubernetes.io/component: "proxy"
       annotations:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-shared-loadbalancer-ingress/out-Service-twocluster-sni.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-shared-loadbalancer-ingress/out-Service-twocluster-sni.yaml
@@ -14,9 +14,8 @@ metadata:
       :\"foo\",\"ingressName\":\"load-balancer\",\"bootstrapServers\":\"foo.kafkaproxy:9083\"\
       }]}"
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   name: "twocluster-sni"
@@ -32,10 +31,8 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "twocluster"
     app.kubernetes.io/component: "proxy"
   type: "LoadBalancer"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-ConfigMap-example-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-ConfigMap-example-config-state.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example-config-state"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-ConfigMap-example-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-ConfigMap-example-proxy-config.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example-proxy-config"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Deployment-example.yaml
@@ -9,10 +9,8 @@ apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   labels:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "example"
@@ -25,19 +23,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: "kroxylicious"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
-      app.kubernetes.io/name: "kroxylicious-proxy"
+      app.kubernetes.io/name: "kroxylicious"
       app.kubernetes.io/instance: "example"
       app.kubernetes.io/component: "proxy"
   template:
     metadata:
       labels:
-        app: "kroxylicious"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
-        app.kubernetes.io/name: "kroxylicious-proxy"
+        app.kubernetes.io/name: "kroxylicious"
         app.kubernetes.io/instance: "example"
         app.kubernetes.io/component: "proxy"
       annotations:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Service-foo-cluster-ip-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Service-foo-cluster-ip-bootstrap.yaml
@@ -13,9 +13,8 @@ metadata:
       :\"cluster-ip\",\"bootstrapServers\":\"foo-cluster-ip-bootstrap.proxy-ns.svc.cluster.local:9292\"\
       }]}"
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"
   name: "foo-cluster-ip-bootstrap"
@@ -49,9 +48,7 @@ spec:
       protocol: "TCP"
       targetPort: 9295
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "example"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-ConfigMap-use-pod-template-spec-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-ConfigMap-use-pod-template-spec-config-state.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "use-pod-template-spec"
     app.kubernetes.io/component: "proxy"
   name: "use-pod-template-spec-config-state"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-ConfigMap-use-pod-template-spec-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-ConfigMap-use-pod-template-spec-proxy-config.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "use-pod-template-spec"
     app.kubernetes.io/component: "proxy"
   name: "use-pod-template-spec-proxy-config"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Deployment-use-pod-template-spec.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Deployment-use-pod-template-spec.yaml
@@ -9,10 +9,8 @@ apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   labels:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "use-pod-template-spec"
     app.kubernetes.io/component: "proxy"
   name: "use-pod-template-spec"
@@ -25,21 +23,17 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: "kroxylicious"
       environment: "production-from-podTemplate"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
-      app.kubernetes.io/name: "kroxylicious-proxy"
+      app.kubernetes.io/name: "kroxylicious"
       app.kubernetes.io/instance: "use-pod-template-spec"
       app.kubernetes.io/component: "proxy"
   template:
     metadata:
       labels:
-        app: "kroxylicious"
         environment: "production-from-podTemplate"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
-        app.kubernetes.io/name: "kroxylicious-proxy"
+        app.kubernetes.io/name: "kroxylicious"
         app.kubernetes.io/instance: "use-pod-template-spec"
         app.kubernetes.io/component: "proxy"
       annotations:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Service-one-cluster-ip-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Service-one-cluster-ip-bootstrap.yaml
@@ -13,9 +13,8 @@ metadata:
         :\"cluster-ip\",\"bootstrapServers\":\"one-cluster-ip-bootstrap.proxy-ns.svc.cluster.local:9292\"\
         }]}"
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "use-pod-template-spec"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-bootstrap"
@@ -49,11 +48,8 @@ spec:
       protocol: "TCP"
       targetPort: 9295
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     environment: "production-from-podTemplate"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "use-pod-template-spec"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-ConfigMap-minimal-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-ConfigMap-minimal-config-state.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal-config-state"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-ConfigMap-minimal-proxy-config.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal-proxy-config"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Deployment-minimal.yaml
@@ -9,10 +9,8 @@ apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   labels:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal"
@@ -25,10 +23,8 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: "kroxylicious"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
-      app.kubernetes.io/name: "kroxylicious-proxy"
+      app.kubernetes.io/name: "kroxylicious"
       app.kubernetes.io/instance: "minimal"
       app.kubernetes.io/component: "proxy"
   template:
@@ -36,10 +32,8 @@ spec:
       annotations:
         kroxylicious.io/referent-checksum: "AAAAAAAB4wY"
       labels:
-        app: "kroxylicious"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
-        app.kubernetes.io/name: "kroxylicious-proxy"
+        app.kubernetes.io/name: "kroxylicious"
         app.kubernetes.io/instance: "minimal"
         app.kubernetes.io/component: "proxy"
     spec:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Service-one-cluster-ip-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Service-one-cluster-ip-0.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-0"
@@ -32,9 +31,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Service-one-cluster-ip-1.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Service-one-cluster-ip-1.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-1"
@@ -32,9 +31,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Service-one-cluster-ip-2.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Service-one-cluster-ip-2.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-2"
@@ -32,9 +31,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Service-one-cluster-ip-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Service-one-cluster-ip-bootstrap.yaml
@@ -13,9 +13,8 @@ metadata:
         :\"cluster-ip\",\"bootstrapServers\":\"one-cluster-ip-bootstrap.proxy-ns.svc.cluster.local:9292\"\
         }]}"
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-bootstrap"
@@ -36,9 +35,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-ConfigMap-minimal-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-ConfigMap-minimal-config-state.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal-config-state"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-ConfigMap-minimal-proxy-config.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal-proxy-config"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Deployment-minimal.yaml
@@ -9,10 +9,8 @@ apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   labels:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal"
@@ -25,10 +23,8 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: "kroxylicious"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
-      app.kubernetes.io/name: "kroxylicious-proxy"
+      app.kubernetes.io/name: "kroxylicious"
       app.kubernetes.io/instance: "minimal"
       app.kubernetes.io/component: "proxy"
   template:
@@ -36,10 +32,8 @@ spec:
       annotations:
         kroxylicious.io/referent-checksum: "AAAAAAAB4wY"
       labels:
-        app: "kroxylicious"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
-        app.kubernetes.io/name: "kroxylicious-proxy"
+        app.kubernetes.io/name: "kroxylicious"
         app.kubernetes.io/instance: "minimal"
         app.kubernetes.io/component: "proxy"
     spec:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Service-one-cluster-ip-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Service-one-cluster-ip-0.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-0"
@@ -32,9 +31,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Service-one-cluster-ip-1.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Service-one-cluster-ip-1.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-1"
@@ -32,9 +31,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Service-one-cluster-ip-2.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Service-one-cluster-ip-2.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-2"
@@ -32,9 +31,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Service-one-cluster-ip-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Service-one-cluster-ip-bootstrap.yaml
@@ -13,9 +13,8 @@ metadata:
         :\"cluster-ip\",\"bootstrapServers\":\"one-cluster-ip-bootstrap.proxy-ns.svc.cluster.local:9292\"\
         }]}"
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-bootstrap"
@@ -36,9 +35,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-ConfigMap-minimal-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-ConfigMap-minimal-config-state.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal-config-state"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-ConfigMap-minimal-proxy-config.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal-proxy-config"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Deployment-minimal.yaml
@@ -9,10 +9,8 @@ apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   labels:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal"
@@ -25,10 +23,8 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: "kroxylicious"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
-      app.kubernetes.io/name: "kroxylicious-proxy"
+      app.kubernetes.io/name: "kroxylicious"
       app.kubernetes.io/instance: "minimal"
       app.kubernetes.io/component: "proxy"
   template:
@@ -36,10 +32,8 @@ spec:
       annotations:
         kroxylicious.io/referent-checksum: "AAAAAAAB4wY"
       labels:
-        app: "kroxylicious"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
-        app.kubernetes.io/name: "kroxylicious-proxy"
+        app.kubernetes.io/name: "kroxylicious"
         app.kubernetes.io/instance: "minimal"
         app.kubernetes.io/component: "proxy"
     spec:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Service-one-cluster-ip-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Service-one-cluster-ip-0.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-0"
@@ -32,9 +31,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Service-one-cluster-ip-1.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Service-one-cluster-ip-1.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-1"
@@ -32,9 +31,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Service-one-cluster-ip-2.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Service-one-cluster-ip-2.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-2"
@@ -32,9 +31,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Service-one-cluster-ip-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Service-one-cluster-ip-bootstrap.yaml
@@ -13,9 +13,8 @@ metadata:
         :\"cluster-ip\",\"bootstrapServers\":\"one-cluster-ip-bootstrap.proxy-ns.svc.cluster.local:9292\"\
         }]}"
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-bootstrap"
@@ -36,9 +35,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-ConfigMap-minimal-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-ConfigMap-minimal-config-state.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal-config-state"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-ConfigMap-minimal-proxy-config.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal-proxy-config"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Deployment-minimal.yaml
@@ -9,10 +9,8 @@ apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   labels:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal"
@@ -25,10 +23,8 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: "kroxylicious"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
-      app.kubernetes.io/name: "kroxylicious-proxy"
+      app.kubernetes.io/name: "kroxylicious"
       app.kubernetes.io/instance: "minimal"
       app.kubernetes.io/component: "proxy"
   template:
@@ -36,10 +32,8 @@ spec:
       annotations:
         kroxylicious.io/referent-checksum: "AAAAAAAB4wY"
       labels:
-        app: "kroxylicious"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
-        app.kubernetes.io/name: "kroxylicious-proxy"
+        app.kubernetes.io/name: "kroxylicious"
         app.kubernetes.io/instance: "minimal"
         app.kubernetes.io/component: "proxy"
     spec:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Service-one-cluster-ip-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Service-one-cluster-ip-0.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-0"
@@ -32,9 +31,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Service-one-cluster-ip-1.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Service-one-cluster-ip-1.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-1"
@@ -32,9 +31,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Service-one-cluster-ip-2.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Service-one-cluster-ip-2.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-2"
@@ -32,9 +31,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Service-one-cluster-ip-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Service-one-cluster-ip-bootstrap.yaml
@@ -13,9 +13,8 @@ metadata:
         :\"cluster-ip\",\"bootstrapServers\":\"one-cluster-ip-bootstrap.proxy-ns.svc.cluster.local:9292\"\
         }]}"
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-bootstrap"
@@ -36,9 +35,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-ConfigMap-minimal-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-ConfigMap-minimal-config-state.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal-config-state"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-ConfigMap-minimal-proxy-config.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal-proxy-config"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Deployment-minimal.yaml
@@ -9,10 +9,8 @@ apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   labels:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal"
@@ -25,10 +23,8 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: "kroxylicious"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
-      app.kubernetes.io/name: "kroxylicious-proxy"
+      app.kubernetes.io/name: "kroxylicious"
       app.kubernetes.io/instance: "minimal"
       app.kubernetes.io/component: "proxy"
   template:
@@ -36,10 +32,8 @@ spec:
       annotations:
         kroxylicious.io/referent-checksum: "AAAAAAAB4wY"
       labels:
-        app: "kroxylicious"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
-        app.kubernetes.io/name: "kroxylicious-proxy"
+        app.kubernetes.io/name: "kroxylicious"
         app.kubernetes.io/instance: "minimal"
         app.kubernetes.io/component: "proxy"
     spec:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Service-one-cluster-ip-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Service-one-cluster-ip-0.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-0"
@@ -32,9 +31,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Service-one-cluster-ip-1.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Service-one-cluster-ip-1.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-1"
@@ -32,9 +31,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Service-one-cluster-ip-2.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Service-one-cluster-ip-2.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-2"
@@ -32,9 +31,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Service-one-cluster-ip-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Service-one-cluster-ip-bootstrap.yaml
@@ -13,9 +13,8 @@ metadata:
         :\"cluster-ip\",\"bootstrapServers\":\"one-cluster-ip-bootstrap.proxy-ns.svc.cluster.local:9292\"\
         }]}"
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-bootstrap"
@@ -36,9 +35,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-ConfigMap-minimal-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-ConfigMap-minimal-config-state.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal-config-state"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-ConfigMap-minimal-proxy-config.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "ConfigMap"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal-proxy-config"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Deployment-minimal.yaml
@@ -9,10 +9,8 @@ apiVersion: "apps/v1"
 kind: "Deployment"
 metadata:
   labels:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "minimal"
@@ -25,19 +23,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: "kroxylicious"
-      app.kubernetes.io/part-of: "kafka"
       app.kubernetes.io/managed-by: "kroxylicious-operator"
-      app.kubernetes.io/name: "kroxylicious-proxy"
+      app.kubernetes.io/name: "kroxylicious"
       app.kubernetes.io/instance: "minimal"
       app.kubernetes.io/component: "proxy"
   template:
     metadata:
       labels:
-        app: "kroxylicious"
-        app.kubernetes.io/part-of: "kafka"
         app.kubernetes.io/managed-by: "kroxylicious-operator"
-        app.kubernetes.io/name: "kroxylicious-proxy"
+        app.kubernetes.io/name: "kroxylicious"
         app.kubernetes.io/instance: "minimal"
         app.kubernetes.io/component: "proxy"
       annotations:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Service-one-cluster-ip-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Service-one-cluster-ip-0.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-0"
@@ -32,9 +31,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Service-one-cluster-ip-1.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Service-one-cluster-ip-1.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-1"
@@ -32,9 +31,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Service-one-cluster-ip-2.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Service-one-cluster-ip-2.yaml
@@ -9,9 +9,8 @@ apiVersion: "v1"
 kind: "Service"
 metadata:
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-2"
@@ -32,9 +31,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Service-one-cluster-ip-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Service-one-cluster-ip-bootstrap.yaml
@@ -13,9 +13,8 @@ metadata:
         :\"cluster-ip\",\"bootstrapServers\":\"one-cluster-ip-bootstrap.proxy-ns.svc.cluster.local:9292\"\
         }]}"
   labels:
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"
   name: "one-cluster-ip-bootstrap"
@@ -36,9 +35,7 @@ spec:
       protocol: "TCP"
       targetPort: 9291
   selector:
-    app: "kroxylicious"
-    app.kubernetes.io/part-of: "kafka"
     app.kubernetes.io/managed-by: "kroxylicious-operator"
-    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/instance: "minimal"
     app.kubernetes.io/component: "proxy"


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

* Drop the 'app' label (it is superfluous)
* Drop the 'app.kubernetes.io/part-of' - it is [supposed to carry](https://kubernetes.io/docs/reference/labels-annotations-taints/#app-kubernetes-io-part-of) the 'higher level' application (as known to end users).  We were misusing by setting the value of `kafka`.
* 'app.kubernetes.io/name' is [supposed to carry](https://kubernetes.io/docs/reference/labels-annotations-taints/#app-kubernetes-io-name) an application name, so both the operator and proxy should use the name 'kroxylicious'.  (The [app.kubernetes.io/component](https://kubernetes.io/docs/reference/labels-annotations-taints/#app-kubernetes-io-component) allows a user to distinguish between the resources of the two).

_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [x] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
