### PR TITLE
Client ssl principal propagation

### DIFF
--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
@@ -12,6 +12,7 @@ import javax.annotation.Nullable;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -49,10 +50,10 @@ public interface FilterContext {
      * such as "CN=clientName, O=organizationName, C=US". This information can be used
      * by filters for client authentication, authorization decisions, or audit logging.
      *
-     * @return the client certificate principal as a string
+     * @return the client certificate principal as a KafkaPrincipal
      */
     @Nullable
-    default String downstreamCertificatePrincipal() {
+    default KafkaPrincipal downstreamCertificatePrincipal() {
         return null;
     }
 

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
@@ -42,8 +42,19 @@ public interface FilterContext {
     @Nullable
     String sniHostname();
 
+    /**
+     * Returns the principal name from the client's TLS certificate.
+     * <p>
+     * For X.509 certificates, this is typically the Distinguished Name (DN) in format
+     * such as "CN=clientName, O=organizationName, C=US". This information can be used
+     * by filters for client authentication, authorization decisions, or audit logging.
+     *
+     * @return the client certificate principal as a string
+     */
     @Nullable
-    String downStreamCertificatePrincipal();
+    default String downstreamCertificatePrincipal() {
+        return null;
+    }
 
     /**
      * Creates a builder for a request filter result objects.  This object encapsulates

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
@@ -44,17 +44,14 @@ public interface FilterContext {
     String sniHostname();
 
     /**
-     * Returns the principal name from the client's TLS certificate.
      * <p>
-     * For X.509 certificates, this is typically the Distinguished Name (DN) in format
-     * such as "CN=clientName, O=organizationName, C=US". This information can be used
+     * The authenticated client principal, This information can be used
      * by filters for client authentication, authorization decisions, or audit logging.
      *
-     * @return the client certificate principal as a KafkaPrincipal
+     * @return the authenticated client principal as a KafkaPrincipal otherwise ANONYMOUS
      */
-    @Nullable
-    default KafkaPrincipal downstreamCertificatePrincipal() {
-        return null;
+    default KafkaPrincipal clientPrincipal() {
+        return KafkaPrincipal.ANONYMOUS;
     }
 
     /**

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
@@ -42,6 +42,9 @@ public interface FilterContext {
     @Nullable
     String sniHostname();
 
+    @Nullable
+    String downStreamCertificatePrincipal();
+
     /**
      * Creates a builder for a request filter result objects.  This object encapsulates
      * the request to forward and optionally orders for actions such as closing

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -59,6 +59,7 @@ public class FilterHandler extends ChannelDuplexHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(FilterHandler.class);
     private final long timeoutMs;
     private final String sniHostname;
+    private final String downStreamCertificatePrincipal;
     private final VirtualClusterModel virtualClusterModel;
     private final Channel inboundChannel;
     private final FilterAndInvoker filterAndInvoker;
@@ -67,10 +68,11 @@ public class FilterHandler extends ChannelDuplexHandler {
     private ChannelHandlerContext ctx;
     private PromiseFactory promiseFactory;
 
-    public FilterHandler(FilterAndInvoker filterAndInvoker, long timeoutMs, String sniHostname, VirtualClusterModel virtualClusterModel, Channel inboundChannel) {
+    public FilterHandler(FilterAndInvoker filterAndInvoker, long timeoutMs, String sniHostname, String downStreamCertificatePrincipal, VirtualClusterModel virtualClusterModel, Channel inboundChannel) {
         this.filterAndInvoker = Objects.requireNonNull(filterAndInvoker);
         this.timeoutMs = Assertions.requireStrictlyPositive(timeoutMs, "timeout");
         this.sniHostname = sniHostname;
+        this.downStreamCertificatePrincipal = downStreamCertificatePrincipal;
         this.virtualClusterModel = virtualClusterModel;
         this.inboundChannel = inboundChannel;
     }
@@ -473,6 +475,12 @@ public class FilterHandler extends ChannelDuplexHandler {
         @Override
         public String sniHostname() {
             return sniHostname;
+        }
+
+        @Nullable
+        @Override
+        public String downStreamCertificatePrincipal() {
+            return downStreamCertificatePrincipal;
         }
 
         public String getVirtualClusterName() {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -60,7 +60,7 @@ public class FilterHandler extends ChannelDuplexHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(FilterHandler.class);
     private final long timeoutMs;
     private final String sniHostname;
-    private final KafkaPrincipal downstreamCertificatePrincipal;
+    private final KafkaPrincipal clientPrincipal;
     private final VirtualClusterModel virtualClusterModel;
     private final Channel inboundChannel;
     private final FilterAndInvoker filterAndInvoker;
@@ -69,12 +69,12 @@ public class FilterHandler extends ChannelDuplexHandler {
     private ChannelHandlerContext ctx;
     private PromiseFactory promiseFactory;
 
-    public FilterHandler(FilterAndInvoker filterAndInvoker, long timeoutMs, String sniHostname, KafkaPrincipal downstreamCertificatePrincipal,
+    public FilterHandler(FilterAndInvoker filterAndInvoker, long timeoutMs, String sniHostname, KafkaPrincipal clientPrincipal,
                          VirtualClusterModel virtualClusterModel, Channel inboundChannel) {
         this.filterAndInvoker = Objects.requireNonNull(filterAndInvoker);
         this.timeoutMs = Assertions.requireStrictlyPositive(timeoutMs, "timeout");
         this.sniHostname = sniHostname;
-        this.downstreamCertificatePrincipal = downstreamCertificatePrincipal;
+        this.clientPrincipal = clientPrincipal;
         this.virtualClusterModel = virtualClusterModel;
         this.inboundChannel = inboundChannel;
     }
@@ -481,8 +481,8 @@ public class FilterHandler extends ChannelDuplexHandler {
 
         @Nullable
         @Override
-        public KafkaPrincipal downstreamCertificatePrincipal() {
-            return downstreamCertificatePrincipal;
+        public KafkaPrincipal clientPrincipal() {
+            return clientPrincipal;
         }
 
         public String getVirtualClusterName() {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -59,7 +59,7 @@ public class FilterHandler extends ChannelDuplexHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(FilterHandler.class);
     private final long timeoutMs;
     private final String sniHostname;
-    private final String downStreamCertificatePrincipal;
+    private final String downstreamCertificatePrincipal;
     private final VirtualClusterModel virtualClusterModel;
     private final Channel inboundChannel;
     private final FilterAndInvoker filterAndInvoker;
@@ -68,12 +68,12 @@ public class FilterHandler extends ChannelDuplexHandler {
     private ChannelHandlerContext ctx;
     private PromiseFactory promiseFactory;
 
-    public FilterHandler(FilterAndInvoker filterAndInvoker, long timeoutMs, String sniHostname, String downStreamCertificatePrincipal,
+    public FilterHandler(FilterAndInvoker filterAndInvoker, long timeoutMs, String sniHostname, String downstreamCertificatePrincipal,
                          VirtualClusterModel virtualClusterModel, Channel inboundChannel) {
         this.filterAndInvoker = Objects.requireNonNull(filterAndInvoker);
         this.timeoutMs = Assertions.requireStrictlyPositive(timeoutMs, "timeout");
         this.sniHostname = sniHostname;
-        this.downStreamCertificatePrincipal = downStreamCertificatePrincipal;
+        this.downstreamCertificatePrincipal = downstreamCertificatePrincipal;
         this.virtualClusterModel = virtualClusterModel;
         this.inboundChannel = inboundChannel;
     }
@@ -481,7 +481,7 @@ public class FilterHandler extends ChannelDuplexHandler {
         @Nullable
         @Override
         public String downstreamCertificatePrincipal() {
-            return downStreamCertificatePrincipal;
+            return downstreamCertificatePrincipal;
         }
 
         public String getVirtualClusterName() {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -68,7 +68,8 @@ public class FilterHandler extends ChannelDuplexHandler {
     private ChannelHandlerContext ctx;
     private PromiseFactory promiseFactory;
 
-    public FilterHandler(FilterAndInvoker filterAndInvoker, long timeoutMs, String sniHostname, String downStreamCertificatePrincipal, VirtualClusterModel virtualClusterModel, Channel inboundChannel) {
+    public FilterHandler(FilterAndInvoker filterAndInvoker, long timeoutMs, String sniHostname, String downStreamCertificatePrincipal,
+                         VirtualClusterModel virtualClusterModel, Channel inboundChannel) {
         this.filterAndInvoker = Objects.requireNonNull(filterAndInvoker);
         this.timeoutMs = Assertions.requireStrictlyPositive(timeoutMs, "timeout");
         this.sniHostname = sniHostname;
@@ -479,7 +480,7 @@ public class FilterHandler extends ChannelDuplexHandler {
 
         @Nullable
         @Override
-        public String downStreamCertificatePrincipal() {
+        public String downstreamCertificatePrincipal() {
             return downStreamCertificatePrincipal;
         }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -15,6 +15,7 @@ import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.security.auth.KafkaPrincipal;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,7 +60,7 @@ public class FilterHandler extends ChannelDuplexHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(FilterHandler.class);
     private final long timeoutMs;
     private final String sniHostname;
-    private final String downstreamCertificatePrincipal;
+    private final KafkaPrincipal downstreamCertificatePrincipal;
     private final VirtualClusterModel virtualClusterModel;
     private final Channel inboundChannel;
     private final FilterAndInvoker filterAndInvoker;
@@ -68,7 +69,7 @@ public class FilterHandler extends ChannelDuplexHandler {
     private ChannelHandlerContext ctx;
     private PromiseFactory promiseFactory;
 
-    public FilterHandler(FilterAndInvoker filterAndInvoker, long timeoutMs, String sniHostname, String downstreamCertificatePrincipal,
+    public FilterHandler(FilterAndInvoker filterAndInvoker, long timeoutMs, String sniHostname, KafkaPrincipal downstreamCertificatePrincipal,
                          VirtualClusterModel virtualClusterModel, Channel inboundChannel) {
         this.filterAndInvoker = Objects.requireNonNull(filterAndInvoker);
         this.timeoutMs = Assertions.requireStrictlyPositive(timeoutMs, "timeout");
@@ -480,7 +481,7 @@ public class FilterHandler extends ChannelDuplexHandler {
 
         @Nullable
         @Override
-        public String downstreamCertificatePrincipal() {
+        public KafkaPrincipal downstreamCertificatePrincipal() {
             return downstreamCertificatePrincipal;
         }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -71,6 +71,7 @@ public class KafkaProxyFrontendHandler
 
     private static final String NET_FILTER_INVOKED_IN_WRONG_STATE = "NetFilterContext invoked in wrong session state";
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProxyFrontendHandler.class);
+    private static final String ANONYMOUS = "ANONYMOUS";
 
     /** Cache ApiVersions response which we use when returning ApiVersions ourselves */
     private static final ApiVersionsResponseData API_VERSIONS_RESPONSE;
@@ -90,13 +91,12 @@ public class KafkaProxyFrontendHandler
     private boolean pendingClientFlushes;
     private @Nullable AuthenticationEvent authentication;
     private @Nullable String sniHostname;
+    private @Nullable String downstreamCertificatePrincipal;
 
     @Nullable
-    public String getDownStreamCertificatePrincipal() {
-        return downStreamCertificatePrincipal;
+    public String getDownstreamCertificatePrincipal() {
+        return downstreamCertificatePrincipal;
     }
-
-    private @Nullable String downStreamCertificatePrincipal;
 
     @VisibleForTesting
     SslHandler getSslHandler(ChannelHandlerContext ctx) {
@@ -194,10 +194,11 @@ public class KafkaProxyFrontendHandler
             if (sslHandshakeCompletionEvent.isSuccess()) {
                 SslHandler sslHandler = getSslHandler(ctx);
                 try {
-                    downStreamCertificatePrincipal = sslHandler.engine().getSession().getPeerPrincipal().toString();
-                } catch (SSLPeerUnverifiedException e) {
+                    downstreamCertificatePrincipal = sslHandler.engine().getSession().getPeerPrincipal().toString();
+                }
+                catch (SSLPeerUnverifiedException e) {
                     LOGGER.debug("No client principal received, setting principal as ANONYMOUS");
-                    downStreamCertificatePrincipal = "ANONYMOUS";
+                    downstreamCertificatePrincipal = ANONYMOUS;
                 }
             }
         }
@@ -670,7 +671,7 @@ public class KafkaProxyFrontendHandler
                             protocolFilter,
                             20000,
                             sniHostname,
-                            downStreamCertificatePrincipal,
+                            downstreamCertificatePrincipal,
                             virtualClusterModel,
                             inboundChannel));
         }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
@@ -91,7 +91,7 @@ public abstract class FilterHarness {
                     return d2;
                 })) // reverses order
                 .stream()
-                .map(f -> new FilterHandler(getOnlyElement(FilterAndInvoker.build(f.getClass().getSimpleName(), f)), timeoutMs, null, testVirtualCluster, inboundChannel))
+                .map(f -> new FilterHandler(getOnlyElement(FilterAndInvoker.build(f.getClass().getSimpleName(), f)), timeoutMs, null, null, testVirtualCluster, inboundChannel))
                 .map(ChannelHandler.class::cast);
         var handlers = Stream.concat(channelProcessors, filterHandlers);
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
@@ -91,7 +91,8 @@ public abstract class FilterHarness {
                     return d2;
                 })) // reverses order
                 .stream()
-                .map(f -> new FilterHandler(getOnlyElement(FilterAndInvoker.build(f.getClass().getSimpleName(), f)), timeoutMs, null, null, testVirtualCluster, inboundChannel))
+                .map(f -> new FilterHandler(getOnlyElement(FilterAndInvoker.build(f.getClass().getSimpleName(), f)), timeoutMs, null, null, testVirtualCluster,
+                        inboundChannel))
                 .map(ChannelHandler.class::cast);
         var handlers = Stream.concat(channelProcessors, filterHandlers);
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -344,7 +344,7 @@ class KafkaProxyFrontendHandlerTest {
     /**
      * Test the normal flow, in a number of configurations.
      *
-     * @param clientAuthConfigured
+     * @param clientAuthConfigured  whether mTLS is configured
      * @param sslConfigured         Whether SSL is configured
      * @param haProxyConfigured
      * @param saslOffloadConfigured
@@ -409,7 +409,7 @@ class KafkaProxyFrontendHandlerTest {
         var handler = handler(filter, dp, endpointBinding);
         initialiseInboundChannel(handler);
 
-        if (clientAuthConfigured){
+        if (clientAuthConfigured) {
             try {
                 when(sslSession.getPeerPrincipal()).thenReturn(mockPrincipal);
             }
@@ -426,22 +426,18 @@ class KafkaProxyFrontendHandlerTest {
             }
         }
 
-
         if (sslConfigured) {
             // Simulate the SSL handler
             inboundChannel.pipeline().fireUserEventTriggered(new SniCompletionEvent(SNI_HOSTNAME));
             inboundChannel.pipeline().fireUserEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
-            if (clientAuthConfigured) {
-                inboundChannel.pipeline().fireUserEventTriggered(SslHandshakeCompletionEvent.SUCCESS);
-            }
         }
 
         if (sslConfigured) {
             if (clientAuthConfigured) {
-                assertEquals(CLIENT_PRINCIPAL, handler.getDownStreamCertificatePrincipal());
+                assertEquals(CLIENT_PRINCIPAL, handler.getDownstreamCertificatePrincipal());
             }
             else {
-                assertEquals("ANONYMOUS", handler.getDownStreamCertificatePrincipal());
+                assertEquals("ANONYMOUS", handler.getDownstreamCertificatePrincipal());
             }
         }
         assertThat(proxyChannelStateMachine.state()).isExactlyInstanceOf(ProxyChannelState.ClientActive.class);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -328,7 +328,7 @@ class KafkaProxyFrontendHandlerTest {
                 // We don't need to test SSL here, so just return a mock
                 SSLEngine sslEngine = mock(SSLEngine.class);
                 when(sslEngine.getSession()).thenReturn(sslSession);
-                when(mockPrincipal.toString()).thenReturn(CLIENT_PRINCIPAL);
+                when(mockPrincipal.getName()).thenReturn(CLIENT_PRINCIPAL);
                 return new SslHandler(sslEngine) {
                     @Override
                     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
@@ -434,10 +434,10 @@ class KafkaProxyFrontendHandlerTest {
 
         if (sslConfigured) {
             if (clientAuthConfigured) {
-                assertEquals(CLIENT_PRINCIPAL, handler.getDownstreamCertificatePrincipal());
+                assertEquals(CLIENT_PRINCIPAL, handler.getDownstreamCertificatePrincipal().getName());
             }
             else {
-                assertEquals("ANONYMOUS", handler.getDownstreamCertificatePrincipal());
+                assertEquals("ANONYMOUS", handler.getDownstreamCertificatePrincipal().getName());
             }
         }
         assertThat(proxyChannelStateMachine.state()).isExactlyInstanceOf(ProxyChannelState.ClientActive.class);


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

This is a first step for multiple requests raised on Kroxylicious. ( see https://github.com/kroxylicious/kroxylicious/issues/2166 and https://github.com/kroxylicious/kroxylicious/issues/1637), this adds support of getting the client principal and making it available for filters to consume.

### Additional Context

_Why are you making this pull request?_
This will make the downstream client certificate principal, which is received during SSL handshake if mTLS is enabled on the proxy, available to the filter context, so that filters can be added which can do authentication swapping/ audit logging for the received principal.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
