### PR TITLE
Draft: Add OpenShift Route ingress

### DIFF
--- a/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kafkaproxyingresses.kroxylicious.io-v1.yml
+++ b/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kafkaproxyingresses.kroxylicious.io-v1.yml
@@ -53,6 +53,7 @@ spec:
               oneOf:
               - required: ["proxyRef", "clusterIP"]
               - required: ["proxyRef", "loadBalancer"]
+              - required: ["proxyRef", "openShiftRoutes"]
               properties:
                 proxyRef:
                   # Mapped to Java type io.kroxylicious.kubernetes.api. io.kroxylicious.kubernetes.api.common.common.ProxyRef
@@ -76,6 +77,16 @@ spec:
                       description: "Protocol specifies the network protocol this ingress expects to receive."
                       type: string
                       enum: ["TCP", "TLS"]
+                openShiftRoutes:
+                  type: object
+                  description: |-
+                    openShiftRoutes specifies that this ingress is for access via OpenShift Routes manifested by the
+                    Operator.
+                  required: [ "ingressDomain" ]
+                  properties:
+                    ingressDomain:
+                      type: string
+                      description: the ingress domain the routes should be created in
                 loadBalancer:
                   type: object
                   description: |-

--- a/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/kubernetes/operator/assertj/ObjectMetaAssert.java
+++ b/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/kubernetes/operator/assertj/ObjectMetaAssert.java
@@ -6,13 +6,16 @@
 
 package io.kroxylicious.kubernetes.operator.assertj;
 
+import java.util.Map;
 import java.util.function.Consumer;
 
 import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.MapAssert;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.OwnerReference;
 
 @SuppressWarnings("UnusedReturnValue")
 public class ObjectMetaAssert extends AbstractObjectAssert<ObjectMetaAssert, ObjectMeta> {
@@ -46,5 +49,25 @@ public class ObjectMetaAssert extends AbstractObjectAssert<ObjectMetaAssert, Obj
 
     public MapAssert<String, String> doesNotHaveAnnotation(String annotationName) {
         return getAnnotationsAssert().doesNotContainKey(annotationName);
+    }
+
+    public ObjectMetaAssert hasName(String expected) {
+        Assertions.assertThat(actual.getName()).isEqualTo(expected);
+        return this;
+    }
+
+    public ObjectMetaAssert hasNamespace(String expected) {
+        Assertions.assertThat(actual.getNamespace()).isEqualTo(expected);
+        return this;
+    }
+
+    public ObjectMetaAssert hasOwnerRefs(OwnerReference... ownerReferences) {
+        Assertions.assertThat(actual.getOwnerReferences()).containsExactly(ownerReferences);
+        return this;
+    }
+
+    public ObjectMetaAssert hasLabels(Map<String, String> labels) {
+        Assertions.assertThat(actual.getLabels()).isEqualTo(labels);
+        return this;
     }
 }

--- a/kroxylicious-operator/examples/open-shift-routes-ingress/00.Namespace.my-proxy.yaml
+++ b/kroxylicious-operator/examples/open-shift-routes-ingress/00.Namespace.my-proxy.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+# A Namespace for a single KafkaProxy instance
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-proxy
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: proxy

--- a/kroxylicious-operator/examples/open-shift-routes-ingress/01.KafkaProxy.simple.yaml
+++ b/kroxylicious-operator/examples/open-shift-routes-ingress/01.KafkaProxy.simple.yaml
@@ -1,0 +1,13 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: simple
+  namespace: my-proxy
+spec: {}

--- a/kroxylicious-operator/examples/open-shift-routes-ingress/02.KafkaProxyIngress-loadbalancer.yaml
+++ b/kroxylicious-operator/examples/open-shift-routes-ingress/02.KafkaProxyIngress-loadbalancer.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxyIngress
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: loadbalancer
+  namespace: my-proxy
+spec:
+  proxyRef:
+    name: simple
+  openShiftRoutes:
+    ingressDomain: '$$INGRESS_DOMAIN$$'

--- a/kroxylicious-operator/examples/open-shift-routes-ingress/03.KafkaService.my-cluster.yaml
+++ b/kroxylicious-operator/examples/open-shift-routes-ingress/03.KafkaService.my-cluster.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaService
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: my-cluster
+  namespace: my-proxy
+spec:
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+  nodeIdRanges:
+    - start: 0
+      end: 2

--- a/kroxylicious-operator/examples/open-shift-routes-ingress/04.VirtualKafkaCluster.my-cluster.yaml
+++ b/kroxylicious-operator/examples/open-shift-routes-ingress/04.VirtualKafkaCluster.my-cluster.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: VirtualKafkaCluster
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: my-cluster
+  namespace: my-proxy
+spec:
+  proxyRef:
+    name: simple
+  targetKafkaServiceRef:
+    name: my-cluster
+  ingresses:
+    - ingressRef:
+        name: loadbalancer
+      tls:
+        certificateRef:
+          name: server-certificate
+          kind: Secret

--- a/kroxylicious-operator/examples/open-shift-routes-ingress/05.Issuer.self-signed-issuer.yaml
+++ b/kroxylicious-operator/examples/open-shift-routes-ingress/05.Issuer.self-signed-issuer.yaml
@@ -1,0 +1,14 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: my-proxy
+spec:
+  selfSigned: {}

--- a/kroxylicious-operator/examples/open-shift-routes-ingress/06.Certificate.server-certificate.yaml
+++ b/kroxylicious-operator/examples/open-shift-routes-ingress/06.Certificate.server-certificate.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: server-certificate
+  namespace: my-proxy
+spec:
+  commonName: $$INGRESS_DOMAIN$$
+  secretName: server-certificate
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS8
+    size: 4096
+  dnsNames:
+    - '*.my-cluster-loadbalancer.$$INGRESS_DOMAIN$$'
+  usages:
+    - server auth
+  issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io

--- a/kroxylicious-operator/examples/open-shift-routes-ingress/README.md
+++ b/kroxylicious-operator/examples/open-shift-routes-ingress/README.md
@@ -1,0 +1,41 @@
+These manifests declare a minimal proxy which simply forwards all requests to a single backend Apache Kafka cluster without doing anything clever either in terms of networking of protocol filters.
+In this example, the downstream connection (that is, between the Kafka client and the proxy) uses TLS.
+
+For the purposes of this example we use
+* an in-cluster Apache Kafka provided by [Strimzi](https://strimzi.io/)
+* cert manager to create a server certificate which is signed by a self-signed issuer.
+
+To try this example out:
+1. Install oc
+2. `cd` to this directory
+3. Apply cert-manager
+   ```shell
+    oc apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml
+    oc wait deployment/cert-manager-webhook --for=condition=Available=True --timeout=300s -n cert-manager
+    ```
+4. Install Strimzi and a Kafka cluster
+   ```shell
+   oc create namespace kafka
+   oc apply -n kafka -f 'https://strimzi.io/install/latest?namespace=kafka'
+   oc wait -n kafka deployment/strimzi-cluster-operator --for=condition=Available=True --timeout=300s
+   oc apply -n kafka -f https://strimzi.io/examples/latest/kafka/kafka-single-node.yaml
+   oc wait -n kafka kafka/my-cluster --for=condition=Ready --timeout=300s
+   ```
+4. Apply the example
+   ```shell
+   INGRESS_DOMAIN="$(oc get ingresses.config/cluster -o jsonpath={.spec.domain})"
+   find . -type f -name '*.yaml' -exec sed -i "s/\\\$\\\$INGRESS_DOMAIN\\\$\\\$/${INGRESS_DOMAIN}/g" {} \;
+   oc apply -f .
+   ```
+5. Wait for external ip to be allocated to service `my-cluster-sni`.
+   ```shell
+   oc get service -n  my-proxy simple-sni -o jsonpath='{.status.loadBalancer.ingress[0].ip}' --watch
+   ```
+6. Try producing and consuming some messages with commands like this (obtain a kafka distribution):
+   ```
+   CA=$(oc get secret -n my-proxy server-certificate -o json | jq -r ".data.\"ca.crt\" | @base64d")
+   BOOTSTRAP="$(oc get vkc -n my-proxy my-cluster -ojsonpath='{.status.ingresses[].bootstrapServer}')"
+   ./bin/kafka-console-producer.sh --bootstrap-server ${BOOTSTRAP} --topic mytopic --producer-property ssl.truststore.type=PEM --producer-property security.protocol=SSL --producer-property ssl.truststore.certificates="${CA}"
+   ./bin/kafka-console-consumer.sh --bootstrap-server ${BOOTSTRAP} --topic mytopic --from-beginning --consumer-property ssl.truststore.type=PEM --consumer-property security.protocol=SSL --consumer-property ssl.truststore.certificates="${CA}"
+   ```
+

--- a/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-dependent.yaml
+++ b/kroxylicious-operator/install/01.ClusterRole.kroxylicious-operator-dependent.yaml
@@ -39,3 +39,16 @@ rules:
       - patch
       - update
       - delete
+  - apiGroups:
+      - "route.openshift.io"
+    resources:
+      - routes
+      - "routes/custom-host"
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+      - delete

--- a/kroxylicious-operator/pom.xml
+++ b/kroxylicious-operator/pom.xml
@@ -107,6 +107,10 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>openshift-model</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client-api</artifactId>
         </dependency>
         <dependency>

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ClusterServiceDependentResource.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ClusterServiceDependentResource.java
@@ -112,7 +112,7 @@ public class ClusterServiceDependentResource
             return Stream.empty();
         }
         else {
-            String serviceName = ResourcesUtil.name(primary) + "-sni";
+            String serviceName = sharedSniLoadbalancerServiceName(primary);
             var serviceSpecBuilder = new ServiceBuilder()
                     .withMetadata(sniLoadbalancerServiceMetadata(primary, serviceName, bootstraps))
                     .withNewSpec()
@@ -129,6 +129,10 @@ public class ClusterServiceDependentResource
             }
             return Stream.of(serviceSpecBuilder.endSpec().build());
         }
+    }
+
+    public static String sharedSniLoadbalancerServiceName(KafkaProxy primary) {
+        return ResourcesUtil.name(primary) + "-sni";
     }
 
     @Override

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconciler.java
@@ -116,6 +116,12 @@ import static io.kroxylicious.kubernetes.operator.ResourcesUtil.toLocalRef;
                 name = KafkaProxyReconciler.CLUSTERS_DEP,
                 type = ClusterServiceDependentResource.class,
                 dependsOn = { KafkaProxyReconciler.DEPLOYMENT_DEP }
+        ),
+        @Dependent(
+                name = KafkaProxyReconciler.OPEN_SHIFT_ROUTES_DEP,
+                type = OpenShiftRouteDependentResource.class,
+                activationCondition = RoutesApiGroupPresentCondition.class,
+                dependsOn = { KafkaProxyReconciler.CLUSTERS_DEP }
         )
 })
 // @formatter:on
@@ -129,6 +135,7 @@ public class KafkaProxyReconciler implements
     public static final String CONFIG_DEP = "config";
     public static final String DEPLOYMENT_DEP = "deployment";
     public static final String CLUSTERS_DEP = "clusters";
+    public static final String OPEN_SHIFT_ROUTES_DEP = "routes";
     public static final Path MOUNTS_BASE_DIR = Path.of("/opt/kroxylicious/");
     private static final Path TARGET_CLUSTER_MOUNTS_BASE = MOUNTS_BASE_DIR.resolve("target-cluster");
     private static final Path CLIENT_CERTS_BASE_DIR = TARGET_CLUSTER_MOUNTS_BASE.resolve("client-certs");

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OpenShiftRouteDependentResource.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OpenShiftRouteDependentResource.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.kubernetes.operator;
+
+import java.util.Map;
+import java.util.Set;
+
+import io.fabric8.openshift.api.model.Route;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.processing.dependent.BulkDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.CRUDKubernetesDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependent;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.operator.model.networking.ProxyNetworkingModel;
+import io.kroxylicious.kubernetes.operator.resolver.ClusterResolutionResult;
+
+import static io.kroxylicious.kubernetes.operator.ResourcesUtil.toByNameMap;
+
+/**
+ * Generates the Kube {@code Route}s for a single KafkaProxy.
+ */
+@KubernetesDependent
+public class OpenShiftRouteDependentResource
+        extends CRUDKubernetesDependentResource<Route, KafkaProxy>
+        implements BulkDependentResource<Route, KafkaProxy> {
+
+    public OpenShiftRouteDependentResource() {
+        super(Route.class);
+    }
+
+    @Override
+    public Map<String, Route> desiredResources(
+                                               KafkaProxy primary,
+                                               Context<KafkaProxy> context) {
+        KafkaProxyContext kafkaProxyContext = KafkaProxyContext.proxyContext(context);
+        var model = kafkaProxyContext.model();
+        var clusterNetworkingModels = model.clustersWithValidNetworking().stream()
+                .map(ClusterResolutionResult::cluster)
+                .filter(cluster -> !kafkaProxyContext.isBroken(cluster))
+                .flatMap(cluster -> model.networkingModel().clusterIngressModel(cluster).stream())
+                .toList();
+
+        var routes = clusterNetworkingModels.stream()
+                .flatMap(ProxyNetworkingModel.ClusterNetworkingModel::routes);
+        return routes.collect(toByNameMap());
+    }
+
+    @Override
+    public Map<String, Route> getSecondaryResources(
+                                                    KafkaProxy primary,
+                                                    Context<KafkaProxy> context) {
+        Set<Route> secondaryResources = context.eventSourceRetriever().getEventSourceFor(Route.class)
+                .getSecondaryResources(primary);
+        return secondaryResources.stream().collect(toByNameMap());
+    }
+}

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/RoutesApiGroupPresentCondition.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/RoutesApiGroupPresentCondition.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.fabric8.kubernetes.api.model.APIGroup;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.workflow.Condition;
+
+import io.kroxylicious.proxy.tag.VisibleForTesting;
+
+public class RoutesApiGroupPresentCondition<R extends HasMetadata, P extends HasMetadata> implements Condition<R, P> {
+
+    private enum State {
+        INITIAL,
+        MISSING,
+        PRESENT
+    }
+
+    private static final AtomicReference<State> isPresentCache = new AtomicReference<>(State.INITIAL);
+
+    RoutesApiGroupPresentCondition() {
+    }
+
+    public boolean isMet(DependentResource<R, P> dependentResource, P primary, Context<P> context) {
+        State state = isPresentCache.get();
+        if (state == State.MISSING) {
+            return false;
+        }
+        else if (state == State.PRESENT) {
+            return true;
+        }
+        else {
+            State newState = discoverIfPresent("route.openshift.io", "v1", context.getClient());
+            isPresentCache.compareAndExchange(State.INITIAL, newState);
+            return isPresentCache.get() == State.PRESENT;
+        }
+    }
+
+    private static State discoverIfPresent(String group, String version, KubernetesClient client) {
+        APIGroup apiGroup = client.getApiGroup(group);
+        if (apiGroup != null) {
+            if (apiGroup.getVersions().stream().anyMatch(v -> version.equals(v.getVersion()))) {
+                return State.PRESENT;
+            }
+        }
+        return State.MISSING;
+    }
+
+    @VisibleForTesting
+    static void reset() {
+        isPresentCache.set(State.INITIAL);
+    }
+}

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/VirtualKafkaClusterReconciler.java
@@ -43,11 +43,13 @@ import io.kroxylicious.kubernetes.api.common.TrustAnchorRef;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProtocolFilter;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngressSpec;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterSpec;
 import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyingressspec.ClusterIP;
 import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyingressspec.LoadBalancer;
+import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyingressspec.OpenShiftRoutes;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.Ingresses;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterstatus.Ingresses.Protocol;
@@ -629,12 +631,14 @@ public final class VirtualKafkaClusterReconciler implements
     }
 
     private static ClusterIP.Protocol getIngressProtocol(KafkaProxyIngress proxyIngress) {
-        ClusterIP clusterIP = proxyIngress.getSpec().getClusterIP();
+        KafkaProxyIngressSpec spec = proxyIngress.getSpec();
+        ClusterIP clusterIP = spec.getClusterIP();
         if (clusterIP != null) {
             return clusterIP.getProtocol();
         }
-        LoadBalancer loadBalancer = proxyIngress.getSpec().getLoadBalancer();
-        if (loadBalancer != null) {
+        LoadBalancer loadBalancer = spec.getLoadBalancer();
+        OpenShiftRoutes openShiftRoutes = spec.getOpenShiftRoutes();
+        if (loadBalancer != null || openShiftRoutes != null) {
             return ClusterIP.Protocol.TLS;
         }
         throw new IllegalStateException("No protocol could be determined for " + proxyIngress);

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/ClusterIngressNetworkingModel.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/ClusterIngressNetworkingModel.java
@@ -11,6 +11,7 @@ import java.util.stream.Stream;
 
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.openshift.api.model.RouteBuilder;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
@@ -83,5 +84,13 @@ public interface ClusterIngressNetworkingModel {
      */
     default Optional<SharedLoadBalancerServiceRequirements> sharedLoadBalancerServiceRequirements() {
         return Optional.empty();
+    }
+
+    /**
+     * OpenShift Routes to be created for this model
+     * @return a stream of RouteBuilders
+     */
+    default Stream<RouteBuilder> routes() {
+        return Stream.empty();
     }
 }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/OpenShiftRoutesClusterIngressNetworkingModel.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/OpenShiftRoutesClusterIngressNetworkingModel.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator.model.networking;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.openshift.api.model.RouteBuilder;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
+import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyingressspec.OpenShiftRoutes;
+import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.NodeIdRanges;
+import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls;
+import io.kroxylicious.kubernetes.operator.Annotations;
+import io.kroxylicious.kubernetes.operator.ClusterServiceDependentResource;
+import io.kroxylicious.kubernetes.operator.Labels;
+import io.kroxylicious.kubernetes.operator.ResourcesUtil;
+import io.kroxylicious.proxy.config.NodeIdentificationStrategy;
+import io.kroxylicious.proxy.config.SniHostIdentifiesNodeIdentificationStrategy;
+import io.kroxylicious.proxy.service.HostPort;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
+import static io.kroxylicious.kubernetes.operator.ResourcesUtil.namespace;
+
+public record OpenShiftRoutesClusterIngressNetworkingModel(VirtualKafkaCluster cluster,
+                                                           KafkaProxyIngress ingress,
+                                                           KafkaProxy proxy,
+                                                           OpenShiftRoutes openShiftRoutes,
+                                                           java.util.List<NodeIdRanges> nodeIdRanges,
+                                                           Tls tls,
+                                                           int sharedSniPort)
+        implements ClusterIngressNetworkingModel, SharedLoadBalancerServiceRequirements {
+
+    public OpenShiftRoutesClusterIngressNetworkingModel {
+        Objects.requireNonNull(cluster);
+        Objects.requireNonNull(ingress);
+        Objects.requireNonNull(proxy);
+        Objects.requireNonNull(nodeIdRanges);
+        Objects.requireNonNull(openShiftRoutes);
+        Objects.requireNonNull(tls);
+    }
+
+    private static final int ROUTE_TLS_PORT = 443;
+
+    public static final int DEFAULT_CLIENT_FACING_LOADBALANCER_PORT = 9083;
+
+    @Override
+    public Stream<ServiceBuilder> services() {
+        return Stream.empty();
+    }
+
+    @Override
+    public Stream<ContainerPort> identifyingProxyContainerPorts() {
+        return Stream.empty();
+    }
+
+    @Override
+    public NodeIdentificationStrategy nodeIdentificationStrategy() {
+        String bootstrap = bootstrapServersHost();
+        String advertisedBrokerAddressPattern = prefixedClusterIngressHost("broker-$(nodeId)");
+        return new SniHostIdentifiesNodeIdentificationStrategy(HostPort.asString(bootstrap, sharedSniPort),
+                HostPort.asString(advertisedBrokerAddressPattern, ROUTE_TLS_PORT));
+    }
+
+    public String prefixedClusterIngressHost(String prefix) {
+        String baseDomain = name(cluster) + "-" + name(ingress) + "." + openShiftRoutes.getIngressDomain();
+        return prefix + "." + baseDomain;
+    }
+
+    @Override
+    public Stream<RouteBuilder> routes() {
+        RouteBuilder bootstrapRoute = routeBuilder(name(cluster) + "-" + name(ingress) + "-bootstrap", bootstrapServersHost());
+        IntStream upstreamNodeIds = nodeIdRanges.stream()
+                .flatMapToInt(nodeIdRanges -> IntStream.rangeClosed(Math.toIntExact(nodeIdRanges.getStart()),
+                        Math.toIntExact(nodeIdRanges.getEnd())));
+        var upstreamNodeRoutes = upstreamNodeIds
+                .mapToObj(nodeId -> routeBuilder(name(cluster) + "-" + name(ingress) + "-" + nodeId, prefixedClusterIngressHost("broker-" + nodeId)));
+        return Stream.concat(Stream.of(bootstrapRoute), upstreamNodeRoutes);
+    }
+
+    private RouteBuilder routeBuilder(String routeName, String host) {
+        return new RouteBuilder().withNewMetadata().withName(routeName).withNamespace(namespace(proxy))
+                .withOwnerReferences(ResourcesUtil.newOwnerReferenceTo(proxy), ResourcesUtil.newOwnerReferenceTo(ingress), ResourcesUtil.newOwnerReferenceTo(cluster))
+                .withLabels(Labels.standardLabels(proxy))
+                .endMetadata()
+                .withNewSpec().withHost(host)
+                .withNewPort().withTargetPort(new IntOrString(sharedSniPort)).endPort()
+                .withNewTls().withTermination("passthrough").withInsecureEdgeTerminationPolicy("None").endTls()
+                .withNewTo().withKind("Service").withName(ClusterServiceDependentResource.sharedSniLoadbalancerServiceName(proxy)).endTo()
+                .endSpec();
+    }
+
+    @Override
+    public Optional<Tls> downstreamTls() {
+        return Optional.of(tls);
+    }
+
+    @Override
+    public boolean requiresSharedSniContainerPort() {
+        return true;
+    }
+
+    @Override
+    public Stream<Integer> requiredClientFacingPorts() {
+        return Stream.of(DEFAULT_CLIENT_FACING_LOADBALANCER_PORT);
+    }
+
+    @Override
+    public Annotations.ClusterIngressBootstrapServers bootstrapServersToAnnotate() {
+        return new Annotations.ClusterIngressBootstrapServers(name(cluster), name(ingress), HostPort.asString(bootstrapServersHost(), ROUTE_TLS_PORT));
+    }
+
+    @NonNull
+    private String bootstrapServersHost() {
+        return prefixedClusterIngressHost("bootstrap");
+    }
+
+    @Override
+    public Optional<SharedLoadBalancerServiceRequirements> sharedLoadBalancerServiceRequirements() {
+        return Optional.of(this);
+    }
+}

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/ProxyNetworkingModel.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/networking/ProxyNetworkingModel.java
@@ -16,6 +16,8 @@ import java.util.stream.Stream;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.api.model.RouteBuilder;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 
@@ -51,6 +53,10 @@ public record ProxyNetworkingModel(List<ClusterNetworkingModel> clusterNetworkin
 
         public Stream<Service> services() {
             return clusterIngressNetworkingModelResults.stream().flatMap(it -> it.clusterIngressNetworkingModel().services()).map(ServiceBuilder::build);
+        }
+
+        public Stream<Route> routes() {
+            return clusterIngressNetworkingModelResults.stream().flatMap(it -> it.clusterIngressNetworkingModel().routes()).map(RouteBuilder::build);
         }
 
         public Set<IngressConflictException> ingressExceptions() {

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/DerivedResourcesTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/DerivedResourcesTest.java
@@ -180,7 +180,8 @@ class DerivedResourcesTest {
                 new SingletonDependentResourceDesiredFn<>(new ProxyConfigDependentResource(), "ConfigMap", new ProxyConfigReconcilePrecondition(),
                         ProxyConfigDependentResource::desired),
                 new SingletonDependentResourceDesiredFn<>(new ProxyDeploymentDependentResource(), "Deployment", null, ProxyDeploymentDependentResource::desired),
-                new BulkDependentResourceDesiredFn<>(new ClusterServiceDependentResource(), "Service", ClusterServiceDependentResource::desiredResources));
+                new BulkDependentResourceDesiredFn<>(new ClusterServiceDependentResource(), "Service", ClusterServiceDependentResource::desiredResources),
+                new BulkDependentResourceDesiredFn<>(new OpenShiftRouteDependentResource(), "Route", OpenShiftRouteDependentResource::desiredResources));
         return dependentResourcesShouldEqual(list);
     }
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/RoutesApiGroupPresentConditionTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/RoutesApiGroupPresentConditionTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.fabric8.kubernetes.api.model.APIGroup;
+import io.fabric8.kubernetes.api.model.APIGroupBuilder;
+import io.fabric8.kubernetes.api.model.GroupVersionForDiscovery;
+import io.fabric8.kubernetes.api.model.GroupVersionForDiscoveryBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.openshift.api.model.Route;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RoutesApiGroupPresentConditionTest {
+
+    @Mock
+    Context<KafkaProxy> context;
+    @Mock
+    KubernetesClient client;
+
+    RoutesApiGroupPresentCondition<Route, KafkaProxy> routesApiGroupPresentCondition = new RoutesApiGroupPresentCondition<>();
+
+    @BeforeEach
+    void setup() {
+        RoutesApiGroupPresentCondition.reset();
+        when(context.getClient()).thenReturn(client);
+    }
+
+    @Test
+    public void routesApiGroupNotPresentInCluster() {
+        // given
+        when(client.getApiGroup("route.openshift.io")).thenReturn(null);
+        // when
+        boolean met = isMet();
+        // then
+        assertThat(met).isFalse();
+    }
+
+    @Test
+    public void negativeResultIsCached() {
+        // given
+        when(client.getApiGroup("route.openshift.io")).thenReturn(null);
+        isMet();
+        boolean secondCall = isMet();
+        // then
+        assertThat(secondCall).isFalse();
+        verify(client, times(1)).getApiGroup("route.openshift.io");
+    }
+
+    @Test
+    public void positiveResultIsCached() {
+        // given
+        when(client.getApiGroup("route.openshift.io")).thenReturn(apiGroupWithVersions("v1"));
+        isMet();
+        boolean secondCall = isMet();
+        // then
+        assertThat(secondCall).isTrue();
+        verify(client, times(1)).getApiGroup("route.openshift.io");
+    }
+
+    @Test
+    public void canRecoverFromInitialClientException() {
+        // given
+        RuntimeException exception = new RuntimeException("boom!");
+        when(client.getApiGroup("route.openshift.io")).thenThrow(exception);
+        assertThatThrownBy(this::isMet).isEqualTo(exception);
+        doReturn(apiGroupWithVersions("v1")).when(client).getApiGroup("route.openshift.io");
+
+        // when
+        boolean secondCall = isMet();
+        // then
+        assertThat(secondCall).isTrue();
+    }
+
+    @Test
+    public void routesApiGroupPresentInClusterWithMismatchedVersion() {
+        // given
+        when(client.getApiGroup("route.openshift.io")).thenReturn(apiGroupWithVersions("v2"));
+        // when
+        boolean met = isMet();
+        // then
+        assertThat(met).isFalse();
+    }
+
+    @Test
+    public void routesApiGroupPresentInClusterWithExpectedVersion() {
+        // given
+        when(client.getApiGroup("route.openshift.io")).thenReturn(apiGroupWithVersions("v1"));
+        // when
+        boolean met = isMet();
+        // then
+        assertThat(met).isTrue();
+    }
+
+    @Test
+    public void routesApiGroupPresentInClusterWithMultipleVersions() {
+        // given
+        when(client.getApiGroup("route.openshift.io")).thenReturn(apiGroupWithVersions("v0", "v1"));
+        // when
+        boolean met = isMet();
+        // then
+        assertThat(met).isTrue();
+    }
+
+    private static APIGroup apiGroupWithVersions(String... versions) {
+        List<GroupVersionForDiscovery> groupVersions = Arrays.stream(versions).map(v -> new GroupVersionForDiscoveryBuilder().withVersion(v).build()).toList();
+        return new APIGroupBuilder().withVersions(groupVersions).build();
+    }
+
+    private boolean isMet() {
+        return routesApiGroupPresentCondition.isMet(new OpenShiftRouteDependentResource(), new KafkaProxy(), context);
+    }
+
+}

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/model/networking/OpenShiftRoutesClusterIngressNetworkingModelTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/model/networking/OpenShiftRoutesClusterIngressNetworkingModelTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.operator.model.networking;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.api.model.RouteBuilder;
+import io.fabric8.openshift.api.model.RouteSpec;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngressBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyingressspec.OpenShiftRoutes;
+import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyingressspec.OpenShiftRoutesBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.NodeIdRanges;
+import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.NodeIdRangesBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls;
+import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.TlsBuilder;
+import io.kroxylicious.kubernetes.operator.KafkaProxyReconciler;
+import io.kroxylicious.kubernetes.operator.ResourcesUtil;
+import io.kroxylicious.kubernetes.operator.assertj.OperatorAssertions;
+import io.kroxylicious.proxy.config.VirtualClusterGateway;
+import io.kroxylicious.proxy.service.HostPort;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+class OpenShiftRoutesClusterIngressNetworkingModelTest {
+    private static final String INGRESS_NAME = "my-ingress";
+    private static final String CLUSTER_NAME = "my-cluster";
+    private static final String NAMESPACE = "my-namespace";
+
+    private static final String INGRESS_DOMAIN = "ingress.openshiftapps.com";
+
+    // @formatter:off
+    private static final OpenShiftRoutes OPEN_SHIFT_ROUTES = new OpenShiftRoutesBuilder()
+            .withIngressDomain(INGRESS_DOMAIN)
+            .build();
+
+    private static final String PROXY_NAME = "my-proxy";
+    private static final KafkaProxy PROXY = new KafkaProxyBuilder()
+            .withNewMetadata()
+                .withName(PROXY_NAME)
+                .withNamespace(NAMESPACE)
+            .endMetadata()
+            .build();
+
+    private static final KafkaProxyIngress INGRESS = new KafkaProxyIngressBuilder()
+            .withNewMetadata()
+                .withName(INGRESS_NAME)
+                .withNamespace(NAMESPACE)
+            .endMetadata()
+            .withNewSpec()
+                .withOpenShiftRoutes(OPEN_SHIFT_ROUTES)
+            .endSpec()
+            .build();
+
+    private static final Tls TLS = new TlsBuilder()
+            .withNewCertificateRef()
+                .withName("server-cert")
+            .endCertificateRef()
+            .build();
+
+    private static final VirtualKafkaCluster VIRTUAL_KAFKA_CLUSTER = new VirtualKafkaClusterBuilder()
+            .withNewMetadata()
+                .withName(CLUSTER_NAME)
+                .withNamespace(NAMESPACE)
+            .endMetadata()
+            .withNewSpec()
+                .addNewIngress()
+                    .withNewIngressRef()
+                        .withName(INGRESS_NAME)
+                    .endIngressRef()
+                    .withTls(TLS)
+                .endIngress()
+            .endSpec()
+            .build();
+    // @formatter:on
+    public static final NodeIdRanges NODE_ID_RANGE = createNodeIdRange("a", 1L, 3L);
+
+    @Test
+    void gatewayConfig() {
+        // given
+        int sharedSniPort = 1;
+        OpenShiftRoutesClusterIngressNetworkingModel model = new OpenShiftRoutesClusterIngressNetworkingModel(VIRTUAL_KAFKA_CLUSTER, INGRESS, PROXY, OPEN_SHIFT_ROUTES,
+                List.of(NODE_ID_RANGE), TLS, sharedSniPort);
+
+        // when
+        VirtualClusterGateway gateway = KafkaProxyReconciler.buildVirtualClusterGateway(model).fragment();
+
+        // then
+        assertThat(gateway).isNotNull();
+        assertThat(gateway.name()).isEqualTo(INGRESS_NAME);
+        assertThat(gateway.tls()).isNotNull();
+        assertThat(gateway.portIdentifiesNode()).isNull();
+        assertThat(gateway.sniHostIdentifiesNode()).isNotNull().satisfies(sniStrategy -> {
+            assertThat(sniStrategy.bootstrapAddress()).isEqualTo(
+                    new HostPort(expectedRouteHostname("bootstrap", CLUSTER_NAME, INGRESS_NAME, INGRESS_DOMAIN), sharedSniPort).toString());
+            assertThat(sniStrategy.advertisedBrokerAddressPattern()).isEqualTo(
+                    new HostPort(expectedRouteHostname("broker-$(nodeId)", CLUSTER_NAME, INGRESS_NAME, INGRESS_DOMAIN), 443).toString());
+        });
+    }
+
+    @Test
+    void doesNotSupplyAnyServices() {
+        // given
+        OpenShiftRoutesClusterIngressNetworkingModel model = new OpenShiftRoutesClusterIngressNetworkingModel(VIRTUAL_KAFKA_CLUSTER, INGRESS, PROXY, OPEN_SHIFT_ROUTES,
+                List.of(NODE_ID_RANGE), TLS, 9093);
+        assertThat(model).isNotNull();
+
+        // when
+        Stream<ServiceBuilder> services = model.services();
+
+        // then
+        assertThat(services).isEmpty();
+    }
+
+    @Test
+    void requestsRoutes() {
+        // given
+        int sharedSniPort = 9093;
+        OpenShiftRoutesClusterIngressNetworkingModel model = new OpenShiftRoutesClusterIngressNetworkingModel(VIRTUAL_KAFKA_CLUSTER, INGRESS, PROXY, OPEN_SHIFT_ROUTES,
+                List.of(NODE_ID_RANGE), TLS, sharedSniPort);
+        assertThat(model).isNotNull();
+
+        // when
+        List<RouteBuilder> routes = model.routes().toList();
+
+        // then
+        List<Route> builtRoutes = routes.stream().map(RouteBuilder::build).toList();
+        var listAssert = assertThat(builtRoutes);
+        listAssert.hasSize(4);
+        listAssert.element(0).satisfies(route -> {
+            assertRoute(route, CLUSTER_NAME + "-" + INGRESS_NAME + "-bootstrap", "bootstrap", sharedSniPort);
+        });
+        listAssert.element(1).satisfies(route -> {
+            assertRoute(route, CLUSTER_NAME + "-" + INGRESS_NAME + "-1", "broker-1", sharedSniPort);
+        });
+        listAssert.element(2).satisfies(route -> {
+            assertRoute(route, CLUSTER_NAME + "-" + INGRESS_NAME + "-2", "broker-2", sharedSniPort);
+        });
+        listAssert.element(3).satisfies(route -> {
+            assertRoute(route, CLUSTER_NAME + "-" + INGRESS_NAME + "-3", "broker-3", sharedSniPort);
+        });
+    }
+
+    private static void assertRoute(Route route, String routeName, String routePrefix, int sharedSniPort) {
+        Map<String, String> orderedStandardLabels = commonLabels(PROXY_NAME);
+        OperatorAssertions.assertThat(route.getMetadata())
+                .hasName(routeName)
+                .hasNamespace(NAMESPACE)
+                .hasLabels(orderedStandardLabels)
+                .hasOwnerRefs(ResourcesUtil.newOwnerReferenceTo(PROXY), ResourcesUtil.newOwnerReferenceTo(INGRESS),
+                        ResourcesUtil.newOwnerReferenceTo(VIRTUAL_KAFKA_CLUSTER));
+        RouteSpec spec = route.getSpec();
+        assertThat(spec.getHost()).isEqualTo(expectedRouteHostname(routePrefix, CLUSTER_NAME, INGRESS_NAME, INGRESS_DOMAIN));
+        assertThat(spec.getTo()).satisfies(routeTarget -> {
+            assertThat(routeTarget.getKind()).isEqualTo("Service");
+            assertThat(routeTarget.getName()).isEqualTo(PROXY_NAME + "-sni");
+        });
+        assertThat(spec.getPort().getTargetPort()).isEqualTo(new IntOrString(sharedSniPort));
+        assertThat(spec.getTls()).isNotNull().satisfies(tlsConfig -> {
+            assertThat(tlsConfig.getTermination()).isEqualTo("passthrough");
+            assertThat(tlsConfig.getInsecureEdgeTerminationPolicy()).isEqualTo("None");
+        });
+    }
+
+    @Test
+    void requestsLoadBalancerServicePorts() {
+        // given
+        OpenShiftRoutesClusterIngressNetworkingModel model = new OpenShiftRoutesClusterIngressNetworkingModel(VIRTUAL_KAFKA_CLUSTER, INGRESS, PROXY, OPEN_SHIFT_ROUTES,
+                List.of(NODE_ID_RANGE), TLS, 9093);
+        assertThat(model).isNotNull();
+
+        // when
+        var services = model.sharedLoadBalancerServiceRequirements();
+
+        // then
+        assertThat(services).isPresent();
+        assertThat(services.get().requiredClientFacingPorts()).containsExactly(9083);
+    }
+
+    @Test
+    void requestsSharedSniPort() {
+        // given
+        OpenShiftRoutesClusterIngressNetworkingModel model = new OpenShiftRoutesClusterIngressNetworkingModel(VIRTUAL_KAFKA_CLUSTER, INGRESS, PROXY, OPEN_SHIFT_ROUTES,
+                List.of(NODE_ID_RANGE), TLS, 9093);
+
+        // when
+        boolean requiresSharedSniPort = model.requiresSharedSniContainerPort();
+
+        // then
+        assertThat(requiresSharedSniPort).isTrue();
+    }
+
+    @Test
+    void sharedLoadBalancerServiceBootstrapServers() {
+        // given
+        OpenShiftRoutesClusterIngressNetworkingModel model = new OpenShiftRoutesClusterIngressNetworkingModel(VIRTUAL_KAFKA_CLUSTER, INGRESS, PROXY, OPEN_SHIFT_ROUTES,
+                List.of(NODE_ID_RANGE), TLS, 9093);
+
+        // when
+        Optional<SharedLoadBalancerServiceRequirements> requirements = model.sharedLoadBalancerServiceRequirements();
+
+        // then
+        assertThat(requirements).isPresent();
+        assertThat(requirements.get().bootstrapServersToAnnotate()).satisfies(bootstrapServers -> {
+            assertThat(bootstrapServers.clusterName()).isEqualTo(CLUSTER_NAME);
+            assertThat(bootstrapServers.ingressName()).isEqualTo(INGRESS_NAME);
+            assertThat(bootstrapServers.bootstrapServers()).isEqualTo(expectedRouteHostname("bootstrap", CLUSTER_NAME, INGRESS_NAME, INGRESS_DOMAIN) + ":443");
+        });
+    }
+
+    private static String expectedRouteHostname(String prefix, String clusterName, String ingressName, String ingressDomain) {
+        return prefix + "." + clusterName + "-" + ingressName + "." + ingressDomain;
+    }
+
+    public static Stream<Arguments> constructorArgsMustBeNonNull() {
+        ThrowableAssert.ThrowingCallable nullIngress = () -> new OpenShiftRoutesClusterIngressNetworkingModel(VIRTUAL_KAFKA_CLUSTER, null, PROXY, OPEN_SHIFT_ROUTES,
+                List.of(NODE_ID_RANGE), TLS, 9093);
+        ThrowableAssert.ThrowingCallable nullCluster = () -> new OpenShiftRoutesClusterIngressNetworkingModel(null, INGRESS, PROXY, OPEN_SHIFT_ROUTES,
+                List.of(NODE_ID_RANGE), TLS, 9093);
+        ThrowableAssert.ThrowingCallable nullRoutes = () -> new OpenShiftRoutesClusterIngressNetworkingModel(VIRTUAL_KAFKA_CLUSTER, INGRESS, PROXY, null,
+                List.of(NODE_ID_RANGE), TLS, 9093);
+        ThrowableAssert.ThrowingCallable nullTls = () -> new OpenShiftRoutesClusterIngressNetworkingModel(VIRTUAL_KAFKA_CLUSTER, INGRESS, PROXY, OPEN_SHIFT_ROUTES,
+                List.of(NODE_ID_RANGE), null, 9093);
+        ThrowableAssert.ThrowingCallable nullNodeIdRanges = () -> new OpenShiftRoutesClusterIngressNetworkingModel(VIRTUAL_KAFKA_CLUSTER, INGRESS, PROXY,
+                OPEN_SHIFT_ROUTES, null, TLS, 9093);
+        ThrowableAssert.ThrowingCallable nullProxy = () -> new OpenShiftRoutesClusterIngressNetworkingModel(VIRTUAL_KAFKA_CLUSTER, INGRESS, null, OPEN_SHIFT_ROUTES,
+                List.of(NODE_ID_RANGE), TLS, 9093);
+        return Stream.of(argumentSet("ingress", nullIngress),
+                argumentSet("cluster", nullCluster),
+                argumentSet("openShiftRoutes", nullRoutes),
+                argumentSet("nnodeIdRanges", nullNodeIdRanges),
+                argumentSet("proxy", nullProxy),
+                argumentSet("tls", nullTls));
+    }
+
+    private static @NonNull Map<String, String> commonLabels(String proxyName) {
+        Map<String, String> orderedLabels = new java.util.LinkedHashMap<>();
+        orderedLabels.put("app.kubernetes.io/part-of", "kafka");
+        orderedLabels.put("app.kubernetes.io/managed-by", "kroxylicious-operator");
+        orderedLabels.put("app.kubernetes.io/name", "kroxylicious-proxy");
+        orderedLabels.put("app.kubernetes.io/instance", proxyName);
+        orderedLabels.put("app.kubernetes.io/component", "proxy");
+        return orderedLabels;
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void constructorArgsMustBeNonNull(ThrowableAssert.ThrowingCallable callable) {
+        assertThatThrownBy(callable).isInstanceOf(NullPointerException.class);
+    }
+
+    private static NodeIdRanges createNodeIdRange(@Nullable String name, long start, long endInclusive) {
+        return new NodeIdRangesBuilder().withName(name).withStart(start).withEnd(endInclusive).build();
+    }
+}

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/in-KafkaProxy.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/in-KafkaProxy.yaml
@@ -1,0 +1,13 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: minimal
+  namespace: proxy-ns
+  generation: 1

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/in-KafkaProxyIngress-shift-route.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/in-KafkaProxyIngress-shift-route.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxyIngress
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: shift-route
+  namespace: proxy-ns
+  generation: 2
+spec:
+  proxyRef:
+    name: minimal
+  openShiftRoutes:
+    ingressDomain: 'myingressdomain.com'
+status:
+  observedGeneration: 2

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/in-KafkaService-kafka.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/in-KafkaService-kafka.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaService
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: kafka
+  namespace: proxy-ns
+  generation: 3
+spec:
+  bootstrapServers: my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092
+status:
+  observedGeneration: 3

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/in-Secret-downstream-tls-cert.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/in-Secret-downstream-tls-cert.yaml
@@ -1,0 +1,14 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+kind: Secret
+apiVersion: v1
+metadata:
+  name: downstream-tls-cert
+type: kubernetes.io/tls
+data:
+  tls.crt: whatever
+  tls.key: whatever

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/in-VirtualKafkaCluster-one.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/in-VirtualKafkaCluster-one.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: VirtualKafkaCluster
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: one
+  namespace: proxy-ns
+  generation: 4
+spec:
+  proxyRef:
+    name: minimal
+  targetKafkaServiceRef:
+    name: kafka
+  ingresses:
+    - ingressRef:
+        name: shift-route
+      tls:
+        certificateRef:
+          name: downstream-tls-cert
+status:
+  observedGeneration: 4

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/out-ConfigMap-minimal-config-state.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/out-ConfigMap-minimal-config-state.yaml
@@ -1,0 +1,39 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: "v1"
+kind: "ConfigMap"
+metadata:
+  labels:
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/instance: "minimal"
+    app.kubernetes.io/component: "proxy"
+  name: "minimal-config-state"
+  namespace: "proxy-ns"
+  ownerReferences:
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxy"
+      name: "minimal"
+data:
+  cluster-one: |-
+    ---
+    metadata:
+      generation: 4
+      name: "one"
+      namespace: "proxy-ns"
+    status:
+      conditions:
+      - observedGeneration: 4
+        type: "Accepted"
+        status: "True"
+        lastTransitionTime: "1970-01-01T00:00:00Z"
+        reason: "Accepted"
+        message: ""
+      ingresses: []
+      observedGeneration: 4

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/out-ConfigMap-minimal-proxy-config.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/out-ConfigMap-minimal-proxy-config.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: "v1"
+kind: "ConfigMap"
+metadata:
+  labels:
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/instance: "minimal"
+    app.kubernetes.io/component: "proxy"
+  name: "minimal-proxy-config"
+  namespace: "proxy-ns"
+  ownerReferences:
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxy"
+      name: "minimal"
+data:
+  proxy-config.yaml: |-
+    ---
+    management:
+      endpoints:
+        prometheus: {}
+    virtualClusters:
+    - name: "one"
+      targetCluster:
+        bootstrapServers: "my-cluster-kafka-bootstrap.kafka.svc.cluster.local:9092"
+      gateways:
+      - name: "shift-route"
+        sniHostIdentifiesNode:
+          bootstrapAddress: "bootstrap.one-shift-route.myingressdomain.com:9291"
+          advertisedBrokerAddressPattern: "broker-$(nodeId).one-shift-route.myingressdomain.com:443"
+        tls:
+          key:
+            privateKeyFile: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert/tls.key"
+            certificateFile: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert/tls.crt"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/out-Deployment-minimal.yaml
@@ -1,0 +1,89 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  labels:
+    app: "kroxylicious"
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/instance: "minimal"
+    app.kubernetes.io/component: "proxy"
+  name: "minimal"
+  namespace: "proxy-ns"
+  ownerReferences:
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxy"
+      name: "minimal"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: "kroxylicious"
+      app.kubernetes.io/part-of: "kafka"
+      app.kubernetes.io/managed-by: "kroxylicious-operator"
+      app.kubernetes.io/name: "kroxylicious-proxy"
+      app.kubernetes.io/instance: "minimal"
+      app.kubernetes.io/component: "proxy"
+  template:
+    metadata:
+      labels:
+        app: "kroxylicious"
+        app.kubernetes.io/part-of: "kafka"
+        app.kubernetes.io/managed-by: "kroxylicious-operator"
+        app.kubernetes.io/name: "kroxylicious-proxy"
+        app.kubernetes.io/instance: "minimal"
+        app.kubernetes.io/component: "proxy"
+      annotations:
+        kroxylicious.io/referent-checksum: "AAAAAAAB4wY"
+    spec:
+      containers:
+        - name: "proxy"
+          image: "quay.io/kroxylicious/kroxylicious:test"
+          args:
+            - "--config"
+            - "/opt/kroxylicious/config/proxy-config.yaml"
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: "/livez"
+              port: "management"
+            initialDelaySeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          ports:
+            - containerPort: 9190
+              name: "management"
+            - containerPort: 9291
+              name: "shared-sni-port"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+            readOnlyRootFilesystem: true
+          terminationMessagePolicy: "FallbackToLogsOnError"
+          volumeMounts:
+            - mountPath: "/opt/kroxylicious/config/proxy-config.yaml"
+              name: "config-volume"
+              subPath: "proxy-config.yaml"
+            - mountPath: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert"
+              name: "secrets-downstream-tls-cert"
+              readOnly: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: "RuntimeDefault"
+      volumes:
+        - configMap:
+            name: "minimal-proxy-config"
+          name: "config-volume"
+        - name: "secrets-downstream-tls-cert"
+          secret:
+            secretName: "downstream-tls-cert"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/out-Route-one-shift-route-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/out-Route-one-shift-route-0.yaml
@@ -1,0 +1,38 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: "route.openshift.io/v1"
+kind: "Route"
+metadata:
+  labels:
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/instance: "minimal"
+    app.kubernetes.io/component: "proxy"
+  name: "one-shift-route-0"
+  namespace: "proxy-ns"
+  ownerReferences:
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxy"
+      name: "minimal"
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxyIngress"
+      name: "shift-route"
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "VirtualKafkaCluster"
+      name: "one"
+spec:
+  host: "broker-0.one-shift-route.myingressdomain.com"
+  port:
+    targetPort: 9291
+  tls:
+    insecureEdgeTerminationPolicy: "None"
+    termination: "passthrough"
+  to:
+    kind: "Service"
+    name: "minimal-sni"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/out-Route-one-shift-route-1.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/out-Route-one-shift-route-1.yaml
@@ -1,0 +1,38 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: "route.openshift.io/v1"
+kind: "Route"
+metadata:
+  labels:
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/instance: "minimal"
+    app.kubernetes.io/component: "proxy"
+  name: "one-shift-route-1"
+  namespace: "proxy-ns"
+  ownerReferences:
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxy"
+      name: "minimal"
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxyIngress"
+      name: "shift-route"
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "VirtualKafkaCluster"
+      name: "one"
+spec:
+  host: "broker-1.one-shift-route.myingressdomain.com"
+  port:
+    targetPort: 9291
+  tls:
+    insecureEdgeTerminationPolicy: "None"
+    termination: "passthrough"
+  to:
+    kind: "Service"
+    name: "minimal-sni"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/out-Route-one-shift-route-2.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/out-Route-one-shift-route-2.yaml
@@ -1,0 +1,38 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: "route.openshift.io/v1"
+kind: "Route"
+metadata:
+  labels:
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/instance: "minimal"
+    app.kubernetes.io/component: "proxy"
+  name: "one-shift-route-2"
+  namespace: "proxy-ns"
+  ownerReferences:
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxy"
+      name: "minimal"
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxyIngress"
+      name: "shift-route"
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "VirtualKafkaCluster"
+      name: "one"
+spec:
+  host: "broker-2.one-shift-route.myingressdomain.com"
+  port:
+    targetPort: 9291
+  tls:
+    insecureEdgeTerminationPolicy: "None"
+    termination: "passthrough"
+  to:
+    kind: "Service"
+    name: "minimal-sni"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/out-Route-one-shift-route-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/out-Route-one-shift-route-bootstrap.yaml
@@ -1,0 +1,38 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: "route.openshift.io/v1"
+kind: "Route"
+metadata:
+  labels:
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/instance: "minimal"
+    app.kubernetes.io/component: "proxy"
+  name: "one-shift-route-bootstrap"
+  namespace: "proxy-ns"
+  ownerReferences:
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxy"
+      name: "minimal"
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxyIngress"
+      name: "shift-route"
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "VirtualKafkaCluster"
+      name: "one"
+spec:
+  host: "bootstrap.one-shift-route.myingressdomain.com"
+  port:
+    targetPort: 9291
+  tls:
+    insecureEdgeTerminationPolicy: "None"
+    termination: "passthrough"
+  to:
+    kind: "Service"
+    name: "minimal-sni"

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/out-Service-minimal-sni.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/open-shift-routes-ingress/out-Service-minimal-sni.yaml
@@ -1,0 +1,40 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  annotations:
+    kroxylicious.io/bootstrap-servers: "{\"version\":\"0.13.0\",\"bootstrapServers\"\
+        :[{\"clusterName\":\"one\",\"ingressName\":\"shift-route\",\"bootstrapServers\"\
+        :\"bootstrap.one-shift-route.myingressdomain.com:443\"}]}"
+  labels:
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/instance: "minimal"
+    app.kubernetes.io/component: "proxy"
+  name: "minimal-sni"
+  namespace: "proxy-ns"
+  ownerReferences:
+    - apiVersion: "kroxylicious.io/v1alpha1"
+      kind: "KafkaProxy"
+      name: "minimal"
+spec:
+  ports:
+    - name: "sni-9083"
+      port: 9083
+      protocol: "TCP"
+      targetPort: 9291
+  selector:
+    app: "kroxylicious"
+    app.kubernetes.io/part-of: "kafka"
+    app.kubernetes.io/managed-by: "kroxylicious-operator"
+    app.kubernetes.io/name: "kroxylicious-proxy"
+    app.kubernetes.io/instance: "minimal"
+    app.kubernetes.io/component: "proxy"
+  type: "LoadBalancer"


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds support for exposing a VirtualKafkaCluster via [OpenShift Routes](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/networking/configuring-routes).

#### KafkaProxyIngress CRD changes

1. Adds an `openShiftRoutes` property (mutually exclusive with loadBalancer and clusterIP)
2. `openShiftRoutes` is an object and requires the user to supply an `ingressDomain` String, equivalent to `oc get ingresses.config/cluster -o jsonpath={.spec.domain}`.

For Example:
```
kind: KafkaProxyIngress
apiVersion: kroxylicious.io/v1alpha1
metadata:
  name: loadbalancer
  namespace: my-proxy
spec:
  proxyRef:
    name: simple
  openShiftRoutes:
    ingressDomain: 'apps.rosa.abcd-abcde-123.hijk.p3.openshiftapps.com'
```

#### Implementation

If an openShiftRoutes KafkaProxyIngress is referenced by a VirtualCluster we manifest:

1. the shared SNI Service for the proxy, exactly the same as for LoadBalancer, mapping port 9081 to 9291 on the Proxy pod (I think the port mapping is arbitrary as far as Routes are concerned, you tell a Route the port on the pods not the service port).
2. a bootstrap route named `${clusterName}-${ingressName}-bootstrap` with host `bootstrap.${clusterName}-${ingressName}.${ingressDomain}`
3. for each node id in the KafkaService ranges, a Route named `${clusterName}-${ingressName}-${upstreamNodeId}` with host `broker-${upstreamNodeId}.${clusterName}-${ingressName}.${ingressDomain}` targeting port 9291 of pods targeted by the shared SNI Service.

Users will be responsible for configuring downstream TLS, such that we supply certificates for those domains. In the example we set up a wildcard SAN for `*.${clusterName}-${ingressName}.${ingressDomain}`.

The Route reconciliation is conditional on the `route.openshift.io/v1` ApiGroup being present in the cluster. (note that Route is not a CRD). On a non-Openshift cluster the Routes won't be reconciled, with no feedback to users that this has occured.

Note that to run the example on OpenShift, you need to install a custom Operator image running the code from this branch, to do that I run:

```shell
oc apply -f kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/
oc apply -f kroxylicious-operator/install

PUSH_IMAGE=true IMAGE_EXPIRY=9h CONTAINER_ENGINE=podman REGISTRY_DESTINATION=quay.io/robeyoun/kroxylicious-operator CONTAINERFILE=Dockerfile.operator ./scripts/build-image.sh
oc set image deployment/kroxylicious-operator -n kroxylicious-operator operator=quay.io/robeyoun/kroxylicious-operator:0.13.0-SNAPSHOT
```
sub in your quay org

### Additional Context

To make it easier for users to get off-cluster ingress working on OpenShift.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
