### PR TITLE
[System Tests] added ST to test two proxy resources in different namespaces

### DIFF
--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/AbstractST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/AbstractST.java
@@ -58,7 +58,7 @@ class AbstractST {
      */
     @BeforeEach
     void beforeEachTest() {
-        topicName = "my-topic-" + UUID.randomUUID().toString().replace("-", "").substring(0, 6);
+        topicName = randomTopicName();
     }
 
     /**
@@ -102,5 +102,14 @@ class AbstractST {
     void afterEachTest(TestInfo testInfo) {
         LOGGER.debug(String.join("", Collections.nCopies(76, "=")));
         LOGGER.debug("———————————— {}@After Each - Clean up after test ————————————", testInfo.getTestMethod().get().getName());
+    }
+
+    /**
+     * Random topic name string.
+     *
+     * @return the string
+     */
+    public static String randomTopicName() {
+        return "my-topic-" + UUID.randomUUID().toString().replace("-", "").substring(0, 6);
     }
 }

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/KroxyliciousST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/KroxyliciousST.java
@@ -95,8 +95,7 @@ class KroxyliciousST extends AbstractST {
         bootstrap = kroxylicious2.getBootstrap(clusterName);
         assertThat(bootstrap).withFailMessage("bootstrap " + bootstrap + " does not contain the corresponding namespace " + newNamespace)
                 .contains(newNamespace);
-        String newTopicName = randomTopicName();
-        produceAndConsumeMessage(newNamespace, bootstrap, newTopicName);
+        produceAndConsumeMessage(newNamespace, bootstrap, randomTopicName());
     }
 
     private void produceAndConsumeMessage(String namespace, String bootstrap) {

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/KroxyliciousST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/KroxyliciousST.java
@@ -8,7 +8,6 @@ package io.kroxylicious.systemtests;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.UUID;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -96,11 +95,15 @@ class KroxyliciousST extends AbstractST {
         bootstrap = kroxylicious2.getBootstrap(clusterName);
         assertThat(bootstrap).withFailMessage("bootstrap " + bootstrap + " does not contain the corresponding namespace " + newNamespace)
                 .contains(newNamespace);
-        topicName = "my-topic-" + UUID.randomUUID().toString().replace("-", "").substring(0, 6);
-        produceAndConsumeMessage(newNamespace, bootstrap);
+        String newTopicName = randomTopicName();
+        produceAndConsumeMessage(newNamespace, bootstrap, newTopicName);
     }
 
     private void produceAndConsumeMessage(String namespace, String bootstrap) {
+        produceAndConsumeMessage(namespace, bootstrap, topicName);
+    }
+
+    private void produceAndConsumeMessage(String namespace, String bootstrap, String topicName) {
         int numberOfMessages = 1;
 
         LOGGER.atInfo().setMessage("And a kafka Topic named {}").addArgument(topicName).log();


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Added a system tests that covers the case where two proxy services are deployed in different namespaces to check if the operator can handle them properly.

The new test creates all the kroxylicious resources in one namespace, then creates another kroxylicious resources with the same name in a different namespace. It checks each bootstrap reported and then that they can produce and consume messages.

### Additional Context

Closes #1911 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [x] Update documentation
- [x] Make sure all unit/integration tests pass
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [x] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [x] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [x] Ensure the PR references relevant issue(s) so they are closed on merging.
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
