### PR TITLE
Allow the Kafka proxy resource to be scaled.

### DIFF
--- a/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
+++ b/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
@@ -65,7 +65,7 @@ spec:
                           type: object
                       type: object
                 replicas:
-                  description: "The number of instances of this proxy to run"
+                  description: "The number of pods to run."
                   type: integer
                   format: int32
                   minimum: 0
@@ -179,6 +179,6 @@ spec:
                               description: type of condition in CamelCase or in foo.example.com/CamelCase.
                               type: string
                 replicas:
-                  description: "The number of instances of the proxy that have been scheduled"
+                  description: "The number of instances of the proxy pods that have reported ready."
                   type: integer
                   format: int32

--- a/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
+++ b/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
@@ -65,7 +65,7 @@ spec:
                           type: object
                       type: object
                 replicas:
-                  description: "The number of pods to run."
+                  description: "The number of pods to deploy."
                   type: integer
                   format: int32
                   minimum: 0

--- a/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
+++ b/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
@@ -31,6 +31,9 @@ spec:
       storage: true
       subresources:
         status: { }
+        scale:
+          specReplicasPath: .spec.replicas
+          statusReplicasPath: .status.replicas
       additionalPrinterColumns:
         - name: Ready
           description: Whether the other resources referenced by this proxy can be found.
@@ -61,6 +64,12 @@ spec:
                             type: string
                           type: object
                       type: object
+                replicas:
+                  description: "The number of instances of this proxy to run"
+                  type: integer
+                  format: int32
+                  minimum: 0
+                  default: 1
             status:
               type: object
               properties:
@@ -169,3 +178,7 @@ spec:
                             type:
                               description: type of condition in CamelCase or in foo.example.com/CamelCase.
                               type: string
+                replicas:
+                  description: "The number of instances of the proxy that have been scheduled"
+                  type: integer
+                  format: int32

--- a/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/kubernetes/operator/assertj/KafkaProxyStatusAssert.java
+++ b/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/kubernetes/operator/assertj/KafkaProxyStatusAssert.java
@@ -47,4 +47,8 @@ public class KafkaProxyStatusAssert extends AbstractStatusAssert<KafkaProxyStatu
         return Assertions.assertThat(actual.getClusters())
                 .asInstanceOf(InstanceOfAssertFactories.list(io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxystatus.Clusters.class));
     }
+
+    public void replicas(int expectedReplicaCount) {
+        Assertions.assertThat(actual.getReplicas()).isEqualTo(expectedReplicaCount);
+    }
 }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconciler.java
@@ -31,6 +31,7 @@ import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentStatus;
 import io.javaoperatorsdk.operator.OperatorException;
 import io.javaoperatorsdk.operator.api.config.informer.InformerEventSourceConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
@@ -400,12 +401,12 @@ public class KafkaProxyReconciler implements
     @Override
     public UpdateControl<KafkaProxy> reconcile(KafkaProxy primary,
                                                Context<KafkaProxy> context) {
-        context.getSecondaryResource(Deployment.class, DEPLOYMENT_DEP).ifPresent(deployment -> {
-            Integer readyReplicas = deployment.getStatus().getReadyReplicas();
-            statusFactory.withReplicaCount(Objects.requireNonNullElse(readyReplicas, 0));
-        });
+        Integer readyReplicas = context.getSecondaryResource(Deployment.class, DEPLOYMENT_DEP)
+                .map(Deployment::getStatus)
+                .map(DeploymentStatus::getReadyReplicas)
+                .orElse(0);
 
-        var uc = UpdateControl.patchStatus(statusFactory.newTrueConditionStatusPatch(primary, Condition.Type.Ready, ""));
+        var uc = UpdateControl.patchStatus(statusFactory.newTrueConditionStatusPatch(primary, Condition.Type.Ready, readyReplicas));
         if (LOGGER.isInfoEnabled()) {
             LOGGER.info("Completed reconciliation of {}/{}", namespace(primary), name(primary));
         }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeploymentDependentResource.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeploymentDependentResource.java
@@ -77,6 +77,11 @@ public class ProxyDeploymentDependentResource
         var model = kafkaProxyContext.model();
         String checksum = checksumFor(primary, context, model);
 
+        KafkaProxySpec proxySpec = primary.getSpec();
+        Integer replicas = 1;
+        if (proxySpec != null) {
+            replicas = proxySpec.getReplicas();
+        }
         // @formatter:off
         return new DeploymentBuilder()
                 .editOrNewMetadata()
@@ -86,7 +91,7 @@ public class ProxyDeploymentDependentResource
                     .addToLabels(standardLabels(primary))
                 .endMetadata()
                 .editOrNewSpec()
-                    .withReplicas(1)
+                    .withReplicas(replicas)
                     .editOrNewSelector()
                     .withMatchLabels(deploymentSelector(primary))
                     .endSelector()

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
@@ -176,7 +176,8 @@ class KafkaProxyReconcilerIT {
         int desiredReplicaCount = 5;
         var created = doCreate(kafkaService, kafkaProxy(PROXY_A, desiredReplicaCount));
         Deployment deployment = assertDeploymentReplicaCount(created.proxy(), desiredReplicaCount);
-        Deployment updatedDeployment = deployment.edit().editOrNewStatus().withReplicas(desiredReplicaCount).withReadyReplicas(2).withAvailableReplicas(2).endStatus().build();
+        Deployment updatedDeployment = deployment.edit().editOrNewStatus().withReplicas(desiredReplicaCount).withReadyReplicas(2).withAvailableReplicas(2).endStatus()
+                .build();
 
         // when
         testActor.patchStatus(updatedDeployment);
@@ -202,11 +203,11 @@ class KafkaProxyReconcilerIT {
 
         // then
         assertProxyConfigContents(created.proxy(), Set
-                        .of(
-                                UPSTREAM_TLS_CERTIFICATE_SECRET_NAME,
-                                TRUSTED_CAS_PEM,
-                                PROTOCOL_TLS_V1_3,
-                                TLS_CIPHER_SUITE_AES256GCM_SHA384),
+                .of(
+                        UPSTREAM_TLS_CERTIFICATE_SECRET_NAME,
+                        TRUSTED_CAS_PEM,
+                        PROTOCOL_TLS_V1_3,
+                        TLS_CIPHER_SUITE_AES256GCM_SHA384),
                 Set.of());
         assertDeploymentMountsConfigMap(created.proxy(), CA_BUNDLE_CONFIG_MAP_NAME);
         assertDeploymentMountsSecret(created.proxy(), UPSTREAM_TLS_CERTIFICATE_SECRET_NAME);
@@ -1051,7 +1052,8 @@ class KafkaProxyReconcilerIT {
 
     private void assertDeploymentIsRemoved(KafkaProxy proxy) {
         // wait longer for initial operator image download
-        AWAIT.alias("Deployment is removed").untilAsserted(() -> assertThat(testActor.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy))).isNull());
+        AWAIT.alias("Deployment is removed")
+                .untilAsserted(() -> assertThat(testActor.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy))).isNull());
     }
 
     private AbstractStringAssert<?> assertThatProxyConfigFor(KafkaProxy proxy) {

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
@@ -200,11 +200,11 @@ class KafkaProxyReconcilerIT {
 
         // then
         assertProxyConfigContents(created.proxy(), Set
-                        .of(
-                                UPSTREAM_TLS_CERTIFICATE_SECRET_NAME,
-                                TRUSTED_CAS_PEM,
-                                PROTOCOL_TLS_V1_3,
-                                TLS_CIPHER_SUITE_AES256GCM_SHA384),
+                .of(
+                        UPSTREAM_TLS_CERTIFICATE_SECRET_NAME,
+                        TRUSTED_CAS_PEM,
+                        PROTOCOL_TLS_V1_3,
+                        TLS_CIPHER_SUITE_AES256GCM_SHA384),
                 Set.of());
         assertDeploymentMountsConfigMap(created.proxy(), CA_BUNDLE_CONFIG_MAP_NAME);
         assertDeploymentMountsSecret(created.proxy(), UPSTREAM_TLS_CERTIFICATE_SECRET_NAME);

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
@@ -172,18 +172,15 @@ class KafkaProxyReconcilerIT {
     @Test
     void shouldIncludeReplicaCountInKafkaProxyStatus() {
         // given
+        int desiredReplicaCount = 3;
         KafkaService kafkaService = kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP);
-        int desiredReplicaCount = 5;
-        var created = doCreate(kafkaService, kafkaProxy(PROXY_A, desiredReplicaCount));
-        Deployment deployment = assertDeploymentReplicaCount(created.proxy(), desiredReplicaCount);
-        Deployment updatedDeployment = deployment.edit().editOrNewStatus().withReplicas(desiredReplicaCount).withReadyReplicas(2).withAvailableReplicas(2).endStatus()
-                .build();
 
         // when
-        testActor.patchStatus(updatedDeployment);
+        var created = doCreate(kafkaService, kafkaProxy(PROXY_A, desiredReplicaCount));
+        Deployment deployment = assertDeploymentReplicaCount(created.proxy(), desiredReplicaCount);
 
         // then
-        assertStausReplicaCount(created.proxy(), 2);
+        assertStausReplicaCount(created.proxy(), desiredReplicaCount);
     }
 
     @Test
@@ -203,11 +200,11 @@ class KafkaProxyReconcilerIT {
 
         // then
         assertProxyConfigContents(created.proxy(), Set
-                .of(
-                        UPSTREAM_TLS_CERTIFICATE_SECRET_NAME,
-                        TRUSTED_CAS_PEM,
-                        PROTOCOL_TLS_V1_3,
-                        TLS_CIPHER_SUITE_AES256GCM_SHA384),
+                        .of(
+                                UPSTREAM_TLS_CERTIFICATE_SECRET_NAME,
+                                TRUSTED_CAS_PEM,
+                                PROTOCOL_TLS_V1_3,
+                                TLS_CIPHER_SUITE_AES256GCM_SHA384),
                 Set.of());
         assertDeploymentMountsConfigMap(created.proxy(), CA_BUNDLE_CONFIG_MAP_NAME);
         assertDeploymentMountsSecret(created.proxy(), UPSTREAM_TLS_CERTIFICATE_SECRET_NAME);

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
@@ -174,13 +174,13 @@ class KafkaProxyReconcilerIT {
         KafkaService kafkaService = kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP);
         var created = doCreate(kafkaService, kafkaProxy(PROXY_A, 3));
         Deployment deployment = assertDeploymentReplicaCount(created.proxy(), 3);
-        Deployment updatedDeployment = deployment.edit().editStatus().withReadyReplicas(3).endStatus().build();
+        Deployment updatedDeployment = deployment.edit().editStatus().withReplicas(3).withReadyReplicas(2).endStatus().build();
 
         // when
         testActor.patchStatus(updatedDeployment);
 
         // then
-        assertStausReplicaCount(created.proxy(), 3);
+        assertStausReplicaCount(created.proxy(), 2);
     }
 
     @Test

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconcilerIT.java
@@ -145,7 +145,7 @@ class KafkaProxyReconcilerIT {
     private final LocallyRunningOperatorRbacHandler.TestActor testActor = rbacHandler.testActor(extension);
 
     @AfterEach
-    void stopOperator() throws Exception {
+    void stopOperator() {
         extension.getOperator().stop();
         LOGGER.atInfo().log("Test finished");
     }
@@ -775,7 +775,7 @@ class KafkaProxyReconcilerIT {
                     .extracting(svc -> svc.getSpec().getSelector())
                     .describedAs("Service's selector should select proxy pods")
                     .isEqualTo(ProxyDeploymentDependentResource.podLabels(proxy));
-            assertThat(service.getSpec().getPorts().stream().count()).describedAs("number of ports").isEqualTo(4);
+            assertThat(service.getSpec().getPorts().size()).describedAs("number of ports").isEqualTo(4);
         });
     }
 
@@ -799,7 +799,7 @@ class KafkaProxyReconcilerIT {
                     .describedAs("Deployment template should mount the proxy config configmap")
                     .filteredOn(volume -> volumeSourceExtractor.apply(volume) != null)
                     .map(volumeSourceExtractor)
-                    .anyMatch(volumeSourcePredicate::test);
+                    .anyMatch(volumeSourcePredicate);
         });
     }
 
@@ -1020,6 +1020,7 @@ class KafkaProxyReconcilerIT {
                 .extracting(map -> map.get(ProxyConfigDependentResource.CONFIG_YAML_KEY), InstanceOfAssertFactories.STRING);
     }
 
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     private static VirtualKafkaCluster virtualKafkaCluster(String clusterName, KafkaProxy proxy, KafkaService service,
                                                            List<Ingresses> ingresses, Optional<KafkaProtocolFilter> filter) {
         var filterRefs = filter.map(f -> new FilterRefBuilder().withName(name(f)).build()).stream().toList();

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyStatusFactoryTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyStatusFactoryTest.java
@@ -11,12 +11,18 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.UUID;
 
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.assertj.core.api.InstanceOfAssertFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyStatus;
+import io.kroxylicious.kubernetes.operator.assertj.AssertFactory;
+import io.kroxylicious.kubernetes.operator.assertj.KafkaProxyStatusAssert;
 import io.kroxylicious.kubernetes.operator.checksum.MetadataChecksumGenerator;
 
 import static io.kroxylicious.kubernetes.operator.assertj.OperatorAssertions.assertThat;
@@ -89,4 +95,17 @@ class KafkaProxyStatusFactoryTest {
         assertThat(patchedProxy).doesNotHaveAnnotation(Annotations.REFERENT_CHECKSUM_ANNOTATION_KEY);
     }
 
+    @Test
+    void shouldIncludeReplicaCountInStatus() {
+        // Given
+
+        // When
+        KafkaProxy patchedProxy = kafkaProxyStatusFactory.newTrueConditionStatusPatch(KAFKA_PROXY, Condition.Type.ResolvedRefs, 5);
+
+        // Then
+        assertThat(patchedProxy)
+                .isNotNull()
+                .extracting(KafkaProxy::getStatus, AssertFactory.status())
+                .replicas(5);
+    }
 }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyStatusFactoryTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/KafkaProxyStatusFactoryTest.java
@@ -11,18 +11,13 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.UUID;
 
-import org.assertj.core.api.AbstractAssert;
-import org.assertj.core.api.InstanceOfAssertFactories;
-import org.assertj.core.api.InstanceOfAssertFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyStatus;
 import io.kroxylicious.kubernetes.operator.assertj.AssertFactory;
-import io.kroxylicious.kubernetes.operator.assertj.KafkaProxyStatusAssert;
 import io.kroxylicious.kubernetes.operator.checksum.MetadataChecksumGenerator;
 
 import static io.kroxylicious.kubernetes.operator.assertj.OperatorAssertions.assertThat;

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/kroxylicious/KroxyliciousKafkaProxyTemplates.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/kroxylicious/KroxyliciousKafkaProxyTemplates.java
@@ -18,15 +18,19 @@ public class KroxyliciousKafkaProxyTemplates {
      *
      * @param namespaceName the namespace name
      * @param name the name
+     * @param replicas the number porxy pods to deploy
      * @return the kafka proxy builder
      */
-    public static KafkaProxyBuilder defaultKafkaProxyCR(String namespaceName, String name) {
+    public static KafkaProxyBuilder defaultKafkaProxyCR(String namespaceName, String name, int replicas) {
         // @formatter:off
         return new KafkaProxyBuilder()
                 .withNewMetadata()
                     .withName(name)
                     .withNamespace(namespaceName)
-                .endMetadata();
+                .endMetadata()
+                .withNewSpec()
+                .withReplicas(replicas)
+                .endSpec();
         // @formatter:on
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds scale sub resource to the Kafka Proxy CRD to allow the proxy instance to run with multiple instances.

### Additional Context

This PR allows users to directly control the number of proxy processes running. It also enables them to scale the proxy elastically using the HorizontalPodAutoscaler (HPA). Note it doesn't yet document how do do that (I intend to do so)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
