### PR TITLE
[System Tests] fix operator change detection ST and cert manager installation/uninstallation

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,6 +33,17 @@
     {
       "customType": "regex",
       "fileMatch": [
+        "kroxylicious-systemtests/src/main/resources/helm_cert_manager_overrides.yaml"
+      ],
+      "matchStrings": [
+        "tag:.*(?<currentValue>\\d+\\.\\d+.\\d+)"
+      ],
+      "depNameTemplate": "jetstack/cert-manager",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
         "kroxylicious-kms-provider-aws-kms-test-support/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsTestKmsFacade.java",
         "kroxylicious-systemtests/src/main/resources/helm_localstack_overrides.yaml"],
       "matchStrings": [

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
@@ -121,10 +121,6 @@ public final class Constants {
     public static final String KAF_CLIENT_IMAGE = "quay.io/kroxylicious/kaf:v0.2.7";
 
     /**
-     * The cert manager url to install it on kubernetes
-     */
-    public static final String CERT_MANAGER_URL = "https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml";
-    /**
      * the kubernetes labels used to identify the test kafka clients pods
      */
     public static final String KAFKA_CONSUMER_CLIENT_LABEL = "kafka-consumer-client";

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/CertManager.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kroxylicious/CertManager.java
@@ -7,21 +7,22 @@
 package io.kroxylicious.systemtests.installation.kroxylicious;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.fabric8.certmanager.api.model.v1.CertificateBuilder;
 import io.fabric8.certmanager.api.model.v1.IssuerBuilder;
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.client.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 
 import io.kroxylicious.systemtests.Constants;
 import io.kroxylicious.systemtests.resources.manager.ResourceManager;
-import io.kroxylicious.systemtests.utils.DeploymentUtils;
 import io.kroxylicious.systemtests.utils.NamespaceUtils;
+import io.kroxylicious.systemtests.utils.TestUtils;
 
 import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
 
@@ -32,8 +33,13 @@ public class CertManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(CertManager.class);
     public static final String SELF_SINGED_ISSUER_NAME = "self-signed-issuer";
 
-    private final NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata> deployment;
+    public static final String CERT_MANAGER_SERVICE_NAME = "cert-manager";
+    public static final String CERT_MANAGER_HELM_REPOSITORY_URL = "https://charts.jetstack.io";
+    public static final String CERT_MANAGER_HELM_REPOSITORY_NAME = "jetstack";
+    public static final String CERT_MANAGER_HELM_CHART_NAME = "jetstack/cert-manager";
+
     private boolean deleteCertManager = true;
+    private final String deploymentNamespace;
 
     /**
      * Instantiates a new Cert manager.
@@ -41,8 +47,7 @@ public class CertManager {
      * @throws IOException the io exception
      */
     public CertManager() throws IOException {
-        deployment = kubeClient().getClient()
-                .load(DeploymentUtils.getDeploymentFileFromURL(Constants.CERT_MANAGER_URL));
+        deploymentNamespace = Constants.CERT_MANAGER_NAMESPACE;
     }
 
     public IssuerBuilder issuer(String namespace) {
@@ -103,10 +108,15 @@ public class CertManager {
             deleteCertManager = false;
             return;
         }
+
         LOGGER.info("Deploy cert manager in {} namespace", Constants.CERT_MANAGER_NAMESPACE);
-        deployment.create();
-        DeploymentUtils.waitForDeploymentReady(Constants.CERT_MANAGER_NAMESPACE, "cert-manager-webhook");
-        NamespaceUtils.addNamespaceToSet(Constants.CERT_MANAGER_NAMESPACE, ResourceManager.getTestContext().getRequiredTestClass().getName());
+        NamespaceUtils.createNamespaceAndPrepare(deploymentNamespace);
+        ResourceManager.helmClient().addRepository(CERT_MANAGER_HELM_REPOSITORY_NAME, CERT_MANAGER_HELM_REPOSITORY_URL);
+        ResourceManager.helmClient().namespace(deploymentNamespace).install(CERT_MANAGER_HELM_CHART_NAME, CERT_MANAGER_SERVICE_NAME,
+                Optional.empty(),
+                Optional.of(Path.of(TestUtils.getResourcesURI("helm_cert_manager_overrides.yaml"))),
+                Optional.of(Map.of("crds.enabled", "true",
+                                    "crds.keep", "false")));
     }
 
     /**
@@ -118,8 +128,7 @@ public class CertManager {
             return;
         }
         LOGGER.info("Deleting Cert Manager in {} namespace", Constants.CERT_MANAGER_NAMESPACE);
-        deployment.withGracePeriod(0).delete();
-        DeploymentUtils.waitForDeploymentDeletion(Constants.CERT_MANAGER_NAMESPACE, "cert-manager-webhook");
+        ResourceManager.helmClient().delete(deploymentNamespace, CERT_MANAGER_SERVICE_NAME);
         NamespaceUtils.deleteNamespaceWithWaitAndRemoveFromSet(Constants.CERT_MANAGER_NAMESPACE, ResourceManager.getTestContext().getRequiredTestClass().getName());
     }
 }

--- a/kroxylicious-systemtests/src/main/resources/helm_cert_manager_overrides.yaml
+++ b/kroxylicious-systemtests/src/main/resources/helm_cert_manager_overrides.yaml
@@ -1,0 +1,9 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# Helm Overrides File for cert manager used by the system tests.
+image:
+  tag: v1.18.0

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/OperatorChangeDetectionST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/OperatorChangeDetectionST.java
@@ -122,11 +122,8 @@ class OperatorChangeDetectionST extends AbstractST {
     }
 
     @Test
-    void shouldUpdateDeploymentWhenDownstreamTlsCertUpdated(String namespace) throws IOException {
+    void shouldUpdateDeploymentWhenDownstreamTlsCertUpdated(String namespace) {
         // Given
-        certManager = new CertManager();
-        certManager.deploy();
-
         var issuer = certManager.issuer(namespace);
         var cert = certManager.certFor(namespace, "my-cluster-cluster-ip." + namespace + ".svc.cluster.local");
 
@@ -151,11 +148,8 @@ class OperatorChangeDetectionST extends AbstractST {
     }
 
     @Test
-    void shouldUpdateDeploymentWhenDownstreamTrustUpdated(String namespace) throws IOException {
+    void shouldUpdateDeploymentWhenDownstreamTrustUpdated(String namespace) {
         // Given
-        certManager = new CertManager();
-        certManager.deploy();
-
         var issuer = certManager.issuer(namespace);
         var cert = certManager.certFor(namespace, "my-cluster-cluster-ip." + namespace + ".svc.cluster.local");
 
@@ -285,8 +279,10 @@ class OperatorChangeDetectionST extends AbstractST {
     }
 
     @BeforeEach
-    void setUp(String namespace) {
+    void setUp(String namespace) throws IOException {
         kroxylicious = new Kroxylicious(namespace);
+        certManager = new CertManager();
+        certManager.deploy();
     }
 
     @AfterAll
@@ -309,7 +305,7 @@ class OperatorChangeDetectionST extends AbstractST {
         var kubeClient = kubeClient(namespace);
         AtomicReference<String> checksumFromAnnotation = new AtomicReference<>();
         await().atMost(Duration.ofSeconds(90))
-                .untilAsserted(() -> kubeClient.listPods(namespace, "app.kubernetes.io/name", "kroxylicious-proxy"),
+                .untilAsserted(() -> kubeClient.listPods(namespace, "app.kubernetes.io/name", "kroxylicious"),
                         proxyPods -> {
                             assertThat(proxyPods)
                                     .singleElement()


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

* Fixed the name of the label `app.kubernetes.io/name` to be set to `kroxylicious` instead of `kroxylicious-proxy`
* Fixed the cert manager installation. 
   * The issue was related to leftovers made rerun tests not possible.
   * Replaced to helm chart installation: it is cleaner, easier to remove resources and we can control the version we are using as well.

### Additional Context

Closes #2300 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
