### PR TITLE
Added new metrics for record encyption

### DIFF
--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryptionMetrics.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryptionMetrics.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Meter;
+
+import static io.micrometer.core.instrument.Metrics.globalRegistry;
+
+public class RecordEncryptionMetrics {
+
+    public static final String VIRTUAL_CLUSTER_LABEL = "virtual_cluster";
+    public static final String TOPIC_NAME = "topic_name";
+
+    // Base Metric Names
+    protected static final String KROXYLICIOUS_ENCRYPTED_RECORDS_BASE_METER_NAME = "kroxylicious_encrypted_records_total";
+    protected static final String KROXYLICIOUS_NOT_ENCRYPTED_RECORDS_BASE_METER_NAME = "kroxylicious_not_encrypted_records_total";
+
+    // Meter Providers
+    // (Callers use the providers to create the meters they need, augmenting with any tags).
+    public static final ClusterNodeSpecificMetricProviderCreator<Counter> KROXYLICIOUS_ENCRYPTED_RECORDS_BASE_METER_NAME_TOTAL_METER_PROVIDER = (virtualClusterName,
+                                                                                                                                                 nodeId) -> Counter
+                                                                                                                                                         .builder(
+                                                                                                                                                                 KROXYLICIOUS_ENCRYPTED_RECORDS_BASE_METER_NAME)
+                                                                                                                                                         .description(
+                                                                                                                                                                 "Incremented by the number of records encrypted.")
+                                                                                                                                                         .tag(VIRTUAL_CLUSTER_LABEL,
+                                                                                                                                                                 virtualClusterName)
+                                                                                                                                                         .tag(TOPIC_NAME,
+                                                                                                                                                                 nodeId)
+                                                                                                                                                         .withRegistry(
+                                                                                                                                                                 globalRegistry);
+
+    public static final ClusterNodeSpecificMetricProviderCreator<Counter> KROXYLICIOUS_NOT_ENCRYPTED_RECORDS_TOTAL_METER_PROVIDER = (virtualClusterName,
+                                                                                                                                     nodeId) -> Counter.builder(
+                                                                                                                                             KROXYLICIOUS_NOT_ENCRYPTED_RECORDS_BASE_METER_NAME)
+                                                                                                                                             .description(
+                                                                                                                                                     "Incremented by the number of records not encrypted.")
+                                                                                                                                             .tag(VIRTUAL_CLUSTER_LABEL,
+                                                                                                                                                     virtualClusterName)
+                                                                                                                                             .tag(TOPIC_NAME,
+                                                                                                                                                     nodeId)
+                                                                                                                                             .withRegistry(
+                                                                                                                                                     globalRegistry);
+
+    @FunctionalInterface
+    public interface ClusterNodeSpecificMetricProviderCreator<T extends Meter> {
+
+        Meter.MeterProvider<T> create(String virtualCluster, String nodeId);
+    }
+}

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/EncryptionManager.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/EncryptionManager.java
@@ -29,7 +29,7 @@ public interface EncryptionManager<K> {
      * @return A completion stage that completes with the output MemoryRecords when all the records have been processed and transformed.
      */
     @NonNull
-    CompletionStage<MemoryRecords> encrypt(
+    CompletionStage<MemoryRecords> encrypt(@NonNull String virtualClusterName,
                                            @NonNull String topicName,
                                            int partition,
                                            @NonNull EncryptionScheme<K> encryptionScheme,

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/InBandEncryptionManager.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/encrypt/InBandEncryptionManager.java
@@ -16,6 +16,7 @@ import org.apache.kafka.common.errors.NetworkException;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 
+import io.kroxylicious.filter.encryption.RecordEncryptionMetrics;
 import io.kroxylicious.filter.encryption.common.EncryptionException;
 import io.kroxylicious.filter.encryption.common.FilterThreadExecutor;
 import io.kroxylicious.filter.encryption.common.RecordEncryptionUtil;
@@ -76,7 +77,8 @@ public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
 
     @Override
     @NonNull
-    public CompletionStage<MemoryRecords> encrypt(@NonNull String topicName,
+    public CompletionStage<MemoryRecords> encrypt(@NonNull String virtualClusterName,
+                                                  @NonNull String topicName,
                                                   int partition,
                                                   @NonNull EncryptionScheme<K> encryptionScheme,
                                                   @NonNull MemoryRecords records,
@@ -92,7 +94,7 @@ public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
         if (totalRecords == 0) {
             return CompletableFuture.completedFuture(records);
         }
-        return attemptEncrypt(topicName, partition, encryptionScheme, records, 0, bufferAllocator, totalRecords);
+        return attemptEncrypt(virtualClusterName, topicName, partition, encryptionScheme, records, 0, bufferAllocator, totalRecords);
     }
 
     private ByteBufferOutputStream allocateBufferForEncrypt(@NonNull MemoryRecords records,
@@ -102,13 +104,18 @@ public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
         return bufferAllocator.apply(sizeEstimate);
     }
 
-    private CompletionStage<MemoryRecords> attemptEncrypt(@NonNull String topicName,
+    private CompletionStage<MemoryRecords> attemptEncrypt(@NonNull String virtualClusterName,
+                                                          @NonNull String topicName,
                                                           int partition,
                                                           @NonNull EncryptionScheme<K> encryptionScheme,
                                                           @NonNull MemoryRecords records,
                                                           int attempt,
                                                           @NonNull IntFunction<ByteBufferOutputStream> bufferAllocator,
                                                           int allRecordsCount) {
+        var encyptedRecordsTotal = RecordEncryptionMetrics.KROXYLICIOUS_ENCRYPTED_RECORDS_BASE_METER_NAME_TOTAL_METER_PROVIDER
+                .create(virtualClusterName, topicName)
+                .withTags();
+
         if (attempt >= MAX_ATTEMPTS) {
             return CompletableFuture.failedFuture(
                     new RequestNotSatisfiable("failed to reserve an EDEK to encrypt " + allRecordsCount + " records for topic " + topicName + " partition "
@@ -126,6 +133,7 @@ public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
                             records,
                             encryptor,
                             bufferAllocator);
+                    encyptedRecordsTotal.increment(allRecordsCount);
                     return CompletableFuture.completedFuture(encryptedMemoryRecords);
                 }
                 catch (DestroyedDekException | ExhaustedDekException e) {
@@ -137,7 +145,8 @@ public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
                 }
             }
             // recurse, incrementing the attempt number
-            return attemptEncrypt(topicName,
+            return attemptEncrypt(virtualClusterName,
+                    topicName,
                     partition,
                     encryptionScheme,
                     records,
@@ -145,6 +154,10 @@ public class InBandEncryptionManager<K, E> implements EncryptionManager<K> {
                     bufferAllocator,
                     allRecordsCount);
         });
+    }
+
+    private void initMetrics(String virtualClusterName, String topicName) {
+
     }
 
     @NonNull

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionFilterTest.java
@@ -145,7 +145,7 @@ class RecordEncryptionFilterTest {
             return CompletableFuture.completedFuture(new TopicNameKekSelection<>(topicNameToKekId, Set.of(UNRESOLVED_TOPIC)));
         });
 
-        when(encryptionManager.encrypt(any(), anyInt(), any(), any(), any()))
+        when(encryptionManager.encrypt(any(), any(), anyInt(), any(), any(), any()))
                 .thenReturn(CompletableFuture.completedFuture(RecordTestUtils.singleElementMemoryRecords("key", "value")));
 
         when(decryptionManager.decrypt(any(), anyInt(), any(), any()))
@@ -166,7 +166,7 @@ class RecordEncryptionFilterTest {
         encryptionFilter.onProduceRequest(ProduceRequestData.HIGHEST_SUPPORTED_VERSION, new RequestHeaderData(), produceRequestData, context);
 
         // Then
-        verify(encryptionManager, never()).encrypt(any(), anyInt(), any(), any(), any());
+        verify(encryptionManager, never()).encrypt(any(), any(), anyInt(), any(), any(), any());
     }
 
     @Test
@@ -180,7 +180,7 @@ class RecordEncryptionFilterTest {
         encryptionFilter.onProduceRequest(ProduceRequestData.HIGHEST_SUPPORTED_VERSION, new RequestHeaderData(), produceRequestData, context);
 
         // Then
-        verify(encryptionManager).encrypt(any(), anyInt(), any(), any(), any());
+        verify(encryptionManager).encrypt(any(), any(), anyInt(), any(), any(), any());
     }
 
     @Test
@@ -197,7 +197,7 @@ class RecordEncryptionFilterTest {
         encryptionFilter.onProduceRequest(ProduceRequestData.HIGHEST_SUPPORTED_VERSION, new RequestHeaderData(), produceRequestData, context);
 
         // Then
-        verify(encryptionManager).encrypt(any(), anyInt(), any(),
+        verify(encryptionManager).encrypt(any(), any(), anyInt(), any(),
                 argThat(records -> assertThat(records.records())
                         .hasSize(1)
                         .allSatisfy(record -> assertThat(record.value()).isEqualTo(ByteBuffer.wrap(HELLO_CIPHER_WORLD)))),
@@ -227,7 +227,7 @@ class RecordEncryptionFilterTest {
                 new RequestHeaderData(), produceRequestData, context);
 
         // Then
-        verify(encryptionManager, never()).encrypt(any(), anyInt(), any(), any(), any());
+        verify(encryptionManager, never()).encrypt(any(), any(), anyInt(), any(), any(), any());
         verify(requestFilterResultBuilder).errorResponse(any(), any(),
                 Mockito.argThat(e -> e instanceof InvalidRecordException && e.getMessage().equals("failed to resolve key for: [unresolved]")));
 

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/decrypt/InBandDecryptionManagerTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/decrypt/InBandDecryptionManagerTest.java
@@ -301,7 +301,7 @@ class InBandDecryptionManagerTest {
                                                    List<Record> initial,
                                                    List<Record> encrypted) {
         MemoryRecords records = RecordTestUtils.memoryRecords(initial);
-        return encryptionManager.encrypt(topic, partition, scheme, records, ByteBufferOutputStream::new)
+        return encryptionManager.encrypt("demo", topic, partition, scheme, records, ByteBufferOutputStream::new)
                 .thenApply(memoryRecords -> {
                     memoryRecords.records().forEach(encrypted::add);
                     return null;
@@ -1067,7 +1067,7 @@ class InBandDecryptionManagerTest {
 
     @NonNull
     private static CompletionStage<MemoryRecords> encrypt(InBandEncryptionManager<UUID, InMemoryEdek> km, EncryptionScheme<UUID> scheme, MemoryRecords records) {
-        return km.encrypt("topic", 1, scheme, records, ByteBufferOutputStream::new);
+        return km.encrypt("demo", "topic", 1, scheme, records, ByteBufferOutputStream::new);
     }
 
 }

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/encrypt/InBandEncryptionManagerTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/encrypt/InBandEncryptionManagerTest.java
@@ -84,7 +84,7 @@ class InBandEncryptionManagerTest {
                                                    List<Record> initial,
                                                    List<Record> encrypted) {
         MemoryRecords records = RecordTestUtils.memoryRecords(initial);
-        return encryptionManager.encrypt(topic, partition, scheme, records, ByteBufferOutputStream::new)
+        return encryptionManager.encrypt("demo", topic, partition, scheme, records, ByteBufferOutputStream::new)
                 .thenApply(memoryRecords -> {
                     memoryRecords.records().forEach(encrypted::add);
                     return null;


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

This PR fixes #789. This PR add the new metrics `kroxylicious_encrypted_records_total` and `"kroxylicious_encrypted_records_total` which counts the records that are encrypted/not encyrpted.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
