### PR TITLE
CRD: Enable user to specify proxy container resources

### DIFF
--- a/kroxylicious-kubernetes-api/pom.xml
+++ b/kroxylicious-kubernetes-api/pom.xml
@@ -150,6 +150,9 @@
                         <io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyspec.PodTemplate>
                             io.fabric8.kubernetes.api.model.PodTemplateSpec
                         </io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyspec.PodTemplate>
+                        <io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyspec.infrastructure.proxycontainer.Resources>
+                            io.fabric8.kubernetes.api.model.ResourceRequirements
+                        </io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyspec.infrastructure.proxycontainer.Resources>
 
                         <!-- Common types used across our own CRDs -->
                         <io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyingressspec.ProxyRef>

--- a/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
+++ b/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kafkaproxies.kroxylicious.io-v1.yml
@@ -54,6 +54,62 @@ spec:
             spec:
               type: object
               properties:
+                infrastructure:
+                  type: object
+                  description: |
+                    A collection of infrastructure-level settings that may be applied across all (or a subset of) 
+                    manifested resources for a KafkaProxy. This includes settings that affect resource behaviour at
+                    the platform layer, such as:
+                    - Resource limits and requests
+                  properties:
+                    proxyContainer:
+                      description: |
+                        infrastructure-level settings applied to proxy containers
+                      type: object
+                      properties:
+                        resources:
+                          type: object
+                          description: "A specification for the compute/memory requirements of the proxy container."
+                          properties:
+                            limits:
+                              description: "Limits describes the maximum amount of each resource allowed."
+                              properties:
+                                cpu:
+                                  description: "The maximum compute allowed"
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                                  x-kubernetes-int-or-string: true
+                                memory:
+                                  description: "The maximum memory allowed"
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              type: object
+                              description: |
+                                Requests describes the minimum amount of each resources required. If
+                                Requests is omitted for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined value.
+                              properties:
+                                cpu:
+                                  description: "The minimum compute required"
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                                  x-kubernetes-int-or-string: true
+                                memory:
+                                  description: "The minimum memory required"
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$"
+                                  x-kubernetes-int-or-string: true
                 podTemplate:
                   type: object
                   properties:

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/invalid-infrastructure-not-object.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/invalid-infrastructure-not-object.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxy
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: abc
+    namespace: proxy-ns
+  spec:
+    infrastructure: []
+expectFailureMessageToContain: |
+  spec.infrastructure: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/invalid-proxyContainer-not-object.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/invalid-proxyContainer-not-object.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxy
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: abc
+    namespace: proxy-ns
+  spec:
+    infrastructure:
+      proxyContainer: []
+expectFailureMessageToContain: |
+  spec.infrastructure.proxyContainer: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/invalid-resources.not-object.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/invalid-resources.not-object.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxy
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: use-pod-template-spec
+    namespace: proxy-ns
+  spec:
+    infrastructure:
+      proxyContainer:
+        resources: [ ]
+expectFailureMessageToContain: |
+  spec.infrastructure.proxyContainer.resources: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/limits/cpu/invalid-cpu-not-string-or-int.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/limits/cpu/invalid-cpu-not-string-or-int.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxy
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: use-pod-template-spec
+    namespace: proxy-ns
+  spec:
+    infrastructure:
+      proxyContainer:
+        resources:
+          limits:
+            cpu: [ ]
+expectFailureMessageToContain: |
+  spec.infrastructure.proxyContainer.resources.limits.cpu: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/limits/cpu/invalid-cpu-string-doesnt-match-pattern.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/limits/cpu/invalid-cpu-string-doesnt-match-pattern.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxy
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: use-pod-template-spec
+    namespace: proxy-ns
+  spec:
+    infrastructure:
+      proxyContainer:
+        resources:
+          limits:
+            cpu: "notgood"
+expectFailureMessageToContain: |
+  spec.infrastructure.proxyContainer.resources.limits.cpu: Invalid value: "notgood"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/limits/cpu/valid-cpu-int.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/limits/cpu/valid-cpu-int.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: use-pod-template-spec
+  namespace: proxy-ns
+spec:
+  infrastructure:
+    proxyContainer:
+      resources:
+        limits:
+          "cpu": 5000

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/limits/cpu/valid-cpu-string.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/limits/cpu/valid-cpu-string.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: use-pod-template-spec
+  namespace: proxy-ns
+spec:
+  infrastructure:
+    proxyContainer:
+      resources:
+        limits:
+          "cpu": "500m"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/limits/invalid-limits.not-object.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/limits/invalid-limits.not-object.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxy
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: use-pod-template-spec
+    namespace: proxy-ns
+  spec:
+    infrastructure:
+      proxyContainer:
+        resources:
+          limits: [ ]
+expectFailureMessageToContain: |
+  spec.infrastructure.proxyContainer.resources.limits: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/limits/memory/invalid-memory-not-string-or-int.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/limits/memory/invalid-memory-not-string-or-int.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxy
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: use-pod-template-spec
+    namespace: proxy-ns
+  spec:
+    infrastructure:
+      proxyContainer:
+        resources:
+          limits:
+            memory: [ ]
+expectFailureMessageToContain: |
+  spec.infrastructure.proxyContainer.resources.limits.memory: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/limits/memory/invalid-memory-string-doesnt-match-pattern.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/limits/memory/invalid-memory-string-doesnt-match-pattern.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxy
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: use-pod-template-spec
+    namespace: proxy-ns
+  spec:
+    infrastructure:
+      proxyContainer:
+        resources:
+          limits:
+            memory: "notgood"
+expectFailureMessageToContain: |
+  spec.infrastructure.proxyContainer.resources.limits.memory: Invalid value: "notgood"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/limits/memory/valid-memory-int.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/limits/memory/valid-memory-int.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: use-pod-template-spec
+  namespace: proxy-ns
+spec:
+  infrastructure:
+    proxyContainer:
+      resources:
+        limits:
+          "memory": 5000

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/limits/memory/valid-memory-string.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/limits/memory/valid-memory-string.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: use-pod-template-spec
+  namespace: proxy-ns
+spec:
+  infrastructure:
+    proxyContainer:
+      resources:
+        limits:
+          "memory": "512Mi"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/limits/valid-limits-empty.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/limits/valid-limits-empty.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: use-pod-template-spec
+  namespace: proxy-ns
+spec:
+  infrastructure:
+    proxyContainer:
+      resources:
+        limits: { }

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/limits/valid-limits-null.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/limits/valid-limits-null.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: use-pod-template-spec
+  namespace: proxy-ns
+spec:
+  infrastructure:
+    proxyContainer:
+      resources:
+        limits: null

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/requests/cpu/invalid-cpu-not-string-or-int.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/requests/cpu/invalid-cpu-not-string-or-int.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxy
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: use-pod-template-spec
+    namespace: proxy-ns
+  spec:
+    infrastructure:
+      proxyContainer:
+        resources:
+          requests:
+            cpu: [ ]
+expectFailureMessageToContain: |
+  spec.infrastructure.proxyContainer.resources.requests.cpu: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/requests/cpu/invalid-cpu-string-doesnt-match-pattern.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/requests/cpu/invalid-cpu-string-doesnt-match-pattern.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxy
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: use-pod-template-spec
+    namespace: proxy-ns
+  spec:
+    infrastructure:
+      proxyContainer:
+        resources:
+          requests:
+            cpu: "notgood"
+expectFailureMessageToContain: |
+  spec.infrastructure.proxyContainer.resources.requests.cpu: Invalid value: "notgood"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/requests/cpu/valid-cpu-int.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/requests/cpu/valid-cpu-int.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: use-pod-template-spec
+  namespace: proxy-ns
+spec:
+  infrastructure:
+    proxyContainer:
+      resources:
+        requests:
+          "cpu": 5000

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/requests/cpu/valid-cpu-string.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/requests/cpu/valid-cpu-string.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: use-pod-template-spec
+  namespace: proxy-ns
+spec:
+  infrastructure:
+    proxyContainer:
+      resources:
+        requests:
+          "cpu": "500m"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/requests/invalid-requests.not-object.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/requests/invalid-requests.not-object.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxy
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: use-pod-template-spec
+    namespace: proxy-ns
+  spec:
+    infrastructure:
+      proxyContainer:
+        resources:
+          requests: [ ]
+expectFailureMessageToContain: |
+  spec.infrastructure.proxyContainer.resources.requests: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/requests/memory/invalid-memory-not-string-or-int.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/requests/memory/invalid-memory-not-string-or-int.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxy
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: use-pod-template-spec
+    namespace: proxy-ns
+  spec:
+    infrastructure:
+      proxyContainer:
+        resources:
+          requests:
+            memory: [ ]
+expectFailureMessageToContain: |
+  spec.infrastructure.proxyContainer.resources.requests.memory: Invalid value: "array"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/requests/memory/invalid-memory-string-doesnt-match-pattern.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/requests/memory/invalid-memory-string-doesnt-match-pattern.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxy
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: use-pod-template-spec
+    namespace: proxy-ns
+  spec:
+    infrastructure:
+      proxyContainer:
+        resources:
+          requests:
+            memory: "notgood"
+expectFailureMessageToContain: |
+  spec.infrastructure.proxyContainer.resources.requests.memory: Invalid value: "notgood"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/requests/memory/valid-memory-int.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/requests/memory/valid-memory-int.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: use-pod-template-spec
+  namespace: proxy-ns
+spec:
+  infrastructure:
+    proxyContainer:
+      resources:
+        requests:
+          "memory": 5000

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/requests/memory/valid-memory-string.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/requests/memory/valid-memory-string.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: use-pod-template-spec
+  namespace: proxy-ns
+spec:
+  infrastructure:
+    proxyContainer:
+      resources:
+        requests:
+          "memory": "512Mi"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/requests/valid-requests-empty.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/requests/valid-requests-empty.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: use-pod-template-spec
+  namespace: proxy-ns
+spec:
+  infrastructure:
+    proxyContainer:
+      resources:
+        requests: { }

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/requests/valid-requests-null.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/requests/valid-requests-null.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: use-pod-template-spec
+  namespace: proxy-ns
+spec:
+  infrastructure:
+    proxyContainer:
+      resources:
+        requests: null

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/valid-resources-empty.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/valid-resources-empty.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: use-pod-template-spec
+  namespace: proxy-ns
+spec:
+  infrastructure:
+    proxyContainer:
+      resources: { }

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/valid-resources-null.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/resources/valid-resources-null.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: use-pod-template-spec
+  namespace: proxy-ns
+spec:
+  infrastructure:
+    proxyContainer:
+      resources: null

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/valid-proxyContainer-empty.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/valid-proxyContainer-empty.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: 12345678901234567890123456789012345678901234567890
+  namespace: proxy-ns
+spec:
+  infrastructure:
+    proxyContainer: {}

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/valid-proxyContainer-null.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/proxyContainer/valid-proxyContainer-null.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: 12345678901234567890123456789012345678901234567890
+  namespace: proxy-ns
+spec:
+  infrastructure:
+    proxyContainer: null

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/valid-infrastructure-empty.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/valid-infrastructure-empty.yaml
@@ -1,0 +1,14 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: 12345678901234567890123456789012345678901234567890
+  namespace: proxy-ns
+spec:
+  infrastructure: {}

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/valid-infrastructure-null.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/infrastructure/valid-infrastructure-null.yaml
@@ -1,0 +1,14 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: 12345678901234567890123456789012345678901234567890
+  namespace: proxy-ns
+spec:
+  infrastructure: null

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/replicas/invalid-replicas-negative.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/replicas/invalid-replicas-negative.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxy
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: abc
+    namespace: proxy-ns
+  spec:
+    replicas: -1
+expectFailureMessageToContain: |
+  spec.replicas: Invalid value: -1

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/replicas/invalid-replicas-not-int.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/replicas/invalid-replicas-not-int.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KafkaProxy
+  apiVersion: kroxylicious.io/v1alpha1
+  metadata:
+    name: abc
+    namespace: proxy-ns
+  spec:
+    replicas: "abc"
+expectFailureMessageToContain: |
+  spec.replicas: Invalid value: "string"

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/replicas/valid-replicas-max.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/replicas/valid-replicas-max.yaml
@@ -1,0 +1,14 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: 12345678901234567890123456789012345678901234567890
+  namespace: proxy-ns
+spec:
+  replicas: 2147483647

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/replicas/valid-replicas-min.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/replicas/valid-replicas-min.yaml
@@ -1,0 +1,14 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: 12345678901234567890123456789012345678901234567890
+  namespace: proxy-ns
+spec:
+  replicas: 0

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/replicas/valid-replicas-null.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/replicas/valid-replicas-null.yaml
@@ -1,0 +1,14 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: 12345678901234567890123456789012345678901234567890
+  namespace: proxy-ns
+spec:
+  replicas: null

--- a/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/valid-spec-empty.yaml
+++ b/kroxylicious-operator/src/test/resources/CustomResourceValidationIT/kafkaproxy/valid-spec-empty.yaml
@@ -1,0 +1,13 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: 12345678901234567890123456789012345678901234567890
+  namespace: proxy-ns
+spec: {}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

1. Adds `spec.infrastructure` as a parent for anything concerned with configuring implementation-specific pieces of infrastructure at a platform level.
2. Adds `spec.infrastructure.proxyContainer` as a parent for configuration specific to the proxy container.
3. Adds `spec.infrastructure.proxyContainer.resources` for configuring the container requests/limits as you would in a PodSpec, like:
    ``` yaml
       resources:
         requests:
           cpu: '500m'
           memory: '512Mi'
         limits:
           cpu: '1000m'
           memory: '1024Mi'
    ```
    
We have intentionally tried to limit the `proxyContainer` spec to something minimal, rather than trying to replicate the structure of a`PodSpec`. We think it might be more flexible in future to introduce something like `spec.infrastructure.proxyPodSpecRef` to reference a full `PodSpec` to give the user more control over the details of the pod spec without us having to duplicate the spec. Perhaps we could also give them a mechanism to have the Operator generate an initial PodSpec resource for them.

#### Complete Example

```yaml
kind: KafkaProxy
apiVersion: kroxylicious.io/v1alpha1
metadata:
  name: my-proxy
  namespace: proxy-ns
spec:
  replicas: 2
  infrastructure:
    proxyContainer:
      resources:
        requests:
          "cpu": '500m'
          "memory": '256Mi'
        limits:
          "cpu": '1000m'
          "memory": '512Mi'
```

### Why

We want users to have control over the compute/memory requests/limits of the manifested pods. We want users to be able to scale their KafkaProxy pod replicas.

contributes towards #1575

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
