### PR TITLE
Fix #2222: Github workflow to make a multi-arch kaf container.

### DIFF
--- a/.github/workflows/kaf.yaml
+++ b/.github/workflows/kaf.yaml
@@ -5,8 +5,6 @@
 # - REGISTRY_USERNAME - - your username on the service (or username of your robot account)
 # - REGISTRY_TOKEN - the access token that corresponds to `REGISTRY_USERNAME`
 #
-# If the required repository variables aren't set the workflow will be skipped.  This means the workflow won't fail
-# on the forks of developers who haven't configured the variables/secrets.
 
 name: Kaf Container 
 on:
@@ -18,10 +16,10 @@ on:
         required: true
       registry-destination:
         description: 'The release version, e.g. quay.io/<my org>/kaf'
-        default: 'quay.io/k_wall/kaf'
+        default: 'quay.io/kroxylicious/kaf'
         required: true
       ref:
-        description: 'Ref (branch/tag)'
+        description: 'Ref (branch/tag) to build'
         required: true
         default: 'master'
 jobs:
@@ -52,3 +50,5 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           push: true
           tags: ${{ github.event.inputs.registry-destination }}:${{ github.event.inputs.ref }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max,compression=zstd

--- a/.github/workflows/kaf.yaml
+++ b/.github/workflows/kaf.yaml
@@ -1,0 +1,54 @@
+# kaf.yaml - builds and pushes a Kaf container image.
+#
+# Requires repository variables:
+# - REGISTRY_SERVER - the server of the container registry service e.g. `quay.io` or `docker.io`
+# - REGISTRY_USERNAME - - your username on the service (or username of your robot account)
+# - REGISTRY_TOKEN - the access token that corresponds to `REGISTRY_USERNAME`
+#
+# If the required repository variables aren't set the workflow will be skipped.  This means the workflow won't fail
+# on the forks of developers who haven't configured the variables/secrets.
+
+name: Kaf Container 
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: 'Repository containing kaf'
+        default: 'birdayz/kaf'
+        required: true
+      registry-destination:
+        description: 'The release version, e.g. quay.io/<my org>/kaf'
+        default: 'quay.io/k_wall/kaf'
+        required: true
+      ref:
+        description: 'Ref (branch/tag)'
+        required: true
+        default: 'master'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: ${{ vars.REGISTRY_SERVER != '' && vars.REGISTRY_USERNAME != '' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository:  ${{ github.event.inputs.repository }}
+          ref: ${{ github.event.inputs.ref }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ vars.REGISTRY_SERVER }}
+          username: ${{ vars.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+      - name: Build and push Kaf container image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
+          push: true
+          tags: ${{ github.event.inputs.registry-destination }}:${{ github.event.inputs.ref }}


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

The system tests use the Kaf command line client to get rudimentaryr test coverage of using a non-Java Kafka Client.

#2222 requested:

* an up-to-date Kaf
* multi-arch support

Kaf don't publish images themselves, although it has a Dockerfile.  I've written a Github workflow that can be trigger to publish an image.

I've run the workflow locally and tested amd64 and amr64.

https://quay.io/repository/k_wall/kaf?tab=tags

_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
