### PR TITLE
Add default resource requirements to operand proxy container

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeploymentDependentResource.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ProxyDeploymentDependentResource.java
@@ -23,6 +23,7 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.PodTemplateSpecBuilder;
 import io.fabric8.kubernetes.api.model.PodTemplateSpecFluent;
+import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.client.utils.KubernetesResourceUtil;
@@ -56,6 +57,8 @@ public class ProxyDeploymentDependentResource
     private static final String MANAGEMENT_PORT_NAME = "management";
     public static final int PROXY_PORT_START = 9292;
     public static final int SHARED_SNI_PORT = 9291;
+    private static final Map<String, Quantity> DEFAULT_LIMITS = Map.of("cpu", Quantity.parse("500m"), "memory", Quantity.parse("512Mi"));
+
     private final String kroxyliciousImage = getOperandImage();
     static final String KROXYLICIOUS_IMAGE_ENV_VAR = "KROXYLICIOUS_IMAGE";
 
@@ -197,6 +200,10 @@ public class ProxyDeploymentDependentResource
                     .withMountPath(ProxyDeploymentDependentResource.CONFIG_PATH_IN_CONTAINER)
                     .withSubPath(ProxyConfigDependentResource.CONFIG_YAML_KEY)
                 .endVolumeMount()
+                .withNewResources()
+                    .withRequests(DEFAULT_LIMITS)
+                    .withLimits(DEFAULT_LIMITS)
+                .endResources()
                 .addAllToVolumeMounts(kafkaProxyContext.mounts())
                 // management port
                 .addNewPort()
@@ -248,4 +255,5 @@ public class ProxyDeploymentDependentResource
         }
 
     }
+
 }

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-Deployment-example.yaml
@@ -65,6 +65,13 @@ spec:
             - mountPath: "/opt/kroxylicious/config/proxy-config.yaml"
               name: "config-volume"
               subPath: "proxy-config.yaml"
+          resources:
+            limits:
+              "cpu": "500m"
+              "memory": "512Mi"
+            requests:
+              "cpu": "500m"
+              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Deployment-example.yaml
@@ -85,6 +85,13 @@ spec:
             - mountPath: "/opt/kroxylicious/secure/configmap/bar"
               name: "configmaps-bar"
               readOnly: true
+          resources:
+            limits:
+              "cpu": "500m"
+              "memory": "512Mi"
+            requests:
+              "cpu": "500m"
+              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Deployment-example.yaml
@@ -65,6 +65,13 @@ spec:
             - mountPath: "/opt/kroxylicious/config/proxy-config.yaml"
               name: "config-volume"
               subPath: "proxy-config.yaml"
+          resources:
+            limits:
+              "cpu": "500m"
+              "memory": "512Mi"
+            requests:
+              "cpu": "500m"
+              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/kafka-service-with-tls/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/kafka-service-with-tls/out-Deployment-minimal.yaml
@@ -82,6 +82,13 @@ spec:
             - mountPath: "/opt/kroxylicious/secure/secret/upstream-tls-cert"
               name: "secrets-upstream-tls-cert"
               readOnly: true
+          resources:
+            limits:
+              "cpu": "500m"
+              "memory": "512Mi"
+            requests:
+              "cpu": "500m"
+              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Deployment-minimal.yaml
@@ -70,6 +70,13 @@ spec:
             - mountPath: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert"
               name: "secrets-downstream-tls-cert"
               readOnly: true
+          resources:
+            limits:
+              "cpu": "500m"
+              "memory": "512Mi"
+            requests:
+              "cpu": "500m"
+              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress-with-no-downstream-tls-on-cluster/out-Deployment-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress-with-no-downstream-tls-on-cluster/out-Deployment-twocluster.yaml
@@ -70,6 +70,13 @@ spec:
             - mountPath: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert"
               name: "secrets-downstream-tls-cert"
               readOnly: true
+          resources:
+            limits:
+              "cpu": "500m"
+              "memory": "512Mi"
+            requests:
+              "cpu": "500m"
+              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress/out-Deployment-minimal.yaml
@@ -70,6 +70,13 @@ spec:
             - mountPath: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert"
               name: "secrets-downstream-tls-cert"
               readOnly: true
+          resources:
+            limits:
+              "cpu": "500m"
+              "memory": "512Mi"
+            requests:
+              "cpu": "500m"
+              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Deployment-minimal.yaml
@@ -73,6 +73,13 @@ spec:
             - mountPath: "/opt/kroxylicious/config/proxy-config.yaml"
               name: "config-volume"
               subPath: "proxy-config.yaml"
+          resources:
+            limits:
+              "cpu": "500m"
+              "memory": "512Mi"
+            requests:
+              "cpu": "500m"
+              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-Deployment-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-Deployment-twocluster.yaml
@@ -73,6 +73,13 @@ spec:
             - mountPath: "/opt/kroxylicious/config/proxy-config.yaml"
               name: "config-volume"
               subPath: "proxy-config.yaml"
+          resources:
+            limits:
+              "cpu": "500m"
+              "memory": "512Mi"
+            requests:
+              "cpu": "500m"
+              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-Deployment-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-Deployment-twocluster.yaml
@@ -73,6 +73,13 @@ spec:
             - mountPath: "/opt/kroxylicious/config/proxy-config.yaml"
               name: "config-volume"
               subPath: "proxy-config.yaml"
+          resources:
+            limits:
+              "cpu": "500m"
+              "memory": "512Mi"
+            requests:
+              "cpu": "500m"
+              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/out-Deployment-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/out-Deployment-twocluster.yaml
@@ -65,6 +65,13 @@ spec:
             - mountPath: "/opt/kroxylicious/config/proxy-config.yaml"
               name: "config-volume"
               subPath: "proxy-config.yaml"
+          resources:
+            limits:
+              "cpu": "500m"
+              "memory": "512Mi"
+            requests:
+              "cpu": "500m"
+              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-shared-loadbalancer-ingress/out-Deployment-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-shared-loadbalancer-ingress/out-Deployment-twocluster.yaml
@@ -70,6 +70,13 @@ spec:
             - mountPath: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert"
               name: "secrets-downstream-tls-cert"
               readOnly: true
+          resources:
+            limits:
+              "cpu": "500m"
+              "memory": "512Mi"
+            requests:
+              "cpu": "500m"
+              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Deployment-example.yaml
@@ -76,6 +76,13 @@ spec:
             - mountPath: "/opt/kroxylicious/secure/secret/my-secret"
               name: "secrets-my-secret"
               readOnly: true
+          resources:
+            limits:
+              "cpu": "500m"
+              "memory": "512Mi"
+            requests:
+              "cpu": "500m"
+              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Deployment-use-pod-template-spec.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/use-pod-template-spec/out-Deployment-use-pod-template-spec.yaml
@@ -75,6 +75,13 @@ spec:
             - mountPath: "/opt/kroxylicious/config/proxy-config.yaml"
               name: "config-volume"
               subPath: "proxy-config.yaml"
+          resources:
+            limits:
+              "cpu": "500m"
+              "memory": "512Mi"
+            requests:
+              "cpu": "500m"
+              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Deployment-minimal.yaml
@@ -70,6 +70,13 @@ spec:
             - mountPath: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert"
               name: "secrets-downstream-tls-cert"
               readOnly: true
+          resources:
+            limits:
+              "cpu": "500m"
+              "memory": "512Mi"
+            requests:
+              "cpu": "500m"
+              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Deployment-minimal.yaml
@@ -73,6 +73,13 @@ spec:
             - mountPath: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert"
               name: "secrets-downstream-tls-cert"
               readOnly: true
+          resources:
+            limits:
+              "cpu": "500m"
+              "memory": "512Mi"
+            requests:
+              "cpu": "500m"
+              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Deployment-minimal.yaml
@@ -73,6 +73,13 @@ spec:
             - mountPath: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert"
               name: "secrets-downstream-tls-cert"
               readOnly: true
+          resources:
+            limits:
+              "cpu": "500m"
+              "memory": "512Mi"
+            requests:
+              "cpu": "500m"
+              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Deployment-minimal.yaml
@@ -73,6 +73,13 @@ spec:
             - mountPath: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert"
               name: "secrets-downstream-tls-cert"
               readOnly: true
+          resources:
+            limits:
+              "cpu": "500m"
+              "memory": "512Mi"
+            requests:
+              "cpu": "500m"
+              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Deployment-minimal.yaml
@@ -73,6 +73,13 @@ spec:
             - mountPath: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert"
               name: "secrets-downstream-tls-cert"
               readOnly: true
+          resources:
+            limits:
+              "cpu": "500m"
+              "memory": "512Mi"
+            requests:
+              "cpu": "500m"
+              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Deployment-minimal.yaml
@@ -70,6 +70,13 @@ spec:
             - mountPath: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert"
               name: "secrets-downstream-tls-cert"
               readOnly: true
+          resources:
+            limits:
+              "cpu": "500m"
+              "memory": "512Mi"
+            requests:
+              "cpu": "500m"
+              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

We want to avoid the operand pod being scheduled to a node with no resources, so we should supply some default resource limits.

The defaults for both requests/limits are:
* 512Mi memory
* 500m cpu

Contributes towards #1575 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
