### PR TITLE
Fix #2302: Add metric to the Operator that reports the version build info

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
@@ -12,7 +12,6 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.IntSupplier;
-import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,7 +53,6 @@ public class OperatorMain {
      * name emitted by Prometheus will be called {@code kroxylicious_operator_build_info}.
      */
     private static final String BUILD_INFO_METRIC_NAME = "kroxylicious_operator_build.info";
-    private static final Supplier<Double> BUILD_INFO_VALUE_SUPPLIER = () -> 1.0;
     private final Operator operator;
     private final HttpServer managementServer;
 
@@ -196,10 +194,11 @@ public class OperatorMain {
     }
 
     private static void versionInfoMetric(VersionInfo versionInfo) {
-        Gauge.builder(BUILD_INFO_METRIC_NAME, BUILD_INFO_VALUE_SUPPLIER)
+        Gauge.builder(BUILD_INFO_METRIC_NAME, () -> 1.0)
                 .description("Reports Kroxylicious Operator version information")
                 .tag("version", versionInfo.version())
                 .tag("commit_id", versionInfo.commitId())
+                .strongReference(true)
                 .register(Metrics.globalRegistry);
     }
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
@@ -173,6 +173,7 @@ class OperatorMainIT {
                     assertThat(response.statusCode()).isEqualTo(200);
                     assertThat(response.body())
                             .isNotEmpty()
+                            .anySatisfy(line -> assertThat(line).contains("kroxylicious_operator_build_info"))
                             .anySatisfy(line -> assertThat(line).contains("operator_sdk_reconciliations_executions_kafkaproxyreconciler"))
                             .anySatisfy(line -> assertThat(line).contains("operator_sdk_events_received"));
                 });

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/util/Metrics.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/util/Metrics.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
@@ -64,7 +63,6 @@ public class Metrics {
      * name emitted by Prometheus will be called {@code kroxylicious_build_info}.
      */
     private static final String INFO_METRIC_NAME = "kroxylicious_build.info";
-    private static final Supplier<Double> ONE_SUPPLIER = () -> 1.0;
 
     /**
      * @deprecated use kroxylicious_client_to_proxy_request_count instead.
@@ -338,15 +336,16 @@ public class Metrics {
     }
 
     /**
-     * Exposes a <a href="https://www.robustperception.io/exposing-the-software-version-to-prometheus/">build info metric</a>  describing Kroxylicious version etc.
+     * Exposes a <a href="https://www.robustperception.io/exposing-the-software-version-to-prometheus/">build info metric</a> describing Kroxylicious version etc.
      *
      * @param versionInfo version info
      */
     public static void versionInfoMetric(VersionInfo versionInfo) {
-        Gauge.builder(INFO_METRIC_NAME, ONE_SUPPLIER)
+        Gauge.builder(INFO_METRIC_NAME, () -> 1.0)
                 .description("Reports Kroxylicious version information")
                 .tag("version", versionInfo.version())
                 .tag("commit_id", versionInfo.commitId())
+                .strongReference(true)
                 .register(globalRegistry);
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/util/Metrics.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/util/Metrics.java
@@ -61,7 +61,7 @@ public class Metrics {
     /**
      * Name of the build_info metric.  Note that the {@code .info} suffix is significant
      * to Micrometer and is used to indicate an 'info' metric to it.  The metric
-     * name emitted by Prometheus will be called {@code kroxylicious_build.info}
+     * name emitted by Prometheus will be called {@code kroxylicious_build_info}.
      */
     private static final String INFO_METRIC_NAME = "kroxylicious_build.info";
     private static final Supplier<Double> ONE_SUPPLIER = () -> 1.0;


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

It is common for applications to expose a [build_info](https://www.robustperception.io/exposing-the-software-version-to-prometheus/) metric exposing information about themselves (version information etc). This helps an enterprise manage its software deployments.

#2311 made the change to the proxy.  This makes the equivalent change to the Operator.



### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
