### PR TITLE
[System Tests] skip kcat for those archs different from x86_64

### DIFF
--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
@@ -57,6 +57,7 @@ public class Environment {
     private static final String CATALOG_SOURCE_NAME_ENV = "CATALOG_SOURCE_NAME";
     private static final String CATALOG_NAMESPACE_ENV = "CATALOG_NAMESPACE";
     private static final String KROXYLICIOUS_OLM_DEPLOYMENT_NAME_ENV = "KROXYLICIOUS_OLM_DEPLOYMENT_NAME";
+    private static final String ARCHITECTURE_ENV = "ARCHITECTURE";
 
     /**
      * The kafka version default value
@@ -112,6 +113,7 @@ public class Environment {
     private static final String CATALOG_SOURCE_NAME_DEFAULT = "kroxylicious-source";
     private static final String KROXYLICIOUS_OLM_DEPLOYMENT_NAME_DEFAULT = "kroxylicious-operator";
     private static final String CATALOG_NAMESPACE_DEFAULT = "openshift-marketplace";
+    public static final String ARCHITECTURE_DEFAULT = "x86_64";
 
     public static final String KAFKA_VERSION = ENVIRONMENT_VARIABLES.getOrDefault(KAFKA_VERSION_ENV, KAFKA_VERSION_DEFAULT);
     public static final String KROXYLICIOUS_OPERATOR_VERSION = ENVIRONMENT_VARIABLES.getOrDefault(KROXYLICIOUS_OPERATOR_VERSION_ENV, KROXYLICIOUS_VERSION_DEFAULT);
@@ -160,6 +162,7 @@ public class Environment {
     public static final String CATALOG_NAMESPACE = ENVIRONMENT_VARIABLES.getOrDefault(CATALOG_NAMESPACE_ENV, CATALOG_NAMESPACE_DEFAULT);
     public static final String KROXYLICIOUS_OLM_DEPLOYMENT_NAME = ENVIRONMENT_VARIABLES.getOrDefault(KROXYLICIOUS_OLM_DEPLOYMENT_NAME_ENV,
             KROXYLICIOUS_OLM_DEPLOYMENT_NAME_DEFAULT);
+    public static final String ARCHITECTURE = ENVIRONMENT_VARIABLES.getOrDefault(ARCHITECTURE_ENV, ARCHITECTURE_DEFAULT);
 
     private static String readMetadataProperty(String property) {
         var p = new Properties();

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/NonJVMClientsST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/NonJVMClientsST.java
@@ -31,6 +31,7 @@ import io.kroxylicious.systemtests.templates.strimzi.KafkaTemplates;
 import static io.kroxylicious.systemtests.TestTags.EXTERNAL_KAFKA_CLIENTS;
 import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
  * The non-JVM clients system tests.
@@ -51,6 +52,8 @@ class NonJVMClientsST extends AbstractST {
      */
     @Test
     void produceAndConsumeWithKcatClients(String namespace) {
+        // Skip Kcat execution when architecture is different from x86_64
+        assumeThat(Environment.ARCHITECTURE.equals(Environment.ARCHITECTURE_DEFAULT)).isTrue();
         int numberOfMessages = 2;
         LOGGER.atInfo().setMessage("When the message '{}' is sent to the topic '{}'").addArgument(MESSAGE).addArgument(topicName).log();
         KafkaClients.kcat().inNamespace(namespace).produceMessages(topicName, bootstrap, MESSAGE, numberOfMessages);
@@ -95,6 +98,8 @@ class NonJVMClientsST extends AbstractST {
      */
     @Test
     void produceWithKcatAndConsumeWithTestClients(String namespace) {
+        // Skip Kcat execution when architecture is different from x86_64
+        assumeThat(Environment.ARCHITECTURE.equals(Environment.ARCHITECTURE_DEFAULT)).isTrue();
         int numberOfMessages = 2;
         LOGGER.atInfo().setMessage("When the message '{}' is sent to the topic '{}'").addArgument(MESSAGE).addArgument(topicName).log();
         KafkaClients.kcat().inNamespace(namespace).produceMessages(topicName, bootstrap, MESSAGE, numberOfMessages);
@@ -117,6 +122,8 @@ class NonJVMClientsST extends AbstractST {
      */
     @Test
     void produceWithTestClientsAndConsumeWithKcat(String namespace) {
+        // Skip Kcat execution when architecture is different from x86_64
+        assumeThat(Environment.ARCHITECTURE.equals(Environment.ARCHITECTURE_DEFAULT)).isTrue();
         int numberOfMessages = 2;
         LOGGER.atInfo().setMessage("When the message '{}' is sent to the topic '{}'").addArgument(MESSAGE).addArgument(topicName).log();
         KafkaClients.strimziTestClient().inNamespace(namespace).produceMessages(topicName, bootstrap, MESSAGE, numberOfMessages);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

As discussed when updated kaf client, we should skip kcat client when the architecture used to run the tests is different from `x86_64`, while targeted this #2330 

### Additional Context

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
