### PR TITLE
remove Operator supplied defaults for resources

### DIFF
--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyDeploymentTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/ProxyDeploymentTest.java
@@ -115,28 +115,6 @@ class ProxyDeploymentTest {
     }
 
     @Test
-    void proxyContainerHasDefaultResourceRequirements() {
-        // Given
-        var proxyModel = new ProxyModel(EMPTY_RESOLUTION_RESULT, new ProxyNetworkingModel(List.of()), List.of());
-        configureProxyModel(proxyModel);
-        ProxyDeploymentDependentResource proxyDeploymentDependentResource = new ProxyDeploymentDependentResource();
-
-        // When
-        Deployment actual = proxyDeploymentDependentResource.desired(kafkaProxy, kubernetesContext);
-
-        // Then
-        assertThat(actual.getSpec().getTemplate().getSpec().getContainers()).singleElement().satisfies(container -> {
-            assertThat(container.getResources()).isNotNull();
-            assertThat(container.getResources().getLimits())
-                    .containsEntry("cpu", Quantity.parse("500m"))
-                    .containsEntry("memory", Quantity.parse("512Mi"));
-            assertThat(container.getResources().getRequests())
-                    .containsEntry("cpu", Quantity.parse("500m"))
-                    .containsEntry("memory", Quantity.parse("512Mi"));
-        });
-    }
-
-    @Test
     void shouldSpecifySecCompProfile() {
         // Given
         ProxyDeploymentDependentResource proxyDeploymentDependentResource = new ProxyDeploymentDependentResource();

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-Deployment-example.yaml
@@ -65,13 +65,6 @@ spec:
             - mountPath: "/opt/kroxylicious/config/proxy-config.yaml"
               name: "config-volume"
               subPath: "proxy-config.yaml"
-          resources:
-            limits:
-              "cpu": "500m"
-              "memory": "512Mi"
-            requests:
-              "cpu": "500m"
-              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Deployment-example.yaml
@@ -85,13 +85,6 @@ spec:
             - mountPath: "/opt/kroxylicious/secure/configmap/bar"
               name: "configmaps-bar"
               readOnly: true
-          resources:
-            limits:
-              "cpu": "500m"
-              "memory": "512Mi"
-            requests:
-              "cpu": "500m"
-              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Deployment-example.yaml
@@ -65,13 +65,6 @@ spec:
             - mountPath: "/opt/kroxylicious/config/proxy-config.yaml"
               name: "config-volume"
               subPath: "proxy-config.yaml"
-          resources:
-            limits:
-              "cpu": "500m"
-              "memory": "512Mi"
-            requests:
-              "cpu": "500m"
-              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/kafka-service-with-tls/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/kafka-service-with-tls/out-Deployment-minimal.yaml
@@ -82,13 +82,6 @@ spec:
             - mountPath: "/opt/kroxylicious/secure/secret/upstream-tls-cert"
               name: "secrets-upstream-tls-cert"
               readOnly: true
-          resources:
-            limits:
-              "cpu": "500m"
-              "memory": "512Mi"
-            requests:
-              "cpu": "500m"
-              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Deployment-minimal.yaml
@@ -70,13 +70,6 @@ spec:
             - mountPath: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert"
               name: "secrets-downstream-tls-cert"
               readOnly: true
-          resources:
-            limits:
-              "cpu": "500m"
-              "memory": "512Mi"
-            requests:
-              "cpu": "500m"
-              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress-with-no-downstream-tls-on-cluster/out-Deployment-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress-with-no-downstream-tls-on-cluster/out-Deployment-twocluster.yaml
@@ -70,13 +70,6 @@ spec:
             - mountPath: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert"
               name: "secrets-downstream-tls-cert"
               readOnly: true
-          resources:
-            limits:
-              "cpu": "500m"
-              "memory": "512Mi"
-            requests:
-              "cpu": "500m"
-              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress/out-Deployment-minimal.yaml
@@ -70,13 +70,6 @@ spec:
             - mountPath: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert"
               name: "secrets-downstream-tls-cert"
               readOnly: true
-          resources:
-            limits:
-              "cpu": "500m"
-              "memory": "512Mi"
-            requests:
-              "cpu": "500m"
-              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Deployment-minimal.yaml
@@ -73,13 +73,6 @@ spec:
             - mountPath: "/opt/kroxylicious/config/proxy-config.yaml"
               name: "config-volume"
               subPath: "proxy-config.yaml"
-          resources:
-            limits:
-              "cpu": "500m"
-              "memory": "512Mi"
-            requests:
-              "cpu": "500m"
-              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-Deployment-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-Deployment-twocluster.yaml
@@ -73,13 +73,6 @@ spec:
             - mountPath: "/opt/kroxylicious/config/proxy-config.yaml"
               name: "config-volume"
               subPath: "proxy-config.yaml"
-          resources:
-            limits:
-              "cpu": "500m"
-              "memory": "512Mi"
-            requests:
-              "cpu": "500m"
-              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-Deployment-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-Deployment-twocluster.yaml
@@ -73,13 +73,6 @@ spec:
             - mountPath: "/opt/kroxylicious/config/proxy-config.yaml"
               name: "config-volume"
               subPath: "proxy-config.yaml"
-          resources:
-            limits:
-              "cpu": "500m"
-              "memory": "512Mi"
-            requests:
-              "cpu": "500m"
-              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/out-Deployment-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/out-Deployment-twocluster.yaml
@@ -65,13 +65,6 @@ spec:
             - mountPath: "/opt/kroxylicious/config/proxy-config.yaml"
               name: "config-volume"
               subPath: "proxy-config.yaml"
-          resources:
-            limits:
-              "cpu": "500m"
-              "memory": "512Mi"
-            requests:
-              "cpu": "500m"
-              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-shared-loadbalancer-ingress/out-Deployment-twocluster.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-shared-loadbalancer-ingress/out-Deployment-twocluster.yaml
@@ -70,13 +70,6 @@ spec:
             - mountPath: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert"
               name: "secrets-downstream-tls-cert"
               readOnly: true
-          resources:
-            limits:
-              "cpu": "500m"
-              "memory": "512Mi"
-            requests:
-              "cpu": "500m"
-              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Deployment-example.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Deployment-example.yaml
@@ -76,13 +76,6 @@ spec:
             - mountPath: "/opt/kroxylicious/secure/secret/my-secret"
               name: "secrets-my-secret"
               readOnly: true
-          resources:
-            limits:
-              "cpu": "500m"
-              "memory": "512Mi"
-            requests:
-              "cpu": "500m"
-              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-controls/out-Deployment-minimal.yaml
@@ -70,13 +70,6 @@ spec:
             - mountPath: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert"
               name: "secrets-downstream-tls-cert"
               readOnly: true
-          resources:
-            limits:
-              "cpu": "500m"
-              "memory": "512Mi"
-            requests:
-              "cpu": "500m"
-              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-default-client-auth/out-Deployment-minimal.yaml
@@ -73,13 +73,6 @@ spec:
             - mountPath: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert"
               name: "secrets-downstream-tls-cert"
               readOnly: true
-          resources:
-            limits:
-              "cpu": "500m"
-              "memory": "512Mi"
-            requests:
-              "cpu": "500m"
-              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-none/out-Deployment-minimal.yaml
@@ -73,13 +73,6 @@ spec:
             - mountPath: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert"
               name: "secrets-downstream-tls-cert"
               readOnly: true
-          resources:
-            limits:
-              "cpu": "500m"
-              "memory": "512Mi"
-            requests:
-              "cpu": "500m"
-              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-requested/out-Deployment-minimal.yaml
@@ -73,13 +73,6 @@ spec:
             - mountPath: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert"
               name: "secrets-downstream-tls-cert"
               readOnly: true
-          resources:
-            limits:
-              "cpu": "500m"
-              "memory": "512Mi"
-            requests:
-              "cpu": "500m"
-              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls-with-explicit-client-auth-required/out-Deployment-minimal.yaml
@@ -73,13 +73,6 @@ spec:
             - mountPath: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert"
               name: "secrets-downstream-tls-cert"
               readOnly: true
-          resources:
-            limits:
-              "cpu": "500m"
-              "memory": "512Mi"
-            requests:
-              "cpu": "500m"
-              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Deployment-minimal.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-tls/out-Deployment-minimal.yaml
@@ -70,13 +70,6 @@ spec:
             - mountPath: "/opt/kroxylicious/virtual-cluster/server-certs/downstream-tls-cert"
               name: "secrets-downstream-tls-cert"
               readOnly: true
-          resources:
-            limits:
-              "cpu": "500m"
-              "memory": "512Mi"
-            requests:
-              "cpu": "500m"
-              "memory": "512Mi"
       securityContext:
         runAsNonRoot: true
         seccompProfile:


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

Reviewing https://github.com/kroxylicious/kroxylicious/pull/2340#discussion_r2153618772 we came to the conclusion that we should merge user supplied values with the operator defaults. However that had the downside that there was no way for the users to use `requests` to control scheduling without also specifying `limits` which has issues for performance sensitive workloads (a big hello to the proxy). So our consensus is that we should remove the operator defaults and document how to control `requests` and `limits`.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
