### PR TITLE
Initialise the meter registry before registering a metric. Fixes: #2345

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/KafkaProxy.java
@@ -119,6 +119,7 @@ public final class KafkaProxy implements AutoCloseable {
         }
         try {
             STARTUP_SHUTDOWN_LOGGER.info("Kroxylicious is starting");
+            meterRegistries = new MeterRegistries(pfr, micrometerConfig);
             initVersionInfoMetric();
 
             var portConflictDefector = new PortConflictDetector();
@@ -127,7 +128,6 @@ public final class KafkaProxy implements AutoCloseable {
             portConflictDefector.validate(virtualClusterModels, managementHostPort);
 
             var availableCores = Runtime.getRuntime().availableProcessors();
-            meterRegistries = new MeterRegistries(pfr, micrometerConfig);
 
             this.managementEventGroup = buildNettyEventGroups("management", availableCores, config.isUseIoUring());
             this.serverEventGroup = buildNettyEventGroups("server", availableCores, config.isUseIoUring());


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Initialise the meter registry before registering a metric. Fixes: #2345

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
