### PR TITLE
[System Tests] added retry when consumer fails to connect

### DIFF
--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/KcatClient.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/KcatClient.java
@@ -90,7 +90,7 @@ public class KcatClient implements KafkaClient {
         LOGGER.atInfo().log("Consuming messages using kcat");
         String name = Constants.KAFKA_CONSUMER_CLIENT_LABEL + "-kcat-" + TestUtils.getRandomPodNameSuffix();
         // Running consumer with parameters to get the latest N number of messages received to avoid consuming twice the same messages
-        List<String> args = List.of("-b", bootstrap, "-K ,", "-t", topicName, "-C", "-o", "-" + numOfMessages, "-e", "-J");
+        List<String> args = List.of("-b", bootstrap, "-K ,", "-t", topicName, "-C", "-o", "-" + numOfMessages, "-e", "-J", "-E");
         Job kCatClientJob = TestClientsJobTemplates.defaultKcatJob(name, args).build();
         String podName = KafkaUtils.createJob(deployNamespace, name, kCatClientJob);
         String log = waitForConsumer(deployNamespace, podName, timeout);

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/KcatClient.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/clients/KcatClient.java
@@ -90,7 +90,7 @@ public class KcatClient implements KafkaClient {
         LOGGER.atInfo().log("Consuming messages using kcat");
         String name = Constants.KAFKA_CONSUMER_CLIENT_LABEL + "-kcat-" + TestUtils.getRandomPodNameSuffix();
         // Running consumer with parameters to get the latest N number of messages received to avoid consuming twice the same messages
-        List<String> args = List.of("-b", bootstrap, "-K ,", "-t", topicName, "-C", "-o", "-" + numOfMessages, "-e", "-J", "-E");
+        List<String> args = List.of("-b", bootstrap, "-K ,", "-t", topicName, "-C", "-o", "-" + numOfMessages, "-e", "-J");
         Job kCatClientJob = TestClientsJobTemplates.defaultKcatJob(name, args).build();
         String podName = KafkaUtils.createJob(deployNamespace, name, kCatClientJob);
         String log = waitForConsumer(deployNamespace, podName, timeout);

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/testclients/TestClientsJobTemplates.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/testclients/TestClientsJobTemplates.java
@@ -143,8 +143,10 @@ public class TestClientsJobTemplates {
     public static JobBuilder defaultKcatJob(String jobName, List<String> args) {
         return baseClientJob(jobName)
                 .editSpec()
+                .withBackoffLimit(3)
                 .editTemplate()
                 .editSpec()
+                .withRestartPolicy(Constants.RESTART_POLICY_ONFAILURE)
                 .withContainers(ContainerTemplates.baseImageBuilder("kcat", Constants.KCAT_CLIENT_IMAGE)
                         .withArgs(args)
                         .build())


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Added restart policy  `OnFailure` with `backOffLimit` to 3 for kcat to avoid exit when consumer fails to connect and retry,

### Additional Context

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
