### PR TITLE
Update gitignores and header check to ignore jbang temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ target/
 bin/
 dependency-reduced-pom.xml
 /apis/
+.jbang
 
 # VS Code
 .factorypath

--- a/pom.xml
+++ b/pom.xml
@@ -552,6 +552,7 @@
                                     <exclude>DCO.txt</exclude>
                                     <exclude>LICENSE.txt</exclude>
                                     <exclude>**/.dontdelete</exclude>
+                                    <exclude>**/.jbang/**</exclude>
                                     <exclude>docs/**</exclude>
                                     <exclude>**/*.adoc</exclude>
                                     <!-- Need to keep original copyright for Vert.x classes -->


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

a .jbang directory is being created in `kroxylicious-operator` when you build with `-Pdist`, which was showing up as an uncommitted dir and failing the build (locally when I run `mvn -Pci verify -DskipTests -DskipDocker -DskipITs -DskipKTs -T3` my pre-commit hook to check everything is formatted etc) for missing license headers.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
