### PR TITLE
Prevent NPEs occuring during unit test

### DIFF
--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -77,6 +77,7 @@ class KafkaProxyFrontendHandlerTest {
     public static final String SNI_HOSTNAME = "external.example.com";
     public static final String CLUSTER_HOST = "internal.example.org";
     public static final int CLUSTER_PORT = 9092;
+    public static final String CLUSTER_NAME = "RandomCluster";
     EmbeddedChannel inboundChannel;
     EmbeddedChannel outboundChannel;
 
@@ -109,7 +110,7 @@ class KafkaProxyFrontendHandlerTest {
     void buildChannel() {
         inboundChannel = new EmbeddedChannel();
         corrId = 0;
-        proxyChannelStateMachine = new ProxyChannelStateMachine("RandomCluster", null);
+        proxyChannelStateMachine = new ProxyChannelStateMachine(CLUSTER_NAME, null);
     }
 
     @AfterEach
@@ -147,7 +148,7 @@ class KafkaProxyFrontendHandlerTest {
     void testMessageHandledAfterConnectingBeforeConnected() {
         // Given
         VirtualClusterModel virtualClusterModel = mock(VirtualClusterModel.class);
-        when(virtualClusterModel.getClusterName()).thenReturn("cluster");
+        when(virtualClusterModel.getClusterName()).thenReturn(CLUSTER_NAME);
         VirtualClusterGatewayModel virtualClusterListenerModel = mock(VirtualClusterGatewayModel.class);
         when(virtualClusterListenerModel.virtualCluster()).thenReturn(virtualClusterModel);
         EndpointBinding endpointBinding = mock(EndpointBinding.class);
@@ -478,8 +479,10 @@ class KafkaProxyFrontendHandlerTest {
     @MethodSource("requests")
     void shouldTransitionToFailedOnExceptionForFrameOversizedException(Short version, ApiMessage apiMessage) {
         // Given
+        VirtualClusterModel model = mock(VirtualClusterModel.class);
+        when(model.getClusterName()).thenReturn(CLUSTER_NAME);
         VirtualClusterGatewayModel virtualClusterListenerModel = mock(VirtualClusterGatewayModel.class);
-        when(virtualClusterListenerModel.virtualCluster()).thenReturn(mock(VirtualClusterModel.class));
+        when(virtualClusterListenerModel.virtualCluster()).thenReturn(model);
         EndpointBinding endpointBinding = mock(EndpointBinding.class);
         when(endpointBinding.endpointGateway()).thenReturn(virtualClusterListenerModel);
         KafkaProxyFrontendHandler handler = handler(this::getNetFilter, new SaslDecodePredicate(false), endpointBinding);


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Prevent NPEs occuring during unit test `io.kroxylicious.proxy.internal.KafkaProxyFrontendHandlerTest#shouldTransitionToFailedOnExceptionForFrameOversizedException`


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
