### PR TITLE
fail promotion early if release PR is not approved

### DIFF
--- a/.github/workflows/promote_release.yaml
+++ b/.github/workflows/promote_release.yaml
@@ -77,6 +77,17 @@ jobs:
         run: |
           gh issue comment  ${{ github.event.issue.number }} --body "${{ github.actor }} is not a member of https://github.com/orgs/kroxylicious/teams/release-engineers)"
           exit -1
+      
+      - name: 'Stop workflow if PR is not approved'
+        env:
+          GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
+        run: |
+            PR_APPROVAL="$(gh pr view ${{ inputs.release-pr-issue-number}} --json reviewDecision | jq -r .reviewDecision)"
+            if [[ "$PR_APPROVAL" != "APPROVED" ]]; then
+              echo "PR is not Approved! You must approve the release PR before promoting it"
+              exit -1
+            fi
+            echo "PR is Approved, Continuing promotion."
 
       - name: 'Get the branch name associated with the PR'
         env:

--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -201,7 +201,9 @@ jobs:
           * [ ] Review the "[Sonatype] iokroxylicious-nnnn repository report" email for unexpected threats.
           * [ ] [Kick the tyres](https://github.com/kroxylicious/kroxylicious-junit5-extension/blob/main/RELEASING.md#making-the-release-public) on the Maven artefacts.
           
-          Once done, comment <code>&commat;kroxylicious-robot promote-release</code> on this PR. This will release the artefacts to Maven Central and merge this PR to main.
+          Once done:
+          1. Approve this PR
+          2. comment <code>&commat;kroxylicious-robot promote-release</code> on this PR. This will release the artefacts to Maven Central and merge this PR to main.
           
           If things don't look good, abort the release by saying <code>&commat;kroxylicious-robot drop-release</code>.
           


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Else the promotion will go all the way through then fail to merge the PR.

Tested the `gp pr` command locally with a couple of PRs:

```
$ gh pr view 2375 --json reviewDecision | jq -r .reviewDecision
APPROVED
$ gh pr view 2365 --json reviewDecision | jq -r .reviewDecision
REVIEW_REQUIRED
```

Closes #2373 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
