### PR TITLE
Faster its

### DIFF
--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousConfigUtils.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousConfigUtils.java
@@ -12,6 +12,9 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.NamedRange;
@@ -40,8 +43,20 @@ public class KroxyliciousConfigUtils {
 
     public static final String DEFAULT_VIRTUAL_CLUSTER = "demo";
     public static final String DEFAULT_GATEWAY_NAME = "default";
+    private static final Logger LOGGER = LoggerFactory.getLogger(KroxyliciousConfigUtils.class);
 
-    static final HostPort DEFAULT_PROXY_BOOTSTRAP = new HostPort("localhost", 9192);
+    static final HostPort DEFAULT_PROXY_BOOTSTRAP = new HostPort("localhost", startPort());
+
+    public static int startPort() {
+        int forkNumber = Integer.parseInt(System.getProperty("forkNumber", "0"));
+        int offset = 50 * forkNumber;
+        LOGGER.info("Using fork number " + forkNumber + " and offset " + offset);
+        return 9192 + offset;
+    }
+
+    public static int metricsPort() {
+        return startPort() - 1;
+    }
 
     /**
      * Create a KroxyliciousConfigBuilder with a single virtual cluster configured to

--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -263,6 +263,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration combine.children="append">
+                    <forkCount>3</forkCount>
+                    <reuseForks>true</reuseForks>
+                    <argLine>-DforkNumber=${surefire.forkNumber}</argLine>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/DeprecatedConfigurationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/DeprecatedConfigurationIT.java
@@ -22,6 +22,7 @@ import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.PortPerBrokerClusterNetworkAddressConfigProvider;
 import io.kroxylicious.proxy.internal.clusternetworkaddressconfigprovider.RangeAwarePortPerNodeClusterNetworkAddressConfigProvider;
 import io.kroxylicious.proxy.service.HostPort;
+import io.kroxylicious.test.tester.KroxyliciousConfigUtils;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 
 import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
@@ -33,7 +34,7 @@ import static org.junit.jupiter.params.provider.Arguments.argumentSet;
  */
 public class DeprecatedConfigurationIT extends BaseIT {
 
-    private static final HostPort PROXY_ADDRESS = HostPort.parse("localhost:9192");
+    private static final HostPort PROXY_ADDRESS = HostPort.parse("localhost:" + KroxyliciousConfigUtils.startPort());
 
     @SuppressWarnings("removal")
     static Stream<Arguments> shouldSupportDeprecatedClusterNetworkAddressConfigProvider() {

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/MetricsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/MetricsIT.java
@@ -55,6 +55,7 @@ import io.kroxylicious.proxy.config.VirtualClusterGateway;
 import io.kroxylicious.proxy.micrometer.CommonTagsHook;
 import io.kroxylicious.proxy.micrometer.StandardBindersHook;
 import io.kroxylicious.proxy.service.HostPort;
+import io.kroxylicious.test.tester.KroxyliciousConfigUtils;
 import io.kroxylicious.test.tester.KroxyliciousTester;
 import io.kroxylicious.test.tester.SimpleMetric;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
@@ -90,7 +91,7 @@ class MetricsIT {
     private static final HostPort PORT_IDENTIFIES_BROKER_BOOTSTRAP = new HostPort("localhost", 9092);
     private static final String SNI_IDENTIFIES_BROKER_BASE_ADDRESS = IntegrationTestInetAddressResolverProvider.generateFullyQualifiedDomainName("sni");
 
-    private static final HostPort SNI_IDENTIFIES_BROKER_BOOTSTRAP = new HostPort("bootstrap." + SNI_IDENTIFIES_BROKER_BASE_ADDRESS, 9192);
+    private static final HostPort SNI_IDENTIFIES_BROKER_BOOTSTRAP = new HostPort("bootstrap." + SNI_IDENTIFIES_BROKER_BASE_ADDRESS, KroxyliciousConfigUtils.startPort());
     private static final String SNI_IDENTIFIES_BROKER_ADDRESS_PATTERN = "broker-$(nodeId)." + SNI_IDENTIFIES_BROKER_BASE_ADDRESS;
     private static final String TEST_CLUSTER = "test-cluster";
 
@@ -936,6 +937,7 @@ class MetricsIT {
     private ConfigurationBuilder configWithMetrics(KafkaCluster cluster) {
         return proxy(cluster)
                 .withNewManagement()
+                .withPort(KroxyliciousConfigUtils.metricsPort())
                 .withNewEndpoints()
                 .withNewPrometheus()
                 .endPrometheus()

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/TlsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/TlsIT.java
@@ -58,6 +58,7 @@ import io.kroxylicious.proxy.config.tls.AllowDeny;
 import io.kroxylicious.proxy.config.tls.TlsClientAuth;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.test.Request;
+import io.kroxylicious.test.tester.KroxyliciousConfigUtils;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.clients.CloseableAdmin;
 import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
@@ -83,12 +84,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 @ExtendWith(KafkaClusterExtension.class)
 class TlsIT extends BaseIT {
-    private static final HostPort PROXY_ADDRESS = HostPort.parse("localhost:9192");
+    private static final HostPort PROXY_ADDRESS = HostPort.parse("localhost:" + KroxyliciousConfigUtils.startPort());
     private static final String TOPIC = "my-test-topic";
 
     private static final String SNI_BASE_ADDRESS = IntegrationTestInetAddressResolverProvider.generateFullyQualifiedDomainName("sni");
     private static final String SNI_BROKER_ADDRESS_PATTERN = "broker-$(nodeId)." + SNI_BASE_ADDRESS;
-    private static final HostPort SNI_BOOTSTRAP_ADDRESS = HostPort.parse("bootstrap." + SNI_BASE_ADDRESS + ":9192");
+    private static final HostPort SNI_BOOTSTRAP_ADDRESS = HostPort.parse("bootstrap." + SNI_BASE_ADDRESS + ":" + KroxyliciousConfigUtils.startPort());
     private static final String TLS_CLUSTER = "tlsCluster";
     private static final String PLAIN_CLUSTER = "plainCluster";
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/validation/JsonSchemaRecordValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/validation/JsonSchemaRecordValidationIT.java
@@ -104,6 +104,7 @@ class JsonSchemaRecordValidationIT extends RecordValidationBaseIT {
     public static long secondGlobalId;
 
     private static GenericContainer registryContainer;
+    static KafkaCluster cluster;
 
     @BeforeAll
     public static void init() throws IOException {
@@ -131,7 +132,7 @@ class JsonSchemaRecordValidationIT extends RecordValidationBaseIT {
     }
 
     @Test
-    void shouldAcceptValidJsonInProduceRequest(KafkaCluster cluster, Topic topic) throws Exception {
+    void shouldAcceptValidJsonInProduceRequest(Topic topic) throws Exception {
         var config = createGlobalIdRecordValidationConfig(cluster, topic, "valueRule", firstGlobalId);
 
         try (var tester = kroxyliciousTester(config);
@@ -145,7 +146,7 @@ class JsonSchemaRecordValidationIT extends RecordValidationBaseIT {
     }
 
     @Test
-    void invalidAgeProduceRejectedUsingTopicNames(KafkaCluster cluster, Topic topic1, Topic topic2) throws Exception {
+    void invalidAgeProduceRejectedUsingTopicNames(Topic topic1, Topic topic2) throws Exception {
         // Topic 2 has schema validation, invalid data cannot be sent.
         var config = createGlobalIdRecordValidationConfig(cluster, topic2, "valueRule", firstGlobalId);
 
@@ -167,7 +168,7 @@ class JsonSchemaRecordValidationIT extends RecordValidationBaseIT {
     }
 
     @Test
-    void nonExistentSchema(KafkaCluster cluster, Topic topic) {
+    void nonExistentSchema(Topic topic) {
         var config = createGlobalIdRecordValidationConfig(cluster, topic, "valueRule", 3L);
 
         try (var tester = kroxyliciousTester(config);
@@ -181,7 +182,7 @@ class JsonSchemaRecordValidationIT extends RecordValidationBaseIT {
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
-    void clientSideUsesValueSchemasToo(boolean schemaIdInHeader, KafkaCluster cluster, Topic topic) throws Exception {
+    void clientSideUsesValueSchemasToo(boolean schemaIdInHeader, Topic topic) throws Exception {
         var config = createGlobalIdRecordValidationConfig(cluster, topic, "valueRule", firstGlobalId);
 
         var keySerde = new Serdes.StringSerde();
@@ -204,7 +205,7 @@ class JsonSchemaRecordValidationIT extends RecordValidationBaseIT {
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
-    void clientSideUsesKeySchemasToo(boolean schemaIdInHeader, KafkaCluster cluster, Topic topic) throws Exception {
+    void clientSideUsesKeySchemasToo(boolean schemaIdInHeader, Topic topic) throws Exception {
         var config = createGlobalIdRecordValidationConfig(cluster, topic, "keyRule", firstGlobalId);
 
         boolean isKey = true;
@@ -227,7 +228,7 @@ class JsonSchemaRecordValidationIT extends RecordValidationBaseIT {
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
-    void detectsClientProducingWithWrongValueSchemaId(boolean schemaIdInHeader, KafkaCluster cluster, Topic topic) {
+    void detectsClientProducingWithWrongValueSchemaId(boolean schemaIdInHeader, Topic topic) {
         var config = createGlobalIdRecordValidationConfig(cluster, topic, "valueRule", secondGlobalId);
 
         var keySerde = new Serdes.StringSerde();
@@ -242,7 +243,7 @@ class JsonSchemaRecordValidationIT extends RecordValidationBaseIT {
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
-    void detectsClientProducingWithWrongKeySchemaId(boolean schemaIdInHeader, KafkaCluster cluster, Topic topic) {
+    void detectsClientProducingWithWrongKeySchemaId(boolean schemaIdInHeader, Topic topic) {
         var config = createGlobalIdRecordValidationConfig(cluster, topic, "keyRule", secondGlobalId);
 
         var valueSerde = new Serdes.StringSerde();

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/validation/JsonSyntaxRecordValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/validation/JsonSyntaxRecordValidationIT.java
@@ -34,9 +34,10 @@ class JsonSyntaxRecordValidationIT extends RecordValidationBaseIT {
 
     public static final String SYNTACTICALLY_CORRECT_JSON = "{\"value\":\"json\"}";
     public static final String SYNTACTICALLY_INCORRECT_JSON = "Not Json";
+    static KafkaCluster cluster;
 
     @Test
-    void invalidJsonProduceRejected(KafkaCluster cluster, Topic topic) {
+    void invalidJsonProduceRejected(Topic topic) {
         NamedFilterDefinition filterDef = createFilterDef(topic);
         var config = proxy(cluster)
                 .addToFilterDefinitions(filterDef)
@@ -49,7 +50,7 @@ class JsonSyntaxRecordValidationIT extends RecordValidationBaseIT {
     }
 
     @Test
-    void invalidJsonProduceRejectedUsingTopicNames(KafkaCluster cluster, Topic topic1, Topic topic2) {
+    void invalidJsonProduceRejectedUsingTopicNames(Topic topic1, Topic topic2) {
         assertThat(cluster.getNumOfBrokers()).isOne();
 
         NamedFilterDefinition filterDef = createFilterDef(topic1);
@@ -73,7 +74,7 @@ class JsonSyntaxRecordValidationIT extends RecordValidationBaseIT {
     }
 
     @Test
-    void invalidJsonProduceRejectedUsingTransaction(KafkaCluster cluster, Topic topic1, Topic topic2) {
+    void invalidJsonProduceRejectedUsingTransaction(Topic topic1, Topic topic2) {
         assertThat(cluster.getNumOfBrokers()).isOne();
 
         NamedFilterDefinition filterDef = createFilterDef(topic1);
@@ -95,7 +96,7 @@ class JsonSyntaxRecordValidationIT extends RecordValidationBaseIT {
     }
 
     @Test
-    void singleValidationFailureCausesRejectionOfWholeBatch(KafkaCluster cluster, Topic topic1, Topic topic2) {
+    void singleValidationFailureCausesRejectionOfWholeBatch(Topic topic1, Topic topic2) {
         assertThat(cluster.getNumOfBrokers()).isOne();
 
         NamedFilterDefinition filterDef = createFilterDef(topic1);
@@ -114,7 +115,7 @@ class JsonSyntaxRecordValidationIT extends RecordValidationBaseIT {
     }
 
     @Test
-    void singleValidationFailureCausesRejectionOfWholeBatchSameTopic(KafkaCluster cluster, @TopicPartitions(2) Topic topic) {
+    void singleValidationFailureCausesRejectionOfWholeBatchSameTopic(@TopicPartitions(2) Topic topic) {
         assertThat(cluster.getNumOfBrokers()).isOne();
 
         NamedFilterDefinition filterDef = createFilterDef(topic);
@@ -133,7 +134,7 @@ class JsonSyntaxRecordValidationIT extends RecordValidationBaseIT {
     }
 
     @Test
-    void validJsonProduceAccepted(KafkaCluster cluster, Topic topic) {
+    void validJsonProduceAccepted(Topic topic) {
         NamedFilterDefinition filterDef = createFilterDef(topic);
         var config = proxy(cluster)
                 .addToFilterDefinitions(filterDef)
@@ -153,7 +154,7 @@ class JsonSyntaxRecordValidationIT extends RecordValidationBaseIT {
     }
 
     @Test
-    void allowNulls(KafkaCluster cluster, Topic topic) {
+    void allowNulls(Topic topic) {
         String className = RecordValidation.class.getName();
         NamedFilterDefinition namedFilterDefinition = new NamedFilterDefinitionBuilder(className, className).withConfig("rules",
                 List.of(Map.of("topicNames", List.of(topic.name()), "valueRule",
@@ -177,7 +178,7 @@ class JsonSyntaxRecordValidationIT extends RecordValidationBaseIT {
     }
 
     @Test
-    void rejectNulls(KafkaCluster cluster, Topic topic) {
+    void rejectNulls(Topic topic) {
 
         String className = RecordValidation.class.getName();
         NamedFilterDefinition namedFilterDefinition = new NamedFilterDefinitionBuilder(className, className).withConfig("rules",

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/multitenant/BaseMultiTenantIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/multitenant/BaseMultiTenantIT.java
@@ -44,6 +44,7 @@ import io.kroxylicious.proxy.config.NamedFilterDefinitionBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.proxy.filter.multitenant.MultiTenant;
 import io.kroxylicious.proxy.service.HostPort;
+import io.kroxylicious.test.tester.KroxyliciousConfigUtils;
 import io.kroxylicious.test.tester.KroxyliciousTester;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
@@ -60,10 +61,10 @@ public abstract class BaseMultiTenantIT extends BaseIT {
 
     public static final String TENANT_1_CLUSTER = "foo";
     static final HostPort TENANT_1_PROXY_ADDRESS = HostPort
-            .parse(IntegrationTestInetAddressResolverProvider.generateFullyQualifiedDomainName(TENANT_1_CLUSTER, 9192));
+            .parse(IntegrationTestInetAddressResolverProvider.generateFullyQualifiedDomainName(TENANT_1_CLUSTER, KroxyliciousConfigUtils.startPort()));
     public static final String TENANT_2_CLUSTER = "bar";
     static final HostPort TENANT_2_PROXY_ADDRESS = HostPort
-            .parse(IntegrationTestInetAddressResolverProvider.generateFullyQualifiedDomainName(TENANT_2_CLUSTER, 9292));
+            .parse(IntegrationTestInetAddressResolverProvider.generateFullyQualifiedDomainName(TENANT_2_CLUSTER, KroxyliciousConfigUtils.startPort() + 10));
 
     static final long FUTURE_TIMEOUT_SECONDS = 5L;
     Map<String, Object> clientConfig;


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

We currently have to tell the proxy what ports to listen on. The
integration tests all rely on stopping and starting the proxy on
that port, and make assumptions that certain other ports are available
to bind to if they wish to create further virtual clusters.

This change configures things so that surefire runs the tests in 3
parallel forks and passes the forkNumber as a system property to the
fork, the tests then use this to offset the ports. Each fork can use
50 ports without colliding.

### Additional Context

The integration tests test 17 minutes to run on main, looking for ways to reduce that.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
