### PR TITLE
Refactor in-cluster deploying into a sub-section of deploying

### DIFF
--- a/docs/assemblies/assembly-operator-deploy-a-proxy-with-in-cluster-plain-ingress.adoc
+++ b/docs/assemblies/assembly-operator-deploy-a-proxy-with-in-cluster-plain-ingress.adoc
@@ -1,0 +1,39 @@
+// file included in the following:
+//
+// assembly-operator-deploy-a-proxy.adoc
+
+
+[id='assembly-operator-deploy-a-proxy-with-in-cluster-plain-ingress-{context}']
+= Deploying a proxy exposed to Kafka clients on the same Kubernetes Cluster
+
+[role="_abstract"]
+Deploy a basic proxy instance with a single virtual cluster exposed to Kafka clients on the same Kubernetes cluster.
+
+== Prerequisites
+
+* The operator must be installed in the Kubernetes cluster
+* A Kafka cluster to be proxied
+
+== The required resources
+
+include::../modules/configuring/con-kafkaproxy.adoc[leveloffset=+2]
+
+include::../modules/configuring/con-kafkaproxyingress-for-on-cluster-access.adoc[leveloffset=+2]
+
+include::../modules/configuring/con-kafkaservice-by-bootstrap.adoc[leveloffset=+2]
+
+include::../modules/configuring/con-virtualkafkacluster-tcp.adoc[leveloffset=+2]
+
+// TODO
+// == Deploying the example proxy
+//
+// include::../modules/configuring/proc-deploying-example-proxy.adoc[leveloffset=+1]
+//
+
+// configuring filters
+include::assembly-operator-configuring-kafkaprotocolfilters.adoc[leveloffset=+3]
+
+// TODO
+// == Configuring a filter
+//
+// include::../modules/configuring/proc-configuring-filter.adoc[leveloffset=+1]

--- a/docs/assemblies/assembly-operator-deploy-a-proxy.adoc
+++ b/docs/assemblies/assembly-operator-deploy-a-proxy.adoc
@@ -7,33 +7,6 @@
 = Deploying a proxy
 
 [role="_abstract"]
-Deploy a basic proxy instance with a single virtual cluster exposed to Kafka clients on the same Kubernetes cluster.
+This section provides a series of guides for deploying a proxy. We will explore different patterns for accessing the proxy.
 
-== Prerequisites
-
-* The operator must be installed in the Kubernetes cluster
-* A Kafka cluster to be proxied
-
-== The required resources
-
-include::../modules/configuring/con-kafkaproxy.adoc[leveloffset=+2]
-
-include::../modules/configuring/con-kafkaproxyingress-for-on-cluster-access.adoc[leveloffset=+2]
-
-include::../modules/configuring/con-kafkaservice-by-bootstrap.adoc[leveloffset=+2]
-
-include::../modules/configuring/con-virtualkafkacluster-tcp.adoc[leveloffset=+2]
-
-// TODO
-// == Deploying the example proxy
-//
-// include::../modules/configuring/proc-deploying-example-proxy.adoc[leveloffset=+1]
-//
-
-// configuring filters
-include::assembly-operator-configuring-kafkaprotocolfilters.adoc[leveloffset=+1]
-
-// TODO
-// == Configuring a filter
-//
-// include::../modules/configuring/proc-configuring-filter.adoc[leveloffset=+1]
+include::assembly-operator-deploy-a-proxy-with-in-cluster-plain-ingress.adoc[leveloffset=+1]


### PR DESCRIPTION
### Type of change

- Documentation

### Description
Refactor `Deploying a proxy` section so that the content is now in a subsection `Deploying a proxy exposed to Kafka clients on the same Kubernetes Cluster`

### Additional Context

We want to introduce a corresponding guide for off-cluster access at the same level.

Contributes towards #2388 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
