### PR TITLE
refactor: #2372 Changes relating to the OSSRH Sunset

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -60,7 +60,7 @@ This will:
 * raise single PR that will contain two commits:
   1. the first will version the artefacts at `release-version`.  A `release-version` tag will point at this commit.
   2. the second will re-open main for development, at the next snapshot.
-* stage a release [Nexus UI](https://s01.oss.sonatype.org/). It'll be named `iokroxylicious-nn`.
+* stage a release at [Maven Central Publishing](https://central.sonatype.com/publishing/namespaces). It'll be named `iokroxylicious-nn`.
 
 If anything goes wrong, follow the steps in [Failed Releases](#failed-releases)
 
@@ -72,7 +72,7 @@ You can validate the staged artefacts by using a test application, `T`, use the 
 1. Find the staging repository URL by executing.
    ```shell
    curl -sS --header 'Accept: application/json' \
-     https://s01.oss.sonatype.org/service/local/all_repositories \
+     https://ossrh-staging-api.central.sonatype.com/service/local/all_repositories \
      | jq '.data[] | select(.name | contains("kroxylicious")) | .contentResourceURI'
    ```
    The repository url should include `iokroxylious-nn`. You can also browse to it via the [Nexus UI](https://s01.oss.sonatype.org/).

--- a/kroxylicious-bom/pom.xml
+++ b/kroxylicious-bom/pom.xml
@@ -86,11 +86,11 @@
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
             <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1029,11 +1029,11 @@
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
             <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 

--- a/scripts/transition-staging-repository-state.sh
+++ b/scripts/transition-staging-repository-state.sh
@@ -18,7 +18,7 @@ exit 1
 }
 
 PLUGIN=org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13
-MVN_ARGS=("--batch-mode" "--no-transfer-progress" "-DnexusUrl=https://s01.oss.sonatype.org/" "-DserverId=ossrh")
+MVN_ARGS=("--batch-mode" "--no-transfer-progress" "-DnexusUrl=https://ossrh-staging-api.central.sonatype.com" "-DserverId=ossrh")
 
 ASSERT_NO_STAGING_REPOS="false"
 STATE=""
@@ -37,7 +37,7 @@ while getopts ":s:ah" opt; do
 done
 
 # TODO: refactor to use the REST API https://oss.sonatype.org/nexus-staging-plugin/default/docs/index.html to avoid the awkish hell
-# curl --silent -u xxxx:xxx  -H "accept: application/json" -X GET https://s01.oss.sonatype.org/service/local/staging/profile_repositories | jq .
+# curl --silent -u xxxx:xxx  -H "accept: application/json" -X GET https://ossrh-staging-api.central.sonatype.com/service/local/staging/profile_repositories | jq .
 
 
 # The rc-list table looks like this:

--- a/scripts/transition-staging-repository-state.sh
+++ b/scripts/transition-staging-repository-state.sh
@@ -5,6 +5,9 @@
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
+# KWTODO
+exit 0
+
 set -euo pipefail
 
 usage() {
@@ -45,7 +48,7 @@ done
 #[INFO] iokroxylicious-1032  CLOSED   unknown
 #[INFO] ------------------------------------------------------------------------
 
-STAGING_REPO_IDS=$(mvn ${PLUGIN}:rc-list "${MVN_ARGS[@]}" 2>/dev/null \
+STAGING_REPO_IDS=$(mvn -X ${PLUGIN}:rc-list "${MVN_ARGS[@]}" 2>/dev/null \
                  | awk '/\[INFO\] ---*/{found=0} found==1{print $2} /\[INFO\] ID.*State.*Description/{found=1}')
 
 NUM_REPOS=$(echo "${STAGING_REPO_IDS}" | (grep -c . || true))


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Refactoring

### Description

I've opted for this approach: https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/

I think it boils down to:

* updating the URL (s01.oss.sonatype.org => ossrh-staging-api.central.sonatype.com)
* creating an auth token from the new service.
* possibly changes related to https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#deploying.  It is not clear to me if the drop|close parts of the old API are maintained.

why: As of June 30, 2025 OSSRH has reached end of life and has been shut down. All OSSRH namespaces have been migrated to Central Publisher Portal.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
