### PR TITLE
Draft: Create a convenience YAML for installing the operator

### DIFF
--- a/kroxylicious-operator-dist/pom.xml
+++ b/kroxylicious-operator-dist/pom.xml
@@ -36,6 +36,54 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>concat-yaml-files</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <concat destfile="${project.build.directory}/kroxylicious-operator-${project.version}.yaml"
+                                                fixlastline="yes"
+                                                append="true">
+                                            <fileset
+                                                    dir="${project.basedir}/../kroxylicious-operator/target/packaged/install"
+                                                    includes="*.yaml"/>
+                                        </concat>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-artifacts</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>attach-artifact</goal>
+                                </goals>
+                                <configuration>
+                                    <artifacts>
+                                        <artifact>
+                                            <file>
+                                                ${project.build.directory}/kroxylicious-operator-${project.version}.yaml
+                                            </file>
+                                            <type>yaml</type>
+                                            <classifier>quickstart</classifier>
+                                        </artifact>
+                                    </artifacts>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <artifactId>maven-assembly-plugin</artifactId>
                         <executions>
                             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -477,6 +477,11 @@
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.11.2</version>
                 </plugin>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

We want to have a really compelling quickstart for Record Encryption and other features. Other projects like cert-manager and strimzi offer all-in-one YAML files to install their operators with a standard kubectl command. For example:

* `kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.18.0/cert-manager.yaml`
* `kubectl create namespace kafka && kubectl create -f 'https://strimzi.io/install/latest?namespace=kafka' -n kafka`

Cert-manager offers a static file, Strimzi has some dynamic part to substitute your namespace, allowing you to customize the namespace (more relevant since the parameter determines which namespace Strimzi operator watches).

As part of kroxylicious-operator-dist packaging we now concatenate all the install manifests into a single kroxylicious-operator-${version}.yaml file. This is attached to kroxylicious-operator-dist with classifier 'quickstart', and type 'yaml'.

We attach this to the release so that users can apply it with kubectl with a single command

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
