### PR TITLE
feat: enable Micrometer pause detection (#151)

### DIFF
--- a/docs/modules/monitoring/con-proxy-integrating-micrometer.adoc
+++ b/docs/modules/monitoring/con-proxy-integrating-micrometer.adoc
@@ -88,6 +88,20 @@ micrometer:
 
 |===
 
+== Pause detector
+
+See https://micrometer.io/docs/concepts#_pause_detection[Micrometer Pause Detection^]
+
+.Example pause detector configuration
+[source,yaml]
+----
+micrometer:
+  - type: "PauseDetectorHook"
+    config:
+      sleepIntervalMs: 500
+      pauseThresholdMs: 500
+----
+
 == Using Micrometer with filters
 
 Use the static methods of https://www.javadoc.io/doc/io.micrometer/micrometer-core/1.10.5/io/micrometer/core/instrument/Metrics.html[Micrometer Metrics^] to register metrics with the global registry. 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/micrometer/PauseDetectorHook.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/micrometer/PauseDetectorHook.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy.micrometer;
+
+import java.beans.ConstructorProperties;
+import java.time.Duration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.distribution.pause.ClockDriftPauseDetector;
+import io.micrometer.core.instrument.distribution.pause.PauseDetector;
+
+import io.kroxylicious.proxy.plugin.Plugin;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ *
+ * @author Hari Mani
+ */
+@Plugin(configType = PauseDetectorHook.PauseDetectorHookConfig.class)
+public class PauseDetectorHook implements MicrometerConfigurationHookService<PauseDetectorHook.PauseDetectorHookConfig> {
+
+    private static final Logger log = LoggerFactory.getLogger(PauseDetectorHook.class);
+
+    @NonNull
+    @Override
+    public MicrometerConfigurationHook build(PauseDetectorHookConfig config) {
+        return new Hook(config);
+    }
+
+    public static class PauseDetectorHookConfig {
+
+        // 100ms is the micrometer recommended default
+        static final long DEFAULT_SLEEP_INTERVAL_MS = 100;
+
+        // 100ms is the micrometer recommended default
+        static final long DEFAULT_PAUSE_THRESHOLD_MS = 100;
+
+        private final Duration sleepIntervalMs;
+
+        private final Duration pauseThresholdMs;
+
+        @JsonCreator
+        @ConstructorProperties({"sleepIntervalMs", "pauseThresholdMs"})
+        public PauseDetectorHookConfig(final Long sleepIntervalMs, final Long pauseThresholdMs) {
+            this.sleepIntervalMs = Duration.ofMillis(sleepIntervalMs != null ? sleepIntervalMs : DEFAULT_SLEEP_INTERVAL_MS);
+            this.pauseThresholdMs = Duration.ofMillis(pauseThresholdMs != null ? pauseThresholdMs : DEFAULT_PAUSE_THRESHOLD_MS);
+        }
+
+        public Duration getSleepInterval() {
+            return sleepIntervalMs;
+        }
+
+        public Duration getPauseThreshold() {
+            return pauseThresholdMs;
+        }
+    }
+
+    @SuppressWarnings("ClassCanBeRecord")
+    private static class Hook implements MicrometerConfigurationHook {
+
+        private final PauseDetectorHookConfig config;
+
+        Hook(PauseDetectorHookConfig config) {
+            if (config == null) {
+                throw new IllegalArgumentException("config must be non null");
+            }
+            this.config = config;
+        }
+
+        @Override
+        public void configure(MeterRegistry targetRegistry) {
+            final PauseDetector pauseDetector = new ClockDriftPauseDetector(config.getSleepInterval(), config.getPauseThreshold());
+            targetRegistry.config().pauseDetector(pauseDetector);
+            // TODO log configuration parameters
+            log.info("configured micrometer registry with pause detector");
+        }
+    }
+
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/micrometer/PauseDetectorHook.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/micrometer/PauseDetectorHook.java
@@ -21,10 +21,6 @@ import io.kroxylicious.proxy.plugin.Plugin;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
-/**
- *
- * @author Hari Mani
- */
 @Plugin(configType = PauseDetectorHook.PauseDetectorHookConfig.class)
 public class PauseDetectorHook implements MicrometerConfigurationHookService<PauseDetectorHook.PauseDetectorHookConfig> {
 
@@ -49,7 +45,7 @@ public class PauseDetectorHook implements MicrometerConfigurationHookService<Pau
         private final Duration pauseThresholdMs;
 
         @JsonCreator
-        @ConstructorProperties({"sleepIntervalMs", "pauseThresholdMs"})
+        @ConstructorProperties({ "sleepIntervalMs", "pauseThresholdMs" })
         public PauseDetectorHookConfig(final Long sleepIntervalMs, final Long pauseThresholdMs) {
             this.sleepIntervalMs = Duration.ofMillis(sleepIntervalMs != null ? sleepIntervalMs : DEFAULT_SLEEP_INTERVAL_MS);
             this.pauseThresholdMs = Duration.ofMillis(pauseThresholdMs != null ? pauseThresholdMs : DEFAULT_PAUSE_THRESHOLD_MS);
@@ -80,8 +76,8 @@ public class PauseDetectorHook implements MicrometerConfigurationHookService<Pau
         public void configure(MeterRegistry targetRegistry) {
             final PauseDetector pauseDetector = new ClockDriftPauseDetector(config.getSleepInterval(), config.getPauseThreshold());
             targetRegistry.config().pauseDetector(pauseDetector);
-            // TODO log configuration parameters
-            log.info("configured micrometer registry with pause detector");
+            log.info("configured pause detector on micrometer registry with sleep interval: {} and pause threshold: {}", config.getSleepInterval(),
+                    config.getPauseThreshold());
         }
     }
 

--- a/kroxylicious-runtime/src/main/resources/META-INF/services/io.kroxylicious.proxy.micrometer.MicrometerConfigurationHookService
+++ b/kroxylicious-runtime/src/main/resources/META-INF/services/io.kroxylicious.proxy.micrometer.MicrometerConfigurationHookService
@@ -1,2 +1,3 @@
 io.kroxylicious.proxy.micrometer.CommonTagsHook
 io.kroxylicious.proxy.micrometer.StandardBindersHook
+io.kroxylicious.proxy.micrometer.PauseDetectorHook

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/micrometer/PauseDetectorHookTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/micrometer/PauseDetectorHookTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.micrometer;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.distribution.pause.ClockDriftPauseDetector;
+import io.micrometer.core.instrument.distribution.pause.PauseDetector;
+
+import static io.kroxylicious.proxy.micrometer.PauseDetectorHook.PauseDetectorHookConfig.DEFAULT_PAUSE_THRESHOLD_MS;
+import static io.kroxylicious.proxy.micrometer.PauseDetectorHook.PauseDetectorHookConfig.DEFAULT_SLEEP_INTERVAL_MS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PauseDetectorHookTest {
+
+    @Test
+    void build_whenGivenConfigIsNull_shouldThrowException() {
+        final PauseDetectorHook pauseDetectorHook = new PauseDetectorHook();
+        //noinspection resource
+        assertThatThrownBy(() -> pauseDetectorHook.build(null)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void whenConfigIsGiven_shouldUseGivenValue() {
+        final long sleepIntervalMs = 250;
+        final long pauseThresholdMs = 250;
+        final PauseDetectorHook.PauseDetectorHookConfig config = new PauseDetectorHook.PauseDetectorHookConfig(sleepIntervalMs, pauseThresholdMs);
+        try (MicrometerConfigurationHook hook = new PauseDetectorHook().build(config)) {
+            final MeterRegistry meterRegistry = givenRegistryConfiguredWith(hook);
+            final PauseDetector pauseDetector = meterRegistry.config().pauseDetector();
+            thenPauseDetectorEquals(pauseDetector, sleepIntervalMs, pauseThresholdMs);
+        }
+    }
+
+    @Test
+    void whenConfigIsNotGiven_shouldUseDefaults() {
+        final PauseDetectorHook.PauseDetectorHookConfig config = new PauseDetectorHook.PauseDetectorHookConfig(null, null);
+        try (MicrometerConfigurationHook hook = new PauseDetectorHook().build(config)) {
+            final MeterRegistry meterRegistry = givenRegistryConfiguredWith(hook);
+            final PauseDetector pauseDetector = meterRegistry.config().pauseDetector();
+            thenPauseDetectorEquals(pauseDetector, DEFAULT_SLEEP_INTERVAL_MS, DEFAULT_PAUSE_THRESHOLD_MS);
+        }
+    }
+
+    private static MeterRegistry givenRegistryConfiguredWith(MicrometerConfigurationHook hook) {
+        MeterRegistry registry = new CompositeMeterRegistry();
+        hook.configure(registry);
+        return registry;
+    }
+
+    private static void thenPauseDetectorEquals(final PauseDetector pauseDetector, final long sleepInterval, final long pauseThreshold) {
+        assertThat(pauseDetector).isInstanceOf(ClockDriftPauseDetector.class);
+        final ClockDriftPauseDetector clockDriftPauseDetector = (ClockDriftPauseDetector) pauseDetector;
+        assertThat(clockDriftPauseDetector.getPauseThreshold()).isEqualTo(Duration.ofMillis(sleepInterval));
+        assertThat(clockDriftPauseDetector.getSleepInterval()).isEqualTo(Duration.ofMillis(pauseThreshold));
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/micrometer/PauseDetectorHookTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/micrometer/PauseDetectorHookTest.java
@@ -28,12 +28,12 @@ class PauseDetectorHookTest {
     @Test
     void build_whenGivenConfigIsNull_shouldThrowException() {
         final PauseDetectorHook pauseDetectorHook = new PauseDetectorHook();
-        //noinspection resource
+        // noinspection resource
         assertThatThrownBy(() -> pauseDetectorHook.build(null)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    void whenConfigIsGiven_shouldUseGivenValue() {
+    void configure_whenConfigIsGiven_shouldUseGivenValue() {
         final long sleepIntervalMs = 250;
         final long pauseThresholdMs = 250;
         final PauseDetectorHook.PauseDetectorHookConfig config = new PauseDetectorHook.PauseDetectorHookConfig(sleepIntervalMs, pauseThresholdMs);
@@ -45,7 +45,7 @@ class PauseDetectorHookTest {
     }
 
     @Test
-    void whenConfigIsNotGiven_shouldUseDefaults() {
+    void configure_whenConfigIsNotGiven_shouldUseDefaults() {
         final PauseDetectorHook.PauseDetectorHookConfig config = new PauseDetectorHook.PauseDetectorHookConfig(null, null);
         try (MicrometerConfigurationHook hook = new PauseDetectorHook().build(config)) {
             final MeterRegistry meterRegistry = givenRegistryConfiguredWith(hook);


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Enable micrometer pause detection by implementing a new micrometer configuration hook. 

Resolves #151


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [x] Update documentation
- [x] Make sure all unit/integration tests pass
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [x] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
