### PR TITLE
Throw meaningful exception if downstream tls has no 'key'

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -34,6 +34,7 @@ import io.kroxylicious.proxy.config.tls.AllowDeny;
 import io.kroxylicious.proxy.config.tls.NettyKeyProvider;
 import io.kroxylicious.proxy.config.tls.NettyTrustProvider;
 import io.kroxylicious.proxy.config.tls.PlatformTrustProvider;
+import io.kroxylicious.proxy.config.tls.SslContextBuildException;
 import io.kroxylicious.proxy.config.tls.Tls;
 import io.kroxylicious.proxy.config.tls.TrustOptions;
 import io.kroxylicious.proxy.config.tls.TrustProvider;
@@ -235,7 +236,7 @@ public class VirtualClusterModel {
             return SSLContext.getDefault().getDefaultSSLParameters();
         }
         catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
+            throw new SslContextBuildException(e);
         }
     }
 
@@ -244,7 +245,7 @@ public class VirtualClusterModel {
             return SSLContext.getDefault().getSupportedSSLParameters();
         }
         catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
+            throw new SslContextBuildException(e);
         }
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -374,6 +374,10 @@ public class VirtualClusterModel {
 
         private Optional<SslContext> buildDownstreamSslContext() {
             return tls.map(tlsConfiguration -> {
+                if (tlsConfiguration.key() == null) {
+                    throw new IllegalConfigurationException(("Virtual cluster '%s', gateway '%s': 'tls' object is missing the mandatory attribute 'key'.")
+                            .formatted(virtualCluster.getClusterName(), name()));
+                }
                 try {
                     var sslContextBuilder = Optional.of(tlsConfiguration.key()).map(NettyKeyProvider::new).map(NettyKeyProvider::forServer)
                             .orElseThrow();

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -392,6 +392,28 @@ class ConfigParserTest {
     }
 
     @Test
+    void shouldRequireKeyIfDownstreamTlsObjectPresent() {
+        // given
+        Configuration configuration = configParser.parseConfiguration("""
+                virtualClusters:
+                  - name: mycluster1
+                    targetCluster:
+                      bootstrapServers: kafka1.example:1234
+                    gateways:
+                    - name: default
+                      tls: {}
+                      portIdentifiesNode:
+                        bootstrapAddress: cluster1:9192
+                """);
+        ServiceBasedPluginFactoryRegistry registry = new ServiceBasedPluginFactoryRegistry();
+        // When/Then
+        assertThatThrownBy(() -> {
+            configuration.virtualClusterModel(registry);
+        }).isInstanceOf(IllegalConfigurationException.class)
+                .hasMessage("Virtual cluster 'mycluster1', gateway 'default': 'tls' object is missing the mandatory attribute 'key'.");
+    }
+
+    @Test
     void shouldDetectInconsistentClusterNameInDeprecatedVirtualClusterMap() {
         // When/Then
         assertThatThrownBy(() -> {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

If the user does something odd like add an empty 'tls' object to their gateway, or only fills in the 'trust' options or cipher configuration, then we will fail with a message explaining that we need a key for downstream TLS. Produces a log like:

> io.kroxylicious.proxy.config.IllegalConfigurationException: Gateway 'mygateway' of virtual cluster 'demo' has a `tls' object defined with no 'key' configured. The Proxy requires a 'key' to terminate TLS connections from clients. Please add a 'key' to your gateway's 'tls' object.

Prior it caused a grotesque NullPointerException

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
