### PR TITLE
Fail fast on unknown properties in proxy configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#2440](https://github.com/kroxylicious/kroxylicious/issues/2440): Fail fast on unknown properties in proxy configuration file 
 * [#2450](https://github.com/kroxylicious/kroxylicious/issues/2450): fix(proxy): Forward ApiVersions v0 response on UNSUPPORTED_VERSION v0 response from upstream
 * [#2455](https://github.com/kroxylicious/kroxylicious/pull/2455): refactor: make oauth bearer validation filter content into a standalone guide.
 * [#2378](https://github.com/kroxylicious/kroxylicious/issues/2378): refactor: Finish factoring out filter documentation into standalone guides.
@@ -23,6 +24,8 @@ Format `<github issue/pr number>: <short description>`.
 
 * Remove deprecated `tls` and `clusterNetworkAddressConfigProvider` fields from virtual cluster. You must define
   at least one gateway in the `gateways` array of your virtual cluster instead.
+* Warning: We have made the Proxy configuration parsing less lenient. If your configuration YAML contains unknown properties, then this will cause
+  the proxy to log an exception and fail to start.
 
 ## 0.13.0
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/ConfigParser.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/ConfigParser.java
@@ -105,7 +105,7 @@ public class ConfigParser implements PluginFactoryRegistry {
                 .setVisibility(PropertyAccessor.CREATOR, Visibility.ANY)
                 .setConstructorDetector(ConstructorDetector.USE_PROPERTIES_BASED)
                 .enable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
-                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .disable(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY)
                 .enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION)
                 .setSerializationInclusion(JsonInclude.Include.NON_DEFAULT);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -514,6 +514,28 @@ class ConfigParserTest {
     }
 
     @Test
+    void shouldErrorOnAnyUnknownProperties() {
+        // Given
+        assertThatThrownBy(() ->
+        // When
+        configParser.parseConfiguration("""
+                virtualClusters:
+                  - name: demo1
+                    targetCluster:
+                      bootstrapServers: kafka.example:1234
+                      unknownProperty: unknownProperty
+                    gateways:
+                    - name: default
+                      portIdentifiesNode:
+                        bootstrapAddress: cluster1:9192
+                """))
+                // Then
+                .isInstanceOf(IllegalArgumentException.class)
+                .cause()
+                .hasMessageContaining("Unrecognized field \"unknownProperty\"");
+    }
+
+    @Test
     void shouldDetectMissingTargetCluster() {
         // Given
         assertThatThrownBy(() ->


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Fail fast on unknown properties in the Kroxylicious config file

### Additional Context

The proxy was lenient, allowing you to start up with unknown properties in the configuration file. This can have a couple of bad effects:

1. users may see the `bootstrapServers` configuration of `targetCluster` and guess that they can plug in other typical kafka client configurations. This would be quite common in other kafka integrated technology. The proxy then starts up happily despite their config not affecting the proxy at all.
2. a typo in an optional field name may cause the proxy to happily start but not apply the user's behaviour. For example a typo in a gateway `tls` field might cause no TLS settings to be applied, and the proxy server would not protect that gateway's endpoints.

There is a downside to being harsh in that we lose forward compatibility. If we ever implemented dynamic configuration reloading, forward compatibility could be a useful property during deployments of new versions. Old proxies could be exposed to new configuration versions with new fields, and potentially be able to keep operating.

However I think the real problems we are battling right now with users getting mislead by lenient config are more pressing.

Closes #2440 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
