### PR TITLE
bugfix: docker build not triggering for pull requests from forks

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -25,7 +25,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ vars.REGISTRY_SERVER != '' && vars.REGISTRY_USERNAME != '' && vars.REGISTRY_ORGANISATION != '' && vars.PROXY_IMAGE_NAME != '' && vars.OPERATOR_IMAGE_NAME != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -43,14 +42,26 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - name: Set env variables
+      - name: Determine Build Configuration
+        id: build_configuration
         run: |
-          echo "RELEASE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_ENV
-          echo "PROXY_IMAGE=${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.PROXY_IMAGE_NAME }}" >> $GITHUB_ENV
-          echo "OPERATOR_IMAGE=${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.OPERATOR_IMAGE_NAME }}" >> $GITHUB_ENV
+          RELEASE_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "release_version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+
+          if [[ "${{ github.event_name }}" == "pull_request" || "${{ vars.REGISTRY_SERVER }}" == "" ]]; then
+            echo "proxy_tags=kroxylicious-proxy:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+            echo "operator_tags=kroxylicious-operator:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+            echo "push_images=false" >> $GITHUB_OUTPUT
+          else
+            PROXY_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.PROXY_IMAGE_NAME }}"
+            OPERATOR_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.OPERATOR_IMAGE_NAME }}"
+            echo "proxy_tags=${PROXY_IMAGE}:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+            echo "operator_tags=${OPERATOR_IMAGE}:${RELEASE_VERSION},${OPERATOR_IMAGE}:latest" >> $GITHUB_OUTPUT
+            echo "push_images=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Login to container registry
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        if: steps.build_configuration.outputs.push_images == 'true'
         uses: docker/login-action@v3
         with:
           registry: ${{ vars.REGISTRY_SERVER }}
@@ -62,10 +73,10 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+          push: ${{ steps.build_configuration.outputs.push_images == 'true' }}
           build-args: |
-            KROXYLICIOUS_VERSION=${{ env.RELEASE_VERSION }}
-          tags: ${{ env.PROXY_IMAGE }}:${{ env.RELEASE_VERSION }}
+            KROXYLICIOUS_VERSION=${{ steps.build_configuration.outputs.release_version }}
+          tags: ${{ steps.build_configuration.outputs.proxy_tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max,compression=zstd
 
@@ -75,9 +86,9 @@ jobs:
           context: .
           file: ./Dockerfile.operator
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+          push: ${{ steps.build_configuration.outputs.push_images == 'true' }}
           build-args: |
-            KROXYLICIOUS_VERSION=${{ env.RELEASE_VERSION }}
-          tags: ${{ env.OPERATOR_IMAGE }}:${{ env.RELEASE_VERSION }},${{ env.OPERATOR_IMAGE }}:latest
+            KROXYLICIOUS_VERSION=${{ steps.build_configuration.outputs.release_version }}
+          tags: ${{ steps.build_configuration.outputs.operator_tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max,compression=zstd


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Refactors to prevent accessing vars and secrets when the action is triggered by pull request.

Why:

the top level if was preventing PRs from triggering the docker build because they can't access the repository vars/secrets for security reasons. When building a PR we just want to excercise the build and don't need to push anywhere, so we can use an arbitrary tag.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
