### PR TITLE
fix: fix BrokerEndpointBinding comment error

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/BrokerEndpointBinding.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/BrokerEndpointBinding.java
@@ -18,7 +18,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * @param endpointGateway                      the endpoint listener
  * @param upstreamTarget                       the upstream target of this binding
  * @param nodeId                               kafka nodeId of the target broker
- * @param restrictUpstreamToMetadataDiscovery  true if the upstreamTarget corresponds to a broker, false if it points at a bootstrap.
+ * @param restrictUpstreamToMetadataDiscovery  false if the upstream target corresponds to a broker, true if it points at a bootstrap.
  */
 public record BrokerEndpointBinding(EndpointGateway endpointGateway, HostPort upstreamTarget, Integer nodeId, boolean restrictUpstreamToMetadataDiscovery)
         implements EndpointBinding {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/BrokerEndpointBinding.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/BrokerEndpointBinding.java
@@ -18,7 +18,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * @param endpointGateway                      the endpoint listener
  * @param upstreamTarget                       the upstream target of this binding
  * @param nodeId                               kafka nodeId of the target broker
- * @param restrictUpstreamToMetadataDiscovery  false if the upstream target corresponds to a broker, true if it points at a bootstrap.
+ * @param restrictUpstreamToMetadataDiscovery  false if the upstreamTarget corresponds to a broker, true if it points at a bootstrap.
  */
 public record BrokerEndpointBinding(EndpointGateway endpointGateway, HostPort upstreamTarget, Integer nodeId, boolean restrictUpstreamToMetadataDiscovery)
         implements EndpointBinding {


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

`BrokerEndpointBinding` comment have a error , when `restrictUpstreamToMetadataDiscovery` is `true` , it means point at a bootstrap.

### Additional Context

Fix comment error.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
