### PR TITLE
fix: Kroxylicious does not forward KIP-511 ApiVersions v0 response from upstream correctly

### DIFF
--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/Response.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/Response.java
@@ -7,4 +7,6 @@
 package io.kroxylicious.test;
 
 public record Response(ResponsePayload payload,
-                       int sequenceNumber) {}
+                       int sequenceNumber,
+                       int correlationId,
+                       byte[] rawHeaderAndBodyBytes) {}

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/KafkaClient.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/KafkaClient.java
@@ -203,7 +203,8 @@ public final class KafkaClient implements AutoCloseable {
 
     private static Response toResponse(SequencedResponse sequencedResponse) {
         DecodedResponseFrame<?> frame = sequencedResponse.frame();
-        return new Response(new ResponsePayload(frame.apiKey(), frame.apiVersion(), frame.body()), sequencedResponse.sequenceNumber());
+        return new Response(new ResponsePayload(frame.apiKey(), frame.apiVersion(), frame.body()), sequencedResponse.sequenceNumber(), frame.correlationId(),
+                sequencedResponse.rawResponseHeaderAndBody());
     }
 
     private static SslContext buildTrustAllSslContext() {

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/SequencedResponse.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/SequencedResponse.java
@@ -8,4 +8,4 @@ package io.kroxylicious.test.client;
 
 import io.kroxylicious.test.codec.DecodedResponseFrame;
 
-public record SequencedResponse(DecodedResponseFrame<?> frame, int sequenceNumber) {}
+public record SequencedResponse(DecodedResponseFrame<?> frame, int sequenceNumber, byte[] rawResponseHeaderAndBody) {}

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/KafkaResponseDecoder.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/KafkaResponseDecoder.java
@@ -66,8 +66,11 @@ public class KafkaResponseDecoder extends KafkaMessageDecoder {
         log().trace("{}: Header: {}", ctx, header);
         ApiMessage body = BodyDecoder.decodeResponse(apiKey, apiVersion, accessor);
         log().trace("{}: Body: {}", ctx, body);
+        in.readerIndex(ri);
+        byte[] rawHeaderAndBody = new byte[length];
+        in.readBytes(rawHeaderAndBody);
         frame = new DecodedResponseFrame<>(apiVersion, correlationId, header, body);
-        correlation.responseFuture().complete(new SequencedResponse(frame, i++));
+        correlation.responseFuture().complete(new SequencedResponse(frame, i++, rawHeaderAndBody));
         return frame;
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/DecodedApiMessage.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/DecodedApiMessage.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.codec;
+
+import org.apache.kafka.common.protocol.ApiMessage;
+
+/**
+ * A record of which api version was used to decode an ApiMessage off the wire
+ * @param apiMessage apiMessage
+ * @param decodeApiVersion api version used to decode the message
+ */
+public record DecodedApiMessage(ApiMessage apiMessage, short decodeApiVersion) {}

--- a/kroxylicious-runtime/src/main/templates/BodyDecoder.ftl
+++ b/kroxylicious-runtime/src/main/templates/BodyDecoder.ftl
@@ -66,7 +66,7 @@ public class BodyDecoder {
     * @see <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-511%3A+Collect+and+Expose+Client%27s+Name+and+Version+in+the+Brokers#KIP511:CollectandExposeClient'sNameandVersionintheBrokers-ApiVersionsRequest/ResponseHandling">KIP-511: Collect and Expose Client's Name and Version in the Brokers</a>
     * ApiVersions Request/Response Handling
     */
-    static ApiMessage decodeResponse(ApiKeys apiKey, short apiVersion, ByteBufAccessor accessor) {
+    static DecodedApiMessage decodeResponse(ApiKeys apiKey, short apiVersion, ByteBufAccessor accessor) {
         return switch (apiKey) {
 <#list messageSpecs as messageSpec>
     <#if messageSpec.type?lower_case == 'response'>
@@ -76,12 +76,12 @@ public class BodyDecoder {
                 // Use the same algorithm as https://github.com/apache/kafka/blob/a41c10fd49841381b5207c184a385622094ed440/clients/src/main/java/org/apache/kafka/common/requests/ApiVersionsResponse.java#L90-L106
                 int prev = accessor.readerIndex();
                 try {
-                    yield new ${messageSpec.name}Data(accessor, apiVersion);
+                    yield new DecodedApiMessage(new ${messageSpec.name}Data(accessor, apiVersion), apiVersion);
                 }
                 catch (RuntimeException e) {
                     accessor.readerIndex(prev);
                     if (apiVersion != 0) {
-                        yield new ${messageSpec.name}Data(accessor, (short) 0);
+                        yield new DecodedApiMessage(new ${messageSpec.name}Data(accessor, (short) 0), (short) 0);
                     }
                     else {
                         throw e;
@@ -89,7 +89,7 @@ public class BodyDecoder {
                 }
             }
         <#else>
-            case ${retrieveApiKey(messageSpec)} -> new ${messageSpec.name}Data(accessor, apiVersion);
+            case ${retrieveApiKey(messageSpec)} -> new DecodedApiMessage(new ${messageSpec.name}Data(accessor, apiVersion), apiVersion);
         </#if>
     </#if>
 </#list>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

If we receive an API_VERSIONS response from upstream with error code 35 (UNKNOWN_VERSION), following [KIP-511](https://cwiki.apache.org/confluence/display/KAFKA/KIP-511%3A+Collect+and+Expose+Client%27s+Name+and+Version+in+the+Brokers#KIP511:CollectandExposeClient'sNameandVersionintheBrokers-ApiVersionsRequest/ResponseHandling) we assume that the response was written with api version 0. This is the response prescribed for when the server receives an API_VERSION api version it does not understand. The message forwarded on to the client will be encoded as v0.

We also add in a sanity check, we expect that we decoded the upstream message at v0 if they supplied an error code 35. If we encounter a 35 error code in an Api Versions response, but we decoded the message at a higher api version, we are in an illegal state and fail immediately as the upstream is misbehaving.
    
Why:

A user (thanks @Pavelsky89) discovered that a Kafka client (twmb/franz-go) was failing to connect to Kafka 3.8.0 via the proxy. The flow is something like this:

1. franz-go sends a version 4 API_VERSIONS request
2. kroxylicious 0.13.0 understands version 4 and forwards it upstream
3. upstream doesn't understand and responds with v0 Api Versions response and error code 35
4. kroxylicious leniently tries to decode it as v4, then retries with a v0 decode on exception.
5. kroxylicious assumed the frame was v4 and forwarded it to the client, encoded at v4.
6. [franz-go expects that error code 35](https://github.com/twmb/franz-go/blob/37eecbb8927fce0aede1d6af39849839f7b0b3cf/pkg/kgo/broker.go#L812) implies the remainder of the message is written with v0 and it barfs because there are too many bytes in the response.

So the fix is to preserve the v0 encoding of the response from the upstream broker so we behave as specified by KIP-511.
    
Closes #2450

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
