### PR TITLE
kroxylicious-runtime: Remove a limitation from FilterInvokers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#2472](https://github.com/kroxylicious/kroxylicious/pull/2472): Restrictions on which interfaces Filter implementations an implementation could implement have been relaxed.
 * [#2440](https://github.com/kroxylicious/kroxylicious/issues/2440): Fail fast on unknown properties in proxy configuration file 
 * [#2450](https://github.com/kroxylicious/kroxylicious/issues/2450): fix(proxy): Forward ApiVersions v0 response on UNSUPPORTED_VERSION v0 response from upstream
 * [#2455](https://github.com/kroxylicious/kroxylicious/pull/2455): refactor: make oauth bearer validation filter content into a standalone guide.

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestFilter.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/RequestFilter.java
@@ -13,11 +13,13 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
 
 /**
- * A Filter implementation intended to simplify cases where we want to handle all or
- * most request types, for example to modify the request headers. If a Filter implements
- * RequestFilter, it cannot also implement any of the specific message Filter interfaces
- * like {@link ApiVersionsRequestFilter}. If a Filter implements RequestFilter, it may
- * also implement {@link ResponseFilter}.
+ * <p>A Filter that handles all request types, for example to modify the request headers.</p>
+ *
+ * <p>When a Filter implements {@code RequestFilter}:</p>
+ * <ul>
+ *  <li>it must not also implement any of the message-specific {@code *RequestFilter} interfaces like {@link ApiVersionsRequestFilter}.</li>
+ *  <li>it may also implement either {@link ResponseFilter} or any of the message-specific {@code *ResponseFilter} interfaces, but not both.</li>
+ * </ul>
  */
 public interface RequestFilter extends Filter {
 

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/ResponseFilter.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/ResponseFilter.java
@@ -13,11 +13,13 @@ import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
 
 /**
- * A Filter implementation intended to simplify cases where we want to handle all or
- * most response types, for example to modify the response headers. If a Filter implements
- * ResponseFilter, it cannot also implement any of the specific message Filter interfaces
- * like {@link ApiVersionsRequestFilter}. If a Filter implements ResponseFilter, it may also
- * implement {@link RequestFilter}.
+ * <p>A Filter that handles all response types.</p>
+ *
+ * <p>When a Filter implements {@code ResponseFilter}:</p>
+ * <ul>
+ *  <li>it must not also implement any of the message-specific {@code *ResponseFilter} interfaces like {@link ApiVersionsResponseFilter}.</li>
+ *  <li>it may also implement either {@link RequestFilter} or any of the message-specific {@code *RequestFilter} interfaces, but not both.</li>
+ * </ul>
  */
 public interface ResponseFilter extends Filter {
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/GenericRequestSpecificResponseFilter.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/GenericRequestSpecificResponseFilter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.types.RawTaggedField;
+
+public class GenericRequestSpecificResponseFilter implements RequestFilter, ApiVersionsResponseFilter {
+
+    public static final int CLIENT_ID_TAG = 99;
+    Map<Integer, String> clientIdPerCorrelationId = new HashMap<>();
+
+    @Override
+    public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage request, FilterContext context) {
+        String clientId = header.clientId();
+        clientIdPerCorrelationId.put(header.correlationId(), clientId);
+        return context.forwardRequest(header, request);
+    }
+
+    @Override
+    public CompletionStage<ResponseFilterResult> onApiVersionsResponse(short apiVersion, ResponseHeaderData header, ApiVersionsResponseData response,
+                                                                       FilterContext context) {
+        String requestClientId = clientIdPerCorrelationId.remove(header.correlationId());
+        response.unknownTaggedFields().add(new RawTaggedField(CLIENT_ID_TAG, requestClientId.getBytes(StandardCharsets.UTF_8)));
+        return context.forwardResponse(header, response);
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/GenericRequestSpecificResponseFilterFactory.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/GenericRequestSpecificResponseFilterFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import io.kroxylicious.proxy.plugin.Plugin;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+@Plugin(configType = Void.class)
+public class GenericRequestSpecificResponseFilterFactory implements FilterFactory<Void, Void> {
+
+    @Override
+    public Void initialize(FilterFactoryContext context, Void config) {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public GenericRequestSpecificResponseFilter createFilter(FilterFactoryContext context, Void configuration) {
+        return new GenericRequestSpecificResponseFilter();
+    }
+
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/GenericResponseSpecificRequestFilter.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/GenericResponseSpecificRequestFilter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.types.RawTaggedField;
+
+public class GenericResponseSpecificRequestFilter implements ResponseFilter, ApiVersionsRequestFilter {
+    public static final int CLIENT_ID_TAG = 100;
+    Map<Integer, String> clientIdPerCorrelationId = new HashMap<>();
+
+    @Override
+    public CompletionStage<RequestFilterResult> onApiVersionsRequest(short apiVersion, RequestHeaderData header, ApiVersionsRequestData request, FilterContext context) {
+        String clientId = header.clientId();
+        clientIdPerCorrelationId.put(header.correlationId(), clientId);
+        return context.forwardRequest(header, request);
+    }
+
+    @Override
+    public CompletionStage<ResponseFilterResult> onResponse(ApiKeys apiKey, ResponseHeaderData header, ApiMessage response, FilterContext context) {
+        String requestClientId = clientIdPerCorrelationId.remove(header.correlationId());
+        response.unknownTaggedFields().add(new RawTaggedField(CLIENT_ID_TAG, requestClientId.getBytes(StandardCharsets.UTF_8)));
+        return context.forwardResponse(header, response);
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/GenericResponseSpecificRequestFilterFactory.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/GenericResponseSpecificRequestFilterFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import io.kroxylicious.proxy.plugin.Plugin;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+@Plugin(configType = Void.class)
+public class GenericResponseSpecificRequestFilterFactory implements FilterFactory<Void, Void> {
+
+    @Override
+    public Void initialize(FilterFactoryContext context, Void config) {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public GenericResponseSpecificRequestFilter createFilter(FilterFactoryContext context, Void configuration) {
+        return new GenericResponseSpecificRequestFilter();
+    }
+
+}

--- a/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
+++ b/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
@@ -3,5 +3,7 @@ io.kroxylicious.proxy.filter.RequestResponseMarkingFilterFactory
 io.kroxylicious.proxy.filter.OutOfBandSendFilterFactory
 io.kroxylicious.proxy.filter.RejectingCreateTopicFilterFactory
 io.kroxylicious.proxy.filter.DecodeAll
+io.kroxylicious.proxy.filter.GenericRequestSpecificResponseFilterFactory
+io.kroxylicious.proxy.filter.GenericResponseSpecificRequestFilterFactory
 io.kroxylicious.proxy.InvocationCountingFilterFactory
 io.kroxylicious.proxy.CreateTopicRequest

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/filter/FilterInvokers.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/filter/FilterInvokers.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.proxy.filter;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
@@ -44,62 +45,60 @@ public class FilterInvokers {
     }
 
     private static List<FilterAndInvoker> invokersForFilter(String filterName, Filter filter) {
-        validateFilter(filterName, filter);
-        boolean isAnyRequestFilter = filter instanceof RequestFilter;
-        boolean isAnyResponseFilter = filter instanceof ResponseFilter;
-        boolean isSpecificRequestFilter = SpecificFilterArrayInvoker.implementsAnySpecificRequestFilterInterface(filter);
-        boolean isSpecificResponseFilter = SpecificFilterArrayInvoker.implementsAnySpecificResponseFilterInterface(filter);
-        if (isAnyRequestFilter && isAnyResponseFilter) {
-            return singleFilterAndInvoker(filterName, filter, new RequestResponseInvoker((RequestFilter) filter, (ResponseFilter) filter));
-        }
-        else if (isAnyRequestFilter && isSpecificResponseFilter) {
-            return List.of(new FilterAndInvoker(filterName, filter, new RequestFilterInvoker((RequestFilter) filter)),
-                    new FilterAndInvoker(filterName, filter, arrayInvoker(filter)));
-        }
-        else if (isSpecificRequestFilter && isAnyResponseFilter) {
-            return List.of(new FilterAndInvoker(filterName, filter, arrayInvoker(filter)),
-                    new FilterAndInvoker(filterName, filter, new ResponseFilterInvoker((ResponseFilter) filter)));
-        }
-        else if (isAnyRequestFilter) {
-            return singleFilterAndInvoker(filterName, filter, new RequestFilterInvoker((RequestFilter) filter));
-        }
-        else if (isAnyResponseFilter) {
-            return singleFilterAndInvoker(filterName, filter, new ResponseFilterInvoker((ResponseFilter) filter));
+        FilterCharacteristics characteristics = FilterCharacteristics.describeCharacteristics(filter);
+        validateFilter(filterName, characteristics);
+        Optional<FilterAndInvoker> genericInvoker = maybeGenericInvoker(filterName, filter, characteristics);
+        Optional<FilterAndInvoker> specificInvoker = maybeSpecificInvoker(filterName, filter, characteristics);
+        return Stream.concat(genericInvoker.stream(), specificInvoker.stream()).toList();
+    }
+
+    private static Optional<FilterAndInvoker> maybeSpecificInvoker(String filterName, Filter filter, FilterCharacteristics characteristics) {
+        if (characteristics.isSpecificRequestFilter || characteristics.isSpecificResponseFilter) {
+            return Optional.of(getFilterAndInvoker(filterName, filter, arrayInvoker(filter)));
         }
         else {
-            return singleFilterAndInvoker(filterName, filter, arrayInvoker(filter));
+            return Optional.empty();
         }
+    }
+
+    private static Optional<FilterAndInvoker> maybeGenericInvoker(String filterName, Filter filter, FilterCharacteristics characteristics) {
+        if (characteristics.isAnyRequestFilter && characteristics.isAnyResponseFilter) {
+            return Optional.of(getFilterAndInvoker(filterName, filter, new RequestResponseInvoker((RequestFilter) filter, (ResponseFilter) filter)));
+        }
+        else if (characteristics.isAnyResponseFilter) {
+            return Optional.of(getFilterAndInvoker(filterName, filter, new ResponseFilterInvoker((ResponseFilter) filter)));
+        }
+        else if (characteristics.isAnyRequestFilter) {
+            return Optional.of(getFilterAndInvoker(filterName, filter, new RequestFilterInvoker((RequestFilter) filter)));
+        }
+        return Optional.empty();
     }
 
     private static Stream<FilterAndInvoker> wrapAllInSafeInvoker(List<FilterAndInvoker> filterInvokers) {
         return filterInvokers.stream()
-                .map(filterAndInvoker -> new FilterAndInvoker(filterAndInvoker.filterName(), filterAndInvoker.filter(), new SafeInvoker(filterAndInvoker.invoker())));
+                .map(filterAndInvoker -> getFilterAndInvoker(filterAndInvoker.filterName(), filterAndInvoker.filter(), new SafeInvoker(filterAndInvoker.invoker())));
     }
 
-    private static void validateFilter(String filterName, Filter filter) {
-        boolean isAnyRequestFilter = filter instanceof RequestFilter;
-        boolean isSpecificRequestFilter = SpecificFilterArrayInvoker.implementsAnySpecificRequestFilterInterface(filter);
-        boolean isAnyResponseFilter = filter instanceof ResponseFilter;
-        boolean isSpecificResponseFilter = SpecificFilterArrayInvoker.implementsAnySpecificResponseFilterInterface(filter);
-        if (isAnyRequestFilter
-                && isSpecificRequestFilter) {
-            throw unsupportedFilterInstance(filterName, "Cannot mix specific message filter interfaces and [RequestFilter|ResponseFilter] interfaces");
+    private static void validateFilter(String filterName, FilterCharacteristics characteristics) {
+        if (characteristics.isAnyRequestFilter
+                && characteristics.isSpecificRequestFilter) {
+            throw unsupportedFilterInstance(filterName, "Cannot mix specific request message filter interfaces and RequestFilter interfaces");
         }
-        if (isAnyResponseFilter
-                && isSpecificResponseFilter) {
-            throw unsupportedFilterInstance(filterName, "Cannot mix specific message filter interfaces and [RequestFilter|ResponseFilter] interfaces");
+        if (characteristics.isAnyResponseFilter
+                && characteristics.isSpecificResponseFilter) {
+            throw unsupportedFilterInstance(filterName, "Cannot mix specific response message filter interfaces and ResponseFilter interfaces");
         }
-        if (!isAnyRequestFilter
-                && !isAnyResponseFilter
-                && !isSpecificRequestFilter
-                && !isSpecificResponseFilter) {
+        if (!characteristics.isAnyRequestFilter
+                && !characteristics.isAnyResponseFilter
+                && !characteristics.isSpecificRequestFilter
+                && !characteristics.isSpecificResponseFilter) {
             throw unsupportedFilterInstance(filterName,
                     "Filter must implement ResponseFilter, RequestFilter or any combination of specific message Filter interfaces");
         }
     }
 
-    private static List<FilterAndInvoker> singleFilterAndInvoker(String filterName, Filter filter, FilterInvoker invoker) {
-        return List.of(new FilterAndInvoker(filterName, filter, invoker));
+    private static FilterAndInvoker getFilterAndInvoker(String filterName, Filter filter, FilterInvoker invoker) {
+        return new FilterAndInvoker(filterName, filter, invoker);
     }
 
     /**
@@ -123,6 +122,16 @@ public class FilterInvokers {
 
     private static IllegalArgumentException unsupportedFilterInstance(String filterName, String message) {
         return new IllegalArgumentException("Invoker could not be created for filter: " + filterName + ". " + message);
+    }
+
+    private record FilterCharacteristics(boolean isAnyRequestFilter, boolean isAnyResponseFilter, boolean isSpecificRequestFilter, boolean isSpecificResponseFilter) {
+        static FilterCharacteristics describeCharacteristics(Filter filter) {
+            boolean isAnyRequestFilter = filter instanceof RequestFilter;
+            boolean isSpecificRequestFilter = SpecificFilterArrayInvoker.implementsAnySpecificRequestFilterInterface(filter);
+            boolean isAnyResponseFilter = filter instanceof ResponseFilter;
+            boolean isSpecificResponseFilter = SpecificFilterArrayInvoker.implementsAnySpecificResponseFilterInterface(filter);
+            return new FilterCharacteristics(isAnyRequestFilter, isAnyResponseFilter, isSpecificRequestFilter, isSpecificResponseFilter);
+        }
     }
 
 }

--- a/kroxylicious-runtime/src/main/templates/SpecificFilterArrayInvoker.ftl
+++ b/kroxylicious-runtime/src/main/templates/SpecificFilterArrayInvoker.ftl
@@ -189,8 +189,40 @@ class SpecificFilterArrayInvoker implements FilterInvoker {
     * @return true if the filter implements any Specific Message Filter interfaces
     */
     public static boolean implementsAnySpecificFilterInterface(Filter filter) {
-        return <#list messageSpecs as messageSpec>filter instanceof ${messageSpec.name}Filter<#sep> ||
-        </#sep></#list>;
+        return implementsAnySpecificRequestFilterInterface(filter)
+                || implementsAnySpecificResponseFilterInterface(filter);
+    }
+
+    /**
+    * Check if a Filter implements any of the Specific Request Filter interfaces
+    * @param filter the filter
+    * @return true if the filter implements any Specific Request Filter interfaces
+    */
+    public static boolean implementsAnySpecificRequestFilterInterface(Filter filter) {
+<#list messageSpecs as messageSpec>
+    <#if messageSpec.type?lower_case == 'request'>
+        if (filter instanceof ${messageSpec.name}Filter) {
+            return true;
+        }
+    </#if>
+</#list>
+        return false;
+    }
+
+    /**
+    * Check if a Filter implements any of the Specific Response Filter interfaces
+    * @param filter the filter
+    * @return true if the filter implements any Specific Response Filter interfaces
+    */
+    public static boolean implementsAnySpecificResponseFilterInterface(Filter filter) {
+<#list messageSpecs as messageSpec>
+    <#if messageSpec.type?lower_case == 'response'>
+        if (filter instanceof ${messageSpec.name}Filter) {
+            return true;
+        }
+    </#if>
+</#list>
+        return false;
     }
 
     private static FilterInvoker[] createHandleNothing() {

--- a/kroxylicious-runtime/src/main/templates/SpecificFilterArrayInvoker.ftl
+++ b/kroxylicious-runtime/src/main/templates/SpecificFilterArrayInvoker.ftl
@@ -184,16 +184,6 @@ class SpecificFilterArrayInvoker implements FilterInvoker {
     }
 
     /**
-    * Check if a Filter implements any of the Specific Message Filter interfaces
-    * @param filter the filter
-    * @return true if the filter implements any Specific Message Filter interfaces
-    */
-    public static boolean implementsAnySpecificFilterInterface(Filter filter) {
-        return implementsAnySpecificRequestFilterInterface(filter)
-                || implementsAnySpecificResponseFilterInterface(filter);
-    }
-
-    /**
     * Check if a Filter implements any of the Specific Request Filter interfaces
     * @param filter the filter
     * @return true if the filter implements any Specific Request Filter interfaces

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/filter/FilterInvokersTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/filter/FilterInvokersTest.java
@@ -40,8 +40,8 @@ class FilterInvokersTest {
 
         };
         return Stream.of(noFilterSubinterfacesImplemented,
-                new SpecificAndRequestFilter(),
-                new SpecificAndResponseFilter());
+                new SpecificRequestAndGenericRequestFilter(),
+                new SpecificResponseAndGenericResponseFilter());
     }
 
     public static Stream<Filter> validFilters() {
@@ -49,13 +49,15 @@ class FilterInvokersTest {
         RequestFilter requestFilter = (apiKey, header, body, filterContext) -> null;
         ResponseFilter responseFilter = (apiKey, header, body, filterContext) -> null;
         return Stream.of(singleSpecificMessageFilter,
-                new MultipleSpecificFilter(),
+                new SpecificRequestSpecificResponseFilter(),
                 requestFilter,
                 responseFilter,
-                new RequestResponseFilter());
+                new GenericRequestGenericResponseFilter(),
+                new SpecificRequestAndGenericResponseFilter(),
+                new GenericRequestSpecificResponseFilter());
     }
 
-    static class RequestResponseFilter implements RequestFilter, ResponseFilter {
+    static class GenericRequestGenericResponseFilter implements RequestFilter, ResponseFilter {
 
         @Override
         public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage request, FilterContext context) {
@@ -68,7 +70,7 @@ class FilterInvokersTest {
         }
     }
 
-    static class MultipleSpecificFilter implements ApiVersionsRequestFilter, ApiVersionsResponseFilter {
+    static class SpecificRequestSpecificResponseFilter implements ApiVersionsRequestFilter, ApiVersionsResponseFilter {
 
         @Override
         public CompletionStage<RequestFilterResult> onApiVersionsRequest(short apiVersion, RequestHeaderData header, ApiVersionsRequestData request,
@@ -85,7 +87,7 @@ class FilterInvokersTest {
         }
     }
 
-    static class SpecificAndResponseFilter implements ApiVersionsRequestFilter, ResponseFilter {
+    static class SpecificRequestAndGenericResponseFilter implements ApiVersionsRequestFilter, ResponseFilter {
 
         @Override
         public CompletionStage<RequestFilterResult> onApiVersionsRequest(short apiVersion, RequestHeaderData header, ApiVersionsRequestData request,
@@ -101,7 +103,23 @@ class FilterInvokersTest {
         }
     }
 
-    static class SpecificAndRequestFilter implements ApiVersionsRequestFilter, RequestFilter {
+    static class SpecificResponseAndGenericResponseFilter implements ApiVersionsResponseFilter, ResponseFilter {
+
+        @Override
+        public CompletionStage<ResponseFilterResult> onApiVersionsResponse(short apiVersion, ResponseHeaderData header, ApiVersionsResponseData request,
+                                                                           FilterContext context) {
+
+            return null;
+        }
+
+        @Override
+        public CompletionStage<ResponseFilterResult> onResponse(ApiKeys apiKey, ResponseHeaderData header, ApiMessage response, FilterContext context) {
+
+            return null;
+        }
+    }
+
+    static class SpecificRequestAndGenericRequestFilter implements ApiVersionsRequestFilter, RequestFilter {
 
         @Override
         public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage request, FilterContext context) {
@@ -112,6 +130,22 @@ class FilterInvokersTest {
         @Override
         public CompletionStage<RequestFilterResult> onApiVersionsRequest(short apiVersion, RequestHeaderData header, ApiVersionsRequestData request,
                                                                          FilterContext context) {
+
+            return null;
+        }
+    }
+
+    static class GenericRequestSpecificResponseFilter implements RequestFilter, ApiVersionsResponseFilter {
+
+        @Override
+        public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage request, FilterContext context) {
+
+            return null;
+        }
+
+        @Override
+        public CompletionStage<ResponseFilterResult> onApiVersionsResponse(short apiVersion, ResponseHeaderData header, ApiVersionsResponseData request,
+                                                                           FilterContext context) {
 
             return null;
         }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

* Relax the current restriction on implementing both specific and generic filter interfaces. 
* Allow filter implementations that implement some specific request filters plus the generic `ResponseFilter`
* Allow filter implementations that implement the generic `RequestFilter` plus specific response Filter interfaces

### Additional Context

A filter acting as a SASL initiator needs to implement RequestFilter so it can block all client requests while it performs a SASL exchange. To do this is needs to start off by making a ApiVersions request and handling the response. It is better (more specific, and in theory more performant) for it to implement `ApiVersionsResponseFilter` than the generic `ResponseFilter`.