### PR TITLE
kroxylicious-filter-test-support: Add some new Asserts

### DIFF
--- a/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/test/assertj/ConsumerRecordAssert.java
+++ b/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/test/assertj/ConsumerRecordAssert.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test.assertj;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Headers;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.InstanceOfAssertFactory;
+
+public class ConsumerRecordAssert extends AbstractAssert<ConsumerRecordAssert, ConsumerRecord<?, ?>> {
+    protected ConsumerRecordAssert(ConsumerRecord consumerRecord) {
+        super(consumerRecord, ConsumerRecordAssert.class);
+    }
+
+    public static ConsumerRecordAssert assertThat(ConsumerRecord<?, ?> actual) {
+        return new ConsumerRecordAssert(actual);
+    }
+
+    public HeadersAssert headers() {
+        isNotNull();
+        return extracting(ConsumerRecord::headers,
+                new InstanceOfAssertFactory<>(Headers.class, HeadersAssert::assertThat));
+    }
+}

--- a/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/test/assertj/HeaderAssert.java
+++ b/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/test/assertj/HeaderAssert.java
@@ -53,4 +53,7 @@ public class HeaderAssert extends AbstractAssert<HeaderAssert, Header> {
         return headerValue;
     }
 
+    public AbstractByteArrayAssert<?> hasValue() {
+        return Assertions.assertThat(actual.value());
+    }
 }

--- a/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/test/assertj/HeadersAssert.java
+++ b/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/test/assertj/HeadersAssert.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test.assertj;
+
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.assertj.core.api.InstanceOfAssertFactory;
+import org.assertj.core.api.IterableAssert;
+
+public class HeadersAssert extends AbstractAssert<HeadersAssert, Headers> {
+    protected HeadersAssert(Headers headers) {
+        super(headers, HeadersAssert.class);
+        describedAs(headers == null ? "null headers" : "headers");
+    }
+
+    public static HeadersAssert assertThat(Headers actual) {
+        return new HeadersAssert(actual);
+    }
+
+    private IterableAssert<Header> headerIterable() {
+        isNotNull();
+        IterableAssert<Header> records = IterableAssert.assertThatIterable(actual)
+                .describedAs("headers");
+        return records;
+    }
+
+    public HeaderAssert firstHeader() {
+        isNotNull();
+        return headerIterable()
+                .isNotEmpty()
+                .first(new InstanceOfAssertFactory<>(Header.class, HeaderAssert::assertThat))
+                .describedAs("first header");
+    }
+
+    public HeaderAssert lastHeader() {
+        isNotNull();
+        return headerIterable()
+                .last(new InstanceOfAssertFactory<>(Header.class, HeaderAssert::assertThat))
+                .describedAs("last header");
+    }
+
+    public HeaderAssert singleHeader() {
+        isNotNull();
+        return headerIterable()
+                .singleElement(new InstanceOfAssertFactory<>(Header.class, HeaderAssert::assertThat))
+                .describedAs("single header");
+    }
+
+    public HeaderAssert firstHeaderWithKey(String key) {
+        isNotNull();
+        return extracting(actual -> actual.headers(key), InstanceOfAssertFactories.iterable(Header.class))
+                .as("headers with key " + key)
+                .isNotEmpty()
+                .first(new InstanceOfAssertFactory<>(Header.class, HeaderAssert::assertThat))
+                .describedAs("first header with key " + key);
+    }
+
+    public HeaderAssert lastHeaderWithKey(String key) {
+        isNotNull();
+        return extracting(actual -> actual.headers(key), InstanceOfAssertFactories.iterable(Header.class))
+                .as("headers with key " + key)
+                .isNotEmpty()
+                .last(new InstanceOfAssertFactory<>(Header.class, HeaderAssert::assertThat))
+                .describedAs("last header with key " + key);
+    }
+
+    public HeaderAssert singleHeaderWithKey(String key) {
+        isNotNull();
+        return extracting(actual -> actual.headers(key), InstanceOfAssertFactories.iterable(Header.class))
+                .as("headers with key " + key)
+                .isNotEmpty()
+                .singleElement(new InstanceOfAssertFactory<>(Header.class, HeaderAssert::assertThat))
+                .describedAs("single header with key " + key);
+    }
+
+    public HeadersAssert hasSize(int expected) {
+        headerIterable()
+                .hasSize(expected);
+        return this;
+    }
+}

--- a/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/test/assertj/KafkaAssertions.java
+++ b/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/test/assertj/KafkaAssertions.java
@@ -6,7 +6,9 @@
 
 package io.kroxylicious.test.assertj;
 
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.record.MemoryRecords;
 import org.apache.kafka.common.record.Record;
 import org.apache.kafka.common.record.RecordBatch;
@@ -27,6 +29,14 @@ public class KafkaAssertions {
 
     public static RecordAssert assertThat(Record actual) {
         return RecordAssert.assertThat(actual);
+    }
+
+    public static ConsumerRecordAssert assertThat(ConsumerRecord actual) {
+        return ConsumerRecordAssert.assertThat(actual);
+    }
+
+    public static HeadersAssert assertThat(Headers actual) {
+        return HeadersAssert.assertThat(actual);
     }
 
     public static HeaderAssert assertThat(Header actual) {

--- a/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/assertj/ConsumerRecordAssertTest.java
+++ b/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/assertj/ConsumerRecordAssertTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test.assertj;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.TimestampType;
+import org.junit.jupiter.api.Test;
+
+public class ConsumerRecordAssertTest {
+
+    long timestamp = System.currentTimeMillis();
+
+    ConsumerRecord<String, String> record = new ConsumerRecord<>("topic",
+            3,
+            42L,
+            timestamp,
+            TimestampType.LOG_APPEND_TIME,
+            ConsumerRecord.NULL_SIZE,
+            ConsumerRecord.NULL_SIZE,
+            "my key",
+            "my value",
+            new RecordHeaders().add("my header", "my header value".getBytes(StandardCharsets.UTF_8)),
+            Optional.of(128));
+
+    @Test
+    void headers() {
+        KafkaAssertions.assertThat(record).headers().hasSize(1);
+    }
+}

--- a/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/assertj/HeadersAssertTest.java
+++ b/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/assertj/HeadersAssertTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.test.assertj;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class HeadersAssertTest {
+
+    HeadersAssert headersAssert = KafkaAssertions.assertThat(new RecordHeaders()
+            .add("foo", "1".getBytes(StandardCharsets.UTF_8))
+            .add("foo", "2".getBytes(StandardCharsets.UTF_8))
+            .add("bar", "3".getBytes(StandardCharsets.UTF_8)));
+    private final HeadersAssert emptyAssert = KafkaAssertions.assertThat(new RecordHeaders());
+
+    @Test
+    void firstHeader() {
+        Assertions.assertThatThrownBy(emptyAssert::firstHeader).isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("[headers] \n"
+                        + "Expecting actual not to be empty");
+        headersAssert.firstHeader().hasKeyEqualTo("foo").hasValueEqualTo("1");
+    }
+
+    @Test
+    void lastHeader() {
+        Assertions.assertThatThrownBy(emptyAssert::lastHeader).isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("[headers] \n"
+                        + "Expecting actual not to be empty");
+        headersAssert.lastHeader().hasKeyEqualTo("bar").hasValueEqualTo("3");
+    }
+
+    @Test
+    void singleHeader() {
+        Assertions.assertThatThrownBy(emptyAssert::singleHeader).isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("[headers] \n"
+                        + "Expected size: 1 but was: 0 in:\n"
+                        + "RecordHeaders(headers = [], isReadOnly = false)");
+        Assertions.assertThatThrownBy(headersAssert::singleHeader).isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void firstHeaderWithKey() {
+        headersAssert.firstHeaderWithKey("foo").hasKeyEqualTo("foo").hasValueEqualTo("1");
+        headersAssert.firstHeaderWithKey("bar").hasKeyEqualTo("bar").hasValueEqualTo("3");
+        Assertions.assertThatThrownBy(() -> headersAssert.firstHeaderWithKey("gee"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("[headers with key gee] \n"
+                        + "Expecting actual not to be empty");
+    }
+
+    @Test
+    void lastHeaderWithKey() {
+        headersAssert.lastHeaderWithKey("foo").hasKeyEqualTo("foo").hasValueEqualTo("2");
+        headersAssert.lastHeaderWithKey("bar").hasKeyEqualTo("bar").hasValueEqualTo("3");
+        Assertions.assertThatThrownBy(() -> headersAssert.lastHeaderWithKey("gee"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("[headers with key gee] \n"
+                        + "Expecting actual not to be empty");
+    }
+
+    @Test
+    void singleHeaderWithKey() {
+        headersAssert.singleHeaderWithKey("bar").hasKeyEqualTo("bar").hasValueEqualTo("3");
+        Assertions.assertThatThrownBy(() -> headersAssert.singleHeaderWithKey("foo"))
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("[headers with key foo] \n"
+                        + "Expected size: 1 but was: 2 in:\n"
+                        + "[RecordHeader(key = foo, value = [49]), RecordHeader(key = foo, value = [50])]");
+    }
+}

--- a/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/assertj/HeadersAssertTest.java
+++ b/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/assertj/HeadersAssertTest.java
@@ -20,7 +20,7 @@ public class HeadersAssertTest {
             .add("bar", "3".getBytes(StandardCharsets.UTF_8)));
     private final HeadersAssert emptyAssert = KafkaAssertions.assertThat(new RecordHeaders());
     HeadersAssert singletonAssert = KafkaAssertions.assertThat(new RecordHeaders()
-            .add("foo", "1".getBytes(StandardCharsets.UTF_8)));
+            .add("foo", null));
 
     @Test
     void firstHeader() {
@@ -45,7 +45,7 @@ public class HeadersAssertTest {
                         + "Expected size: 1 but was: 0 in:\n"
                         + "RecordHeaders(headers = [], isReadOnly = false)");
         Assertions.assertThatThrownBy(headersAssert::singleHeader).isInstanceOf(AssertionError.class);
-        singletonAssert.singleHeader().hasValue();
+        singletonAssert.singleHeader().hasNullValue();
     }
 
     @Test
@@ -76,5 +76,16 @@ public class HeadersAssertTest {
                 .hasMessage("[headers with key foo] \n"
                         + "Expected size: 1 but was: 2 in:\n"
                         + "[RecordHeader(key = foo, value = [49]), RecordHeader(key = foo, value = [50])]");
+    }
+
+    @Test
+    void nullHeaders() {
+        HeadersAssert nullAssert = KafkaAssertions.assertThat((RecordHeaders) null);
+        nullAssert.isNull();
+
+        Assertions.assertThatThrownBy(nullAssert::isNotNull)
+                .isExactlyInstanceOf(AssertionError.class)
+                .hasMessage("[null headers] \n"
+                        + "Expecting actual not to be null");
     }
 }

--- a/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/assertj/HeadersAssertTest.java
+++ b/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/assertj/HeadersAssertTest.java
@@ -19,6 +19,8 @@ public class HeadersAssertTest {
             .add("foo", "2".getBytes(StandardCharsets.UTF_8))
             .add("bar", "3".getBytes(StandardCharsets.UTF_8)));
     private final HeadersAssert emptyAssert = KafkaAssertions.assertThat(new RecordHeaders());
+    HeadersAssert singletonAssert = KafkaAssertions.assertThat(new RecordHeaders()
+            .add("foo", "1".getBytes(StandardCharsets.UTF_8)));
 
     @Test
     void firstHeader() {
@@ -43,6 +45,7 @@ public class HeadersAssertTest {
                         + "Expected size: 1 but was: 0 in:\n"
                         + "RecordHeaders(headers = [], isReadOnly = false)");
         Assertions.assertThatThrownBy(headersAssert::singleHeader).isInstanceOf(AssertionError.class);
+        singletonAssert.singleHeader().hasValue();
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Test

### Description

This PR adds some more assertj Asserts for `ConsumerRecord` and `Headers`. 

### Additional Context

I will be using these in a forthcoming PR, but they're obviously also usable by other tests in the future too.
