### PR TITLE
Add `ClientTlsContext`

### DIFF
--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
@@ -5,6 +5,7 @@
  */
 package io.kroxylicious.proxy.filter;
 
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 import javax.annotation.Nullable;
@@ -13,6 +14,8 @@ import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
+
+import io.kroxylicious.proxy.tls.ClientTlsContext;
 
 /**
  * A context to allow filters to interact with other filters and the pipeline.
@@ -135,6 +138,10 @@ public interface FilterContext {
      * @return virtual cluster name
      */
     String getVirtualClusterName();
-    // TODO an API to allow a filter to add/remove another filter from the pipeline
+
+    /**
+     * @return The TLS context for the client connection, or empty if the client connection is not TLS.
+     */
+    Optional<ClientTlsContext> clientTlsContext();
 
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/tls/ClientTlsContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/tls/ClientTlsContext.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.tls;
+
+import java.security.cert.X509Certificate;
+import java.util.Optional;
+
+import io.kroxylicious.proxy.filter.FilterContext;
+
+/**
+ * Exposes TLS information about the client-to-proxy connection to plugins, for example using {@link FilterContext#clientTlsContext()}.
+ * This is implemented by the runtime for use by plugins.
+ */
+public interface ClientTlsContext {
+    /**
+     * @return The TLS server certificate that the proxy presented to the client during TLS handshake.
+     */
+    X509Certificate proxyServerCertificate();
+
+    /**
+     * @return the client's certificate, or empty if no TLS client certificate was presented during TLS handshake.
+     */
+    Optional<X509Certificate> clientCertificate();
+
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/tls/package-info.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/tls/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * APIs for plugins that are exposed to details of TLS connections between the proxy and its network peers.
+ */
+@ReturnValuesAreNonnullByDefault
+@DefaultAnnotationForParameters(NonNull.class)
+@DefaultAnnotation(NonNull.class)
+package io.kroxylicious.proxy.tls;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotationForParameters;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;

--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -120,6 +120,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-kafka-message-tools</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-filter-test-support</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/AbstractTlsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/AbstractTlsIT.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.SSLHandshakeException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.kroxylicious.net.IntegrationTestInetAddressResolverProvider;
+import io.kroxylicious.proxy.config.secret.FilePassword;
+import io.kroxylicious.proxy.config.secret.InlinePassword;
+import io.kroxylicious.proxy.config.secret.PasswordProvider;
+import io.kroxylicious.proxy.service.HostPort;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.clients.CloseableAdmin;
+import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
+import io.kroxylicious.testing.kafka.common.KafkaClusterFactory;
+import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public abstract class AbstractTlsIT extends BaseIT {
+    static final HostPort PROXY_ADDRESS = HostPort.parse("localhost:9192");
+    static final String TOPIC = "my-test-topic";
+
+    static final String SNI_BASE_ADDRESS = IntegrationTestInetAddressResolverProvider.generateFullyQualifiedDomainName("sni");
+    static final String SNI_BROKER_ADDRESS_PATTERN = "broker-$(nodeId)." + SNI_BASE_ADDRESS;
+    static final HostPort SNI_BOOTSTRAP_ADDRESS = HostPort.parse("bootstrap." + SNI_BASE_ADDRESS + ":9192");
+
+    @TempDir
+    Path certsDirectory;
+    KeytoolCertificateGenerator downstreamCertificateGenerator;
+    KeytoolCertificateGenerator clientCertGenerator;
+    Path clientTrustStore;
+    Path proxyTrustStore;
+
+    static PasswordProvider constructPasswordProvider(Class<? extends PasswordProvider> providerClazz, String password) {
+        if (providerClazz.equals(InlinePassword.class)) {
+            return new InlinePassword(password);
+        }
+        else if (providerClazz.equals(FilePassword.class)) {
+            return new FilePassword(writePasswordToFile(password));
+        }
+        else {
+            throw new IllegalArgumentException("Unexpected provider class: " + providerClazz);
+        }
+    }
+
+    @NonNull
+    static String writePasswordToFile(String password) {
+        try {
+            File tmp = File.createTempFile("password", ".txt");
+            tmp.deleteOnExit();
+            makeFileOwnerReadWriteOnly(tmp);
+            Files.writeString(tmp.toPath(), password);
+            // remove write from owner
+            assertThat(tmp.setWritable(false, true)).isTrue();
+            return tmp.getAbsolutePath();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException("Failed to write password to file", e);
+        }
+    }
+
+    static File writeTrustToTemporaryFile(List<X509Certificate> certificates) {
+        try {
+            var file = File.createTempFile("trust", ".pem");
+            makeFileOwnerReadWriteOnly(file);
+            file.deleteOnExit();
+            var mimeLineEnding = new byte[]{ '\r', '\n' };
+
+            try (var out = new FileOutputStream(file)) {
+                certificates.forEach(c -> {
+                    var encoder = Base64.getMimeEncoder();
+                    try {
+                        out.write("-----BEGIN CERTIFICATE-----".getBytes(StandardCharsets.UTF_8));
+                        out.write(mimeLineEnding);
+                        out.write(encoder.encode(c.getEncoded()));
+                        out.write(mimeLineEnding);
+                        out.write("-----END CERTIFICATE-----".getBytes(StandardCharsets.UTF_8));
+                        out.write(mimeLineEnding);
+                    }
+                    catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                    catch (CertificateEncodingException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+                assertThat(file.setWritable(false, true)).isTrue();
+                return file;
+            }
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException("Failed to write trust to temporary file", e);
+        }
+    }
+
+    private static void makeFileOwnerReadWriteOnly(File f) {
+        // remove read/write from everyone
+        assertThat(f.setReadable(false, false)).isTrue();
+        assertThat(f.setWritable(false, false)).isTrue();
+        // add read/write for owner
+        assertThat(f.setReadable(true, true)).isTrue();
+        assertThat(f.setWritable(true, true)).isTrue();
+    }
+
+    @BeforeEach
+    void beforeEach() throws Exception {
+        // Note that the KeytoolCertificateGenerator generates key stores that are PKCS12 format.
+        this.downstreamCertificateGenerator = new KeytoolCertificateGenerator();
+        this.downstreamCertificateGenerator.generateSelfSignedCertificateEntry("test@kroxylicious.io", "localhost", "KI", "kroxylicious.io", null, null, "US");
+        this.clientTrustStore = certsDirectory.resolve("kafka.truststore.jks");
+        this.downstreamCertificateGenerator.generateTrustStore(this.downstreamCertificateGenerator.getCertFilePath(), "client",
+                clientTrustStore.toAbsolutePath().toString());
+
+        // Generator for certificate that will identify the client
+        this.clientCertGenerator = new KeytoolCertificateGenerator();
+        this.clientCertGenerator.generateSelfSignedCertificateEntry("clientTest@kroxylicious.io", "client", "Dev", "kroxylicious.io", null, null, "US");
+        this.proxyTrustStore = certsDirectory.resolve("proxy.truststore.jks");
+        this.clientCertGenerator.generateTrustStore(clientCertGenerator.getCertFilePath(), "proxy",
+                proxyTrustStore.toAbsolutePath().toString());
+    }
+
+    KafkaCluster createMTlsCluster(KeytoolCertificateGenerator brokerCert, KeytoolCertificateGenerator clientCert) throws Exception {
+        // Note that the annotation driven Kroxylicious Extension doesn't support configuring a cluster that expects client-auth.
+
+        var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
+                .brokerKeytoolCertificateGenerator(brokerCert)
+                // note passing client generator causes ssl.client.auth to be set 'required'
+                .clientKeytoolCertificateGenerator(clientCert)
+                .kraftMode(true)
+                .securityProtocol("SSL")
+                .build());
+        cluster.start();
+
+        var config = new HashMap<>(cluster.getKafkaClientConfiguration());
+
+        // Get the client key material provided by the framework. This will be used to configure Kroxylicious.
+        var keyStore = config.get("ssl.keystore.location").toString();
+        var keyPassword = config.get("ssl.keystore.password").toString();
+        assertThat(keyStore).isNotNull();
+        assertThat(keyPassword).isNotNull();
+
+        var trustStore = config.get("ssl.truststore.location").toString();
+        var trustPassword = config.get("ssl.truststore.password").toString();
+        assertThat(trustStore).isNotNull();
+        assertThat(trustPassword).isNotNull();
+
+        // Validate a TLS client-auth connection to direct the cluster succeeds/fails as expected.
+        assertSuccessfulDirectClientAuthConnectionWithClientCert(cluster);
+        assertUnsuccessfulDirectClientAuthConnectionWithoutClientCert(cluster);
+
+        return cluster;
+    }
+
+    void assertSuccessfulDirectClientAuthConnectionWithClientCert(KafkaCluster cluster) {
+        try (var admin = CloseableAdmin.create(cluster.getKafkaClientConfiguration())) {
+            // Any operation to test successful connection to cluster
+            var result = admin.describeCluster().clusterId();
+            assertThat(result).succeedsWithin(Duration.ofSeconds(10));
+        }
+    }
+
+    void assertUnsuccessfulDirectClientAuthConnectionWithoutClientCert(KafkaCluster cluster) {
+        var config = new HashMap<>(cluster.getKafkaClientConfiguration());
+
+        // remove the client's certificate that the framework has provides.
+        assertThat(config.remove("ssl.keystore.location")).isNotNull();
+        assertThat(config.remove("ssl.keystore.password")).isNotNull();
+
+        try (var admin = CloseableAdmin.create(config)) {
+            // Any operation to test that connection to cluster fails as we don't present a certificate.
+            assertThatThrownBy(() -> admin.describeCluster().clusterId().get(10, TimeUnit.SECONDS)).hasRootCauseInstanceOf(SSLHandshakeException.class)
+                    .hasRootCauseMessage("Received fatal alert: bad_certificate");
+        }
+    }
+
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/PluginTlsApiIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/PluginTlsApiIT.java
@@ -79,8 +79,6 @@ public class PluginTlsApiIT extends AbstractTlsIT {
                 "CN=localhost, OU=KI, O=kroxylicious.io, L=null, ST=null, C=US, emailAddress=test@kroxylicious.io");
     }
 
-
-
     @Test
     void clientTlsContextUnilateralTls(KafkaCluster cluster,
                                        Topic topic) {
@@ -99,7 +97,7 @@ public class PluginTlsApiIT extends AbstractTlsIT {
                 "CN=localhost, OU=KI, O=kroxylicious.io, L=null, ST=null, C=US, emailAddress=test@kroxylicious.io");
     }
 
-        @NonNull
+    @NonNull
     private Optional<Tls> buildGatewayTls(@NonNull TlsClientAuth required,
                                           @Nullable String proxyKeystorePassword) {
         if (required == TlsClientAuth.NONE) {

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/PluginTlsApiIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/PluginTlsApiIT.java
@@ -54,7 +54,7 @@ public class PluginTlsApiIT extends AbstractTlsIT {
                         CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.PLAINTEXT.name),
                 cluster,
                 topic,
-                (byte) 0,
+                false,
                 null,
                 null);
     }
@@ -74,7 +74,7 @@ public class PluginTlsApiIT extends AbstractTlsIT {
                         SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, clientCertGenerator.getPassword()),
                 cluster,
                 topic,
-                (byte) 1,
+                true,
                 "CN=client, OU=Dev, O=kroxylicious.io, L=null, ST=null, C=US, emailAddress=clientTest@kroxylicious.io",
                 "CN=localhost, OU=KI, O=kroxylicious.io, L=null, ST=null, C=US, emailAddress=test@kroxylicious.io");
     }
@@ -92,7 +92,7 @@ public class PluginTlsApiIT extends AbstractTlsIT {
                         SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, proxyKeystorePassword),
                 cluster,
                 topic,
-                (byte) 1,
+                true,
                 null,
                 "CN=localhost, OU=KI, O=kroxylicious.io, L=null, ST=null, C=US, emailAddress=test@kroxylicious.io");
     }
@@ -128,7 +128,7 @@ public class PluginTlsApiIT extends AbstractTlsIT {
                                         Map<String, Object> clientConfigs,
                                         KafkaCluster cluster,
                                         Topic topic,
-                                        byte expectedHeaderKeyClientTls,
+                                        boolean expectHeaderKeyClientTlsPresent,
                                         @Nullable String expectedClientPrincipalName,
                                         @Nullable String expectedProxyPrincipalName) {
         var bootstrapServers = cluster.getBootstrapServers();
@@ -168,8 +168,8 @@ public class PluginTlsApiIT extends AbstractTlsIT {
             }
             var recordHeaders = assertThat(records).singleElement().asInstanceOf(new InstanceOfAssertFactory<>(ConsumerRecord.class, KafkaAssertions::assertThat))
                     .headers();
-            recordHeaders.singleHeaderWithKey(ClientAuthAwareLawyerFilter.HEADER_KEY_CLIENT_TLS).value()
-                    .containsExactly(expectedHeaderKeyClientTls);
+            recordHeaders.singleHeaderWithKey(ClientAuthAwareLawyerFilter.HEADER_KEY_CLIENT_TLS_IS_PRESENT).value()
+                    .containsExactly(expectHeaderKeyClientTlsPresent ? (byte) 1 : (byte) 0);
             recordHeaders.singleHeaderWithKey(ClientAuthAwareLawyerFilter.HEADER_KEY_CLIENT_TLS_CLIENT_X500PRINCIPAL_NAME)
                     .hasValueEqualTo(expectedClientPrincipalName);
             recordHeaders.singleHeaderWithKey(ClientAuthAwareLawyerFilter.HEADER_KEY_CLIENT_TLS_PROXY_X500PRINCIPAL_NAME)

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/PluginTlsApiIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/PluginTlsApiIT.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.assertj.core.api.InstanceOfAssertFactory;
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.proxy.config.ConfigurationBuilder;
+import io.kroxylicious.proxy.config.VirtualClusterBuilder;
+import io.kroxylicious.proxy.config.secret.InlinePassword;
+import io.kroxylicious.proxy.config.tls.TlsClientAuth;
+import io.kroxylicious.proxy.testplugins.ClientAuthAwareLawyerFilter;
+import io.kroxylicious.proxy.testplugins.ClientTlsAwareLawyer;
+import io.kroxylicious.test.assertj.KafkaAssertions;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.junit5ext.Topic;
+
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.defaultPortIdentifiesNodeGatewayBuilder;
+import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PluginTlsApiIT extends AbstractTlsIT {
+
+    @Test
+    void clientTlsAwareFilters(KafkaCluster cluster,
+                               Topic topic) {
+        var bootstrapServers = cluster.getBootstrapServers();
+        var proxyKeystoreLocation = downstreamCertificateGenerator.getKeyStoreLocation();
+        var proxyKeystorePassword = downstreamCertificateGenerator.getPassword();
+
+        var proxyKeystorePasswordProvider = constructPasswordProvider(InlinePassword.class, proxyKeystorePassword);
+
+        // @formatter:off
+        String demoCluster = "demo";
+        var builder = new ConfigurationBuilder()
+                .addNewFilterDefinition("clientConnection", ClientTlsAwareLawyer.class.getName(), null)
+                .addToVirtualClusters(new VirtualClusterBuilder()
+                        .withName(demoCluster)
+                        .addToFilters("clientConnection")
+                            .withNewTargetCluster()
+                                .withBootstrapServers(bootstrapServers)
+                            .endTargetCluster()
+                        .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
+                                .withNewTls()
+                                    .withNewKeyStoreKey()
+                                        .withStoreFile(proxyKeystoreLocation)
+                                        .withStorePasswordProvider(proxyKeystorePasswordProvider)
+                                    .endKeyStoreKey()
+                                    .withNewTrustStoreTrust()
+                                        .withNewServerOptionsTrust()
+                                            .withClientAuth(TlsClientAuth.REQUIRED)
+                                        .endServerOptionsTrust()
+                                        .withStoreFile(proxyTrustStore.toAbsolutePath().toString())
+                                        .withNewInlinePasswordStoreProvider(clientCertGenerator.getPassword())
+                                    .endTrustStoreTrust()
+                                .endTls()
+                                .build())
+                        .build());
+        // @formatter:on
+
+        var clientConfigs = Map.<String, Object> of(
+                CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name,
+                SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, clientTrustStore.toAbsolutePath().toString(),
+                SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, proxyKeystorePassword,
+                SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, clientCertGenerator.getKeyStoreLocation(),
+                SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, clientCertGenerator.getPassword());
+
+        try (var tester = kroxyliciousTester(builder)) {
+
+            try (Producer<String, String> producer = tester.producer(demoCluster, clientConfigs)) {
+                producer.send(new ProducerRecord<>(topic.name(), "hello", "world"));
+                producer.flush();
+            }
+
+            List<ConsumerRecord<String, String>> records;
+            try (var consumer = tester.consumer(demoCluster, clientConfigs)) {
+                TopicPartition tp = new TopicPartition(topic.name(), 0);
+                consumer.assign(Set.of(tp));
+                consumer.seekToBeginning(Set.of(tp));
+                do {
+                    ConsumerRecords<String, String> poll = consumer.poll(Duration.ofMillis(100));
+                    records = poll.records(tp);
+                } while (records.isEmpty());
+            }
+            var recordHeaders = assertThat(records).singleElement().asInstanceOf(new InstanceOfAssertFactory<>(ConsumerRecord.class, KafkaAssertions::assertThat))
+                    .headers();
+            recordHeaders.singleHeaderWithKey(ClientAuthAwareLawyerFilter.HEADER_KEY_CLIENT_TLS).hasValue().containsExactly(1);
+            recordHeaders.singleHeaderWithKey(ClientAuthAwareLawyerFilter.HEADER_KEY_CLIENT_TLS_CLIENT_X500PRINCIPAL_NAME)
+                    .hasValueEqualTo("CN=client, OU=Dev, O=kroxylicious.io, L=null, ST=null, C=US, emailAddress=clientTest@kroxylicious.io");
+            recordHeaders.singleHeaderWithKey(ClientAuthAwareLawyerFilter.HEADER_KEY_CLIENT_TLS_PROXY_X500PRINCIPAL_NAME)
+                    .hasValueEqualTo("CN=localhost, OU=KI, O=kroxylicious.io, L=null, ST=null, C=US, emailAddress=test@kroxylicious.io");
+        }
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/TlsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/TlsIT.java
@@ -7,20 +7,10 @@
 package io.kroxylicious.proxy;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.security.KeyStore;
-import java.security.cert.CertificateEncodingException;
 import java.security.cert.PKIXParameters;
 import java.security.cert.TrustAnchor;
-import java.security.cert.X509Certificate;
 import java.time.Duration;
-import java.util.Base64;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -40,10 +30,8 @@ import org.apache.kafka.common.message.ApiVersionsRequestData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -55,17 +43,11 @@ import io.kroxylicious.proxy.config.secret.InlinePassword;
 import io.kroxylicious.proxy.config.secret.PasswordProvider;
 import io.kroxylicious.proxy.config.tls.AllowDeny;
 import io.kroxylicious.proxy.config.tls.TlsClientAuth;
-import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.test.Request;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
-import io.kroxylicious.testing.kafka.clients.CloseableAdmin;
-import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
-import io.kroxylicious.testing.kafka.common.KafkaClusterFactory;
 import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
 import io.kroxylicious.testing.kafka.common.Tls;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
-
-import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.baseVirtualClusterBuilder;
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.defaultPortIdentifiesNodeGatewayBuilder;
@@ -80,37 +62,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * TODO add integration tests covering kroylicious's ability to use JKS and PEM material. Needs <a href="https://github.com/kroxylicious/kroxylicious-junit5-extension/issues/120">issues#120</a>
  */
 @ExtendWith(KafkaClusterExtension.class)
-class TlsIT extends BaseIT {
-    private static final HostPort PROXY_ADDRESS = HostPort.parse("localhost:9192");
-    private static final String TOPIC = "my-test-topic";
-
-    private static final String SNI_BASE_ADDRESS = IntegrationTestInetAddressResolverProvider.generateFullyQualifiedDomainName("sni");
-    private static final String SNI_BROKER_ADDRESS_PATTERN = "broker-$(nodeId)." + SNI_BASE_ADDRESS;
-    private static final HostPort SNI_BOOTSTRAP_ADDRESS = HostPort.parse("bootstrap." + SNI_BASE_ADDRESS + ":9192");
-
-    @TempDir
-    private Path certsDirectory;
-    private KeytoolCertificateGenerator downstreamCertificateGenerator;
-    private KeytoolCertificateGenerator clientCertGenerator;
-    private Path clientTrustStore;
-    private Path proxyTrustStore;
-
-    @BeforeEach
-    void beforeEach() throws Exception {
-        // Note that the KeytoolCertificateGenerator generates key stores that are PKCS12 format.
-        this.downstreamCertificateGenerator = new KeytoolCertificateGenerator();
-        this.downstreamCertificateGenerator.generateSelfSignedCertificateEntry("test@kroxylicious.io", "localhost", "KI", "kroxylicious.io", null, null, "US");
-        this.clientTrustStore = certsDirectory.resolve("kafka.truststore.jks");
-        this.downstreamCertificateGenerator.generateTrustStore(this.downstreamCertificateGenerator.getCertFilePath(), "client",
-                clientTrustStore.toAbsolutePath().toString());
-
-        // Generator for certificate that will identify the client
-        this.clientCertGenerator = new KeytoolCertificateGenerator();
-        this.clientCertGenerator.generateSelfSignedCertificateEntry("clientTest@kroxylicious.io", "client", "Dev", "kroxylicious.io", null, null, "US");
-        this.proxyTrustStore = certsDirectory.resolve("proxy.truststore.jks");
-        this.clientCertGenerator.generateTrustStore(clientCertGenerator.getCertFilePath(), "proxy",
-                proxyTrustStore.toAbsolutePath().toString());
-    }
+class TlsIT extends AbstractTlsIT {
 
     @Test
     void upstreamUsesSelfSignedTls_TrustStore(@Tls KafkaCluster cluster) {
@@ -120,21 +72,23 @@ class TlsIT extends BaseIT {
         assertThat(brokerTruststore).isNotEmpty();
         assertThat(brokerTruststorePassword).isNotEmpty();
 
+        // @formatter:off
         var builder = new ConfigurationBuilder()
                 .addToVirtualClusters(new VirtualClusterBuilder()
                         .withName("demo")
                         .withNewTargetCluster()
-                        .withBootstrapServers(bootstrapServers)
-                        .withNewTls()
-                        .withNewTrustStoreTrust()
-                        .withStoreFile(brokerTruststore)
-                        .withNewInlinePasswordStoreProvider(brokerTruststorePassword)
-                        .endTrustStoreTrust()
-                        .endTls()
+                            .withBootstrapServers(bootstrapServers)
+                            .withNewTls()
+                                .withNewTrustStoreTrust()
+                                    .withStoreFile(brokerTruststore)
+                                    .withNewInlinePasswordStoreProvider(brokerTruststorePassword)
+                                .endTrustStoreTrust()
+                            .endTls()
                         .endTargetCluster()
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .build())
                         .build());
+        // @formatter:on
 
         try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
             // do some work to ensure connection is opened
@@ -151,22 +105,24 @@ class TlsIT extends BaseIT {
         assertThat(brokerTruststore).isNotEmpty();
         assertThat(brokerTruststorePassword).isNotEmpty();
 
+        // @formatter:off
         var builder = new ConfigurationBuilder()
                 .addToVirtualClusters(new VirtualClusterBuilder()
                         .withName("demo")
                         .withNewTargetCluster()
-                        .withBootstrapServers(bootstrapServers.replace("localhost", "127.0.0.1"))
-                        // 127.0.0.1 is not included as Subject Alternate Name (SAN) so hostname validation will fail.
-                        .withNewTls()
-                        .withNewTrustStoreTrust()
-                        .withStoreFile(brokerTruststore)
-                        .withNewInlinePasswordStoreProvider(brokerTruststorePassword)
-                        .endTrustStoreTrust()
-                        .endTls()
+                            .withBootstrapServers(bootstrapServers.replace("localhost", "127.0.0.1"))
+                            // 127.0.0.1 is not included as Subject Alternate Name (SAN) so hostname validation will fail.
+                            .withNewTls()
+                                .withNewTrustStoreTrust()
+                                    .withStoreFile(brokerTruststore)
+                                    .withNewInlinePasswordStoreProvider(brokerTruststorePassword)
+                                .endTrustStoreTrust()
+                            .endTls()
                         .endTargetCluster()
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .build())
                         .build());
+        // @formatter:on
 
         try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
             // do some work to ensure connection is opened
@@ -197,21 +153,23 @@ class TlsIT extends BaseIT {
 
         var file = writeTrustToTemporaryFile(certificates);
 
+        // @formatter:off
         var builder = new ConfigurationBuilder()
                 .addToVirtualClusters(new VirtualClusterBuilder()
                         .withName("demo")
                         .withNewTargetCluster()
-                        .withBootstrapServers(bootstrapServers)
-                        .withNewTls()
-                        .withNewTrustStoreTrust()
-                        .withStoreFile(file.getAbsolutePath())
-                        .withStoreType("PEM")
-                        .endTrustStoreTrust()
-                        .endTls()
+                            .withBootstrapServers(bootstrapServers)
+                            .withNewTls()
+                                .withNewTrustStoreTrust()
+                                    .withStoreFile(file.getAbsolutePath())
+                                    .withStoreType("PEM")
+                                .endTrustStoreTrust()
+                            .endTls()
                         .endTargetCluster()
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .build())
                         .build());
+        // @formatter:on
 
         try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
             // do some work to ensure connection is opened
@@ -224,17 +182,19 @@ class TlsIT extends BaseIT {
     void upstreamUsesTlsInsecure(@Tls KafkaCluster cluster) {
         var bootstrapServers = cluster.getBootstrapServers();
 
+        // @formatter:off
         var builder = new ConfigurationBuilder()
                 .addToVirtualClusters(new VirtualClusterBuilder()
                         .withName("demo")
                         .withNewTargetCluster()
-                        .withBootstrapServers(bootstrapServers)
-                        .withNewTls()
-                        .withNewInsecureTlsTrust(true)
-                        .endTls()
+                            .withBootstrapServers(bootstrapServers)
+                            .withNewTls()
+                                .withNewInsecureTlsTrust(true)
+                            .endTls()
                         .endTargetCluster()
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS).build())
                         .build());
+        // @formatter:on
 
         try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
             // do some work to ensure connection is opened
@@ -251,78 +211,33 @@ class TlsIT extends BaseIT {
         var clientCert = new KeytoolCertificateGenerator();
         clientCert.generateSelfSignedCertificateEntry("clientTest@kroxylicious.io", "client", "Dev", "Kroxylicious.io", null, null, "US");
 
-        try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
-                .brokerKeytoolCertificateGenerator(brokerCert)
-                // note passing client generator causes ssl.client.auth to be set 'required'
-                .clientKeytoolCertificateGenerator(clientCert)
-                .kraftMode(true)
-                .securityProtocol("SSL")
-                .build())) {
-            cluster.start();
-
-            var config = new HashMap<>(cluster.getKafkaClientConfiguration());
-
-            // Get the client key material provided by the framework. This will be used to configure Kroxylicious.
-            var keyStore = config.get("ssl.keystore.location").toString();
-            var keyPassword = config.get("ssl.keystore.password").toString();
-            assertThat(keyStore).isNotNull();
-            assertThat(keyPassword).isNotNull();
-
-            var trustStore = config.get("ssl.truststore.location").toString();
-            var trustPassword = config.get("ssl.truststore.password").toString();
-            assertThat(trustStore).isNotNull();
-            assertThat(trustPassword).isNotNull();
-
-            // Validate a TLS client-auth connection to direct the cluster succeeds/fails as expected.
-            assertSuccessfulDirectClientAuthConnectionWithClientCert(cluster);
-            assertUnsuccessfulDirectClientAuthConnectionWithoutClientCert(cluster);
-
+        try (var cluster = createMTlsCluster(brokerCert, clientCert)) {
+            // @formatter:off
             var builder = new ConfigurationBuilder()
                     .addToVirtualClusters(new VirtualClusterBuilder()
                             .withName("demo")
                             .withNewTargetCluster()
-                            .withBootstrapServers(cluster.getBootstrapServers())
-                            .withNewTls()
-                            .withNewTrustStoreTrust()
-                            .withStoreFile(trustStore)
-                            .withNewInlinePasswordStoreProvider(trustPassword)
-                            .endTrustStoreTrust()
-                            .withNewKeyStoreKey()
-                            .withStoreFile(keyStore)
-                            .withNewInlinePasswordStoreProvider(keyPassword)
-                            .endKeyStoreKey()
-                            .endTls()
+                                .withBootstrapServers(cluster.getBootstrapServers())
+                                .withNewTls()
+                                    .withNewTrustStoreTrust()
+                                        .withStoreFile((String) cluster.getKafkaClientConfiguration().get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG))
+                                        .withNewInlinePasswordStoreProvider((String) cluster.getKafkaClientConfiguration().get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG))
+                                    .endTrustStoreTrust()
+                                    .withNewKeyStoreKey()
+                                        .withStoreFile((String) cluster.getKafkaClientConfiguration().get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG))
+                                        .withNewInlinePasswordStoreProvider((String) cluster.getKafkaClientConfiguration().get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG))
+                                    .endKeyStoreKey()
+                                .endTls()
                             .endTargetCluster()
                             .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS).build())
                             .build());
+            // @formatter:on
 
             try (var tester = kroxyliciousTester(builder); var admin = tester.admin("demo")) {
                 // do some work to ensure connection is opened
                 final var result = admin.describeCluster().clusterId();
                 assertThat(result).as("Unable to get the clusterId from the Kafka cluster").succeedsWithin(Duration.ofSeconds(10));
             }
-        }
-    }
-
-    private void assertSuccessfulDirectClientAuthConnectionWithClientCert(KafkaCluster cluster) {
-        try (var admin = CloseableAdmin.create(cluster.getKafkaClientConfiguration())) {
-            // Any operation to test successful connection to cluster
-            var result = admin.describeCluster().clusterId();
-            assertThat(result).succeedsWithin(Duration.ofSeconds(10));
-        }
-    }
-
-    private void assertUnsuccessfulDirectClientAuthConnectionWithoutClientCert(KafkaCluster cluster) {
-        var config = new HashMap<>(cluster.getKafkaClientConfiguration());
-
-        // remove the client's certificate that the framework has provides.
-        assertThat(config.remove("ssl.keystore.location")).isNotNull();
-        assertThat(config.remove("ssl.keystore.password")).isNotNull();
-
-        try (var admin = CloseableAdmin.create(config)) {
-            // Any operation to test that connection to cluster fails as we don't present a certificate.
-            assertThatThrownBy(() -> admin.describeCluster().clusterId().get(10, TimeUnit.SECONDS)).hasRootCauseInstanceOf(SSLHandshakeException.class)
-                    .hasRootCauseMessage("Received fatal alert: bad_certificate");
         }
     }
 
@@ -340,27 +255,29 @@ class TlsIT extends BaseIT {
         var brokerTrustPasswordProvider = constructPasswordProvider(providerClazz, brokerTruststorePassword);
         var proxyKeystorePasswordProvider = constructPasswordProvider(providerClazz, proxyKeystorePassword);
 
+        // @formatter:off
         var builder = new ConfigurationBuilder()
                 .addToVirtualClusters(new VirtualClusterBuilder()
                         .withName("demo")
                         .withNewTargetCluster()
-                        .withBootstrapServers(bootstrapServers)
-                        .withNewTls()
-                        .withNewTrustStoreTrust()
-                        .withStoreFile(brokerTruststore)
-                        .withStorePasswordProvider(brokerTrustPasswordProvider)
-                        .endTrustStoreTrust()
-                        .endTls()
+                            .withBootstrapServers(bootstrapServers)
+                            .withNewTls()
+                                .withNewTrustStoreTrust()
+                                    .withStoreFile(brokerTruststore)
+                                    .withStorePasswordProvider(brokerTrustPasswordProvider)
+                                .endTrustStoreTrust()
+                            .endTls()
                         .endTargetCluster()
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .withNewTls()
-                                .withNewKeyStoreKey()
-                                .withStoreFile(proxyKeystoreLocation)
-                                .withStorePasswordProvider(proxyKeystorePasswordProvider)
-                                .endKeyStoreKey()
+                                    .withNewKeyStoreKey()
+                                        .withStoreFile(proxyKeystoreLocation)
+                                        .withStorePasswordProvider(proxyKeystorePasswordProvider)
+                                    .endKeyStoreKey()
                                 .endTls()
                                 .build())
                         .build());
+        // @formatter:on
 
         try (var tester = kroxyliciousTester(builder);
                 var admin = tester.admin("demo",
@@ -378,18 +295,20 @@ class TlsIT extends BaseIT {
         // Protocol we want to use
         AllowDeny<String> protocols = new AllowDeny<>(List.of("TLSv1.2"), null);
 
+        // @formatter:off
         var builder = new ConfigurationBuilder()
                 .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .withNewTls()
-                                .withNewKeyStoreKey()
-                                .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
-                                .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
-                                .endKeyStoreKey()
-                                .withProtocols(protocols)
+                                    .withNewKeyStoreKey()
+                                        .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
+                                        .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
+                                    .endKeyStoreKey()
+                                    .withProtocols(protocols)
                                 .endTls()
                                 .build())
                         .build());
+        // @formatter:on
 
         try (var tester = kroxyliciousTester(builder);
                 var admin = tester.admin("demo",
@@ -426,17 +345,19 @@ class TlsIT extends BaseIT {
     void downstream_UnrecognizedSniHostNameClosesConnection(KafkaCluster cluster) {
         var duffBootstrap = "bootstrap." + IntegrationTestInetAddressResolverProvider.generateFullyQualifiedDomainName("duff") + ":" + SNI_BOOTSTRAP_ADDRESS.port();
 
+        // @formatter:off
         var builder = new ConfigurationBuilder()
                 .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultSniHostIdentifiesNodeGatewayBuilder(SNI_BOOTSTRAP_ADDRESS, SNI_BROKER_ADDRESS_PATTERN)
                                 .withNewTls()
-                                .withNewKeyStoreKey()
-                                .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
-                                .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
-                                .endKeyStoreKey()
+                                    .withNewKeyStoreKey()
+                                        .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
+                                        .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
+                                    .endKeyStoreKey()
                                 .endTls()
                                 .build())
                         .build());
+        // @formatter:on
 
         try (var tester = kroxyliciousTester(builder);
                 var testClient = tester.simpleTestClient(duffBootstrap, true)) {
@@ -454,17 +375,19 @@ class TlsIT extends BaseIT {
     @Test
     void downstream_UntrustedCertificateClosesConnection(KafkaCluster cluster) {
 
+        // @formatter:off
         var builder = new ConfigurationBuilder()
                 .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .withNewTls()
-                                .withNewKeyStoreKey()
-                                .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
-                                .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
-                                .endKeyStoreKey()
+                                    .withNewKeyStoreKey()
+                                        .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
+                                        .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
+                                    .endKeyStoreKey()
                                 .endTls()
                                 .build())
                         .build());
+        // @formatter:on
 
         try (var tester = kroxyliciousTester(builder);
                 // admin won't trust the self signed cert of the broker.
@@ -483,18 +406,20 @@ class TlsIT extends BaseIT {
         // Protocol we want to use
         AllowDeny<String> protocols = new AllowDeny<>(List.of("TLSv1.2"), null);
 
+        // @formatter:off
         var builder = new ConfigurationBuilder()
                 .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .withNewTls()
-                                .withNewKeyStoreKey()
-                                .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
-                                .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
-                                .endKeyStoreKey()
-                                .withProtocols(protocols)
+                                    .withNewKeyStoreKey()
+                                        .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
+                                        .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
+                                    .endKeyStoreKey()
+                                    .withProtocols(protocols)
                                 .endTls()
                                 .build())
                         .build());
+        // @formatter:off
 
         try (var tester = kroxyliciousTester(builder);
                 var admin = tester.admin("demo",
@@ -515,18 +440,20 @@ class TlsIT extends BaseIT {
         // Protocol we want to use
         AllowDeny<String> protocols = new AllowDeny<>(null, Set.of("TLSv1.2"));
 
+        // @formatter:off
         var builder = new ConfigurationBuilder()
                 .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .withNewTls()
-                                .withNewKeyStoreKey()
-                                .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
-                                .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
-                                .endKeyStoreKey()
-                                .withProtocols(protocols)
+                                    .withNewKeyStoreKey()
+                                        .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
+                                        .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
+                                    .endKeyStoreKey()
+                                    .withProtocols(protocols)
                                 .endTls()
                                 .build())
                         .build());
+        // @formatter:on
 
         try (var tester = kroxyliciousTester(builder);
                 var admin = tester.admin("demo",
@@ -555,21 +482,23 @@ class TlsIT extends BaseIT {
         // Protocol we want to use
         AllowDeny<String> protocols = new AllowDeny<>(List.of("TLSv1.2"), null);
 
+        // @formatter:off
         var builder = new ConfigurationBuilder()
                 .addToVirtualClusters(new VirtualClusterBuilder()
                         .withName("demo")
                         .withNewTargetCluster()
-                        .withBootstrapServers(bootstrapServers)
-                        .withNewTls()
-                        .withNewTrustStoreTrust()
-                        .withStoreFile(brokerTruststore)
-                        .withStorePasswordProvider(brokerTrustPasswordProvider)
-                        .endTrustStoreTrust()
-                        .withProtocols(protocols)
-                        .endTls()
+                            .withBootstrapServers(bootstrapServers)
+                            .withNewTls()
+                                .withNewTrustStoreTrust()
+                                    .withStoreFile(brokerTruststore)
+                                    .withStorePasswordProvider(brokerTrustPasswordProvider)
+                                .endTrustStoreTrust()
+                                .withProtocols(protocols)
+                            .endTls()
                         .endTargetCluster()
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS).build())
                         .build());
+        // @formatter:on
 
         try (var tester = kroxyliciousTester(builder);
                 var admin = tester.admin("demo")) {
@@ -592,21 +521,23 @@ class TlsIT extends BaseIT {
         // Protocol we want to use
         AllowDeny<String> protocols = new AllowDeny<>(List.of("TLSv1.1"), null);
 
+        // @formatter:off
         var builder = new ConfigurationBuilder()
                 .addToVirtualClusters(new VirtualClusterBuilder()
                         .withName("demo")
                         .withNewTargetCluster()
-                        .withBootstrapServers(bootstrapServers)
-                        .withNewTls()
-                        .withNewTrustStoreTrust()
-                        .withStoreFile(brokerTruststore)
-                        .withStorePasswordProvider(brokerTrustPasswordProvider)
-                        .endTrustStoreTrust()
-                        .withProtocols(protocols)
-                        .endTls()
+                            .withBootstrapServers(bootstrapServers)
+                            .withNewTls()
+                                .withNewTrustStoreTrust()
+                                    .withStoreFile(brokerTruststore)
+                                    .withStorePasswordProvider(brokerTrustPasswordProvider)
+                                .endTrustStoreTrust()
+                                .withProtocols(protocols)
+                            .endTls()
                         .endTargetCluster()
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS).build())
                         .build());
+        // @formatter:on
 
         try (var tester = kroxyliciousTester(builder);
                 var admin = tester.admin("demo")) {
@@ -625,18 +556,20 @@ class TlsIT extends BaseIT {
         // Cipher we want to use
         AllowDeny<String> cipherSuites = new AllowDeny<>(List.of("TLS_CHACHA20_POLY1305_SHA256"), null);
 
+        // @formatter:off
         var builder = new ConfigurationBuilder()
                 .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .withNewTls()
-                                .withNewKeyStoreKey()
-                                .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
-                                .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
-                                .endKeyStoreKey()
-                                .withCipherSuites(cipherSuites)
+                                    .withNewKeyStoreKey()
+                                        .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
+                                        .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
+                                    .endKeyStoreKey()
+                                    .withCipherSuites(cipherSuites)
                                 .endTls()
                                 .build())
                         .build());
+        // @formatter:on
 
         try (var tester = kroxyliciousTester(builder);
                 var admin = tester.admin("demo",
@@ -673,18 +606,20 @@ class TlsIT extends BaseIT {
         // Cipher we want to use
         AllowDeny<String> cipherSuites = new AllowDeny<>(List.of("TLS_AES_128_GCM_SHA256"), null);
 
+        // @formatter:off
         var builder = new ConfigurationBuilder()
                 .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .withNewTls()
-                                .withNewKeyStoreKey()
-                                .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
-                                .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
-                                .endKeyStoreKey()
-                                .withCipherSuites(cipherSuites)
+                                    .withNewKeyStoreKey()
+                                        .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
+                                        .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
+                                    .endKeyStoreKey()
+                                    .withCipherSuites(cipherSuites)
                                 .endTls()
                                 .build())
                         .build());
+        // @formatter:on
 
         try (var tester = kroxyliciousTester(builder);
                 var admin = tester.admin("demo",
@@ -705,18 +640,20 @@ class TlsIT extends BaseIT {
         // Cipher we want to use
         AllowDeny<String> cipherSuites = new AllowDeny<>(List.of("TLS_CHACHA20_POLY1305_SHA256"), Set.of("TLS_AES_128_GCM_SHA256"));
 
+        // @formatter:off
         var builder = new ConfigurationBuilder()
                 .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .withNewTls()
-                                .withNewKeyStoreKey()
-                                .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
-                                .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
-                                .endKeyStoreKey()
-                                .withCipherSuites(cipherSuites)
+                                    .withNewKeyStoreKey()
+                                        .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
+                                        .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
+                                    .endKeyStoreKey()
+                                    .withCipherSuites(cipherSuites)
                                 .endTls()
                                 .build())
                         .build());
+        // @formatter:on
 
         try (var tester = kroxyliciousTester(builder);
                 var admin = tester.admin("demo",
@@ -745,21 +682,23 @@ class TlsIT extends BaseIT {
         // Cipher we want to use
         AllowDeny<String> cipherSuites = new AllowDeny<>(List.of("TLS_CHACHA20_POLY1305_SHA256"), null);
 
+        // @formatter:off
         var builder = new ConfigurationBuilder()
                 .addToVirtualClusters(new VirtualClusterBuilder()
                         .withName("demo")
                         .withNewTargetCluster()
-                        .withBootstrapServers(bootstrapServers)
-                        .withNewTls()
-                        .withNewTrustStoreTrust()
-                        .withStoreFile(brokerTruststore)
-                        .withStorePasswordProvider(brokerTrustPasswordProvider)
-                        .endTrustStoreTrust()
-                        .withCipherSuites(cipherSuites)
-                        .endTls()
+                            .withBootstrapServers(bootstrapServers)
+                            .withNewTls()
+                                .withNewTrustStoreTrust()
+                                    .withStoreFile(brokerTruststore)
+                                    .withStorePasswordProvider(brokerTrustPasswordProvider)
+                                .endTrustStoreTrust()
+                                .withCipherSuites(cipherSuites)
+                            .endTls()
                         .endTargetCluster()
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS).build())
                         .build());
+        // @formatter:on
 
         try (var tester = kroxyliciousTester(builder);
                 var admin = tester.admin("demo")) {
@@ -782,21 +721,23 @@ class TlsIT extends BaseIT {
         // Cipher we want to use upstream
         AllowDeny<String> upstreamCipherSuites = new AllowDeny<>(List.of("TLS_AES_128_WRONG_CIPHER"), null);
 
+        // @formatter:off
         var builder = new ConfigurationBuilder()
                 .addToVirtualClusters(new VirtualClusterBuilder()
                         .withName("demo")
                         .withNewTargetCluster()
-                        .withBootstrapServers(bootstrapServers)
-                        .withNewTls()
-                        .withNewTrustStoreTrust()
-                        .withStoreFile(brokerTruststore)
-                        .withStorePasswordProvider(brokerTrustPasswordProvider)
-                        .endTrustStoreTrust()
-                        .withCipherSuites(upstreamCipherSuites)
-                        .endTls()
+                            .withBootstrapServers(bootstrapServers)
+                            .withNewTls()
+                                .withNewTrustStoreTrust()
+                                    .withStoreFile(brokerTruststore)
+                                    .withStorePasswordProvider(brokerTrustPasswordProvider)
+                                .endTrustStoreTrust()
+                                .withCipherSuites(upstreamCipherSuites)
+                            .endTls()
                         .endTargetCluster()
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS).build())
                         .build());
+        // @formatter:on
 
         try (var tester = kroxyliciousTester(builder);
                 var admin = tester.admin("demo")) {
@@ -931,96 +872,27 @@ class TlsIT extends BaseIT {
     }
 
     private ConfigurationBuilder constructMutualTlsBuilder(KafkaCluster cluster, TlsClientAuth tlsClientAuth) {
-
+        // @formatter:off
         return new ConfigurationBuilder()
                 .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
-                        .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
+                        .addToGateways(
+                                defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .withNewTls()
-                                .withNewKeyStoreKey()
-                                .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
-                                .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
-                                .endKeyStoreKey()
-                                .withNewTrustStoreTrust()
-                                .withNewServerOptionsTrust()
-                                .withClientAuth(tlsClientAuth)
-                                .endServerOptionsTrust()
-                                .withStoreFile(proxyTrustStore.toAbsolutePath().toString())
-                                .withNewInlinePasswordStoreProvider(clientCertGenerator.getPassword())
-                                .endTrustStoreTrust()
+                                    .withNewKeyStoreKey()
+                                        .withStoreFile(downstreamCertificateGenerator.getKeyStoreLocation())
+                                        .withNewInlinePasswordStoreProvider(downstreamCertificateGenerator.getPassword())
+                                    .endKeyStoreKey()
+                                    .withNewTrustStoreTrust()
+                                        .withNewServerOptionsTrust()
+                                            .withClientAuth(tlsClientAuth)
+                                        .endServerOptionsTrust()
+                                        .withStoreFile(proxyTrustStore.toAbsolutePath().toString())
+                                        .withNewInlinePasswordStoreProvider(clientCertGenerator.getPassword())
+                                    .endTrustStoreTrust()
                                 .endTls()
-                                .build())
+                            .build())
                         .build());
+        // @formatter:on
     }
 
-    private PasswordProvider constructPasswordProvider(Class<? extends PasswordProvider> providerClazz, String password) {
-        if (providerClazz.equals(InlinePassword.class)) {
-            return new InlinePassword(password);
-        }
-        else if (providerClazz.equals(FilePassword.class)) {
-            return new FilePassword(writePasswordToFile(password));
-        }
-        else {
-            throw new IllegalArgumentException("Unexpected provider class: " + providerClazz);
-        }
-
-    }
-
-    @NonNull
-    private String writePasswordToFile(String password) {
-        try {
-            File tmp = File.createTempFile("password", ".txt");
-            tmp.deleteOnExit();
-            makeFileOwnerReadWriteOnly(tmp);
-            Files.writeString(tmp.toPath(), password);
-            // remove write from owner
-            assertThat(tmp.setWritable(false, true)).isTrue();
-            return tmp.getAbsolutePath();
-        }
-        catch (IOException e) {
-            throw new UncheckedIOException("Failed to write password to file", e);
-        }
-    }
-
-    private File writeTrustToTemporaryFile(List<X509Certificate> certificates) {
-        try {
-            var file = File.createTempFile("trust", ".pem");
-            makeFileOwnerReadWriteOnly(file);
-            file.deleteOnExit();
-            var mimeLineEnding = new byte[]{ '\r', '\n' };
-
-            try (var out = new FileOutputStream(file)) {
-                certificates.forEach(c -> {
-                    var encoder = Base64.getMimeEncoder();
-                    try {
-                        out.write("-----BEGIN CERTIFICATE-----".getBytes(StandardCharsets.UTF_8));
-                        out.write(mimeLineEnding);
-                        out.write(encoder.encode(c.getEncoded()));
-                        out.write(mimeLineEnding);
-                        out.write("-----END CERTIFICATE-----".getBytes(StandardCharsets.UTF_8));
-                        out.write(mimeLineEnding);
-                    }
-                    catch (IOException e) {
-                        throw new UncheckedIOException(e);
-                    }
-                    catch (CertificateEncodingException e) {
-                        throw new RuntimeException(e);
-                    }
-                });
-                assertThat(file.setWritable(false, true)).isTrue();
-                return file;
-            }
-        }
-        catch (IOException e) {
-            throw new UncheckedIOException("Failed to write trust to temporary file", e);
-        }
-    }
-
-    private void makeFileOwnerReadWriteOnly(File f) {
-        // remove read/write from everyone
-        assertThat(f.setReadable(false, false)).isTrue();
-        assertThat(f.setWritable(false, false)).isTrue();
-        // add read/write for owner
-        assertThat(f.setReadable(true, true)).isTrue();
-        assertThat(f.setWritable(true, true)).isTrue();
-    }
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/AbstractProduceHeaderInjectionFilter.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/AbstractProduceHeaderInjectionFilter.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.testplugins;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.Record;
+import org.apache.kafka.common.record.RecordBatch;
+
+import io.kroxylicious.kafka.transform.RecordStream;
+import io.kroxylicious.kafka.transform.RecordTransform;
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.ProduceRequestFilter;
+import io.kroxylicious.proxy.filter.RequestFilterResult;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Abstract {@link ProduceRequestFilter} implementation applying the abstract method pattern:
+ * Subclasses implement {@link #headersToAdd(FilterContext)} to return
+ * the headers to be added to the produced records.
+ */
+public abstract class AbstractProduceHeaderInjectionFilter implements ProduceRequestFilter {
+
+    @NonNull
+    protected abstract List<RecordHeader> headersToAdd(FilterContext context);
+
+    @Override
+    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion,
+                                                                 RequestHeaderData header,
+                                                                 ProduceRequestData request,
+                                                                 FilterContext context) {
+        List<RecordHeader> headers = headersToAdd(context);
+
+        for (ProduceRequestData.TopicProduceData topicDatum : request.topicData()) {
+            for (ProduceRequestData.PartitionProduceData partitionDatum : topicDatum.partitionData()) {
+                MemoryRecords records = (MemoryRecords) partitionDatum.records();
+                partitionDatum.setRecords(RecordStream.ofRecords(records)
+                        .toMemoryRecords(
+                                context.createByteBufferOutputStream(records.sizeInBytes()),
+                                new RecordTransform<Void>() {
+                                    @Override
+                                    public void initBatch(RecordBatch batch) {
+
+                                    }
+
+                                    @Override
+                                    public void init(@Nullable Void state, org.apache.kafka.common.record.Record record) {
+
+                                    }
+
+                                    @Override
+                                    public void resetAfterTransform(Void state, org.apache.kafka.common.record.Record record) {
+
+                                    }
+
+                                    @Override
+                                    public long transformOffset(org.apache.kafka.common.record.Record record) {
+                                        return record.offset();
+                                    }
+
+                                    @Override
+                                    public long transformTimestamp(org.apache.kafka.common.record.Record record) {
+                                        return record.timestamp();
+                                    }
+
+                                    @Nullable
+                                    @Override
+                                    public ByteBuffer transformKey(org.apache.kafka.common.record.Record record) {
+                                        return record.key();
+                                    }
+
+                                    @Nullable
+                                    @Override
+                                    public ByteBuffer transformValue(org.apache.kafka.common.record.Record record) {
+                                        return record.value();
+                                    }
+
+                                    @Nullable
+                                    @Override
+                                    public Header[] transformHeaders(Record record) {
+                                        return getHeaders(record, headers);
+                                    }
+                                }));
+            }
+        }
+        return context.forwardRequest(header, request);
+    }
+
+    private Header[] getHeaders(Record record,
+                                List<RecordHeader> headers) {
+        List<Header> result = new ArrayList<>(record.headers().length + headers.size());
+        result.addAll(Arrays.asList(record.headers()));
+        result.addAll(headers);
+        return result.toArray(new Header[0]);
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/ClientAuthAwareLawyerFilter.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/ClientAuthAwareLawyerFilter.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.proxy.testplugins;
 
+import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,24 +34,24 @@ public class ClientAuthAwareLawyerFilter
         return ClientAuthAwareLawyerFilter.class.getSimpleName() + hashtag;
     }
 
-    public static final String HEADER_KEY_CLIENT_TLS = headerName("#clientTlsContext.isPresent");
+    public static final String HEADER_KEY_CLIENT_TLS_IS_PRESENT = headerName("#clientTlsContext.isPresent");
     public static final String HEADER_KEY_CLIENT_TLS_PROXY_X500PRINCIPAL_NAME = headerName("#clientTlsContext.proxyServerCertificate.principalName");
     public static final String HEADER_KEY_CLIENT_TLS_CLIENT_X500PRINCIPAL_NAME = headerName("#clientTlsContext.clientCertificate.principalName");
 
     private static final Map<String, Function<FilterContext, byte[]>> HEADERS = Map.of(
-            HEADER_KEY_CLIENT_TLS,
+            HEADER_KEY_CLIENT_TLS_IS_PRESENT,
             context -> context.clientTlsContext().isPresent() ? new byte[]{ 1 } : new byte[]{ 0 },
             HEADER_KEY_CLIENT_TLS_PROXY_X500PRINCIPAL_NAME,
             context -> context.clientTlsContext()
                     .map(ClientTlsContext::proxyServerCertificate)
                     .map(ClientAuthAwareLawyerFilter::principalName)
-                    .map(String::getBytes)
+                    .map(string -> string.getBytes(StandardCharsets.UTF_8))
                     .orElse(null),
             HEADER_KEY_CLIENT_TLS_CLIENT_X500PRINCIPAL_NAME,
             context -> context.clientTlsContext()
                     .map(ClientTlsContext::clientCertificate)
                     .flatMap(opt -> opt.map(ClientAuthAwareLawyerFilter::principalName))
-                    .map(String::getBytes)
+                    .map(string -> string.getBytes(StandardCharsets.UTF_8))
                     .orElse(null));
 
     private static String principalName(X509Certificate x509Certificate) {

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/ClientAuthAwareLawyerFilter.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/ClientAuthAwareLawyerFilter.java
@@ -16,10 +16,8 @@ import javax.security.auth.x500.X500Principal;
 
 import org.apache.kafka.common.header.internals.RecordHeader;
 
-import io.kroxylicious.proxy.authentication.ClientSaslContext;
 import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.tls.ClientTlsContext;
-import io.kroxylicious.proxy.tls.ServerTlsContext;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -39,14 +37,6 @@ public class ClientAuthAwareLawyerFilter
     public static final String HEADER_KEY_CLIENT_TLS_PROXY_X500PRINCIPAL_NAME = headerName("#clientTlsContext.proxyServerCertificate.principalName");
     public static final String HEADER_KEY_CLIENT_TLS_CLIENT_X500PRINCIPAL_NAME = headerName("#clientTlsContext.clientCertificate.principalName");
 
-    public static final String HEADER_KEY_SERVER_TLS = headerName("#serverTlsContext.isPresent");
-    public static final String HEADER_KEY_SERVER_TLS_PROXY_X500PRINCIPAL_NAME = headerName("#serverTlsContext.serverCertificate.principalName");
-    public static final String HEADER_KEY_SERVER_TLS_SERVER_X500PRINCIPAL_NAME = headerName("#serverTlsContext.proxyClientCertificate.principalName");
-
-    public static final String HEADER_KEY_CLIENT_SASL_CLIENT_SASLPRINCIPAL_NAME = headerName("#clientSaslContext.clientPrincipal");
-    public static final String HEADER_KEY_CLIENT_SASL_MECH_NAME = headerName("#clientSaslContext.mechanismName");
-    public static final String HEADER_KEY_CLIENT_SASL_PROXY_SASLPRINCIPAL_NAME = headerName("#clientSaslContext.proxyServerPrincipal");
-
     private static final Map<String, Function<FilterContext, byte[]>> HEADERS = Map.of(
             HEADER_KEY_CLIENT_TLS,
             context -> context.clientTlsContext().isPresent() ? new byte[]{ 1 } : new byte[]{ 0 },
@@ -61,40 +51,7 @@ public class ClientAuthAwareLawyerFilter
                     .map(ClientTlsContext::clientCertificate)
                     .flatMap(opt -> opt.map(ClientAuthAwareLawyerFilter::principalName))
                     .map(String::getBytes)
-                    .orElse(null),
-
-            HEADER_KEY_SERVER_TLS,
-            context -> context.serverTlsContext().isPresent() ? new byte[]{ 1 } : new byte[]{ 0 },
-            HEADER_KEY_SERVER_TLS_PROXY_X500PRINCIPAL_NAME,
-            context -> context.serverTlsContext()
-                    .map(ServerTlsContext::proxyClientCertificate)
-                    .flatMap(opt -> opt.map(ClientAuthAwareLawyerFilter::principalName))
-                    .map(String::getBytes)
-                    .orElse(null),
-            HEADER_KEY_SERVER_TLS_SERVER_X500PRINCIPAL_NAME,
-            context -> context.serverTlsContext()
-                    .map(ServerTlsContext::serverCertificate)
-                    .map(ClientAuthAwareLawyerFilter::principalName)
-                    .map(String::getBytes)
-                    .orElse(null),
-
-            HEADER_KEY_CLIENT_SASL_CLIENT_SASLPRINCIPAL_NAME,
-            context -> context.clientSaslContext()
-                    .map(ClientSaslContext::authorizationId)
-                    .map(String::getBytes)
-                    .orElse(null),
-            HEADER_KEY_CLIENT_SASL_MECH_NAME,
-            context -> context.clientSaslContext()
-                    .map(ClientSaslContext::mechanismName)
-                    .map(String::getBytes)
-                    .orElse(null),
-            HEADER_KEY_CLIENT_SASL_PROXY_SASLPRINCIPAL_NAME,
-            context -> context.clientSaslContext()
-                    .flatMap(ClientSaslContext::proxyServerId)
-                    .map(String::getBytes)
-                    .orElse(null)
-
-    );
+                    .orElse(null));
 
     private static String principalName(X509Certificate x509Certificate) {
         return x509Certificate.getSubjectX500Principal()

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/ClientAuthAwareLawyerFilter.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/ClientAuthAwareLawyerFilter.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.testplugins;
+
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import javax.security.auth.x500.X500Principal;
+
+import org.apache.kafka.common.header.internals.RecordHeader;
+
+import io.kroxylicious.proxy.authentication.ClientSaslContext;
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.tls.ClientTlsContext;
+import io.kroxylicious.proxy.tls.ServerTlsContext;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A filter that adds {@linkplain FilterContext#clientTlsContext() client-facing TLS context}-dependent headers to produced records.
+ * Tests can consume the produced records and assert that those records have the expected header values.
+ */
+public class ClientAuthAwareLawyerFilter
+        extends AbstractProduceHeaderInjectionFilter {
+
+    @NonNull
+    private static String headerName(String hashtag) {
+        return ClientAuthAwareLawyerFilter.class.getSimpleName() + hashtag;
+    }
+
+    public static final String HEADER_KEY_CLIENT_TLS = headerName("#clientTlsContext.isPresent");
+    public static final String HEADER_KEY_CLIENT_TLS_PROXY_X500PRINCIPAL_NAME = headerName("#clientTlsContext.proxyServerCertificate.principalName");
+    public static final String HEADER_KEY_CLIENT_TLS_CLIENT_X500PRINCIPAL_NAME = headerName("#clientTlsContext.clientCertificate.principalName");
+
+    public static final String HEADER_KEY_SERVER_TLS = headerName("#serverTlsContext.isPresent");
+    public static final String HEADER_KEY_SERVER_TLS_PROXY_X500PRINCIPAL_NAME = headerName("#serverTlsContext.serverCertificate.principalName");
+    public static final String HEADER_KEY_SERVER_TLS_SERVER_X500PRINCIPAL_NAME = headerName("#serverTlsContext.proxyClientCertificate.principalName");
+
+    public static final String HEADER_KEY_CLIENT_SASL_CLIENT_SASLPRINCIPAL_NAME = headerName("#clientSaslContext.clientPrincipal");
+    public static final String HEADER_KEY_CLIENT_SASL_MECH_NAME = headerName("#clientSaslContext.mechanismName");
+    public static final String HEADER_KEY_CLIENT_SASL_PROXY_SASLPRINCIPAL_NAME = headerName("#clientSaslContext.proxyServerPrincipal");
+
+    private static final Map<String, Function<FilterContext, byte[]>> HEADERS = Map.of(
+            HEADER_KEY_CLIENT_TLS,
+            context -> context.clientTlsContext().isPresent() ? new byte[]{ 1 } : new byte[]{ 0 },
+            HEADER_KEY_CLIENT_TLS_PROXY_X500PRINCIPAL_NAME,
+            context -> context.clientTlsContext()
+                    .map(ClientTlsContext::proxyServerCertificate)
+                    .map(ClientAuthAwareLawyerFilter::principalName)
+                    .map(String::getBytes)
+                    .orElse(null),
+            HEADER_KEY_CLIENT_TLS_CLIENT_X500PRINCIPAL_NAME,
+            context -> context.clientTlsContext()
+                    .map(ClientTlsContext::clientCertificate)
+                    .flatMap(opt -> opt.map(ClientAuthAwareLawyerFilter::principalName))
+                    .map(String::getBytes)
+                    .orElse(null),
+
+            HEADER_KEY_SERVER_TLS,
+            context -> context.serverTlsContext().isPresent() ? new byte[]{ 1 } : new byte[]{ 0 },
+            HEADER_KEY_SERVER_TLS_PROXY_X500PRINCIPAL_NAME,
+            context -> context.serverTlsContext()
+                    .map(ServerTlsContext::proxyClientCertificate)
+                    .flatMap(opt -> opt.map(ClientAuthAwareLawyerFilter::principalName))
+                    .map(String::getBytes)
+                    .orElse(null),
+            HEADER_KEY_SERVER_TLS_SERVER_X500PRINCIPAL_NAME,
+            context -> context.serverTlsContext()
+                    .map(ServerTlsContext::serverCertificate)
+                    .map(ClientAuthAwareLawyerFilter::principalName)
+                    .map(String::getBytes)
+                    .orElse(null),
+
+            HEADER_KEY_CLIENT_SASL_CLIENT_SASLPRINCIPAL_NAME,
+            context -> context.clientSaslContext()
+                    .map(ClientSaslContext::authorizationId)
+                    .map(String::getBytes)
+                    .orElse(null),
+            HEADER_KEY_CLIENT_SASL_MECH_NAME,
+            context -> context.clientSaslContext()
+                    .map(ClientSaslContext::mechanismName)
+                    .map(String::getBytes)
+                    .orElse(null),
+            HEADER_KEY_CLIENT_SASL_PROXY_SASLPRINCIPAL_NAME,
+            context -> context.clientSaslContext()
+                    .flatMap(ClientSaslContext::proxyServerId)
+                    .map(String::getBytes)
+                    .orElse(null)
+
+    );
+
+    private static String principalName(X509Certificate x509Certificate) {
+        return x509Certificate.getSubjectX500Principal()
+                .getName(X500Principal.RFC1779,
+                        Map.of("1.2.840.113549.1.9.1", "emailAddress"));
+    }
+
+    @NonNull
+    @Override
+    protected List<RecordHeader> headersToAdd(FilterContext context) {
+        var headers = new ArrayList<RecordHeader>();
+        for (var entry : HEADERS.entrySet()) {
+            headers.add(new RecordHeader(entry.getKey(), entry.getValue().apply(context)));
+        }
+        return headers;
+    }
+
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/ClientTlsAwareLawyer.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/ClientTlsAwareLawyer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.testplugins;
+
+import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.filter.FilterFactory;
+import io.kroxylicious.proxy.filter.FilterFactoryContext;
+import io.kroxylicious.proxy.plugin.Plugin;
+import io.kroxylicious.proxy.plugin.PluginConfigurationException;
+
+@Plugin(configType = Void.class)
+public class ClientTlsAwareLawyer
+        implements FilterFactory<Void, Void> {
+
+    @Override
+    public Void initialize(FilterFactoryContext context, Void config) throws PluginConfigurationException {
+        return config;
+    }
+
+    @Override
+    public Filter createFilter(FilterFactoryContext context, Void config) {
+        return new ClientAuthAwareLawyerFilter();
+    }
+
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/package-info.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+@ReturnValuesAreNonnullByDefault
+@DefaultAnnotationForParameters(NonNull.class)
+@DefaultAnnotation(NonNull.class)
+package io.kroxylicious.proxy.testplugins;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotationForParameters;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;

--- a/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
+++ b/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
@@ -7,3 +7,4 @@ io.kroxylicious.proxy.filter.GenericRequestSpecificResponseFilterFactory
 io.kroxylicious.proxy.filter.GenericResponseSpecificRequestFilterFactory
 io.kroxylicious.proxy.InvocationCountingFilterFactory
 io.kroxylicious.proxy.CreateTopicRequest
+io.kroxylicious.proxy.testplugins.ClientTlsAwareLawyer

--- a/kroxylicious-microbenchmarks/src/main/java/io/kroxylicious/microbenchmarks/InvokerDispatchBenchmark.java
+++ b/kroxylicious-microbenchmarks/src/main/java/io/kroxylicious/microbenchmarks/InvokerDispatchBenchmark.java
@@ -35,7 +35,6 @@ import io.kroxylicious.filters.FourInterfaceFilter1;
 import io.kroxylicious.filters.FourInterfaceFilter2;
 import io.kroxylicious.filters.FourInterfaceFilter3;
 import io.kroxylicious.proxy.filter.ArrayFilterInvoker;
-import io.kroxylicious.proxy.tls.ClientTlsContext;
 import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.FilterInvoker;
@@ -45,6 +44,7 @@ import io.kroxylicious.proxy.filter.RequestFilterResultBuilder;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
 import io.kroxylicious.proxy.filter.ResponseFilterResultBuilder;
 import io.kroxylicious.proxy.filter.SpecificFilterInvoker;
+import io.kroxylicious.proxy.tls.ClientTlsContext;
 
 // try hard to make shouldHandleXYZ to observe different receivers concrete types, saving unrolling to bias a specific call-site to a specific concrete type
 @Fork(value = 2, jvmArgsAppend = "-XX:LoopUnrollLimit=1")

--- a/kroxylicious-microbenchmarks/src/main/java/io/kroxylicious/microbenchmarks/InvokerDispatchBenchmark.java
+++ b/kroxylicious-microbenchmarks/src/main/java/io/kroxylicious/microbenchmarks/InvokerDispatchBenchmark.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.microbenchmarks;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
@@ -34,6 +35,7 @@ import io.kroxylicious.filters.FourInterfaceFilter1;
 import io.kroxylicious.filters.FourInterfaceFilter2;
 import io.kroxylicious.filters.FourInterfaceFilter3;
 import io.kroxylicious.proxy.filter.ArrayFilterInvoker;
+import io.kroxylicious.proxy.tls.ClientTlsContext;
 import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.FilterInvoker;
@@ -176,6 +178,11 @@ public class InvokerDispatchBenchmark {
         @Override
         public String getVirtualClusterName() {
             return null;
+        }
+
+        @Override
+        public Optional<ClientTlsContext> clientTlsContext() {
+            return Optional.empty();
         }
 
         @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientTlsContextImpl.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientTlsContextImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import java.security.cert.X509Certificate;
+import java.util.Optional;
+
+import io.kroxylicious.proxy.tls.ClientTlsContext;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotationForParameters;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;
+
+@ReturnValuesAreNonnullByDefault
+@DefaultAnnotationForParameters(NonNull.class)
+@DefaultAnnotation(NonNull.class)
+class ClientTlsContextImpl implements ClientTlsContext {
+    private final X509Certificate proxyCertificate;
+    private final @Nullable X509Certificate clientCertificate;
+
+    ClientTlsContextImpl(X509Certificate proxyCertificate, @Nullable X509Certificate clientCertificate) {
+        this.proxyCertificate = proxyCertificate;
+        this.clientCertificate = clientCertificate;
+    }
+
+    @Override
+    public X509Certificate proxyServerCertificate() {
+        return proxyCertificate;
+    }
+
+    @Override
+    public Optional<X509Certificate> clientCertificate() {
+        return Optional.ofNullable(clientCertificate);
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -5,10 +5,16 @@
  */
 package io.kroxylicious.proxy.internal;
 
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
 
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.RequestHeaderData;
@@ -25,6 +31,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.netty.handler.ssl.SslHandler;
 
 import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
@@ -46,6 +53,7 @@ import io.kroxylicious.proxy.internal.filter.ResponseFilterResultBuilderImpl;
 import io.kroxylicious.proxy.internal.util.Assertions;
 import io.kroxylicious.proxy.internal.util.ByteBufOutputStream;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
+import io.kroxylicious.proxy.tls.ClientTlsContext;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -480,6 +488,16 @@ public class FilterHandler extends ChannelDuplexHandler {
         }
 
         @Override
+        public @NonNull Optional<ClientTlsContext> clientTlsContext() {
+            return Optional.ofNullable(inboundChannel.pipeline().get(SslHandler.class))
+                    .map(clientFacingSslHandler -> {
+                        final X509Certificate proxyCertificate = Objects.requireNonNull(localTlsCertificate(clientFacingSslHandler));
+                        final X509Certificate clientCertificate = getPeerTlsCertificate(clientFacingSslHandler);
+                        return new ClientTlsContextImpl(proxyCertificate, clientCertificate);
+                    });
+        }
+
+        @Override
         public RequestFilterResultBuilder requestFilterResultBuilder() {
             return new RequestFilterResultBuilderImpl();
         }
@@ -547,6 +565,45 @@ public class FilterHandler extends ChannelDuplexHandler {
             return filterPromise.minimalCompletionStage();
         }
 
+    }
+
+    private @Nullable X509Certificate getPeerTlsCertificate(SslHandler sslHandler) {
+        if (sslHandler != null) {
+            SSLSession session = sslHandler.engine().getSession();
+
+            Certificate[] peerCertificates;
+            try {
+                peerCertificates = session.getPeerCertificates();
+            }
+            catch (SSLPeerUnverifiedException e) {
+                peerCertificates = null;
+            }
+            if (peerCertificates != null && peerCertificates.length > 0) {
+                return Objects.requireNonNull((X509Certificate) peerCertificates[0]);
+            }
+            else {
+                return null;
+            }
+        }
+        else {
+            return null;
+        }
+    }
+
+    private @Nullable X509Certificate localTlsCertificate(SslHandler sslHandler) {
+        if (sslHandler != null) {
+            SSLSession session = sslHandler.engine().getSession();
+            Certificate[] localCertificates = session.getLocalCertificates();
+            if (localCertificates != null && localCertificates.length > 0) {
+                return Objects.requireNonNull((X509Certificate) localCertificates[0]);
+            }
+            else {
+                return null;
+            }
+        }
+        else {
+            return null;
+        }
     }
 
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHandlerTest.java
@@ -5,6 +5,8 @@
  */
 package io.kroxylicious.proxy.internal;
 
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -18,6 +20,10 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
 
 import org.apache.kafka.common.message.ApiMessageType;
 import org.apache.kafka.common.message.ApiVersionsRequestData;
@@ -38,9 +44,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.handler.ssl.SslHandler;
 
 import io.kroxylicious.proxy.filter.ApiVersionsRequestFilter;
 import io.kroxylicious.proxy.filter.ApiVersionsResponseFilter;
@@ -57,14 +65,19 @@ import io.kroxylicious.proxy.frame.OpaqueResponseFrame;
 import io.kroxylicious.proxy.internal.filter.RequestFilterResultBuilderImpl;
 import io.kroxylicious.proxy.internal.filter.ResponseFilterResultBuilderImpl;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class FilterHandlerTest extends FilterHarness {
 
@@ -1196,5 +1209,76 @@ class FilterHandlerTest extends FilterHarness {
             }
         });
         return future;
+    }
+
+    static List<Arguments> clientTlsContext() throws SSLPeerUnverifiedException {
+
+        X509Certificate proxyCertificate = mock(X509Certificate.class);
+        X509Certificate proxyIssuer = mock(X509Certificate.class);
+        X509Certificate clientCertificate = mock(X509Certificate.class);
+        X509Certificate clientIssuer = mock(X509Certificate.class);
+        return List.of(
+                Arguments.argumentSet("mTLS self-signed",
+                        getSslHandler(List.of(proxyCertificate), false, List.of(clientCertificate)),
+                        clientCertificate, proxyCertificate),
+                Arguments.argumentSet("mTLS chains",
+                        getSslHandler(List.of(proxyCertificate, proxyIssuer), false, List.of(clientCertificate, clientIssuer)),
+                        clientCertificate, proxyCertificate),
+                Arguments.argumentSet("null client cert",
+                        getSslHandler(List.of(proxyCertificate), false, null),
+                        null, proxyCertificate),
+                Arguments.argumentSet("empty client cert",
+                        getSslHandler(List.of(proxyCertificate), false, List.of()),
+                        null, proxyCertificate),
+                Arguments.argumentSet("peer unverified",
+                        getSslHandler(List.of(proxyCertificate), true, null),
+                        null, proxyCertificate),
+                Arguments.argumentSet("No TLS",
+                        null, null, null),
+                Arguments.argumentSet("No TLS (empty local certs)",
+                        getSslHandler(List.of(), true, null),
+                        null, null),
+                Arguments.argumentSet("No TLS (empty local certs)",
+                        getSslHandler(null, true, null),
+                        null, null));
+
+    }
+
+    @NonNull
+    private static SslHandler getSslHandler(@Nullable List<X509Certificate> proxyCertificates,
+                                            boolean peerUnverified,
+                                            @Nullable List<X509Certificate> clientCertificates)
+            throws SSLPeerUnverifiedException {
+        var session = mock(SSLSession.class);
+        when(session.getLocalCertificates()).thenReturn(proxyCertificates != null ? proxyCertificates.toArray(new Certificate[0]) : null);
+        if (peerUnverified) {
+            if (clientCertificates != null) {
+                throw new IllegalStateException();
+            }
+            when(session.getPeerCertificates()).thenThrow(new SSLPeerUnverifiedException(""));
+        }
+        else {
+            when(session.getPeerCertificates()).thenReturn(clientCertificates != null ? clientCertificates.toArray(new Certificate[0]) : null);
+        }
+        var engine = mock(SSLEngine.class);
+        Mockito.when(engine.getSession()).thenReturn(session);
+        var handler = mock(SslHandler.class);
+        Mockito.when(handler.engine()).thenReturn(engine);
+        return handler;
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void clientTlsContext(@Nullable SslHandler handler,
+                          @Nullable X509Certificate clientCertificate,
+                          @Nullable X509Certificate proxyCertificate) {
+
+        // when
+        var localCert = FilterHandler.localTlsCertificate(handler);
+        var peerCert = FilterHandler.getPeerTlsCertificate(handler);
+
+        // then
+        assertThat(localCert).isSameAs(proxyCertificate);
+        assertThat(peerCert).isSameAs(clientCertificate);
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR:
* adds the ClientTlsContext interface to the API, 
* adds an accessor from FilterContext, 
* adds the implementation in the runtime
* refactors the existing TlsIT so we can more easily have multiple ITs for TLS-related use cases
* adds a new IT covering the new API. This uses a pattern which I will be reusing in later PRs where we use a header-injecting ProduceRequest filter to add information obtained from the new ClientTlsContext to records, and then assert that, those records have the expected content when consuming those records.

### Additional Context

The PR forms part of the implementation of the new authentication APIs defined in https://github.com/kroxylicious/design/pull/71

This PR allows filters to use information from the TLS client certificate provided by the Kafka client. This could be used for:
* logging purposes
* to implement a SASL initiator for selecting SASL credentials for the exchange with the server based on the client's TLS identity (either principal name, or SAN)
* for filters applying logic which depends on client's TLS identity

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
