### PR TITLE
Better API for `createEndpoint` method in Endpoint class

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -8,7 +8,6 @@ package io.kroxylicious.proxy.internal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
 import org.slf4j.Logger;
@@ -20,7 +19,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
-import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.handler.codec.haproxy.HAProxyMessageDecoder;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
@@ -96,34 +94,22 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
 
         LOGGER.trace("Connection from {} to my address {}", ch.remoteAddress(), ch.localAddress());
 
-        ChannelPipeline pipeline = ch.pipeline();
-
-        var serverSocketChannel = getAcceptingChannel(ch);
-        var serverSocketAddress = serverSocketChannel.localAddress();
-        int targetPort = serverSocketAddress.getPort();
-        var bindingAddress = serverSocketAddress.getAddress().isAnyLocalAddress() ? Optional.<String> empty()
-                : Optional.of(serverSocketAddress.getAddress().getHostAddress());
         if (tls) {
-            initTlsChannel(ch, pipeline, bindingAddress, targetPort);
+            initTlsChannel(ch, ch.pipeline());
         }
         else {
-            initPlainChannel(ch, pipeline, bindingAddress, targetPort);
+            initPlainChannel(ch, ch.pipeline());
         }
-        addLoggingErrorHandler(pipeline);
-    }
-
-    @VisibleForTesting
-    protected ServerSocketChannel getAcceptingChannel(Channel ch) {
-        return (ServerSocketChannel) ch.parent();
+        addLoggingErrorHandler(ch.pipeline());
     }
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    private void initPlainChannel(Channel ch, ChannelPipeline pipeline, Optional<String> bindingAddress, int targetPort) {
+    private void initPlainChannel(Channel ch, ChannelPipeline pipeline) {
         pipeline.addLast("plainResolver", new ChannelInboundHandlerAdapter() {
             @Override
             public void channelActive(ChannelHandlerContext ctx) {
 
-                bindingResolver.resolve(Endpoint.createEndpoint(bindingAddress, targetPort, tls), null)
+                bindingResolver.resolve(Endpoint.createEndpoint(ch, tls), null)
                         .handle((binding, t) -> {
                             if (t != null) {
                                 ctx.fireExceptionCaught(t);
@@ -147,11 +133,11 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
 
     // deep inheritance tree of SniHandler not something we can fix
     @SuppressWarnings({ "OptionalUsedAsFieldOrParameterType", "java:S110" })
-    private void initTlsChannel(Channel ch, ChannelPipeline pipeline, Optional<String> bindingAddress, int targetPort) {
+    private void initTlsChannel(Channel ch, ChannelPipeline pipeline) {
         LOGGER.debug("Adding SSL/SNI handler");
         pipeline.addLast("sniResolver", new SniHandler((sniHostname, promise) -> {
             try {
-                Endpoint endpoint = Endpoint.createEndpoint(bindingAddress, targetPort, tls);
+                Endpoint endpoint = Endpoint.createEndpoint(ch, tls);
                 var stage = bindingResolver.resolve(endpoint, sniHostname);
                 // completes the netty promise when then resolution completes (success/otherwise).
                 stage.handle((binding, t) -> {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/Endpoint.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/net/Endpoint.java
@@ -9,6 +9,9 @@ package io.kroxylicious.proxy.internal.net;
 import java.util.Objects;
 import java.util.Optional;
 
+import io.netty.channel.Channel;
+import io.netty.channel.socket.ServerSocketChannel;
+
 /**
  * Represents a network endpoint.  Network endpoints accepts Kafka protocol traffic on behalf of a virtual clusters.
  *
@@ -19,6 +22,15 @@ import java.util.Optional;
 public record Endpoint(Optional<String> bindingAddress, int port, boolean tls) {
     public Endpoint {
         Objects.requireNonNull(bindingAddress);
+    }
+
+    public static Endpoint createEndpoint(Channel ch, boolean tls) {
+        var serverSocketChannel = (ServerSocketChannel) ch.parent();
+        var serverSocketAddress = serverSocketChannel.localAddress();
+        var bindingAddress = serverSocketAddress.getAddress().isAnyLocalAddress() ? Optional.<String> empty()
+                : Optional.of(serverSocketAddress.getAddress().getHostAddress());
+
+        return new Endpoint(bindingAddress, serverSocketAddress.getPort(), tls);
     }
 
     public static Endpoint createEndpoint(Optional<String> bindingAddress, int port, boolean tls) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -27,10 +27,10 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.netty.buffer.Unpooled;
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.DefaultChannelId;
 import io.netty.channel.EventLoop;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.channel.socket.ServerSocketChannel;
@@ -107,6 +107,7 @@ class KafkaProxyInitializerTest {
         bindingStage = CompletableFuture.completedStage(vcb);
         filterChainFactory = new FilterChainFactory(pfr, List.of());
         final InetSocketAddress localhost = new InetSocketAddress(0);
+        when(channel.parent()).thenReturn(acceptingSocketChannel);
         when(channel.pipeline()).thenReturn(channelPipeline);
         when(channel.eventLoop()).thenReturn(eventLoop);
         when(channel.localAddress()).thenReturn(InetSocketAddress.createUnresolved("localhost", 9099));
@@ -298,7 +299,7 @@ class KafkaProxyInitializerTest {
     void shouldCloseConnectionOnUnrecognizedSniHostName() {
         // Given
         var endpointBindingResolver = mock(EndpointBindingResolver.class);
-        var embeddedChannel = new EmbeddedChannel();
+        var embeddedChannel = new EmbeddedChannel(acceptingSocketChannel, DefaultChannelId.newInstance(), true, false);
         kafkaProxyInitializer = createKafkaProxyInitializer(true, endpointBindingResolver, Map.of());
         kafkaProxyInitializer.initChannel(embeddedChannel);
         when(endpointBindingResolver.resolve(any(), eq("chat4.leancloud.cn"))).thenReturn(CompletableFuture.failedStage(new EndpointResolutionException("not resolved")));
@@ -350,13 +351,7 @@ class KafkaProxyInitializerTest {
                 bindingResolver,
                 (virtualCluster, upstreamNodes) -> null,
                 false,
-                authnMechanismHandlers, new ApiVersionsServiceImpl()) {
-
-            @Override
-            protected ServerSocketChannel getAcceptingChannel(Channel ch) {
-                return acceptingSocketChannel;
-            }
-        };
+                authnMechanismHandlers, new ApiVersionsServiceImpl());
     }
 
     private void assertErrorHandlerAdded() {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/net/EndpointTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/net/EndpointTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.net;
+
+import java.net.InetSocketAddress;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.netty.channel.Channel;
+import io.netty.channel.DefaultChannelId;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EndpointTest {
+
+    @Test
+    void shouldCreateEndpointFromChannel() {
+        // Given
+        Channel ch = new EmbeddedChannel(new NioServerSocketChannel() {
+            @Override
+            public InetSocketAddress localAddress() {
+                return new InetSocketAddress("localhost", 1234);
+            }
+        }, DefaultChannelId.newInstance(), true, false);
+
+        // When
+        Endpoint actual = Endpoint.createEndpoint(ch, false);
+
+        // Then
+        assertThat(actual)
+                .isNotNull()
+                .satisfies(
+                        endpoint -> {
+                            assertThat(endpoint.bindingAddress()).isPresent().hasValue("127.0.0.1");
+                            assertThat(endpoint.port()).isEqualTo(1234);
+                        });
+    }
+
+    @Test
+    void shouldCreateEndpointFromPort() {
+        // Given
+        int port = 1234;
+
+        // When
+        Endpoint actual = Endpoint.createEndpoint(port, false);
+
+        // Then
+        assertThat(actual)
+                .isNotNull()
+                .satisfies(
+                        endpoint -> {
+                            assertThat(endpoint.bindingAddress()).isEmpty();
+                            assertThat(endpoint.port()).isEqualTo(1234);
+                        });
+    }
+
+    @Test
+    void shouldCreateEndpointFromBindingAddress() {
+        // Given
+        var bindingAddress = "127.0.0.1";
+
+        // When
+        Endpoint actual = Endpoint.createEndpoint(Optional.of(bindingAddress), 1234, false);
+
+        // Then
+        assertThat(actual)
+                .isNotNull()
+                .satisfies(
+                        endpoint -> {
+                            assertThat(endpoint.bindingAddress()).isPresent().hasValue("127.0.0.1");
+                            assertThat(endpoint.port()).isEqualTo(1234);
+                        });
+    }
+}


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

This PR fixes #2288. With this PR, we improve the `Endpoint#createEndpoint()` and make sure that the `Endpoint#createEndpoint` method is now responsible for working out which port the accepting channel is associated with, and which network interfaces that port is bound to.


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
