### PR TITLE
fix: record encryption deterministically fails with large messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#2504](https://github.com/kroxylicious/kroxylicious/issues/2504): fix(record-encryption): Record Encryption fails when event size exceeds 1MB
 * [#2491](https://github.com/kroxylicious/kroxylicious/pull/2491): build(deps): bump io.netty:netty-bom from 4.1.121.Final to 4.1.123.Final
 * [#2472](https://github.com/kroxylicious/kroxylicious/pull/2472): Restrictions on which interfaces Filter implementations an implementation could implement have been relaxed.
 * [#2440](https://github.com/kroxylicious/kroxylicious/issues/2440): Fail fast on unknown properties in proxy configuration file 

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryption.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryption.java
@@ -71,6 +71,7 @@ public class RecordEncryption<K, E> implements FilterFactory<RecordEncryptionCon
     });
     private static final KmsMetrics kmsMetrics = MicrometerKmsMetrics.create(Metrics.globalRegistry);
     private static final Logger LOGGER = LoggerFactory.getLogger(RecordEncryption.class);
+    public static final int RECORD_BUFFER_INITIAL_BYTES = 1024 * 1024;
 
     /**
      * Checks that we can build a Cipher for all known CipherSpecs. This prevents us from
@@ -128,7 +129,7 @@ public class RecordEncryption<K, E> implements FilterFactory<RecordEncryptionCon
         FilterThreadExecutor executor = new FilterThreadExecutor(filterThreadExecutor);
         var encryptionManager = new InBandEncryptionManager<>(Encryption.V2,
                 sharedEncryptionContext.dekManager().edekSerde(),
-                1024 * 1024,
+                RECORD_BUFFER_INITIAL_BYTES,
                 8 * 1024 * 1024,
                 sharedEncryptionContext.encryptionDekCache(),
                 executor);

--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -142,6 +142,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes #2504 

> **TL;DR:** This PR fixes a bug where encryption would consistently fail for large message batches (> 1MB). The retry mechanism was incorrectly re-using a partially consumed `Encryptor`. The fix ensures a **new** `Encryptor` is requested from the DEK for any retry attempt.

### The Problem

When a Kafka client sent a large batch of messages that required an encrypted output buffer larger than the initial 1MB, the operation would consistently fail and return an error to the client.

### The Root Cause

The encryption logic follows these steps:
1.  An `Encryptor` object is requested from the Data Encryption Key (DEK) service, authorized for `N` encryption operations to match the `N` records in the batch.
2.  An initial 1MB buffer is allocated for the encrypted output.
3.  As each record is prepared for encryption, the `Encryptor`'s available operation count is decremented.

If the 1MB buffer proved insufficient, a `BufferTooSmallException` was thrown. The process was designed to catch this, increase the buffer size, and retry the entire batch.

The bug was that the **same `Encryptor` object was used for the retry**. By this point, its operation count had already been partially decremented from the first failed attempt. The remaining operation count was now less than the total number of records in the batch, guaranteeing that the retry would also fail.

### The Solution

The fix is to **request a new `Encryptor`** for the retry operation. When a `BufferTooSmallException` occurs:
- The existing, partially used `Encryptor` is discarded.
- A fresh `Encryptor` with the full operation count is fetched from the DEK.
- The encryption is attempted again with the larger buffer.

This change ensures that retries for large messages can succeed. While this may leave some authorized operations from the original `Encryptor` unused, it correctly enforces the security model by preventing any over-spending of encryption allowances. Contrast with #2506 a potential solution that can credit operations back to the Encryptor.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
