### PR TITLE
@NonNull-by-default in kroxylicious-multitenant; Fix API for unknown …

### DIFF
--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactory.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterFactory.java
@@ -7,6 +7,8 @@ package io.kroxylicious.proxy.filter;
 
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 
+import edu.umd.cs.findbugs.annotations.UnknownNullness;
+
 /**
  * <p>A pluggable source of {@link Filter} instances.</p>
  * <p>FilterFactories are:</p>
@@ -44,7 +46,8 @@ public interface FilterFactory<C, I> {
      * @return A configuration state object, specific to the given {@code config}, which will be passed to the other methods of this interface.
      * @throws PluginConfigurationException when the configuration is invalid
      */
-    I initialize(FilterFactoryContext context, C config) throws PluginConfigurationException;
+    @UnknownNullness
+    I initialize(FilterFactoryContext context, @UnknownNullness C config) throws PluginConfigurationException;
 
     /**
      * Creates an instance of the Filter.
@@ -57,7 +60,7 @@ public interface FilterFactory<C, I> {
      * @param initializationData The initialization data that was returned from {@link #initialize(FilterFactoryContext, Object)}.
      * @return the Filter instance.
      */
-    Filter createFilter(FilterFactoryContext context, I initializationData);
+    Filter createFilter(FilterFactoryContext context, @UnknownNullness I initializationData);
 
     /**
      * Called by the runtime to release any resources associated with the given {@code initializationData}.
@@ -65,6 +68,6 @@ public interface FilterFactory<C, I> {
      * Once this method has been called {@link #createFilter(FilterFactoryContext, Object)} won't be called again.
      * @param initializationData The initialization data that was returned from {@link #initialize(FilterFactoryContext, Object)}.
      */
-    default void close(I initializationData) {
+    default void close(@UnknownNullness I initializationData) {
     }
 }

--- a/kroxylicious-filters/kroxylicious-multitenant/pom.xml
+++ b/kroxylicious-filters/kroxylicious-multitenant/pom.xml
@@ -102,6 +102,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/kroxylicious-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenant.java
+++ b/kroxylicious-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenant.java
@@ -8,10 +8,13 @@ package io.kroxylicious.proxy.filter.multitenant;
 
 import java.util.Objects;
 
+import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterFactory;
 import io.kroxylicious.proxy.filter.FilterFactoryContext;
 import io.kroxylicious.proxy.filter.multitenant.config.MultiTenantConfig;
 import io.kroxylicious.proxy.plugin.Plugin;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * A {@link FilterFactory} for {@link MultiTenantFilter}.
@@ -22,12 +25,12 @@ public class MultiTenant implements FilterFactory<MultiTenantConfig, MultiTenant
     private static final MultiTenantConfig DEFAULT_TENANT_CONFIG = new MultiTenantConfig(null);
 
     @Override
-    public MultiTenantConfig initialize(FilterFactoryContext context, MultiTenantConfig config) {
+    public @Nullable MultiTenantConfig initialize(FilterFactoryContext context, @Nullable MultiTenantConfig config) {
         return config;
     }
 
     @Override
-    public MultiTenantFilter createFilter(FilterFactoryContext context, MultiTenantConfig configuration) {
+    public Filter createFilter(FilterFactoryContext context, @Nullable MultiTenantConfig configuration) {
         return new MultiTenantFilter(Objects.requireNonNullElse(configuration, DEFAULT_TENANT_CONFIG));
     }
 }

--- a/kroxylicious-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilter.java
+++ b/kroxylicious-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/MultiTenantFilter.java
@@ -105,7 +105,7 @@ import io.kroxylicious.proxy.filter.TxnOffsetCommitRequestFilter;
 import io.kroxylicious.proxy.filter.TxnOffsetCommitResponseFilter;
 import io.kroxylicious.proxy.filter.multitenant.config.MultiTenantConfig;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Simple multi-tenant filter.
@@ -144,7 +144,7 @@ class MultiTenantFilter
         AddOffsetsToTxnRequestFilter,
         TxnOffsetCommitRequestFilter, TxnOffsetCommitResponseFilter {
     private final String prefixResourceNameSeparator;
-    private String kafkaResourcePrefix;
+    private @Nullable String kafkaResourcePrefix;
 
     @Override
     public CompletionStage<ResponseFilterResult> onApiVersionsResponse(short apiVersion, ResponseHeaderData header, ApiVersionsResponseData response,
@@ -540,7 +540,7 @@ class MultiTenantFilter
         return kafkaResourcePrefix;
     }
 
-    MultiTenantFilter(@NonNull MultiTenantConfig configuration) {
+    MultiTenantFilter(MultiTenantConfig configuration) {
         Objects.requireNonNull(configuration);
         this.prefixResourceNameSeparator = configuration.prefixResourceNameSeparator();
     }

--- a/kroxylicious-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/config/MultiTenantConfig.java
+++ b/kroxylicious-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/config/MultiTenantConfig.java
@@ -10,6 +10,8 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 /**
  * Configuration for the Multi Tenant Filter.
  * @param prefixResourceNameSeparator separator character used to form the prefixed resource name, if not null
@@ -19,7 +21,7 @@ public record MultiTenantConfig(String prefixResourceNameSeparator) {
 
     public static final String DEFAULT_SEPARATOR = "-";
 
-    public MultiTenantConfig(@JsonProperty(required = false) String prefixResourceNameSeparator) {
+    public MultiTenantConfig(@Nullable @JsonProperty(required = false) String prefixResourceNameSeparator) {
         this.prefixResourceNameSeparator = Objects.requireNonNullElse(prefixResourceNameSeparator, DEFAULT_SEPARATOR);
     }
 }

--- a/kroxylicious-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/config/package-info.java
+++ b/kroxylicious-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/config/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+@ReturnValuesAreNonnullByDefault
+@DefaultAnnotationForParameters(NonNull.class)
+@DefaultAnnotation(NonNull.class)
+package io.kroxylicious.proxy.filter.multitenant.config;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotationForParameters;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;

--- a/kroxylicious-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/package-info.java
+++ b/kroxylicious-filters/kroxylicious-multitenant/src/main/java/io/kroxylicious/proxy/filter/multitenant/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+@ReturnValuesAreNonnullByDefault
+@DefaultAnnotationForParameters(NonNull.class)
+@DefaultAnnotation(NonNull.class)
+package io.kroxylicious.proxy.filter.multitenant;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotationForParameters;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;

--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidation.java
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidation.java
@@ -39,6 +39,7 @@ import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 import io.kroxylicious.proxy.plugin.Plugins;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 import static org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule.OAUTHBEARER_MECHANISM;
@@ -69,10 +70,10 @@ public class OauthBearerValidation implements FilterFactory<OauthBearerValidatio
 
     @Override
     @SuppressWarnings("java:S2245") // secure randomization not needed for exponential backoff
-    public SharedOauthBearerValidationContext initialize(FilterFactoryContext context, Config config) throws PluginConfigurationException {
-        Plugins.requireConfig(this, config);
-        setAllowedSaslOauthbearerSysPropIfNecessary(config.jwksEndpointUrl().toString());
-        Config configWithDefaults = initConfigWithDefaults(config);
+    public SharedOauthBearerValidationContext initialize(FilterFactoryContext context, @Nullable Config config) throws PluginConfigurationException {
+        var cfg = Plugins.requireConfig(this, config);
+        setAllowedSaslOauthbearerSysPropIfNecessary(cfg.jwksEndpointUrl().toString());
+        Config configWithDefaults = initConfigWithDefaults(cfg);
         oauthHandler.configure(
                 createSaslConfigMap(configWithDefaults),
                 OAUTHBEARER_MECHANISM,
@@ -119,7 +120,7 @@ public class OauthBearerValidation implements FilterFactory<OauthBearerValidatio
     }
 
     @Override
-    public OauthBearerValidationFilter createFilter(FilterFactoryContext context, SharedOauthBearerValidationContext sharedContext) {
+    public OauthBearerValidationFilter createFilter(FilterFactoryContext context, @NonNull SharedOauthBearerValidationContext sharedContext) {
         return new OauthBearerValidationFilter(context.filterDispatchExecutor(), sharedContext);
     }
 

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/RecordValidation.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/RecordValidation.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.proxy.filter.validation;
 
+import javax.annotation.Nullable;
+
 import io.kroxylicious.proxy.filter.FilterFactory;
 import io.kroxylicious.proxy.filter.FilterFactoryContext;
 import io.kroxylicious.proxy.filter.validation.config.ValidationConfig;
@@ -13,16 +15,18 @@ import io.kroxylicious.proxy.filter.validation.validators.request.ProduceRequest
 import io.kroxylicious.proxy.plugin.Plugin;
 import io.kroxylicious.proxy.plugin.Plugins;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 @Plugin(configType = ValidationConfig.class)
 public class RecordValidation implements FilterFactory<ValidationConfig, ValidationConfig> {
 
     @Override
-    public ValidationConfig initialize(FilterFactoryContext context, ValidationConfig config) {
+    public @NonNull ValidationConfig initialize(FilterFactoryContext context, @Nullable ValidationConfig config) {
         return Plugins.requireConfig(this, config);
     }
 
     @Override
-    public RecordValidationFilter createFilter(FilterFactoryContext context, ValidationConfig configuration) {
+    public RecordValidationFilter createFilter(FilterFactoryContext context, @NonNull ValidationConfig configuration) {
         ProduceRequestValidator validator = ProduceRequestValidatorBuilder.build(configuration);
         return new RecordValidationFilter(validator);
     }

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/proxy/filter/simpletransform/FetchResponseTransformation.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/proxy/filter/simpletransform/FetchResponseTransformation.java
@@ -18,6 +18,9 @@ import io.kroxylicious.proxy.plugin.PluginImplConfig;
 import io.kroxylicious.proxy.plugin.PluginImplName;
 import io.kroxylicious.proxy.plugin.Plugins;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 /**
  * A {@link FilterFactory} for {@link FetchResponseTransformationFilter}.
  */
@@ -25,13 +28,13 @@ import io.kroxylicious.proxy.plugin.Plugins;
 public class FetchResponseTransformation implements FilterFactory<Config, Config> {
 
     @Override
-    public Config initialize(FilterFactoryContext context, Config config) {
+    public @NonNull Config initialize(FilterFactoryContext context, @Nullable Config config) {
         return Plugins.requireConfig(this, config);
     }
 
     @Override
     public FetchResponseTransformationFilter createFilter(FilterFactoryContext context,
-                                                          Config configuration) {
+                                                          @NonNull Config configuration) {
         var factory = context.pluginInstance(ByteBufferTransformationFactory.class, configuration.transformation());
         Objects.requireNonNull(factory, "Violated contract of FilterCreationContext");
         return new FetchResponseTransformationFilter(factory.createTransformation(configuration.transformationConfig()));

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/proxy/filter/simpletransform/ProduceRequestTransformation.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/proxy/filter/simpletransform/ProduceRequestTransformation.java
@@ -6,8 +6,11 @@
 
 package io.kroxylicious.proxy.filter.simpletransform;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterFactory;
 import io.kroxylicious.proxy.filter.FilterFactoryContext;
 import io.kroxylicious.proxy.filter.simpletransform.ProduceRequestTransformation.Config;
@@ -15,6 +18,8 @@ import io.kroxylicious.proxy.plugin.Plugin;
 import io.kroxylicious.proxy.plugin.PluginImplConfig;
 import io.kroxylicious.proxy.plugin.PluginImplName;
 import io.kroxylicious.proxy.plugin.Plugins;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * A {@link FilterFactory} for {@link ProduceRequestTransformationFilter}.
@@ -29,19 +34,19 @@ public class ProduceRequestTransformation
 
     @Override
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public ProduceRequestTransformationFilter createFilter(FilterFactoryContext context,
-                                                           Config configuration) {
+    public Filter createFilter(FilterFactoryContext context,
+                               @NonNull Config configuration) {
         ByteBufferTransformationFactory factory = context.pluginInstance(ByteBufferTransformationFactory.class, configuration.transformation());
         return new ProduceRequestTransformationFilter(factory.createTransformation(configuration.transformationConfig()));
     }
 
     @Override
     @SuppressWarnings({ "unchecked" })
-    public Config initialize(FilterFactoryContext context, Config config) {
-        Plugins.requireConfig(this, config);
-        var transformationFactory = context.pluginInstance(ByteBufferTransformationFactory.class, config.transformation());
-        transformationFactory.validateConfiguration(config.transformationConfig());
-        return config;
+    public @NonNull Config initialize(FilterFactoryContext context, @Nullable Config config) {
+        var result = Plugins.requireConfig(this, config);
+        var transformationFactory = context.pluginInstance(ByteBufferTransformationFactory.class, result.transformation());
+        transformationFactory.validateConfiguration(result.transformationConfig());
+        return result;
     }
 
 }

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/test/java/io/kroxylicious/proxy/filter/simpletransform/ProduceRequestTransformationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/test/java/io/kroxylicious/proxy/filter/simpletransform/ProduceRequestTransformationFilterTest.java
@@ -57,6 +57,10 @@ class ProduceRequestTransformationFilterTest {
     private static final String EXPECTED_TRANSFORMED_RECORD_VALUE = ORIGINAL_RECORD_VALUE.toUpperCase(Locale.ROOT);
     private static final String RECORD_KEY = "key";
     private ProduceRequestTransformationFilter filter;
+
+    @Mock(strictness = Mock.Strictness.LENIENT)
+    FilterFactoryContext factoryContext;
+
     @Mock(strictness = Mock.Strictness.LENIENT)
     FilterContext context;
 
@@ -92,10 +96,24 @@ class ProduceRequestTransformationFilterTest {
     }
 
     @Test
-    void testFactory() {
+    void testFactoryRejectsNullConfig() {
         var factory = new ProduceRequestTransformation();
         assertThatThrownBy(() -> factory.initialize(null, null)).isInstanceOf(PluginConfigurationException.class)
                 .hasMessage(ProduceRequestTransformation.class.getSimpleName() + " requires configuration, but config object is null");
+    }
+
+    @Test
+    void testFactoryAcceptedValidConfig() {
+        var factory = new ProduceRequestTransformation();
+        var tfactory = mock(ByteBufferTransformationFactory.class);
+        when(factoryContext.pluginInstance(any(), any())).thenReturn(tfactory);
+        var cfg = new ProduceRequestTransformation.Config(null, null);
+        factory.initialize(factoryContext, cfg);
+    }
+
+    @Test
+    void testFactory() {
+        var factory = new ProduceRequestTransformation();
         FilterFactoryContext constructContext = mock(FilterFactoryContext.class);
         doReturn(new UpperCasing()).when(constructContext).pluginInstance(any(), any());
         var config = new ProduceRequestTransformation.Config(UpperCasing.class.getName(),

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -71,8 +72,8 @@ public class VirtualClusterModel {
                                boolean logNetwork,
                                boolean logFrames,
                                List<NamedFilterDefinition> filters) {
-        this.clusterName = clusterName;
-        this.targetCluster = targetCluster;
+        this.clusterName = Objects.requireNonNull(clusterName);
+        this.targetCluster = Objects.requireNonNull(targetCluster);
         this.logNetwork = logNetwork;
         this.logFrames = logFrames;
         this.filters = filters;


### PR DESCRIPTION
…nullness

### Type of change


- Refactoring

### Description

* Similar to #2507 but for the multitenant filter. 
* The multitenant filter has _optional_ configuration which has prompted the switch to using @UnknownNullness on the `FilterFactory` interface. This annotation seems to allow subclasses to add their own annotations clarifying their own nullness behaviour which is not the case for @NonNull or @Nullable, where sub- and subclasses have to agree.
* Sadly the plugin factory registry doesn't really handle validating nullness itself. Filters which require config are supposed to use `Plugins.requireConfig(this, config);` in their `initialize()` if their configuration is required. But that forces us into annotating `@Nullable config` in the initialize, and using the `@NonNull` value returned from `requireConfig()` in the rest of the initialize method. This is all a bit unsatisfying.

### Additional Context

Contributes to https://github.com/kroxylicious/kroxylicious/issues/2327
