### PR TITLE
add experimental configuration options to control encryption buffer

### DIFF
--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryption.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/RecordEncryption.java
@@ -27,6 +27,7 @@ import io.micrometer.core.instrument.Metrics;
 
 import io.kroxylicious.filter.encryption.common.FilterThreadExecutor;
 import io.kroxylicious.filter.encryption.config.CipherSpec;
+import io.kroxylicious.filter.encryption.config.EncryptionBufferConfig;
 import io.kroxylicious.filter.encryption.config.EncryptionConfigurationException;
 import io.kroxylicious.filter.encryption.config.KekSelectorService;
 import io.kroxylicious.filter.encryption.config.KmsCacheConfig;
@@ -71,7 +72,6 @@ public class RecordEncryption<K, E> implements FilterFactory<RecordEncryptionCon
     });
     private static final KmsMetrics kmsMetrics = MicrometerKmsMetrics.create(Metrics.globalRegistry);
     private static final Logger LOGGER = LoggerFactory.getLogger(RecordEncryption.class);
-    public static final int RECORD_BUFFER_INITIAL_BYTES = 1024 * 1024;
 
     /**
      * Checks that we can build a Cipher for all known CipherSpecs. This prevents us from
@@ -105,6 +105,7 @@ public class RecordEncryption<K, E> implements FilterFactory<RecordEncryptionCon
     public SharedEncryptionContext<K, E> initialize(FilterFactoryContext context,
                                                     RecordEncryptionConfig configuration)
             throws PluginConfigurationException {
+        LOGGER.debug("Record encryption buffer size configuration: {}", configuration.encryptionBuffer());
         checkCipherSuite();
         KmsService<Object, K, E> kmsPlugin = context.pluginInstance(KmsService.class, configuration.kms());
         kmsPlugin.initialize(configuration.kmsConfig());
@@ -127,10 +128,11 @@ public class RecordEncryption<K, E> implements FilterFactory<RecordEncryptionCon
 
         ScheduledExecutorService filterThreadExecutor = context.filterDispatchExecutor();
         FilterThreadExecutor executor = new FilterThreadExecutor(filterThreadExecutor);
+        EncryptionBufferConfig encryptionBufferConfig = sharedEncryptionContext.configuration().encryptionBuffer();
         var encryptionManager = new InBandEncryptionManager<>(Encryption.V2,
                 sharedEncryptionContext.dekManager().edekSerde(),
-                RECORD_BUFFER_INITIAL_BYTES,
-                8 * 1024 * 1024,
+                encryptionBufferConfig.minSizeBytes(),
+                encryptionBufferConfig.maxSizeBytes(),
                 sharedEncryptionContext.encryptionDekCache(),
                 executor);
 

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/EncryptionBufferConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/config/EncryptionBufferConfig.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.encryption.config;
+
+/**
+ *
+ * @param minSizeBytes the minimum size of the encryption buffer
+ * @param maxSizeBytes the maximum size of the encryption buffer
+ */
+public record EncryptionBufferConfig(int minSizeBytes, int maxSizeBytes) {
+    public EncryptionBufferConfig {
+        if (minSizeBytes <= 0) {
+            throw new IllegalArgumentException("minSizeBytes must be greater than zero");
+        }
+        if (maxSizeBytes <= 0) {
+            throw new IllegalArgumentException("maxSizeBytes must be greater than zero");
+        }
+        if (minSizeBytes > maxSizeBytes) {
+            throw new IllegalArgumentException("minSizeBytes must be less than or equal to maxSizeBytes");
+        }
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/RecordEncryptionFilterIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/encryption/RecordEncryptionFilterIT.java
@@ -59,6 +59,7 @@ import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
 
 import io.kroxylicious.filter.encryption.RecordEncryption;
 import io.kroxylicious.filter.encryption.TemplateKekSelector;
+import io.kroxylicious.filter.encryption.config.RecordEncryptionConfig;
 import io.kroxylicious.filter.encryption.config.UnresolvedKeyPolicy;
 import io.kroxylicious.filter.encryption.crypto.Encryption;
 import io.kroxylicious.filter.encryption.crypto.EncryptionHeader;
@@ -126,7 +127,7 @@ class RecordEncryptionFilterIT {
     }
 
     // Covers a bug, #2504, where large record batches failed to be encrypted. This occurred when the encrypted output for a record batch exceeded
-    // io.kroxylicious.filter.encryption.RecordEncryption#RECORD_BUFFER_INITIAL_BYTES
+    // io.kroxylicious.filter.encryption.config.RecordEncryptionConfig#RECORD_BUFFER_DEFAULT_INITIAL_BYTES
     @TestTemplate
     void roundTripBigRecord(@BrokerConfig(name = "message.max.bytes", value = "2000000") KafkaCluster cluster, Topic topic, TestKmsFacade<?, ?, ?> testKmsFacade)
             throws Exception {
@@ -143,7 +144,7 @@ class RecordEncryptionFilterIT {
                 var producer = tester.producer(Map.of(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, 2000000));
                 var consumer = tester.consumer()) {
 
-            String largerThanInitialEncryptionBuffer = Strings.repeat("a", RecordEncryption.RECORD_BUFFER_INITIAL_BYTES + 1);
+            String largerThanInitialEncryptionBuffer = Strings.repeat("a", RecordEncryptionConfig.RECORD_BUFFER_DEFAULT_INITIAL_BYTES + 1);
             producer.send(new ProducerRecord<>(topic.name(), largerThanInitialEncryptionBuffer)).get(5, TimeUnit.SECONDS);
 
             consumer.subscribe(List.of(topic.name()));


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Users max wish to control the buffer sizes to match their upstream brokers max message size and to tune the initial buffer size to match their workload better.

This is spurred by issue #2504 where a large message cannot be encrypted. I chose to make the settings experimental as the issue is prompting rethinking of the encryption mechanisms.

The potential fix in #2508 may 'waste' some number of encryptions. We always try initializing the buffer at the init size, so if all the traffic is up near the size limit we may waste many encryptions and cause DEKs to rotate without having truly encrypted as much material as we hoped.

We could also potentially track the maximum size of output memory records we've observed globally or per-topic and use that as the initial size.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
