### PR TITLE
fix(docs) align metric names with those actually in use

### DIFF
--- a/docs/_modules/monitoring/con-prometheus-metrics-proxy.adoc
+++ b/docs/_modules/monitoring/con-prometheus-metrics-proxy.adoc
@@ -36,7 +36,7 @@ NOTE: Error conditions signaled _within_ the Kafka protocol response (such as `R
 |===
 |Metric Name |Type |Labels|Description
 
-|`kroxylicious_client_to_proxy_connection_total`
+|`kroxylicious_client_to_proxy_connections_total`
 |Counter
 |`virtual_cluster`, `node_id`
 |Incremented by one every time a connection is accepted from a client by the proxy. +
@@ -77,9 +77,9 @@ Use these metrics to help understand:
 
 * Upstream metrics
 ** `kroxylicious_proxy_to_server_request_total` counts requests as they go to the broker.
-** `kroxylicious_proxy_to_server_response_total` counts responses as they are returned by the broker.
+** `kroxylicious_server_to_proxy_response_total` counts responses as they are returned by the broker.
 ** `kroxylicious_proxy_to_server_request_size_bytes` is incremented by the size of each request as it goes to the broker.
-** `kroxylicious_proxy_to_server_response_size_bytes` is incremented by the size of each response as it is returned by the broker.
+** `kroxylicious_server_to_proxy_response_size_bytes` is incremented by the size of each response as it is returned by the broker.
 
 The size recorded is the encoded size of the protocol message. It includes the 4 byte {kafka-protocol}#protocol_common[message size].
 


### PR DESCRIPTION
### Type of change
- Bugfix
- Documentation

### Description

Fixes a couple of documented metric names which were out of sync with the code

### Additional Context

fixes: #2516 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [x] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
