### PR TITLE
bugfix: asset signatures not attached to release

### DIFF
--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -208,13 +208,19 @@ echo "Creating draft release notes."
 API_COMPATABILITY_REPORT=kroxylicious-api/target/japicmp/"${RELEASE_VERSION}"-compatability.html
 cp kroxylicious-api/target/japicmp/japicmp.html "${API_COMPATABILITY_REPORT}"
 # csplit will create a file for every version as we use ## to denote versions. We also use # CHANGELOG as a header so the current release is actually in the 01 file (zero based)
+APP_BINARY_DISTRIBUTION_ASSET="./kroxylicious-app/target/kroxylicious-app-${RELEASE_VERSION}-bin"
+OPERATOR_BINARY_DISTRIBUTION_ASSET="./kroxylicious-operator-dist/target/kroxylicious-operator-${RELEASE_VERSION}"
 gh release create --title "${RELEASE_TAG}" \
   --notes-file "${RELEASE_NOTES_DIR}/release-notes_01" \
   --draft "${RELEASE_TAG}" \
-  ./kroxylicious-app/target/kroxylicious-app-*.tar.gz \
-  ./kroxylicious-app/target/kroxylicious-app-*.zip \
-  ./kroxylicious-operator-dist/target/kroxylicious-operator-*.tar.gz \
-  ./kroxylicious-operator-dist/target/kroxylicious-operator-*.zip \
+  "${APP_BINARY_DISTRIBUTION_ASSET}.tar.gz" \
+  "${APP_BINARY_DISTRIBUTION_ASSET}.tar.gz.asc" \
+  "${APP_BINARY_DISTRIBUTION_ASSET}.zip" \
+  "${APP_BINARY_DISTRIBUTION_ASSET}.zip.asc" \
+  "${OPERATOR_BINARY_DISTRIBUTION_ASSET}.tar.gz" \
+  "${OPERATOR_BINARY_DISTRIBUTION_ASSET}.tar.gz.asc" \
+  "${OPERATOR_BINARY_DISTRIBUTION_ASSET}.zip" \
+  "${OPERATOR_BINARY_DISTRIBUTION_ASSET}.zip.asc" \
   "${API_COMPATABILITY_REPORT}"
 
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Closes #2503

The 0.13.0 release did not have accompanying .asc files alongside the release assets attached to the github release. I've added them manually after the fact (using the asc files from maven central), we need to fix it for 0.14.0

I've tested locally by building with signing on and checked that the globs line up with the files we want:

```
robeyoun:kroxylicious$ ls -l ./kroxylicious-app/target/kroxylicious-app-*.tar.gz*
-rw-r--r--. 1 robeyoun robeyoun 33685920 Aug  1 15:26 ./kroxylicious-app/target/kroxylicious-app-0.14.0-bin.tar.gz
-rw-r--r--. 1 robeyoun robeyoun      228 Aug  1 15:26 ./kroxylicious-app/target/kroxylicious-app-0.14.0-bin.tar.gz.asc
robeyoun:kroxylicious$ ls -l ./kroxylicious-app/target/kroxylicious-app-*.zip*
-rw-r--r--. 1 robeyoun robeyoun 33695699 Aug  1 15:26 ./kroxylicious-app/target/kroxylicious-app-0.14.0-bin.zip
-rw-r--r--. 1 robeyoun robeyoun      228 Aug  1 15:26 ./kroxylicious-app/target/kroxylicious-app-0.14.0-bin.zip.asc
robeyoun:kroxylicious$ ls -l ./kroxylicious-operator-dist/target/kroxylicious-operator-*.tar.gz*
-rw-r--r--. 1 robeyoun robeyoun 14596 Aug  1 15:26 ./kroxylicious-operator-dist/target/kroxylicious-operator-0.14.0.tar.gz
-rw-r--r--. 1 robeyoun robeyoun   228 Aug  1 15:26 ./kroxylicious-operator-dist/target/kroxylicious-operator-0.14.0.tar.gz.asc
robeyoun:kroxylicious$ ls -l ./kroxylicious-operator-dist/target/kroxylicious-operator-*.zip*
-rw-r--r--. 1 robeyoun robeyoun 40718 Aug  1 15:26 ./kroxylicious-operator-dist/target/kroxylicious-operator-0.14.0.zip
-rw-r--r--. 1 robeyoun robeyoun   228 Aug  1 15:26 ./kroxylicious-operator-dist/target/kroxylicious-operator-0.14.0.zip.asc
```

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
