### PR TITLE
prevent release promotion on a forked repository

### DIFF
--- a/.github/workflows/promote_release.yaml
+++ b/.github/workflows/promote_release.yaml
@@ -63,6 +63,12 @@ jobs:
           fetch-tags: true
           fetch-depth: 0
 
+      - name: 'Require promote-release to be run on base repository'
+        if: ${{ inputs.command == 'promote-release' && github.repository != 'kroxylicious/kroxylicious' }}
+        run: |
+          echo "The 'promote-release' command can only be run from the 'kroxylicious/kroxylicious' repository."
+          exit 1
+
       - name: 'Check team membership'
         if: ${{ github.repository == 'kroxylicious/kroxylicious' }}
         uses: tspascoal/get-user-teams-membership@v3


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

We are able to test release automation changes on a fork, however, we must take care to not actually release! This guardrail helps prevent this accidental release scenario.

Originally suggested by @k-wall here

https://github.com/kroxylicious/kroxylicious/pull/2524#issuecomment-3143608097

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
