### PR TITLE
Build and load operand image into minikube before operator tests

### DIFF
--- a/.github/workflows/operator-maven.yaml
+++ b/.github/workflows/operator-maven.yaml
@@ -82,10 +82,6 @@ jobs:
           load: 'true'
       - name: 'Load Kroxylicious Operand Docker Image in Minikube'
         run: minikube image load  ${{ env.KROXYLICIOUS_IMAGE }}
-      - name: 'Test for unpublished reference release (japicmp)'
-        run: |
-          REFERENCE_RELEASE=$(mvn --quiet -pl kroxylicious-api help:evaluate -Dexpression=ApiCompatability.ReferenceVersion -DforceStdout)
-          echo "REFERENCE_RELEASE_UNPUBLISHED=$(mvn --quiet dependency:get -Dartifact=io.kroxylicious:kroxylicious-parent:${REFERENCE_RELEASE}:pom 1>/dev/null && echo false || echo true)" >> $GITHUB_ENV
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
         if: github.ref_name == 'main' || env.SONAR_TOKEN_SET == 'true'
@@ -103,13 +99,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mvn -B install -Pci -Djapicmp.skip=${REFERENCE_RELEASE_UNPUBLISHED} -pl ':kroxylicious-operator' -am
+          mvn -B install -Pci -Djapicmp.skip=true -pl ':kroxylicious-operator' -am
       - name: 'Build Kroxylicious maven project on main with Sonar'
         if: github.event_name == 'push' && github.ref_name == 'main' && env.SONAR_TOKEN_SET == 'true'
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -B verify -Pci -Djapicmp.skip=${REFERENCE_RELEASE_UNPUBLISHED} org.sonarsource.scanner.maven:sonar-maven-plugin:5.0.0.4389:sonar -Dsonar.projectKey=kroxylicious_kroxylicious  -pl ':kroxylicious-operator,:kroxylicious-parent'
+        run: mvn -B verify -Pci -Djapicmp.skip=true org.sonarsource.scanner.maven:sonar-maven-plugin:5.0.0.4389:sonar -Dsonar.projectKey=kroxylicious_kroxylicious  -pl ':kroxylicious-operator,:kroxylicious-parent'
       - name: Save PR number to file
         if: github.event_name == 'pull_request'
         run: echo ${{ github.event.number }} > PR_NUMBER.txt

--- a/.github/workflows/operator-maven.yaml
+++ b/.github/workflows/operator-maven.yaml
@@ -55,6 +55,33 @@ jobs:
           "kubernetes version": 'v1.32.0'
           "github token": ${{ secrets.GITHUB_TOKEN }}
           driver: docker
+      - name: 'Set up Docker Buildx'
+        uses: docker/setup-buildx-action@v3
+      - name: 'Configure build environment'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          GIT_HASH="$(git rev-parse HEAD)"
+          IMAGE_TAG="dev-git-${GIT_HASH}"
+          KROXYLICIOUS_VERSION="$(mvn org.apache.maven.plugins:maven-help-plugin:3.4.0:evaluate -Dexpression=project.version -q -DforceStdout)"
+          KROXYLICIOUS_IMAGE="quay.io/kroxylicious/kroxylicious:${IMAGE_TAG}"
+          echo "KROXYLICIOUS_VERSION=${KROXYLICIOUS_VERSION}" >> "$GITHUB_ENV"
+          # KROXYLICIOUS_IMAGE env var is used by the Operator ITs
+          echo "KROXYLICIOUS_IMAGE=${KROXYLICIOUS_IMAGE}" >> "$GITHUB_ENV"
+      - name: 'Build tagged Kroxylicious Operand Docker image'
+        uses: docker/build-push-action@v6
+        with:
+          file: Dockerfile
+          context: .
+          build-args:
+            KROXYLICIOUS_VERSION=${{ env.KROXYLICIOUS_VERSION }}
+          tags: ${{ env.KROXYLICIOUS_IMAGE }}
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max,compression=zstd
+          load: 'true'
+      - name: 'Load Kroxylicious Operand Docker Image in Minikube'
+        run: minikube image load  ${{ env.KROXYLICIOUS_IMAGE }}
       - name: 'Test for unpublished reference release (japicmp)'
         run: |
           REFERENCE_RELEASE=$(mvn --quiet -pl kroxylicious-api help:evaluate -Dexpression=ApiCompatability.ReferenceVersion -DforceStdout)
@@ -72,35 +99,11 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - name: 'Build & unit test Kroxylicious operator'
+      - name: 'Build & test Kroxylicious operator'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          GIT_HASH="$(git rev-parse HEAD)"
-          IMAGE_TAG="dev-git-${GIT_HASH}"
-          KROXYLICIOUS_VERSION="$(mvn org.apache.maven.plugins:maven-help-plugin:3.4.0:evaluate -Dexpression=project.version -q -DforceStdout)"
-          KROXYLICIOUS_IMAGE="quay.io/kroxylicious/kroxylicious:${IMAGE_TAG}"
-          echo "KROXYLICIOUS_VERSION=${KROXYLICIOUS_VERSION}" >> "$GITHUB_ENV"
-          # KROXYLICIOUS_IMAGE env var is used by the Operator ITs
-          echo "KROXYLICIOUS_IMAGE=${KROXYLICIOUS_IMAGE}" >> "$GITHUB_ENV"
-          # make sure everything is built and compiles
           mvn -B install -Pci -Djapicmp.skip=${REFERENCE_RELEASE_UNPUBLISHED} -pl ':kroxylicious-operator' -am
-      - name: 'Set up Docker Buildx'
-        uses: docker/setup-buildx-action@v3
-      - name: 'Build tagged Docker image'
-        uses: docker/build-push-action@v6
-        with:
-          file: Dockerfile
-          context: .
-          build-args:
-            KROXYLICIOUS_VERSION=${{ env.KROXYLICIOUS_VERSION }}
-          tags: ${{ env.KROXYLICIOUS_IMAGE }}
-          push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,compression=zstd
-          load: 'true'
-      - name: 'Load Kroxylicious Image in Minikube'
-        run: minikube image load  ${{ env.KROXYLICIOUS_IMAGE }}
       - name: 'Build Kroxylicious maven project on main with Sonar'
         if: github.event_name == 'push' && github.ref_name == 'main' && env.SONAR_TOKEN_SET == 'true'
         env:

--- a/.github/workflows/operator-maven.yaml
+++ b/.github/workflows/operator-maven.yaml
@@ -58,6 +58,7 @@ jobs:
       - name: 'Set up Docker Buildx'
         uses: docker/setup-buildx-action@v3
       - name: 'Configure build environment'
+        id: build_configuration
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -65,23 +66,22 @@ jobs:
           IMAGE_TAG="dev-git-${GIT_HASH}"
           KROXYLICIOUS_VERSION="$(mvn org.apache.maven.plugins:maven-help-plugin:3.4.0:evaluate -Dexpression=project.version -q -DforceStdout)"
           KROXYLICIOUS_IMAGE="quay.io/kroxylicious/kroxylicious:${IMAGE_TAG}"
-          echo "KROXYLICIOUS_VERSION=${KROXYLICIOUS_VERSION}" >> "$GITHUB_ENV"
-          # KROXYLICIOUS_IMAGE env var is used by the Operator ITs
-          echo "KROXYLICIOUS_IMAGE=${KROXYLICIOUS_IMAGE}" >> "$GITHUB_ENV"
+          echo "kroxylicious_version=${KROXYLICIOUS_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "kroxylicious_image=${KROXYLICIOUS_IMAGE}" >> "$GITHUB_OUTPUT"
       - name: 'Build tagged Kroxylicious Operand Docker image'
         uses: docker/build-push-action@v6
         with:
           file: Dockerfile
           context: .
           build-args:
-            KROXYLICIOUS_VERSION=${{ env.KROXYLICIOUS_VERSION }}
-          tags: ${{ env.KROXYLICIOUS_IMAGE }}
+            KROXYLICIOUS_VERSION=${{ steps.build_configuration.outputs.kroxylicious_version }}
+          tags: ${{ steps.build_configuration.outputs.kroxylicious_image }}
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max,compression=zstd
           load: 'true'
       - name: 'Load Kroxylicious Operand Docker Image in Minikube'
-        run: minikube image load  ${{ env.KROXYLICIOUS_IMAGE }}
+        run: minikube image load  ${{ steps.build_configuration.outputs.kroxylicious_image }}
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
         if: github.ref_name == 'main' || env.SONAR_TOKEN_SET == 'true'
@@ -98,6 +98,7 @@ jobs:
       - name: 'Build & test Kroxylicious operator'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KROXYLICIOUS_IMAGE: ${{ steps.build_configuration.outputs.kroxylicious_image }}
         run: |
           mvn -B install -Pci -Djapicmp.skip=true -pl ':kroxylicious-operator' -am
       - name: 'Build Kroxylicious maven project on main with Sonar'
@@ -105,6 +106,7 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KROXYLICIOUS_IMAGE: ${{ steps.build_configuration.outputs.kroxylicious_image }}
         run: mvn -B verify -Pci -Djapicmp.skip=true org.sonarsource.scanner.maven:sonar-maven-plugin:5.0.0.4389:sonar -Dsonar.projectKey=kroxylicious_kroxylicious  -pl ':kroxylicious-operator,:kroxylicious-parent'
       - name: Save PR number to file
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

https://github.com/robobario/kroxylicious/actions/runs/16736506672/job/47376318074?pr=31
```
Error:    KafkaProtocolFilterReconcilerIT.preloadOperandImage:54 » KubernetesClientTimeout Timed out waiting for [120000] milliseconds for [Pod] with name:[preload-operand-image] in namespace [default].
```

Why:
While testing release staging, my release PR failed as the operand tag doesn't exist in quay yet at release time. The intent is to build up a docker image and install it into minikube, using it in the operator integration tests. This means we are testing the operand from the same commit too.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
