### PR TITLE
chore: remove superfluous dependencyManagement declaration (enforcer-…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,6 @@
         <!-- Test dependencies -->
         <strimzi.version>0.47.0</strimzi.version>  <!-- when bumping strimzi, be sure to comment out the kafka.version override in the systemtest module's pom -->
         <kubernetes-client.version>7.3.1</kubernetes-client.version>
-        <enforcer.api.version>3.5.0</enforcer.api.version>
         <maven.core.version>3.9.11</maven.core.version>
         <awaitility.version>4.3.0</awaitility.version>
         <testcontainers.version>1.21.0</testcontainers.version>
@@ -373,11 +372,6 @@
                 <groupId>org.wiremock</groupId>
                 <artifactId>wiremock</artifactId>
                 <version>${wiremock.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.maven.enforcer</groupId>
-                <artifactId>enforcer-api</artifactId>
-                <version>${enforcer.api.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

`enforcer-api` was, AFAIK, never a project dependency.  It somehow crept into the dependencyManagement section of the parent POM.  It is superfluous.  Its removal will cause no functional impact.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
