### PR TITLE
Increase sonatype max wait time for validation to 1 hour

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1034,6 +1034,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>
+                    <waitMaxTime>3600</waitMaxTime>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

https://central.sonatype.org/publish/publish-portal-maven/#waitmaxtime

It took ~40 minutes for sonatype to validate 0.14.0, the default wait time in the maven plugin is 30 minutes. The timeout caused an error log in the release build but did not otherwise prevent any release logic because we were still able to obtain the uploaded deployment id from the maven output.

A bit dodgy perhaps that we don't require the deployment mvn command to succeed. We don't set pipefail so the `| tee` is preventing the maven failure from causing the script to fail.

https://github.com/kroxylicious/kroxylicious/actions/runs/16817598964/job/47637908851

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
