### PR TITLE
Update sonatype docs

### DIFF
--- a/.github/AUTOMATION_README.md
+++ b/.github/AUTOMATION_README.md
@@ -24,22 +24,6 @@ that user initiated actions can, you have to create a separate set of Secrets at
 [docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot).
 In practice this means we have some duplicated secrets across `Actions` and `Dependabot`.
 
-## Sonatype / Maven Central
-
-In order to release to Maven Central, the Kroxylicious Robot has an account at https://central.sonatype.com/.
-This is used by the release stage and promote workflows.
-The credentials for the Kroxylicious Robot are in the 1Password safe.
-
-The workflows themselves authenticate using a Sonatype *user token* belonging to the  Kroxylicious Robot.  There's no
-expiration on the token.
-
-To refresh the token:
-
-1. Login to https://central.sonatype.com/ as the Kroxylicious Robot.
-2. Navigate to "View Account".
-3. Select "Generate user token"
-4. Store the username and password at the Github organisational level in variable/secret `KROXYLICIOUS_SONATYPE_TOKEN_USERNAME` and `KROXYLICIOUS_SONATYPE_TOKEN_PASSWORD`
-
 ## Fortanix DSM Integration Tests
 
 In order for CI to execute the Fortanix DSM Integration Tests, a Fortanix DSM SaaS account has been created.  kroxylicious-admin@.. is an

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,10 +8,12 @@ At a high level, the process is as follows:
 
 1. The developer prepares the release blog post.
 1. The developer adds their private key/passphrase as repository secrets
+1. The developer generates a new sonatype User Token, installs it credentials into GitHub, installs it into their local maven settings for testing
 1. The workflow `stage_release` tags, builds/signs the release, and stages the release on a Nexus staging repository. This process uses the GitHub machine account [kroxylicious-robot](https://github.com/kroxylicious-robot) and a user token owned by Sonatype account `kroxylicious` account.
 1. The stage release is verified using manual verification steps.
 1. The release is made public.
 1. The developer removes their private key/passphrase from the repository secrets.
+1. The developer revokes the sonatype User Token
 
 ## Pre-Requisites
 
@@ -39,6 +41,25 @@ gpg --armor --export-secret-key ${KEY_ID} | pbcopy
 ```
 
 While `pbcopy` is macOS specific, similar utilities exist for Linux see [StackExchange](https://superuser.com/a/288333)
+
+## Generate Sonatype Usen Token and install it
+
+In order to release to Maven Central, the Kroxylicious Robot has an account at https://central.sonatype.com/.
+This is used by the release stage and promote workflows.
+The credentials for the Kroxylicious Robot are in the 1Password safe.
+
+The workflows themselves authenticate using a Sonatype *user token* belonging to the  Kroxylicious Robot.  There's no
+expiration on the token, so we create a token for the duration of the release, and then revoke it at the end.
+
+To create the token and install it:
+
+1. Login to https://central.sonatype.com/ as the Kroxylicious Robot.
+2. Navigate to "View Account".
+3. Select "Generate user token"
+4. Store the username and password at the Github organisational level in variable/secret `KROXYLICIOUS_SONATYPE_TOKEN_USERNAME` and `KROXYLICIOUS_SONATYPE_TOKEN_PASSWORD`
+5. [Configure Maven](https://central.sonatype.org/publish/publish-portal-api/#maven) to download staged artefacts from Central Publishing Portal.
+   You will need to replace the example Bearer token with the Sonatype User Token credentials, run `printf "example_username:example_password" | base64` 
+   to obtain your Bearer token.
 
 ## Prepare the release blog post
 
@@ -69,11 +90,10 @@ If anything goes wrong, follow the steps in [Failed Releases](#failed-releases)
 You can validate the staged artefacts by using a test application, `T`, use the Maven artefacts.   The [kroxylicious-wasm](https://github.com/andreaTP/kroxylicious-wasm) from the
 [community-gallery](https://github.com/kroxylicious/kroxylicious-community-gallery) is a suitable choice.
 
-1. [Configure Maven](https://central.sonatype.org/publish/publish-portal-api/#verify-status-of-the-deployment)) to download staged artefacts from Central Publishing Portal.
 1. Run `T` build/test cycle but use an alternative cache location to be sure artefacts are being fetched.  Check the build output, you'll see the
    kroxylicious comes from the staging location.
 ```bash
-MAVEN_OPTS="-Dmaven.repo.local=/tmp/repository" mvn verify -Dkroxylicious.version=<new release version>
+MAVEN_OPTS="-Dmaven.repo.local=/tmp/repository" mvn verify -Dkroxylicious.version=<new release version> -Pcentral.manual.testing
 ```
 If the build passes, proceed to make the release public.
 The local changes made to `T`'s POM can be reverted.
@@ -98,5 +118,11 @@ This will drop the snapshot repository, delete the release notes and close PR.
 Update the private key/passphrase secrets from the
 [repository secrets](https://github.com/kroxylicious/kroxylicious/settings/secrets/actions) to whitespace.
 
+### Revoke Sonatype Token
 
-
+To revoke the User Token:
+1. Login to https://central.sonatype.com/ as the Kroxylicious Robot.
+2. Navigate to "View Account".
+3. Select "Revoke User Token"
+4. Update the kroxylicious organization variable/secret `KROXYLICIOUS_SONATYPE_TOKEN_USERNAME` and `KROXYLICIOUS_SONATYPE_TOKEN_PASSWORD` to empty string.
+5. Remove the sonatype Bearer token from your local `~/.m2/settings.xml`


### PR DESCRIPTION
### Type of change

- Documentation

### Description

1. moves sonatype token generation details into the releasing doc. seems more natural than the github automation doc
2. makes sonatype token generation and revocation part of the workflow

Why generate and revoke sonatype user tokens?

This mitigates:
1. deployment failures if the token is regenerated between releases for purposes like automation testing, where we run staging jobs on our forks.
2. risks of the token being compromised. If we use a single long-lived token that gets left loafing around in our local ~/.m2/settings.xml we are risking our token getting stolen and a bad actor deploying to sonatype/central.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
