### PR TITLE
Fix quick start proxy port

### DIFF
--- a/docs/proxy-quick-start/index.adoc
+++ b/docs/proxy-quick-start/index.adoc
@@ -1,6 +1,7 @@
 :experimental:
 :kafka-version: 4.0.0
 :kafka-image: apache/kafka:{kafka-version}
+:proxy-bootstrap: localhost:9192
 include::_assets/attributes.adoc[]
 
 = Proxy Quick Start
@@ -100,28 +101,28 @@ Finally, point your Kafka clients to the proxy's bootstrap address and send it s
 
 Use the `kafka-topics.sh` client to create a topic named `my_topic` through the proxy.
 
-[source,bash]
+[source,bash,subs="attributes"]
 ----
 bin/kafka-topics.sh --create --topic my_topic \
---bootstrap-server localhost:9292
+--bootstrap-server {proxy-bootstrap}
 ----
 
 === Produce a Message
 
 Send "hello world" to your new topic using the console producer.
 
-[source,bash]
+[source,bash,subs="attributes"]
 ----
 echo "hello world" | bin/kafka-console-producer.sh --topic my_topic \
---bootstrap-server localhost:9292
+--bootstrap-server {proxy-bootstrap}
 ----
 
 === Consume the Message
 
 Read the message back from your topic using the console consumer.
 
-[source,bash]
+[source,bash,subs="attributes"]
 ----
 bin/kafka-console-consumer.sh --topic my_topic --from-beginning \
---bootstrap-server localhost:9292
+--bootstrap-server {proxy-bootstrap}
 ----


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The proxy listens on 9192 in the example config. D'oh!

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
