### PR TITLE
Prototype: Principal-aware Labelling API

### DIFF
--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
@@ -16,6 +16,7 @@ import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 
 import io.kroxylicious.proxy.authentication.ClientSaslContext;
+import io.kroxylicious.proxy.labels.LabelService;
 import io.kroxylicious.proxy.tls.ClientTlsContext;
 
 /**
@@ -183,5 +184,7 @@ public interface FilterContext {
      * has not successfully authenticated using SASL.
      */
     Optional<ClientSaslContext> clientSaslContext();
+
+    LabelService labels();
 
 }

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/labels/Label.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/labels/Label.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.labels;
+
+public record Label(String key, String value) {}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/labels/LabelService.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/labels/LabelService.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.labels;
+
+import java.util.Set;
+
+public interface LabelService {
+    Set<Label> labels(LabelledResource resource, String resourceName);
+
+    // real service should be async
+    default boolean hasAnyOf(LabelledResource resource, String resourceName, Set<Label> labels) {
+        var allLabels = labels(resource, resourceName);
+        return labels.stream().anyMatch(allLabels::contains);
+    }
+
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/labels/LabelledResource.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/labels/LabelledResource.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.labels;
+
+// enum? or we could make it String, so user Filters can label business resources?
+public enum LabelledResource {
+    TOPIC
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/labels/package-info.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/labels/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+@ReturnValuesAreNonnullByDefault
+@DefaultAnnotationForParameters(NonNull.class)
+@DefaultAnnotation(NonNull.class)
+package io.kroxylicious.proxy.labels;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotationForParameters;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;

--- a/kroxylicious-bom/pom.xml
+++ b/kroxylicious-bom/pom.xml
@@ -161,6 +161,12 @@
 
             <dependency>
                 <groupId>io.kroxylicious</groupId>
+                <artifactId>kroxylicious-labels</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.kroxylicious</groupId>
                 <artifactId>kroxylicious-multitenant</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/kroxylicious-filters/pom.xml
+++ b/kroxylicious-filters/pom.xml
@@ -57,6 +57,7 @@
                                         <include>io.kroxylicious:kroxylicious-integration-test-support</include>
                                         <include>io.kroxylicious:kroxylicious-kafka-message-tools</include>
                                         <include>io.kroxylicious:kroxylicious-runtime:*:*:test</include>
+                                        <include>io.kroxylicious:kroxylicious-labels:*:*:test</include>
                                     </includes>
                                 </bannedDependencies>
                             </rules>

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
@@ -492,7 +492,7 @@ class ConfigurationTest {
         List<VirtualClusterGateway> defaultGateway = List.of(VIRTUAL_CLUSTER_GATEWAY);
         TargetCluster targetCluster = new TargetCluster("unused:9082", Optional.empty());
         List<VirtualCluster> virtualClusters = List
-                .of(new VirtualCluster("vc1", targetCluster, defaultGateway, false, false, List.of("missing")));
+                .of(new VirtualCluster("vc1", targetCluster, defaultGateway, false, false, List.of("missing"), null));
         assertThatThrownBy(() -> new Configuration(
                 null, filterDefinitions,
                 null,
@@ -516,7 +516,7 @@ class ConfigurationTest {
         List<String> defaultFilters = List.of("used1");
         List<VirtualClusterGateway> defaultGateway = List.of(VIRTUAL_CLUSTER_GATEWAY);
         TargetCluster targetCluster = new TargetCluster("unused:9082", Optional.empty());
-        List<VirtualCluster> virtualClusters = List.of(new VirtualCluster("vc1", targetCluster, defaultGateway, false, false, List.of("used2")));
+        List<VirtualCluster> virtualClusters = List.of(new VirtualCluster("vc1", targetCluster, defaultGateway, false, false, List.of("used2"), null));
         assertThatThrownBy(() -> new Configuration(null, filterDefinitions,
                 defaultFilters,
                 virtualClusters,
@@ -539,7 +539,7 @@ class ConfigurationTest {
                         Optional.empty())),
                 false,
                 false,
-                List.of("foo")); // filters defined on cluster
+                List.of("foo"), null); // filters defined on cluster
 
         VirtualCluster defaulted = new VirtualCluster("defaulted", new TargetCluster("x:9092", Optional.empty()),
                 List.of(new VirtualClusterGateway("mygateway",
@@ -548,7 +548,7 @@ class ConfigurationTest {
                         Optional.empty())),
                 false,
                 false,
-                null); // filters not defined => should default to the top level
+                null, null); // filters not defined => should default to the top level
 
         Configuration configuration = new Configuration(
                 null, filterDefinitions,

--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -35,6 +35,11 @@
         </dependency>
         <dependency>
             <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-labels</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-runtime</artifactId>
             <scope>test</scope>
         </dependency>

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/LabelIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/LabelIT.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.proxy;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.assertj.core.api.InstanceOfAssertFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
+
+import io.kroxylicious.proxy.config.ConfigurationBuilder;
+import io.kroxylicious.proxy.config.NamedFilterDefinition;
+import io.kroxylicious.proxy.config.NamedLabelSourceDefinition;
+import io.kroxylicious.proxy.config.VirtualClusterBuilder;
+import io.kroxylicious.proxy.config.secret.InlinePassword;
+import io.kroxylicious.proxy.config.tls.Tls;
+import io.kroxylicious.proxy.config.tls.TlsBuilder;
+import io.kroxylicious.proxy.config.tls.TlsClientAuth;
+import io.kroxylicious.proxy.labels.Label;
+import io.kroxylicious.proxy.labels.LabelledResource;
+import io.kroxylicious.proxy.labels.source.simple.InlineLabelSourceFactory;
+import io.kroxylicious.proxy.labels.source.simple.MtlsAwareInlineLabelSourceFactory;
+import io.kroxylicious.proxy.testplugins.AbstractProduceHeaderInjectionFilter;
+import io.kroxylicious.proxy.testplugins.LabelHeaderInjection;
+import io.kroxylicious.test.assertj.KafkaAssertions;
+import io.kroxylicious.test.tester.KroxyliciousConfigUtils;
+import io.kroxylicious.test.tester.KroxyliciousTester;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
+import io.kroxylicious.testing.kafka.junit5ext.Topic;
+
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.defaultPortIdentifiesNodeGatewayBuilder;
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
+import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
+import static org.apache.kafka.clients.producer.ProducerConfig.CLIENT_ID_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(KafkaClusterExtension.class)
+@ExtendWith(NettyLeakDetectorExtension.class)
+class LabelIT extends AbstractTlsIT {
+    @Test
+    void shouldLabelTopicWithInlineLabel(KafkaCluster cluster, Topic topic, Topic topic2) throws Exception {
+
+        ConfigurationBuilder proxy = KroxyliciousConfigUtils.proxy(cluster.getBootstrapServers(), KroxyliciousConfigUtils.DEFAULT_VIRTUAL_CLUSTER);
+        InlineLabelSourceFactory.Config config = new InlineLabelSourceFactory.Config(
+                Map.of(LabelledResource.TOPIC, new InlineLabelSourceFactory.ResourceLabels(Map.of(topic.name(), Set.of(new Label("is-a-topic", "true"))))));
+        proxy.editFirstVirtualCluster().addToFilters("label").addToLabelSources(new NamedLabelSourceDefinition("inline", "InlineLabelSourceFactory", config))
+                .endVirtualCluster();
+
+        proxy.addToFilterDefinitions(new NamedFilterDefinition("label", LabelHeaderInjection.class.getSimpleName(),
+                new LabelHeaderInjection.Config(Map.of(topic.name(), new LabelHeaderInjection.TopicLabels(
+                        List.of("is-a-topic"))))));
+
+        try (var tester = kroxyliciousTester(proxy);
+                var producer = tester.producer(Map.of(CLIENT_ID_CONFIG, "shouldPassThroughRecordUnchanged", DELIVERY_TIMEOUT_MS_CONFIG, 3_600_000));
+                var consumer = tester.consumer()) {
+            producer.send(new ProducerRecord<>(topic.name(), "my-key", "Hello, world!")).get();
+            producer.send(new ProducerRecord<>(topic2.name(), "my-key", "Hello, world!")).get();
+            consumer.subscribe(Set.of(topic.name()));
+            var records = consumer.poll(Duration.ofSeconds(10));
+
+            assertThat(records.records(topic.name()))
+                    .as("topic %s records", topic.name())
+                    .singleElement()
+                    .asInstanceOf(new InstanceOfAssertFactory<>(ConsumerRecord.class, KafkaAssertions::assertThat))
+                    .headers().singleHeaderWithKey(AbstractProduceHeaderInjectionFilter.headerName(LabelHeaderInjection.class, "is-a-topic")).hasValueEqualTo("true");
+
+            consumer.subscribe(Set.of(topic2.name()));
+            var records2 = consumer.poll(Duration.ofSeconds(10));
+            assertThat(records2.records(topic2.name()))
+                    .as("topic %s records", topic.name())
+                    .singleElement()
+                    .asInstanceOf(new InstanceOfAssertFactory<>(ConsumerRecord.class, KafkaAssertions::assertThat))
+                    .headers().hasSize(0);
+
+        }
+    }
+
+    @Test
+    void clientTlsContextMutualTls(KafkaCluster cluster,
+                                   Admin admin) {
+        var proxyKeystorePassword = downstreamCertificateGenerator.getPassword();
+        String applePrefixTopic = "apple-a";
+        String bananaPrefixTopic = "banana-a";
+        CreateTopicsResult topics = admin.createTopics(List.of(new NewTopic(applePrefixTopic, 1, (short) 1), new NewTopic(bananaPrefixTopic, 1, (short) 1)));
+        try {
+            topics.all().get(5, TimeUnit.SECONDS);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        Optional<Tls> gatewayTls;
+        Objects.requireNonNull(proxyKeystorePassword, "proxyKeystorePassword is null");
+        var proxyKeystoreLocation = downstreamCertificateGenerator.getKeyStoreLocation();
+        var proxyKeystorePasswordProvider = constructPasswordProvider(InlinePassword.class, proxyKeystorePassword);
+        // @formatter:off
+        gatewayTls=Optional.of(new TlsBuilder()
+                .withNewKeyStoreKey()
+                .withStoreFile(proxyKeystoreLocation)
+                .withStorePasswordProvider(proxyKeystorePasswordProvider)
+                .endKeyStoreKey()
+                .withNewTrustStoreTrust()
+                .withNewServerOptionsTrust()
+                .withClientAuth(TlsClientAuth.REQUIRED)
+                .endServerOptionsTrust()
+                .withStoreFile(proxyTrustStore.toAbsolutePath().toString())
+                .withNewInlinePasswordStoreProvider(clientCertGenerator.getPassword())
+                .endTrustStoreTrust()
+                .build());
+        // @formatter:on
+
+        Map<String, Object> clientConfigs = Map.of(
+                CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, SecurityProtocol.SSL.name,
+                SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, clientTrustStore.toAbsolutePath().toString(),
+                SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, proxyKeystorePassword,
+                SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, clientCertGenerator.getKeyStoreLocation(),
+                SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, clientCertGenerator.getPassword());
+        var bootstrapServers = cluster.getBootstrapServers();
+
+        /**
+         * VirtualCluster has an MTLS labelling source
+         * principal: client
+         *  TOPIC:
+         *    - resourceNamePattern: apple-.*
+         *      labels:
+         *        is_allowed: true
+         *    - resourceNamePattern: banana-.*
+         *      labels:
+         *        is_allowed: false
+         *
+         * (What if multiple LabelSources disagree on a label value? Do we make the API multi-valued, or fail fast?)
+         */
+        MtlsAwareInlineLabelSourceFactory.LabelPolicy appleLabelPolicy = new MtlsAwareInlineLabelSourceFactory.LabelPolicy(
+                Map.of("apple-.*", Set.of(new Label("is_allowed", "true")), "banana-.*", Set.of(new Label("is_allowed", "false"))));
+        MtlsAwareInlineLabelSourceFactory.ResourceLabels resourceLabels = new MtlsAwareInlineLabelSourceFactory.ResourceLabels(
+                Map.of(LabelledResource.TOPIC, appleLabelPolicy));
+        MtlsAwareInlineLabelSourceFactory.Config labelConfig = new MtlsAwareInlineLabelSourceFactory.Config(Map.of("client", resourceLabels));
+
+        /**
+         * Filter looks up the label for key is_allowed and adds it to the Produce Record as a header. The Filter is unaware
+         * that the Principal is involved in deriving the label value this is not surfaced in the LabelService API.
+         *
+         * The framework is responsible for routing the authentication details to the Label Source.
+         */
+        LabelHeaderInjection.TopicLabels labelsToInject = new LabelHeaderInjection.TopicLabels(List.of("is_allowed"));
+        // @formatter:off
+        String demoCluster = "demo";
+        var builder = new ConfigurationBuilder()
+                .addNewFilterDefinition("clientConnection", LabelHeaderInjection.class.getName(), new LabelHeaderInjection.Config(Map.of(applePrefixTopic, labelsToInject, bananaPrefixTopic, labelsToInject)))
+                .addToVirtualClusters(new VirtualClusterBuilder()
+                        .withName(demoCluster)
+                        .addToFilters("clientConnection")
+                        .withNewTargetCluster()
+                        .withBootstrapServers(bootstrapServers)
+                        .endTargetCluster()
+                        .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
+                                .withTls(gatewayTls)
+                                .build())
+                        .addToLabelSources(new NamedLabelSourceDefinition("mtlsAware", MtlsAwareInlineLabelSourceFactory.class.getName(), labelConfig))
+                        .build());
+        // @formatter:on
+
+        String headerKey = AbstractProduceHeaderInjectionFilter.headerName(LabelHeaderInjection.class, "is_allowed");
+        try (var tester = kroxyliciousTester(builder)) {
+            assertProducedMessageHasHeaderAdded(tester, demoCluster, clientConfigs, applePrefixTopic, headerKey, "true");
+            assertProducedMessageHasHeaderAdded(tester, demoCluster, clientConfigs, bananaPrefixTopic, headerKey, "false");
+        }
+    }
+
+    private static void assertProducedMessageHasHeaderAdded(KroxyliciousTester tester, String demoCluster, Map<String, Object> clientConfigs, String topic,
+                                                            String headerKey,
+                                                            String expectedHeaderValue) {
+        try (Producer<String, String> producer = tester.producer(demoCluster, clientConfigs)) {
+            producer.send(new ProducerRecord<>(topic, "hello", "world"));
+            producer.flush();
+        }
+
+        List<ConsumerRecord<String, String>> records;
+        try (var consumer = tester.consumer(demoCluster, clientConfigs)) {
+            TopicPartition tp = new TopicPartition(topic, 0);
+            consumer.assign(Set.of(tp));
+            consumer.seekToBeginning(Set.of(tp));
+            do {
+                ConsumerRecords<String, String> poll = consumer.poll(Duration.ofMillis(100));
+                records = poll.records(tp);
+            } while (records.isEmpty());
+        }
+        var recordHeaders = assertThat(records).singleElement().asInstanceOf(new InstanceOfAssertFactory<>(ConsumerRecord.class, KafkaAssertions::assertThat))
+                .headers();
+        recordHeaders.singleHeaderWithKey(headerKey)
+                .hasValueEqualTo(expectedHeaderValue);
+    }
+
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/LabelHeaderInjection.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/LabelHeaderInjection.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.testplugins;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.record.Record;
+
+import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.FilterFactory;
+import io.kroxylicious.proxy.filter.FilterFactoryContext;
+import io.kroxylicious.proxy.labels.Label;
+import io.kroxylicious.proxy.labels.LabelledResource;
+import io.kroxylicious.proxy.plugin.Plugin;
+import io.kroxylicious.proxy.plugin.PluginConfigurationException;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+@Plugin(configType = LabelHeaderInjection.Config.class)
+public class LabelHeaderInjection implements FilterFactory<LabelHeaderInjection.Config, LabelHeaderInjection.Config> {
+
+    @Override
+    public Config initialize(FilterFactoryContext context, Config config) throws PluginConfigurationException {
+        return config;
+    }
+
+    @Override
+    public Filter createFilter(FilterFactoryContext context, Config initializationData) {
+        return new AbstractProduceHeaderInjectionFilter() {
+
+            @NonNull
+            @Override
+            protected List<RecordHeader> headersToAdd(Record record, String topic, int partition, FilterContext context) {
+                TopicLabels labelsToLookup = initializationData.topicNameToLabels.getOrDefault(topic, new TopicLabels(List.of()));
+                Set<Label> labels = context.labels().labels(LabelledResource.TOPIC, topic);
+                Stream<Label> labelStream = labelsToLookup.labelKeys.stream().flatMap(key -> labels.stream().filter(label -> label.key().equals(key)));
+                Stream<RecordHeader> recordHeaderStream = labelStream.map(
+                        label -> new RecordHeader(AbstractProduceHeaderInjectionFilter.headerName(LabelHeaderInjection.class, label.key()), label.value().getBytes()));
+                return recordHeaderStream.toList();
+            }
+        };
+    }
+
+    public record TopicLabels(List<String> labelKeys) {
+
+    }
+
+    public record Config(Map<String, TopicLabels> topicNameToLabels) {
+
+    }
+}

--- a/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
+++ b/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
@@ -13,3 +13,4 @@ io.kroxylicious.proxy.testplugins.SaslInspection
 io.kroxylicious.proxy.testplugins.ClientTlsAwareLawyer
 io.kroxylicious.proxy.testplugins.ConstantSasl
 io.kroxylicious.proxy.testplugins.ProtocolCounter
+io.kroxylicious.proxy.testplugins.LabelHeaderInjection

--- a/kroxylicious-labels/pom.xml
+++ b/kroxylicious-labels/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.kroxylicious</groupId>
+        <artifactId>kroxylicious-parent</artifactId>
+        <version>0.16.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kroxylicious-labels</artifactId>
+    <name>Kafka message tools</name>
+    <description>Tools for manipulating kafka messages, depends only on kafka-clients, has no dependency on the rest of Kroxylicious</description>
+    <dependencies>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/kroxylicious-labels/src/main/java/io/kroxylicious/proxy/labels/source/LabelSource.java
+++ b/kroxylicious-labels/src/main/java/io/kroxylicious/proxy/labels/source/LabelSource.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.labels.source;
+
+import java.util.Set;
+
+import io.kroxylicious.proxy.labels.Label;
+import io.kroxylicious.proxy.labels.LabelledResource;
+
+public interface LabelSource {
+    Set<Label> labels(LabelledResource resource, String resourceName, LabellingContext context);
+
+    // real service should be async
+    default boolean hasAnyOf(LabelledResource resource, String resourceName, Set<Label> labels, LabellingContext context) {
+        var allLabels = labels(resource, resourceName, context);
+        return labels.stream().anyMatch(allLabels::contains);
+    }
+
+}

--- a/kroxylicious-labels/src/main/java/io/kroxylicious/proxy/labels/source/LabelSourceFactory.java
+++ b/kroxylicious-labels/src/main/java/io/kroxylicious/proxy/labels/source/LabelSourceFactory.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.labels.source;
+
+import edu.umd.cs.findbugs.annotations.UnknownNullness;
+
+public interface LabelSourceFactory<C, I> {
+
+    @UnknownNullness
+    I initialize(LabelSourceFactoryContext context, @UnknownNullness C config);
+
+    LabelSource create(I initializationData);
+
+    default void close(@UnknownNullness I initializationData) {
+    }
+}

--- a/kroxylicious-labels/src/main/java/io/kroxylicious/proxy/labels/source/LabelSourceFactoryContext.java
+++ b/kroxylicious-labels/src/main/java/io/kroxylicious/proxy/labels/source/LabelSourceFactoryContext.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.labels.source;
+
+import io.kroxylicious.proxy.plugin.UnknownPluginInstanceException;
+
+public interface LabelSourceFactoryContext {
+    /**
+     * Gets a plugin instance for the given plugin type and name
+     * @param pluginClass The plugin type
+     * @param instanceName The plugin instance name
+     * @return The plugin instance
+     * @param <P> The plugin manager type
+     * @throws UnknownPluginInstanceException
+     */
+    <P> P pluginInstance(Class<P> pluginClass, String instanceName);
+}

--- a/kroxylicious-labels/src/main/java/io/kroxylicious/proxy/labels/source/LabellingContext.java
+++ b/kroxylicious-labels/src/main/java/io/kroxylicious/proxy/labels/source/LabellingContext.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.labels.source;
+
+import java.util.Optional;
+
+import io.kroxylicious.proxy.authentication.ClientSaslContext;
+import io.kroxylicious.proxy.tls.ClientTlsContext;
+
+public interface LabellingContext {
+    /**
+     * @return The SASL context for the client connection, or empty if the client
+     * has not successfully authenticated using SASL.
+     */
+    Optional<ClientSaslContext> clientSaslContext();
+
+    /**
+     * @return The TLS context for the client connection, or empty if the client connection is not TLS.
+     */
+    Optional<ClientTlsContext> clientTlsContext();
+}

--- a/kroxylicious-labels/src/main/java/io/kroxylicious/proxy/labels/source/package-info.java
+++ b/kroxylicious-labels/src/main/java/io/kroxylicious/proxy/labels/source/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+@ReturnValuesAreNonnullByDefault
+@DefaultAnnotationForParameters(NonNull.class)
+@DefaultAnnotation(NonNull.class)
+package io.kroxylicious.proxy.labels.source;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotationForParameters;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;

--- a/kroxylicious-labels/src/main/java/io/kroxylicious/proxy/labels/source/simple/InlineLabelSourceFactory.java
+++ b/kroxylicious-labels/src/main/java/io/kroxylicious/proxy/labels/source/simple/InlineLabelSourceFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.labels.source.simple;
+
+import java.util.Map;
+import java.util.Set;
+
+import io.kroxylicious.proxy.labels.Label;
+import io.kroxylicious.proxy.labels.LabelledResource;
+import io.kroxylicious.proxy.labels.source.LabelSource;
+import io.kroxylicious.proxy.labels.source.LabelSourceFactory;
+import io.kroxylicious.proxy.labels.source.LabelSourceFactoryContext;
+import io.kroxylicious.proxy.labels.source.LabellingContext;
+import io.kroxylicious.proxy.plugin.Plugin;
+
+@Plugin(configType = InlineLabelSourceFactory.Config.class)
+public class InlineLabelSourceFactory implements LabelSourceFactory<InlineLabelSourceFactory.Config, InlineLabelSourceFactory.Config> {
+
+    @Override
+    public Config initialize(LabelSourceFactoryContext context, Config config) {
+        return config;
+    }
+
+    @Override
+    public LabelSource create(Config initializationData) {
+        return initializationData;
+    }
+
+    public record ResourceLabels(Map<String, Set<Label>> resourceNameToLabels) {
+
+    }
+
+    public record Config(Map<LabelledResource, ResourceLabels> resourceLabels) implements LabelSource {
+
+        @Override
+        public Set<Label> labels(LabelledResource resource, String resourceName, LabellingContext context) {
+            ResourceLabels labels = resourceLabels.getOrDefault(resource, new ResourceLabels(Map.of()));
+            return labels.resourceNameToLabels().getOrDefault(resourceName, Set.of());
+        }
+    }
+}

--- a/kroxylicious-labels/src/main/java/io/kroxylicious/proxy/labels/source/simple/MtlsAwareInlineLabelSourceFactory.java
+++ b/kroxylicious-labels/src/main/java/io/kroxylicious/proxy/labels/source/simple/MtlsAwareInlineLabelSourceFactory.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.labels.source.simple;
+
+import java.security.cert.X509Certificate;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.naming.InvalidNameException;
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.Rdn;
+
+import io.kroxylicious.proxy.labels.Label;
+import io.kroxylicious.proxy.labels.LabelledResource;
+import io.kroxylicious.proxy.labels.source.LabelSource;
+import io.kroxylicious.proxy.labels.source.LabelSourceFactory;
+import io.kroxylicious.proxy.labels.source.LabelSourceFactoryContext;
+import io.kroxylicious.proxy.labels.source.LabellingContext;
+import io.kroxylicious.proxy.plugin.Plugin;
+import io.kroxylicious.proxy.tls.ClientTlsContext;
+
+import static java.util.stream.Collectors.toSet;
+
+@Plugin(configType = MtlsAwareInlineLabelSourceFactory.Config.class)
+public class MtlsAwareInlineLabelSourceFactory implements LabelSourceFactory<MtlsAwareInlineLabelSourceFactory.Config, MtlsAwareInlineLabelSourceFactory.Config> {
+
+    @Override
+    public Config initialize(LabelSourceFactoryContext context, Config config) {
+        return config;
+    }
+
+    @Override
+    public LabelSource create(Config initializationData) {
+        return initializationData;
+    }
+
+    public static final class LabelPolicy {
+        private final Map<Pattern, Set<Label>> resourceNamePatternToLabels;
+
+        public LabelPolicy(Map<String, Set<Label>> resourceNamePatternToLabels) {
+            this.resourceNamePatternToLabels = resourceNamePatternToLabels.entrySet().stream()
+                    .collect(Collectors.toMap(e -> Pattern.compile(e.getKey()), Map.Entry::getValue));
+        }
+
+        public Set<Label> labels(String resourceName) {
+            return resourceNamePatternToLabels
+                    .entrySet().stream().filter(e -> e.getKey().matcher(resourceName).matches())
+                    .flatMap(e -> e.getValue().stream()).collect(toSet());
+        }
+    }
+
+    public record ResourceLabels(Map<LabelledResource, LabelPolicy> resourceNameToLabels) {
+        public Set<Label> labels(LabelledResource resource, String resourceName) {
+            LabelPolicy policy = resourceNameToLabels.getOrDefault(resource, new LabelPolicy(Map.of()));
+            return policy.labels(resourceName);
+        }
+    }
+
+    public record Config(Map<String, ResourceLabels> resourceLabelsPerPrincipal) implements LabelSource {
+
+        @Override
+        public Set<Label> labels(LabelledResource resource, String resourceName, LabellingContext context) {
+            String principalName = getPrincipalName(context).orElseThrow(() -> new IllegalStateException("could not extract principal name"));
+            ResourceLabels labelPolicy = resourceLabelsPerPrincipal.getOrDefault(principalName, new ResourceLabels(Map.of()));
+            return labelPolicy.labels(resource, resourceName);
+        }
+
+        private Optional<String> getPrincipalName(LabellingContext context) {
+            X509Certificate certificate = context.clientTlsContext().flatMap(ClientTlsContext::clientCertificate)
+                    .orElseThrow(() -> new IllegalStateException("No client TLS context"));
+            String principalName = certificate.getSubjectX500Principal().getName();
+            try {
+                LdapName name = new LdapName(principalName);
+                for (Rdn rdn : name.getRdns()) {
+                    if (rdn.getType().equalsIgnoreCase("CN")) {
+                        return Optional.of(rdn.getValue().toString());
+                    }
+                }
+            }
+            catch (InvalidNameException e) {
+                throw new RuntimeException(e);
+            }
+            return Optional.empty();
+        }
+    }
+}

--- a/kroxylicious-labels/src/main/java/io/kroxylicious/proxy/labels/source/simple/package-info.java
+++ b/kroxylicious-labels/src/main/java/io/kroxylicious/proxy/labels/source/simple/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+@ReturnValuesAreNonnullByDefault
+@DefaultAnnotationForParameters(NonNull.class)
+@DefaultAnnotation(NonNull.class)
+package io.kroxylicious.proxy.labels.source.simple;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotationForParameters;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;

--- a/kroxylicious-labels/src/main/resources/META-INF/services/io.kroxylicious.proxy.labels.source.LabelSourceFactory
+++ b/kroxylicious-labels/src/main/resources/META-INF/services/io.kroxylicious.proxy.labels.source.LabelSourceFactory
@@ -1,0 +1,8 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+io.kroxylicious.proxy.labels.source.simple.InlineLabelSourceFactory
+io.kroxylicious.proxy.labels.source.simple.MtlsAwareInlineLabelSourceFactory

--- a/kroxylicious-microbenchmarks/src/main/java/io/kroxylicious/microbenchmarks/InvokerDispatchBenchmark.java
+++ b/kroxylicious-microbenchmarks/src/main/java/io/kroxylicious/microbenchmarks/InvokerDispatchBenchmark.java
@@ -45,6 +45,7 @@ import io.kroxylicious.proxy.filter.RequestFilterResultBuilder;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
 import io.kroxylicious.proxy.filter.ResponseFilterResultBuilder;
 import io.kroxylicious.proxy.filter.SpecificFilterInvoker;
+import io.kroxylicious.proxy.labels.LabelService;
 import io.kroxylicious.proxy.tls.ClientTlsContext;
 
 // try hard to make shouldHandleXYZ to observe different receivers concrete types, saving unrolling to bias a specific call-site to a specific concrete type
@@ -199,6 +200,11 @@ public class InvokerDispatchBenchmark {
         @Override
         public Optional<ClientSaslContext> clientSaslContext() {
             return Optional.empty();
+        }
+
+        @Override
+        public LabelService labels() {
+            throw new RuntimeException("not implemented");
         }
 
         @Override

--- a/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/kubernetes/operator/assertj/OperatorAssertionsTest.java
+++ b/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/kubernetes/operator/assertj/OperatorAssertionsTest.java
@@ -102,7 +102,7 @@ class OperatorAssertionsTest {
                                 Optional.empty())),
                         false,
                         false,
-                        List.of())),
+                        List.of(), null)),
                 List.of(),
                 false,
                 Optional.empty());

--- a/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/kubernetes/operator/assertj/ProxyConfigAssertTest.java
+++ b/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/kubernetes/operator/assertj/ProxyConfigAssertTest.java
@@ -28,7 +28,7 @@ class ProxyConfigAssertTest {
                 new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 9292), null, null, null), null, Optional.empty());
         VirtualCluster virtualCluster = new VirtualCluster("cluster", new TargetCluster("localhost:9092", Optional.empty()),
                 List.of(virtualClusterGateway), false,
-                false, List.of());
+                false, List.of(), null);
         Configuration config = new Configuration(null, null, null, List.of(virtualCluster), List.of(), false, Optional.empty());
 
         Assertions.assertThatThrownBy(() -> {
@@ -43,7 +43,7 @@ class ProxyConfigAssertTest {
         String clusterName = "cluster";
         VirtualCluster virtualCluster = new VirtualCluster(clusterName, new TargetCluster("localhost:9092", Optional.empty()),
                 List.of(virtualClusterGateway), false,
-                false, List.of());
+                false, List.of(), null);
         Configuration config = new Configuration(null, null, null, List.of(virtualCluster), List.of(), false, Optional.empty());
 
         ProxyConfigAssert.ProxyConfigClusterAssert cluster = OperatorAssertions.assertThat(config).cluster(clusterName);
@@ -56,7 +56,7 @@ class ProxyConfigAssertTest {
                 new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 9292), null, null, null), null, Optional.empty());
         VirtualCluster virtualCluster = new VirtualCluster("cluster", new TargetCluster("localhost:9092", Optional.empty()),
                 List.of(virtualClusterGateway), false,
-                false, List.of());
+                false, List.of(), null);
         ProxyConfigAssert.ProxyConfigClusterAssert proxyConfigClusterAssert = new ProxyConfigAssert.ProxyConfigClusterAssert(virtualCluster);
         Assertions.assertThatThrownBy(() -> {
             proxyConfigClusterAssert.gateway("anything");
@@ -70,7 +70,7 @@ class ProxyConfigAssertTest {
                 new PortIdentifiesNodeIdentificationStrategy(new HostPort("localhost", 9292), null, null, null), null, Optional.empty());
         VirtualCluster virtualCluster = new VirtualCluster("cluster", new TargetCluster("localhost:9092", Optional.empty()),
                 List.of(virtualClusterGateway), false,
-                false, List.of());
+                false, List.of(), null);
         ProxyConfigAssert.ProxyConfigClusterAssert proxyConfigClusterAssert = new ProxyConfigAssert.ProxyConfigClusterAssert(virtualCluster);
         ProxyConfigAssert.ProxyConfigGatewayAssert gatewayAssert = proxyConfigClusterAssert.gateway(gatewayName);
         Assertions.assertThat(gatewayAssert.actual()).isNotNull().isSameAs(virtualClusterGateway);

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconciler.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/KafkaProxyReconciler.java
@@ -273,7 +273,7 @@ public class KafkaProxyReconciler implements
                         clusterCfs,
                         false,
                         false,
-                        filterNamesForCluster(cluster))));
+                        filterNamesForCluster(cluster), null)));
         return ConfigurationFragment.combine(virtualClusterConfigurationFragment,
                 gatewayFragments,
                 (virtualCluster, gateways) -> virtualCluster);

--- a/kroxylicious-runtime/pom.xml
+++ b/kroxylicious-runtime/pom.xml
@@ -39,6 +39,10 @@
             <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-labels</artifactId>
+        </dependency>
 
         <!-- project dependencies - test -->
         <dependency>

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/NamedLabelSourceDefinition.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/NamedLabelSourceDefinition.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.kroxylicious.proxy.internal.util.Assertions;
+import io.kroxylicious.proxy.labels.source.LabelSourceFactory;
+import io.kroxylicious.proxy.plugin.PluginImplConfig;
+import io.kroxylicious.proxy.plugin.PluginImplName;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * A named label source definition
+ * @param name The name of the label source
+ * @param type The type of the label source
+ * @param config Config for the label source
+ * @see Configuration#filterDefinitions()
+ */
+public record NamedLabelSourceDefinition(
+                                         @JsonProperty(required = true) String name,
+                                         @PluginImplName(LabelSourceFactory.class) @JsonProperty(required = true) String type,
+                                         @Nullable @PluginImplConfig(implNameProperty = "type") Object config) {
+
+    @JsonCreator
+    public NamedLabelSourceDefinition {
+        Objects.requireNonNull(name);
+        Assertions.requireStrictlyPositive(name.length(), "name length");
+        Objects.requireNonNull(type);
+    }
+
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
@@ -24,6 +24,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * @param logNetwork if true, network will be logged
  * @param logFrames if true, kafka rpcs will be logged
  * @param filters filers.
+ * @param labelSources
  */
 @SuppressWarnings("java:S1123") // suppressing the spurious warning about missing @deprecated in javadoc. It is the field that is deprecated, not the class.
 public record VirtualCluster(@JsonProperty(required = true) String name,
@@ -31,7 +32,8 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
                              @JsonProperty(required = true) List<VirtualClusterGateway> gateways,
                              boolean logNetwork,
                              boolean logFrames,
-                             @Nullable List<String> filters) {
+                             @Nullable List<String> filters,
+                             @Nullable List<NamedLabelSourceDefinition> labelSources) {
 
     private static final Pattern DNS_LABEL_PATTERN = Pattern.compile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", Pattern.CASE_INSENSITIVE);
 
@@ -76,4 +78,8 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
         }
     }
 
+    @Override
+    public List<NamedLabelSourceDefinition> labelSources() {
+        return labelSources == null ? List.of() : labelSources;
+    }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -53,6 +53,7 @@ import io.kroxylicious.proxy.internal.filter.RequestFilterResultBuilderImpl;
 import io.kroxylicious.proxy.internal.filter.ResponseFilterResultBuilderImpl;
 import io.kroxylicious.proxy.internal.util.Assertions;
 import io.kroxylicious.proxy.internal.util.ByteBufOutputStream;
+import io.kroxylicious.proxy.labels.LabelService;
 import io.kroxylicious.proxy.model.VirtualClusterModel;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 import io.kroxylicious.proxy.tls.ClientTlsContext;
@@ -538,6 +539,11 @@ public class FilterHandler extends ChannelDuplexHandler {
         @Override
         public Optional<ClientSaslContext> clientSaslContext() {
             return FilterHandler.this.clientSaslManager.clientSaslContext();
+        }
+
+        @Override
+        public LabelService labels() {
+            throw new RuntimeException("not implemented yet");
         }
 
         @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/InitializedLabelSource.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/InitializedLabelSource.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.model;
+
+import java.util.Set;
+
+import io.kroxylicious.proxy.labels.Label;
+import io.kroxylicious.proxy.labels.LabelledResource;
+import io.kroxylicious.proxy.labels.source.LabelSource;
+import io.kroxylicious.proxy.labels.source.LabelSourceFactory;
+import io.kroxylicious.proxy.labels.source.LabellingContext;
+
+public record InitializedLabelSource(LabelSourceFactory<?, ?> labelSourceFactory, LabelSource source) implements LabelSource {
+
+    @Override
+    public Set<Label> labels(LabelledResource resource, String resourceName, LabellingContext context) {
+        return source.labels(resource, resourceName, context);
+    }
+
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/model/VirtualClusterModel.java
@@ -64,6 +64,7 @@ public class VirtualClusterModel {
     private final Map<String, VirtualClusterGatewayModel> gateways = new HashMap<>();
 
     private final List<NamedFilterDefinition> filters;
+    private final List<InitializedLabelSource> labelSources;
 
     private final Optional<SslContext> upstreamSslContext;
 
@@ -71,13 +72,14 @@ public class VirtualClusterModel {
                                TargetCluster targetCluster,
                                boolean logNetwork,
                                boolean logFrames,
-                               List<NamedFilterDefinition> filters) {
+                               List<NamedFilterDefinition> filters,
+                               List<InitializedLabelSource> initializedLabelSources) {
         this.clusterName = Objects.requireNonNull(clusterName);
         this.targetCluster = Objects.requireNonNull(targetCluster);
         this.logNetwork = logNetwork;
         this.logFrames = logFrames;
         this.filters = filters;
-
+        this.labelSources = initializedLabelSources;
         // TODO: https://github.com/kroxylicious/kroxylicious/issues/104 be prepared to reload the SslContext at runtime.
         this.upstreamSslContext = buildUpstreamSslContext();
     }
@@ -256,6 +258,10 @@ public class VirtualClusterModel {
 
     public Map<String, EndpointGateway> gateways() {
         return Collections.unmodifiableMap(gateways);
+    }
+
+    public List<InitializedLabelSource> getLabelSources() {
+        return labelSources;
     }
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -814,7 +814,7 @@ class ConfigParserTest {
         var config = new Configuration(null,
                 List.of(new NamedFilterDefinition("foo", "", new NonSerializableConfig(""))),
                 List.of("foo"),
-                List.of(new VirtualCluster("demo", targetCluster, List.of(gateway), false, false, List.of())),
+                List.of(new VirtualCluster("demo", targetCluster, List.of(gateway), false, false, List.of(), null)),
                 null,
                 false,
                 Optional.empty());

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/VirtualClusterTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/VirtualClusterTest.java
@@ -44,7 +44,7 @@ class VirtualClusterTest {
                 new VirtualClusterGateway("mygateway2", portIdentifiesNode2, null, Optional.empty()));
 
         // When
-        var vc = new VirtualCluster("mycluster", targetCluster, gateways, false, false, NO_FILTERS);
+        var vc = new VirtualCluster("mycluster", targetCluster, gateways, false, false, NO_FILTERS, null);
 
         // Then
         assertThat(vc.gateways())
@@ -55,7 +55,7 @@ class VirtualClusterTest {
     @Test
     void disallowMissingGateways() {
         // Given/When/Then
-        assertThatThrownBy(() -> new VirtualCluster("mycluster", targetCluster, null, false, false, NO_FILTERS))
+        assertThatThrownBy(() -> new VirtualCluster("mycluster", targetCluster, null, false, false, NO_FILTERS, null))
                 .isInstanceOf(IllegalConfigurationException.class);
     }
 
@@ -64,7 +64,7 @@ class VirtualClusterTest {
         // Given
         var noGateways = List.<VirtualClusterGateway> of();
         // When/Then
-        assertThatThrownBy(() -> new VirtualCluster("mycluster", targetCluster, noGateways, false, false, NO_FILTERS))
+        assertThatThrownBy(() -> new VirtualCluster("mycluster", targetCluster, noGateways, false, false, NO_FILTERS, null))
                 .isInstanceOf(IllegalConfigurationException.class);
     }
 
@@ -74,7 +74,7 @@ class VirtualClusterTest {
         var gateways = List.of(new VirtualClusterGateway("dup", portIdentifiesNode1, null, Optional.empty()),
                 new VirtualClusterGateway("dup", portIdentifiesNode2, null, Optional.empty()));
         // When/Then
-        assertThatThrownBy(() -> new VirtualCluster("mycluster", targetCluster, gateways, false, false, NO_FILTERS))
+        assertThatThrownBy(() -> new VirtualCluster("mycluster", targetCluster, gateways, false, false, NO_FILTERS, null))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("Gateway names for a virtual cluster must be unique. The following gateway names are duplicated: [dup]");
     }
@@ -95,7 +95,7 @@ class VirtualClusterTest {
         // When
         // Then
         assertThatThrownBy(() -> {
-            new VirtualCluster(clusterName, targetCluster, gateways, false, false, NO_FILTERS);
+            new VirtualCluster(clusterName, targetCluster, gateways, false, false, NO_FILTERS, null);
         }).isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("Virtual cluster name '" + clusterName
                         + "' is invalid. It must be less than 64 characters long and match pattern ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ (case insensitive)");
@@ -120,7 +120,7 @@ class VirtualClusterTest {
         // When
         // Then
         assertThatCode(() -> {
-            new VirtualCluster(clusterName, targetCluster, gateways, false, false, NO_FILTERS);
+            new VirtualCluster(clusterName, targetCluster, gateways, false, false, NO_FILTERS, null);
         }).doesNotThrowAnyException();
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
@@ -81,7 +81,7 @@ public abstract class FilterHarness {
         final TargetCluster targetCluster = mock(TargetCluster.class);
         when(targetCluster.bootstrapServersList()).thenReturn(TARGET_CLUSTER_BOOTSTRAP);
         var testVirtualCluster = new VirtualClusterModel("TestVirtualCluster", targetCluster, false,
-                false, List.of());
+                false, List.of(), List.of());
         testVirtualCluster.addGateway("default", mock(NodeIdentificationStrategy.class), Optional.empty());
         var inboundChannel = new EmbeddedChannel();
         var channelProcessors = Stream.<ChannelHandler> of(new InternalRequestTracker(), new CorrelationIdIssuer());

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyBackendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyBackendHandlerTest.java
@@ -57,7 +57,7 @@ class KafkaProxyBackendHandlerTest {
     void setUp() {
         outboundChannel = new EmbeddedChannel();
         var virtualClusterModel = new VirtualClusterModel(CLUSTER_NAME, new TargetCluster("localhost:9090", Optional.empty()), false, false,
-                List.of());
+                List.of(), List.of());
         virtualClusterModel.addGateway("default", NODE_IDENTIFICATION_STRATEGY, Optional.empty());
         kafkaProxyBackendHandler = new KafkaProxyBackendHandler(proxyChannelStateMachine,
                 virtualClusterModel);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -117,7 +117,7 @@ class KafkaProxyInitializerTest {
     private VirtualClusterModel buildVirtualCluster(boolean logNetwork, boolean logFrames) {
         final Optional<Tls> tls = Optional.empty();
         VirtualClusterModel testCluster = new VirtualClusterModel("testCluster", new TargetCluster("localhost:9090", tls), logNetwork,
-                logFrames, List.of());
+                logFrames, List.of(), List.of());
         testCluster.addGateway("defaullt", mock(NodeIdentificationStrategy.class), tls);
         return testCluster;
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
@@ -82,7 +82,7 @@ class ProxyChannelStateMachineTest {
     private static final Offset<Double> CLOSE_ENOUGH = Offset.offset(0.00005);
     private static final String CLUSTER_NAME = "virtualClusterA";
     private static final VirtualClusterModel VIRTUAL_CLUSTER_MODEL = new VirtualClusterModel(CLUSTER_NAME, new TargetCluster("", Optional.empty()), false, false,
-            List.of());
+            List.of(), List.of());
     private final RuntimeException failure = new RuntimeException("There's Klingons on the starboard bow");
     private ProxyChannelStateMachine proxyChannelStateMachine;
     private KafkaProxyBackendHandler backendHandler;

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/model/VirtualClusterModelTest.java
@@ -67,7 +67,7 @@ class VirtualClusterModelTest {
         final TargetCluster targetCluster = new TargetCluster("bootstrap:9092", downstreamTls);
 
         // When/Then
-        assertThatThrownBy(() -> new VirtualClusterModel("wibble", targetCluster, false, false, EMPTY_FILTERS))
+        assertThatThrownBy(() -> new VirtualClusterModel("wibble", targetCluster, false, false, EMPTY_FILTERS, List.of()))
                 .isInstanceOf(IllegalConfigurationException.class)
                 .hasMessageContaining("Cannot apply trust options");
     }

--- a/pom.xml
+++ b/pom.xml
@@ -449,6 +449,7 @@
         <module>kroxylicious-kms-provider-kroxylicious-inmemory-test-support</module>
         <module>kroxylicious-kms-provider-hashicorp-vault</module>
         <module>kroxylicious-kms-provider-hashicorp-vault-test-support</module>
+        <module>kroxylicious-labels</module>
         <module>kroxylicious-bom</module>
         <module>kroxylicious-api</module>
         <module>kroxylicious-app</module>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

We have been considering virtualization features where the client identity may play a part in determining things like:
* which topics are visible to a User
* what prefix should we use to mangle a clients consumer group ids and transactions.

Along with complementary, but distinct behaviours like:
* abort the connection quickly if the proxy is unaware of the User

This PR prototypes an idea where we introduce a concept of Labelling entities like Topics with key-value labels.

Then we introduce principal-aware sources of labels that can dynamically construct labels for the entities based on the current client identity.

This decouples things so that Filters target behaviours against labels. The filter doesn't have to know the labels are derived from the current client identity.

1. A VirtualCluster has a configurable list of **LabelSource**s (factories actually, but that's details)
    ```java
    public enum LabelledResource {
        TOPIC
    }
    
    public record Label(String key, String value) {}
    
    public interface LabellingContext {
        Optional<ClientSaslContext> clientSaslContext();
        Optional<ClientTlsContext> clientTlsContext();
    }
    
    public interface LabelSource {
        Set<Label> labels(LabelledResource resource, String resourceName, LabellingContext context);
    
        default boolean hasAnyOf(LabelledResource resource, String resourceName, Set<Label> labels, LabellingContext context) {
            var allLabels = labels(resource, resourceName, context);
            return labels.stream().anyMatch(allLabels::contains);
        }
    }
    ```

2. `FilterContext` offers a **LabelService** which does not surface anything related to Principal:
    ``` java
    public interface LabelService {
        Set<Label> labels(LabelledResource resource, String resourceName);
        default boolean hasAnyOf(LabelledResource resource, String resourceName, Set<Label> labels) {
            var allLabels = labels(resource, resourceName);
            return labels.stream().anyMatch(allLabels::contains);
        }
    }
    
    public interface FilterContext {
        LabelService labels();
    }
    ``` 
3. The runtime binds things together so that a call to LabelService queries all the LabelSources, providing them with client identity information.

There are two implementations:

1. `InlineLabelSourceFactory`. This can be configured with an inline set of labels per resource type. So you can say "label all topics with label fruit=apple"
2. `MtlsAwareInlineLabelSourceFactory`. This is more fancy, it allows you to configure sets of labels to be applied to resource patterns per MTLS client principal (I used CN from the subject principal name). The config is effectively like:
    ```yaml
    principal: client
        TOPIC:
          - resourceNamePattern: apple-.*
            labels:
              is_allowed: true
          - resourceNamePattern: banana-.*
            labels:
              is_allowed: false
    ```

With the effect that if you connect with an MTLS client cert with CN=client, and a Filter uses:
```
context.labels().labels(LabelledResource.TOPIC, "apple-1")
```
then they will receive a label `is_allowed: true`.

If the filter looked up another topic:
```
context.labels().labels(LabelledResource.TOPIC, "banana-1")
```
Then they would receive a label `is_allowed: false`.

### Why?!

The payoff for this complexity is that Filters can take advantage of principals without each filter having to be aware of SASL or TLS. We can indirect through labels and have smart framework support for labelling topics (and groups/transactions/etc) based on the principal.

Potentially a single configuration file could be used for targeting behaviours to topics/groups/transactions/principals, and used across multiple filters.

This opens the door to new LabelSources that call out to k8s to extract labels from some Custom Resources, or from other external sources of entity metadata.

The next steps could be
* Add LabelledResource.PRINCIPAL, so we can label the principal itself. Then you could imagine a Filter enforcing the business rule that the principal has some tag like "principal_known_to_proxy: true`. Which would be up to the label source to attach to the principal by configuration or implicitly.

#### Thoughts

First thought is that with multiple LabelSource's and strategies like this, we may discover multiple values for a label key. Should we accept that Labels are multi-valued (diverging from k8s)? Or we could make our systems fail fast. Or we could use some prioritization, like we prefer the first label discovered from all sources, and within sources. 

It's hard to prevent multi-valued labels if the label is the leaf in the configuration tree, maybe we could instead organize it so labels are the top of the configuration tree like:

```
resource: TOPIC
  - labels:
        topic_visible: true
    applyTo:
        - user: keith
          resourceNamePattern: prefix-.*
        - users: [rob, grace]
          resourceNamePattern: other-.*
```

Then you can ensure that there's only one path for a given label to be applied in the Source.

For allow/deny. Instead of using a single label, it might be safer to have an allow label `topic_is_allowed: true` and a denied label `topic_is_denied: true`. The business logic would be it must have the allowed label and not have the denied label. Allowing for easier rules to allow `prefix-*` and then exclude `prefix-specialized`.

Caching will be useful to prevent endless regexing, including negative caching for misses.

A LabelledResource enum might be a little too restrictive. Users could create their own classes of labelled entities if we left it as a String, maybe just using constants to name our built in supported entities (or we could support all of Kafkas ResourceTypes?)

Filter composition? If filters have different views of what entity names are, how does labelling work? Should the filter chain be able to manipulate Label queries? Having reread the Labelling discussion Tom proposed making it composable https://github.com/kroxylicious/kroxylicious/discussions/1226#discussioncomment-9439172 so rules would be in terms of the physical resources and Filters like multi-tenant would have a mechanism to intercept label requests and mangle the resource names.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
