### PR TITLE
fix: sendRequest and short-circuit response do not compose

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/ShortCircuitErrorResponse.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/ShortCircuitErrorResponse.java
@@ -6,29 +6,71 @@
 
 package io.kroxylicious.proxy.testplugins;
 
+import java.util.concurrent.CompletionStage;
+
 import org.apache.kafka.common.errors.UnknownServerException;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.requests.AbstractResponse;
 
 import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.FilterFactory;
 import io.kroxylicious.proxy.filter.FilterFactoryContext;
 import io.kroxylicious.proxy.filter.RequestFilter;
+import io.kroxylicious.proxy.filter.RequestFilterResult;
+import io.kroxylicious.proxy.internal.KafkaProxyExceptionMapper;
 import io.kroxylicious.proxy.plugin.Plugin;
 import io.kroxylicious.proxy.plugin.PluginConfigurationException;
 
 /**
  * Responds to all requests with an unknown server exception
  */
-@Plugin(configType = Void.class)
-public class ShortCircuitErrorResponse implements FilterFactory<Void, Void> {
-    @Override
-    public Void initialize(FilterFactoryContext context, Void config) throws PluginConfigurationException {
-        return null;
+@Plugin(configType = ShortCircuitErrorResponse.Config.class)
+public class ShortCircuitErrorResponse implements FilterFactory<ShortCircuitErrorResponse.Config, ShortCircuitErrorResponse.ResponseMechanism> {
+
+    private static final UnknownServerException EXCEPTION = new UnknownServerException(ShortCircuitErrorResponse.class.getName() + ": responding error to all requests");
+
+    public enum ResponseMechanism implements RequestFilter {
+        ERROR {
+            @Override
+            public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage request, FilterContext context) {
+                return context.requestFilterResultBuilder()
+                        .errorResponse(header, request, EXCEPTION)
+                        .completed();
+            }
+        },
+        SHORTCIRCUIT_MESSAGE {
+            @Override
+            public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage request, FilterContext context) {
+                final AbstractResponse errorResponseMessage = KafkaProxyExceptionMapper.errorResponseForMessage(header, request, EXCEPTION);
+                return context.requestFilterResultBuilder().shortCircuitResponse(errorResponseMessage.data()).completed();
+            }
+        },
+        SHORTCIRCUIT_MESSAGE_AND_HEADER {
+            @Override
+            public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage request, FilterContext context) {
+                final AbstractResponse errorResponseMessage = KafkaProxyExceptionMapper.errorResponseForMessage(header, request, EXCEPTION);
+                final ResponseHeaderData responseHeaders = new ResponseHeaderData();
+                responseHeaders.setCorrelationId(header.correlationId());
+                return context.requestFilterResultBuilder().shortCircuitResponse(responseHeaders, errorResponseMessage.data()).completed();
+            }
+        }
     }
 
     @Override
-    public Filter createFilter(FilterFactoryContext context, Void initializationData) {
-        return (RequestFilter) (apiKey, header, request, context1) -> context1.requestFilterResultBuilder()
-                .errorResponse(header, request, new UnknownServerException(ShortCircuitErrorResponse.class.getName() + ": responding error to all requests"))
-                .completed();
+    public ResponseMechanism initialize(FilterFactoryContext context, Config config) throws PluginConfigurationException {
+        return config.responseMechanism();
+    }
+
+    @Override
+    public Filter createFilter(FilterFactoryContext context, ResponseMechanism initializationData) {
+        return initializationData;
+    }
+
+    public record Config(ResponseMechanism responseMechanism) {
+
     }
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/ShortCircuitErrorResponse.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/ShortCircuitErrorResponse.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.testplugins;
+
+import org.apache.kafka.common.errors.UnknownServerException;
+
+import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.filter.FilterFactory;
+import io.kroxylicious.proxy.filter.FilterFactoryContext;
+import io.kroxylicious.proxy.filter.RequestFilter;
+import io.kroxylicious.proxy.plugin.Plugin;
+import io.kroxylicious.proxy.plugin.PluginConfigurationException;
+
+/**
+ * Responds to all requests with an unknown server exception
+ */
+@Plugin(configType = Void.class)
+public class ShortCircuitErrorResponse implements FilterFactory<Void, Void> {
+    @Override
+    public Void initialize(FilterFactoryContext context, Void config) throws PluginConfigurationException {
+        return null;
+    }
+
+    @Override
+    public Filter createFilter(FilterFactoryContext context, Void initializationData) {
+        return (RequestFilter) (apiKey, header, request, context1) -> context1.requestFilterResultBuilder()
+                .errorResponse(header, request, new UnknownServerException(ShortCircuitErrorResponse.class.getName() + ": responding error to all requests"))
+                .completed();
+    }
+}

--- a/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
+++ b/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
@@ -13,3 +13,4 @@ io.kroxylicious.proxy.testplugins.SaslInspection
 io.kroxylicious.proxy.testplugins.ClientTlsAwareLawyer
 io.kroxylicious.proxy.testplugins.ConstantSasl
 io.kroxylicious.proxy.testplugins.ProtocolCounter
+io.kroxylicious.proxy.testplugins.ShortCircuitErrorResponse

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/DecodedRequestFrame.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/DecodedRequestFrame.java
@@ -7,6 +7,7 @@ package io.kroxylicious.proxy.frame;
 
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
 
 import static org.apache.kafka.common.protocol.ApiKeys.PRODUCE;
@@ -46,6 +47,10 @@ public class DecodedRequestFrame<B extends ApiMessage>
 
     private boolean isZeroAcksProduceRequest() {
         return apiKeyId() == PRODUCE.id && ((ProduceRequestData) body).acks() == 0;
+    }
+
+    public DecodedResponseFrame<?> responseFrame(ResponseHeaderData header, ApiMessage message) {
+        return new DecodedResponseFrame<>(apiVersion(), correlationId(), header, message);
     }
 
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/RequestFrame.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/frame/RequestFrame.java
@@ -20,5 +20,4 @@ public interface RequestFrame extends Frame {
     default boolean hasResponse() {
         return true;
     }
-
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -48,7 +48,6 @@ import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 import io.kroxylicious.proxy.frame.OpaqueFrame;
 import io.kroxylicious.proxy.frame.OpaqueRequestFrame;
 import io.kroxylicious.proxy.frame.OpaqueResponseFrame;
-import io.kroxylicious.proxy.frame.RequestFrame;
 import io.kroxylicious.proxy.internal.filter.RequestFilterResultBuilderImpl;
 import io.kroxylicious.proxy.internal.filter.ResponseFilterResultBuilderImpl;
 import io.kroxylicious.proxy.internal.util.Assertions;
@@ -393,14 +392,13 @@ public class FilterHandler extends ChannelDuplexHandler {
         if (!name.endsWith("ResponseData")) {
             throw new AssertionError("Filter '" + filterDescriptor() + "': Attempt to use forwardResponse with a non-response: " + name);
         }
-        if (decodedFrame instanceof RequestFrame) {
+        if (decodedFrame instanceof DecodedRequestFrame<?> decodedRequestFrame) {
             if (message.apiKey() != decodedFrame.apiKeyId()) {
                 throw new AssertionError(
                         "Filter '" + filterDescriptor() + "': Attempt to respond with ApiMessage of type " + ApiKeys.forId(message.apiKey()) + " but request is of type "
                                 + decodedFrame.apiKey());
             }
-            DecodedResponseFrame<?> responseFrame = new DecodedResponseFrame<>(decodedFrame.apiVersion(), decodedFrame.correlationId(),
-                    header, message);
+            DecodedResponseFrame<?> responseFrame = decodedRequestFrame.responseFrame(header, message);
             decodedFrame.transferBuffersTo(responseFrame);
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("{}: Filter '{}' forwarding response: {}", channelDescriptor(), filterDescriptor(), msgDescriptor(decodedFrame));

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/InternalRequestFrame.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/InternalRequestFrame.java
@@ -9,10 +9,12 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
 
 import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 
 public class InternalRequestFrame<B extends ApiMessage> extends DecodedRequestFrame<B> {
 
@@ -37,5 +39,10 @@ public class InternalRequestFrame<B extends ApiMessage> extends DecodedRequestFr
 
     public CompletableFuture<?> promise() {
         return promise;
+    }
+
+    @Override
+    public DecodedResponseFrame<?> responseFrame(ResponseHeaderData header, ApiMessage message) {
+        return new InternalResponseFrame<>(recipient, apiVersion, correlationId, header, message, promise);
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/InternalRequestFrame.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/InternalRequestFrame.java
@@ -42,7 +42,7 @@ public class InternalRequestFrame<B extends ApiMessage> extends DecodedRequestFr
     }
 
     @Override
-    public DecodedResponseFrame<?> responseFrame(ResponseHeaderData header, ApiMessage message) {
+    protected DecodedResponseFrame<? extends ApiMessage> createResponseFrame(ResponseHeaderData header, ApiMessage message) {
         return new InternalResponseFrame<>(recipient, apiVersion, correlationId, header, message, promise);
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/frame/DecodedRequestFrameTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/frame/DecodedRequestFrameTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.frame;
+
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DecodedRequestFrameTest {
+
+    private static final int CORRELATION_ID = 1;
+    private static final short API_VERSION = ApiKeys.METADATA.latestVersion();
+
+    @Test
+    void testDecodedRequestFrame() {
+        DecodedRequestFrame<MetadataRequestData> frame = createRequestFrame();
+        ResponseHeaderData responseHeaderData = new ResponseHeaderData();
+        MetadataResponseData responseBody = new MetadataResponseData();
+        DecodedResponseFrame<? extends ApiMessage> responseFrame = frame.responseFrame(responseHeaderData, responseBody);
+        assertThat(responseFrame.correlationId()).isEqualTo(CORRELATION_ID);
+        assertThat(responseFrame.apiVersion()).isEqualTo(API_VERSION);
+        assertThat(responseFrame.body()).isSameAs(responseBody);
+        assertThat(responseFrame.header()).isSameAs(responseHeaderData);
+    }
+
+    @Test
+    void testResponseFrameApiKeyMustMatch() {
+        DecodedRequestFrame<MetadataRequestData> frame = createRequestFrame();
+        ResponseHeaderData responseHeaderData = new ResponseHeaderData();
+        ApiVersionsResponseData responseBody = new ApiVersionsResponseData();
+        assertThatThrownBy(() -> {
+            frame.responseFrame(responseHeaderData, responseBody);
+        }).isInstanceOf(AssertionError.class).hasMessage("Attempt to create responseFrame with ApiMessage of type API_VERSIONS but request is of type METADATA");
+    }
+
+    private static DecodedRequestFrame<MetadataRequestData> createRequestFrame() {
+        RequestHeaderData header = new RequestHeaderData();
+        header.setCorrelationId(CORRELATION_ID);
+        MetadataRequestData request = new MetadataRequestData();
+        return new DecodedRequestFrame<>(API_VERSION, CORRELATION_ID,
+                true, header, request);
+    }
+
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
@@ -120,6 +120,23 @@ public abstract class FilterHarness {
 
     /**
      * Write a client request to the pipeline.
+     * @param data The request body.
+     * @return The frame that was sent.
+     * @param <B> The type of the request.
+     */
+    protected <B extends ApiMessage> InternalRequestFrame<B> writeInternalRequest(B data, Filter recipient) {
+        var apiKey = ApiKeys.forId(data.apiKey());
+        var header = new RequestHeaderData();
+        int correlationId = 42;
+        header.setCorrelationId(correlationId);
+        header.setRequestApiKey(apiKey.id);
+        header.setRequestApiVersion(apiKey.latestVersion());
+        header.setClientId(TEST_CLIENT);
+        return writeInternalRequest(header, data, recipient);
+    }
+
+    /**
+     * Write a client request to the pipeline.
      * @param headerData The request header.
      * @param data The request body.
      * @return The frame that was sent.
@@ -128,6 +145,12 @@ public abstract class FilterHarness {
     protected <B extends ApiMessage> DecodedRequestFrame<B> writeRequest(RequestHeaderData headerData, B data) {
         var frame = new DecodedRequestFrame<>(headerData.requestApiVersion(), headerData.correlationId(), false, headerData, data);
         return writeRequest(frame);
+    }
+
+    protected <B extends ApiMessage> InternalRequestFrame<B> writeInternalRequest(RequestHeaderData headerData, B data, Filter recipient) {
+        var frame = new InternalRequestFrame<>(headerData.requestApiVersion(), headerData.correlationId(), false, recipient, new CompletableFuture<>(), headerData, data);
+        writeRequest(frame);
+        return frame;
     }
 
     /**

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/InternalRequestFrameTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/InternalRequestFrameTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(MockitoExtension.class)
+class InternalRequestFrameTest {
+    private static final int CORRELATION_ID = 1;
+    private static final short API_VERSION = ApiKeys.METADATA.latestVersion();
+    public static final CompletableFuture<Object> PROMISE = new CompletableFuture<>();
+
+    @Mock
+    private Filter filter;
+
+    @Test
+    void testDecodedRequestFrame() {
+        InternalRequestFrame<MetadataRequestData> frame = createRequestFrame();
+        ResponseHeaderData responseHeaderData = new ResponseHeaderData();
+        MetadataResponseData responseBody = new MetadataResponseData();
+        DecodedResponseFrame<? extends ApiMessage> responseFrame = frame.responseFrame(responseHeaderData, responseBody);
+        assertThat(responseFrame).isInstanceOfSatisfying(InternalResponseFrame.class, internalResponseFrame -> {
+            assertThat(internalResponseFrame.correlationId()).isEqualTo(CORRELATION_ID);
+            assertThat(internalResponseFrame.apiVersion()).isEqualTo(API_VERSION);
+            assertThat(internalResponseFrame.body()).isSameAs(responseBody);
+            assertThat(internalResponseFrame.header()).isSameAs(responseHeaderData);
+            assertThat(internalResponseFrame.promise()).isSameAs(PROMISE);
+            assertThat(internalResponseFrame.recipient()).isSameAs(filter);
+        });
+    }
+
+    @Test
+    void testResponseFrameApiKeyMustMatch() {
+        InternalRequestFrame<MetadataRequestData> frame = createRequestFrame();
+        ResponseHeaderData responseHeaderData = new ResponseHeaderData();
+        ApiVersionsResponseData responseBody = new ApiVersionsResponseData();
+        assertThatThrownBy(() -> {
+            frame.responseFrame(responseHeaderData, responseBody);
+        }).isInstanceOf(AssertionError.class).hasMessage("Attempt to create responseFrame with ApiMessage of type API_VERSIONS but request is of type METADATA");
+    }
+
+    private InternalRequestFrame<MetadataRequestData> createRequestFrame() {
+        RequestHeaderData header = new RequestHeaderData();
+        header.setCorrelationId(CORRELATION_ID);
+        MetadataRequestData request = new MetadataRequestData();
+        return new InternalRequestFrame<>(API_VERSION, CORRELATION_ID,
+                true, filter, PROMISE, header, request);
+    }
+}


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Transfers the promise and recipient internal fields when a Filter generates a short-circuit response to an out-of-band request initiated by a downstream filter.

Previously, the internal fields were not transferred, breaking the internal request mechanism as the promise was lost forever. It caused the connection to hang and never respond to the client.

Fixes #2584

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
