### PR TITLE
Enhancement: Active Connections Gauge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,5 @@ fabric.properties
 docs/*.html
 .sdkmanrc
 .releaseNotes
+
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ For changes that effect a public API, the [deprecation policy](./DEV_GUIDE.md#de
 Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
+* [#2598](https://github.com/kroxylicious/kroxylicious/pull/2598): feat(metrics): Add metrics for the number of active connections
+
 ## 0.15.0
 
-* [#2585](https://github.com/kroxylicious/kroxylicious/pull/2585) feat(runtime): Optional configurable policy for selecting the upstream bootstrap server from the bootstrap servers list on connection to the proxies bootstrap address. Available options are `round-robin` (default) and `random`.
+* [#2585](https://github.com/kroxylicious/kroxylicious/pull/2585): feat(runtime): Optional configurable policy for selecting the upstream bootstrap server from the bootstrap servers list on connection to the proxies bootstrap address. Available options are `round-robin` (default) and `random`.
 * [#2402](https://github.com/kroxylicious/kroxylicious/issues/2402): feat(docs): Encryption-at-rest quickstart
 * [#2565](https://github.com/kroxylicious/kroxylicious/pull/2565): build(deps): bump io.javaoperatorsdk:operator-framework-bom from 5.0.4 to 5.1.2
 

--- a/kroxylicious-docs/docs/_modules/monitoring/con-prometheus-metrics-proxy.adoc
+++ b/kroxylicious-docs/docs/_modules/monitoring/con-prometheus-metrics-proxy.adoc
@@ -19,7 +19,7 @@ They allow users to assess the impact of the proxy and its filters on their Kafk
 Connection metrics count the TCP connections made from the client to the proxy (`kroxylicious_client_to_proxy_request_total`) and from the proxy to the broker (`kroxylicious_proxy_to_server_connections_total`).
 These metrics count connection _attempts_, so the connection count is incremented even if the connection attempt ultimately fails.
 
-In addition to the count metrics, there are error metrics.
+In addition to the count metrics, there are active connection gauge metrics that track the current number of open connections, and error metrics.
 
 * If an error occurs whilst the proxy is accepting a connection from the client the `kroxylicious_client_to_proxy_errors_total` metric is incremented by one.
 * If an error occurs whilst the proxy is attempting a connection to a broker the `kroxylicious_proxy_to_server_errors_total` metric is incremented by one.
@@ -31,6 +31,13 @@ The `kroxylicious_client_to_proxy_errors_total` metric also counts connection er
 For these specific errors, the `virtual_cluster` and `node_id` labels are set to an empty string ("").
 
 NOTE: Error conditions signaled _within_ the Kafka protocol response (such as `RESOURCE_NOT_FOUND` or `UNKNOWN_TOPIC_ID`) are not classed as errors by these metrics.
+
+=== Understanding connection counter vs gauge metrics
+
+The proxy provides both counter and gauge metrics for connections:
+
+* **Connection counters** (`kroxylicious_*_connections_total`) track the total number of connection attempts over time. These values only increase and provide a historical view of connection activity.
+* **Active connection gauges** (`kroxylicious_*_active_connections`) show the current number of open connections at any given moment. These values increase when connections are established and decrease when connections are closed.
 
 .Connection metrics for client and broker interactions
 |===
@@ -57,6 +64,18 @@ NOTE: Error conditions signaled _within_ the Kafka protocol response (such as `R
 |Counter
 |`virtual_cluster`, `node_id`
 |Incremented by one every time a connection is closed due to any upstream error.
+
+|`kroxylicious_client_to_proxy_active_connections`
+|Gauge
+|`virtual_cluster`, `node_id`
+|Shows the current number of active TCP connections from clients to the proxy. +
+ This gauge reflects real-time connection state and decreases when connections are closed.
+
+|`kroxylicious_proxy_to_server_active_connections`
+|Gauge
+|`virtual_cluster`, `node_id`
+|Shows the current number of active TCP connections from the proxy to servers. +
+ This gauge reflects real-time connection state and decreases when connections are closed.
 |===
 
 == Message metrics

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/MeterRegistries.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/MeterRegistries.java
@@ -96,5 +96,6 @@ public class MeterRegistries implements AutoCloseable {
         var copy = List.copyOf(prometheusMeterRegistry.getMeters());
         copy.forEach(Metrics.globalRegistry::remove);
         Metrics.removeRegistry(prometheusMeterRegistry);
+        io.kroxylicious.proxy.internal.util.Metrics.clear();
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/util/ActivationToken.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/util/ActivationToken.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.util;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A thread-safe state that ensures exactly-once increment and decrement operations.
+ * <p>
+ * This counter prevents race conditions in connection lifecycle management by tracking
+ * its own state and only allowing state transitions: INITIAL → ACTIVE → INACTIVE.
+ * Multiple calls to increment/decrement methods are safe and idempotent.
+ * </p>
+ *
+ * <p><strong>Thread Safety:</strong> This class is thread-safe and can be used
+ * concurrently from multiple threads.</p>
+ */
+public class ActivationToken {
+
+    // state values
+    private static final int INITIAL_VALUE = 0;
+    private static final int ACQUIRED = 1;
+    private static final int RELEASED = -1;
+
+    // the state of this instance
+    private final AtomicInteger state = new AtomicInteger(INITIAL_VALUE);
+
+    // the tracker of all active instances
+    private final AtomicInteger currentCounter;
+
+    public ActivationToken(AtomicInteger currentCounter) {
+        this.currentCounter = currentCounter;
+    }
+
+    /**
+     * Attempts to increment the counter if it is in the INITIAL state.
+     * If the state is already ACQUIRED or RELEASED, this method has no effect.
+     */
+    public void acquire() {
+        if (this.state.compareAndSet(INITIAL_VALUE, ACQUIRED)) {
+            this.currentCounter.incrementAndGet();
+        }
+    }
+
+    public void release() {
+        if (this.state.compareAndSet(ACQUIRED, RELEASED)) {
+            this.currentCounter.decrementAndGet();
+        }
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/util/VirtualClusterNode.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/util/VirtualClusterNode.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.util;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Represents a node in a virtual cluster, identified by its cluster name and an optional node ID.
+ * This is used to track nodes within a virtual cluster context.
+ */
+public record VirtualClusterNode(String clusterName, @Nullable Integer nodeId) {
+
+    @Override
+    public String toString() {
+        return "VirtualClusterNode{" +
+                "clusterName='" + clusterName + '\'' +
+                ", nodeId=" + nodeId +
+                '}';
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/util/ActivationTokenTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/util/ActivationTokenTest.java
@@ -1,0 +1,444 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.util;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test cases for {@link ActivationToken}.
+ *
+ * This class tests the thread-safe state management and exactly-once semantics
+ * of the ActivationToken class, ensuring proper lifecycle management and
+ * race condition prevention.
+ */
+class ActivationTokenTest {
+
+    private AtomicInteger counter;
+    private ActivationToken token;
+
+    @BeforeEach
+    void setUp() {
+        counter = new AtomicInteger(0);
+        token = new ActivationToken(counter);
+    }
+
+    @Test
+    @DisplayName("acquire() increments counter exactly once")
+    void testAcquireIncrementsCounterOnce() {
+        // Given: token in initial state, counter at 0
+        assertEquals(0, counter.get());
+
+        // When: acquire is called
+        token.acquire();
+
+        // Then: counter is incremented to 1
+        assertEquals(1, counter.get());
+    }
+
+    @Test
+    @DisplayName("multiple acquire() calls are idempotent")
+    void testMultipleAcquireCallsAreIdempotent() {
+        // Given: token in initial state
+        assertEquals(0, counter.get());
+
+        // When: acquire is called multiple times
+        token.acquire();
+        token.acquire();
+        token.acquire();
+
+        // Then: counter is incremented only once
+        assertEquals(1, counter.get());
+    }
+
+    @Test
+    @DisplayName("release() decrements counter exactly once after acquire()")
+    void testReleaseDecrementsCounterOnce() {
+        // Given: token has been acquired
+        token.acquire();
+        assertEquals(1, counter.get());
+
+        // When: release is called
+        token.release();
+
+        // Then: counter is decremented to 0
+        assertEquals(0, counter.get());
+    }
+
+    @Test
+    @DisplayName("multiple release() calls are idempotent")
+    void testMultipleReleaseCallsAreIdempotent() {
+        // Given: token has been acquired and released once
+        token.acquire();
+        token.release();
+        assertEquals(0, counter.get());
+
+        // When: release is called multiple times
+        token.release();
+        token.release();
+        token.release();
+
+        // Then: counter remains at 0
+        assertEquals(0, counter.get());
+    }
+
+    @Test
+    @DisplayName("release() without acquire() has no effect")
+    void testReleaseWithoutAcquireHasNoEffect() {
+        // Given: token in initial state
+        assertEquals(0, counter.get());
+
+        // When: release is called without prior acquire
+        token.release();
+
+        // Then: counter remains at 0
+        assertEquals(0, counter.get());
+    }
+
+    @Test
+    @DisplayName("acquire() after release() has no effect")
+    void testAcquireAfterReleaseHasNoEffect() {
+        // Given: token has been acquired and released
+        token.acquire();
+        token.release();
+        assertEquals(0, counter.get());
+
+        // When: acquire is called again
+        token.acquire();
+
+        // Then: counter remains at 0 (token is in released state)
+        assertEquals(0, counter.get());
+    }
+
+    @Test
+    @DisplayName("complete lifecycle: initial -> acquired -> released")
+    void testCompleteLifecycle() {
+        // Initial state: counter should be 0
+        assertEquals(0, counter.get());
+
+        // Acquire: counter should be 1
+        token.acquire();
+        assertEquals(1, counter.get());
+
+        // Release: counter should be 0
+        token.release();
+        assertEquals(0, counter.get());
+
+        // Further operations should have no effect
+        token.acquire();
+        token.release();
+        assertEquals(0, counter.get());
+    }
+
+    @Test
+    @DisplayName("multiple tokens share the same counter correctly")
+    void testMultipleTokensSharedCounter() {
+        // Given: multiple tokens sharing the same counter
+        ActivationToken token1 = new ActivationToken(counter);
+        ActivationToken token2 = new ActivationToken(counter);
+        ActivationToken token3 = new ActivationToken(counter);
+
+        // When: each token is acquired
+        token1.acquire();
+        assertEquals(1, counter.get());
+
+        token2.acquire();
+        assertEquals(2, counter.get());
+
+        token3.acquire();
+        assertEquals(3, counter.get());
+
+        // When: tokens are released
+        token1.release();
+        assertEquals(2, counter.get());
+
+        token2.release();
+        assertEquals(1, counter.get());
+
+        token3.release();
+        assertEquals(0, counter.get());
+    }
+
+    @Test
+    @DisplayName("tokens are independent - one token's release doesn't affect others")
+    void testTokensAreIndependent() {
+        // Given: multiple tokens, some acquired, some not
+        ActivationToken token1 = new ActivationToken(counter);
+        ActivationToken token2 = new ActivationToken(counter);
+
+        token1.acquire();
+        // token2 remains unacquired
+        assertEquals(1, counter.get());
+
+        // When: releasing unacquired token
+        token2.release();
+
+        // Then: counter remains unchanged
+        assertEquals(1, counter.get());
+
+        // When: releasing acquired token
+        token1.release();
+
+        // Then: counter decrements properly
+        assertEquals(0, counter.get());
+    }
+
+    @Test
+    @DisplayName("concurrent acquire() operations are thread-safe")
+    @Timeout(5)
+    void testConcurrentAcquireOperations() throws InterruptedException {
+        final int threadCount = 10;
+        final ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        final CountDownLatch latch = new CountDownLatch(threadCount);
+        final CyclicBarrier barrier = new CyclicBarrier(threadCount);
+
+        try {
+            // When: multiple threads try to acquire the same token concurrently
+            IntStream.range(0, threadCount).forEach(i -> {
+                executor.submit(() -> {
+                    try {
+                        barrier.await(); // Synchronize thread start
+                        token.acquire();
+                    }
+                    catch (Exception e) {
+                        fail("Unexpected exception: " + e.getMessage());
+                    }
+                    finally {
+                        latch.countDown();
+                    }
+                });
+            });
+
+            // Wait for all threads to complete
+            assertTrue(latch.await(3, TimeUnit.SECONDS));
+
+            // Then: counter should be incremented exactly once
+            assertEquals(1, counter.get());
+        }
+        finally {
+            executor.shutdown();
+            executor.awaitTermination(1, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    @DisplayName("concurrent acquire() and release() operations are thread-safe")
+    @Timeout(5)
+    void testConcurrentAcquireAndReleaseOperations() throws InterruptedException {
+        final int threadCount = 20; // 10 acquire, 10 release
+        final ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        final CountDownLatch latch = new CountDownLatch(threadCount);
+        final CyclicBarrier barrier = new CyclicBarrier(threadCount);
+
+        try {
+            // When: multiple threads try to acquire and release concurrently
+            IntStream.range(0, threadCount).forEach(i -> {
+                executor.submit(() -> {
+                    try {
+                        barrier.await(); // Synchronize thread start
+                        if (i < 10) {
+                            token.acquire();
+                        }
+                        else {
+                            token.release();
+                        }
+                    }
+                    catch (Exception e) {
+                        fail("Unexpected exception: " + e.getMessage());
+                    }
+                    finally {
+                        latch.countDown();
+                    }
+                });
+            });
+
+            // Wait for all threads to complete
+            assertTrue(latch.await(3, TimeUnit.SECONDS));
+
+            // Then: final state should be consistent (either 0 or 1 depending on timing)
+            int finalValue = counter.get();
+            assertTrue(finalValue >= 0 && finalValue <= 1,
+                    "Counter value should be 0 or 1, but was: " + finalValue);
+        }
+        finally {
+            executor.shutdown();
+            executor.awaitTermination(1, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    @DisplayName("concurrent operations on multiple tokens are thread-safe")
+    @Timeout(5)
+    void testConcurrentMultipleTokenOperations() throws InterruptedException {
+        final int tokenCount = 5;
+        final int threadsPerToken = 4;
+        final int totalThreads = tokenCount * threadsPerToken;
+        final ExecutorService executor = Executors.newFixedThreadPool(totalThreads);
+        final CountDownLatch latch = new CountDownLatch(totalThreads);
+        final ActivationToken[] tokens = new ActivationToken[tokenCount];
+
+        // Create multiple tokens sharing the same counter
+        for (int i = 0; i < tokenCount; i++) {
+            tokens[i] = new ActivationToken(counter);
+        }
+
+        try {
+            // When: multiple threads operate on different tokens concurrently
+            for (int tokenIndex = 0; tokenIndex < tokenCount; tokenIndex++) {
+                final int finalTokenIndex = tokenIndex;
+                for (int threadIndex = 0; threadIndex < threadsPerToken; threadIndex++) {
+                    final int finalThreadIndex = threadIndex;
+                    executor.submit(() -> {
+                        try {
+                            ActivationToken currentToken = tokens[finalTokenIndex];
+                            if (finalThreadIndex % 2 == 0) {
+                                currentToken.acquire();
+                            }
+                            else {
+                                currentToken.release();
+                            }
+                        }
+                        catch (Exception e) {
+                            fail("Unexpected exception: " + e.getMessage());
+                        }
+                        finally {
+                            latch.countDown();
+                        }
+                    });
+                }
+            }
+
+            // Wait for all threads to complete
+            assertTrue(latch.await(5, TimeUnit.SECONDS));
+
+            // Then: counter should be non-negative and not exceed token count
+            int finalValue = counter.get();
+            assertTrue(finalValue >= 0 && finalValue <= tokenCount,
+                    "Counter value should be between 0 and " + tokenCount + ", but was: " + finalValue);
+        }
+        finally {
+            executor.shutdown();
+            executor.awaitTermination(1, TimeUnit.SECONDS);
+        }
+    }
+
+    @RepeatedTest(10)
+    @DisplayName("stress test - repeated concurrent operations")
+    @Timeout(3)
+    void stressTestRepeatedConcurrentOperations() throws InterruptedException {
+        final int threadCount = 20;
+        final int operationsPerThread = 10;
+        final ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        final CountDownLatch latch = new CountDownLatch(threadCount);
+        final AtomicReference<Exception> exceptionRef = new AtomicReference<>();
+
+        try {
+            IntStream.range(0, threadCount).forEach(i -> {
+                executor.submit(() -> {
+                    try {
+                        for (int j = 0; j < operationsPerThread; j++) {
+                            if (j % 2 == 0) {
+                                token.acquire();
+                            }
+                            else {
+                                token.release();
+                            }
+                        }
+                    }
+                    catch (Exception e) {
+                        exceptionRef.set(e);
+                    }
+                    finally {
+                        latch.countDown();
+                    }
+                });
+            });
+
+            assertTrue(latch.await(2, TimeUnit.SECONDS));
+            assertNull(exceptionRef.get(), "No exceptions should occur during concurrent operations");
+
+            // Counter should be in a valid state (0 or 1)
+            int finalValue = counter.get();
+            assertTrue(finalValue >= 0 && finalValue <= 1,
+                    "Counter should be 0 or 1, but was: " + finalValue);
+        }
+        finally {
+            executor.shutdown();
+            executor.awaitTermination(1, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    @DisplayName("edge case - rapid acquire/release cycles")
+    void testRapidAcquireReleaseCycles() {
+        // Test rapid acquire/release cycles to ensure state consistency
+        for (int i = 0; i < 1000; i++) {
+            token.acquire();
+            assertEquals(1, counter.get(), "Counter should be 1 after acquire in iteration " + i);
+
+            token.release();
+            assertEquals(0, counter.get(), "Counter should be 0 after release in iteration " + i);
+
+            // Create new token for next iteration to reset state
+            token = new ActivationToken(counter);
+        }
+    }
+
+    @Test
+    @DisplayName("counter starts from non-zero value")
+    void testCounterStartsFromNonZeroValue() {
+        // Given: counter starts at 42
+        AtomicInteger nonZeroCounter = new AtomicInteger(42);
+        ActivationToken nonZeroToken = new ActivationToken(nonZeroCounter);
+
+        // When: token is acquired
+        nonZeroToken.acquire();
+
+        // Then: counter is incremented from its initial value
+        assertEquals(43, nonZeroCounter.get());
+
+        // When: token is released
+        nonZeroToken.release();
+
+        // Then: counter is decremented back to initial value
+        assertEquals(42, nonZeroCounter.get());
+    }
+
+    @Test
+    @DisplayName("negative counter values are handled correctly")
+    void testNegativeCounterValues() {
+        // Given: counter starts at -5
+        AtomicInteger negativeCounter = new AtomicInteger(-5);
+        ActivationToken negativeToken = new ActivationToken(negativeCounter);
+
+        // When: token is acquired
+        negativeToken.acquire();
+
+        // Then: counter is incremented from negative value
+        assertEquals(-4, negativeCounter.get());
+
+        // When: token is released
+        negativeToken.release();
+
+        // Then: counter is decremented back to original negative value
+        assertEquals(-5, negativeCounter.get());
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/util/ActivationTokenTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/util/ActivationTokenTest.java
@@ -21,11 +21,13 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test cases for {@link ActivationToken}.
- *
  * This class tests the thread-safe state management and exactly-once semantics
  * of the ActivationToken class, ensuring proper lifecycle management and
  * race condition prevention.


### PR DESCRIPTION
### Type of change
Enhancement / New Feature 

### Description
This PR introduces a new metric—active connection gauge (covering both client→proxy and proxy→server)—to track the current number of active connections handled by the proxy. Unlike the existing cumulative counter (which only increases and does not decrease on connection closure), this metric reflects the real-time state of the system.

#### Benefits
1. Provides operational visibility into live connection counts.
2. Assists teams with load analysis, diagnosing connection churn, and ensuring proxy health.
3. Useful for validating migrations and post-deployment scenarios (e.g., confirming that connection levels return to expected baselines).

### Additional Context

_Why are you making this pull request?_
Currently, the metrics include the cumulative count of connections created (does not reduce on connection closure). The active connection count metrics will provide active connections.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [x] Update documentation
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.


### Test Screens
1. Metrics endpoint (http://localhost:9190/metrics) output:
```
# TYPE kroxylicious_active_client_to_proxy_connections gauge
kroxylicious_active_client_to_proxy_connections{node_id="1",virtual_cluster="demo"} 0.0
kroxylicious_active_client_to_proxy_connections{node_id="bootstrap",virtual_cluster="demo"} 0.0
# HELP kroxylicious_active_proxy_to_server_connections Number of currently active connections from the proxy to servers.
# TYPE kroxylicious_active_proxy_to_server_connections gauge
kroxylicious_active_proxy_to_server_connections{node_id="1",virtual_cluster="demo"} 0.0
kroxylicious_active_proxy_to_server_connections{node_id="bootstrap",virtual_cluster="demo"} 0.0
```
2. Activity recorded:

https://github.com/user-attachments/assets/3259913c-73f6-41ce-b47b-91bfcfaea52c

3. Grafana Dashboard
<img width="1604" height="323" alt="Screenshot 2025-08-21 at 6 10 57 PM" src="https://github.com/user-attachments/assets/af377de9-0144-4efb-bfc0-68bb5da19800" />
