### PR TITLE
refactor: use java to build the operand image for the operator test Github workflow

### DIFF
--- a/.github/workflows/operator-maven.yaml
+++ b/.github/workflows/operator-maven.yaml
@@ -57,31 +57,24 @@ jobs:
           driver: docker
       - name: 'Set up Docker Buildx'
         uses: docker/setup-buildx-action@v3
-      - name: 'Configure build environment'
-        id: build_configuration
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Cache Maven packages'
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: 'Build Kroxylicious Operand Container Image'
         run: |
           GIT_HASH="$(git rev-parse HEAD)"
-          IMAGE_TAG="dev-git-${GIT_HASH}"
           KROXYLICIOUS_VERSION="$(mvn org.apache.maven.plugins:maven-help-plugin:3.4.0:evaluate -Dexpression=project.version -q -DforceStdout)"
-          KROXYLICIOUS_IMAGE="quay.io/kroxylicious/kroxylicious:${IMAGE_TAG}"
-          echo "kroxylicious_version=${KROXYLICIOUS_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "kroxylicious_image=${KROXYLICIOUS_IMAGE}" >> "$GITHUB_OUTPUT"
-      - name: 'Build tagged Kroxylicious Operand Docker image'
-        uses: docker/build-push-action@v6
-        with:
-          file: Dockerfile
-          context: .
-          build-args:
-            KROXYLICIOUS_VERSION=${{ steps.build_configuration.outputs.kroxylicious_version }}
-          tags: ${{ steps.build_configuration.outputs.kroxylicious_image }}
-          push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,compression=zstd
-          load: 'true'
+          KROXYLICIOUS_IMAGE=quay.io/kroxylicious/proxy:${KROXYLICIOUS_VERSION}-${GIT_HASH}
+          mvn --batch-mode --activate-profiles dist --also-make --projects :kroxylicious-app -DskipTests clean package -Dio.kroxylicious.proxy.image.name=${KROXYLICIOUS_IMAGE}
+          echo "KROXYLICIOUS_IMAGE=${KROXYLICIOUS_IMAGE}" >> "${GITHUB_ENV}"
       - name: 'Load Kroxylicious Operand Docker Image in Minikube'
-        run: minikube image load  ${{ steps.build_configuration.outputs.kroxylicious_image }}
+        run: |
+          # https://github.com/kubernetes/minikube/issues/21393 - minikube image load doesn't fail if the load fails.
+          minikube image load kroxylicious-app/target/kroxylicious-proxy.img.tar.gz
+          minikube image ls | grep --fixed-strings ${KROXYLICIOUS_IMAGE}
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
         if: github.ref_name == 'main' || env.SONAR_TOKEN_SET == 'true'
@@ -89,16 +82,9 @@ jobs:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
-      - name: 'Cache Maven packages'
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
       - name: 'Build & test Kroxylicious operator'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          KROXYLICIOUS_IMAGE: ${{ steps.build_configuration.outputs.kroxylicious_image }}
         run: |
           mvn -B install -Pci -Djapicmp.skip=true -pl ':kroxylicious-operator' -am
       - name: 'Build Kroxylicious maven project on main with Sonar'
@@ -106,7 +92,6 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          KROXYLICIOUS_IMAGE: ${{ steps.build_configuration.outputs.kroxylicious_image }}
         run: mvn -B verify -Pci -Djapicmp.skip=true org.sonarsource.scanner.maven:sonar-maven-plugin:5.0.0.4389:sonar -Dsonar.projectKey=kroxylicious_kroxylicious  -pl ':kroxylicious-operator,:kroxylicious-parent'
       - name: Save PR number to file
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

We want to use our maven/java approach to building our container images, rather than invoking `docker build` directly.
The operator-maven Github workflow is currently using the old way.  It should be refactored to use the new.


This change won't affect the images shipped as part of the release (IOW those generated by the docker.yaml workflow).

### Additional Context

Takes a step toward eliminating the old way of building images.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
