### PR TITLE
Refactor dockerfiles to pull tini from #2614 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,36 +6,8 @@
 
 FROM registry.access.redhat.com/ubi9/openjdk-17:1.23-6.1755674726 AS builder
 
-ARG TARGETOS
-ARG TARGETARCH
-
 USER root
 WORKDIR /opt/kroxylicious
-
-# Download Tini
-ENV TINI_VERSION=v0.19.0
-ENV TINI_SHA256_AMD64=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c
-ENV TINI_SHA256_ARM64=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81
-ENV TINI_SHA256_PPC64LE=3f658420974768e40810001a038c29d003728c5fe86da211cff5059e48cfdfde
-ENV TINI_SHA256_S390X=931b70a182af879ca249ae9de87ef68423121b38d235c78997fafc680ceab32d
-ENV TINI_DEST=/opt/tini/bin/tini
-
-RUN set -ex; \
-    mkdir -p /opt/tini/bin/; \
-    if [[ "${TARGETOS}/${TARGETARCH}" = "linux/ppc64le" ]]; then \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-ppc64le -o ${TINI_DEST}; \
-        echo "${TINI_SHA256_PPC64LE} *${TINI_DEST}" | sha256sum -c; \
-    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/arm64" ]]; then \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 -o ${TINI_DEST}; \
-        echo "${TINI_SHA256_ARM64} *${TINI_DEST}" | sha256sum -c; \
-    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/s390x" ]]; then \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x -o ${TINI_DEST}; \
-        echo "${TINI_SHA256_S390X} *${TINI_DEST}" | sha256sum -c; \
-    else \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o ${TINI_DEST}; \
-        echo "${TINI_SHA256_AMD64} *${TINI_DEST}" | sha256sum -c; \
-    fi; \
-    chmod +x ${TINI_DEST}
 
 COPY . .
 RUN mvn -q -B clean package -Pdist -Dquick -DskipDocker=true -DskipDocs=true
@@ -60,7 +32,7 @@ RUN microdnf -y update \
 
 ENV JAVA_HOME=/usr/lib/jvm/jre-17
 
-COPY --from=builder /opt/tini/bin/tini /usr/bin/tini
+COPY --from=quay.io/k_wall/tini:0.19.0 /usr/bin/tini /usr/bin/tini
 COPY --from=builder /opt/kroxylicious/kroxylicious-app/target/kroxylicious-app-${KROXYLICIOUS_VERSION}-bin/kroxylicious-app-${KROXYLICIOUS_VERSION}/ /opt/kroxylicious/
 
 USER ${CONTAINER_USER_UID}

--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -6,36 +6,8 @@
 
 FROM registry.access.redhat.com/ubi9/openjdk-17:1.23-6.1755674726 AS builder
 
-ARG TARGETOS=linux
-ARG TARGETARCH
-
 USER root
 WORKDIR /opt/kroxylicious
-
-# Download Tini
-ENV TINI_VERSION=v0.19.0
-ENV TINI_SHA256_AMD64=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c
-ENV TINI_SHA256_ARM64=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81
-ENV TINI_SHA256_PPC64LE=3f658420974768e40810001a038c29d003728c5fe86da211cff5059e48cfdfde
-ENV TINI_SHA256_S390X=931b70a182af879ca249ae9de87ef68423121b38d235c78997fafc680ceab32d
-ENV TINI_DEST=/opt/tini/bin/tini
-
-RUN set -ex; \
-    mkdir -p /opt/tini/bin/; \
-    if [[ "${TARGETOS}/${TARGETARCH}" = "linux/ppc64le" ]]; then \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-ppc64le -o ${TINI_DEST}; \
-        echo "${TINI_SHA256_PPC64LE} *${TINI_DEST}" | sha256sum -c; \
-    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/arm64" ]]; then \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 -o ${TINI_DEST}; \
-        echo "${TINI_SHA256_ARM64} *${TINI_DEST}" | sha256sum -c; \
-    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/s390x" ]]; then \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x -o ${TINI_DEST}; \
-        echo "${TINI_SHA256_S390X} *${TINI_DEST}" | sha256sum -c; \
-    else \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o ${TINI_DEST}; \
-        echo "${TINI_SHA256_AMD64} *${TINI_DEST}" | sha256sum -c; \
-    fi; \
-    chmod +x ${TINI_DEST}
 
 COPY . .
 
@@ -61,7 +33,7 @@ RUN microdnf -y update \
 
 ENV JAVA_HOME=/usr/lib/jvm/jre-17
 
-COPY --from=builder /opt/tini/bin/tini /usr/bin/tini
+COPY --from=quay.io/k_wall/tini:0.19.0 /usr/bin/tini /usr/bin/tini
 COPY --from=builder /opt/kroxylicious/kroxylicious-operator/target/kroxylicious-operator-${KROXYLICIOUS_VERSION}-app/kroxylicious-operator-${KROXYLICIOUS_VERSION} /opt/kroxylicious-operator
 
 USER ${CONTAINER_USER_UID}

--- a/kroxylicious-app/src/main/docker/proxy.dockerfile
+++ b/kroxylicious-app/src/main/docker/proxy.dockerfile
@@ -6,8 +6,6 @@
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1755695350
 
-ARG TARGETOS
-ARG TARGETARCH
 ARG JAVA_VERSION=17
 ARG KROXYLICIOUS_VERSION
 ARG CONTAINER_USER=kroxylicious
@@ -15,31 +13,6 @@ ARG CONTAINER_USER_UID=185
 
 USER root
 WORKDIR /opt/kroxylicious
-
-# Download Tini
-ENV TINI_VERSION=v0.19.0
-ENV TINI_SHA256_AMD64=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c
-ENV TINI_SHA256_ARM64=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81
-ENV TINI_SHA256_PPC64LE=3f658420974768e40810001a038c29d003728c5fe86da211cff5059e48cfdfde
-ENV TINI_SHA256_S390X=931b70a182af879ca249ae9de87ef68423121b38d235c78997fafc680ceab32d
-ENV TINI_DEST=/usr/bin/tini
-
-RUN set -ex; \
-    mkdir -p /opt/tini/bin/; \
-    if [[ "${TARGETOS}/${TARGETARCH}" = "linux/ppc64le" ]]; then \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-ppc64le -o ${TINI_DEST}; \
-        echo "${TINI_SHA256_PPC64LE} *${TINI_DEST}" | sha256sum -c; \
-    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/arm64" ]]; then \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 -o ${TINI_DEST}; \
-        echo "${TINI_SHA256_ARM64} *${TINI_DEST}" | sha256sum -c; \
-    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/s390x" ]]; then \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x -o ${TINI_DEST}; \
-        echo "${TINI_SHA256_S390X} *${TINI_DEST}" | sha256sum -c; \
-    else \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o ${TINI_DEST}; \
-        echo "${TINI_SHA256_AMD64} *${TINI_DEST}" | sha256sum -c; \
-    fi; \
-    chmod +x ${TINI_DEST}
 
 RUN microdnf -y update \
     && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
@@ -51,6 +24,8 @@ RUN microdnf -y update \
     && microdnf clean all
 
 ENV JAVA_HOME=/usr/lib/jvm/jre-${JAVA_VERSION}
+
+COPY --from=quay.io/k_wall/tini:0.19.0 /usr/bin/tini /usr/bin/tini
 
 COPY target/kroxylicious-app-${KROXYLICIOUS_VERSION}-bin/kroxylicious-app-${KROXYLICIOUS_VERSION}/ .
 

--- a/kroxylicious-operator/src/main/docker/operator.dockerfile
+++ b/kroxylicious-operator/src/main/docker/operator.dockerfile
@@ -6,8 +6,6 @@
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1755695350
 
-ARG TARGETOS=linux
-ARG TARGETARCH
 ARG JAVA_VERSION=17
 ARG KROXYLICIOUS_VERSION
 ARG CONTAINER_USER=kroxylicious
@@ -15,31 +13,6 @@ ARG CONTAINER_USER_UID=185
 
 USER root
 WORKDIR /opt/kroxylicious-operator
-
-# Download Tini
-ENV TINI_VERSION=v0.19.0
-ENV TINI_SHA256_AMD64=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c
-ENV TINI_SHA256_ARM64=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81
-ENV TINI_SHA256_PPC64LE=3f658420974768e40810001a038c29d003728c5fe86da211cff5059e48cfdfde
-ENV TINI_SHA256_S390X=931b70a182af879ca249ae9de87ef68423121b38d235c78997fafc680ceab32d
-ENV TINI_DEST=/usr/bin/tini
-
-RUN set -ex; \
-    mkdir -p /opt/tini/bin/; \
-    if [[ "${TARGETOS}/${TARGETARCH}" = "linux/ppc64le" ]]; then \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-ppc64le -o ${TINI_DEST}; \
-        echo "${TINI_SHA256_PPC64LE} *${TINI_DEST}" | sha256sum -c; \
-    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/arm64" ]]; then \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 -o ${TINI_DEST}; \
-        echo "${TINI_SHA256_ARM64} *${TINI_DEST}" | sha256sum -c; \
-    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/s390x" ]]; then \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x -o ${TINI_DEST}; \
-        echo "${TINI_SHA256_S390X} *${TINI_DEST}" | sha256sum -c; \
-    else \
-        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o ${TINI_DEST}; \
-        echo "${TINI_SHA256_AMD64} *${TINI_DEST}" | sha256sum -c; \
-    fi; \
-    chmod +x ${TINI_DEST}
 
 RUN microdnf -y update \
     && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
@@ -51,6 +24,8 @@ RUN microdnf -y update \
     && microdnf clean all
 
 ENV JAVA_HOME=/usr/lib/jvm/jre-${JAVA_VERSION}
+
+COPY --from=quay.io/k_wall/tini:0.19.0 /usr/bin/tini /usr/bin/tini
 
 COPY target/kroxylicious-operator-${KROXYLICIOUS_VERSION}-app/kroxylicious-operator-${KROXYLICIOUS_VERSION}/ .
 

--- a/scripts/build-operator.sh
+++ b/scripts/build-operator.sh
@@ -12,5 +12,4 @@ IMAGE_TAG="${IMAGE_TAG:-dev-git-${GIT_HASH}}"
 OPERATOR_PULL_SPEC=$(buildPullSpec "operator")
 info "building operator image (${OPERATOR_PULL_SPEC}) in minikube for commit ${GIT_HASH}"
 KROXYLICIOUS_VERSION=${KROXYLICIOUS_VERSION:-$(mvn org.apache.maven.plugins:maven-help-plugin:3.4.0:evaluate -Dexpression=project.version -q -DforceStdout)}
-TARGETARCH=${TARGETARCH:-$(uname -m)}
-minikube image build . -f Dockerfile.operator -t "${OPERATOR_PULL_SPEC}" --build-opt=build-arg=KROXYLICIOUS_VERSION="${KROXYLICIOUS_VERSION}" --build-opt=build-arg=TARGETARCH="${TARGETARCH}"
+minikube image build . -f Dockerfile.operator -t "${OPERATOR_PULL_SPEC}" --build-opt=build-arg=KROXYLICIOUS_VERSION="${KROXYLICIOUS_VERSION}"


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

Refactor all dockerfiles to get the arch specific `tini` binary from the Kroxylicious tini base image introduced by #2614.

_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
