### PR TITLE
fix: Restrict the metrics/health HTTP interface to GET requests

### DIFF
--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/ManagementClient.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/ManagementClient.java
@@ -14,6 +14,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.List;
+import java.util.Objects;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -26,9 +27,11 @@ public class ManagementClient implements Closeable {
     private static final String METRICS = "metrics";
 
     private final HttpClient httpClient = HttpClient.newHttpClient();
+
     private final URI uri;
 
     ManagementClient(@NonNull URI uri) {
+        Objects.requireNonNull(uri, "uri");
         this.uri = uri;
     }
 
@@ -55,6 +58,11 @@ public class ManagementClient implements Closeable {
     public List<SimpleMetric> scrapeMetrics() {
         var text = getFromAdminEndpoint(METRICS).body();
         return SimpleMetric.parse(text);
+    }
+
+    @NonNull
+    public URI getUri() {
+        return uri;
     }
 
     @Override


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

fix: Restrict the metrics/health HTTP interface to GET requests (#1039).

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
