### PR TITLE
make KrpcGenerator not modify existing up-to-date sources

### DIFF
--- a/kroxylicious-krpc-plugin/src/test/java/io/kroxylicious/krpccodegen/main/KrpcGeneratorTest.java
+++ b/kroxylicious-krpc-plugin/src/test/java/io/kroxylicious/krpccodegen/main/KrpcGeneratorTest.java
@@ -5,25 +5,33 @@
  */
 package io.kroxylicious.krpccodegen.main;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.google.common.io.Files;
 import com.google.common.io.Resources;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.writeString;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -62,6 +70,28 @@ class KrpcGeneratorTest {
 
         File file = join(tempDir, "com", "foo", "FetchRequest.txt");
         assertFileHasExpectedContents(file, "hello-world/example-expected-FetchRequest.txt");
+    }
+
+    @Test
+    void singleGenerateDoesNotModifyFileIfContentsUnchanged(@TempDir File tempDir) throws Exception {
+        KrpcGenerator gen = KrpcGenerator.single()
+                .withMessageSpecDir(getMessageSpecDir())
+                .withMessageSpecFilter("*.json")
+                .withTemplateDir(getTemplateDir())
+                .withTemplateNames(List.of("hello-world/example.ftl"))
+                .withOutputPackage("com.foo")
+                .withOutputDir(tempDir)
+                .withOutputFilePattern("${messageSpecName}.txt")
+                .build();
+
+        gen.generate();
+
+        File file = join(tempDir, "com", "foo", "FetchRequest.txt");
+        long lastModified = file.lastModified();
+        Thread.sleep(10);
+        gen.generate();
+        long lastModifiedAfterGen = file.lastModified();
+        assertThat(lastModifiedAfterGen).isEqualTo(lastModified);
     }
 
     @Test
@@ -118,11 +148,108 @@ class KrpcGeneratorTest {
         assertFileHasExpectedContents(file, "Kproxy/KrpcRequestFilter-expected.txt");
     }
 
+    @Test
+    void multiGenerateDoesNotModifyFileIfContentsUnchanged(@TempDir File tempDir) throws Exception {
+        KrpcGenerator gen = KrpcGenerator.multi()
+                .withMessageSpecDir(getMessageSpecDir())
+                .withMessageSpecFilter("*{Request}.json")
+                .withTemplateDir(getTemplateDir())
+                .withTemplateNames(List.of("Kproxy/KrpcRequestFilter.ftl"))
+                .withOutputPackage("com.foo")
+                .withOutputDir(tempDir)
+                .withOutputFilePattern("${templateName}.java")
+                .build();
+
+        gen.generate();
+
+        File file = join(tempDir, "com", "foo", "KrpcRequestFilter.java");
+        long lastModified = file.lastModified();
+        Thread.sleep(10);
+        gen.generate();
+        long lastModifiedAfterGen = file.lastModified();
+        assertThat(lastModifiedAfterGen).isEqualTo(lastModified);
+    }
+
     @ParameterizedTest
     @CsvSource({ "AddPartitionsToTxnRequest.json,yes,no", "FetchRequest.json,no,no" })
     void testLatestVersionUnstable(String messageSpec, String expectField, String expectValue, @TempDir File tempDir) throws Exception {
         testSingleGeneration(tempDir, messageSpec, "${messageSpec.latestVersionUnstable.isPresent()?string('yes', 'no')}", expectField);
         testSingleGeneration(tempDir, messageSpec, "${messageSpec.latestVersionUnstable.orElse(false)?string('yes', 'no')}", expectValue);
+    }
+
+    @CsvSource(nullValues = "null", value = { "a,b,false", "a,a,true", "aa,a,false", "a,aa,false", "a,null,false" })
+    @ParameterizedTest
+    void filesEqual(String fileAContent, String fileBContent, boolean expectedEquality, @TempDir File tempDir) throws IOException {
+        Path fileA = tempDir.toPath().resolve("a");
+        Path fileB = tempDir.toPath().resolve("b");
+        writeString(fileA, fileAContent, UTF_8);
+        if (fileBContent != null) {
+            writeString(fileB, fileBContent, UTF_8);
+        }
+        boolean filesEqual = KrpcGenerator.filesEqual(fileA, fileB);
+        assertThat(filesEqual).isEqualTo(expectedEquality);
+    }
+
+    @Test
+    void largeFilesEqual(@TempDir File tempDir) throws IOException {
+        Path fileA = tempDir.toPath().resolve("a");
+        Path fileB = tempDir.toPath().resolve("b");
+        try (BufferedWriter bufferedWriter = java.nio.file.Files.newBufferedWriter(fileA);
+                BufferedWriter bufferedWriterB = java.nio.file.Files.newBufferedWriter(fileB)) {
+            for (int i = 0; i < 100000; i++) {
+                bufferedWriter.write("Hello, world!");
+                bufferedWriterB.write("Hello, world!");
+                bufferedWriter.newLine();
+                bufferedWriterB.newLine();
+            }
+        }
+        boolean filesEqual = KrpcGenerator.filesEqual(fileA, fileB);
+        assertThat(filesEqual).isTrue();
+    }
+
+    public static Stream<Arguments> filesEqualInvalidArguments() {
+        return Stream.of(Arguments.argumentSet("generated file does not exist", (Consumer<Path>) tempDir -> {
+            Path fileB = tempDir.resolve("b");
+            touch(fileB);
+            Path fileA = tempDir.resolve("a");
+            KrpcGenerator.filesEqual(fileA, fileB);
+        }, IllegalArgumentException.class, "does not exist"),
+                Arguments.argumentSet("generated file is not a file", (Consumer<Path>) tempDir -> {
+                    Path fileB = tempDir.resolve("b");
+                    touch(fileB);
+                    KrpcGenerator.filesEqual(tempDir, fileB);
+                }, IllegalArgumentException.class, "exists but is not a regular file"),
+                Arguments.argumentSet("generated file null", (Consumer<Path>) tempDir -> {
+                    Path fileB = tempDir.resolve("b");
+                    touch(fileB);
+                    KrpcGenerator.filesEqual(null, fileB);
+                }, NullPointerException.class, "generatedFile cannot be null"),
+                Arguments.argumentSet("final file null", (Consumer<Path>) tempDir -> {
+                    Path fileB = tempDir.resolve("b");
+                    touch(fileB);
+                    KrpcGenerator.filesEqual(fileB, null);
+                }, NullPointerException.class, "finalFile cannot be null"),
+                Arguments.argumentSet("final file is not a file", (Consumer<Path>) tempDir -> {
+                    Path fileA = tempDir.resolve("b");
+                    touch(fileA);
+                    KrpcGenerator.filesEqual(fileA, tempDir);
+                }, IllegalArgumentException.class, "exists but is not a regular file"));
+    }
+
+    private static void touch(Path fileB) {
+        try {
+            java.nio.file.Files.createFile(fileB);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void filesEqualInvalidArguments(Consumer<Path> tempDirConsumer, Class<? extends Exception> exceptionType, String message, @TempDir File tempDir) {
+        Path path = tempDir.toPath();
+        assertThatThrownBy(() -> tempDirConsumer.accept(path)).isInstanceOf(exceptionType).hasMessageContaining(message);
     }
 
     private void assertFileHasExpectedContents(File file, String expectedFile) throws IOException {


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

We generate to a temporary file and then compare the entire contents to the existing file in the generated source dir (if it is present). If the file is identical, we delete the temporary file, leaving the existing file untouched. Else, we replace it with the new generated file.

Why:
Currently kroxylicious-api will recompile on every build because the generated sources are overwritten with files with fresh timestamps. This will provoke all of the dependant modules to recompile. We are experimenting with re-using the built output in github actions to parallelize the build via an artifact and currently this behaviour causes unneccesary rebuilding to occur.

The ticket suggests that ideally we would skip code generation if the inputs/outputs haven't changed but we have some trouble upstream of this plugin because our unpack invocations are modifying the message spec files on every build.

Fixes: #2617

Contributes towards https://github.com/kroxylicious/kroxylicious/issues/2602 as currently even if we upload the target contents as an artifact and restore them into downstream jobs we will likely incur a lot of re-compilation because kroxylicious-api is rebuilt every time.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
