### PR TITLE
Upgrade to netty 4.1.126.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <log4j.version>2.25.1</log4j.version>
         <caffeine.version>3.2.2</caffeine.version>
         <picocli.version>4.7.7</picocli.version>
-        <netty.version>4.1.123.Final</netty.version>
+        <netty.version>4.1.126.Final</netty.version>
         <netty.io_uring.version>0.0.26.Final</netty.io_uring.version>
         <netty.epoll.classifier>linux-x86_64</netty.epoll.classifier>
         <netty.io_uring.classifier>linux-x86_64</netty.io_uring.classifier>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Fixes a couple of high-prio CVEs CVE-2025-58057 and CVE-2025-58056 in netty-codec-http, which we use for the metrics endpoint.

Was hoping dependabot would pick it up, I kicked off a scan and it didn't, guess it operates on cached maven central data or some such.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
