### PR TITLE
Fix zero-ack message detection when clientId or transactionId are null

### DIFF
--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoderTest.java
@@ -6,16 +6,28 @@
 
 package io.kroxylicious.proxy.internal.codec;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.function.IntPredicate;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import org.apache.kafka.common.message.ApiVersionsRequestData;
+import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.protocol.ObjectSerializationCache;
 import org.apache.kafka.common.protocol.types.RawTaggedField;
+import org.apache.kafka.common.requests.ProduceRequest;
+import org.apache.kafka.common.requests.RequestHeader;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -23,18 +35,23 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderException;
 
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.frame.RequestFrame;
 import io.kroxylicious.proxy.internal.ApiVersionsServiceImpl;
+import io.kroxylicious.test.record.RecordTestUtils;
 
+import static java.util.function.Function.identity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class KafkaRequestDecoderTest {
 
+    private static final IntPredicate ALL_VERSIONS = i -> true;
+
     @Test
     void decodeUnknownApiVersionsRespectsOverriddenLatestVersion() {
         short latestSupportedApiVersionsOverride = (short) 2;
         ApiVersionsServiceImpl apiVersionsService = new ApiVersionsServiceImpl(Map.of(ApiKeys.API_VERSIONS, latestSupportedApiVersionsOverride));
-        EmbeddedChannel embeddedChannel = newEmbeddedChannel(apiVersionsService);
+        EmbeddedChannel embeddedChannel = newEmbeddedChannel(apiVersionsService, RequestDecoderTest.DECODE_EVERYTHING);
         RequestHeaderData header = latestVersionHeaderWithAllFields(ApiKeys.API_VERSIONS, (short) (latestSupportedApiVersionsOverride + 1));
         byte[] arbitraryBodyBytes = new byte[]{ 1, 2, 3, 4 };
         ObjectSerializationCache cache = new ObjectSerializationCache();
@@ -71,7 +88,7 @@ class KafkaRequestDecoderTest {
 
     @Test
     void decodeUnknownApiVersions() {
-        EmbeddedChannel embeddedChannel = newEmbeddedChannel(new ApiVersionsServiceImpl());
+        EmbeddedChannel embeddedChannel = newEmbeddedChannel(new ApiVersionsServiceImpl(), RequestDecoderTest.DECODE_EVERYTHING);
         RequestHeaderData header = latestVersionHeaderWithAllFields(ApiKeys.API_VERSIONS, Short.MAX_VALUE);
         byte[] arbitraryBodyBytes = new byte[]{ 1, 2, 3, 4 };
         ObjectSerializationCache cache = new ObjectSerializationCache();
@@ -109,7 +126,7 @@ class KafkaRequestDecoderTest {
     // after ApiVersions negotiation we should never encounter a request from the client for an api version unknown to the proxy
     @Test
     void throwsOnUnsupportedVersionOfNonApiVersionsRequests() {
-        EmbeddedChannel embeddedChannel = newEmbeddedChannel(new ApiVersionsServiceImpl());
+        EmbeddedChannel embeddedChannel = newEmbeddedChannel(new ApiVersionsServiceImpl(), RequestDecoderTest.DECODE_EVERYTHING);
         short maxSupportedVersion = ApiKeys.METADATA.latestVersion(true);
         short unsupportedVersion = (short) (maxSupportedVersion + 1);
         RequestHeaderData header = latestVersionHeaderWithAllFields(ApiKeys.METADATA, unsupportedVersion);
@@ -127,9 +144,106 @@ class KafkaRequestDecoderTest {
                 .hasMessage("client apiVersion %d ahead of proxy maximum %d for api key: METADATA", unsupportedVersion, maxSupportedVersion);
     }
 
-    private static EmbeddedChannel newEmbeddedChannel(ApiVersionsServiceImpl apiVersionsService) {
+    private static Stream<Arguments> produceRequestCases() {
+        return Stream.concat(produceRequestsDoNotRequireResponse((short) 0, false), produceRequestsDoNotRequireResponse((short) 1, true));
+    }
+
+    private static Stream<Arguments> produceRequestsDoNotRequireResponse(short acks, boolean hasResponse) {
+        Function<Short, ProduceRequest> nonNullTransactionId = version -> produceRequest(version, acks, "transactionId");
+        Function<Short, ProduceRequest> nullTransactionId = version -> produceRequest(version, acks, null);
+        Function<Short, RequestHeader> withClientId = version -> new RequestHeader(ApiKeys.PRODUCE, version, "client", 2);
+        Function<Short, RequestHeader> withNullClientId = version -> new RequestHeader(ApiKeys.PRODUCE, version, null, 2);
+        Function<Short, RequestHeader> withTaggedField = version -> {
+            RequestHeader header = new RequestHeader(ApiKeys.PRODUCE, version, null, 2);
+            header.data().unknownTaggedFields().add(new RawTaggedField(1, new byte[]{ 1 }));
+            return header;
+        };
+        Function<Short, RequestHeader> withTaggedFields = version -> {
+            RequestHeader header = new RequestHeader(ApiKeys.PRODUCE, version, null, 2);
+            List<RawTaggedField> fields = header.data().unknownTaggedFields();
+            fields.add(new RawTaggedField(1, new byte[]{ 1 }));
+            fields.add(new RawTaggedField(2, new byte[]{ 3 }));
+            return header;
+        };
+
+        Stream<Arguments> targetedForDecode = produceRequestVersionFrames(RequestDecoderTest.DECODE_EVERYTHING,
+                "acks " + acks + " targeted for decode - no transaction id", nullTransactionId, withClientId, ALL_VERSIONS, hasResponse);
+        Stream<Arguments> targetedForDecodeWithTransactionId = produceRequestVersionFrames(RequestDecoderTest.DECODE_EVERYTHING,
+                "acks " + acks + " targeted for decode - transaction id", nonNullTransactionId, withClientId, ALL_VERSIONS, hasResponse);
+        Stream<Arguments> notTargetedForDecode = produceRequestVersionFrames(RequestDecoderTest.DECODE_NOTHING,
+                "acks " + acks + " not targeted for decode - no transaction id", nullTransactionId, withClientId, ALL_VERSIONS, hasResponse);
+        Stream<Arguments> notTargetedForDecodeWithTransactionId = produceRequestVersionFrames(RequestDecoderTest.DECODE_NOTHING,
+                "acks " + acks + " not targeted for decode - transaction id", nonNullTransactionId, withClientId, ALL_VERSIONS, hasResponse);
+        Stream<Arguments> notTargetedForDecodeWithNullClientId = produceRequestVersionFrames(RequestDecoderTest.DECODE_NOTHING,
+                "acks " + acks + " not targeted for decode - null client id", nullTransactionId, withNullClientId, ALL_VERSIONS, hasResponse);
+        Stream<Arguments> targetedForDecodeWithNullClientId = produceRequestVersionFrames(RequestDecoderTest.DECODE_EVERYTHING,
+                "acks " + acks + " not targeted for decode - null client id", nullTransactionId, withNullClientId, ALL_VERSIONS, hasResponse);
+        Stream<Arguments> withTaggedFieldInHeader = produceRequestVersionFrames(RequestDecoderTest.DECODE_EVERYTHING,
+                "acks " + acks + " tagged field in header", nullTransactionId, withTaggedField, version -> version >= 9, hasResponse);
+        Stream<Arguments> withTaggedFieldsInHeader = produceRequestVersionFrames(RequestDecoderTest.DECODE_EVERYTHING,
+                "acks " + acks + " multiple tagged fields in header", nullTransactionId, withTaggedFields, version -> version >= 9, hasResponse);
+        return Stream.of(targetedForDecode, notTargetedForDecode, targetedForDecodeWithTransactionId, notTargetedForDecodeWithTransactionId,
+                notTargetedForDecodeWithNullClientId, targetedForDecodeWithNullClientId, withTaggedFieldInHeader, withTaggedFieldsInHeader).flatMap(identity());
+    }
+
+    private static ProduceRequest produceRequest(short version, short acks, String transactionId) {
+        ProduceRequestData.TopicProduceDataCollection collection = new ProduceRequestData.TopicProduceDataCollection();
+        ProduceRequestData.TopicProduceData newElement = new ProduceRequestData.TopicProduceData();
+        newElement.setName("topic");
+        ProduceRequestData.PartitionProduceData ppd = new ProduceRequestData.PartitionProduceData();
+        ppd.setIndex(1);
+        ppd.setRecords(RecordTestUtils.singleElementMemoryRecords("a", "b"));
+        newElement.partitionData().add(ppd);
+        collection.add(newElement);
+        ProduceRequestData record = new ProduceRequestData().setAcks(acks).setTransactionalId(transactionId).setTopicData(collection);
+        return new ProduceRequest(record, version);
+    }
+
+    private static Stream<Arguments> produceRequestVersionFrames(DecodePredicate decodePredicate, String decodeMessage,
+                                                                 Function<Short, ProduceRequest> bodyFunction, Function<Short, RequestHeader> headerFunction,
+                                                                 IntPredicate versionPredicate, boolean hasResponse) {
+
+        IntStream produceVersions = IntStream.rangeClosed(ApiKeys.PRODUCE.oldestVersion(), ApiKeys.PRODUCE.latestVersion(true)).filter(versionPredicate);
+        return produceVersions.mapToObj(
+                value -> Arguments.argumentSet("producer version " + value + " : " + decodeMessage,
+                        createProduceRequestFrameWithAcksAndTransactionId((short) value, bodyFunction, headerFunction),
+                        decodePredicate, hasResponse));
+    }
+
+    @MethodSource("produceRequestCases")
+    @ParameterizedTest
+    void zeroAckProduceRequestsDoNotRequireResponse(ByteBuffer frameBuffer, DecodePredicate decodePredicate, boolean hasResponse) {
+        EmbeddedChannel embeddedChannel = newEmbeddedChannel(new ApiVersionsServiceImpl(), decodePredicate);
+        int remaining = frameBuffer.remaining();
+        ByteBuf buffer = Unpooled.buffer(Integer.BYTES + remaining);
+        buffer.writeInt(remaining);
+        buffer.writeBytes(frameBuffer);
+        embeddedChannel.writeInbound(buffer);
+        Object inboundMessage = embeddedChannel.readInbound();
+        assertThat(inboundMessage).isInstanceOfSatisfying(RequestFrame.class, decodedRequestFrame -> {
+            assertThat(decodedRequestFrame.hasResponse()).isEqualTo(hasResponse);
+        });
+    }
+
+    // this is an extra safety check to ensure we scrutinize new Produce versions and ensure we can pluck the
+    // ack value out of the frame, skipping all variations of all preceding fields.
+    @Test
+    void zeroAckProduceRequestThrowsOnNextVersion() {
+        EmbeddedChannel embeddedChannel = newEmbeddedChannel(new ApiVersionsServiceImpl(), RequestDecoderTest.DECODE_NOTHING);
+        int headerLength = Short.BYTES + Short.BYTES + Integer.BYTES;
+        ByteBuf buffer = Unpooled.buffer(Integer.BYTES + headerLength);
+        buffer.writeInt(headerLength);
+        buffer.writeShort(ApiKeys.PRODUCE.id);
+        short apiVersion = 13;
+        buffer.writeShort(apiVersion);
+        buffer.writeInt(2); // correlationId
+        assertThatThrownBy(() -> embeddedChannel.writeInbound(buffer)).isInstanceOf(AssertionError.class)
+                .hasMessageContaining("Unsupported Produce version: " + apiVersion);
+    }
+
+    private static EmbeddedChannel newEmbeddedChannel(ApiVersionsServiceImpl apiVersionsService, DecodePredicate predicate) {
         return new EmbeddedChannel(
-                new KafkaRequestDecoder(RequestDecoderTest.DECODE_EVERYTHING, 1024, apiVersionsService, null));
+                new KafkaRequestDecoder(predicate, 1024, apiVersionsService, null));
     }
 
     private static RequestHeaderData latestVersionHeaderWithAllFields(ApiKeys requestApiKey, short requestApiVersion) {
@@ -146,6 +260,13 @@ class KafkaRequestDecoderTest {
         assertThatThrownBy(() -> requestHeaderData.size(cache, version)).isInstanceOf(UnsupportedOperationException.class);
         ByteBufAccessorImpl byteBufAccessor = new ByteBufAccessorImpl(Unpooled.buffer());
         assertThatThrownBy(() -> requestHeaderData.write(byteBufAccessor, cache, version)).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    private static ByteBuffer createProduceRequestFrameWithAcksAndTransactionId(short version,
+                                                                                Function<Short, ProduceRequest> produceRequestFunction,
+                                                                                Function<Short, RequestHeader> headerFunction) {
+        ProduceRequest produceRequest = produceRequestFunction.apply(version);
+        return produceRequest.serializeWithHeader(headerFunction.apply(version));
     }
 
 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Kafka Clients that either:
- do not set a clientId in zero-ack Produce header
- do not set a transaction id in zero-ack Produce requests from v3 to v8 inclusive

Will result in the proxy incorrectly determining whether we expect an upstream response when there are no Filters interested in intercepting those requests. This could lead to a memory leak and OOM in the proxy.

### The Problem

We have code to determine whether a request will have a response from the upstream cluster, this is to avoid adding such a request to the correlation manager and causing a leak when the upstream never responds. The only class of messages that this applies to are zero-ack produce requests.

The worst case being where:
1. the proxy does not want to decode the produce request, no filter is interested in intercepting it
2. the client has configured 0 acks, so the upstream will not respond

We have code to optimize this path. We avoid decoding the ProduceRequest by using our own buffer-reading code to extract the acks value from the bytes, without reading the whole buffer into an object. This means our code needs to know how to read all versions of the produce request.

While upgrading the code to handle kafka 4.1.0 which brings a new Produce version, I discovered that some cases were not handled correctly. Those being a `null` client id in the header and a `null` transaction id in the body for versions <= 8. In this case it is a nullable String and a short -1 is emitted, followed by no body bytes. In the non-null case the length of the string is emitted as short, followed by body bytes. We interpreted -1 as a length and then read the acks from the wrong position. Resulting in the frame incorrectly specifying `hasResponse=true` for these old versions if the values are null. These messages would cause a memory leak by being stored in the CorrellationManager never to be married up to a response.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
