### PR TITLE
Upgrade to kafka 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#2542](https://github.com/kroxylicious/kroxylicious/issues/2542): Add support for Kafka 4.1.0
 * [#2688](https://github.com/kroxylicious/kroxylicious/pull/2688): bump io.netty:netty-bom from 4.1.126.Final to 4.1.127.Final
 * [#2685](https://github.com/kroxylicious/kroxylicious/pull/2685): build(deps): bump kubernetes-client.version from 7.3.1 to 7.4.0
 * [#1927](https://github.com/kroxylicious/kroxylicious/issues/1927): chore(docs): Remove deprecated adminHttp configuration property.
@@ -19,6 +20,9 @@ Format `<github issue/pr number>: <short description>`.
   for supplying a virtual cluster map (which was deprecated at 0.11.0) is now removed.
 * Support for the `adminHttp` configuration property (which was deprecated in 0.11.0) is removed. Use `management` instead.
   Also support for the `host` configuration property within that object (which was also deprecated in 0.11.0) is removed. Use `bindAddress` instead.
+* **breaking** kroxylicious-api change. `ListClientMetricsResourcesResponseFilter` and `ListClientMetricsResourcesRequestFilter` are removed, replaced
+  with `ListConfigResourcesResponseFilter` and `ListConfigResourcesRequestFilter` due to the RPC being renamed in kafka-clients. Filters that implement
+  the old interfaces will be incompatible with this version of the proxy and must migrate to the new interfaces.
 
 ## 0.15.0
 

--- a/kroxylicious-api/pom.xml
+++ b/kroxylicious-api/pom.xml
@@ -157,17 +157,9 @@
                         <breakBuildOnBinaryIncompatibleModifications>false</breakBuildOnBinaryIncompatibleModifications>
                         <breakBuildBasedOnSemanticVersioningForMajorVersionZero>${ApiCompatability.EnforceForMajorVersionZero}</breakBuildBasedOnSemanticVersioningForMajorVersionZero>
                         <excludes>
-                            <exclude>io.kroxylicious.proxy.filter.FilterFactoryContext#eventLoop()</exclude> <!-- https://github.com/kroxylicious/kroxylicious/issues/1380 scheduled removal of deprecated API method -->
-                            <exclude>io.kroxylicious.proxy.config.tls.Tls#Tls(io.kroxylicious.proxy.config.tls.KeyProvider, io.kroxylicious.proxy.config.tls.TrustProvider)</exclude>
-                            <!-- The following filter exclusions relate to RPCs that were removed at Kafka 4.0 -->
-                            <exclude>io.kroxylicious.proxy.filter.ControlledShutdownRequestFilter</exclude>
-                            <exclude>io.kroxylicious.proxy.filter.ControlledShutdownResponseFilter</exclude>
-                            <excludes>io.kroxylicious.proxy.filter.LeaderAndIsrRequestFilter</excludes>
-                            <excludes>io.kroxylicious.proxy.filter.LeaderAndIsrResponseFilter</excludes>
-                            <excludes>io.kroxylicious.proxy.filter.StopReplicaRequestFilter</excludes>
-                            <excludes>io.kroxylicious.proxy.filter.StopReplicaResponseFilter</excludes>
-                            <excludes>io.kroxylicious.proxy.filter.UpdateMetadataRequestFilter</excludes>
-                            <excludes>io.kroxylicious.proxy.filter.UpdateMetadataResponseFilter</excludes>
+                            <!-- The following filter exclusions relate to RPCs that were renamed in kafka-clients 4.1 -->
+                            <exclude>io.kroxylicious.proxy.filter.ListClientMetricsResourcesResponseFilter</exclude>
+                            <exclude>io.kroxylicious.proxy.filter.ListClientMetricsResourcesRequestFilter</exclude>
                         </excludes>
                         <!-- see documentation -->
                     </parameter>

--- a/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/test/RequestFactory.java
+++ b/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/test/RequestFactory.java
@@ -21,6 +21,7 @@ import java.util.stream.Stream;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
+import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.message.ConsumerGroupDescribeRequestData;
 import org.apache.kafka.common.message.CreateAclsRequestData;
 import org.apache.kafka.common.message.CreateTopicsRequestData;
@@ -31,9 +32,11 @@ import org.apache.kafka.common.message.DeleteShareGroupStateRequestData;
 import org.apache.kafka.common.message.DeleteTopicsRequestData;
 import org.apache.kafka.common.message.DescribeAclsRequestData;
 import org.apache.kafka.common.message.DescribeGroupsRequestData;
+import org.apache.kafka.common.message.DescribeShareGroupOffsetsRequestData;
 import org.apache.kafka.common.message.InitProducerIdRequestData;
 import org.apache.kafka.common.message.InitializeShareGroupStateRequestData;
 import org.apache.kafka.common.message.LeaveGroupRequestData;
+import org.apache.kafka.common.message.ListConfigResourcesRequestData;
 import org.apache.kafka.common.message.ListOffsetsRequestData;
 import org.apache.kafka.common.message.MetadataRequestData;
 import org.apache.kafka.common.message.OffsetCommitRequestData;
@@ -43,6 +46,7 @@ import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.ReadShareGroupStateRequestData;
 import org.apache.kafka.common.message.ReadShareGroupStateSummaryRequestData;
 import org.apache.kafka.common.message.ShareGroupDescribeRequestData;
+import org.apache.kafka.common.message.StreamsGroupDescribeRequestData;
 import org.apache.kafka.common.message.WriteShareGroupStateRequestData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
@@ -98,6 +102,9 @@ public class RequestFactory {
         messagePopulators.put(ApiKeys.WRITE_SHARE_GROUP_STATE, RequestFactory::populateWriteShareGroupStateRequest);
         messagePopulators.put(ApiKeys.DELETE_SHARE_GROUP_STATE, RequestFactory::populateDeleteShareGroupStateRequest);
         messagePopulators.put(ApiKeys.READ_SHARE_GROUP_STATE_SUMMARY, RequestFactory::populateReadShareGroupStateSummaryRequest);
+        messagePopulators.put(ApiKeys.STREAMS_GROUP_DESCRIBE, RequestFactory::populateStreamsGroupDescribeRequest);
+        messagePopulators.put(ApiKeys.DESCRIBE_SHARE_GROUP_OFFSETS, RequestFactory::populateDescribeShareGroupOffsetsRequest);
+        messagePopulators.put(ApiKeys.LIST_CONFIG_RESOURCES, RequestFactory::populateListConfigResourcesRequest);
     }
 
     private RequestFactory() {
@@ -178,6 +185,14 @@ public class RequestFactory {
         t1.setPartitionIndexes(List.of(0, 1));
         offsetFetchRequestData.setGroupId(MobyNamesGenerator.getRandomName());
         offsetFetchRequestData.setTopics(List.of(t1));
+        OffsetFetchRequestData.OffsetFetchRequestGroup group = new OffsetFetchRequestData.OffsetFetchRequestGroup();
+        group.setGroupId(MobyNamesGenerator.getRandomName());
+        OffsetFetchRequestData.OffsetFetchRequestTopics topics = new OffsetFetchRequestData.OffsetFetchRequestTopics();
+        topics.setName(MobyNamesGenerator.getRandomName());
+        topics.setTopicId(Uuid.ONE_UUID);
+        topics.setPartitionIndexes(List.of(0, 1));
+        group.setTopics(List.of(topics));
+        offsetFetchRequestData.setGroups(List.of(group));
     }
 
     private static void populateMetadataRequest(ApiMessage apiMessage) {
@@ -342,4 +357,26 @@ public class RequestFactory {
         readStateData.setPartitions(List.of(new ReadShareGroupStateSummaryRequestData.PartitionData()));
         readShareGroupStateSummaryRequestData.setTopics(List.of(readStateData));
     }
+
+    private static void populateStreamsGroupDescribeRequest(ApiMessage apiMessage) {
+        final StreamsGroupDescribeRequestData readShareGroupStateSummaryRequestData = (StreamsGroupDescribeRequestData) apiMessage;
+        readShareGroupStateSummaryRequestData.setGroupIds(List.of(MobyNamesGenerator.getRandomName()));
+    }
+
+    private static void populateDescribeShareGroupOffsetsRequest(ApiMessage apiMessage) {
+        final DescribeShareGroupOffsetsRequestData describeShareGroupOffsetsRequest = (DescribeShareGroupOffsetsRequestData) apiMessage;
+        DescribeShareGroupOffsetsRequestData.DescribeShareGroupOffsetsRequestGroup group = new DescribeShareGroupOffsetsRequestData.DescribeShareGroupOffsetsRequestGroup();
+        group.setGroupId(MobyNamesGenerator.getRandomName());
+        DescribeShareGroupOffsetsRequestData.DescribeShareGroupOffsetsRequestTopic topic = new DescribeShareGroupOffsetsRequestData.DescribeShareGroupOffsetsRequestTopic();
+        topic.setTopicName(MobyNamesGenerator.getRandomName());
+        topic.setPartitions(List.of(1, 2, 3));
+        group.setTopics(List.of(topic));
+        describeShareGroupOffsetsRequest.setGroups(List.of(group));
+    }
+
+    private static void populateListConfigResourcesRequest(ApiMessage apiMessage) {
+        final ListConfigResourcesRequestData listConfigResourcesRequestData = (ListConfigResourcesRequestData) apiMessage;
+        listConfigResourcesRequestData.setResourceTypes(List.of(ConfigResource.Type.CLIENT_METRICS.id())); // the only type you can use with v0 LIST_CONFIG_RESOURCES
+    }
+
 }

--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidation.java
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/main/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidation.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.security.auth.login.AppConfigurationEntry;
 
 import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.security.oauthbearer.BrokerJwtValidator;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler;
 import org.apache.kafka.common.security.oauthbearer.internals.OAuthBearerSaslServerProvider;
 
@@ -143,7 +144,8 @@ public class OauthBearerValidation implements FilterFactory<OauthBearerValidatio
                          @JsonProperty @Nullable Long authenticateBackOffMaxMs,
                          @JsonProperty @Nullable Long authenticateCacheMaxSize,
                          @JsonProperty @Nullable String expectedAudience,
-                         @JsonProperty @Nullable String expectedIssuer) {}
+                         @JsonProperty @Nullable String expectedIssuer,
+                         @JsonProperty @Nullable String jwtValidatorClass) {}
 
     private Map<String, ?> createSaslConfigMap(Config config) {
         Map<String, Object> saslConfig = new HashMap<>();
@@ -153,6 +155,7 @@ public class OauthBearerValidation implements FilterFactory<OauthBearerValidatio
         saslConfig.put(SaslConfigs.SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS, config.jwksEndpointRetryBackoffMaxMs());
         saslConfig.put(SaslConfigs.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME, config.scopeClaimName());
         saslConfig.put(SaslConfigs.SASL_OAUTHBEARER_SUB_CLAIM_NAME, config.subClaimName());
+        saslConfig.put(SaslConfigs.SASL_OAUTHBEARER_JWT_VALIDATOR_CLASS, config.jwtValidatorClass());
         if (config.expectedAudience() != null) {
             List<String> audience = Arrays.stream(config.expectedAudience().split(","))
                     .map(String::trim)
@@ -181,7 +184,8 @@ public class OauthBearerValidation implements FilterFactory<OauthBearerValidatio
                 defaultIfNullOrNegative(config.authenticateBackOffMaxMs(), 60000L),
                 defaultIfNullOrNonPositive(config.authenticateCacheMaxSize(), 1000L),
                 defaultIfNullOrEmpty(config.expectedAudience(), null),
-                defaultIfNullOrEmpty(config.expectedIssuer(), null));
+                defaultIfNullOrEmpty(config.expectedIssuer(), null),
+                defaultIfNullOrEmpty(config.jwtValidatorClass(), BrokerJwtValidator.class.getName()));
     }
 
     private @Nullable Long defaultIfNullOrNegative(@Nullable Long value, @Nullable Long defaultValue) {

--- a/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationTest.java
+++ b/kroxylicious-filters/kroxylicious-oauthbearer-validation/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationTest.java
@@ -14,6 +14,8 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.security.oauthbearer.BrokerJwtValidator;
+import org.apache.kafka.common.security.oauthbearer.DefaultJwtValidator;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -87,6 +89,7 @@ class OauthBearerValidationTest {
                 -1L,
                 -1L,
                 null,
+                null,
                 null);
         mustInitAndCreateFilter(config);
     }
@@ -107,7 +110,8 @@ class OauthBearerValidationTest {
                 10000L,
                 500L,
                 "https://first.audience, https://second.audience",
-                "https://issuer.endpoint");
+                "https://issuer.endpoint",
+                DefaultJwtValidator.class.getName());
 
         // when
         SharedOauthBearerValidationContext sharedContext = oauthBearerValidation.initialize(ffc, config);
@@ -124,6 +128,7 @@ class OauthBearerValidationTest {
                     assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_SUB_CLAIM_NAME)).isEqualTo("otherClaim");
                     assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_EXPECTED_AUDIENCE)).isEqualTo(List.of("https://first.audience", "https://second.audience"));
                     assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_EXPECTED_ISSUER)).isEqualTo("https://issuer.endpoint");
+                    assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_JWT_VALIDATOR_CLASS)).isEqualTo(DefaultJwtValidator.class.getName());
                 }),
                 eq("OAUTHBEARER"),
                 anyList());
@@ -212,6 +217,7 @@ class OauthBearerValidationTest {
                             .isEqualTo(SaslConfigs.DEFAULT_SASL_OAUTHBEARER_JWKS_ENDPOINT_RETRY_BACKOFF_MAX_MS);
                     assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_SCOPE_CLAIM_NAME)).isEqualTo(SaslConfigs.DEFAULT_SASL_OAUTHBEARER_SCOPE_CLAIM_NAME);
                     assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_SUB_CLAIM_NAME)).isEqualTo(SaslConfigs.DEFAULT_SASL_OAUTHBEARER_SUB_CLAIM_NAME);
+                    assertThat(configMap.get(SaslConfigs.SASL_OAUTHBEARER_JWT_VALIDATOR_CLASS)).isEqualTo(BrokerJwtValidator.class.getName());
                 }),
                 eq("OAUTHBEARER"),
                 anyList());
@@ -227,6 +233,7 @@ class OauthBearerValidationTest {
     private Config defaultConfig(URI jwksEndpointUrl) {
         return new Config(
                 jwksEndpointUrl,
+                null,
                 null,
                 null,
                 null,

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/RecordValidationFilter.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/proxy/filter/validation/RecordValidationFilter.java
@@ -147,7 +147,7 @@ public class RecordValidationFilter implements ProduceRequestFilter, ProduceResp
 
     private void augmentResponseWithInvalidTopicPartitions(ProduceResponseData response, ProduceRequestValidationResult produceRequestValidationResult) {
         produceRequestValidationResult.topicsWithInvalidPartitions().forEach(topicWithInvalidPartitions -> {
-            ProduceResponseData.TopicProduceResponse topicProduceResponse = response.responses().find(topicWithInvalidPartitions.topicName());
+            ProduceResponseData.TopicProduceResponse topicProduceResponse = response.responses().find(topicWithInvalidPartitions.topicName(), null);
             if (topicProduceResponse == null) {
                 topicProduceResponse = new ProduceResponseData.TopicProduceResponse();
                 topicProduceResponse.setName(topicWithInvalidPartitions.topicName());

--- a/kroxylicious-filters/kroxylicious-simple-transform/pom.xml
+++ b/kroxylicious-filters/kroxylicious-simple-transform/pom.xml
@@ -29,6 +29,11 @@
             <artifactId>kroxylicious-api</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-kafka-message-tools</artifactId>
+        </dependency>
+
         <!-- third party dependencies - runtime and compile  -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/MirrorImageNameSubstitutor.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/MirrorImageNameSubstitutor.java
@@ -14,7 +14,7 @@ import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.ImageNameSubstitutor;
 
 public class MirrorImageNameSubstitutor extends ImageNameSubstitutor {
-    private static final Set<String> DOMAIN_ALLOW_LIST = Set.of("quay.io", "ghcr.io", "gcr.io");
+    private static final Set<String> DOMAIN_ALLOW_LIST = Set.of("quay.io", "ghcr.io", "gcr.io", "redhat.com");
     private static final String MIRROR_REPOSITORY = "mirror.gcr.io";
     private static final Logger LOGGER = LoggerFactory.getLogger(MirrorImageNameSubstitutor.class);
 

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/ByteBufAccessorImpl.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/codec/ByteBufAccessorImpl.java
@@ -7,6 +7,8 @@ package io.kroxylicious.test.codec;
 
 import java.nio.ByteBuffer;
 
+import org.apache.kafka.common.protocol.Readable;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 
@@ -176,6 +178,11 @@ public class ByteBufAccessorImpl implements ByteBufAccessor {
     @Override
     public int remaining() {
         return buf.writerIndex() - buf.readerIndex();
+    }
+
+    @Override
+    public Readable slice() {
+        throw new IllegalStateException("slice() not supported");
     }
 
     @Override

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationIT.java
@@ -29,7 +29,7 @@ import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule;
-import org.apache.kafka.common.security.oauthbearer.OAuthBearerValidatorCallbackHandler;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.VerificationKeyResolverFactory;
 import org.assertj.core.api.InstanceOfAssertFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -135,7 +135,7 @@ class OauthBearerValidationIT {
         // cache. This is impactful to the proxy because its config is constant (so cache hits).
         // The reason kafka broker doesn't suffer this itself is because the config is different between
         // clusters instances (port numbers, log dir etc. are different).
-        var cacheField = OAuthBearerValidatorCallbackHandler.class.getDeclaredField("VERIFICATION_KEY_RESOLVER_CACHE");
+        var cacheField = VerificationKeyResolverFactory.class.getDeclaredField("CACHE");
         cacheField.setAccessible(true);
         ((Map<?, ?>) cacheField.get(null)).clear();
     }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/multitenant/MultiTenantIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/multitenant/MultiTenantIT.java
@@ -44,6 +44,7 @@ import org.apache.kafka.common.TopicCollection;
 import org.apache.kafka.common.TopicCollection.TopicNameCollection;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.GroupIdNotFoundException;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -332,11 +333,12 @@ class MultiTenantIT extends BaseMultiTenantIT {
                 produceAndAssert(tester, this.clientConfig, TENANT_1_CLUSTER,
                         Stream.of(new ProducerRecord<>(TOPIC_1, MY_KEY, "1")),
                         Optional.of(transactionalId));
-
-                var describeTransactionsResult = admin.describeTransactions(List.of(transactionalId));
-                var transactionMap = describeTransactionsResult.all().get();
-                assertThat(transactionMap).hasEntrySatisfying(transactionalId,
-                        allOf(matches(TransactionDescription::state, TransactionState.COMPLETE_COMMIT)));
+                Awaitility.await().untilAsserted(() -> {
+                    var describeTransactionsResult = admin.describeTransactions(List.of(transactionalId));
+                    var transactionMap = describeTransactionsResult.all().get();
+                    assertThat(transactionMap).hasEntrySatisfying(transactionalId,
+                            allOf(matches(TransactionDescription::state, TransactionState.COMPLETE_COMMIT)));
+                });
             }
         }
     }

--- a/kroxylicious-krpc-plugin/src/test/resources/Data/example-expected-FetchRequest.java.txt
+++ b/kroxylicious-krpc-plugin/src/test/resources/Data/example-expected-FetchRequest.java.txt
@@ -65,11 +65,12 @@ public class FetchRequestData implements ApiMessage {
         SCHEMA_14,
         SCHEMA_15,
         SCHEMA_16,
-        SCHEMA_17
+        SCHEMA_17,
+        SCHEMA_18
     };
 
     public static final short LOWEST_SUPPORTED_VERSION = 4;
-    public static final short HIGHEST_SUPPORTED_VERSION = 17;
+    public static final short HIGHEST_SUPPORTED_VERSION = 18;
 
     public FetchRequestData(Readable _readable, short _version) {
         read(_readable, _version);
@@ -105,7 +106,7 @@ public class FetchRequestData implements ApiMessage {
     /** @return the highest valid version for this message. */
     @Override
     public short highestSupportedVersion() {
-        return 17;
+        return 18;
     }
 
     @Override

--- a/kroxylicious-krpc-plugin/src/test/resources/Kproxy/KrpcRequestFilter-expected.txt
+++ b/kroxylicious-krpc-plugin/src/test/resources/Kproxy/KrpcRequestFilter-expected.txt
@@ -15,6 +15,7 @@ import org.apache.kafka.common.message.AlterConfigsRequestData;
 import org.apache.kafka.common.message.AlterPartitionReassignmentsRequestData;
 import org.apache.kafka.common.message.AlterPartitionRequestData;
 import org.apache.kafka.common.message.AlterReplicaLogDirsRequestData;
+import org.apache.kafka.common.message.AlterShareGroupOffsetsRequestData;
 import org.apache.kafka.common.message.AlterUserScramCredentialsRequestData;
 import org.apache.kafka.common.message.ApiVersionsRequestData;
 import org.apache.kafka.common.message.AssignReplicasToDirsRequestData;
@@ -31,6 +32,7 @@ import org.apache.kafka.common.message.CreateTopicsRequestData;
 import org.apache.kafka.common.message.DeleteAclsRequestData;
 import org.apache.kafka.common.message.DeleteGroupsRequestData;
 import org.apache.kafka.common.message.DeleteRecordsRequestData;
+import org.apache.kafka.common.message.DeleteShareGroupOffsetsRequestData;
 import org.apache.kafka.common.message.DeleteShareGroupStateRequestData;
 import org.apache.kafka.common.message.DeleteTopicsRequestData;
 import org.apache.kafka.common.message.DescribeAclsRequestData;
@@ -42,6 +44,7 @@ import org.apache.kafka.common.message.DescribeGroupsRequestData;
 import org.apache.kafka.common.message.DescribeLogDirsRequestData;
 import org.apache.kafka.common.message.DescribeProducersRequestData;
 import org.apache.kafka.common.message.DescribeQuorumRequestData;
+import org.apache.kafka.common.message.DescribeShareGroupOffsetsRequestData;
 import org.apache.kafka.common.message.DescribeTopicPartitionsRequestData;
 import org.apache.kafka.common.message.DescribeTransactionsRequestData;
 import org.apache.kafka.common.message.DescribeUserScramCredentialsRequestData;
@@ -60,7 +63,7 @@ import org.apache.kafka.common.message.InitProducerIdRequestData;
 import org.apache.kafka.common.message.InitializeShareGroupStateRequestData;
 import org.apache.kafka.common.message.JoinGroupRequestData;
 import org.apache.kafka.common.message.LeaveGroupRequestData;
-import org.apache.kafka.common.message.ListClientMetricsResourcesRequestData;
+import org.apache.kafka.common.message.ListConfigResourcesRequestData;
 import org.apache.kafka.common.message.ListGroupsRequestData;
 import org.apache.kafka.common.message.ListOffsetsRequestData;
 import org.apache.kafka.common.message.ListPartitionReassignmentsRequestData;
@@ -82,6 +85,8 @@ import org.apache.kafka.common.message.ShareAcknowledgeRequestData;
 import org.apache.kafka.common.message.ShareFetchRequestData;
 import org.apache.kafka.common.message.ShareGroupDescribeRequestData;
 import org.apache.kafka.common.message.ShareGroupHeartbeatRequestData;
+import org.apache.kafka.common.message.StreamsGroupDescribeRequestData;
+import org.apache.kafka.common.message.StreamsGroupHeartbeatRequestData;
 import org.apache.kafka.common.message.SyncGroupRequestData;
 import org.apache.kafka.common.message.TxnOffsetCommitRequestData;
 import org.apache.kafka.common.message.UnregisterBrokerRequestData;
@@ -166,6 +171,9 @@ public /* sealed */ interface KrpcRequestFilter extends KrpcFilter /* TODO permi
             case ALTER_REPLICA_LOG_DIRS:
                 state = ((AlterReplicaLogDirsRequestFilter) this).onAlterReplicaLogDirsRequest((AlterReplicaLogDirsRequestData) decodedFrame.body(), filterContext);
                 break;
+            case ALTER_SHARE_GROUP_OFFSETS:
+                state = ((AlterShareGroupOffsetsRequestFilter) this).onAlterShareGroupOffsetsRequest((AlterShareGroupOffsetsRequestData) decodedFrame.body(), filterContext);
+                break;
             case ALTER_USER_SCRAM_CREDENTIALS:
                 state = ((AlterUserScramCredentialsRequestFilter) this).onAlterUserScramCredentialsRequest((AlterUserScramCredentialsRequestData) decodedFrame.body(), filterContext);
                 break;
@@ -214,6 +222,9 @@ public /* sealed */ interface KrpcRequestFilter extends KrpcFilter /* TODO permi
             case DELETE_RECORDS:
                 state = ((DeleteRecordsRequestFilter) this).onDeleteRecordsRequest((DeleteRecordsRequestData) decodedFrame.body(), filterContext);
                 break;
+            case DELETE_SHARE_GROUP_OFFSETS:
+                state = ((DeleteShareGroupOffsetsRequestFilter) this).onDeleteShareGroupOffsetsRequest((DeleteShareGroupOffsetsRequestData) decodedFrame.body(), filterContext);
+                break;
             case DELETE_SHARE_GROUP_STATE:
                 state = ((DeleteShareGroupStateRequestFilter) this).onDeleteShareGroupStateRequest((DeleteShareGroupStateRequestData) decodedFrame.body(), filterContext);
                 break;
@@ -246,6 +257,9 @@ public /* sealed */ interface KrpcRequestFilter extends KrpcFilter /* TODO permi
                 break;
             case DESCRIBE_QUORUM:
                 state = ((DescribeQuorumRequestFilter) this).onDescribeQuorumRequest((DescribeQuorumRequestData) decodedFrame.body(), filterContext);
+                break;
+            case DESCRIBE_SHARE_GROUP_OFFSETS:
+                state = ((DescribeShareGroupOffsetsRequestFilter) this).onDescribeShareGroupOffsetsRequest((DescribeShareGroupOffsetsRequestData) decodedFrame.body(), filterContext);
                 break;
             case DESCRIBE_TOPIC_PARTITIONS:
                 state = ((DescribeTopicPartitionsRequestFilter) this).onDescribeTopicPartitionsRequest((DescribeTopicPartitionsRequestData) decodedFrame.body(), filterContext);
@@ -301,8 +315,8 @@ public /* sealed */ interface KrpcRequestFilter extends KrpcFilter /* TODO permi
             case LEAVE_GROUP:
                 state = ((LeaveGroupRequestFilter) this).onLeaveGroupRequest((LeaveGroupRequestData) decodedFrame.body(), filterContext);
                 break;
-            case LIST_CLIENT_METRICS_RESOURCES:
-                state = ((ListClientMetricsResourcesRequestFilter) this).onListClientMetricsResourcesRequest((ListClientMetricsResourcesRequestData) decodedFrame.body(), filterContext);
+            case LIST_CONFIG_RESOURCES:
+                state = ((ListConfigResourcesRequestFilter) this).onListConfigResourcesRequest((ListConfigResourcesRequestData) decodedFrame.body(), filterContext);
                 break;
             case LIST_GROUPS:
                 state = ((ListGroupsRequestFilter) this).onListGroupsRequest((ListGroupsRequestData) decodedFrame.body(), filterContext);
@@ -366,6 +380,12 @@ public /* sealed */ interface KrpcRequestFilter extends KrpcFilter /* TODO permi
                 break;
             case SHARE_GROUP_HEARTBEAT:
                 state = ((ShareGroupHeartbeatRequestFilter) this).onShareGroupHeartbeatRequest((ShareGroupHeartbeatRequestData) decodedFrame.body(), filterContext);
+                break;
+            case STREAMS_GROUP_DESCRIBE:
+                state = ((StreamsGroupDescribeRequestFilter) this).onStreamsGroupDescribeRequest((StreamsGroupDescribeRequestData) decodedFrame.body(), filterContext);
+                break;
+            case STREAMS_GROUP_HEARTBEAT:
+                state = ((StreamsGroupHeartbeatRequestFilter) this).onStreamsGroupHeartbeatRequest((StreamsGroupHeartbeatRequestData) decodedFrame.body(), filterContext);
                 break;
             case SYNC_GROUP:
                 state = ((SyncGroupRequestFilter) this).onSyncGroupRequest((SyncGroupRequestData) decodedFrame.body(), filterContext);
@@ -433,6 +453,8 @@ public /* sealed */ interface KrpcRequestFilter extends KrpcFilter /* TODO permi
                 return this instanceof AlterPartitionRequestFilter;
             case ALTER_REPLICA_LOG_DIRS:
                 return this instanceof AlterReplicaLogDirsRequestFilter;
+            case ALTER_SHARE_GROUP_OFFSETS:
+                return this instanceof AlterShareGroupOffsetsRequestFilter;
             case ALTER_USER_SCRAM_CREDENTIALS:
                 return this instanceof AlterUserScramCredentialsRequestFilter;
             case API_VERSIONS:
@@ -465,6 +487,8 @@ public /* sealed */ interface KrpcRequestFilter extends KrpcFilter /* TODO permi
                 return this instanceof DeleteGroupsRequestFilter;
             case DELETE_RECORDS:
                 return this instanceof DeleteRecordsRequestFilter;
+            case DELETE_SHARE_GROUP_OFFSETS:
+                return this instanceof DeleteShareGroupOffsetsRequestFilter;
             case DELETE_SHARE_GROUP_STATE:
                 return this instanceof DeleteShareGroupStateRequestFilter;
             case DELETE_TOPICS:
@@ -487,6 +511,8 @@ public /* sealed */ interface KrpcRequestFilter extends KrpcFilter /* TODO permi
                 return this instanceof DescribeProducersRequestFilter;
             case DESCRIBE_QUORUM:
                 return this instanceof DescribeQuorumRequestFilter;
+            case DESCRIBE_SHARE_GROUP_OFFSETS:
+                return this instanceof DescribeShareGroupOffsetsRequestFilter;
             case DESCRIBE_TOPIC_PARTITIONS:
                 return this instanceof DescribeTopicPartitionsRequestFilter;
             case DESCRIBE_TRANSACTIONS:
@@ -523,8 +549,8 @@ public /* sealed */ interface KrpcRequestFilter extends KrpcFilter /* TODO permi
                 return this instanceof JoinGroupRequestFilter;
             case LEAVE_GROUP:
                 return this instanceof LeaveGroupRequestFilter;
-            case LIST_CLIENT_METRICS_RESOURCES:
-                return this instanceof ListClientMetricsResourcesRequestFilter;
+            case LIST_CONFIG_RESOURCES:
+                return this instanceof ListConfigResourcesRequestFilter;
             case LIST_GROUPS:
                 return this instanceof ListGroupsRequestFilter;
             case LIST_OFFSETS:
@@ -567,6 +593,10 @@ public /* sealed */ interface KrpcRequestFilter extends KrpcFilter /* TODO permi
                 return this instanceof ShareGroupDescribeRequestFilter;
             case SHARE_GROUP_HEARTBEAT:
                 return this instanceof ShareGroupHeartbeatRequestFilter;
+            case STREAMS_GROUP_DESCRIBE:
+                return this instanceof StreamsGroupDescribeRequestFilter;
+            case STREAMS_GROUP_HEARTBEAT:
+                return this instanceof StreamsGroupHeartbeatRequestFilter;
             case SYNC_GROUP:
                 return this instanceof SyncGroupRequestFilter;
             case TXN_OFFSET_COMMIT:

--- a/kroxylicious-krpc-plugin/src/test/resources/hello-world/example-expected-FetchRequest.txt
+++ b/kroxylicious-krpc-plugin/src/test/resources/hello-world/example-expected-FetchRequest.txt
@@ -10,7 +10,7 @@ apiKey: Optional[1]
 struct:
   name: FetchRequest
   hasKeys: no
-  versions: 4-17
+  versions: 4-18
 fields:
     ClusterId
     ReplicaId
@@ -24,8 +24,8 @@ fields:
     Topics
     ForgottenTopicsData
     RackId
-validVersions: 4-17
-validVersionsString: 4-17
+validVersions: 4-18
+validVersionsString: 4-18
 flexibleVersions: 12+
 flexibleVersionsString: 12+
 dataClassName: FetchRequestData

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/ByteBufAccessorImpl.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/ByteBufAccessorImpl.java
@@ -7,6 +7,8 @@ package io.kroxylicious.proxy.internal.codec;
 
 import java.nio.ByteBuffer;
 
+import org.apache.kafka.common.protocol.Readable;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 
@@ -174,6 +176,11 @@ public class ByteBufAccessorImpl implements ByteBufAccessor {
     @Override
     public int remaining() {
         return buf.writerIndex() - buf.readerIndex();
+    }
+
+    @Override
+    public Readable slice() {
+        throw new IllegalStateException("slice() not supported");
     }
 
     @Override

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoder.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoder.java
@@ -28,7 +28,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 public class KafkaRequestDecoder extends KafkaMessageDecoder {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaRequestDecoder.class);
-    private static final int CURRENT_PRODUCE_REQUEST_VERSION = 12;
+    private static final int CURRENT_PRODUCE_REQUEST_VERSION = 13;
 
     private final DecodePredicate decodePredicate;
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoderTest.java
@@ -234,7 +234,7 @@ class KafkaRequestDecoderTest {
         ByteBuf buffer = Unpooled.buffer(Integer.BYTES + headerLength);
         buffer.writeInt(headerLength);
         buffer.writeShort(ApiKeys.PRODUCE.id);
-        short apiVersion = 13;
+        short apiVersion = (short) (ApiKeys.PRODUCE.latestVersion(true) + 1);
         buffer.writeShort(apiVersion);
         buffer.writeInt(2); // correlationId
         assertThatThrownBy(() -> embeddedChannel.writeInbound(buffer)).isInstanceOf(AssertionError.class)

--- a/kroxylicious-runtime/src/test/resources/io/kroxylicious/proxy/internal/filter/ShareFetch.test.yaml
+++ b/kroxylicious-runtime/src/test/resources/io/kroxylicious/proxy/internal/filter/ShareFetch.test.yaml
@@ -12,6 +12,7 @@
       errorCode: 0
       errorMessage: ""
       responses: []
+      acquisitionLockTimeoutMs: 1000
       nodeEndpoints:
         - nodeId: 0
           host: upstreamz

--- a/kroxylicious-systemtests/pom.xml
+++ b/kroxylicious-systemtests/pom.xml
@@ -26,9 +26,7 @@
 
     <properties>
         <!-- Override for kafka version - used when Apache Kafka is ahead of the Strimzi release  -->
-        <!--
         <kafka.version>4.0.0</kafka.version>
-        -->
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <hamcrest.version>3.0</hamcrest.version>
         <jackson.version>2.20.0</jackson.version>
         <junit.version>5.13.4</junit.version>
-        <kafka.version>4.0.0</kafka.version>
+        <kafka.version>4.1.0</kafka.version>
         <kroxy.extension.version>0.12.0</kroxy.extension.version>
         <log4j.version>2.25.1</log4j.version>
         <caffeine.version>3.2.2</caffeine.version>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

- Upgrade to Kafka 4.1.0
- There is a `kroxylicious-api` **breaking** impact, some data classes were renamed in `kafka-clients`. [KIP-1142](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1142) renamed an RPC from `ListClientMetricsResources` to `ListConfigResources`. Consequently our corresponding `ListClientMetricsResourcesResponseFilter` and `ListClientMetricsResourcesRequestFilter` interfaces are removed and replaced with `ListConfigResourcesResponseFilter`, `ListConfigResourcesRequestFilter`. Since we use the `kafka-client` data classes in our signatures, there's no escaping a break without some kind of total overhaul like taking ownership of data classes and serialization.
- OAuth Bearer Filter needed modification because `sasl.oauthbearer.jwt.validator.class` became a required configuration. It is exposed as a config option `jwtValidatorClass` and has a default of `BrokerJwtValidator.class.getName()`, differing from Kafka's default. The `DefaultJwtValidator` can manifest a delegate client or broker validator depending on how it's configured. We know which one we want to use in the proxy.
- Simple Transform Filter downgrades the max API version of produce requests to 12 to prevent receiving topic ids. This is to defer deciding what to do with the Filter.
- ByteBufAccessorImpl needs to implement a slice() method, which is only used in kafka-clients code around handling the ApiVersions downgrade case and not code we use in the proxy, so I've made it throw for now.
- The signature for `TopicProduceResponseCollection#find` changed in kafka-clients, so technically older versions of the validation Filter will not work in the next version of the Proxy, but because we bundle the filter with our release artefacts this is unlikely to affect users.

Closes #2542 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
