### PR TITLE
fix: more IT fixes for Java 25

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/TlsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/TlsIT.java
@@ -794,7 +794,8 @@ class TlsIT extends AbstractTlsIT {
             assertThatThrownBy(() -> admin.describeCluster().clusterId().get(10, TimeUnit.SECONDS))
                     .hasRootCauseInstanceOf(SSLHandshakeException.class)
                     .rootCause()
-                    .hasMessageContaining("Received fatal alert: bad_certificate");
+                    .satisfiesAnyOf(e -> assertThat(e).hasMessageContaining("Received fatal alert: bad_certificate") /* <JDK-25 */,
+                            e -> assertThat(e).hasMessageContaining("Received fatal alert: certificate_required") /* JDK-25 */);
         }
     }
 
@@ -826,7 +827,8 @@ class TlsIT extends AbstractTlsIT {
             assertThatThrownBy(() -> admin.describeCluster().clusterId().get(10, TimeUnit.SECONDS))
                     .hasRootCauseInstanceOf(SSLHandshakeException.class)
                     .rootCause()
-                    .hasMessageContaining("Received fatal alert: bad_certificate");
+                    .satisfiesAnyOf(e -> assertThat(e).hasMessageContaining("Received fatal alert: bad_certificate") /* <JDK-25 */,
+                            e -> assertThat(e).hasMessageContaining("Received fatal alert: certificate_required") /* JDK-25 */);
         }
     }
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description



More IT fixes for Java 25. My first attempt was incomplete.   Exception message differs in these scenarios differ with the new Java version.

```
Error:  Failures: 
Error:    TlsIT.downstreamMutualTls_UnsuccessfulTlsClientAuthRequired:829 
Expecting throwable message:
  "(certificate_required) Received fatal alert: certificate_required"
to contain:
  "Received fatal alert: bad_certificate"
but did not.
```

### Additional Context

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
