### PR TITLE
fix(docs): reincorporate two orphaned operator documents back into the operator guide

### DIFF
--- a/kroxylicious-docs/docs/_assemblies/assembly-operator-operate-proxy.adoc
+++ b/kroxylicious-docs/docs/_assemblies/assembly-operator-operate-proxy.adoc
@@ -8,10 +8,11 @@
 = Operating a proxy
 
 [role="_abstract"]
-Step-by-step guide to operating the proxy.
+Monitor the operational status of the proxy and configure resource usage.
+This section explains how to check the status of the `KafkaProxyIngress` and `VirtualKafkaCluster` resources, and how to set CPU and memory requests and limits for the proxy container.
 
 This section assumes you have a running Kroxylicious Proxy instance.
 
-include::../_modules/configuring/con-understanding-virtualkafkacluster-status.adoc[leveloffset=+1]
-include::../_modules/configuring/con-understanding-kafkaproxyingress-status.adoc[leveloffset=+1]
+include::../_modules/configuring/con-chedcking-virtualkafkacluster-status.adoc[leveloffset=+1]
+include::../_modules/configuring/con-checking-kafkaproxyingress-status.adoc[leveloffset=+1]
 include::../_modules/configuring/con-kafkaproxy-cpu-memory-allocation.adoc[leveloffset=+1]

--- a/kroxylicious-docs/docs/_modules/configuring/con-checking-kafkaproxyingress-status.adoc
+++ b/kroxylicious-docs/docs/_modules/configuring/con-checking-kafkaproxyingress-status.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: CONCEPT
 
-[id='con-understanding-kafkaproxyingress-status-{context}']
-= Understanding the status of the `KafkaProxyIngress` resource
+[id='con-checking-kafkaproxyingress-status-{context}']
+= Checking the status of the `KafkaProxyIngress` resource
 
 [role="_abstract"]
 The status of a `KafkaProxyIngress` resource provides feedback on its configuration through a set of conditions.

--- a/kroxylicious-docs/docs/_modules/configuring/con-chedcking-virtualkafkacluster-status.adoc
+++ b/kroxylicious-docs/docs/_modules/configuring/con-chedcking-virtualkafkacluster-status.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: CONCEPT
 
-[id='con-understanding-virtualkafkacluster-status-{context}']
-= Understanding the status of the `VirtualKafkaCluster` resource
+[id='con-checking-virtualkafkacluster-status-{context}']
+= Checking the status of the `VirtualKafkaCluster` resource
 
 [role="_abstract"]
 The status of a `VirtualKafkaCluster` resource provides feedback on its configuration through a set of conditions. 


### PR DESCRIPTION


### Type of change

_Select the type of your PR_

- Bugfix
- Documentation

### Description

As reported in #2717, two operator documents had become detached from the guide.  This PR
makes them part of the 'operate' section.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [x] Update documentation
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [x] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
