### PR TITLE
chore(renovate): add renovate rules for the dependencies used by the record encryption quickstart

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -100,6 +100,52 @@
         "(?<depName>org.sonarsource.scanner.maven:sonar-maven-plugin):(?<currentValue>\\d+\\.\\d+\\.\\d+\\.\\d+)"
       ],
       "datasourceTemplate": "maven"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "kroxylicious-docs/docs/record-encryption-quickstart/index.adoc"
+      ],
+      "matchStrings": [
+        ":vault-chart-version:.*(?<currentValue>\\d+\\.\\d+.\\d+)"
+      ],
+      "depNameTemplate": "hashicorp/vault-helm",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "kroxylicious-docs/docs/record-encryption-quickstart/index.adoc"
+      ],
+      "matchStrings": [
+        ":localstack-chart-version:.*(?<currentValue>\\d+\\.\\d+.\\d+)"
+      ],
+      "depNameTemplate": "localstack/helm-charts",
+      "extractVersionTemplate": "^localstack-(?<version>.*)$",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "kroxylicious-docs/docs/record-encryption-quickstart/index.adoc"
+      ],
+      "matchStrings": [
+        ":localstack-chart-version:.*(?<currentValue>\\d+\\.\\d+.\\d+)"
+      ],
+      "depNameTemplate": "localstack/helm-charts",
+      "extractVersionTemplate": "^localstack-(?<version>.*)$",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "kroxylicious-docs/docs/record-encryption-quickstart/index.adoc"
+      ],
+      "matchStrings": [
+        ":strimzi-version:.*(?<currentValue>\\d+\\.\\d+.\\d+)"
+      ],
+      "depNameTemplate": "strimzi/strimzi-kafka-operator",
+      "datasourceTemplate": "github-releases"
     }
   ]
 }

--- a/kroxylicious-docs/docs/record-encryption-quickstart/index.adoc
+++ b/kroxylicious-docs/docs/record-encryption-quickstart/index.adoc
@@ -1,8 +1,11 @@
 :experimental:
-:kafka-version: 4.0.0
 :vault-chart-version: 0.30.1
 :localstack-chart-version: 0.6.24
+// A Renovate rule will update the strimzi-version but not kafka-version. Update the kafka-version to the point
+// at the latest kafka version supported by that strimzi.
 :strimzi-version: 0.47.0
+:kafka-version: 4.0.0
+:kafka-image: quay.io/strimzi/kafka:{strimzi-version}-kafka-{kafka-version}
 
 include::_assets/attributes.adoc[]
 
@@ -259,7 +262,7 @@ NOTE: You can safely ignore the warning about the UNKNOWN_TOPIC_OR_PARTITION, th
 
 [source,terminal,subs="attributes"]
 ----
-$ (echo 'IBM:100'; echo 'APPLE:99') | kubectl run -n my-proxy --quiet=true --stdin=true proxy-producer --image=quay.io/strimzi/kafka:{strimzi-version}-kafka-{kafka-version} --rm=true --restart=Never -- ./bin/kafka-console-producer.sh --bootstrap-server $\{PROXIED_CLUSTER_BOOTSTRAP_SERVER} --topic trades
+$ (echo 'IBM:100'; echo 'APPLE:99') | kubectl run -n my-proxy --quiet=true --stdin=true proxy-producer --image={kafka-image} --rm=true --restart=Never -- ./bin/kafka-console-producer.sh --bootstrap-server $\{PROXIED_CLUSTER_BOOTSTRAP_SERVER} --topic trades
 ----
 
 == Consume the messages
@@ -270,7 +273,7 @@ The Record Encryption filter will decrypt the records before they reach consumer
 
 [source,terminal,subs="attributes"]
 ----
-$ kubectl run -n my-proxy --quiet=true --attach=true --stdin=false proxy-consumer --image=quay.io/strimzi/kafka:{strimzi-version}-kafka-{kafka-version} --rm=true --restart=Never -- ./bin/kafka-console-consumer.sh  --bootstrap-server $\{PROXIED_CLUSTER_BOOTSTRAP_SERVER} --topic trades --from-beginning --max-messages 2
+$ kubectl run -n my-proxy --quiet=true --attach=true --stdin=false proxy-consumer --image={kafka-image} --rm=true --restart=Never -- ./bin/kafka-console-consumer.sh  --bootstrap-server $\{PROXIED_CLUSTER_BOOTSTRAP_SERVER} --topic trades --from-beginning --max-messages 2
 ----
 
 == Verify that the records are encrypted on the broker
@@ -284,7 +287,7 @@ We'll get back the records, but they'll contain ciphertext, rather than the plai
 
 [source,terminal,subs="attributes"]
 ----
-$ kubectl run -n kafka --quiet=true --attach=true --stdin=false cluster-consumer --image=quay.io/strimzi/kafka:{strimzi-version}-kafka-{kafka-version} --rm=true --restart=Never -- ./bin/kafka-console-consumer.sh  --bootstrap-server $\{DIRECT_CLUSTER_BOOTSTRAP_SERVERS} --topic trades --from-beginning --max-messages 2
+$ kubectl run -n kafka --quiet=true --attach=true --stdin=false cluster-consumer --image={kafka-image} --rm=true --restart=Never -- ./bin/kafka-console-consumer.sh  --bootstrap-server $\{DIRECT_CLUSTER_BOOTSTRAP_SERVERS} --topic trades --from-beginning --max-messages 2
 ----
 
 == Cleaning up


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Add renovate rules for the record encryption quickstart upgrading Strimzi, Localstack, and Vault.

### Additional Context

Software currency automation.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
