### PR TITLE
(Draft) Added invalid cert test for TLS

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/TlsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/TlsIT.java
@@ -894,7 +894,7 @@ class TlsIT extends AbstractTlsIT {
 
     @ParameterizedTest
     @ValueSource(strings = { "REQUIRED", "REQUESTED" })
-    void downstream_RejectsClientWithInvalidCertificateInRequiredMode(TlsClientAuth clientAuthMode, KafkaCluster cluster) throws Exception {
+    void downstream_RejectsClientWithInvalidCertificateInNotNoneMode(TlsClientAuth clientAuthMode, KafkaCluster cluster) throws Exception {
         // Generate an invalid client certificate not trusted by the server
         var invalidClientCert = new KeytoolCertificateGenerator();
         invalidClientCert.generateSelfSignedCertificateEntry("invalid@test.com", "invalidclient", "Test", "Test", null, null, "US");

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/NettyTrustProvider.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/NettyTrustProvider.java
@@ -72,8 +72,7 @@ public class NettyTrustProvider {
                                 TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
                                 if (trustManagers != null && trustManagers.length > 0 && trustManagers[0] instanceof X509TrustManager) {
                                     return builder.trustManager(
-                                            new RequestedClientAuthTrustManager((X509TrustManager) trustManagers[0])
-                                    );
+                                            new RequestedClientAuthTrustManager((X509TrustManager) trustManagers[0]));
                                 }
                             }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/NettyTrustProvider.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/NettyTrustProvider.java
@@ -33,6 +33,14 @@ public class NettyTrustProvider {
         this.trustProvider = trustProvider;
     }
 
+    private static ClientAuth toNettyClientAuth(TlsClientAuth clientAuth) {
+        return switch (clientAuth) {
+            case REQUIRED -> ClientAuth.REQUIRE;
+            case REQUESTED -> ClientAuth.OPTIONAL;
+            case NONE -> ClientAuth.NONE;
+        };
+    }
+
     public SslContextBuilder apply(SslContextBuilder builder) {
         return trustProvider.accept(new TrustProviderVisitor<>() {
             @Override
@@ -124,14 +132,6 @@ public class NettyTrustProvider {
                 builder.endpointIdentificationAlgorithm(httpsHostnameVerification);
             }
         });
-    }
-
-    private static ClientAuth toNettyClientAuth(TlsClientAuth clientAuth) {
-        return switch (clientAuth) {
-            case REQUIRED -> ClientAuth.REQUIRE;
-            case REQUESTED -> ClientAuth.OPTIONAL;
-            case NONE -> ClientAuth.NONE;
-        };
     }
 
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/NettyTrustProvider.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/NettyTrustProvider.java
@@ -70,9 +70,9 @@ public class NettyTrustProvider {
                             // For REQUESTED mode, wrap the trust manager to validate certificates if presented
                             if (clientAuthMode == TlsClientAuth.REQUESTED) {
                                 TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
-                                if (trustManagers != null && trustManagers.length > 0 && trustManagers[0] instanceof X509TrustManager) {
+                                if (trustManagers != null && trustManagers.length > 0 && trustManagers[0] instanceof X509TrustManager x509TrustManager) {
                                     return builder.trustManager(
-                                            new RequestedClientAuthTrustManager((X509TrustManager) trustManagers[0]));
+                                            new RequestedClientAuthTrustManager(x509TrustManager));
                                 }
                             }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/RequestedClientAuthTrustManager.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/RequestedClientAuthTrustManager.java
@@ -46,8 +46,8 @@ public class RequestedClientAuthTrustManager extends X509ExtendedTrustManager {
     public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket) throws CertificateException {
         // If a client certificate chain is presented, validate it
         if (chain != null && chain.length > 0) {
-            if (delegate instanceof X509ExtendedTrustManager) {
-                ((X509ExtendedTrustManager) delegate).checkClientTrusted(chain, authType, socket);
+            if (delegate instanceof X509ExtendedTrustManager x509ExtendedTrustManager) {
+                x509ExtendedTrustManager.checkClientTrusted(chain, authType, socket);
             }
             else {
                 delegate.checkClientTrusted(chain, authType);
@@ -60,8 +60,8 @@ public class RequestedClientAuthTrustManager extends X509ExtendedTrustManager {
     public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine) throws CertificateException {
         // If a client certificate chain is presented, validate it
         if (chain != null && chain.length > 0) {
-            if (delegate instanceof X509ExtendedTrustManager) {
-                ((X509ExtendedTrustManager) delegate).checkClientTrusted(chain, authType, engine);
+            if (delegate instanceof X509ExtendedTrustManager x509ExtendedTrustManager) {
+                x509ExtendedTrustManager.checkClientTrusted(chain, authType, engine);
             }
             else {
                 delegate.checkClientTrusted(chain, authType);
@@ -77,8 +77,8 @@ public class RequestedClientAuthTrustManager extends X509ExtendedTrustManager {
 
     @Override
     public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket) throws CertificateException {
-        if (delegate instanceof X509ExtendedTrustManager) {
-            ((X509ExtendedTrustManager) delegate).checkServerTrusted(chain, authType, socket);
+        if (delegate instanceof X509ExtendedTrustManager x509ExtendedTrustManager) {
+            x509ExtendedTrustManager.checkServerTrusted(chain, authType, socket);
         }
         else {
             delegate.checkServerTrusted(chain, authType);
@@ -87,8 +87,8 @@ public class RequestedClientAuthTrustManager extends X509ExtendedTrustManager {
 
     @Override
     public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine) throws CertificateException {
-        if (delegate instanceof X509ExtendedTrustManager) {
-            ((X509ExtendedTrustManager) delegate).checkServerTrusted(chain, authType, engine);
+        if (delegate instanceof X509ExtendedTrustManager x509ExtendedTrustManager) {
+            x509ExtendedTrustManager.checkServerTrusted(chain, authType, engine);
         }
         else {
             delegate.checkServerTrusted(chain, authType);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/RequestedClientAuthTrustManager.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/RequestedClientAuthTrustManager.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config.tls;
+
+import java.net.Socket;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.X509ExtendedTrustManager;
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * A TrustManager that implements Kafka's "requested" client authentication semantics.
+ * <br/>
+ * This differs from Netty's OPTIONAL mode in that:
+ * - Netty OPTIONAL: Client cert is optional and NOT validated if presented
+ * - Kafka REQUESTED: Client cert is optional BUT must be valid if presented
+ * <br/>
+ * This TrustManager:
+ * - Allows connections without client certificates (returns null accepted issuers to indicate optional)
+ * - Validates client certificates if they ARE presented
+ */
+public class RequestedClientAuthTrustManager extends X509ExtendedTrustManager {
+
+    private final X509TrustManager delegate;
+
+    public RequestedClientAuthTrustManager(X509TrustManager delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        // If a client certificate chain is presented, validate it
+        if (chain != null && chain.length > 0) {
+            delegate.checkClientTrusted(chain, authType);
+        }
+        // If no certificate is presented, allow the connection (requested, not required)
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket) throws CertificateException {
+        // If a client certificate chain is presented, validate it
+        if (chain != null && chain.length > 0) {
+            if (delegate instanceof X509ExtendedTrustManager) {
+                ((X509ExtendedTrustManager) delegate).checkClientTrusted(chain, authType, socket);
+            }
+            else {
+                delegate.checkClientTrusted(chain, authType);
+            }
+        }
+        // If no certificate is presented, allow the connection (requested, not required)
+    }
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine) throws CertificateException {
+        // If a client certificate chain is presented, validate it
+        if (chain != null && chain.length > 0) {
+            if (delegate instanceof X509ExtendedTrustManager) {
+                ((X509ExtendedTrustManager) delegate).checkClientTrusted(chain, authType, engine);
+            }
+            else {
+                delegate.checkClientTrusted(chain, authType);
+            }
+        }
+        // If no certificate is presented, allow the connection (requested, not required)
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        delegate.checkServerTrusted(chain, authType);
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket) throws CertificateException {
+        if (delegate instanceof X509ExtendedTrustManager) {
+            ((X509ExtendedTrustManager) delegate).checkServerTrusted(chain, authType, socket);
+        }
+        else {
+            delegate.checkServerTrusted(chain, authType);
+        }
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine) throws CertificateException {
+        if (delegate instanceof X509ExtendedTrustManager) {
+            ((X509ExtendedTrustManager) delegate).checkServerTrusted(chain, authType, engine);
+        }
+        else {
+            delegate.checkServerTrusted(chain, authType);
+        }
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+        // Return empty array to indicate client auth is optional
+        // Returning delegate.getAcceptedIssuers() would make it required
+        return new X509Certificate[0];
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/SslContextBuildException.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/tls/SslContextBuildException.java
@@ -8,6 +8,10 @@ package io.kroxylicious.proxy.config.tls;
 
 public class SslContextBuildException extends RuntimeException {
 
+    public SslContextBuildException(String message) {
+        super(message);
+    }
+
     public SslContextBuildException(Throwable cause) {
         super(cause);
     }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/NettyTrustProviderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/NettyTrustProviderTest.java
@@ -202,7 +202,11 @@ class NettyTrustProviderTest {
                         new ServerOptions(TlsClientAuth.REQUESTED)));
 
         // When/Then - should throw exception for unsupported combination
+        // Note: The exception gets wrapped, so we check the root cause
         assertThatCode(() -> trustStoreWithPEM.apply(sslContextBuilder))
+                .isInstanceOf(SslContextBuildException.class)
+                .hasMessageContaining("Error building SSLContext for TrustStore")
+                .cause()
                 .isInstanceOf(SslContextBuildException.class)
                 .hasMessageContaining("REQUESTED client authentication mode is not supported for PEM trust stores")
                 .hasMessageContaining("Please use JKS or PKCS12 format");

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/RequestedClientAuthTrustManagerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/RequestedClientAuthTrustManagerTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config.tls;
+
+import java.net.Socket;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.X509ExtendedTrustManager;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class RequestedClientAuthTrustManagerTest {
+
+    @Mock
+    private X509ExtendedTrustManager delegateTrustManager;
+
+    @Mock
+    private X509Certificate mockCertificate;
+
+    private RequestedClientAuthTrustManager trustManager;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        trustManager = new RequestedClientAuthTrustManager(delegateTrustManager);
+    }
+
+    @Test
+    void getAcceptedIssuers_returnsEmptyArray() {
+        // When
+        X509Certificate[] acceptedIssuers = trustManager.getAcceptedIssuers();
+
+        // Then - returning empty array indicates client auth is optional
+        assertThat(acceptedIssuers)
+                .isNotNull()
+                .isEmpty();
+    }
+
+    @Test
+    void checkClientTrusted_withNullChain_allowsConnection() throws CertificateException {
+        // When/Then - no certificate presented, connection should be allowed
+        assertThatCode(() -> trustManager.checkClientTrusted(null, "RSA"))
+                .doesNotThrowAnyException();
+
+        // Verify delegate was never called
+        verify(delegateTrustManager, never()).checkClientTrusted(any(), any());
+    }
+
+    @Test
+    void checkClientTrusted_withEmptyChain_allowsConnection() throws CertificateException {
+        // Given
+        X509Certificate[] emptyChain = new X509Certificate[0];
+
+        // When/Then - no certificate presented, connection should be allowed
+        assertThatCode(() -> trustManager.checkClientTrusted(emptyChain, "RSA"))
+                .doesNotThrowAnyException();
+
+        // Verify delegate was never called
+        verify(delegateTrustManager, never()).checkClientTrusted(any(), any());
+    }
+
+    @Test
+    void checkClientTrusted_withValidCertificate_delegatesValidation() throws CertificateException {
+        // Given
+        X509Certificate[] validChain = new X509Certificate[] { mockCertificate };
+
+        // When
+        trustManager.checkClientTrusted(validChain, "RSA");
+
+        // Then - should delegate to underlying trust manager for validation
+        verify(delegateTrustManager).checkClientTrusted(validChain, "RSA");
+    }
+
+    @Test
+    void checkClientTrusted_withInvalidCertificate_throwsCertificateException() throws CertificateException {
+        // Given
+        X509Certificate[] invalidChain = new X509Certificate[] { mockCertificate };
+        CertificateException expectedException = new CertificateException("Invalid certificate");
+        
+        // Use doThrow().when() pattern for void methods
+        Mockito.doThrow(expectedException)
+                .when(delegateTrustManager)
+                .checkClientTrusted(invalidChain, "RSA");
+
+        // When/Then - should propagate the exception from delegate
+        assertThatThrownBy(() -> trustManager.checkClientTrusted(invalidChain, "RSA"))
+                .isInstanceOf(CertificateException.class)
+                .hasMessage("Invalid certificate");
+
+        verify(delegateTrustManager).checkClientTrusted(invalidChain, "RSA");
+    }
+
+    @Test
+    void checkClientTrusted_withSocket_withNullChain_allowsConnection() throws CertificateException {
+        // When/Then - no certificate presented, connection should be allowed
+        assertThatCode(() -> trustManager.checkClientTrusted(null, "RSA", (java.net.Socket) null))
+                .doesNotThrowAnyException();
+
+        // Verify delegate was never called - checking the base method since we can't check extended
+        verify(delegateTrustManager, never()).checkClientTrusted(any(X509Certificate[].class), any(String.class));
+    }
+
+    @Test
+    void checkClientTrusted_withSocket_withValidCertificate_delegatesValidation() throws CertificateException {
+        // Given
+        X509Certificate[] validChain = new X509Certificate[] { mockCertificate };
+
+        // When
+        trustManager.checkClientTrusted(validChain, "RSA", (java.net.Socket) null);
+
+        // Then - should delegate to the extended trust manager method with null Socket
+        verify(delegateTrustManager).checkClientTrusted(eq(validChain), eq("RSA"), (Socket) isNull());
+    }
+
+    @Test
+    void checkClientTrusted_withSSLEngine_withNullChain_allowsConnection() throws CertificateException {
+        // When/Then - no certificate presented, connection should be allowed
+        assertThatCode(() -> trustManager.checkClientTrusted(null, "RSA", (javax.net.ssl.SSLEngine) null))
+                .doesNotThrowAnyException();
+
+        // Verify delegate was never called - checking the base method
+        verify(delegateTrustManager, never()).checkClientTrusted(any(X509Certificate[].class), any(String.class));
+    }
+
+    @Test
+    void checkClientTrusted_withSSLEngine_withValidCertificate_delegatesValidation() throws CertificateException {
+        // Given
+        X509Certificate[] validChain = new X509Certificate[] { mockCertificate };
+
+        // When
+        trustManager.checkClientTrusted(validChain, "RSA", (javax.net.ssl.SSLEngine) null);
+
+        // Then - should delegate to the extended trust manager method with null SSLEngine
+        verify(delegateTrustManager).checkClientTrusted(eq(validChain), eq("RSA"), (SSLEngine) isNull());
+    }
+
+    @Test
+    void checkServerTrusted_alwaysDelegatesToUnderlying() throws CertificateException {
+        // Given
+        X509Certificate[] chain = new X509Certificate[] { mockCertificate };
+
+        // When
+        trustManager.checkServerTrusted(chain, "RSA");
+
+        // Then - should always delegate server validation
+        verify(delegateTrustManager).checkServerTrusted(chain, "RSA");
+    }
+
+    @Test
+    void checkServerTrusted_withSocket_alwaysDelegatesToUnderlying() throws CertificateException {
+        // Given
+        X509Certificate[] chain = new X509Certificate[] { mockCertificate };
+
+        // When
+        trustManager.checkServerTrusted(chain, "RSA", (java.net.Socket) null);
+
+        // Then - should delegate to extended method with null Socket
+        verify(delegateTrustManager).checkServerTrusted(eq(chain), eq("RSA"), (Socket) isNull());
+    }
+
+    @Test
+    void checkServerTrusted_withSSLEngine_alwaysDelegatesToUnderlying() throws CertificateException {
+        // Given
+        X509Certificate[] chain = new X509Certificate[] { mockCertificate };
+
+        // When
+        trustManager.checkServerTrusted(chain, "RSA", (javax.net.ssl.SSLEngine) null);
+
+        // Then - should delegate to extended method with null SSLEngine
+        verify(delegateTrustManager).checkServerTrusted(eq(chain), eq("RSA"), (SSLEngine) isNull());
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/RequestedClientAuthTrustManagerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/tls/RequestedClientAuthTrustManagerTest.java
@@ -81,7 +81,7 @@ class RequestedClientAuthTrustManagerTest {
     @Test
     void checkClientTrusted_withValidCertificate_delegatesValidation() throws CertificateException {
         // Given
-        X509Certificate[] validChain = new X509Certificate[] { mockCertificate };
+        X509Certificate[] validChain = new X509Certificate[]{ mockCertificate };
 
         // When
         trustManager.checkClientTrusted(validChain, "RSA");
@@ -93,9 +93,9 @@ class RequestedClientAuthTrustManagerTest {
     @Test
     void checkClientTrusted_withInvalidCertificate_throwsCertificateException() throws CertificateException {
         // Given
-        X509Certificate[] invalidChain = new X509Certificate[] { mockCertificate };
+        X509Certificate[] invalidChain = new X509Certificate[]{ mockCertificate };
         CertificateException expectedException = new CertificateException("Invalid certificate");
-        
+
         // Use doThrow().when() pattern for void methods
         Mockito.doThrow(expectedException)
                 .when(delegateTrustManager)
@@ -122,7 +122,7 @@ class RequestedClientAuthTrustManagerTest {
     @Test
     void checkClientTrusted_withSocket_withValidCertificate_delegatesValidation() throws CertificateException {
         // Given
-        X509Certificate[] validChain = new X509Certificate[] { mockCertificate };
+        X509Certificate[] validChain = new X509Certificate[]{ mockCertificate };
 
         // When
         trustManager.checkClientTrusted(validChain, "RSA", (java.net.Socket) null);
@@ -144,7 +144,7 @@ class RequestedClientAuthTrustManagerTest {
     @Test
     void checkClientTrusted_withSSLEngine_withValidCertificate_delegatesValidation() throws CertificateException {
         // Given
-        X509Certificate[] validChain = new X509Certificate[] { mockCertificate };
+        X509Certificate[] validChain = new X509Certificate[]{ mockCertificate };
 
         // When
         trustManager.checkClientTrusted(validChain, "RSA", (javax.net.ssl.SSLEngine) null);
@@ -156,7 +156,7 @@ class RequestedClientAuthTrustManagerTest {
     @Test
     void checkServerTrusted_alwaysDelegatesToUnderlying() throws CertificateException {
         // Given
-        X509Certificate[] chain = new X509Certificate[] { mockCertificate };
+        X509Certificate[] chain = new X509Certificate[]{ mockCertificate };
 
         // When
         trustManager.checkServerTrusted(chain, "RSA");
@@ -168,7 +168,7 @@ class RequestedClientAuthTrustManagerTest {
     @Test
     void checkServerTrusted_withSocket_alwaysDelegatesToUnderlying() throws CertificateException {
         // Given
-        X509Certificate[] chain = new X509Certificate[] { mockCertificate };
+        X509Certificate[] chain = new X509Certificate[]{ mockCertificate };
 
         // When
         trustManager.checkServerTrusted(chain, "RSA", (java.net.Socket) null);
@@ -180,7 +180,7 @@ class RequestedClientAuthTrustManagerTest {
     @Test
     void checkServerTrusted_withSSLEngine_alwaysDelegatesToUnderlying() throws CertificateException {
         // Given
-        X509Certificate[] chain = new X509Certificate[] { mockCertificate };
+        X509Certificate[] chain = new X509Certificate[]{ mockCertificate };
 
         // When
         trustManager.checkServerTrusted(chain, "RSA", (javax.net.ssl.SSLEngine) null);


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- BugFix (https://github.com/kroxylicious/kroxylicious/issues/2744)

### Description

The integration test downstream_RejectsClientWithInvalidCertificateInNotNoneMode was added to validate the behaviour for TlsClientAuth.REQUESTED mode. When configured with REQUESTED mode, Kroxylicious was incorrectly accepting invalid client certificates instead of rejecting them. The pr contains the test and additionally the fix

- RequestedClientAuthTrustManager: A custom X509ExtendedTrustManager wrapper that implements Kafka's "requested" semantics
   - Allows connections without certificates
   - Properly rejects invalid certificates when presented
- Updated `NettyTrustProvider` - Wraps the TrustManager with RequestedClientAuthTrustManager for KeyStore files (JKS, PKCS12) when in REQUESTED mode
- Added SslContextBuildException Constructor that accepts just a String message for better exception handling.

### Additional Context

According to documentation (requested mode), if the certificate is presented, it will be validated. However, test failed for requested mode. It worked as expected for required mode.

https://kroxylicious.io/documentation/0.16.0/html/kroxylicious-proxy/#:~:text=(Optional)%20Client%20authentication,is%20REQUIRED.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
