### PR TITLE
Add IT checking untrusted client certs are rejected

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/AbstractTlsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/AbstractTlsIT.java
@@ -50,6 +50,14 @@ public abstract class AbstractTlsIT extends BaseIT {
     static final String SNI_BROKER_ADDRESS_PATTERN = "broker-$(nodeId)." + SNI_BASE_ADDRESS;
     static final HostPort SNI_BOOTSTRAP_ADDRESS = HostPort.parse("bootstrap." + SNI_BASE_ADDRESS + ":9192");
 
+    static final String CLIENT_CERT_EMAIL = "clientTest@kroxylicious.io";
+    static final String CLIENT_CERT_DOMAIN = "client";
+    static final String CLIENT_CERT_ORGANIZATION_UNIT = "Dev";
+    static final String CLIENT_CERT_ORGANIZATION = "kroxylicious.io";
+    static final String CLIENT_CERT_COUNTRY = "US";
+    static final String CLIENT_CERT_CITY = null;
+    static final String CLIENT_CERT_STATE = null;
+
     @TempDir
     Path certsDirectory;
     KeytoolCertificateGenerator downstreamCertificateGenerator;
@@ -139,7 +147,8 @@ public abstract class AbstractTlsIT extends BaseIT {
 
         // Generator for certificate that will identify the client
         this.clientCertGenerator = new KeytoolCertificateGenerator();
-        this.clientCertGenerator.generateSelfSignedCertificateEntry("clientTest@kroxylicious.io", "client", "Dev", "kroxylicious.io", null, null, "US");
+        this.clientCertGenerator.generateSelfSignedCertificateEntry(CLIENT_CERT_EMAIL, CLIENT_CERT_DOMAIN, CLIENT_CERT_ORGANIZATION_UNIT, CLIENT_CERT_ORGANIZATION,
+                CLIENT_CERT_CITY, CLIENT_CERT_STATE, CLIENT_CERT_COUNTRY);
         this.proxyTrustStore = certsDirectory.resolve("proxy.truststore.jks");
         this.clientCertGenerator.generateTrustStore(clientCertGenerator.getCertFilePath(), "proxy",
                 proxyTrustStore.toAbsolutePath().toString());


### PR DESCRIPTION
### Type of change

- Testing

### Description

During a TLS handshake where downstream client auth is 'REQUIRED' or 'REQUESTED', if the client chooses to send a certificate, and that certificate is not trusted by the proxy, then the proxy should terminate the handshake with a TLS Alert.

Note: this is adding coverage for existing behaviour. We recently investigated whether REQUESTED mode was behaving as expected and noticed a lack of coverage of this case.

@hrishabhg I've taken your IT and modified it, have tagged you as co-author, thank you.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
