### PR TITLE
Pin external github actions by SHA

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -30,11 +30,11 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
 
       - name: Set up Java
         uses: actions/setup-java@v5
@@ -62,14 +62,14 @@ jobs:
 
       - name: Login to container registry
         if: steps.build_configuration.outputs.push_images == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
         with:
           registry: ${{ vars.REGISTRY_SERVER }}
           username: ${{ vars.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_TOKEN }}
 
       - name: Build and maybe push Proxy image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -81,7 +81,7 @@ jobs:
           cache-to: type=gha,mode=max,compression=zstd
 
       - name: Build and maybe push Operator image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: .
           file: ./Dockerfile.operator

--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -36,21 +36,21 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
       - name: 'Set up Java'
         uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: 'temurin'
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.14.0
+        uses: manusa/actions-setup-minikube@b589f2d61bf96695c546929c72b38563e856059d
         with:
           "minikube version": 'v1.35.0'
           "kubernetes version": 'v1.32.0'
           "github token": ${{ secrets.GITHUB_TOKEN }}
           driver: docker
       - name: 'Set up Docker Buildx'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
       - name: 'Cache Maven packages'
         uses: actions/cache@v4
         with:

--- a/.github/workflows/kaf.yaml
+++ b/.github/workflows/kaf.yaml
@@ -33,18 +33,18 @@ jobs:
           repository:  ${{ github.event.inputs.repository }}
           ref: ${{ github.event.inputs.ref }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
       - name: Login to container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
         with:
           registry: ${{ vars.REGISTRY_SERVER }}
           username: ${{ vars.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_TOKEN }}
       - name: Build and push Kaf container image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -52,7 +52,7 @@ jobs:
         run: |
           mvn -B -Pci -T1.5C verify -DskipTests -Djapicmp.skip=true
       - name: shellcheck
-        uses: reviewdog/action-shellcheck@v1
+        uses: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review # Change reporter.

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -47,14 +47,14 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
       - name: 'Set up Java'
         uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java.version }}
           distribution: ${{ matrix.java.distro }}
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.14.0
+        uses: manusa/actions-setup-minikube@b589f2d61bf96695c546929c72b38563e856059d
         with:
           minikube version: 'v1.35.0'
           kubernetes version: 'v1.32.0'

--- a/.github/workflows/operator-maven.yaml
+++ b/.github/workflows/operator-maven.yaml
@@ -41,21 +41,21 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
       - name: 'Set up Java'
         uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: 'temurin'
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.14.0
+        uses: manusa/actions-setup-minikube@b589f2d61bf96695c546929c72b38563e856059d
         with:
           "minikube version": 'v1.35.0'
           "kubernetes version": 'v1.32.0'
           "github token": ${{ secrets.GITHUB_TOKEN }}
           driver: docker
       - name: 'Set up Docker Buildx'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
       - name: 'Cache Maven packages'
         uses: actions/cache@v4
         with:

--- a/.github/workflows/promote_release.yaml
+++ b/.github/workflows/promote_release.yaml
@@ -71,7 +71,7 @@ jobs:
 
       - name: 'Check team membership'
         if: ${{ github.repository == 'kroxylicious/kroxylicious' }}
-        uses: tspascoal/get-user-teams-membership@v3
+        uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662
         id: team-membership
         with:
           username: ${{ github.actor }}
@@ -97,7 +97,7 @@ jobs:
           echo "RELCAND_ID=${RELCAND_ID}" >> $GITHUB_ENV
 
       - name: Download release state artefact
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5
         with:
           workflow: stage-release
           run_id: ${{ env.RELCAND_ID }}

--- a/.github/workflows/publish-snapshot-docs-to-website.yaml
+++ b/.github/workflows/publish-snapshot-docs-to-website.yaml
@@ -76,12 +76,12 @@ jobs:
           ref: main
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
         with:
           driver-opts: network=host
 
       - name: Build Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: kroxylicious.github.io
           push: true

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
       - name: Renovate
-        uses: renovatebot/github-action@v43.0.15
+        uses: renovatebot/github-action@53bdcc4ec92f28e5023ac92356ea8bb45f8b807d
         with:
           configurationFile: .github/renovate.json
           token: ${{ env.EFFECTIVE_TOKEN }}

--- a/.github/workflows/robot-command-dispatcher.yaml
+++ b/.github/workflows/robot-command-dispatcher.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: 'Check team membership'
         if: ${{ github.repository == 'kroxylicious/kroxylicious' }}
-        uses: tspascoal/get-user-teams-membership@v3
+        uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662
         id: team-membership
         with:
           username: ${{ github.actor }}

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -17,18 +17,18 @@ jobs:
       - name: echo event
         run: cat $GITHUB_EVENT_PATH
       - name: Download PR number artifact
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5
         with:
           workflow: Build
           run_id: ${{ github.event.workflow_run.id }}
           name: PR_NUMBER
       - name: Read PR_NUMBER.txt
         id: pr_number
-        uses: juliangruber/read-file-action@v1
+        uses: juliangruber/read-file-action@b549046febe0fe86f8cb4f93c24e284433f9ab58
         with:
           path: ./PR_NUMBER.txt
       - name: Request GitHub API for PR data
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@05a2312de9f8207044c4c9e41fe19703986acc13
         id: get_pr_data
         with:
           route: GET /repos/{full_name}/pulls/{number}
@@ -49,7 +49,7 @@ jobs:
           git checkout ${{ github.event.workflow_run.head_branch }}
           git clean -ffdx && git reset --hard HEAD
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/stage_release.yaml
+++ b/.github/workflows/stage_release.yaml
@@ -69,7 +69,7 @@ jobs:
 
       - name: 'Check team membership'
         if: ${{ github.repository == 'kroxylicious/kroxylicious' }}
-        uses: tspascoal/get-user-teams-membership@v3
+        uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662
         id: team-membership
         with:
           username: ${{ github.actor }}
@@ -107,7 +107,7 @@ jobs:
           overwrite-settings: true
 
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.14.0
+        uses: manusa/actions-setup-minikube@b589f2d61bf96695c546929c72b38563e856059d
         with:
           minikube version: 'v1.35.0'
           kubernetes version: 'v1.32.0'


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Shas obtained via https://github.com/redhat-developer/assess-workflows (though I didn't try out it's PR creation feature)

I created a `~/.github` file containing `oauth=${paste your PAT here}`, you can also do it by username/password which might work more easily with the `-pr` flag to open PRs. See also https://hub4j.github.io/github-api/

then ran `jbang assessWorkflows.java -t actions -r kroxylicious kroxylicious` which emits:

```
Fetching kroxylicious repositories
🔍 analyzing https://github.com/kroxylicious/kroxylicious
 👀 https://github.com/kroxylicious/kroxylicious/blob/main/.github/workflows/check-fork-branch.yaml
 👀 https://github.com/kroxylicious/kroxylicious/blob/main/.github/workflows/docker.yaml
	Job build is using action docker/setup-qemu-action@v3 should be: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
	Job build is using action docker/setup-buildx-action@v3 should be: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
	Job build is using action docker/login-action@v3 should be: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
	Job build is using action docker/build-push-action@v6 should be: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
	Job build is using action docker/build-push-action@v6 should be: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
 👀 https://github.com/kroxylicious/kroxylicious/blob/main/.github/workflows/documentation-tests.yml
	Job build_operator is using action docker/setup-qemu-action@v3 should be: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
	Job build_operator is using action manusa/actions-setup-minikube@v2.14.0 should be: manusa/actions-setup-minikube@b589f2d61bf96695c546929c72b38563e856059d
	Job build_operator is using action docker/setup-buildx-action@v3 should be: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
 👀 https://github.com/kroxylicious/kroxylicious/blob/main/.github/workflows/integration-tests.yaml
 👀 https://github.com/kroxylicious/kroxylicious/blob/main/.github/workflows/kaf.yaml
	Job build is using action docker/setup-qemu-action@v3 should be: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
	Job build is using action docker/setup-buildx-action@v3 should be: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
	Job build is using action docker/login-action@v3 should be: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
	Job build is using action docker/build-push-action@v6 should be: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
 👀 https://github.com/kroxylicious/kroxylicious/blob/main/.github/workflows/lint.yaml
	Job lint is using action reviewdog/action-shellcheck@v1 should be: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e
 👀 https://github.com/kroxylicious/kroxylicious/blob/main/.github/workflows/maven.yaml
	Job build_proxy is using action docker/setup-qemu-action@v3 should be: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
	Job build_proxy is using action manusa/actions-setup-minikube@v2.14.0 should be: manusa/actions-setup-minikube@b589f2d61bf96695c546929c72b38563e856059d
 👀 https://github.com/kroxylicious/kroxylicious/blob/main/.github/workflows/operator-maven.yaml
	Job build_operator is using action docker/setup-qemu-action@v3 should be: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
	Job build_operator is using action manusa/actions-setup-minikube@v2.14.0 should be: manusa/actions-setup-minikube@b589f2d61bf96695c546929c72b38563e856059d
	Job build_operator is using action docker/setup-buildx-action@v3 should be: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
 👀 https://github.com/kroxylicious/kroxylicious/blob/main/.github/workflows/promote_release.yaml
	Job promote-release is using action tspascoal/get-user-teams-membership@v3 should be: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662
	Job promote-release is using action dawidd6/action-download-artifact@v11 should be: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5
 👀 https://github.com/kroxylicious/kroxylicious/blob/main/.github/workflows/publish-snapshot-docs-to-website.yaml
	Job build is using action docker/setup-buildx-action@v3 should be: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
	Job build is using action docker/build-push-action@v6 should be: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
 👀 https://github.com/kroxylicious/kroxylicious/blob/main/.github/workflows/renovate.yaml
	Job renovate is using action renovatebot/github-action@v43.0.15 should be: renovatebot/github-action@53bdcc4ec92f28e5023ac92356ea8bb45f8b807d
 👀 https://github.com/kroxylicious/kroxylicious/blob/main/.github/workflows/robot-command-dispatcher.yaml
	Job process-command is using action tspascoal/get-user-teams-membership@v3 should be: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662
 👀 https://github.com/kroxylicious/kroxylicious/blob/main/.github/workflows/sonar.yaml
	Job Sonar is using action dawidd6/action-download-artifact@v11 should be: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5
	Job Sonar is using action juliangruber/read-file-action@v1 should be: juliangruber/read-file-action@b549046febe0fe86f8cb4f93c24e284433f9ab58
	Job Sonar is using action octokit/request-action@v2.x should be: octokit/request-action@05a2312de9f8207044c4c9e41fe19703986acc13
	Job Sonar is using action docker/setup-qemu-action@v3 should be: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
 👀 https://github.com/kroxylicious/kroxylicious/blob/main/.github/workflows/stage_release.yaml
	Job stage-release is using action tspascoal/get-user-teams-membership@v3 should be: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662
	Job stage-release is using action manusa/actions-setup-minikube@v2.14.0 should be: manusa/actions-setup-minikube@b589f2d61bf96695c546929c72b38563e856059d
```

Prevents us running malicious actions code pushed to an existing tag

### Additional Context

sonatype is rightly complaining about the risk

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
