### PR TITLE
Use mock oauth2 server in Azure KMS integration tests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -67,7 +67,10 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationIT.java"],
+      "fileMatch": [
+        "kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/oauthbearer/OauthBearerValidationIT.java",
+        "kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/src/main/java/io/kroxylicious/kms/provider/azure/kms/OauthServerContainer.java"
+      ],
       "matchStrings": [
         "DockerImageName\\.parse\\(\"(?<depName>ghcr.io/navikt/mock-oauth2-server):(?<currentValue>\\d+\\.\\d+.\\d+)\"\\)"
       ],

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/pom.xml
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/pom.xml
@@ -54,11 +54,6 @@
             <artifactId>testcontainers</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wiremock</groupId>
-            <artifactId>wiremock</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.github.nagyesta.lowkey-vault</groupId>
             <artifactId>lowkey-vault-testcontainers</artifactId>
             <scope>compile</scope>

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/src/main/java/io/kroxylicious/kms/provider/azure/kms/OauthServerContainer.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/src/main/java/io/kroxylicious/kms/provider/azure/kms/OauthServerContainer.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kms.provider.azure.kms;
+
+import java.net.URI;
+import java.time.Duration;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+import io.kroxylicious.kms.service.TestKmsFacadeException;
+import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
+
+class OauthServerContainer extends GenericContainer<OauthServerContainer> {
+
+    private static final DockerImageName DOCKER_IMAGE_NAME = DockerImageName.parse("ghcr.io/navikt/mock-oauth2-server:3.0.0");
+    private static final String LOCALHOST = "localhost";
+    private static final String CERT_FILE_MOUNT_PATH = "/etc/custom-certs";
+    private final KeytoolCertificateGenerator certs;
+    private static final int INTERNAL_PORT = 8080;
+
+    private static KeytoolCertificateGenerator entraCerts() {
+        try {
+            KeytoolCertificateGenerator entraCertGen = new KeytoolCertificateGenerator();
+            entraCertGen.generateSelfSignedCertificateEntry("webmaster@example.com", LOCALHOST, "Engineering", "kroxylicious.io", null, null, "NZ");
+            entraCertGen.generateTrustStore(entraCertGen.getCertFilePath(), "website");
+            return entraCertGen;
+        }
+        catch (Exception e) {
+            throw new TestKmsFacadeException(e);
+        }
+    }
+
+    OauthServerContainer() {
+        super(DOCKER_IMAGE_NAME);
+        this.certs = entraCerts();
+        LogMessageWaitStrategy strategy = new LogMessageWaitStrategy().withRegEx(".*started server on address.*");
+        strategy.withStartupTimeout(Duration.ofSeconds(10));
+        setWaitStrategy(strategy);
+        withExposedPorts(INTERNAL_PORT);
+        withEnv("SERVER_PORT", Integer.toString(INTERNAL_PORT));
+        String config = """
+                    {
+                    "httpServer" : {
+                        "type" : "NettyWrapper",
+                        "ssl" : {
+                            "keyPassword" : "%s",
+                            "keystoreFile" : "%s",
+                            "keystoreType" : "%s",
+                            "keystorePassword" : "%s"
+                        }
+                    }
+                }
+                """.formatted(certs.getPassword(), CERT_FILE_MOUNT_PATH, certs.getKeyStoreType(), certs.getPassword());
+        withEnv("JSON_CONFIG", config);
+        withEnv("LOG_LEVEL", "DEBUG"); // required to for the startup message to be logged.
+        withCopyFileToContainer(MountableFile.forHostPath(certs.getKeyStoreLocation()), CERT_FILE_MOUNT_PATH);
+    }
+
+    @Override
+    public void start() {
+        super.start();
+    }
+
+    public String getTrustStoreLocation() {
+        return certs.getTrustStoreLocation();
+    }
+
+    public String getTrustStorePassword() {
+        return certs.getPassword();
+    }
+
+    public String getTrustStoreType() {
+        return certs.getTrustStoreType();
+    }
+
+    public URI getBaseUri() {
+        Integer mappedPort = getMappedPort(INTERNAL_PORT);
+        if (mappedPort == null) {
+            throw new IllegalStateException("oauth mock - mappedPort is null for " + INTERNAL_PORT);
+        }
+        return URI.create("https://" + LOCALHOST + ":" + mappedPort);
+    }
+}


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Using a third-party mock for oauth2 saves crafting a response and may be usable from the system tests. It also aligns the KMS tests with the oauthbearer integration tests which already use this image.

I checked to see if we could avoid using fixed port mappings in the Oauth Bearer tests while we are here and the answer is that it's hard. We configure kafka by annotation and need to know the JWKS endpoint before we build up the oauth server, so it has to come from a constant. So I've left that alone for now.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
