### PR TITLE
Add FilterContext#topicNames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ For changes that effect a public API, the [deprecation policy](./DEV_GUIDE.md#de
 Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
+
+* [#1318](https://github.com/kroxylicious/kroxylicious/issues/1318): Add FilterContext#topicNames to enable filters to retrieve names for topic ids
+
 ## 0.17.0
 
 * [#2830](https://github.com/kroxylicious/kroxylicious/pull/2830): Refactor authentication configuration class names and optional fields in Azure KMS provider for Record Encryption

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
@@ -5,17 +5,21 @@
  */
 package io.kroxylicious.proxy.filter;
 
+import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 import javax.annotation.Nullable;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 
 import io.kroxylicious.proxy.authentication.ClientSaslContext;
+import io.kroxylicious.proxy.filter.metadata.TopicNameMapping;
+import io.kroxylicious.proxy.filter.metadata.TopicNameMappingException;
 import io.kroxylicious.proxy.tls.ClientTlsContext;
 
 /**
@@ -113,6 +117,20 @@ public interface FilterContext {
      */
     <M extends ApiMessage> CompletionStage<M> sendRequest(RequestHeaderData header,
                                                           ApiMessage request);
+
+    /**
+     * Attempts to map all the given {@code topicIds} to the current corresponding topic names.
+     * @param topicIds topic ids to map to names
+     * @return a CompletionStage that will be completed with a complete mapping, with every requested topic id mapped to either an
+     * {@link TopicNameMappingException} or a name. All failure modes should complete the stage with a TopicNameMapping, with the
+     * TopicNameMapping used to convey the reason for failure, rather than failing the Stage.
+     * <h4>Chained Computation stages</h4>
+     * <p>Default and asynchronous default computation stages chained to the returned
+     * {@link java.util.concurrent.CompletionStage} are guaranteed to be executed by the thread
+     * associated with the connection. See {@link io.kroxylicious.proxy.filter} for more details.
+     * </p>
+     */
+    CompletionStage<TopicNameMapping> topicNames(Collection<Uuid> topicIds);
 
     /**
      * Generates a completed filter results containing the given header and response.  When

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/metadata/TopLevelMetadataErrorException.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/metadata/TopLevelMetadataErrorException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.metadata;
+
+import org.apache.kafka.common.protocol.Errors;
+
+/**
+ * Indicates that there was an {@link Error} set at the top level of {@link org.apache.kafka.common.message.MetadataResponseData}.
+ */
+public class TopLevelMetadataErrorException extends TopicNameMappingException {
+    public TopLevelMetadataErrorException(Errors error) {
+        super(error);
+    }
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/metadata/TopicLevelMetadataErrorException.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/metadata/TopicLevelMetadataErrorException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.metadata;
+
+import org.apache.kafka.common.protocol.Errors;
+
+/**
+ * Indicates that there was an {@link Error} set on a {@link org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopic}.
+ */
+public class TopicLevelMetadataErrorException extends TopicNameMappingException {
+    public TopicLevelMetadataErrorException(Errors error) {
+        super(error);
+    }
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/metadata/TopicNameMapping.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/metadata/TopicNameMapping.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.metadata;
+
+import java.util.Map;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.protocol.Errors;
+
+/**
+ * The result of discovering the topic names for a collection of topic ids
+ */
+public interface TopicNameMapping {
+    /**
+     * @return true if there are any failures
+     */
+    boolean anyFailures();
+
+    /**
+     * @return immutable map from topic id to successfully mapped topic name
+     */
+    Map<Uuid, String> topicNames();
+
+    /**
+     * Describes the reason for every failed mapping. Expected exception types are:
+     * <ul>
+     *     <li>{@link TopLevelMetadataErrorException} indicates that we attempted to obtain Metadata from upstream, but received a top-level error in the response</li>
+     *     <li>{@link TopicLevelMetadataErrorException} indicates that we attempted to obtain Metadata from upstream, but received a topic-level error in the response</li>
+     *     <li>{@link TopicNameMappingException} can be used to convey any other exception</li>
+     * </ul>
+     * All the exception types offer {@link TopicNameMappingException#getError()} for conveniently determining the cause. Unhandled
+     * exceptions will be mapped to an {@link Errors#UNKNOWN_SERVER_ERROR}. Callers will be able to use this to detect expected
+     * cases like {@link Errors#UNKNOWN_TOPIC_ID}.
+     * @return immutable map from topic id to kafka server error
+     */
+    Map<Uuid, TopicNameMappingException> failures();
+}

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/metadata/TopicNameMappingException.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/metadata/TopicNameMappingException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.metadata;
+
+import java.util.Objects;
+
+import org.apache.kafka.common.protocol.Errors;
+
+/**
+ * Indicates there was some problem obtaining a name for a topic id
+ */
+public class TopicNameMappingException extends RuntimeException {
+    private final Errors error;
+
+    public TopicNameMappingException(Errors error) {
+        this(error, error.message(), error.exception());
+    }
+
+    public TopicNameMappingException(Errors error, String message) {
+        this(error, message, error.exception());
+    }
+
+    public TopicNameMappingException(Errors error, String message, Throwable cause) {
+        super(message, cause);
+        this.error = Objects.requireNonNull(error);
+    }
+
+    public Errors getError() {
+        return error;
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/TopicIdToNameResponseStamper.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/TopicIdToNameResponseStamper.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.testplugins;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.types.RawTaggedField;
+
+import io.kroxylicious.UnknownTaggedFields;
+import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.FilterFactory;
+import io.kroxylicious.proxy.filter.FilterFactoryContext;
+import io.kroxylicious.proxy.filter.RequestFilter;
+import io.kroxylicious.proxy.filter.RequestFilterResult;
+import io.kroxylicious.proxy.filter.ResponseFilter;
+import io.kroxylicious.proxy.filter.ResponseFilterResult;
+import io.kroxylicious.proxy.filter.metadata.TopicNameMapping;
+import io.kroxylicious.proxy.plugin.Plugin;
+import io.kroxylicious.proxy.plugin.PluginConfigurationException;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Filter that intercepts all requests and if they have an unknownTaggedField with id {@link #TOPIC_ID_TAG}
+ * we expect that tag to contain a comma separated set of {@link Uuid} topic ids (in toString form). The Filter will
+ * look up the corresponding topic names for those topic ids. Then when the response is intercepted we will add
+ * an unknownTaggedField with id {@link #TOPIC_NAME_TAG} containing a comma-separated set of topic names.
+ */
+@Plugin(configType = Void.class)
+public class TopicIdToNameResponseStamper implements FilterFactory<Void, Void> {
+
+    public static final int TOPIC_ID_TAG = 98;
+    public static final int TOPIC_NAME_TAG = 99;
+
+    @Override
+    public Void initialize(FilterFactoryContext context, Void config) throws PluginConfigurationException {
+        return null;
+    }
+
+    @Override
+    public Filter createFilter(FilterFactoryContext context, Void initializationData) {
+        return new TopicIdToNameResponseStamperFilter();
+    }
+
+    static class TopicIdToNameResponseStamperFilter implements RequestFilter, ResponseFilter {
+
+        Map<Integer, TopicNameMapping> correlated = new HashMap<>();
+
+        @Override
+        public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage request, FilterContext context) {
+            List<String> list = UnknownTaggedFields.unknownTaggedFieldsToStrings(request, TOPIC_ID_TAG).toList();
+            if (list.isEmpty()) {
+                return context.forwardRequest(header, request);
+            }
+
+            Set<Uuid> uuids = Arrays.stream(list.getFirst().split(",")).map(Uuid::fromString).collect(Collectors.toSet());
+            return context.topicNames(uuids).thenCompose(topicNames -> {
+                correlated.put(header.correlationId(), topicNames);
+                return context.forwardRequest(header, request);
+            });
+        }
+
+        @Override
+        public CompletionStage<ResponseFilterResult> onResponse(ApiKeys apiKey, ResponseHeaderData header, ApiMessage response, FilterContext context) {
+            TopicNameMapping topicNames = correlated.remove(header.correlationId());
+            if (topicNames == null) {
+                return context.forwardResponse(header, response);
+            }
+            else {
+                Stream<String> success = topicNames.topicNames().entrySet().stream()
+                        .map(uuidStringEntry -> topicNameMapping(uuidStringEntry.getKey(), uuidStringEntry.getValue(), null));
+                Stream<String> fail = topicNames.failures().entrySet().stream()
+                        .map(topicIdToError -> topicNameMapping(topicIdToError.getKey(), null, topicIdToError.getValue().getError().name()));
+                String outcomes = Stream.concat(success, fail).collect(Collectors.joining(","));
+                response.unknownTaggedFields().add(new RawTaggedField(TOPIC_NAME_TAG, outcomes.getBytes(StandardCharsets.UTF_8)));
+                return context.forwardResponse(header, response);
+            }
+        }
+    }
+
+    public static String topicNameMapping(Uuid topicId, @Nullable String topicName, @Nullable String error) {
+        return topicId + "::" + topicName + "::" + error;
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/TopicNameMetadataPrefixer.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/TopicNameMetadataPrefixer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.testplugins;
+
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+
+import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.FilterFactory;
+import io.kroxylicious.proxy.filter.FilterFactoryContext;
+import io.kroxylicious.proxy.filter.MetadataResponseFilter;
+import io.kroxylicious.proxy.filter.ResponseFilterResult;
+import io.kroxylicious.proxy.plugin.Plugin;
+import io.kroxylicious.proxy.plugin.PluginConfigurationException;
+
+/**
+ * This filter exists to test that {@link FilterContext#topicNames(java.util.Collection)} is composable with Filters that
+ * manipulate topic names in the Metadata Response.
+ */
+@Plugin(configType = Void.class)
+public class TopicNameMetadataPrefixer implements FilterFactory<Void, Void> {
+
+    public static final String PREFIX = "prefixed_";
+
+    @Override
+    public Void initialize(FilterFactoryContext context, Void config) throws PluginConfigurationException {
+        return null;
+    }
+
+    @Override
+    public Filter createFilter(FilterFactoryContext context, Void initializationData) {
+        return new TopicNamePrefixerFilter();
+    }
+
+    static class TopicNamePrefixerFilter implements MetadataResponseFilter {
+
+        @Override
+        public CompletionStage<ResponseFilterResult> onMetadataResponse(short apiVersion, ResponseHeaderData header, MetadataResponseData response,
+                                                                        FilterContext context) {
+            for (MetadataResponseData.MetadataResponseTopic topic : response.topics()) {
+                if (topic.name() != null) {
+                    topic.setName(PREFIX + topic.name());
+                }
+            }
+            return context.forwardResponse(header, response);
+        }
+    }
+}

--- a/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
+++ b/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
@@ -5,6 +5,8 @@ io.kroxylicious.proxy.filter.RejectingCreateTopicFilterFactory
 io.kroxylicious.proxy.filter.DecodeAll
 io.kroxylicious.proxy.filter.GenericRequestSpecificResponseFilterFactory
 io.kroxylicious.proxy.filter.GenericResponseSpecificRequestFilterFactory
+io.kroxylicious.proxy.testplugins.TopicIdToNameResponseStamper
+io.kroxylicious.proxy.testplugins.TopicNameMetadataPrefixer
 io.kroxylicious.proxy.InvocationCountingFilterFactory
 io.kroxylicious.proxy.CreateTopicRequest
 io.kroxylicious.proxy.testplugins.SaslPlainTermination

--- a/kroxylicious-microbenchmarks/src/main/java/io/kroxylicious/microbenchmarks/InvokerDispatchBenchmark.java
+++ b/kroxylicious-microbenchmarks/src/main/java/io/kroxylicious/microbenchmarks/InvokerDispatchBenchmark.java
@@ -6,11 +6,13 @@
 
 package io.kroxylicious.microbenchmarks;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ApiVersionsRequestData;
 import org.apache.kafka.common.message.FetchRequestData;
 import org.apache.kafka.common.message.ProduceRequestData;
@@ -45,6 +47,7 @@ import io.kroxylicious.proxy.filter.RequestFilterResultBuilder;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
 import io.kroxylicious.proxy.filter.ResponseFilterResultBuilder;
 import io.kroxylicious.proxy.filter.SpecificFilterInvoker;
+import io.kroxylicious.proxy.filter.metadata.TopicNameMapping;
 import io.kroxylicious.proxy.tls.ClientTlsContext;
 
 // try hard to make shouldHandleXYZ to observe different receivers concrete types, saving unrolling to bias a specific call-site to a specific concrete type
@@ -208,6 +211,11 @@ public class InvokerDispatchBenchmark {
 
         @Override
         public <M extends ApiMessage> CompletionStage<M> sendRequest(RequestHeaderData header, ApiMessage request) {
+            return null;
+        }
+
+        @Override
+        public CompletionStage<TopicNameMapping> topicNames(Collection<Uuid> topicIds) {
             return null;
         }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/TopicNameRetriever.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/TopicNameRetriever.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
+
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.metadata.TopLevelMetadataErrorException;
+import io.kroxylicious.proxy.filter.metadata.TopicLevelMetadataErrorException;
+import io.kroxylicious.proxy.filter.metadata.TopicNameMapping;
+import io.kroxylicious.proxy.filter.metadata.TopicNameMappingException;
+import io.kroxylicious.proxy.tag.VisibleForTesting;
+
+import static java.util.Collections.unmodifiableMap;
+import static java.util.stream.Collectors.toMap;
+
+final class TopicNameRetriever {
+    // Version 12 was the first version that uses topic ids.
+    private static final short METADATA_API_VER_WITH_TOPIC_ID_SUPPORT = (short) 12;
+    private final FilterContext filterContext;
+
+    TopicNameRetriever(FilterContext filterContext) {
+        this.filterContext = filterContext;
+    }
+
+    CompletionStage<TopicNameMapping> topicNames(Collection<Uuid> topicIds) {
+        Objects.requireNonNull(topicIds);
+        CompletionStage<ApiMessage> apiMessageCompletionStage = requestTopicMetadata(topicIds);
+        return apiMessageCompletionStage
+                .thenApply(message -> extractTopicNames(topicIds, message))
+                .exceptionally(throwable -> mapAllIdsToException(topicIds, throwable));
+    }
+
+    private static MapTopicNameMapping mapAllIdsToException(Collection<Uuid> topicIds, Throwable throwable) {
+        TopicNameMappingException exception;
+        if (throwable instanceof CompletionException ce && ce.getCause() instanceof TopicNameMappingException mappingException) {
+            exception = mappingException;
+        }
+        else {
+            exception = new TopicNameMappingException(Errors.UNKNOWN_SERVER_ERROR, throwable.getMessage(), throwable);
+        }
+        return new MapTopicNameMapping(Map.of(), topicIds.stream().collect(toMap(i -> i, i -> exception)));
+    }
+
+    private CompletionStage<ApiMessage> requestTopicMetadata(Collection<Uuid> topicIds) {
+        MetadataRequestData request = new MetadataRequestData();
+        request.setTopics(topicIds.stream().map(topicId -> new MetadataRequestData.MetadataRequestTopic().setTopicId(topicId)).toList());
+        request.setAllowAutoTopicCreation(false);
+        request.setIncludeClusterAuthorizedOperations(false);
+        request.setIncludeTopicAuthorizedOperations(false);
+        RequestHeaderData requestHeaderData = new RequestHeaderData();
+        requestHeaderData.setRequestApiKey(ApiKeys.METADATA.id);
+        requestHeaderData.setRequestApiVersion(METADATA_API_VER_WITH_TOPIC_ID_SUPPORT);
+        return filterContext.sendRequest(requestHeaderData, request);
+    }
+
+    @VisibleForTesting
+    static TopicNameMapping extractTopicNames(Collection<Uuid> topicIds, ApiMessage response) {
+        if (response instanceof MetadataResponseData metadataResponse) {
+            Errors errors = Errors.forCode(metadataResponse.errorCode());
+            if (errors == Errors.NONE) {
+                return doExtractTopicNames(topicIds, metadataResponse);
+            }
+            else {
+                throw new TopLevelMetadataErrorException(errors);
+            }
+        }
+        else {
+            throw new TopicNameMappingException(Errors.UNKNOWN_SERVER_ERROR, "unexpected response type: " + response.getClass().getSimpleName());
+        }
+    }
+
+    private static TopicNameMapping doExtractTopicNames(Collection<Uuid> topicIds, MetadataResponseData d) {
+        Map<Uuid, String> topicNames = new HashMap<>(topicIds.size());
+        Map<Uuid, TopicNameMappingException> failures = new HashMap<>();
+        d.topics().forEach(metadataResponseTopic -> {
+            Errors topicError = Errors.forCode(metadataResponseTopic.errorCode());
+            if (topicError == Errors.NONE) {
+                topicNames.put(metadataResponseTopic.topicId(), metadataResponseTopic.name());
+            }
+            else {
+                failures.put(metadataResponseTopic.topicId(), new TopicLevelMetadataErrorException(topicError));
+            }
+        });
+        List<Uuid> absentFromResponse = topicIds.stream().filter(uuid -> !topicNames.containsKey(uuid) && !failures.containsKey(uuid)).toList();
+        if (!absentFromResponse.isEmpty()) {
+            for (Uuid uuid : absentFromResponse) {
+                failures.put(uuid, new TopicNameMappingException(Errors.UNKNOWN_SERVER_ERROR, "topic id metadata absent from response: " + uuid));
+            }
+        }
+        return new MapTopicNameMapping(unmodifiableMap(topicNames), unmodifiableMap(failures));
+    }
+
+    /**
+     * The result of discovering the topic names for a collection of topic ids
+     * @param topicNames successfully mapped topic names, non-null
+     * @param failures failed topic name mappings, non-null
+     */
+    private record MapTopicNameMapping(Map<Uuid, String> topicNames, Map<Uuid, TopicNameMappingException> failures) implements TopicNameMapping {
+
+        private MapTopicNameMapping {
+            Objects.requireNonNull(topicNames);
+            Objects.requireNonNull(failures);
+        }
+
+        @Override
+        public boolean anyFailures() {
+            return !failures.isEmpty();
+        }
+
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/TopicNameRetrieverTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/TopicNameRetrieverTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.metadata.TopLevelMetadataErrorException;
+import io.kroxylicious.proxy.filter.metadata.TopicLevelMetadataErrorException;
+import io.kroxylicious.proxy.filter.metadata.TopicNameMapping;
+import io.kroxylicious.proxy.filter.metadata.TopicNameMappingException;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TopicNameRetrieverTest {
+
+    public static final Uuid UUID_2 = new Uuid(6L, 6L);
+    private static final Uuid UUID = new Uuid(5L, 5L);
+    public static final String TOPIC_NAME = "topicName";
+    public static final String TOPIC_NAME_2 = "topicName2";
+
+    @Mock
+    private FilterContext filterContext;
+    private TopicNameRetriever retriever;
+
+    @BeforeEach
+    void setUp() {
+        retriever = new TopicNameRetriever(filterContext);
+    }
+
+    @Test
+    void retrieveTopicNamesMapping() {
+        // given
+        MetadataResponseData response = new MetadataResponseData();
+        response.topics().add(getResponseTopic(UUID, TOPIC_NAME));
+        givenSendRequestResponse(completedFuture(response));
+        // when
+        CompletionStage<TopicNameMapping> topicNames = getTopicNamesMapping(Set.of(UUID));
+        // then
+        assertThat(topicNames.toCompletableFuture()).succeedsWithin(Duration.ZERO)
+                .satisfies(topicNamesMapping -> {
+                    assertThat(topicNamesMapping.anyFailures()).isFalse();
+                    assertThat(topicNamesMapping.topicNames()).containsExactly(entry(UUID, TOPIC_NAME));
+                });
+    }
+
+    @Test
+    void retrieveTopicNamesMappingServerPartialResponse() {
+        // given
+        MetadataResponseData response = new MetadataResponseData();
+        response.topics().add(getResponseTopic(UUID, TOPIC_NAME));
+        Set<Uuid> topicIds = Set.of(UUID, UUID_2);
+        givenSendRequestResponse(completedFuture(response));
+        // when
+        CompletionStage<TopicNameMapping> topicNames = getTopicNamesMapping(topicIds);
+        // then
+        assertThat(topicNames.toCompletableFuture()).succeedsWithin(Duration.ZERO)
+                .satisfies(topicNamesMapping -> {
+                    assertThat(topicNamesMapping.anyFailures()).isTrue();
+                    assertThat(topicNamesMapping.failures()).containsOnlyKeys(UUID_2)
+                            .hasEntrySatisfying(UUID_2, errors -> {
+                                assertThat(errors.getError()).isEqualTo(Errors.UNKNOWN_SERVER_ERROR);
+                                assertThat(errors).isInstanceOf(TopicNameMappingException.class);
+                            });
+                    assertThat(topicNamesMapping.topicNames()).containsExactly(entry(UUID, TOPIC_NAME));
+                });
+    }
+
+    @Test
+    void retrieveTopicNamesMappingHandlesSendFutureFailing() {
+        // given
+        RuntimeException exception = new RuntimeException("BOOM");
+        givenSendRequestResponse(failedFuture(exception));
+        // when
+        CompletionStage<TopicNameMapping> topicNames = getTopicNamesMapping(Set.of(UUID));
+        // then
+        assertThat(topicNames.toCompletableFuture()).succeedsWithin(Duration.ZERO)
+                .satisfies(topicNamesMapping -> {
+                    assertThat(topicNamesMapping.anyFailures()).isTrue();
+                    assertThat(topicNamesMapping.failures()).containsOnlyKeys(UUID)
+                            .hasEntrySatisfying(UUID, errors -> {
+                                assertThat(errors.getError()).isEqualTo(Errors.UNKNOWN_SERVER_ERROR);
+                                assertThat(errors).isInstanceOf(TopicNameMappingException.class);
+                            });
+                });
+    }
+
+    @Test
+    void retrieveTopicNamesMappingUnexpectedResponseType() {
+        // given
+        ApiMessage response = new ApiVersionsResponseData();
+        givenSendRequestResponse(completedFuture(response));
+        // when
+        CompletionStage<TopicNameMapping> topicNames = getTopicNamesMapping(Set.of(UUID));
+        // then
+        assertThat(topicNames.toCompletableFuture()).succeedsWithin(Duration.ZERO)
+                .satisfies(topicNamesMapping -> {
+                    assertThat(topicNamesMapping.anyFailures()).isTrue();
+                    assertThat(topicNamesMapping.failures()).containsOnlyKeys(UUID)
+                            .hasEntrySatisfying(UUID, errors -> {
+                                assertThat(errors.getError()).isEqualTo(Errors.UNKNOWN_SERVER_ERROR);
+                                assertThat(errors).isInstanceOf(TopicNameMappingException.class);
+                            });
+                });
+    }
+
+    @Test
+    void retrieveTopicNamesMappingEmptyResponse() {
+        // given
+        MetadataResponseData response = new MetadataResponseData();
+        givenSendRequestResponse(completedFuture(response));
+        // when
+        CompletionStage<TopicNameMapping> topicNames = getTopicNamesMapping(Set.of(UUID));
+        // then
+        assertThat(topicNames.toCompletableFuture()).succeedsWithin(Duration.ZERO)
+                .satisfies(topicNamesMapping -> {
+                    assertThat(topicNamesMapping.anyFailures()).isTrue();
+                    assertThat(topicNamesMapping.failures()).containsOnlyKeys(UUID)
+                            .hasEntrySatisfying(UUID, errors -> {
+                                assertThat(errors.getError()).isEqualTo(Errors.UNKNOWN_SERVER_ERROR);
+                                assertThat(errors).isInstanceOf(TopicNameMappingException.class);
+                            });
+                });
+    }
+
+    @Test
+    void retrieveTopicNamesMappingTopLevelResponseError() {
+        // given
+        MetadataResponseData response = new MetadataResponseData();
+        response.setErrorCode(Errors.UNKNOWN_SERVER_ERROR.code());
+        givenSendRequestResponse(completedFuture(response));
+        // when
+        CompletionStage<TopicNameMapping> topicNames = getTopicNamesMapping(Set.of(UUID));
+        // then
+        assertThat(topicNames.toCompletableFuture()).succeedsWithin(Duration.ZERO)
+                .satisfies(topicNamesMapping -> {
+                    assertThat(topicNamesMapping.anyFailures()).isTrue();
+                    assertThat(topicNamesMapping.failures()).containsOnlyKeys(UUID)
+                            .hasEntrySatisfying(UUID, errors -> {
+                                assertThat(errors.getError()).isEqualTo(Errors.UNKNOWN_SERVER_ERROR);
+                                assertThat(errors).isInstanceOf(TopLevelMetadataErrorException.class);
+                            });
+                });
+    }
+
+    @Test
+    void retrieveTopicNamesMappingTopicLevelError() {
+        // given
+        MetadataResponseData response = new MetadataResponseData();
+        MetadataResponseData.MetadataResponseTopic responseTopic = new MetadataResponseData.MetadataResponseTopic().setTopicId(UUID)
+                .setErrorCode(Errors.UNKNOWN_TOPIC_ID.code());
+        response.topics().add(responseTopic);
+        givenSendRequestResponse(completedFuture(response));
+        // when
+        CompletionStage<TopicNameMapping> topicNames = getTopicNamesMapping(Set.of(UUID));
+        // then
+        assertThat(topicNames.toCompletableFuture()).succeedsWithin(Duration.ZERO)
+                .satisfies(topicNamesMapping -> {
+                    assertThat(topicNamesMapping.anyFailures()).isTrue();
+                    assertThat(topicNamesMapping.failures()).containsOnlyKeys(UUID)
+                            .hasEntrySatisfying(UUID, e -> {
+                                assertThat(e.getError()).isEqualTo(Errors.UNKNOWN_TOPIC_ID);
+                                assertThat(e).isInstanceOf(TopicLevelMetadataErrorException.class);
+                            });
+                });
+    }
+
+    @Test
+    void retrieveTopicNamesMappingMixtureOfSuccessAndTopicLevelFailure() {
+        // given
+        MetadataResponseData response = new MetadataResponseData();
+        MetadataResponseData.MetadataResponseTopic responseTopic = new MetadataResponseData.MetadataResponseTopic().setTopicId(UUID)
+                .setErrorCode(Errors.UNKNOWN_TOPIC_ID.code());
+        MetadataResponseData.MetadataResponseTopic responseTopic2 = new MetadataResponseData.MetadataResponseTopic().setTopicId(UUID_2)
+                .setName(TOPIC_NAME_2);
+        response.topics().add(responseTopic);
+        response.topics().add(responseTopic2);
+        givenSendRequestResponse(completedFuture(response));
+        // when
+        CompletionStage<TopicNameMapping> topicNames = getTopicNamesMapping(Set.of(UUID, UUID_2));
+        // then
+        assertThat(topicNames.toCompletableFuture()).succeedsWithin(Duration.ZERO)
+                .satisfies(topicNamesMapping -> {
+                    assertThat(topicNamesMapping.anyFailures()).isTrue();
+                    assertThat(topicNamesMapping.topicNames()).containsExactly(entry(UUID_2, TOPIC_NAME_2));
+                    assertThat(topicNamesMapping.failures()).containsOnlyKeys(UUID)
+                            .hasEntrySatisfying(UUID, e -> {
+                                assertThat(e.getError()).isEqualTo(Errors.UNKNOWN_TOPIC_ID);
+                                assertThat(e).isInstanceOf(TopicLevelMetadataErrorException.class);
+                            });
+                });
+    }
+
+    private static MetadataResponseData.MetadataResponseTopic getResponseTopic(Uuid uuid, String topicName) {
+        return new MetadataResponseData.MetadataResponseTopic()
+                .setTopicId(uuid)
+                .setName(topicName);
+    }
+
+    private void givenSendRequestResponse(CompletableFuture<ApiMessage> response) {
+        // sendRequest returns a minimal stage that cannot be completed, or converted to future
+        when(filterContext.sendRequest(any(), any())).thenReturn(response.minimalCompletionStage());
+    }
+
+    private CompletionStage<TopicNameMapping> getTopicNamesMapping(Set<Uuid> topicIds) {
+        return retriever.topicNames(topicIds);
+    }
+
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The PR implements https://github.com/kroxylicious/design/pull/77

This API enables Filters to map topic ids to topic names, adding a method to `FilterContext`:

```java
   /**
     * Attempts to map all the given {@code topicIds} to the current corresponding topic names.
     * @param topicIds topic ids to map to names
     * @return a CompletionStage that will be completed with a complete mapping, with every requested topic id mapped to either an
     * {@link TopicNameMappingException} or a name. All failure modes should complete the stage with a TopicNameMapping, with the
     * TopicNameMapping used to convey the reason for failure, rather than failing the Stage.
     * <h4>Chained Computation stages</h4>
     * <p>Default and asynchronous default computation stages chained to the returned
     * {@link java.util.concurrent.CompletionStage} are guaranteed to be executed by the thread
     * associated with the connection. See {@link io.kroxylicious.proxy.filter} for more details.
     * </p>
     */
    CompletionStage<TopicNameMapping> topicNames(Collection<Uuid> topicIds);
``` 

With result types:

```java
/**
 * The result of discovering the topic names for a collection of topic ids
 */
public interface TopicNameMapping {
    /**
     * @return true if there are any failures
     */
    boolean anyFailures();

    /**
     * @return map from topic id to successfully mapped topic name
     */
    Map<Uuid, String> topicNames();

    /**
     * Describes the reason for every failed mapping. Expected exception types are:
     * <ul>
     *     <li>{@link TopLevelMetadataErrorException} indicates that we attempted to obtain Metadata from upstream, but received a top-level error in the response</li>
     *     <li>{@link TopicLevelMetadataErrorException} indicates that we attempted to obtain Metadata from upstream, but received a topic-level error in the response</li>
     *     <li>{@link TopicNameMappingException} can be used to convey any other exception</li>
     * </ul>
     * All the exception types offer {@link TopicNameMappingException#getError()} for conveniently determining the cause. Unhandled
     * exceptions will be mapped to an {@link Errors#UNKNOWN_SERVER_ERROR}. Callers will be able to use this to detect expected
     * cases like {@link Errors#UNKNOWN_TOPIC_ID}.
     * @return map from topic id to kafka server error
     */
    Map<Uuid, TopicNameMappingException> failures();
}
```

Invoking this method causes an out-of-band Metadata request to be sent to the broker requesting the Metadata for the specified set of topic ids. It then processes the response into a `TopicNameMapping`.

Caching will be left as a responsibility for the Filter initially.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
