### PR TITLE
bugfix: azure KMS facade IT fails on OSX

### DIFF
--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/pom.xml
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/pom.xml
@@ -24,6 +24,10 @@
     <name>Azure Key Vault KMS test support</name>
     <description>Test support code for modules testing the Azure Key Vault</description>
 
+    <properties>
+        <java.test.version>21</java.test.version>
+    </properties>
+
     <dependencies>
         <!-- project dependencies - runtime and compile -->
         <dependency>

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/src/test/java/io/kroxylicious/net/LocalhostSubdomainResolverProvider.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/src/test/java/io/kroxylicious/net/LocalhostSubdomainResolverProvider.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.net;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.net.spi.InetAddressResolver;
+import java.net.spi.InetAddressResolverProvider;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+/**
+ * An {@link InetAddressResolverProvider} that resolves all subdomains of localhost to localhost.
+ * <p>
+ * The lowkey mock supports behaving like Azure, handling domains like ${myvaultname}.localhost.
+ * Not all platforms can resolve these local hosts, so we use the JDK 18+ resolver provider to
+ * intercept DNS resolution and resolve them to localhost.
+ */
+public class LocalhostSubdomainResolverProvider extends InetAddressResolverProvider {
+    // supports Azure lowkey mock which uses ${vaultName}.localhost hostnames, which some platforms cannot resolve
+    public static final String LOCALHOST_SUBDOMAIN = ".localhost";
+
+    @Override
+    public InetAddressResolver get(Configuration configuration) {
+        return new InetAddressResolver() {
+            @Override
+            public Stream<InetAddress> lookupByName(String host, LookupPolicy lookupPolicy) throws UnknownHostException {
+                if (host != null && host.toLowerCase(Locale.ROOT).endsWith(LOCALHOST_SUBDOMAIN)) {
+                    var inetAddressStream = configuration.builtinResolver().lookupByName("localhost", lookupPolicy);
+                    return inetAddressStream.map(in -> {
+                        try {
+                            return InetAddress.getByAddress(host, in.getAddress());
+                        }
+                        catch (UnknownHostException e) {
+                            // Should never happen
+                            throw new RuntimeException(e);
+                        }
+                    }).toList().stream();
+                }
+                else {
+                    return configuration.builtinResolver().lookupByName(host, lookupPolicy);
+                }
+            }
+
+            @Override
+            public String lookupByAddress(byte[] addr) throws UnknownHostException {
+                return configuration.builtinResolver().lookupByAddress(addr);
+            }
+        };
+    }
+
+    @Override
+    public String name() {
+        return LocalhostSubdomainResolverProvider.class.getSimpleName();
+    }
+
+}

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/src/test/resources/META-INF/services/java.net.spi.InetAddressResolverProvider
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/src/test/resources/META-INF/services/java.net.spi.InetAddressResolverProvider
@@ -1,0 +1,7 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+io.kroxylicious.net.LocalhostSubdomainResolverProvider


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Some platforms cannot resolve ${subdomain}.localhost, so we use an InetAddressResolverProvider to fiddle with resolution in the JVM.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
