### PR TITLE
fix(docs): make it clear that PEM formatted keys must be PKCS#8 format

### DIFF
--- a/kroxylicious-docs/docs/_modules/configuring/con-configuring-virtual-clusters.adoc
+++ b/kroxylicious-docs/docs/_modules/configuring/con-configuring-virtual-clusters.adoc
@@ -17,4 +17,8 @@ Responses back to clients are rewritten to reflect the appropriate network addre
 
 You can secure virtual cluster connections from clients and to target clusters.
 
-Kroxylicious accepts keys and certificates in PEM (Privacy Enhanced Mail), PKCS #12 (Public-Key Cryptography Standards), or JKS (Java KeyStore) keystore format.
+Kroxylicious accepts key material in the following formats:
+
+* PKCS #12 keystore format (Public-Key Cryptography Standards).
+* Keys and certificates as separate PEM (Privacy Enhanced Mail) files. The key *must* be in PKCS #8 format.
+* JKS (Java KeyStore) keystore format.

--- a/kroxylicious-docs/docs/_modules/configuring/con-virtualkafkacluster-clusterip-generate-tls-certificates.adoc
+++ b/kroxylicious-docs/docs/_modules/configuring/con-virtualkafkacluster-clusterip-generate-tls-certificates.adoc
@@ -22,7 +22,7 @@ The exact procedure for generating the certificate depends on the tooling and pr
 The certificate must meet the following criteria:
 
 * The certificate needs to be signed by a CA that is trusted by the *on-cluster applications* that connect to the virtual cluster.
-* The format of the certificate must be PKCS#8 encoded PEM (Privacy Enhanced Mail).
+* The format of the key must be PKCS#8 encoded PEM (Privacy Enhanced Mail).
   It must not be password protected.
 * The certificate must use SANs (Subject Alternate Names) to list all service names or use a wildcard TLS certificate that covers them all.
 Assuming a virtual cluster name of `my-cluster`, an ingress name of `cluster-ip`, and a Kafka cluster using node IDs (0-2), the following SANs must be listed in the certificate:

--- a/kroxylicious-docs/docs/_modules/configuring/con-virtualkafkacluster-loadbalancer-generate-tls-certificates.adoc
+++ b/kroxylicious-docs/docs/_modules/configuring/con-virtualkafkacluster-loadbalancer-generate-tls-certificates.adoc
@@ -22,7 +22,7 @@ The exact procedure for generating the certificate depends on the tooling and pr
 The certificate must meet the following criteria:
 
 * The certificate needs to be signed by a CA that is trusted by the *off-cluster applications* that connect to the virtual cluster.
-* The format of the certificate must be PKCS#8 encoded PEM (Privacy Enhanced Mail).
+* The format of the key must be PKCS#8 encoded PEM (Privacy Enhanced Mail).
   It must not be password protected.
 * The certificate must use SANs (Subject Alternate Names) to list the bootstrap and all the broker names or use a wildcard TLS certificate that covers them all.
 Assuming a `bootstrapAddress` of `$(virtualClusterName).kafkaproxy.example.com`, an `advertisedBrokerAddressPattern` of `broker-$(nodeId).$(virtualClusterName).kafkaproxy.example.com`, a Kafka cluster using node IDs (0-2), and a virtual cluster name of `my-cluster`, the following SANs must be listed in the certificate:


### PR DESCRIPTION
…tted

### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

The docs don't communicate the the virtualcluster requires a PKCS#8 formatted key.  Users may try to use a PKCS#1 (traditional format), which won't work (unless BC is on the classpath etc).

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
