### PR TITLE
chore(sample): remove the metric instrumentation from sample filter

### DIFF
--- a/kroxylicious-filter-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/kroxylicious-filter-archetype/src/main/resources/archetype-resources/pom.xml
@@ -19,7 +19,6 @@
         <junit.version>@junit.version@</junit.version>
         <mockito.version>@mockito.version@</mockito.version>
         <log4j.version>@log4j.version@</log4j.version>
-        <micrometer.version>@micrometer.version@</micrometer.version>
         <assertj-core.version>@assertj-core.version@</assertj-core.version>
         <java.version>17</java.version>
         <maven.compiler.version>@maven.compiler.version@</maven.compiler.version>
@@ -68,13 +67,6 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
-            <dependency>
-                <groupId>io.micrometer</groupId>
-                <artifactId>micrometer-bom</artifactId>
-                <version>${micrometer.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -116,11 +108,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-core</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/kroxylicious-filter-archetype/src/main/resources/archetype-resources/src/main/java/SampleFetchResponseFilter.java
+++ b/kroxylicious-filter-archetype/src/main/resources/archetype-resources/src/main/java/SampleFetchResponseFilter.java
@@ -5,9 +5,6 @@ import java.util.concurrent.CompletionStage;
 import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 
-import io.micrometer.core.instrument.Metrics;
-import io.micrometer.core.instrument.Timer;
-
 import io.kroxylicious.proxy.filter.FetchResponseFilter;
 import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
@@ -31,15 +28,8 @@ import ${package}.util.SampleFilterTransformer;
 class SampleFetchResponseFilter implements FetchResponseFilter {
 
     private final SampleFilterConfig config;
-    private final Timer timer;
-
     SampleFetchResponseFilter(SampleFilterConfig config) {
         this.config = config;
-        this.timer = Timer
-                .builder("sample_fetch_response_filter_transform")
-                .description("Time taken for the SampleFetchResponseFilter to transform the produce data.")
-                .tag("filter", "SampleFetchResponseFilter")
-                .register(Metrics.globalRegistry);
     }
 
     /**
@@ -54,7 +44,7 @@ class SampleFetchResponseFilter implements FetchResponseFilter {
      */
     @Override
     public CompletionStage<ResponseFilterResult> onFetchResponse(short apiVersion, ResponseHeaderData header, FetchResponseData response, FilterContext context) {
-        this.timer.record(() -> applyTransformation(response, context)); // We're timing this to report how long it takes through Micrometer
+        applyTransformation(response, context);
         return context.forwardResponse(header, response);
     }
 

--- a/kroxylicious-filter-archetype/src/main/resources/archetype-resources/src/main/java/SampleProduceRequestFilter.java
+++ b/kroxylicious-filter-archetype/src/main/resources/archetype-resources/src/main/java/SampleProduceRequestFilter.java
@@ -5,9 +5,6 @@ import java.util.concurrent.CompletionStage;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.RequestHeaderData;
 
-import io.micrometer.core.instrument.Metrics;
-import io.micrometer.core.instrument.Timer;
-
 import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
@@ -31,15 +28,9 @@ import ${package}.util.SampleFilterTransformer;
 class SampleProduceRequestFilter implements ProduceRequestFilter {
 
     private final SampleFilterConfig config;
-    private final Timer timer;
 
     SampleProduceRequestFilter(SampleFilterConfig config) {
         this.config = config;
-        this.timer = Timer
-                .builder("sample_produce_request_filter_transform")
-                .description("Time taken for the SampleProduceRequestFilter to transform the produce data.")
-                .tag("filter", "SampleProduceRequestFilter")
-                .register(Metrics.globalRegistry);
     }
 
     /**
@@ -54,8 +45,7 @@ class SampleProduceRequestFilter implements ProduceRequestFilter {
      */
     @Override
     public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, FilterContext context) {
-        this.timer.record(() -> applyTransformation(request, context)); // We're timing this to report how long it takes through Micrometer
-
+        applyTransformation(request, context);
         return context.forwardRequest(header, request);
     }
 


### PR DESCRIPTION

### Type of change

_Select the type of your PR_


### Description

Remove the metric instrumentation from the Kroxylicious Sample archetype.

why: the metrics instrumentation is a bit of distraction from the main goal of the sample - to demonstrate how to write a filter.

contributes towards ##2764

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
