### PR TITLE
fix(maven): enforce minimal maven module metadata (alternative)

### DIFF
--- a/kroxylicious-filter-archetype/pom.xml
+++ b/kroxylicious-filter-archetype/pom.xml
@@ -16,6 +16,7 @@
     </parent>
     <artifactId>kroxylicious-filter-archetype</artifactId>
     <name>Filter Archetype</name>
+    <description>A Maven Archetype to generate an independent Custom Filter project, demonstrating how to structure a Filter and integration test it against Apache Kafka</description>
     <packaging>maven-archetype</packaging>
     <dependencies>
         <dependency>

--- a/kroxylicious-krpc-plugin/pom.xml
+++ b/kroxylicious-krpc-plugin/pom.xml
@@ -20,6 +20,7 @@
 
     <artifactId>kroxylicious-krpc-plugin</artifactId>
     <name>Code generation plugin</name>
+    <description>A maven-plugin to generate Java source code using Apache Kafka protocol RPC descriptors and code template files</description>
     <packaging>maven-plugin</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -973,6 +973,22 @@
                             </rules>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>project-metadata</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireProperty>
+                                    <!-- note Maven defaults project.name from project.artifactId if it is not specified -->
+                                    <property>project.name</property>
+                                    <regex>^((?!${project.artifactId}).)*$</regex>
+                                    <regexMessage>Module must define a explict project.name property</regexMessage>
+                                </requireProperty>
+                            </rules>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description


why: sonatype enforces some [rules](https://central.sonatype.org/publish/requirements/#required-pom-metadata) which get enforced at publish time.  If we introduce a module that doesn't adhere to the rules, we are unaware of this until the release.   

Following a shift-left philosophy, this change incorporates some of those rules into the our Maven build cycle so we fail early.

This uses the built in features of the enforcer, rather than relying on our own one (the approach of https://github.com/kroxylicious/kroxylicious/pull/2840)

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
