### PR TITLE
Shutdown netty executors immediately when ITs close proxy

### DIFF
--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousConfigUtils.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousConfigUtils.java
@@ -47,7 +47,7 @@ public class KroxyliciousConfigUtils {
      * @return builder
      */
     public static ConfigurationBuilder proxy(String clusterBootstrapServers, String... virtualClusterNames) {
-        final ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
+        final ConfigurationBuilder configurationBuilder = baseConfigurationBuilder();
         for (int i = 0; i < virtualClusterNames.length; i++) {
             String virtualClusterName = virtualClusterNames[i];
             var vcb = new VirtualClusterBuilder()
@@ -130,5 +130,14 @@ public class KroxyliciousConfigUtils {
                 .withBootstrapServers(cluster.getBootstrapServers())
                 .endTargetCluster()
                 .withName(clusterName);
+    }
+
+    public static ConfigurationBuilder baseConfigurationBuilder() {
+        ConfigurationBuilder configurationBuilder = new ConfigurationBuilder();
+        configurationBuilder.withNewNetwork()
+                .withNewManagement().withShutdownQuietPeriodSeconds(0).endManagement()
+                .withNewProxy().withShutdownQuietPeriodSeconds(0).endProxy()
+                .endNetwork();
+        return configurationBuilder;
     }
 }

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/proxy/config/ConfigurationTest.java
@@ -438,6 +438,23 @@ class ConfigurationTest {
                                       portIdentifiesNode:
                                         bootstrapAddress: cluster1:9192
                                 """),
+                argumentSet("Proxy worker shutdown quiet period seconds",
+                        new ConfigurationBuilder().addToVirtualClusters(VIRTUAL_CLUSTER).withNewNetwork().withNewProxy().withShutdownQuietPeriodSeconds(5).endProxy()
+                                .endNetwork()
+                                .build(),
+                        """
+                                network:
+                                    proxy:
+                                        shutdownQuietPeriodSeconds: 5
+                                virtualClusters:
+                                  - name: demo
+                                    targetCluster:
+                                      bootstrapServers: kafka.example:1234
+                                    gateways:
+                                    - name: default
+                                      portIdentifiesNode:
+                                        bootstrapAddress: example.com:1234
+                                """),
                 argumentSet("Proxy worker thread count",
                         new ConfigurationBuilder().addToVirtualClusters(VIRTUAL_CLUSTER).withNewNetwork().withNewProxy().withWorkerThreadCount(5).endProxy().endNetwork()
                                 .build(),
@@ -454,7 +471,24 @@ class ConfigurationTest {
                                       portIdentifiesNode:
                                         bootstrapAddress: example.com:1234
                                 """),
-                argumentSet("Manaegment worker thread count",
+                argumentSet("Management worker shutdown quiet period seconds",
+                        new ConfigurationBuilder().addToVirtualClusters(VIRTUAL_CLUSTER).withNewNetwork().withNewManagement().withShutdownQuietPeriodSeconds(5)
+                                .endManagement()
+                                .endNetwork().build(),
+                        """
+                                network:
+                                    management:
+                                        shutdownQuietPeriodSeconds: 5
+                                virtualClusters:
+                                  - name: demo
+                                    targetCluster:
+                                      bootstrapServers: kafka.example:1234
+                                    gateways:
+                                    - name: default
+                                      portIdentifiesNode:
+                                        bootstrapAddress: example.com:1234
+                                """),
+                argumentSet("Management worker thread count",
                         new ConfigurationBuilder().addToVirtualClusters(VIRTUAL_CLUSTER).withNewNetwork().withNewManagement().withWorkerThreadCount(2).endManagement()
                                 .endNetwork().build(),
                         """

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ExpositionIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ExpositionIT.java
@@ -48,7 +48,6 @@ import org.slf4j.LoggerFactory;
 
 import io.kroxylicious.net.IntegrationTestInetAddressResolverProvider;
 import io.kroxylicious.net.PassthroughProxy;
-import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.NamedRange;
 import io.kroxylicious.proxy.config.SniHostIdentifiesNodeIdentificationStrategy;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
@@ -113,7 +112,7 @@ class ExpositionIT extends BaseIT {
                 .withNewTargetCluster()
                 .withBootstrapServers(cluster.getBootstrapServers())
                 .endTargetCluster();
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(virtualClusterBuilder.build());
 
         try (var tester = kroxyliciousTester(builder);
@@ -133,7 +132,7 @@ class ExpositionIT extends BaseIT {
     void exposesTwoClusterOverPlainWithSeparatePorts(KafkaCluster cluster) {
         List<String> clusterProxyAddresses = List.of("localhost:9192", "localhost:9294");
 
-        var builder = new ConfigurationBuilder();
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder();
 
         for (int i = 0; i < clusterProxyAddresses.size(); i++) {
             var bootstrap = HostPort.parse(clusterProxyAddresses.get(i));
@@ -160,7 +159,7 @@ class ExpositionIT extends BaseIT {
 
     @Test
     void exposesSingleClusterWithMultiplePortPerBrokerGateways(KafkaCluster cluster) throws Exception {
-        var builder = new ConfigurationBuilder();
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder();
 
         VirtualClusterBuilder virtualClusterBuilder = KroxyliciousConfigUtils.baseVirtualClusterBuilder(cluster, "cluster");
         virtualClusterBuilder.addToGateways(portPerBrokerGateway("localhost:9192", "gateway1"),
@@ -223,7 +222,7 @@ class ExpositionIT extends BaseIT {
             var virtualClusterBootstrapPattern = "bootstrap" + virtualClusterCommonNamePattern;
             var virtualClusterBrokerAddressPattern = "broker-$(nodeId)" + virtualClusterCommonNamePattern;
 
-            var builder = new ConfigurationBuilder();
+            var builder = KroxyliciousConfigUtils.baseConfigurationBuilder();
 
             var keystoreTrustStorePair = buildKeystoreTrustStorePair("*" + virtualClusterCommonNamePattern);
 
@@ -265,7 +264,7 @@ class ExpositionIT extends BaseIT {
         var virtualClusterBootstrapPattern = "bootstrap" + virtualClusterCommonNamePattern;
         var virtualClusterBrokerAddressPattern = "broker-$(nodeId)" + virtualClusterCommonNamePattern;
 
-        var builder = new ConfigurationBuilder();
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder();
 
         int numberOfVirtualClusters = 2;
         for (int i = 0; i < numberOfVirtualClusters; i++) {
@@ -311,7 +310,7 @@ class ExpositionIT extends BaseIT {
         VirtualClusterGatewayBuilder sniBuilder = defaultSniHostIdentifiesNodeGatewayBuilder(virtualClusterBootstrapPattern + ":9192",
                 virtualClusterBrokerAddressPattern);
 
-        var builder = new ConfigurationBuilder();
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder();
 
         int numberOfVirtualClusters = 2;
         for (int i = 0; i < numberOfVirtualClusters; i++) {
@@ -361,7 +360,7 @@ class ExpositionIT extends BaseIT {
         var virtualClusterBootstrapPattern = "bootstrap" + virtualClusterCommonNamePattern;
         var virtualClusterBrokerAddressPattern = "broker-$(nodeId)" + virtualClusterCommonNamePattern;
 
-        var builder = new ConfigurationBuilder();
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder();
 
         int numberOfGateways = 2;
         VirtualClusterBuilder virtualClusterBuilder = KroxyliciousConfigUtils.baseVirtualClusterBuilder(cluster, "cluster");
@@ -407,7 +406,7 @@ class ExpositionIT extends BaseIT {
 
     @Test
     void exposesClusterOfTwoBrokersWithRangeAwarePortPerNode(@BrokerCluster(numBrokers = 2) KafkaCluster cluster) throws Exception {
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(KroxyliciousConfigUtils.baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultGatewayBuilder()
                                 .withNewPortIdentifiesNode()
@@ -436,7 +435,7 @@ class ExpositionIT extends BaseIT {
     void exposesClusterOfTwoBrokersWithGapInNodeIds(@BrokerCluster(numBrokers = 2) KafkaCluster cluster) throws Exception {
         cluster.addBroker();
         cluster.removeBroker(1);
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(KroxyliciousConfigUtils.baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultGatewayBuilder()
                                 .withNewPortIdentifiesNode()
@@ -464,7 +463,7 @@ class ExpositionIT extends BaseIT {
     @Test
     void exposesClusterOfTwoBrokers(@BrokerCluster(numBrokers = 2) KafkaCluster cluster) throws Exception {
         HostPort proxyAddress = PROXY_ADDRESS;
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(KroxyliciousConfigUtils.baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(proxyAddress).build())
                         .build());
@@ -589,7 +588,7 @@ class ExpositionIT extends BaseIT {
                 .withBootstrapServers(cluster.getBootstrapServers())
                 .endTargetCluster();
 
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(virtualClusterBuilder.build());
 
         // First, learn the broker endpoints.
@@ -631,7 +630,7 @@ class ExpositionIT extends BaseIT {
                 .withNewTargetCluster()
                 .withBootstrapServers(cluster.getBootstrapServers())
                 .endTargetCluster();
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(virtualClusterBuilder.build());
 
         final HostPort discoveryBrokerAddressToProbe;
@@ -685,7 +684,7 @@ class ExpositionIT extends BaseIT {
 
     @Test
     void targetClusterDynamicallyAddsBroker(@BrokerCluster KafkaCluster cluster) throws Exception {
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(KroxyliciousConfigUtils.baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .build())
@@ -718,7 +717,7 @@ class ExpositionIT extends BaseIT {
         cluster.removeBroker(1);
         await().atMost(Duration.ofSeconds(5)).until(() -> admin.describeCluster().nodes().get(),
                 n -> n.stream().map(Node::id).collect(Collectors.toSet()).equals(Set.of(0, 2)));
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(KroxyliciousConfigUtils.baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultGatewayBuilder()
                                 .withNewPortIdentifiesNode()
@@ -736,7 +735,7 @@ class ExpositionIT extends BaseIT {
 
     @Test
     void targetClusterDynamicallyRemovesBroker(@BrokerCluster(numBrokers = 2) KafkaCluster cluster) throws Exception {
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(KroxyliciousConfigUtils.baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .build())

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/PluginTlsApiIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/PluginTlsApiIT.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.assertj.core.api.InstanceOfAssertFactory;
 import org.junit.jupiter.api.Test;
 
-import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
 import io.kroxylicious.proxy.config.secret.InlinePassword;
 import io.kroxylicious.proxy.config.tls.Tls;
@@ -33,6 +32,7 @@ import io.kroxylicious.proxy.config.tls.TlsClientAuth;
 import io.kroxylicious.proxy.testplugins.ClientAuthAwareLawyer;
 import io.kroxylicious.proxy.testplugins.ClientAuthAwareLawyerFilter;
 import io.kroxylicious.test.assertj.KafkaAssertions;
+import io.kroxylicious.test.tester.KroxyliciousConfigUtils;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.junit5ext.Topic;
 
@@ -135,7 +135,7 @@ public class PluginTlsApiIT extends AbstractTlsIT {
 
         // @formatter:off
         String demoCluster = "demo";
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addNewFilterDefinition("clientConnection", ClientAuthAwareLawyer.class.getName(), null)
                 .addToVirtualClusters(new VirtualClusterBuilder()
                         .withName(demoCluster)
@@ -176,4 +176,5 @@ public class PluginTlsApiIT extends AbstractTlsIT {
                     .hasValueEqualTo(expectedProxyPrincipalName);
         }
     }
+
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/TlsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/TlsIT.java
@@ -48,6 +48,7 @@ import io.kroxylicious.proxy.config.secret.PasswordProvider;
 import io.kroxylicious.proxy.config.tls.AllowDeny;
 import io.kroxylicious.proxy.config.tls.TlsClientAuth;
 import io.kroxylicious.test.Request;
+import io.kroxylicious.test.tester.KroxyliciousConfigUtils;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.clients.CloseableAdmin;
 import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
@@ -76,7 +77,7 @@ class TlsIT extends AbstractTlsIT {
         assertThat(brokerTruststorePassword).isNotEmpty();
 
         // @formatter:off
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(new VirtualClusterBuilder()
                         .withName("demo")
                         .withNewTargetCluster()
@@ -109,7 +110,7 @@ class TlsIT extends AbstractTlsIT {
         assertThat(brokerTruststorePassword).isNotEmpty();
 
         // @formatter:off
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(new VirtualClusterBuilder()
                         .withName("demo")
                         .withNewTargetCluster()
@@ -157,7 +158,7 @@ class TlsIT extends AbstractTlsIT {
         var file = writeTrustToTemporaryFile(certificates);
 
         // @formatter:off
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(new VirtualClusterBuilder()
                         .withName("demo")
                         .withNewTargetCluster()
@@ -186,7 +187,7 @@ class TlsIT extends AbstractTlsIT {
         var bootstrapServers = cluster.getBootstrapServers();
 
         // @formatter:off
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(new VirtualClusterBuilder()
                         .withName("demo")
                         .withNewTargetCluster()
@@ -216,7 +217,7 @@ class TlsIT extends AbstractTlsIT {
 
         try (var cluster = createMTlsCluster(brokerCert, clientCert)) {
             // @formatter:off
-            var builder = new ConfigurationBuilder()
+            var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                     .addToVirtualClusters(new VirtualClusterBuilder()
                             .withName("demo")
                             .withNewTargetCluster()
@@ -259,7 +260,7 @@ class TlsIT extends AbstractTlsIT {
         var proxyKeystorePasswordProvider = constructPasswordProvider(providerClazz, proxyKeystorePassword);
 
         // @formatter:off
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(new VirtualClusterBuilder()
                         .withName("demo")
                         .withNewTargetCluster()
@@ -299,7 +300,7 @@ class TlsIT extends AbstractTlsIT {
         AllowDeny<String> protocols = new AllowDeny<>(List.of("TLSv1.2"), null);
 
         // @formatter:off
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .withNewTls()
@@ -352,7 +353,7 @@ class TlsIT extends AbstractTlsIT {
         var duffBootstrap = "bootstrap." + IntegrationTestInetAddressResolverProvider.generateFullyQualifiedDomainName("duff") + ":" + SNI_BOOTSTRAP_ADDRESS.port();
 
         // @formatter:off
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultSniHostIdentifiesNodeGatewayBuilder(SNI_BOOTSTRAP_ADDRESS, SNI_BROKER_ADDRESS_PATTERN)
                                 .withNewTls()
@@ -382,7 +383,7 @@ class TlsIT extends AbstractTlsIT {
     void downstream_UntrustedCertificateClosesConnection(KafkaCluster cluster) {
 
         // @formatter:off
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .withNewTls()
@@ -413,7 +414,7 @@ class TlsIT extends AbstractTlsIT {
         AllowDeny<String> protocols = new AllowDeny<>(List.of("TLSv1.2"), null);
 
         // @formatter:off
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .withNewTls()
@@ -449,7 +450,7 @@ class TlsIT extends AbstractTlsIT {
         AllowDeny<String> protocols = new AllowDeny<>(null, Set.of("TLSv1.2"));
 
         // @formatter:off
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .withNewTls()
@@ -491,7 +492,7 @@ class TlsIT extends AbstractTlsIT {
         AllowDeny<String> protocols = new AllowDeny<>(List.of("TLSv1.2"), null);
 
         // @formatter:off
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(new VirtualClusterBuilder()
                         .withName("demo")
                         .withNewTargetCluster()
@@ -530,7 +531,7 @@ class TlsIT extends AbstractTlsIT {
         AllowDeny<String> protocols = new AllowDeny<>(List.of("TLSv1.1"), null);
 
         // @formatter:off
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(new VirtualClusterBuilder()
                         .withName("demo")
                         .withNewTargetCluster()
@@ -565,7 +566,7 @@ class TlsIT extends AbstractTlsIT {
         AllowDeny<String> cipherSuites = new AllowDeny<>(List.of("TLS_CHACHA20_POLY1305_SHA256"), null);
 
         // @formatter:off
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .withNewTls()
@@ -620,7 +621,7 @@ class TlsIT extends AbstractTlsIT {
         AllowDeny<String> cipherSuites = new AllowDeny<>(List.of("TLS_AES_128_GCM_SHA256"), null);
 
         // @formatter:off
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .withNewTls()
@@ -656,7 +657,7 @@ class TlsIT extends AbstractTlsIT {
         AllowDeny<String> cipherSuites = new AllowDeny<>(List.of("TLS_CHACHA20_POLY1305_SHA256"), Set.of("TLS_AES_128_GCM_SHA256"));
 
         // @formatter:off
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)
                                 .withNewTls()
@@ -698,7 +699,7 @@ class TlsIT extends AbstractTlsIT {
         AllowDeny<String> cipherSuites = new AllowDeny<>(List.of("TLS_CHACHA20_POLY1305_SHA256"), null);
 
         // @formatter:off
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(new VirtualClusterBuilder()
                         .withName("demo")
                         .withNewTargetCluster()
@@ -737,7 +738,7 @@ class TlsIT extends AbstractTlsIT {
         AllowDeny<String> upstreamCipherSuites = new AllowDeny<>(List.of("TLS_AES_128_WRONG_CIPHER"), null);
 
         // @formatter:off
-        var builder = new ConfigurationBuilder()
+        var builder = KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(new VirtualClusterBuilder()
                         .withName("demo")
                         .withNewTargetCluster()
@@ -920,7 +921,7 @@ class TlsIT extends AbstractTlsIT {
 
     private ConfigurationBuilder constructMutualTlsBuilder(KafkaCluster cluster, TlsClientAuth tlsClientAuth) {
         // @formatter:off
-        return new ConfigurationBuilder()
+        return KroxyliciousConfigUtils.baseConfigurationBuilder()
                 .addToVirtualClusters(baseVirtualClusterBuilder(cluster, "demo")
                         .addToGateways(
                                 defaultPortIdentifiesNodeGatewayBuilder(PROXY_ADDRESS)

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/NettySettings.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/NettySettings.java
@@ -8,6 +8,6 @@ package io.kroxylicious.proxy.config;
 
 import java.util.Optional;
 
-public record NettySettings(Optional<Integer> workerThreadCount) {
+public record NettySettings(Optional<Integer> workerThreadCount, Optional<Integer> shutdownQuietPeriodSeconds) {
 
 }


### PR DESCRIPTION
### Type of change

- Enhancement

### Description

The netty executors enter a quiet period on shutdown, they wait for at least 2 seconds, accepting new tasks. If a new task is accepted, the period starts again up to the timeout. Our tests are usually totally discarding a throwaway proxy after having done some work, so it should be safe to kill the proxy more harshly in exchange for some test speed.

This change introduces a new, optional configuration option to our netty network configuration:
```
   network:
       management:
           shutdownQuietPeriodSeconds: 5 // optional default 2
       proxy:
           shutdownQuietPeriodSeconds: 5 // optional default 2
```
It's expected that this would typically only be of use to tests where we have finished working with the proxy and can harshly shutdown the netty executors. This may make it more likely that netty experiences a RejectedExecutionException and produces some noise in the logs around shutdown, but it should be worth it for a gain of 2 seconds per proxy close.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
