### PR TITLE
Destroy test KafkaClient immediately on close

### DIFF
--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/KafkaClient.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/KafkaClient.java
@@ -191,7 +191,7 @@ public final class KafkaClient implements AutoCloseable {
         if (channelCompletableFuture != null) {
             channelCompletableFuture.thenApply(Channel::close);
         }
-        bossGroup.shutdownGracefully();
+        bossGroup.shutdownGracefully(0, 5, TimeUnit.SECONDS);
     }
 
     private static Channel checkChannelOpen(Channel c) {


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

In some new tests where we want to rapidly create numerous KafkaClients (per-test in a large parameterized test), we hit resource limits as the netty graceful shutdown lingers for 2 seconds. We don't wait for close to complete so within those 2 seconds we can create many clients that occupy resources. This caused failures to create new clients as there was not enough memory for IOUring.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
