### PR TITLE
name retriever short-circuit on empty names request

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/TopicIdToNameResponseStamper.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/TopicIdToNameResponseStamper.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.InvalidRequestException;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -26,6 +27,7 @@ import org.apache.kafka.common.protocol.types.RawTaggedField;
 import io.kroxylicious.UnknownTaggedFields;
 import io.kroxylicious.proxy.filter.Filter;
 import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.FilterDispatchExecutor;
 import io.kroxylicious.proxy.filter.FilterFactory;
 import io.kroxylicious.proxy.filter.FilterFactoryContext;
 import io.kroxylicious.proxy.filter.RequestFilter;
@@ -57,22 +59,31 @@ public class TopicIdToNameResponseStamper implements FilterFactory<Void, Void> {
 
     @Override
     public Filter createFilter(FilterFactoryContext context, Void initializationData) {
-        return new TopicIdToNameResponseStamperFilter();
+        return new TopicIdToNameResponseStamperFilter(context.filterDispatchExecutor());
     }
 
     static class TopicIdToNameResponseStamperFilter implements RequestFilter, ResponseFilter {
 
+        private final FilterDispatchExecutor filterDispatchExecutor;
         Map<Integer, TopicNameMapping> correlated = new HashMap<>();
+
+        TopicIdToNameResponseStamperFilter(FilterDispatchExecutor filterDispatchExecutor) {
+            this.filterDispatchExecutor = filterDispatchExecutor;
+        }
 
         @Override
         public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage request, FilterContext context) {
             List<String> list = UnknownTaggedFields.unknownTaggedFieldsToStrings(request, TOPIC_ID_TAG).toList();
             if (list.isEmpty()) {
-                return context.forwardRequest(header, request);
+                return context.requestFilterResultBuilder().errorResponse(header, request, new InvalidRequestException("no topic id tag")).withCloseConnection()
+                        .completed();
             }
 
-            Set<Uuid> uuids = Arrays.stream(list.getFirst().split(",")).map(Uuid::fromString).collect(Collectors.toSet());
+            Set<Uuid> uuids = Arrays.stream(list.getFirst().split(",")).filter(s -> !s.isEmpty()).map(Uuid::fromString).collect(Collectors.toSet());
             return context.topicNames(uuids).thenCompose(topicNames -> {
+                if (!filterDispatchExecutor.isInFilterDispatchThread()) {
+                    throw new IllegalStateException("work chained to topicNames future should execute in filter dispatch thread");
+                }
                 correlated.put(header.correlationId(), topicNames);
                 return context.forwardRequest(header, request);
             });

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -622,7 +622,7 @@ public class FilterHandler extends ChannelDuplexHandler {
 
         @Override
         public CompletionStage<TopicNameMapping> topicNames(Collection<Uuid> topicIds) {
-            return new TopicNameRetriever(this).topicNames(topicIds);
+            return new TopicNameRetriever(this, Objects.requireNonNull(ctx).executor()).topicNames(topicIds);
         }
 
     }


### PR DESCRIPTION
### Type of change

- Refactor

### Description

If a client requests a mapping for the empty set, immediately supply them with an empty mapping, using the filter dispatch executor associated with the filter (until now we have leant on sendRequest to control which thread chained futures will execute on).

Why:
There is nothing to retrieve, so making a Metadata Request is a waste of time and resources.

In some filters it may be convenient to always request topic names, to simplify async logic, even if the topic name set is empty.


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
