### PR TITLE
Support promoting patch releases which do not merge to main

### DIFF
--- a/.github/workflows/promote_release.yaml
+++ b/.github/workflows/promote_release.yaml
@@ -125,6 +125,7 @@ jobs:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
         run: |
             echo "PR_BRANCH=$(gh pr view ${{ inputs.release-pr-issue-number}} --json headRefName | jq -r .headRefName)" >> $GITHUB_ENV
+            echo "PR_BASE_BRANCH=$(gh pr view ${{ inputs.release-pr-issue-number}} --json baseRefName | jq -r .baseRefName)" >> $GITHUB_ENV
 
       - name: 'Branch name matches naming conventions'
         env:
@@ -151,19 +152,19 @@ jobs:
           echo "PR_REF=$(git rev-list -n 1 origin/${PR_BRANCH})" >> $GITHUB_ENV
 
           # Get main's current head
-          echo "MAIN_HEAD=$(git rev-list -n 1 main)" >> $GITHUB_ENV
+          echo "PR_BASE_HEAD=$(git rev-list -n 1 ${PR_BASE_BRANCH} )" >> $GITHUB_ENV
 
           # Get PR's view of where main ought to be.  This is two commits behind PR's head.
-          echo "PR_MAIN_REF=$(git rev-list -n 1 origin/${PR_BRANCH}^^)" >> $GITHUB_ENV
+          echo "PR_BASE_REF=$(git rev-list -n 1 origin/${PR_BRANCH}^^)" >> $GITHUB_ENV
 
       - name: 'Check for PR/main divergence'
         if: ${{ inputs.command == 'promote-release' }}
         env:
           GH_TOKEN: ${{ secrets.KROXYLICIOUS_RELEASE_TOKEN }}
         run: |
-          if [[ "${MAIN_HEAD}" != "${PR_MAIN_REF}" ]];
+          if [[ "${PR_BASE_HEAD}" != "${PR_BASE_REF}" ]];
           then
-            gh pr comment --body "Release PR (expects main ${PR_MAIN_REF}) has diverged from main (${MAIN_HEAD}). You must drop this release and restage the release." ${{ inputs.release-pr-issue-number }}
+            gh pr comment --body "Release PR (expects ${PR_BASE_BRANCH} to be at ${PR_BASE_REF}) but has found (${PR_BASE_HEAD}). You must drop this release and restage the release." ${{ inputs.release-pr-issue-number }} as there have been commits to ${PR_BASE_BRANCH} since the release was staged.
             exit 1
           fi
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Validate merge when the branch is not main.

### Additional Context

Promoting v0.17.1 failed as it was not merging to main.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
