### PR TITLE
Fail fast if a client sends bytes for an unsupported apiVersion

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaMessageDecoder.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/codec/KafkaMessageDecoder.java
@@ -56,7 +56,10 @@ abstract class KafkaMessageDecoder extends ByteToMessageDecoder {
                 }
             }
             catch (Exception e) {
-                log().error("{}: Error in decoder", ctx, e);
+                log().atError()
+                        .setMessage("{}: Error in decoder: " + e.getMessage())
+                        .addArgument(ctx)
+                        .setCause(log().isDebugEnabled() ? e : null).log();
                 throw e;
             }
         }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoderTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/KafkaRequestDecoderTest.java
@@ -15,6 +15,7 @@ import java.util.function.IntPredicate;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.apache.kafka.common.message.ApiVersionsRequestData;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.RequestHeaderData;
@@ -125,7 +126,7 @@ class KafkaRequestDecoderTest {
 
     // after ApiVersions negotiation we should never encounter a request from the client for an api version unknown to the proxy
     @Test
-    void throwsOnUnsupportedVersionOfNonApiVersionsRequests() {
+    void throwsOnUnsupportedVersion_NonApiVersionsRequestsAheadOfProxyMaximum() {
         EmbeddedChannel embeddedChannel = newEmbeddedChannel(new ApiVersionsServiceImpl(), RequestDecoderTest.DECODE_EVERYTHING);
         short maxSupportedVersion = ApiKeys.METADATA.latestVersion(true);
         short unsupportedVersion = (short) (maxSupportedVersion + 1);
@@ -140,8 +141,28 @@ class KafkaRequestDecoderTest {
         accessor.writeInt(messageSize);
         header.write(accessor, cache, requestHeaderVersion);
         accessor.writeByteArray(arbitraryBodyBytes);
-        assertThatThrownBy(() -> embeddedChannel.writeInbound(buffer)).isInstanceOf(DecoderException.class).cause().isInstanceOf(IllegalStateException.class)
+        assertThatThrownBy(() -> embeddedChannel.writeInbound(buffer)).isInstanceOf(DecoderException.class).cause().isInstanceOf(UnsupportedVersionException.class)
                 .hasMessage("client apiVersion %d ahead of proxy maximum %d for api key: METADATA", unsupportedVersion, maxSupportedVersion);
+    }
+
+    @Test
+    void throwsOnUnsupportedVersionRequestBelowProxyMinimum() {
+        EmbeddedChannel embeddedChannel = newEmbeddedChannel(new ApiVersionsServiceImpl(), RequestDecoderTest.DECODE_EVERYTHING);
+        short minSupportedVersion = ApiKeys.PRODUCE.oldestVersion();
+        short unsupportedVersion = (short) (minSupportedVersion - 1);
+        RequestHeaderData header = latestVersionHeaderWithAllFields(ApiKeys.PRODUCE, unsupportedVersion);
+        byte[] arbitraryBodyBytes = new byte[]{ 1, 2, 3, 4 };
+        ObjectSerializationCache cache = new ObjectSerializationCache();
+        short requestHeaderVersion = ApiKeys.PRODUCE.requestHeaderVersion(ApiKeys.PRODUCE.latestVersion());
+        int headerSize = header.size(cache, requestHeaderVersion);
+        int messageSize = headerSize + arbitraryBodyBytes.length;
+        ByteBuf buffer = Unpooled.buffer();
+        ByteBufAccessorImpl accessor = new ByteBufAccessorImpl(buffer);
+        accessor.writeInt(messageSize);
+        header.write(accessor, cache, requestHeaderVersion);
+        accessor.writeByteArray(arbitraryBodyBytes);
+        assertThatThrownBy(() -> embeddedChannel.writeInbound(buffer)).isInstanceOf(DecoderException.class).cause().isInstanceOf(UnsupportedVersionException.class)
+                .hasMessage("client apiVersion %d below proxy minimum %d for api key: PRODUCE", unsupportedVersion, minSupportedVersion);
     }
 
     private static Stream<Arguments> produceRequestCases() {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/RequestDecoderMockitoTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/codec/RequestDecoderMockitoTest.java
@@ -9,6 +9,7 @@ package io.kroxylicious.proxy.internal.codec;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.kafka.common.protocol.ApiKeys;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -57,6 +58,7 @@ class RequestDecoderMockitoTest {
 
         // Then
         verify(frameBuffer).readerIndex(initialIndex);
+
     }
 
     @SuppressWarnings("DataFlowIssue")
@@ -69,6 +71,7 @@ class RequestDecoderMockitoTest {
         when(frameBuffer.readInt()).thenReturn(10);
         when(frameBuffer.readableBytes()).thenReturn(20);
         when(frameBuffer.readSlice(anyInt())).thenReturn(frameSlice);
+        when(frameSlice.readShort()).thenReturn(ApiKeys.API_VERSIONS.id, (short) 0);
 
         List<Object> messageReceiver = new ArrayList<>();
 
@@ -77,6 +80,5 @@ class RequestDecoderMockitoTest {
         assertThatThrownBy(() -> kafkaRequestDecoder.decode(null, frameBuffer, messageReceiver))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("decodeHeaderAndBody did not read all of the buffer");
-
     }
 }


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

To workaround a librdkafka issue, the proxy (following the behaviour of upstream Kafka) sets the min version for Produce RPCs to 0, despite only being able to decode v3+.

If a client did send us v0-v2 messages then we will probably fail to decode the message, and the kafka message read will throw some unhelpful message, instead we can fail earlier with a better message.


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
