### PR TITLE
Authorization Filter: add more unit tests for PRODUCE

### DIFF
--- a/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/ScenarioDefinition.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/ScenarioDefinition.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -22,7 +23,7 @@ public record ScenarioDefinition(Metadata metadata, Given given, When when, Then
     }
 
     public record MockResponse(ApiKeys expectedRequestKey, short expectedRequestVersion, JsonNode expectedRequestHeader, JsonNode expectedRequest,
-                               JsonNode upstreamResponseHeader, JsonNode upstreamResponse) {
+                               @Nullable JsonNode upstreamResponseHeader, @Nullable JsonNode upstreamResponse) {
 
     }
 
@@ -44,6 +45,22 @@ public record ScenarioDefinition(Metadata metadata, Given given, When when, Then
     /**
      * @param expectedResponseHeader
      * @param expectedResponse
+     * @param expectedErrorResponse in the case that we expect an error response (the message generation is a framework responsibility)
+     * @param hasResponse true if we expect a response (zero-ack produce request is the only case known with no response). default true
+     * @param expectRequestDropped true if we expect the request to be dropped. default false
      */
-    public record Then(@Nullable JsonNode expectedResponseHeader, @Nullable JsonNode expectedResponse) {}
+    public record Then(@Nullable JsonNode expectedResponseHeader,
+                       @Nullable JsonNode expectedResponse,
+                       @Nullable Errors expectedErrorResponse,
+                       @Nullable Boolean hasResponse,
+                       @Nullable Boolean expectRequestDropped) {
+
+        boolean getHasResponse() {
+            return hasResponse == null || hasResponse;
+        }
+
+        boolean isExpectRequestDropped() {
+            return expectRequestDropped != null && expectRequestDropped;
+        }
+    }
 }

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/12/allowed-and-denied-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/12/allowed-and-denied-topic.yaml
@@ -1,0 +1,102 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "PRODUCE"
+  apiVersion: 12
+  scenario: |
+    allowed topics are forwarded to the upstream
+    denied topics are not forwarded to the upstream
+    denied topic errors are augmented into the response
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "PRODUCE"
+      expectedRequestVersion: 12
+      expectedRequestHeader:
+        requestApiKey: 0
+        requestApiVersion: 12
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-292"
+        acks: 1
+        timeoutMs: 141
+        topicData:
+          - name: "my-topic"
+            partitionData:
+              - index: 134
+                records: !!binary ""
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        responses:
+          - name: "my-topic"
+            partitionResponses:
+              - index: 969
+                errorCode: 51
+                baseOffset: 581
+                logAppendTimeMs: 693
+                logStartOffset: 269
+                recordErrors:
+                  - batchIndex: 164
+                    batchIndexErrorMessage: "random-string-410"
+                errorMessage: "random-string-667"
+        throttleTimeMs: 141
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "WRITE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 0
+    requestApiVersion: 12
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-292"
+    acks: 1
+    timeoutMs: 141
+    topicData:
+      - name: "my-topic"
+        partitionData:
+          - index: 134
+            records: !!binary ""
+      - name: "unauthorized"
+        partitionData:
+          - index: 133
+            records: !!binary ""
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    responses:
+      - name: "my-topic"
+        partitionResponses:
+          - index: 969
+            errorCode: 51
+            baseOffset: 581
+            logAppendTimeMs: 693
+            logStartOffset: 269
+            recordErrors:
+              - batchIndex: 164
+                batchIndexErrorMessage: "random-string-410"
+            errorMessage: "random-string-667"
+      - name: "unauthorized"
+        partitionResponses:
+          - index: 133
+            errorCode: 29
+            baseOffset: 0
+            logAppendTimeMs: -1
+            logStartOffset: -1
+            recordErrors: [ ]
+            errorMessage: "Topic authorization failed."
+    throttleTimeMs: 141
+

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/12/allowed-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/12/allowed-topic.yaml
@@ -8,7 +8,7 @@
 metadata:
   apiKeys: "PRODUCE"
   apiVersion: 12
-  scenario: "baseline"
+  scenario: "allowed topic is forwarded upstream"
 given:
   mockedUpstreamResponses:
     - expectedRequestKey: "PRODUCE"

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/12/denied-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/12/denied-topic.yaml
@@ -1,0 +1,40 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "PRODUCE"
+  apiVersion: 12
+  scenario: "all topics denied"
+given:
+  mockedUpstreamResponses: [ ]
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "WRITE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 0
+    requestApiVersion: 12
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-292"
+    acks: 1
+    timeoutMs: 141
+    topicData:
+      - name: "unauthorized"
+        partitionData:
+          - index: 134
+            records: !!binary ""
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedErrorResponse: "TOPIC_AUTHORIZATION_FAILED"

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/12/zero-ack-allowed-and-denied-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/12/zero-ack-allowed-and-denied-topic.yaml
@@ -1,0 +1,61 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "PRODUCE"
+  apiVersion: 12
+  scenario: |
+    zero ack produce request, so no response expected
+    allowed topics are forwarded to the upstream
+    denied topics are not forwarded to the upstream
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "PRODUCE"
+      expectedRequestVersion: 12
+      expectedRequestHeader:
+        requestApiKey: 0
+        requestApiVersion: 12
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-292"
+        acks: 0
+        timeoutMs: 141
+        topicData:
+          - name: "my-topic"
+            partitionData:
+              - index: 134
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "WRITE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 0
+    requestApiVersion: 12
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-292"
+    acks: 0
+    timeoutMs: 141
+    topicData:
+      - name: "unauthorized"
+        partitionData:
+          - index: 134
+            records: !!binary ""
+      - name: "my-topic"
+        partitionData:
+          - index: 134
+            records: !!binary ""
+then:
+  hasResponse: false

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/12/zero-ack-allowed-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/12/zero-ack-allowed-topic.yaml
@@ -1,0 +1,54 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "PRODUCE"
+  apiVersion: 12
+  scenario: "allowed topic is forwarded upstream for a zero-ack produce request"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "PRODUCE"
+      expectedRequestVersion: 12
+      expectedRequestHeader:
+        requestApiKey: 0
+        requestApiVersion: 12
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-292"
+        acks: 0
+        timeoutMs: 141
+        topicData:
+          - name: "my-topic"
+            partitionData:
+              - index: 134
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "WRITE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 0
+    requestApiVersion: 12
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-292"
+    acks: 0
+    timeoutMs: 141
+    topicData:
+      - name: "my-topic"
+        partitionData:
+          - index: 134
+            records: !!binary ""
+then:
+  hasResponse: false

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/12/zero-ack-denied-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/12/zero-ack-denied-topic.yaml
@@ -1,0 +1,39 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "PRODUCE"
+  apiVersion: 12
+  scenario: "denied topic is not forwarded upstream for a zero-ack produce request"
+given:
+  mockedUpstreamResponses: [ ]
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "WRITE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 0
+    requestApiVersion: 12
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-292"
+    acks: 0
+    timeoutMs: 141
+    topicData:
+      - name: "unauthorized"
+        partitionData:
+          - index: 134
+            records: !!binary ""
+then:
+  hasResponse: false
+  expectRequestDropped: true


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds unit test coverage for ProduceEnforcement. The mock test needed some work to:
* deal with the peculiarity of zero-ack produce requests
* handle `FilterContext#errorResponse`. The mock tests don't use the runtime so we aren't exercising the code that actually builds error response that way, but it should be covered elsewhere. These tests just check that we invoked errorResponse with the expected exception.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
