### PR TITLE
Ensure inflight state empty at end of test

### DIFF
--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/AuthorizationFilter.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/AuthorizationFilter.java
@@ -8,6 +8,7 @@
 package io.kroxylicious.filter.authorization;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
@@ -272,5 +273,11 @@ public class AuthorizationFilter implements RequestFilter, ResponseFilter {
         }
         apiVersions.removeAll(toRemove);
 
+    }
+
+    @SuppressWarnings("java:S1452") // wildcard type expected
+    @VisibleForTesting
+    Map<Integer, InflightState<?>> inflightState() {
+        return Collections.unmodifiableMap(inflightState);
     }
 }

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/AuthorizationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/AuthorizationFilterTest.java
@@ -148,6 +148,11 @@ class AuthorizationFilterTest {
         if (!mockUpstream.isFinished()) {
             throw new IllegalStateException("test has finished, but mock responses are still queued");
         }
+        // we expect that any inflight state pushed during a request is always popped on the corresponding response
+        // if it is non-empty then we may have a memory leak
+        assertThat(authorizationFilter.inflightState())
+                .describedAs("inflight state")
+                .isEmpty();
     }
 
     private static String toYaml(Object actualBody) {


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description
If we push inflight state during the request and do not pop it on the response (or erroneously push inflight state for a request that does not have a response a la zero-ack produce), then we will leak memory.

I've chosen to expose the internal map for testing as it exposes the correlationIds that have values stored when the failure message is emitted. (as opposed to adding a method like `isInflightStateEmpty()` that hides the implementation but doesn't tell you what's in the map.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
