### PR TITLE
Metadata request for empty topics are also idempotent

### DIFF
--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/MetadataEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/MetadataEnforcement.java
@@ -59,7 +59,6 @@ class MetadataEnforcement extends ApiEnforcement<MetadataRequestData, MetadataRe
                 && header.requestApiVersion() != 0;
     }
 
-
     private static boolean containsAnyTopicIds(MetadataRequestData request) {
         return request.topics() != null
                 && !request.topics().isEmpty()
@@ -114,7 +113,6 @@ class MetadataEnforcement extends ApiEnforcement<MetadataRequestData, MetadataRe
 
         return onNonIdempotentMetadataRequest(header, request, context, authorizationFilter);
     }
-
 
     private CompletionStage<RequestFilterResult> onNonIdempotentMetadataRequest(RequestHeaderData header,
                                                                                 MetadataRequestData request,


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

While the current code is not _incorrect_, we can treat a `Metadata` request for an empty set of topics as idempotent, because no topics will be created. 

