### PR TITLE
Add warning log to new Authorization Filter

### DIFF
--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/Authorization.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/Authorization.java
@@ -10,6 +10,9 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.kroxylicious.authorizer.service.Authorizer;
 import io.kroxylicious.authorizer.service.AuthorizerService;
 import io.kroxylicious.proxy.filter.Filter;
@@ -28,6 +31,8 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 @Plugin(configType = AuthorizationConfig.class)
 public class Authorization implements FilterFactory<AuthorizationConfig, Authorizer> {
 
+    private static final Logger LOG = LoggerFactory.getLogger(Authorization.class);
+
     private @Nullable AuthorizerService<?> authorizerService = null;
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -35,6 +40,7 @@ public class Authorization implements FilterFactory<AuthorizationConfig, Authori
     public Authorizer initialize(FilterFactoryContext context,
                                  AuthorizationConfig authorizationConfig)
             throws PluginConfigurationException {
+        LOG.warn("Authorization is an experimental Filter not yet recommended for production environments.");
         var configuration = Plugins.requireConfig(this, authorizationConfig);
         this.authorizerService = context.pluginInstance(AuthorizerService.class, configuration.authorizer());
         ((AuthorizerService) authorizerService).initialize(configuration.authorizerConfig());


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

```
2025-11-27 21:19:54 INFO  <main> io.kr.pr.StartupShutdownLogger - Kroxylicious is starting
2025-11-27 21:19:55 INFO  <main> io.kr.pr.KafkaProxy - Binding management endpoint: 0.0.0.0:9190
2025-11-27 21:19:55 WARN  <main> io.kr.fi.au.Authorization - Authorization is an experimental Filter not yet recommended for production environments.
```

authz is quite the sensitive security usecase, maybe we should emit a warning since the Filter is brand new

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
