### PR TITLE
Add further unit test coverage to authz enforcers

### DIFF
--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_PARTITIONS/3/allowed-and-denied-topics.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_PARTITIONS/3/allowed-and-denied-topics.yaml
@@ -1,0 +1,81 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "CREATE_PARTITIONS"
+  apiVersion: 3
+  scenario: |
+    request contains some allowed topics and some denied
+    allowed topics are forwarded upstream
+    denied topics are not forwarded upstream
+    denied topic errors are augmented into response to client
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "CREATE_PARTITIONS"
+      expectedRequestVersion: 3
+      expectedRequestHeader:
+        requestApiKey: 37
+        requestApiVersion: 3
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+            count: 650
+            assignments:
+              - brokerIds:
+                  - 964
+        timeoutMs: 69
+        validateOnly: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 552
+        results:
+          - name: "my-topic"
+            errorCode: 19
+            errorMessage: "random-string-778"
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "ALTER"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 37
+    requestApiVersion: 3
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+        count: 650
+        assignments:
+          - brokerIds:
+              - 964
+      - name: "unauthorized"
+        count: 650
+        assignments:
+          - brokerIds:
+              - 964
+    timeoutMs: 69
+    validateOnly: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 552
+    results:
+      - name: "my-topic"
+        errorCode: 19
+        errorMessage: "random-string-778"
+      - name: "unauthorized"
+        errorCode: 29
+        errorMessage: null

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_PARTITIONS/3/denied-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_PARTITIONS/3/denied-topic.yaml
@@ -1,0 +1,45 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "CREATE_PARTITIONS"
+  apiVersion: 3
+  scenario: "all topics denied, filter short circuit responds"
+given:
+  mockedUpstreamResponses: []
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "ALTER"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 37
+    requestApiVersion: 3
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "unauthorized"
+        count: 650
+        assignments:
+          - brokerIds:
+              - 964
+    timeoutMs: 69
+    validateOnly: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 0
+    results:
+      - name: "unauthorized"
+        errorCode: 29
+        errorMessage: null

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_TOPICS/7/allowed-and-denied.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_TOPICS/7/allowed-and-denied.yaml
@@ -1,0 +1,118 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "CREATE_TOPICS"
+  apiVersion: 7
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "CREATE_TOPICS"
+      expectedRequestVersion: 7
+      expectedRequestHeader:
+        requestApiKey: 19
+        requestApiVersion: 7
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+            numPartitions: 14
+            replicationFactor: 996
+            assignments:
+              - partitionIndex: 910
+                brokerIds:
+                  - 964
+            configs:
+              - name: "random-string-21"
+                value: "random-string-457"
+        timeoutMs: 314
+        validateOnly: true
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 167
+        topics:
+          - name: "my-topic"
+            topicId: "6get6nl1SHiAaBAJ_3XYMw"
+            errorCode: 746
+            errorMessage: "random-string-874"
+            numPartitions: 330
+            replicationFactor: 90
+            configs:
+              - name: "random-string-170"
+                value: "random-string-623"
+                readOnly: false
+                configSource: 103
+                isSensitive: true
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE_CONFIGS"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 19
+    requestApiVersion: 7
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+        numPartitions: 14
+        replicationFactor: 996
+        assignments:
+          - partitionIndex: 910
+            brokerIds:
+              - 964
+        configs:
+          - name: "random-string-21"
+            value: "random-string-457"
+      - name: "unauthorized"
+        numPartitions: 14
+        replicationFactor: 996
+        assignments:
+          - partitionIndex: 910
+            brokerIds:
+              - 964
+        configs:
+          - name: "random-string-21"
+            value: "random-string-457"
+    timeoutMs: 314
+    validateOnly: true
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 167
+    topics:
+      - name: "my-topic"
+        topicId: "6get6nl1SHiAaBAJ_3XYMw"
+        errorCode: 746
+        errorMessage: "random-string-874"
+        numPartitions: 330
+        replicationFactor: 90
+        configs:
+          - name: "random-string-170"
+            value: "random-string-623"
+            readOnly: false
+            configSource: 103
+            isSensitive: true
+      - name: "unauthorized"
+        topicId: "AAAAAAAAAAAAAAAAAAAAAA"
+        errorCode: 29
+        errorMessage: "Authorization failed."
+        numPartitions: -1
+        replicationFactor: -1
+        configs: []

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_TOPICS/7/denied-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/CREATE_TOPICS/7/denied-topic.yaml
@@ -1,0 +1,58 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "CREATE_TOPICS"
+  apiVersion: 7
+  scenario: "all topics denied, filter shortcircuit responds with error"
+given:
+  mockedUpstreamResponses: []
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE_CONFIGS"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 19
+    requestApiVersion: 7
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "unauthorized"
+        numPartitions: 14
+        replicationFactor: 996
+        assignments:
+          - partitionIndex: 910
+            brokerIds:
+              - 964
+        configs:
+          - name: "random-string-21"
+            value: "random-string-457"
+    timeoutMs: 314
+    validateOnly: true
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 0
+    topics:
+      - name: "unauthorized"
+        topicId: "AAAAAAAAAAAAAAAAAAAAAA"
+        errorCode: 29
+        errorMessage: "Authorization failed."
+        numPartitions: -1
+        replicationFactor: -1
+        configs: [ ]

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DELETE_TOPICS/6/allowed-and-denied-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DELETE_TOPICS/6/allowed-and-denied-topic.yaml
@@ -1,0 +1,73 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "DELETE_TOPICS"
+  apiVersion: 6
+  scenario: |
+    request contains some allowed topics and some denied
+    allowed topics are forwarded upstream
+    denied topics are not forwarded upstream
+    denied topic errors are augmented into response to client
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "DELETE_TOPICS"
+      expectedRequestVersion: 6
+      expectedRequestHeader:
+        requestApiKey: 20
+        requestApiVersion: 6
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - name: "my-topic"
+            topicId: "ZVa4q4iBSXSGQewb2tFCJA"
+        timeoutMs: 268
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 945
+        responses:
+          - name: "my-topic"
+            topicId: "iIEpdMZBTBua0UIkDIeF7w"
+            errorCode: 268
+            errorMessage: "my-topic"
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DELETE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 20
+    requestApiVersion: 6
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "my-topic"
+        topicId: "ZVa4q4iBSXSGQewb2tFCJA"
+      - name: "unauthorized"
+        topicId: "ZVa4q4iBSXSGQewb2tFCJA"
+    timeoutMs: 268
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 945
+    responses:
+      - name: "my-topic"
+        topicId: "iIEpdMZBTBua0UIkDIeF7w"
+        errorCode: 268
+        errorMessage: "my-topic"
+      - name: "unauthorized"
+        topicId: "ZVa4q4iBSXSGQewb2tFCJA"
+        errorCode: 29
+        errorMessage: "Topic authorization failed."

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DELETE_TOPICS/6/denied-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/DELETE_TOPICS/6/denied-topic.yaml
@@ -1,0 +1,42 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "DELETE_TOPICS"
+  apiVersion: 6
+  scenario: "all topics denied, filter short circuit responds with error"
+given:
+  mockedUpstreamResponses: [ ]
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DELETE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 20
+    requestApiVersion: 6
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - name: "unauthorized"
+        topicId: AAAAAAAAAAAAAAAAAAAAAA
+    timeoutMs: 268
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 0
+    responses:
+      - name: "unauthorized"
+        topicId: "AAAAAAAAAAAAAAAAAAAAAA"
+        errorCode: 29
+        errorMessage: "Topic authorization failed."

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/13/no-topic-ids-considered-idempotent.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/13/no-topic-ids-considered-idempotent.yaml
@@ -1,0 +1,65 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 13
+  scenario: "request has empty topics, signalling it requests metadata for no topics. The request is forwarded."
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        topics: []
+        allowAutoTopicCreation: true
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers:
+          - nodeId: 179
+            host: "random-string-71"
+            port: 176
+            rack: "random-string-836"
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics: []
+        errorCode: 1003
+  authorizerRules:
+    allowed: []
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 13
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics: []
+    allowAutoTopicCreation: true
+    includeTopicAuthorizedOperations: false
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 746
+    brokers:
+        - nodeId: 179
+          host: "random-string-71"
+          port: 176
+          rack: "random-string-836"
+    clusterId: "random-string-682"
+    controllerId: 892
+    topics: []
+    errorCode: 1003

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_DELETE/0/allowed-and-denied-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_DELETE/0/allowed-and-denied-topic.yaml
@@ -1,0 +1,78 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "OFFSET_DELETE"
+  apiVersion: 0
+  scenario: |
+    request contains some allowed topics and some denied
+    allowed topics are forwarded upstream
+    denied topics are not forwarded upstream
+    denied topic errors are augmented into response to client
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "OFFSET_DELETE"
+      expectedRequestVersion: 0
+      expectedRequestHeader:
+        requestApiKey: 47
+        requestApiVersion: 0
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        groupId: "my-group"
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 1
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        errorCode: 0
+        throttleTimeMs: 52
+        topics:
+          - name: "my-topic"
+            partitions:
+              - partitionIndex: 1
+                errorCode: 0
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 47
+    requestApiVersion: 0
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "my-group"
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 1
+      - name: "unauthorized"
+        partitions:
+          - partitionIndex: 1
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    errorCode: 0
+    throttleTimeMs: 52
+    topics:
+      - name: "my-topic"
+        partitions:
+          - partitionIndex: 1
+            errorCode: 0
+      - name: "unauthorized"
+        partitions:
+          - partitionIndex: 1
+            errorCode: 29

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_DELETE/0/denied-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/OFFSET_DELETE/0/denied-topic.yaml
@@ -1,0 +1,44 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "OFFSET_DELETE"
+  apiVersion: 0
+  scenario: "all topics denied, filter short circuit responds with error"
+given:
+  mockedUpstreamResponses: []
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 47
+    requestApiVersion: 0
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: "my-group"
+    topics:
+      - name: "unauthorized"
+        partitions:
+          - partitionIndex: 1
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    errorCode: 0
+    throttleTimeMs: 0
+    topics:
+      - name: "unauthorized"
+        partitions:
+          - partitionIndex: 1
+            errorCode: 29


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Add further coverage to authz enforcers. Mostly Admin RPCs that didn't have testing on the denied/mixture paths.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
