### PR TITLE
Clean in flight state in authorization filter if request results in exception, or response fails to pop

### DIFF
--- a/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/MockFilterContext.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/MockFilterContext.java
@@ -54,7 +54,7 @@ public record MockFilterContext(ApiMessage header, ApiMessage message, Subject s
     @NonNull
     @Override
     public String sessionId() {
-        throw new UnsupportedOperationException();
+        return "mockSessionId";
     }
 
     @NonNull

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/ScenarioDefinition.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/ScenarioDefinition.java
@@ -43,6 +43,23 @@ public record ScenarioDefinition(Metadata metadata, Given given, When when, Then
     public record When(String subject, JsonNode requestHeader, JsonNode request) {}
 
     /**
+     * Expect request future to be completed exceptionally
+     * @param withCauseType the type of the expected cause
+     * @param withCauseMessage the message of the expected cause
+     */
+    public record RequestError(String withCauseType, String withCauseMessage) {
+        public Class<?> getCauseType() {
+            try {
+                return this.getClass().getClassLoader().loadClass(withCauseType);
+            }
+            catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+    }
+
+    /**
      * @param expectedResponseHeader
      * @param expectedResponse
      * @param expectedErrorResponse in the case that we expect an error response (the message generation is a framework responsibility)
@@ -53,7 +70,8 @@ public record ScenarioDefinition(Metadata metadata, Given given, When when, Then
                        @Nullable JsonNode expectedResponse,
                        @Nullable Errors expectedErrorResponse,
                        @Nullable Boolean hasResponse,
-                       @Nullable Boolean expectRequestDropped) {
+                       @Nullable Boolean expectRequestDropped,
+                       @Nullable RequestError expectedRequestError) {
 
         boolean getHasResponse() {
             return hasResponse == null || hasResponse;

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/13/out-of-band-metadata-request-errors.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/METADATA/13/out-of-band-metadata-request-errors.yaml
@@ -1,0 +1,64 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "METADATA"
+  apiVersion: 13
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "METADATA"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 3
+        requestApiVersion: 13
+        correlationId: 0
+        clientId: "clientId"
+      expectedRequest:
+        topics:
+          - topicId: "e8MvPJPGSteB1fKbMEji0w"
+            name: "my-topic"
+        allowAutoTopicCreation: false
+        includeTopicAuthorizedOperations: false
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 746
+        brokers: []
+        clusterId: "random-string-682"
+        controllerId: 892
+        topics: []
+        # UNKNOWN_SERVER_ERROR
+        errorCode: -1
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "CREATE"
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 3
+    requestApiVersion: 13
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    topics:
+      - topicId: "e8MvPJPGSteB1fKbMEji0w"
+        name: "my-topic"
+    allowAutoTopicCreation: true
+    includeTopicAuthorizedOperations: false
+then:
+  expectedRequestError:
+    withCauseType: io.kroxylicious.filter.authorization.AuthorizationException
+    withCauseMessage: "Internal metadata request failed with UNKNOWN_SERVER_ERROR"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In the `MetadataEnforcer` we weren't popping the inflight state if the out-of-band request failed and we completed the request future exceptionally. This would leak memory.

Rather than fixing it there I've made the AuthorizationFilter responsible for doing a pop on request exception, and also added in a mostly redundant pop on the response path in case an Enforcer throws or doesn't pop due to some logical error.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
