### PR TITLE
Remove shellcheck

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,10 +29,6 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      checks: write
     steps:
       - name: 'Check out repository'
         uses: actions/checkout@v6


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The github permissions are currently blocking [PRs from forks ](https://github.com/kroxylicious/kroxylicious/actions/runs/19845023683/job/56860688858?pr=2982)from writing checks/review commands. It appears we cannot use workflow permissions to give write permissions to runs from forks.

Options are to shuffle the work into a workflow_run triggered after the lint, so we can use the workflow_permissions (could add to the sonar job?). Or use pull_request_target. Or use a PAT with write permissions. edit: Or as @gracegrimwood suggests 

> I think what we ultimately want (not necessarily right now because it looks like a lot of setup and possibly a lot of admin) is a [GitHub App](https://docs.github.com/en/apps/using-github-apps/about-using-github-apps). Specifically because GitHub Apps are meant for doing “things on GitHub like open issues, comment on pull requests, and manage projects” among other stuff. If we want to commit to using Reviewdog, we probably want to set up a GitHub App for doing that within the Kroxy org as a whole.

Lets remove it while we sort out the permissions.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
