### PR TITLE
Fail fast on SASL v0 handshake

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ProxyRpcTest.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/ProxyRpcTest.java
@@ -13,11 +13,14 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.apache.kafka.common.message.ApiMessageType;
+import org.apache.kafka.common.message.SaslHandshakeResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -46,10 +49,12 @@ import static org.apache.kafka.common.protocol.ApiKeys.FIND_COORDINATOR;
 import static org.apache.kafka.common.protocol.ApiKeys.METADATA;
 import static org.apache.kafka.common.protocol.ApiKeys.SHARE_ACKNOWLEDGE;
 import static org.apache.kafka.common.protocol.ApiKeys.SHARE_FETCH;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 public class ProxyRpcTest {
+    public static final Map<ApiAndVersion, ApiMessage> REQUEST_SAMPLES = ApiMessageSampleGenerator.createRequestSamples();
     private static MockServerKroxyliciousTester mockTester;
 
     /**
@@ -57,6 +62,11 @@ public class ProxyRpcTest {
      * FIND_COORDINATOR, METADATA, DESCRIBE_CLUSTER, kroxylicious takes charge of rewriting these responses itself.
      */
     private static final Set<ApiKeys> SKIPPED_API_KEYS = Set.of(API_VERSIONS, FIND_COORDINATOR, METADATA, DESCRIBE_CLUSTER, SHARE_ACKNOWLEDGE, SHARE_FETCH);
+    private static final ApiAndVersion SASL_HANDSHAKE_V0 = new ApiAndVersion(ApiKeys.SASL_HANDSHAKE, (short) 0);
+    /**
+     * SASL_HANDSHAKE v0 is not supported by the proxy, we shortcircuit respond
+     */
+    private static final Set<ApiAndVersion> SKIPPED_API_VERSIONS = Set.of(SASL_HANDSHAKE_V0);
 
     @RegisterExtension
     static NettyLeakDetectorExtension nettyLeakDetectorExtension = new NettyLeakDetectorExtension(false, true, false, true);
@@ -92,12 +102,26 @@ public class ProxyRpcTest {
         }
     }
 
+    // We do not implement SASL v0, so we want to fail early, rather than emit an esoteric exception when we try to interpret
+    // SASL v0 packets as kafka frames, despite them having no Kafka protocol header. Implementing SASL v0 would be quite a bit
+    // of work as we would need to expose Filters to the SASL data (since we already have filters interested in manipulating
+    // SASL exchanges).
+    @Test
+    void testSaslV0Rejected() {
+        ApiMessage apiMessage = REQUEST_SAMPLES.get(SASL_HANDSHAKE_V0);
+        try (KafkaClient kafkaClient = mockTester.simpleTestClient()) {
+            Response response = kafkaClient.getSync(new Request(SASL_HANDSHAKE_V0.keys(), SASL_HANDSHAKE_V0.apiVersion(), "client", apiMessage));
+            assertThat(response.payload().message()).isInstanceOfSatisfying(SaslHandshakeResponseData.class, saslHandshakeResponseData -> {
+                assertThat(Errors.forCode(saslHandshakeResponseData.errorCode())).isEqualTo(Errors.UNSUPPORTED_VERSION);
+            });
+        }
+    }
+
     @NonNull
     private static Stream<Arguments> scenarios() {
-        Map<ApiAndVersion, ApiMessage> requestSamples = ApiMessageSampleGenerator.createRequestSamples();
         Map<ApiAndVersion, ApiMessage> responseSamples = ApiMessageSampleGenerator.createResponseSamples();
         return Arrays.stream(ApiKeys.values()).filter(apiKeys -> !SKIPPED_API_KEYS.contains(apiKeys))
-                .flatMap(apiKeys -> toScenario(requestSamples, responseSamples, apiKeys));
+                .flatMap(apiKeys -> toScenario(REQUEST_SAMPLES, responseSamples, apiKeys));
     }
 
     private static final ApiAndVersion v0HeaderVersion = new ApiAndVersion(CONTROLLED_SHUTDOWN, (short) 0);
@@ -106,22 +130,24 @@ public class ProxyRpcTest {
         ApiMessageType messageType = apiKeys.messageType;
 
         IntStream supported = IntStream.range(messageType.lowestSupportedVersion(), apiKeys.messageType.highestSupportedVersion(true) + 1);
-        return supported.mapToObj(version -> new ApiAndVersion(apiKeys, (short) version)).map(apiAndVersion -> {
-            ApiMessage request = requestSamples.get(apiAndVersion);
-            ApiMessage response = responseSample.get(apiAndVersion);
-            Request clientRequest = createRequestDefinition(apiAndVersion, "mockClientId", request);
-            String expected;
-            if (v0HeaderVersion.equals(apiAndVersion)) {
-                // controlled shutdown is the only usage of a version 0 header schema which doesn't have clientId
-                expected = "";
-            }
-            else {
-                expected = "fixed";
-            }
-            Request expectedAtMock = createRequestDefinition(apiAndVersion, expected, request);
-            ResponsePayload responseJson = createResponseDefinition(apiAndVersion, response);
-            return argumentSet(apiAndVersion.keys().name() + "@v" + apiAndVersion.apiVersion(), responseJson, clientRequest, expectedAtMock, responseJson);
-        });
+        return supported.mapToObj(version -> new ApiAndVersion(apiKeys, (short) version))
+                .filter(apiAndVersion -> !SKIPPED_API_VERSIONS.contains(apiAndVersion))
+                .map(apiAndVersion -> {
+                    ApiMessage request = requestSamples.get(apiAndVersion);
+                    ApiMessage response = responseSample.get(apiAndVersion);
+                    Request clientRequest = createRequestDefinition(apiAndVersion, "mockClientId", request);
+                    String expected;
+                    if (v0HeaderVersion.equals(apiAndVersion)) {
+                        // controlled shutdown is the only usage of a version 0 header schema which doesn't have clientId
+                        expected = "";
+                    }
+                    else {
+                        expected = "fixed";
+                    }
+                    Request expectedAtMock = createRequestDefinition(apiAndVersion, expected, request);
+                    ResponsePayload responseJson = createResponseDefinition(apiAndVersion, response);
+                    return argumentSet(apiAndVersion.keys().name() + "@v" + apiAndVersion.apiVersion(), responseJson, clientRequest, expectedAtMock, responseJson);
+                });
     }
 
     @NonNull

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -208,6 +208,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
         KafkaRequestDecoder decoder = new KafkaRequestDecoder(dp, virtualCluster.socketFrameMaxSizeBytes(), apiVersionsService, decoderListener);
         pipeline.addLast("requestDecoder", decoder);
         pipeline.addLast("responseEncoder", new KafkaResponseEncoder(encoderListener));
+        pipeline.addLast("saslV0Rejecter", new SaslV0RejectionHandler());
         pipeline.addLast("responseOrderer", new ResponseOrderer());
         if (virtualCluster.isLogFrames()) {
             pipeline.addLast("frameLogger", new LoggingHandler("io.kroxylicious.proxy.internal.DownstreamFrameLogger", LogLevel.INFO));

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/SaslV0RejectionHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/SaslV0RejectionHandler.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.message.SaslHandshakeResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+
+import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.frame.Frame;
+
+/**
+ * Short circuit respond with an error code if we encounter a SASL v0 handshake, logging a meaningful warning and closing
+ * the connection. The handler deregisters itself on the first RPC that is neither an API_VERSIONS request nor a v0 SASL
+ * handshake as we presume we have successfully progressed beyond SASL authentication.
+ * <p>
+ * The proxy currently does not support v0 SASL handshakes where the client sends through SASL messages without framing them using
+ * the Kafka protocol. Support for this is ancient, Kafka 4.0.0 preserved this mechanism due to a decision to support common
+ * clients from 4 years prior to the release (python-kafka). We have also encountered a client (kaf) that configures sarama
+ * to use v0 by default. These interactions resulted in an esoteric looking exception in the proxy when we attempted to decode
+ * the SASL frame as a kafka protocol RPC. So this handler is intended to make it fail early with a clear signal in the proxy logs
+ * and response that we can't handle SASL v0.
+ * </p>
+ */
+public class SaslV0RejectionHandler extends ChannelDuplexHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SaslV0RejectionHandler.class);
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        Frame frame = (Frame) msg;
+        if (frame.apiKeyId() == ApiKeys.SASL_HANDSHAKE.id && frame.apiVersion() == (short) 0) {
+            if (LOGGER.isWarnEnabled()) {
+                LOGGER.warn("{}: SASL V0 handshake is not implemented by the proxy, your client is using an ancient SASL api version", ctx.channel().id());
+            }
+            ctx.writeAndFlush(unsupportedVersionFrame(frame)).addListener(ChannelFutureListener.CLOSE);
+        }
+        else {
+            if (frame.apiKeyId() != ApiKeys.API_VERSIONS.id) {
+                // we have advanced beyond api versions negotiation and are either in a non-v0 sasl negotiation, or some other RPC
+                ctx.channel().pipeline().remove(this);
+            }
+            super.channelRead(ctx, msg);
+        }
+    }
+
+    private static DecodedResponseFrame<SaslHandshakeResponseData> unsupportedVersionFrame(Frame frame) {
+        SaslHandshakeResponseData saslHandshakeResponseData = new SaslHandshakeResponseData();
+        saslHandshakeResponseData.setErrorCode(Errors.UNSUPPORTED_VERSION.code());
+        return new DecodedResponseFrame<>((short) 0, frame.correlationId(),
+                new ResponseHeaderData().setCorrelationId(frame.correlationId()),
+                saslHandshakeResponseData);
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -383,6 +383,7 @@ class KafkaProxyInitializerTest {
     private void verifyEncoderAndOrdererAdded(InOrder orderedVerifyer) {
         orderedVerifyer.verify(channelPipeline).addLast(eq("requestDecoder"), any(ByteToMessageDecoder.class));
         orderedVerifyer.verify(channelPipeline).addLast(eq("responseEncoder"), any(MessageToByteEncoder.class));
+        orderedVerifyer.verify(channelPipeline).addLast(eq("saslV0Rejecter"), any(SaslV0RejectionHandler.class));
         orderedVerifyer.verify(channelPipeline).addLast(eq("responseOrderer"), any(ResponseOrderer.class));
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/SaslV0RejectionHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/SaslV0RejectionHandlerTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.message.SaslHandshakeResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.frame.Frame;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SaslV0RejectionHandlerTest {
+
+    private EmbeddedChannel channel;
+    private SaslV0RejectionHandler saslV0RejectionHandler;
+
+    @BeforeEach
+    void setUp() {
+        saslV0RejectionHandler = new SaslV0RejectionHandler();
+        channel = new EmbeddedChannel(saslV0RejectionHandler);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (channel.isActive()) {
+            channel.finish();
+        }
+    }
+
+    @Test
+    void v0SaslHandshakeRequestRejected() {
+        Frame frame = mock(Frame.class);
+        when(frame.apiVersion()).thenReturn((short) 0);
+        when(frame.apiKeyId()).thenReturn(ApiKeys.SASL_HANDSHAKE.id);
+        when(frame.correlationId()).thenReturn(3);
+        channel.writeOneInbound(frame);
+        Object o = channel.readOutbound();
+        assertThat(o).isInstanceOfSatisfying(DecodedResponseFrame.class, decodedResponseFrame -> {
+            assertThat(decodedResponseFrame.apiVersion()).isEqualTo((short) 0);
+            assertThat(decodedResponseFrame.correlationId()).isEqualTo(3);
+            assertThat(decodedResponseFrame.header()).isEqualTo(new ResponseHeaderData().setCorrelationId(3));
+            assertThat(decodedResponseFrame.body()).isInstanceOfSatisfying(SaslHandshakeResponseData.class, saslHandshakeResponseData -> {
+                assertThat(saslHandshakeResponseData.errorCode()).isEqualTo(Errors.UNSUPPORTED_VERSION.code());
+            });
+        });
+        assertThat(channel.isOpen()).isFalse();
+    }
+
+    public static Stream<Arguments> otherSaslHandshakeRequestVersionsForwarded() {
+        return IntStream.rangeClosed(1, ApiKeys.SASL_HANDSHAKE.latestVersion(true))
+                .mapToObj(i -> Arguments.argumentSet("SASL_HANDSHAKE version " + i, (short) i));
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void otherSaslHandshakeRequestVersionsForwarded(short apiVersion) {
+        Frame frame = mock(Frame.class);
+        when(frame.apiVersion()).thenReturn(apiVersion);
+        when(frame.apiKeyId()).thenReturn(ApiKeys.SASL_HANDSHAKE.id);
+        when(frame.correlationId()).thenReturn(3);
+        channel.writeOneInbound(frame);
+        Object o = channel.readInbound();
+        assertThat(o).isSameAs(frame);
+        assertThat(channel.isOpen()).isTrue();
+        assertThat(channel.outboundMessages()).isEmpty();
+    }
+
+    @EnumSource(value = ApiKeys.class, names = { "SASL_HANDSHAKE" }, mode = EnumSource.Mode.EXCLUDE)
+    @ParameterizedTest
+    void otherRpcsForwarded(ApiKeys apiKeys) {
+        Frame frame = mock(Frame.class);
+        when(frame.apiVersion()).thenReturn((short) 0);
+        when(frame.apiKeyId()).thenReturn(apiKeys.id);
+        when(frame.correlationId()).thenReturn(3);
+        channel.writeOneInbound(frame);
+        Object o = channel.readInbound();
+        assertThat(o).isSameAs(frame);
+        assertThat(channel.isOpen()).isTrue();
+        assertThat(channel.outboundMessages()).isEmpty();
+    }
+
+    @EnumSource(value = ApiKeys.class, names = { "SASL_HANDSHAKE", "API_VERSIONS" }, mode = EnumSource.Mode.EXCLUDE)
+    @ParameterizedTest
+    void handlerDeregisteredOnFirstNonHandshakeRpc(ApiKeys apiKeys) {
+        Frame frame = mock(Frame.class);
+        when(frame.apiVersion()).thenReturn((short) 0);
+        when(frame.apiKeyId()).thenReturn(apiKeys.id);
+        when(frame.correlationId()).thenReturn(3);
+        channel.writeOneInbound(frame);
+        assertThat(channel.pipeline().first()).isNull();
+    }
+
+    @CsvSource({ "SASL_HANDSHAKE,1", "SASL_HANDSHAKE,2" })
+    @ParameterizedTest
+    void handlerDeregisteredOnNonV0HandshakeRpc() {
+        Frame frame = mock(Frame.class);
+        when(frame.apiVersion()).thenReturn((short) 1);
+        when(frame.apiKeyId()).thenReturn(ApiKeys.SASL_HANDSHAKE.id);
+        when(frame.correlationId()).thenReturn(3);
+        channel.writeOneInbound(frame);
+        assertThat(channel.pipeline().first()).isNull();
+    }
+
+    @Test
+    void handlerNotDeregisteredOnApiVersionsRpc() {
+        Frame frame = mock(Frame.class);
+        when(frame.apiVersion()).thenReturn((short) 0);
+        when(frame.apiKeyId()).thenReturn(ApiKeys.API_VERSIONS.id);
+        when(frame.correlationId()).thenReturn(3);
+        channel.writeOneInbound(frame);
+        assertThat(channel.pipeline().first()).isSameAs(saslV0RejectionHandler);
+    }
+
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The proxy does not implement SASL v0, where subsequent SASL packets are sent by the client without any kafka protocol framing. This change makes the proxy fail fast on the handshake request, rather than failing to decode the next frame with a scary stack trace.

The proxy supporting v0 would be something that needs care because we have Filters which deal in SASL inspection. We would need to make these messages available to Filters to inspect/manipulate. So far we have had no requests for SASL v0 support as it is quite ancient, most clients use v1. We discovered that we could not use a client (kaf) out of the box as it defaults to v0, you need to configure it's SASL version to 1.

Relates to #822

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
