### PR TITLE
Sonar is flagging a security alert on the test code.

### DIFF
--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/KafkaClient.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/KafkaClient.java
@@ -6,7 +6,6 @@
 
 package io.kroxylicious.test.client;
 
-import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -223,13 +222,15 @@ public final class KafkaClient implements AutoCloseable {
 
     private static class TrustingTrustManager implements X509TrustManager {
 
+        @SuppressWarnings("java:S4830")
         @Override
         public void checkClientTrusted(X509Certificate[] chain, String authType) {
             // we are trust all - nothing to do.
         }
 
+        @SuppressWarnings("java:S4830")
         @Override
-        public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
+        public void checkServerTrusted(X509Certificate[] chain, String authType) {
             // we are trust all - nothing to do.
         }
 


### PR DESCRIPTION
We deliberately want to trust everything so we disable validation.

### Type of change

- Bugfix

### Description

Stop sonar complaining and raising security alerts see (https://github.com/kroxylicious/kroxylicious/security/code-scanning/23 & https://github.com/kroxylicious/kroxylicious/security/code-scanning/24)

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
