### PR TITLE
Fix the new ClientAuthIT so describeConsumerGroup traces actually get compared.

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/ClientAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/ClientAuthzIT.java
@@ -367,8 +367,7 @@ class ClientAuthzIT extends AuthzIT {
             catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
-            trace("describeConsumerGroup", outcome.map(ClientAuthzIT::cleanConsumerGroupDescription));
-            return outcome;
+            return trace("describeConsumerGroup", outcome.map(ClientAuthzIT::cleanConsumerGroupDescription));
         }
     }
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Fix new the ClientAuthIT added by #3005  so describeConsumerGroup traces actually get compared.

_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
