### PR TITLE
Implement #2891: Improve connection logging in Azure KMS

### DIFF
--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/auth/OauthClientCredentialsTokenService.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/auth/OauthClientCredentialsTokenService.java
@@ -22,6 +22,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -56,6 +59,7 @@ public class OauthClientCredentialsTokenService implements BearerTokenService {
 
     private final Oauth2ClientCredentialsConfig oauth2ClientCredentialsConfig;
     private final Clock clock;
+    private static final Logger LOG = LoggerFactory.getLogger(OauthClientCredentialsTokenService.class);
 
     private final HttpClient httpClient;
 
@@ -115,17 +119,20 @@ public class OauthClientCredentialsTokenService implements BearerTokenService {
 
     private static AccessTokenResponse getAccessTokenResponse(HttpResponse<String> r) {
         if (r.statusCode() != 200) {
+            LOG.warn("GET Microsoft Identity Platform OAuth 2.0 token failed. Received unexpected response code {}", r.statusCode());
             throw new UnexpectedHttpStatusCodeException(r);
         }
         else {
             String body = r.body();
             if (body == null || body.isEmpty()) {
+                LOG.warn("GET Microsoft Identity Platform OAuth 2.0 token failed. Received empty response body");
                 throw new MalformedResponseBodyException("response body is null or empty");
             }
             try {
                 return MAPPER.readValue(body, AccessTokenResponse.class);
             }
             catch (JsonProcessingException e) {
+                LOG.warn("GET Microsoft Identity Platform OAuth 2.0 token failed. Error parsing response body");
                 throw new MalformedResponseBodyException("failed to decode response body", e);
             }
         }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Add WARN-level logging to fail/except conditions in Azure KMS auth classes. Log messages include details of operation being attempted and cause of failure.

### Additional Context

Current logging around auth connections in Azure KMS provider is a bit lacklustre, doesn't give enough clarity on where failures are occurring or why unless log level is turned all the way up (and even then it's still a bit unclear). Adding some specific messaging to the auth failure conditions should help a lot with this.

Resolves #2891.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
