### PR TITLE
OffsetForLeaderEpochAuthzIT: Retry if there are any not-leader errors in test

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/OffsetForLeaderEpochAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/filter/authorization/OffsetForLeaderEpochAuthzIT.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData;
 import org.apache.kafka.common.message.OffsetForLeaderEpochRequestData.OffsetForLeaderTopic;
 import org.apache.kafka.common.message.OffsetForLeaderEpochResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.resource.PatternType;
 import org.apache.kafka.common.resource.ResourcePattern;
 import org.apache.kafka.common.resource.ResourceType;
@@ -151,6 +152,12 @@ class OffsetForLeaderEpochAuthzIT extends AuthzIT {
             OffsetForLeaderTopic topicC = createOffsetForLeaderTopic(EXISTING_TOPIC_NAME, 0, 20);
             offsetForLeaderEpochRequestData.topics().addAll(List.of(topicA, topicB, topicC));
             return offsetForLeaderEpochRequestData;
+        }
+
+        @Override
+        public boolean needsRetry(OffsetForLeaderEpochResponseData response) {
+            return response.topics() != null && response.topics().stream().anyMatch(topicResult -> topicResult.partitions() != null
+                    && topicResult.partitions().stream().anyMatch(epochEndOffset -> Errors.forCode(epochEndOffset.errorCode()) == Errors.NOT_LEADER_OR_FOLLOWER));
         }
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This test [failed](https://github.com/kroxylicious/kroxylicious/actions/runs/20042768851/job/57480923991?pr=2926) non-deterministically in another PR.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
