### PR TITLE
Reduce time for PR checks to complete

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -25,10 +25,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  integration_test_proxy:
+  discover_integration_test_chunks:
     runs-on: ubuntu-latest
-
+    outputs:
+      test_chunks: ${{ steps.discover.outputs.test_chunks }}
     steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: 'Discover ITs'
+        working-directory: kroxylicious-integration-tests
+        id: discover
+        run: |
+          TESTS_PER_CHUNK=5
+          TEST_CHUNKS="[$(find . -type f -name "*IT.java" -exec basename {} .java \; | xargs -L ${TESTS_PER_CHUNK} | tr ' ' , | sed 's/.*/"&"/' | sed -z 's/\n/,/g;s/,$/\n/')]"
+          echo "test_chunks=$TEST_CHUNKS" >> $GITHUB_OUTPUT
+  run_integration_tests:
+    needs: discover_integration_test_chunks
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tests: ${{ fromJson(needs.discover_integration_test_chunks.outputs.test_chunks) }}
+    steps:
+      - name: Log tests to run
+        run: echo "Running tests on classes '${{ matrix.tests }}'"
       - name: 'Check out repository'
         uses: actions/checkout@v6
         with:
@@ -58,7 +79,37 @@ jobs:
           KROXYLICIOUS_KMS_FORTANIX_ADMIN_API_KEY: ${{ secrets.KROXYLICIOUS_KMS_FORTANIX_ADMIN_API_KEY }}
           KROXYLICIOUS_KMS_FORTANIX_API_KEY: ${{ secrets.KROXYLICIOUS_KMS_FORTANIX_API_KEY }}
         working-directory: kroxylicious-integration-tests
-        run: mvn -B verify -DskipUTs
+        run: mvn -B verify -DskipUTs -Dit.test="${{ matrix.tests }}"
+  integration_test_proxy:
+    runs-on: ubuntu-latest
+    needs: run_integration_tests
+    if: always()
+    steps:
+    - name: 'Check all matrix builds'
+      run: ${{!contains(needs.*.result, 'failure')}}
+  integration_test_filter_archetype:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: 'Set up Java'
+        uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: 'temurin'
+      - name: 'Cache Maven packages'
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: 'Build Kroxylicious archetype'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mvn -B install -DskipTests -Dmaven.javadoc.skip=true -DskipDocs=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Djapicmp.skip=true -pl :kroxylicious-bom,:kroxylicious-filter-archetype -am
       - name: 'run filter archetype integration tests'
         working-directory: kroxylicious-filter-archetype
         run: mvn -B verify


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The integration test workflow is taking around 26-28 minutes lately https://github.com/kroxylicious/kroxylicious/actions/workflows/integration-tests.yaml

This change drops that step to ~11 minutes. The slowest parts of the build will now be docker build and sonar completing.

* ~~Parallelize github actions docker builds. This action is taking 20 minutes, lets see if we can halve it by parallelizing the build of the two images.~~ (did not speed anything up, the second image hits the build cache. So to drop the docker build time we need to speed up the mvn build step in the dockerfile (or finish the move to maven-docker).
* Parallelize github actions integration testing. The integration tests are our slowest job at >25minutes. We can speed
    this up by running a matrix of groups of tests. We chunk files named `*IT.java` into groups of 5 and then give each run its own job. This makes the bottleneck the slowest test, the `RecordEncryptionIT` which takes something like 6-7 minutes.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
