### PR TITLE
Topic name retriever return internal future on empty result

### DIFF
--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/FilterContext.java
@@ -127,7 +127,7 @@ public interface FilterContext {
      * {@link TopicNameMappingException} or a name. All failure modes should complete the stage with a TopicNameMapping, with the
      * TopicNameMapping used to convey the reason for failure, rather than failing the Stage.
      * <h4>Chained Computation stages</h4>
-     * <p>Default and asynchronous default computation stages chained to the returned
+     * <p>Asynchronous default computation stages chained to the returned
      * {@link java.util.concurrent.CompletionStage} are guaranteed to be executed by the thread
      * associated with the connection. See {@link io.kroxylicious.proxy.filter} for more details.
      * </p>

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/FilterIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/FilterIT.java
@@ -37,7 +37,6 @@ import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.protocol.types.RawTaggedField;
 import org.apache.kafka.common.serialization.Serdes;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -115,28 +114,6 @@ class FilterIT {
     void filtersCanLookUpEmptyTopicNames(KafkaCluster cluster) {
         NamedFilterDefinition namedFilterDefinition = new NamedFilterDefinitionBuilder(TOPIC_ID_LOOKUP_FILTER_NAME,
                 TopicIdToNameResponseStamper.class.getName())
-                .build();
-        var config = proxy(cluster)
-                .addToFilterDefinitions(namedFilterDefinition)
-                .addToDefaultFilters(namedFilterDefinition.name());
-
-        try (var tester = kroxyliciousTester(config);
-                var client = tester.simpleTestClient()) {
-            MetadataRequestData message = new MetadataRequestData();
-            message.unknownTaggedFields().add(
-                    new RawTaggedField(TopicIdToNameResponseStamper.TOPIC_ID_TAG, ("").getBytes(StandardCharsets.UTF_8)));
-            Response response = client.getSync(new Request(METADATA, METADATA.latestVersion(), "client", message));
-            // checking that the request/response flows through despite requesting an empty topic id list
-            assertThat(response).isNotNull();
-        }
-    }
-
-    @Disabled("this test is non-deterministic, due to the nature of CompletableFuture, it is possible for the calling thread to execute the chained work")
-    @Test
-    void filtersCanLookUpEmptyTopicNamesInitiatedFromNonFilterDispatchThread(KafkaCluster cluster) {
-        NamedFilterDefinition namedFilterDefinition = new NamedFilterDefinitionBuilder(TOPIC_ID_LOOKUP_FILTER_NAME,
-                TopicIdToNameResponseStamper.class.getName())
-                .withConfig("asyncTopicNameLookup", true)
                 .build();
         var config = proxy(cluster)
                 .addToFilterDefinitions(namedFilterDefinition)

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/TopicIdToNameResponseStamper.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/testplugins/TopicIdToNameResponseStamper.java
@@ -12,7 +12,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -47,31 +46,29 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * look up the corresponding topic names for those topic ids. Then when the response is intercepted we will add
  * an unknownTaggedField with id {@link #TOPIC_NAME_TAG} containing a comma-separated set of topic names.
  */
-@Plugin(configType = TopicIdToNameResponseStamper.Config.class)
-public class TopicIdToNameResponseStamper implements FilterFactory<TopicIdToNameResponseStamper.Config, TopicIdToNameResponseStamper.Config> {
+@Plugin(configType = Void.class)
+public class TopicIdToNameResponseStamper implements FilterFactory<Void, Void> {
 
     public static final int TOPIC_ID_TAG = 98;
     public static final int TOPIC_NAME_TAG = 99;
 
     @Override
-    public Config initialize(FilterFactoryContext context, @Nullable Config config) throws PluginConfigurationException {
-        return config == null ? new Config(false) : config;
+    public Void initialize(FilterFactoryContext context, @Nullable Void config) throws PluginConfigurationException {
+        return null;
     }
 
     @Override
-    public Filter createFilter(FilterFactoryContext context, Config initializationData) {
-        return new TopicIdToNameResponseStamperFilter(context.filterDispatchExecutor(), initializationData.asyncTopicNameLookup);
+    public Filter createFilter(FilterFactoryContext context, Void initializationData) {
+        return new TopicIdToNameResponseStamperFilter(context.filterDispatchExecutor());
     }
 
     static class TopicIdToNameResponseStamperFilter implements RequestFilter, ResponseFilter {
 
         private final FilterDispatchExecutor filterDispatchExecutor;
-        private final boolean asyncTopicNameLookup;
         Map<Integer, TopicNameMapping> correlated = new HashMap<>();
 
-        TopicIdToNameResponseStamperFilter(FilterDispatchExecutor filterDispatchExecutor, boolean asyncTopicNameLookup) {
+        TopicIdToNameResponseStamperFilter(FilterDispatchExecutor filterDispatchExecutor) {
             this.filterDispatchExecutor = filterDispatchExecutor;
-            this.asyncTopicNameLookup = asyncTopicNameLookup;
         }
 
         @Override
@@ -83,17 +80,10 @@ public class TopicIdToNameResponseStamper implements FilterFactory<TopicIdToName
             }
 
             Set<Uuid> uuids = Arrays.stream(list.getFirst().split(",")).filter(s -> !s.isEmpty()).map(Uuid::fromString).collect(Collectors.toSet());
-            CompletionStage<TopicNameMapping> topicNameLookup;
-            if (asyncTopicNameLookup) {
-                // this is to demonstrate that the composed future executes chained work in the filter dispatch thread
-                topicNameLookup = CompletableFuture.supplyAsync(() -> null).thenCompose(o -> context.topicNames(uuids));
-            }
-            else {
-                topicNameLookup = context.topicNames(uuids);
-            }
-            return topicNameLookup.thenCompose(topicNames -> {
+            CompletionStage<TopicNameMapping> topicNameLookup = context.topicNames(uuids);
+            return topicNameLookup.thenComposeAsync(topicNames -> {
                 if (!filterDispatchExecutor.isInFilterDispatchThread()) {
-                    throw new IllegalStateException("work chained to topicNames future should execute in filter dispatch thread");
+                    throw new IllegalStateException("async work chained to topic name stage should complete in FilterDispatchExecutor");
                 }
                 correlated.put(header.correlationId(), topicNames);
                 return context.forwardRequest(header, request);


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

In the short-circuit case, the TopicNameRetriever wasn't fulfilling the contract that says that:
```
asynchronous default computation stages chained to the returned
     * {@link java.util.concurrent.CompletionStage} are guaranteed to be executed by the thread
     * associated with the connection
 ```

Using the internal Future gives more guarantees about which executor chained async work executes on. 

But note that it prevents the type of async composition that I had been previously using in the IntegrationTest. See the unit test added to `InternalCompletableFutureTest` demonstrating that our stages are unfriendly for composition.

The internal completion stage also doesn't really give you any guarantees about what thread chained work will execute on if you do not use the async methods. They could execute in the caller thread if the future is already completed.

Also, the '*either*' family of methods (`applyToEither`, `acceptEither` ...) do not necessarily propagate the custom executor. We attempt to achieve this by overriding newIncompleteFuture on InternalCompletableFuture, but the either methods may use the parameter stage to create new result future, avoiding our override.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
