### PR TITLE
fix(system-tests): reduce the strimzi cluster operator recon interval

### DIFF
--- a/kroxylicious-systemtests/src/main/resources/helm_strimzi_overrides.yaml
+++ b/kroxylicious-systemtests/src/main/resources/helm_strimzi_overrides.yaml
@@ -8,3 +8,6 @@
 replicas: 1
 #featureGates: ""
 
+# Reduce full recon interval from 120s to 15s to reduce the risk of a delay in the cluster operator
+# reconciliation leading to a spurious system test suite failure.
+fullReconciliationIntervalMs: 15000


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Bugfix

### Description

In a test environment, we saw `KroxyliciousST#produceAndConsumeMessagesWithTls` timeout awaiting for Strimzi Kafka CR to express its listeners on the status section.  Logs suggested that resource hadn't been reconciled sufficiently quickly.

why: avoid the possibility of a delay in the strimzi reconciling a kafka resource leading to a timeout in the system test suite.


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
