### PR TITLE
Tactical change to enhance cacheability of image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,22 +5,12 @@
 #
 
 FROM registry.access.redhat.com/ubi9/openjdk-17:1.23-6.1764765564 AS builder
+
 ARG TARGETOS
 ARG TARGETARCH
 
 USER root
 WORKDIR /opt/kroxylicious
-
-# obtain a baseline set of maven dependencies in a cacheable layer
-ENV BASELINE_KROXYLICIOUS_VERSION=v0.18.0
-RUN microdnf -y update \
-    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y git \
-    && microdnf clean all \
-    && git clone --depth 1 --branch ${BASELINE_KROXYLICIOUS_VERSION} https://github.com/kroxylicious/kroxylicious && cd kroxylicious \
-    && mvn -q -B clean package -Pdist -Dquick -DskipContainerImageBuild=true -DskipDocs=true -Dmaven.test.skip \
-    && rm -rf ~/.m2/repository/io/kroxylicious \
-    && cd .. \
-    && rm -rf ./kroxylicious
 
 # Download Tini
 ENV TINI_VERSION=v0.19.0

--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -12,17 +12,6 @@ ARG TARGETARCH
 USER root
 WORKDIR /opt/kroxylicious
 
-# obtain a baseline set of maven dependencies in a cacheable layer
-ENV BASELINE_KROXYLICIOUS_VERSION=v0.18.0
-RUN microdnf -y update \
-    && microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y git \
-    && microdnf clean all \
-    && git clone --depth 1 --branch ${BASELINE_KROXYLICIOUS_VERSION} https://github.com/kroxylicious/kroxylicious && cd kroxylicious \
-    && mvn -q -B clean package -Pdist -Dquick -DskipContainerImageBuild=true -DskipDocs=true -Dmaven.test.skip \
-    && rm -rf ~/.m2/repository/io/kroxylicious \
-    && cd .. \
-    && rm -rf ./kroxylicious
-
 # Download Tini
 ENV TINI_VERSION=v0.19.0
 ENV TINI_SHA256_AMD64=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c


### PR DESCRIPTION
### Type of change

- Kludgey build speedup

### Description

Currently docker image building is the slowest step of our PR automation in github. This is because we copy all files in and execute a maven build. These steps are very unfriendly to caching because any source change will invalidate the COPY cache and the subsequent maven build has to start from nothing to download every build dependency.

This change addresses that by introducing a cacheable step that builds a known 'baseline' tag of the proxy to populate all the build dependencies into the maven cache. The end result is the build takes roughly the same amount of time uncached, but on subsequent runs it will be able to lean on the GHA caching for the first layer which acquired the vast majority of build dependencies.

Note that we are really wanting to shuffle to using our maven built images, this is just trying to shave some minutes off the build as it stands.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
