### PR TITLE
Only build amd64 image on PR automation

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -52,12 +52,14 @@ jobs:
             echo "proxy_tags=kroxylicious-proxy:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
             echo "operator_tags=kroxylicious-operator:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
             echo "push_images=false" >> $GITHUB_OUTPUT
+            echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
           else
             PROXY_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.PROXY_IMAGE_NAME }}"
             OPERATOR_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.OPERATOR_IMAGE_NAME }}"
             echo "proxy_tags=${PROXY_IMAGE}:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
             echo "operator_tags=${OPERATOR_IMAGE}:${RELEASE_VERSION},${OPERATOR_IMAGE}:latest" >> $GITHUB_OUTPUT
             echo "push_images=true" >> $GITHUB_OUTPUT
+            echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
           fi
 
       - name: Login to container registry
@@ -72,7 +74,7 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ steps.build_configuration.outputs.platforms }}
           push: ${{ steps.build_configuration.outputs.push_images == 'true' }}
           build-args: |
             KROXYLICIOUS_VERSION=${{ steps.build_configuration.outputs.release_version }}
@@ -85,7 +87,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.operator
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ steps.build_configuration.outputs.platforms }}
           push: ${{ steps.build_configuration.outputs.push_images == 'true' }}
           build-args: |
             KROXYLICIOUS_VERSION=${{ steps.build_configuration.outputs.release_version }}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The docker build is currently our slowest PR check at ~22minutes.

The arm64 image build is quite time consuming, we get most of the automation benefits from building just amd64 on PRs, it's quite rare that we're making architecture-dependant changes (like tini installation etc)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
