### PR TITLE
Fix systemtest logging config

### DIFF
--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/manager/ResourceManager.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/resources/manager/ResourceManager.java
@@ -48,6 +48,7 @@ public class ResourceManager {
     static {
         var shcLogger = LoggerFactory.getLogger(StandardHttpClient.class);
         LOGGER.warn("#3065: Debug enabled for {} : {}", shcLogger.getName(), shcLogger.isDebugEnabled());
+        shcLogger.debug("#3065: Debug log test");
 
         // Belt and brace - log the creates/deletes the resource manager thinks it is making.
         KubeResourceManager.get().addCreateCallback(hm -> {

--- a/kroxylicious-systemtests/src/test/resources/log4j2-test.properties
+++ b/kroxylicious-systemtests/src/test/resources/log4j2-test.properties
@@ -11,9 +11,8 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c:%L - %m%n
 
-rootLogger.level = DEBUG
+rootLogger.level = INFO
 rootLogger.appenderRef.console.ref = STDOUT
-rootLogger.appenderRef.console.level = INFO
 rootLogger.additivity = false
 
 # Debug for https://github.com/kroxylicious/kroxylicious/issues/3065


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

We were setting an INFO log level on the console appenderRef meaning that even though our logger was set to DEBUG nothing was emitted to stdout. With this change we remove the appender threshold and set the root logger to INFO.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
