### PR TITLE
docs(glossary): Glossary of Terms improvements

### DIFF
--- a/kroxylicious-docs/docs/_modules/record-encryption/ref-glossary.adoc
+++ b/kroxylicious-docs/docs/_modules/record-encryption/ref-glossary.adoc
@@ -1,0 +1,10 @@
+:_mod-docs-content-type: REFERENCE
+
+= Glossary
+
+[role="_abstract"]
+Glossary of terms used in the Record Encryption guide.
+
+DEK:: Data Encryption Key, a secret key used to encrypt the kafka records
+KEK:: Key Encryption Key, a secret key that resides within the boundaries of a KMS.
+KMS:: Key Management System. A dedicated system for controlling access to cryptographic material, and providing operations which use that material.

--- a/kroxylicious-docs/docs/_modules/ref-glossary.adoc
+++ b/kroxylicious-docs/docs/_modules/ref-glossary.adoc
@@ -1,3 +1,8 @@
+// This glossary is shared by both proxy and operator.
+// For terms that are applicable to only one guide, use ifeval conditionals.
+// Don't define terms specific to the domain of filters here, use a filter guide specific
+// glossary instead.
+
 :_mod-docs-content-type: REFERENCE
 
 = Glossary
@@ -7,9 +12,10 @@ Glossary of terms used in the Kroxylicious documentation.
 
 API:: Application Programmer Interface.
 CA:: Certificate Authority. An organization that issues certificates.
+ifeval::["{guide}" == "operator"]
 CR:: Custom Resource. An instance resource of a CRD. In other words, a resource of a kind that is not built into Kubernetes.
 CRD:: Custom Resource Definition. A Kubernetes API for defining Kubernetes API extensions.
-KMS:: Key Management System. A dedicated system for controlling access to cryptographic material, and providing operations which use that material.
+endif::[]
 mTLS:: Mutual Transport Layer Security. A configuration of TLS where the client presents a certificate to a server, which the server authenticates.
 TLS:: The Transport Layer Security. A secure transport protocol where a server presents a certificate to a client, which the client authenticates. TLS was previously known as the Secure Sockets Layer (SSL).
 TCP:: The Transmission Control Protocol.

--- a/kroxylicious-docs/docs/kroxylicious-proxy/index.adoc
+++ b/kroxylicious-docs/docs/kroxylicious-proxy/index.adoc
@@ -27,5 +27,7 @@ include::_modules/con-community-filters.adoc[leveloffset=+1]
 //monitoring
 include::_assemblies/assembly-{guide}-monitoring.adoc[leveloffset=+1]
 
+include::_modules/ref-glossary.adoc[leveloffset=+1]
+
 //trademark notices
 include::_assets/trademarks.adoc[leveloffset=+1]

--- a/kroxylicious-docs/docs/record-encryption-guide/index.adoc
+++ b/kroxylicious-docs/docs/record-encryption-guide/index.adoc
@@ -51,3 +51,6 @@ include::_assemblies/assembly-operations-record-encryption-filter.adoc[leveloffs
 
 //trademark notices
 include::_assets/trademarks.adoc[leveloffset=+1]
+
+// glossary
+include::_modules/record-encryption/ref-glossary.adoc[leveloffset=+1]


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

We said a while ago that we valued have a glossary of terms in the project's documentation.  Since then we've added a glossary to the operator documentation and some filters now have their own glossaries, defining terms specific to their domains.

The proxy's guide doesn't have a glossary.

This PR proposes a couple of improvements:

* Make the Operator's glossary into one that is shared by both Proxy and Operation (rationale: many terms will be common to each.  Conditions can be used to exclude definitions that belong to one domain (`CRD` etc).
* Start a Record Encryption glossary where we can define terms like KEK, DEK etc (which resolves the specifics #967)

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
