### PR TITLE
Draft: Explore topic id lookup and caching impacts

### DIFF
--- a/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/proxy/filter/simpletransform/NewCachingProduceRequestTransformation.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/proxy/filter/simpletransform/NewCachingProduceRequestTransformation.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.simpletransform;
+
+import javax.annotation.Nullable;
+
+import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.filter.FilterFactory;
+import io.kroxylicious.proxy.filter.FilterFactoryContext;
+import io.kroxylicious.proxy.filter.simpletransform.ProduceRequestTransformation.Config;
+import io.kroxylicious.proxy.plugin.Plugin;
+import io.kroxylicious.proxy.plugin.Plugins;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A {@link FilterFactory} for {@link ProduceRequestTransformationFilter}.
+ *
+ */
+@Plugin(configType = Config.class)
+public class NewCachingProduceRequestTransformation
+        implements FilterFactory<Config, Config> {
+
+    @Override
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public Filter createFilter(FilterFactoryContext context,
+                               @NonNull Config configuration) {
+        ByteBufferTransformationFactory factory = context.pluginInstance(ByteBufferTransformationFactory.class, configuration.transformation());
+        return new NewCachingProduceRequestTransformationFilter(factory.createTransformation(configuration.transformationConfig()));
+    }
+
+    @Override
+    @SuppressWarnings({ "unchecked" })
+    public @NonNull Config initialize(FilterFactoryContext context, @Nullable Config config) {
+        var result = Plugins.requireConfig(this, config);
+        var transformationFactory = context.pluginInstance(ByteBufferTransformationFactory.class, result.transformation());
+        transformationFactory.validateConfiguration(result.transformationConfig());
+        return result;
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/proxy/filter/simpletransform/NewCachingProduceRequestTransformationFilter.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/proxy/filter/simpletransform/NewCachingProduceRequestTransformationFilter.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.simpletransform;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.compress.Compression;
+import org.apache.kafka.common.errors.UnknownServerException;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.MemoryRecordsBuilder;
+import org.apache.kafka.common.record.MutableRecordBatch;
+import org.apache.kafka.common.record.Record;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.record.TimestampType;
+
+import io.kroxylicious.kafka.transform.ApiVersionsResponseTransformer;
+import io.kroxylicious.kafka.transform.ApiVersionsResponseTransformers;
+import io.kroxylicious.proxy.filter.ApiVersionsResponseFilter;
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.ProduceRequestFilter;
+import io.kroxylicious.proxy.filter.RequestFilterResult;
+import io.kroxylicious.proxy.filter.ResponseFilterResult;
+import io.kroxylicious.proxy.filter.metadata.TopicNameMapping;
+import io.kroxylicious.proxy.filter.metadata.TopicNameMappingException;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A filter for modifying the key/value/header/topic of {@link ApiKeys#PRODUCE} requests.
+ * <p>
+ * <strong>Not intended to production use.</strong>
+ * </p>
+ */
+class NewCachingProduceRequestTransformationFilter implements ProduceRequestFilter, ApiVersionsResponseFilter, TopicNameMapping {
+
+    // downgrade to prevent produce requests with topic ids
+    public static final ApiVersionsResponseTransformer DOWNGRADE_PRODUCE_API = ApiVersionsResponseTransformers.limitMaxVersionForApiKeys(
+            Map.of(ApiKeys.PRODUCE, (short) 12));
+
+    private final Map<Uuid, String> topicIdToNameCache = new HashMap<>();
+    /**
+     * Transformation to be applied to record value.
+     */
+    private final ByteBufferTransformation valueTransformation;
+
+    // TODO: add transformation support for key/header/topic
+
+    NewCachingProduceRequestTransformationFilter(ByteBufferTransformation valueTransformation) {
+        this.valueTransformation = valueTransformation;
+    }
+
+    @Override
+    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData data, FilterContext context) {
+        return applyTransformation(context, header, data);
+    }
+
+    private CompletionStage<RequestFilterResult> applyTransformation(FilterContext ctx, RequestHeaderData header, ProduceRequestData req) {
+        List<Uuid> uuids = req.topicData().stream().map(ProduceRequestData.TopicProduceData::topicId).filter(uuid -> uuid != null && !uuid.equals(Uuid.ZERO_UUID))
+                .toList();
+        boolean allCached = uuids.stream().allMatch(topicIdToNameCache::containsKey);
+        CompletionStage<TopicNameMapping> topicNameMappingCompletionStage = allCached ? CompletableFuture.completedStage(this) : lookupTopicIds(ctx,
+                uuids);
+        return topicNameMappingCompletionStage.thenCompose(topicNameMapping -> {
+            if (topicNameMapping.anyFailures()) {
+                return ctx.requestFilterResultBuilder().errorResponse(header, req, new UnknownServerException("failed to obtain topic ids")).completed();
+            }
+            req.topicData().forEach(topicData -> {
+                for (ProduceRequestData.PartitionProduceData partitionData : topicData.partitionData()) {
+                    MemoryRecords records = (MemoryRecords) partitionData.records();
+                    var stream = ctx.createByteBufferOutputStream(records.sizeInBytes());
+                    try (var newRecords = new MemoryRecordsBuilder(stream, RecordBatch.CURRENT_MAGIC_VALUE, Compression.NONE, TimestampType.CREATE_TIME, 0,
+                            System.currentTimeMillis(), RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, RecordBatch.NO_SEQUENCE, false, false,
+                            RecordBatch.NO_PARTITION_LEADER_EPOCH,
+                            stream.remaining())) {
+
+                        for (MutableRecordBatch batch : records.batches()) {
+                            for (Record batchRecord : batch) {
+                                String topicName = topicData.name() != null && !topicData.name().isEmpty()
+                                        ? topicData.name()
+                                        : topicNameMapping.topicNames().get(topicData.topicId());
+                                if (topicName == null || topicName.isEmpty()) {
+                                    throw new IllegalStateException("topic name is null or empty");
+                                }
+                                newRecords.appendWithOffset(batchRecord.offset(), batchRecord.timestamp(), batchRecord.key(),
+                                        valueTransformation.transform(topicData.name(), batchRecord.value()));
+                            }
+                        }
+
+                        partitionData.setRecords(newRecords.build());
+                    }
+                }
+            });
+            return ctx.forwardRequest(header, req);
+        });
+    }
+
+    @NonNull
+    private CompletionStage<TopicNameMapping> lookupTopicIds(FilterContext ctx, List<Uuid> uuids) {
+        return ctx.topicNames(uuids).whenComplete((topicNameMapping, throwable) -> {
+            topicIdToNameCache.putAll(topicNameMapping.topicNames());
+        });
+    }
+
+    @Override
+    public CompletionStage<ResponseFilterResult> onApiVersionsResponse(short apiVersion, ResponseHeaderData header, ApiVersionsResponseData response,
+                                                                       FilterContext context) {
+        return context.forwardResponse(header, DOWNGRADE_PRODUCE_API.transform(response));
+    }
+
+    @Override
+    public boolean anyFailures() {
+        return false;
+    }
+
+    @Override
+    public Map<Uuid, String> topicNames() {
+        return topicIdToNameCache;
+    }
+
+    @Override
+    public Map<Uuid, TopicNameMappingException> failures() {
+        return Map.of();
+    }
+}

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/proxy/filter/simpletransform/NewProduceRequestTransformation.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/proxy/filter/simpletransform/NewProduceRequestTransformation.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.simpletransform;
+
+import javax.annotation.Nullable;
+
+import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.filter.FilterFactory;
+import io.kroxylicious.proxy.filter.FilterFactoryContext;
+import io.kroxylicious.proxy.filter.simpletransform.ProduceRequestTransformation.Config;
+import io.kroxylicious.proxy.plugin.Plugin;
+import io.kroxylicious.proxy.plugin.Plugins;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A {@link FilterFactory} for {@link ProduceRequestTransformationFilter}.
+ *
+ */
+@Plugin(configType = Config.class)
+public class NewProduceRequestTransformation
+        implements FilterFactory<Config, Config> {
+
+    @Override
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public Filter createFilter(FilterFactoryContext context,
+                               @NonNull Config configuration) {
+        ByteBufferTransformationFactory factory = context.pluginInstance(ByteBufferTransformationFactory.class, configuration.transformation());
+        return new NewProduceRequestTransformationFilter(factory.createTransformation(configuration.transformationConfig()));
+    }
+
+    @Override
+    @SuppressWarnings({ "unchecked" })
+    public @NonNull Config initialize(FilterFactoryContext context, @Nullable Config config) {
+        var result = Plugins.requireConfig(this, config);
+        var transformationFactory = context.pluginInstance(ByteBufferTransformationFactory.class, result.transformation());
+        transformationFactory.validateConfiguration(result.transformationConfig());
+        return result;
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/proxy/filter/simpletransform/NewProduceRequestTransformationFilter.java
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/main/java/io/kroxylicious/proxy/filter/simpletransform/NewProduceRequestTransformationFilter.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter.simpletransform;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.compress.Compression;
+import org.apache.kafka.common.errors.UnknownServerException;
+import org.apache.kafka.common.errors.UnknownTopicIdException;
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.MemoryRecordsBuilder;
+import org.apache.kafka.common.record.MutableRecordBatch;
+import org.apache.kafka.common.record.Record;
+import org.apache.kafka.common.record.RecordBatch;
+import org.apache.kafka.common.record.TimestampType;
+
+import io.kroxylicious.kafka.transform.ApiVersionsResponseTransformer;
+import io.kroxylicious.kafka.transform.ApiVersionsResponseTransformers;
+import io.kroxylicious.proxy.filter.ApiVersionsResponseFilter;
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.ProduceRequestFilter;
+import io.kroxylicious.proxy.filter.RequestFilterResult;
+import io.kroxylicious.proxy.filter.ResponseFilterResult;
+
+/**
+ * A filter for modifying the key/value/header/topic of {@link ApiKeys#PRODUCE} requests.
+ * <p>
+ * <strong>Not intended to production use.</strong>
+ * </p>
+ */
+class NewProduceRequestTransformationFilter implements ProduceRequestFilter, ApiVersionsResponseFilter {
+
+    // downgrade to prevent produce requests with topic ids
+    public static final ApiVersionsResponseTransformer DOWNGRADE_PRODUCE_API = ApiVersionsResponseTransformers.limitMaxVersionForApiKeys(
+            Map.of(ApiKeys.PRODUCE, (short) 12));
+    /**
+     * Transformation to be applied to record value.
+     */
+    private final ByteBufferTransformation valueTransformation;
+
+    // TODO: add transformation support for key/header/topic
+
+    NewProduceRequestTransformationFilter(ByteBufferTransformation valueTransformation) {
+        this.valueTransformation = valueTransformation;
+    }
+
+    @Override
+    public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData data, FilterContext context) {
+        return applyTransformation(context, header, data);
+    }
+
+    private CompletionStage<RequestFilterResult> applyTransformation(FilterContext ctx, RequestHeaderData header, ProduceRequestData req) {
+        List<Uuid> uuids = req.topicData().stream().map(ProduceRequestData.TopicProduceData::topicId).filter(uuid -> uuid != null && !uuid.equals(Uuid.ZERO_UUID))
+                .toList();
+        return ctx.topicNames(uuids).thenCompose(topicNameMapping -> {
+            if (topicNameMapping.anyFailures()) {
+                return ctx.requestFilterResultBuilder().errorResponse(header, req, new UnknownServerException("failed to obtain topic ids")).completed();
+            }
+            req.topicData().forEach(topicData -> {
+                for (ProduceRequestData.PartitionProduceData partitionData : topicData.partitionData()) {
+                    MemoryRecords records = (MemoryRecords) partitionData.records();
+                    var stream = ctx.createByteBufferOutputStream(records.sizeInBytes());
+                    try (var newRecords = new MemoryRecordsBuilder(stream, RecordBatch.CURRENT_MAGIC_VALUE, Compression.NONE, TimestampType.CREATE_TIME, 0,
+                            System.currentTimeMillis(), RecordBatch.NO_PRODUCER_ID, RecordBatch.NO_PRODUCER_EPOCH, RecordBatch.NO_SEQUENCE, false, false,
+                            RecordBatch.NO_PARTITION_LEADER_EPOCH,
+                            stream.remaining())) {
+
+                        for (MutableRecordBatch batch : records.batches()) {
+                            for (Record batchRecord : batch) {
+                                String topicName = topicData.name() != null && !topicData.name().isEmpty() ? topicData.name() : topicNameMapping.topicNames().get(topicData.topicId());
+                                if (topicName == null || topicName.isEmpty()) {
+                                    throw new IllegalStateException("topic name is null or empty");
+                                }
+                                newRecords.appendWithOffset(batchRecord.offset(), batchRecord.timestamp(), batchRecord.key(),
+                                        valueTransformation.transform(topicData.name(), batchRecord.value()));
+                            }
+                        }
+
+                        partitionData.setRecords(newRecords.build());
+                    }
+                }
+            });
+            return ctx.forwardRequest(header, req);
+        });
+    }
+
+    @Override
+    public CompletionStage<ResponseFilterResult> onApiVersionsResponse(short apiVersion, ResponseHeaderData header, ApiVersionsResponseData response,
+                                                                       FilterContext context) {
+        return context.forwardResponse(header, DOWNGRADE_PRODUCE_API.transform(response));
+    }
+}

--- a/kroxylicious-filters/kroxylicious-simple-transform/src/main/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
+++ b/kroxylicious-filters/kroxylicious-simple-transform/src/main/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
@@ -1,2 +1,4 @@
 io.kroxylicious.proxy.filter.simpletransform.ProduceRequestTransformation
+io.kroxylicious.proxy.filter.simpletransform.NewProduceRequestTransformation
+io.kroxylicious.proxy.filter.simpletransform.NewCachingProduceRequestTransformation
 io.kroxylicious.proxy.filter.simpletransform.FetchResponseTransformation

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/SimpleMetric.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/SimpleMetric.java
@@ -31,7 +31,7 @@ public record SimpleMetric(String name, Map<String, String> labels, double value
     // note: RE doesn't handle escaping within label values
     @SuppressWarnings("java:S5852") //
     private static final Pattern PROM_TEXT_EXPOSITION_PATTERN = Pattern
-            .compile("^(?<metric>[a-zA-Z_:][a-zA-Z0-9_:]*)(\\{(?<labels>.*)})?[\\t ]*(?<value>[0-9E.]*)[\\t ]*(?<timestamp>\\d+)?$");
+            .compile("^(?<metric>[a-zA-Z_:][a-zA-Z0-9_:]*)(\\{(?<labels>.*)})?[\\t ]*(?<value>[0-9E\\-.]*)[\\t ]*(?<timestamp>\\d+)?$");
     private static final Pattern NAME_WITH_QUOTED_VALUE = Pattern.compile("^(?<name>[a-zA-Z_:][a-zA-Z0-9_:]*)=\"(?<value>.*)\"$");
 
     private record LineMatcher(String line, Matcher matcher) {}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/MetadataTimingIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/proxy/MetadataTimingIT.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.message.ProduceResponseData;
+import org.apache.kafka.common.protocol.Errors;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.google.common.base.Stopwatch;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+
+import io.kroxylicious.proxy.config.NamedFilterDefinition;
+import io.kroxylicious.proxy.config.NamedFilterDefinitionBuilder;
+import io.kroxylicious.proxy.filter.simpletransform.NewCachingProduceRequestTransformation;
+import io.kroxylicious.proxy.filter.simpletransform.NewProduceRequestTransformation;
+import io.kroxylicious.proxy.filter.simpletransform.UpperCasing;
+import io.kroxylicious.test.Request;
+import io.kroxylicious.test.Response;
+import io.kroxylicious.test.client.KafkaClient;
+import io.kroxylicious.test.record.RecordTestUtils;
+import io.kroxylicious.test.tester.KroxyliciousTester;
+import io.kroxylicious.test.tester.KroxyliciousTesters;
+import io.kroxylicious.test.tester.SimpleMetric;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
+import io.kroxylicious.testing.kafka.junit5ext.Topic;
+
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
+import static org.apache.kafka.common.protocol.ApiKeys.PRODUCE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(KafkaClusterExtension.class)
+public class MetadataTimingIT {
+
+    public static final int REPETITIONS = 25000;
+
+    public static Stream<Arguments> measureLatency() {
+        return Stream.of(Arguments.of(NewProduceRequestTransformation.class.getName(), 0),
+                Arguments.of(NewProduceRequestTransformation.class.getName(), 1),
+                Arguments.of(NewProduceRequestTransformation.class.getName(), 5),
+                Arguments.of(NewCachingProduceRequestTransformation.class.getName(), 0),
+                Arguments.of(NewCachingProduceRequestTransformation.class.getName(), 1),
+                Arguments.of(NewCachingProduceRequestTransformation.class.getName(), 5));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void measureLatency(String filterClass, int numFilters, KafkaCluster cluster, Topic topic) {
+        runExperiment(filterClass, numFilters, cluster, topic, true);
+        runExperiment(filterClass, numFilters, cluster, topic, false);
+    }
+
+    private static void runExperiment(String filterClass, int numFilters, KafkaCluster cluster, Topic topic, boolean warmup) {
+        Request request = createProduceRequest(topic.topicId().orElseThrow());
+        var config = proxy(cluster);
+        for (int i = 0; i < numFilters; i++) {
+            NamedFilterDefinition namedFilterDefinition = new NamedFilterDefinitionBuilder(filterClass + "-" + i,
+                    filterClass)
+                    .withConfig("transformation", UpperCasing.class.getName())
+                    .withConfig("transformationConfig", Map.of("charset", "UTF8")).build();
+            config.addToFilterDefinitions(namedFilterDefinition)
+                    .addToDefaultFilters(namedFilterDefinition.name());
+        }
+        config.withNewManagement().withNewEndpoints().withNewPrometheus().endPrometheus().endEndpoints().endManagement();
+        try (KroxyliciousTester kroxyliciousTester = KroxyliciousTesters.kroxyliciousTester(config);
+                KafkaClient kafkaClient = kroxyliciousTester.simpleTestClient()) {
+            repeatWithStatistics(filterClass, numFilters, kafkaClient, client -> {
+                Response response = client.getSync(request);
+                assertThat(response.payload().message()).isInstanceOfSatisfying(ProduceResponseData.class,
+                        produceResponseData -> assertThat(produceResponseData.responses()).allSatisfy(
+                                topicProduceResponse -> assertThat(topicProduceResponse.partitionResponses()).allSatisfy(
+                                        topicProduceResponsePartitionResponse -> assertThat(Errors.forCode(topicProduceResponsePartitionResponse.errorCode())).isEqualTo(
+                                                Errors.NONE))));
+            }, kroxyliciousTester, warmup);
+        }
+    }
+
+    private static void repeatWithStatistics(String filterClass, int numFilters, KafkaClient client, Consumer<KafkaClient> clientConsumer,
+                                             KroxyliciousTester kroxyliciousTester, boolean warmup) {
+        MeterRegistry registry = Metrics.globalRegistry;
+        Timer.Builder builder = Timer.builder("metadata-timing").publishPercentiles(0.95, 0.99, 0.999);
+        Timer timer = builder.register(registry);
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        for (int i = 0; i < MetadataTimingIT.REPETITIONS; i++) {
+            stopwatch.reset();
+            stopwatch.start();
+            clientConsumer.accept(client);
+            stopwatch.stop();
+            timer.record(stopwatch.elapsed());
+        }
+        if (!warmup) {
+            emitMetrics(filterClass, numFilters, kroxyliciousTester);
+        }
+    }
+
+    private static void emitMetrics(String filterClass, int numFilters, KroxyliciousTester kroxyliciousTester) {
+        List<SimpleMetric> simpleMetrics = kroxyliciousTester.getManagementClient().scrapeMetrics();
+        double sentProduceRequests = simpleMetrics.stream().filter(metricName("kroxylicious_proxy_to_server_request_total"))
+                .filter(hasLabel("api_key", "PRODUCE")).mapToDouble(SimpleMetric::value).sum();
+        double sentMetadataRequests = simpleMetrics.stream().filter(metricName("kroxylicious_proxy_to_server_request_total"))
+                .filter(hasLabel("api_key", "METADATA")).mapToDouble(SimpleMetric::value).sum();
+        double receivedProduceResponses = simpleMetrics.stream().filter(metricName("kroxylicious_server_to_proxy_response_total"))
+                .filter(hasLabel("api_key", "PRODUCE")).mapToDouble(SimpleMetric::value).sum();
+        double receivedMetadataResponses = simpleMetrics.stream().filter(metricName("kroxylicious_server_to_proxy_response_total"))
+                .filter(hasLabel("api_key", "METADATA")).mapToDouble(SimpleMetric::value).sum();
+        double experimentSendCount = simpleMetrics.stream().filter(metricName("metadata_timing_seconds_count"))
+                .mapToDouble(SimpleMetric::value).sum();
+        double experimentSend999pSeconds = simpleMetrics.stream().filter(metricName("metadata_timing_seconds"))
+                .filter(hasLabel("quantile", "0.999"))
+                .mapToDouble(SimpleMetric::value).sum();
+        double experimentSend99pSeconds = simpleMetrics.stream().filter(metricName("metadata_timing_seconds"))
+                .filter(hasLabel("quantile", "0.99"))
+                .mapToDouble(SimpleMetric::value).sum();
+        double experimentSend95pSeconds = simpleMetrics.stream().filter(metricName("metadata_timing_seconds"))
+                .filter(hasLabel("quantile", "0.95"))
+                .mapToDouble(SimpleMetric::value).sum();
+        double experimentSendMaxSeconds = simpleMetrics.stream().filter(metricName("metadata_timing_seconds_max"))
+                .mapToDouble(SimpleMetric::value).sum();
+        Stream<?> data = Stream.of(filterClass, numFilters, sentProduceRequests, sentMetadataRequests, receivedProduceResponses, receivedMetadataResponses,
+                experimentSendCount, experimentSend999pSeconds, experimentSend99pSeconds, experimentSend95pSeconds, experimentSendMaxSeconds);
+        System.out.println(data.map(Objects::toString).collect(Collectors.joining(",")));
+    }
+
+    private static Predicate<SimpleMetric> hasLabel(String key, String expectedValue) {
+        return simpleMetric -> simpleMetric.labels().containsKey(key) && simpleMetric.labels().get(key).equals(expectedValue);
+    }
+
+    private static Predicate<SimpleMetric> metricName(String name) {
+        return simpleMetric -> simpleMetric.name().equals(name);
+    }
+
+    private static Request createProduceRequest(Uuid topicId) {
+        ProduceRequestData produceRequest = new ProduceRequestData();
+        produceRequest.setAcks((short) 1);
+        ProduceRequestData.TopicProduceData topicProduceData = new ProduceRequestData.TopicProduceData();
+        topicProduceData.setName(null);
+        topicProduceData.setTopicId(topicId);
+        ProduceRequestData.PartitionProduceData data = new ProduceRequestData.PartitionProduceData();
+        data.setIndex(0);
+        data.setRecords(RecordTestUtils.singleElementMemoryRecords("k", "v"));
+        topicProduceData.partitionData().add(data);
+        ProduceRequestData.TopicProduceDataCollection coll = new ProduceRequestData.TopicProduceDataCollection();
+        coll.mustAdd(topicProduceData);
+        produceRequest.setTopicData(coll);
+        return new Request(PRODUCE, (short) 13, "client", produceRequest);
+    }
+
+}


### PR DESCRIPTION
### Type of change

This is an exploratory PR just to share some findings.

We currently have:
1. Many filters that downgrade the max supported Produce request api version as they do not yet tolerate topic ids. Their logic is in terms of topic names.
2. A method on FilterContext for mapping topicIds to topicNames. This will naively send a Metadata request upstream, there is no caching in the framework.

It's reasonably easy to envisage multiple filters in the chain all needing to access the topic name for a single RPC. So we have this concern that each Filter will make it's own call out for Metadata, despite an earlier RPC already retrieving it, adding more overhead. Generally it's a quite cacheable piece of information, the UUID is unique and should only reference a single topic name (unless Kafka implemented topic renaming, which I believe Keith saw mentioned in a KIP).

This PR is trying to generate some more data to help inform the outcome. In the PR we implement two new variations of the simple Produce transform filter.

1. Uncached. It always looks up Metadata from upstream on every RPC.
2. Cached. We maintain a cache from topic id to name per Filter instance.

And we also vary the number of these Filters that are in the chain. 0, 1 and 5 instances. This lets us compare the performance when the proxy has no filters, a single filter, and multiple filters interested in the topic names.

### Results

|filterClass                                                                        |numFilters|sentProduceRequests|sentMetadataRequests|receivedProduceResponses|receivedMetadataResponses|experimentSendCount|experimentSend999pSeconds|experimentSend99pSeconds|experimentSend95pSeconds|experimentSendMaxSeconds|
|-----------------------------------------------------------------------------------|----------|-------------------|--------------------|------------------------|-------------------------|-------------------|-------------------------|------------------------|------------------------|------------------------|
|NewProduceRequestTransformation       |0         |25000.0            |0.0                 |25000.0                 |0.0                      |25000.0            |0.00221184               |8.02816E-4              |5.7344E-4               |0.031815966             |
|NewProduceRequestTransformation       |1         |25000.0            |25000.0             |25000.0                 |25000.0                  |25000.0            |0.00352256               |0.001359872             |9.99424E-4              |0.03231409              |
|NewProduceRequestTransformation       |5         |25000.0            |125000.0            |25000.0                 |125000.0                 |25000.0            |0.01409024               |0.003080192             |0.00229376              |0.015890285             |
|NewCachingProduceRequestTransformation|0         |25000.0            |0.0                 |25000.0                 |0.0                      |25000.0            |0.00221184               |6.71744E-4              |5.7344E-4               |0.032918484             |
|NewCachingProduceRequestTransformation|1         |25000.0            |1.0                 |25000.0                 |1.0                      |25000.0            |0.002342912              |8.02816E-4              |7.04512E-4              |0.030812192             |
|NewCachingProduceRequestTransformation|5         |25000.0            |5.0                 |25000.0                 |5.0                      |25000.0            |0.005210112              |0.001343488             |0.001081344             |0.012782503             |

<img width="1075" height="664" alt="chart" src="https://github.com/user-attachments/assets/81fcfadf-d308-4069-8d7f-3681500f378a" />

So the cost of an upstream Metadata lookup appears quite tiny for my unrealistic test setup, single-node Kafka, in-process, with a single topic. In a real setup I'd expect it to be more impactful with network overheads etc. Still we can see the caching impact on the quantiles especially with the 5-filter experiments.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
