### PR TITLE
feat(record-encryption): decrypt share fetch responses

### DIFF
--- a/kroxylicious-filters/kroxylicious-record-encryption/etc/module-layering.xml
+++ b/kroxylicious-filters/kroxylicious-record-encryption/etc/module-layering.xml
@@ -24,6 +24,8 @@
     <allow pkg="org.apache.kafka.common.message" local-only="true"/>
     <allow pkg="org.apache.kafka.common.record" local-only="true"/>
     <allow pkg="org.apache.kafka.common.errors" local-only="true"/>
+    <allow pkg="org.apache.kafka.common" local-only="true"/>
+    <allow pkg="org.apache.kafka.common.utils" local-only="true"/>
     <allow pkg="org.apache.kafka.common.protocol" local-only="true"/>
     <allow pkg="io.kroxylicious.proxy.filter" local-only="true"/> <!-- the filter api -->
     <allow pkg="io.kroxylicious.proxy.plugin" local-only="true"/> <!-- the plugin api -->

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/RecordEncryptionFilterTest.java
@@ -20,9 +20,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
 import org.apache.kafka.common.InvalidRecordException;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.compress.Compression;
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.errors.NetworkException;
@@ -36,6 +38,8 @@ import org.apache.kafka.common.message.ProduceRequestData.PartitionProduceData;
 import org.apache.kafka.common.message.ProduceRequestData.TopicProduceData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.message.ShareFetchResponseData;
+import org.apache.kafka.common.message.ShareFetchResponseData.ShareFetchableTopicResponse;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.protocol.Errors;
@@ -76,6 +80,8 @@ import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.filter.RequestFilterResultBuilder;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
 import io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage;
+import io.kroxylicious.proxy.filter.metadata.TopicNameMapping;
+import io.kroxylicious.proxy.filter.metadata.TopicNameMappingException;
 import io.kroxylicious.test.record.RecordTestUtils;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -100,7 +106,9 @@ import static org.mockito.Mockito.when;
 class RecordEncryptionFilterTest {
 
     private static final String UNRESOLVED_TOPIC = "unresolved";
+    private static final Uuid UNRESOLVED_TOPIC_ID = Uuid.randomUuid();
     private static final String ENCRYPTED_TOPIC = "encrypt_me";
+    private static final Uuid ENCRYPTED_TOPIC_ID = Uuid.randomUuid();
     private static final String KEK_ID_1 = "KEK-ID-1";
     private static final byte[] HELLO_PLAIN_WORLD = "Hello World".getBytes(UTF_8);
     private static final byte[] HELLO_CIPHER_WORLD = "Hello Ciphertext World!".getBytes(UTF_8);
@@ -251,7 +259,7 @@ class RecordEncryptionFilterTest {
         verify(encryptionManager).encrypt(any(), anyInt(), any(),
                 argThat(records -> assertThat(records.records())
                         .hasSize(1)
-                        .allSatisfy(record -> assertThat(record.value()).isEqualTo(ByteBuffer.wrap(HELLO_CIPHER_WORLD)))),
+                        .allSatisfy(kafkaRecord -> assertThat(kafkaRecord.value()).isEqualTo(ByteBuffer.wrap(HELLO_CIPHER_WORLD)))),
                 any());
     }
 
@@ -300,6 +308,23 @@ class RecordEncryptionFilterTest {
         // Then
         verify(context).forwardResponse(any(ResponseHeaderData.class), assertArg(actualFetchResponse -> assertThat(actualFetchResponse)
                 .isInstanceOf(FetchResponseData.class).isEqualTo(fetchResponseData)));
+    }
+
+    @Test
+    void shouldPassThroughUnencryptedShareRecords() {
+        // Given
+        givenTopicNameMapping(Set.of(UNRESOLVED_TOPIC_ID), Map.of(UNRESOLVED_TOPIC_ID, UNRESOLVED_TOPIC));
+        var fetchResponseData = buildShareFetchResponseData(new ShareFetchableTopicResponse()
+                .setTopicId(UNRESOLVED_TOPIC_ID)
+                .setPartitions(List.of(new ShareFetchResponseData.PartitionData().setRecords(makeRecord(HELLO_PLAIN_WORLD)))));
+
+        // When
+        encryptionFilter.onShareFetchResponse(ShareFetchResponseData.HIGHEST_SUPPORTED_VERSION,
+                new ResponseHeaderData(), fetchResponseData, context);
+
+        // Then
+        verify(context).forwardResponse(any(ResponseHeaderData.class), assertArg(actualFetchResponse -> assertThat(actualFetchResponse)
+                .isInstanceOf(ShareFetchResponseData.class).isEqualTo(fetchResponseData)));
     }
 
     @Test
@@ -360,6 +385,72 @@ class RecordEncryptionFilterTest {
     }
 
     @Test
+    void shouldPropagateShareResponseExceptions() {
+        // Given
+        givenTopicNameMapping(Set.of(ENCRYPTED_TOPIC_ID), Map.of(ENCRYPTED_TOPIC_ID, ENCRYPTED_TOPIC));
+        var fetchResponseData = buildShareFetchResponseData(new ShareFetchableTopicResponse()
+                .setTopicId(ENCRYPTED_TOPIC_ID)
+                .setPartitions(List.of(new ShareFetchResponseData.PartitionData().setRecords(makeRecord(HELLO_CIPHER_WORLD)))));
+        RuntimeException exception = new RuntimeException("boom");
+        when(decryptionManager.decrypt(any(), anyInt(), any(), any())).thenReturn(CompletableFuture.failedFuture(exception));
+
+        // When
+        CompletionStage<ResponseFilterResult> stage = encryptionFilter.onShareFetchResponse(ShareFetchResponseData.HIGHEST_SUPPORTED_VERSION,
+                new ResponseHeaderData(), fetchResponseData, context);
+
+        // Then
+        assertThat(stage).failsWithin(Duration.ZERO).withThrowableThat().isInstanceOf(ExecutionException.class).havingCause().isSameAs(exception);
+    }
+
+    @Test
+    void topicNameMappingLookupFailureOnShareFetch() {
+        // Given
+        givenTopicNameMappingFailure(Set.of(ENCRYPTED_TOPIC_ID), Errors.UNKNOWN_TOPIC_OR_PARTITION);
+        var fetchResponseData = buildShareFetchResponseData(new ShareFetchableTopicResponse()
+                .setTopicId(ENCRYPTED_TOPIC_ID)
+                .setPartitions(List.of(new ShareFetchResponseData.PartitionData().setRecords(makeRecord(HELLO_PLAIN_WORLD)))));
+
+        // When
+        CompletionStage<ResponseFilterResult> stage = encryptionFilter.onShareFetchResponse(ShareFetchResponseData.HIGHEST_SUPPORTED_VERSION,
+                new ResponseHeaderData(), fetchResponseData, context);
+
+        // Then
+        assertThat(stage).succeedsWithin(Duration.ZERO);
+
+        verify(context).forwardResponse(any(ResponseHeaderData.class), assertArg(actualFetchResponse -> assertThat(actualFetchResponse)
+                .asInstanceOf(InstanceOfAssertFactories.type(ShareFetchResponseData.class))
+                .satisfies(frd -> assertThat(frd.errorCode()).isEqualTo(Errors.NONE.code()))
+                .extracting(ShareFetchResponseData::responses)
+                .satisfies(ftr -> {
+                    assertThat(ftr).hasSize(1);
+                    for (ShareFetchableTopicResponse topicResponse : ftr) {
+                        assertThat(topicResponse.partitions()).hasSize(1).allSatisfy(partitionData -> {
+                            assertThat(partitionData.errorCode()).isEqualTo(Errors.UNKNOWN_TOPIC_OR_PARTITION.code());
+                        });
+                    }
+                })));
+    }
+
+    private void givenTopicNameMappingFailure(Set<Uuid> failedTopicIds, final Errors error) {
+        when(context.topicNames(failedTopicIds)).thenReturn(CompletableFuture.completedFuture(new TopicNameMapping() {
+            @Override
+            public boolean anyFailures() {
+                return true;
+            }
+
+            @Override
+            public Map<Uuid, String> topicNames() {
+                return Map.of();
+            }
+
+            @Override
+            public Map<Uuid, TopicNameMappingException> failures() {
+                return failedTopicIds.stream().collect(Collectors.toMap(id -> id, id -> new TopicNameMappingException(error)));
+            }
+        }));
+    }
+
+    @Test
     void shouldPropagateUnknownKeyToClientAsResourceUnknownError() {
         // Given
         var fetchResponseData = buildFetchResponseData(new FetchableTopicResponse()
@@ -381,6 +472,32 @@ class RecordEncryptionFilterTest {
                 .extracting(FetchResponseData::responses, InstanceOfAssertFactories.list(FetchResponseData.FetchableTopicResponse.class))
                 .singleElement()
                 .satisfies(ftr -> assertHasSingleEmptyPartitionData(ftr, ENCRYPTED_TOPIC, Errors.RESOURCE_NOT_FOUND))));
+    }
+
+    @Test
+    void shouldPropagateUnknownKeyToClientAsResourceUnknownErrorShareFetch() {
+        // Given
+        givenTopicNameMapping(Set.of(ENCRYPTED_TOPIC_ID), Map.of(ENCRYPTED_TOPIC_ID, ENCRYPTED_TOPIC));
+        var fetchResponseData = buildShareFetchResponseData(new ShareFetchableTopicResponse()
+                .setTopicId(ENCRYPTED_TOPIC_ID)
+                .setPartitions(List.of(new ShareFetchResponseData.PartitionData().setRecords(makeRecord(HELLO_CIPHER_WORLD)))));
+        RuntimeException exception = new UnknownKeyException("boom");
+        when(decryptionManager.decrypt(any(), anyInt(), any(), any())).thenReturn(CompletableFuture.failedFuture(exception));
+
+        // When
+        CompletionStage<ResponseFilterResult> stage = encryptionFilter.onShareFetchResponse(ShareFetchResponseData.HIGHEST_SUPPORTED_VERSION,
+                new ResponseHeaderData(), fetchResponseData, context);
+
+        // Then
+        assertThat(stage).succeedsWithin(Duration.ZERO);
+
+        verify(context).forwardResponse(any(ResponseHeaderData.class), assertArg(actualFetchResponse -> assertThat(actualFetchResponse)
+                .asInstanceOf(InstanceOfAssertFactories.type(ShareFetchResponseData.class))
+                .satisfies(frd -> assertThat(frd.errorCode()).isEqualTo(Errors.NONE.code()))
+                .extracting(shareFetchResponseData -> shareFetchResponseData.responses().stream().toList(),
+                        InstanceOfAssertFactories.list(ShareFetchableTopicResponse.class))
+                .singleElement()
+                .satisfies(ftr -> assertHasSingleEmptyPartitionData(ftr, ENCRYPTED_TOPIC_ID, Errors.RESOURCE_NOT_FOUND))));
     }
 
     @Test
@@ -416,8 +533,53 @@ class RecordEncryptionFilterTest {
         ));
     }
 
+    @Test
+    void shouldIdentifyTheTopicPartitionThatSufferedUnknownKeyShareFetch() {
+        // Given
+        Uuid anotherTopicId = Uuid.randomUuid();
+        String anotherTopicName = "anotherTopic";
+        givenTopicNameMapping(Set.of(anotherTopicId, ENCRYPTED_TOPIC_ID), Map.of(anotherTopicId, anotherTopicName, ENCRYPTED_TOPIC_ID, ENCRYPTED_TOPIC));
+        var missingKeyResponse = new ShareFetchableTopicResponse()
+                .setTopicId(ENCRYPTED_TOPIC_ID)
+                .setPartitions(List.of(new ShareFetchResponseData.PartitionData().setRecords(makeRecord(HELLO_CIPHER_WORLD))));
+        var anotherResponse = new ShareFetchableTopicResponse()
+                .setTopicId(anotherTopicId)
+                .setPartitions(List.of(new ShareFetchResponseData.PartitionData().setRecords(makeRecord(HELLO_CIPHER_WORLD))));
+
+        var fetchResponseData = buildShareFetchResponseData(anotherResponse, missingKeyResponse);
+        RuntimeException exception = new UnknownKeyException("boom");
+        when(decryptionManager.decrypt(eq(ENCRYPTED_TOPIC), anyInt(), any(), any())).thenReturn(CompletableFuture.failedFuture(exception));
+        when(decryptionManager.decrypt(eq(anotherTopicName), anyInt(), any(), any())).thenReturn(CompletableFuture.completedStage(makeRecord(HELLO_PLAIN_WORLD)));
+
+        // When
+        CompletionStage<ResponseFilterResult> stage = encryptionFilter.onShareFetchResponse(ShareFetchResponseData.HIGHEST_SUPPORTED_VERSION,
+                new ResponseHeaderData(), fetchResponseData, context);
+
+        // Then
+        assertThat(stage).succeedsWithin(Duration.ZERO);
+
+        verify(context).forwardResponse(any(ResponseHeaderData.class), assertArg(actualFetchResponse -> assertThat(actualFetchResponse)
+                .asInstanceOf(InstanceOfAssertFactories.type(ShareFetchResponseData.class))
+                .satisfies(frd -> assertThat(frd.errorCode()).isEqualTo(Errors.NONE.code()))
+                .extracting(shareFetchResponseData -> shareFetchResponseData.responses().stream().toList(),
+                        InstanceOfAssertFactories.list(ShareFetchableTopicResponse.class))
+                .hasSize(2)
+                .satisfies(ftr -> assertHasSingleEmptyPartitionData(ftr, anotherTopicId, Errors.NONE), atIndex(0))
+                .satisfies(ftr -> assertHasSingleEmptyPartitionData(ftr, ENCRYPTED_TOPIC_ID, Errors.RESOURCE_NOT_FOUND), atIndex(1))));
+    }
+
     private static void assertHasSingleEmptyPartitionData(FetchableTopicResponse ftr, String expectedTopicName, Errors expectedError) {
         assertThat(ftr.topic()).isEqualTo(expectedTopicName);
+        assertThat(ftr.partitions())
+                .singleElement()
+                .satisfies(pd -> {
+                    assertThat(pd.errorCode()).isEqualTo(expectedError.code());
+                    assertThat(pd.records()).isSameAs(MemoryRecords.EMPTY);
+                });
+    }
+
+    private static void assertHasSingleEmptyPartitionData(ShareFetchableTopicResponse ftr, Uuid expectedTopicId, Errors expectedError) {
+        assertThat(ftr.topicId()).isEqualTo(expectedTopicId);
         assertThat(ftr.partitions())
                 .singleElement()
                 .satisfies(pd -> {
@@ -546,8 +708,33 @@ class RecordEncryptionFilterTest {
         return resultBuilder;
     }
 
+    private void givenTopicNameMapping(Set<Uuid> unresolvedTopicId, Map<Uuid, String> mapping) {
+        when(context.topicNames(unresolvedTopicId)).thenReturn(CompletableFuture.completedFuture(new TopicNameMapping() {
+            @Override
+            public boolean anyFailures() {
+                return false;
+            }
+
+            @Override
+            public Map<Uuid, String> topicNames() {
+                return mapping;
+            }
+
+            @Override
+            public Map<Uuid, TopicNameMappingException> failures() {
+                return Map.of();
+            }
+        }));
+    }
+
     private static FetchResponseData buildFetchResponseData(FetchableTopicResponse... topicResponses) {
         var data = new FetchResponseData();
+        data.responses().addAll(Arrays.asList(topicResponses));
+        return data;
+    }
+
+    private static ShareFetchResponseData buildShareFetchResponseData(ShareFetchableTopicResponse... topicResponses) {
+        var data = new ShareFetchResponseData();
         data.responses().addAll(Arrays.asList(topicResponses));
         return data;
     }

--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -217,6 +217,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-server-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-group-coordinator</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j2-impl</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,16 @@
                 <version>${kafka.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-server-common</artifactId>
+                <version>${kafka.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-group-coordinator</artifactId>
+                <version>${kafka.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-bom</artifactId>
                 <version>${log4j.version}</version>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The Record Encryption Filter decrypts Share fetch response data for encrypted topics

Apache Kafka is about to promote Queues for Kafka to stable in 4.2. We want Share Consumers to be able to consume from encrypted topics via the Proxy and receive decrypted content.

edit: This currently does not cache topic id -> name lookups, I think we should either merge #3099 or implement caching within the Filter implementation before merging.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
