### PR TITLE
Cache topic name lookups per Virtual Cluster (alternative)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#3112](https://github.com/kroxylicious/kroxylicious/pull/3112): cache topic name lookups per VirtualCluster
 * [#3129](https://github.com/kroxylicious/kroxylicious/pull/3129): build(deps): bump netty.version from 4.2.7.Final to 4.2.9.Final
 * [#2969](https://github.com/kroxylicious/kroxylicious/issues/2969): Give `ResponseFilter#onResponse` access to the api-version
 * [#3035](https://github.com/kroxylicious/kroxylicious/issues/3035): fix(sasl inspector): Fix config parsing error if SaslInspector with subject builder

--- a/kroxylicious-runtime/pom.xml
+++ b/kroxylicious-runtime/pom.xml
@@ -65,6 +65,10 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/CacheConfiguration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/CacheConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Cache Configuration
+ * @param maxSize the maximum number of entries the cache may contain, default (null) means no maximum
+ * @param expireAfterWrite cache entries should be automatically removed from the cache once this duration has elapsed after the entry's creation, or the most recent replacement of its value. The default is to never expire.
+ * @param expireAfterAccess cache entries should be automatically removed from the cache once this duration has elapsed after the entry's creation, creation, the most recent replacement of its value, or its last access. The default is 1 hour.
+ */
+public record CacheConfiguration(@Nullable Integer maxSize,
+                                 @JsonSerialize(using = DurationSerde.Serializer.class) @JsonDeserialize(using = DurationSerde.Deserializer.class) @Nullable Duration expireAfterWrite,
+                                 @JsonSerialize(using = DurationSerde.Serializer.class) @JsonDeserialize(using = DurationSerde.Deserializer.class) @Nullable Duration expireAfterAccess) {
+
+    public static CacheConfiguration DEFAULT = new CacheConfiguration(null, null, null);
+
+    @Override
+    public Duration expireAfterAccess() {
+        return expireAfterAccess == null ? Duration.of(1L, ChronoUnit.HOURS) : expireAfterAccess;
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/Configuration.java
@@ -133,6 +133,7 @@ public record Configuration(
                 virtualCluster.logNetwork(),
                 virtualCluster.logFrames(),
                 filterDefinitions,
+                virtualCluster.topicNameCacheConfig(),
                 virtualCluster.subjectBuilder());
 
         addGateways(virtualCluster.gateways(), virtualClusterModel);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/VirtualCluster.java
@@ -33,7 +33,8 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
                              boolean logNetwork,
                              boolean logFrames,
                              @Nullable List<String> filters,
-                             @Nullable TransportSubjectBuilderConfig subjectBuilder) {
+                             @Nullable TransportSubjectBuilderConfig subjectBuilder,
+                             @Nullable CacheConfiguration topicNameCache) {
 
     private static final Pattern DNS_LABEL_PATTERN = Pattern.compile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", Pattern.CASE_INSENSITIVE);
 
@@ -61,7 +62,7 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
                           boolean logNetwork,
                           boolean logFrames,
                           @Nullable List<String> filters) {
-        this(name, targetCluster, gateways, logNetwork, logFrames, filters, null);
+        this(name, targetCluster, gateways, logNetwork, logFrames, filters, null, null);
     }
 
     boolean isDnsLabel(String name) {
@@ -85,6 +86,10 @@ public record VirtualCluster(@JsonProperty(required = true) String name,
                     "Gateway names for a virtual cluster must be unique. The following gateway names are duplicated: [%s]".formatted(
                             String.join(", ", duplicates)));
         }
+    }
+
+    CacheConfiguration topicNameCacheConfig() {
+        return topicNameCache == null ? CacheConfiguration.DEFAULT : topicNameCache;
     }
 
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -306,6 +306,7 @@ public class KafkaProxyFrontendHandler
         if (endpointBinding.restrictUpstreamToMetadataDiscovery()) {
             filterAndInvokers.addAll(FilterAndInvoker.build("EagerMetadataLearner (internal)", new EagerMetadataLearner()));
         }
+        filterAndInvokers.addAll(FilterAndInvoker.build("VirtualCluster TopicNameCache (internal)", virtualClusterModel.getTopicNameCacheFilter()));
         List<FilterAndInvoker> brokerAddressFilters = FilterAndInvoker.build("BrokerAddress (internal)",
                 new BrokerAddressFilter(endpointBinding.endpointGateway(), endpointReconciler));
         filterAndInvokers.addAll(brokerAddressFilters);

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/TopicNameRetriever.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/TopicNameRetriever.java
@@ -29,14 +29,15 @@ import io.kroxylicious.proxy.filter.metadata.TopLevelMetadataErrorException;
 import io.kroxylicious.proxy.filter.metadata.TopicLevelMetadataErrorException;
 import io.kroxylicious.proxy.filter.metadata.TopicNameMapping;
 import io.kroxylicious.proxy.filter.metadata.TopicNameMappingException;
+import io.kroxylicious.proxy.internal.util.RequestHeaderTagger;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import static java.util.Collections.unmodifiableMap;
 import static java.util.stream.Collectors.toMap;
 
-final class TopicNameRetriever {
+public final class TopicNameRetriever {
     // Version 12 was the first version that uses topic ids.
-    private static final short METADATA_API_VER_WITH_TOPIC_ID_SUPPORT = (short) 12;
+    public static final short METADATA_API_VER_WITH_TOPIC_ID_SUPPORT = (short) 12;
     private final FilterContext filterContext;
     private final ThreadAwareExecutor filterDispatchExecutor;
 
@@ -76,6 +77,7 @@ final class TopicNameRetriever {
         RequestHeaderData requestHeaderData = new RequestHeaderData();
         requestHeaderData.setRequestApiKey(ApiKeys.METADATA.id);
         requestHeaderData.setRequestApiVersion(METADATA_API_VER_WITH_TOPIC_ID_SUPPORT);
+        RequestHeaderTagger.tag(requestHeaderData, RequestHeaderTagger.Tag.LEARN_TOPIC_NAMES);
         return filterContext.sendRequest(requestHeaderData, request);
     }
 

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/TopicNameCacheFilter.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/filter/TopicNameCacheFilter.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.UnknownServerException;
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.MetadataRequestData.MetadataRequestTopic;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.message.MetadataResponseData.MetadataResponseTopic;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
+
+import io.kroxylicious.proxy.config.CacheConfiguration;
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.MetadataRequestFilter;
+import io.kroxylicious.proxy.filter.MetadataResponseFilter;
+import io.kroxylicious.proxy.filter.RequestFilterResult;
+import io.kroxylicious.proxy.filter.ResponseFilterResult;
+import io.kroxylicious.proxy.internal.util.RequestHeaderTagger;
+import io.kroxylicious.proxy.tag.VisibleForTesting;
+
+import static io.kroxylicious.proxy.internal.util.Metrics.VIRTUAL_CLUSTER_LABEL;
+
+/**
+ * A Filter that learns and caches all topic names, it is responsible for short circuit responding to internal
+ * topic name retrievals.
+ * <p>
+ * Note that this is a special Filter in that a single instance is shared across all connections for a VirtualCluster
+ * rather than an instance per connection. This means it can be invoked by multiple threads concurrently.
+ */
+@ThreadSafe
+public class TopicNameCacheFilter implements MetadataRequestFilter, MetadataResponseFilter {
+    @VisibleForTesting
+    final Cache<Uuid, String> topicNameCache;
+
+    public TopicNameCacheFilter(CacheConfiguration cacheConfiguration,
+                                String clusterName) {
+        this(cacheConfiguration, Map.of(), clusterName);
+    }
+
+    /**
+     * @param topicNames initial topic names to populate the cache with
+     */
+    @VisibleForTesting
+    public TopicNameCacheFilter(CacheConfiguration cacheConfiguration,
+                                Map<Uuid, String> topicNames,
+                                String clusterName) {
+        Objects.requireNonNull(cacheConfiguration, "cacheConfiguration must not be null");
+        Objects.requireNonNull(topicNames, "topicNames must not be null");
+        this.topicNameCache = buildCache(cacheConfiguration);
+        new CaffeineCacheMetrics<>(this.topicNameCache, "topicNames", List.of(Tag.of(VIRTUAL_CLUSTER_LABEL, clusterName))).bindTo(Metrics.globalRegistry);
+        this.topicNameCache.putAll(topicNames);
+    }
+
+    private static Cache<Uuid, String> buildCache(CacheConfiguration cacheConfiguration) {
+        Caffeine<Object, Object> cacheBuilder = Caffeine.newBuilder();
+        cacheBuilder.recordStats();
+        if (cacheConfiguration.maxSize() != null) {
+            cacheBuilder.maximumSize(cacheConfiguration.maxSize());
+        }
+        Duration expireAfterWrite = cacheConfiguration.expireAfterWrite();
+        if (expireAfterWrite != null) {
+            cacheBuilder.expireAfterWrite(expireAfterWrite);
+        }
+        cacheBuilder.expireAfterAccess(cacheConfiguration.expireAfterAccess());
+        return cacheBuilder.build();
+    }
+
+    @Override
+    public CompletionStage<RequestFilterResult> onMetadataRequest(short apiVersion,
+                                                                  RequestHeaderData header,
+                                                                  MetadataRequestData request,
+                                                                  FilterContext context) {
+        if (RequestHeaderTagger.containsTag(header, RequestHeaderTagger.Tag.LEARN_TOPIC_NAMES)) {
+            if (request.topics() != null && !request.topics().isEmpty()) {
+                Map<Uuid, String> names = topicNameCache.getAllPresent(
+                        request.topics().stream().map(MetadataRequestTopic::topicId).toList());
+                if (request.topics().stream().allMatch(metadataRequestTopic -> names.containsKey(metadataRequestTopic.topicId()))) {
+                    MetadataResponseData metadataResponseData = new MetadataResponseData();
+                    request.topics().stream().map(metadataRequestTopic -> {
+                        MetadataResponseTopic responseTopic = new MetadataResponseTopic();
+                        responseTopic.setTopicId(metadataRequestTopic.topicId());
+                        responseTopic.setName(names.get(metadataRequestTopic.topicId()));
+                        return responseTopic;
+                    }).forEach(metadataResponseData.topics()::add);
+                    return context.requestFilterResultBuilder().shortCircuitResponse(metadataResponseData).completed();
+                }
+                else {
+                    // we don't know all the topics so forward
+                    RequestHeaderTagger.removeTags(header);
+                    return context.forwardRequest(header, request);
+                }
+            }
+            else {
+                UnknownServerException exception = new UnknownServerException("received an internal topic name request with no topics");
+                return context.requestFilterResultBuilder().errorResponse(header, request, exception).completed();
+            }
+        }
+        return context.forwardRequest(header, request);
+    }
+
+    @Override
+    public CompletionStage<ResponseFilterResult> onMetadataResponse(short apiVersion,
+                                                                    ResponseHeaderData header,
+                                                                    MetadataResponseData response,
+                                                                    FilterContext context) {
+        if (response.topics() != null) {
+            response.topics().forEach(topic -> {
+                if (topic.name() != null && !topic.name().isEmpty() && topic.topicId() != null && topic.topicId() != Uuid.ZERO_UUID) {
+                    topicNameCache.put(topic.topicId(), topic.name());
+                }
+            });
+        }
+        return context.forwardResponse(header, response);
+    }
+
+    @VisibleForTesting
+    Optional<String> topicName(Uuid topicId) {
+        return Optional.ofNullable(topicNameCache.getIfPresent(topicId));
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/util/RequestHeaderTagger.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/util/RequestHeaderTagger.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.util;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.types.RawTaggedField;
+
+import io.kroxylicious.proxy.tag.VisibleForTesting;
+
+/**
+ * Utility for tagging message headers with internal tags. Such tags should not be propagated
+ * to the upstream broker.
+ */
+public class RequestHeaderTagger {
+    public enum Tag {
+        LEARN_TOPIC_NAMES(new RawTaggedField(14343085, "kroxylicious.io/learn-topic-names".getBytes(StandardCharsets.UTF_8)));
+
+        private final RawTaggedField rawTaggedField;
+
+        Tag(RawTaggedField rawTaggedField) {
+            this.rawTaggedField = rawTaggedField;
+        }
+
+        @VisibleForTesting
+        RawTaggedField getRawTaggedField() {
+            return rawTaggedField;
+        }
+    }
+
+    public static void removeTags(RequestHeaderData header) {
+        List<RawTaggedField> rawTaggedFields = header.unknownTaggedFields();
+        for (Tag value : Tag.values()) {
+            rawTaggedFields.remove(value.getRawTaggedField());
+        }
+    }
+
+    public static void tag(RequestHeaderData headerData, Tag tag) {
+        // clone the data, we don't want to hand out a reference that Filters can mutate
+        headerData.unknownTaggedFields().add(new RawTaggedField(tag.rawTaggedField.tag(), tag.rawTaggedField.data().clone()));
+    }
+
+    public static boolean containsTag(RequestHeaderData headerData, Tag tag) {
+        return headerData.unknownTaggedFields().contains(tag.rawTaggedField);
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/ConfigParserTest.java
@@ -76,6 +76,20 @@ class ConfigParserTest {
                               portIdentifiesNode:
                                   bootstrapAddress: cluster1:9192
                         """),
+                argumentSet("Virtual cluster - topic name cache config", """
+                        virtualClusters:
+                          - name: demo1
+                            topicNameCache:
+                              maxSize: 10000
+                              expireAfterWrite: 10h
+                              expireAfterAccess: 58m
+                            targetCluster:
+                              bootstrapServers: kafka.example:1234
+                            gateways:
+                            - name: default
+                              portIdentifiesNode:
+                                  bootstrapAddress: cluster1:9192
+                        """),
                 argumentSet("Virtual cluster (portIdentifiesNode with start port)", """
                         virtualClusters:
                           - name: demo1

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineEndToEndTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineEndToEndTest.java
@@ -56,10 +56,12 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 
 import io.kroxylicious.proxy.bootstrap.FilterChainFactory;
+import io.kroxylicious.proxy.config.CacheConfiguration;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 import io.kroxylicious.proxy.internal.codec.FrameOversizedException;
+import io.kroxylicious.proxy.internal.filter.TopicNameCacheFilter;
 import io.kroxylicious.proxy.internal.net.EndpointBinding;
 import io.kroxylicious.proxy.internal.net.EndpointGateway;
 import io.kroxylicious.proxy.internal.subject.DefaultSubjectBuilder;
@@ -489,6 +491,8 @@ class ProxyChannelStateMachineEndToEndTest {
         var dp = new DelegatingDecodePredicate();
         VirtualClusterModel virtualClusterModel = mock(VirtualClusterModel.class);
         when(virtualClusterModel.getClusterName()).thenReturn("cluster");
+        TopicNameCacheFilter topicNameCacheFilter = new TopicNameCacheFilter(CacheConfiguration.DEFAULT, "cluster");
+        when(virtualClusterModel.getTopicNameCacheFilter()).thenReturn(topicNameCacheFilter);
         EndpointBinding endpointBinding = mock(EndpointBinding.class);
         EndpointGateway endpointGateway = mock(EndpointGateway.class);
         when(endpointGateway.virtualCluster()).thenReturn(virtualClusterModel);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/TopicNameCacheFilterTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/filter/TopicNameCacheFilterTest.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.filter;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Stream;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.ApiException;
+import org.apache.kafka.common.errors.UnknownServerException;
+import org.apache.kafka.common.message.MetadataRequestData;
+import org.apache.kafka.common.message.MetadataRequestData.MetadataRequestTopic;
+import org.apache.kafka.common.message.MetadataResponseData;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.kroxylicious.proxy.config.CacheConfiguration;
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.RequestFilterResult;
+import io.kroxylicious.proxy.filter.RequestFilterResultBuilder;
+import io.kroxylicious.proxy.filter.ResponseFilterResult;
+import io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage;
+import io.kroxylicious.proxy.internal.util.RequestHeaderTagger;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+import static io.kroxylicious.proxy.config.CacheConfiguration.DEFAULT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TopicNameCacheFilterTest {
+
+    public static final String TOPIC_NAME = "topicName";
+    public static final Uuid TOPIC_ID = Uuid.randomUuid();
+    @Mock
+    private FilterContext filterContext;
+    @Mock
+    private RequestFilterResultBuilder requestFilterResultBuilder;
+    @Mock
+    private CloseOrTerminalStage<RequestFilterResult> closeOrTerminalStage;
+
+    private static final String CLUSTER_NAME = "clusterName";
+
+    @Test
+    void onMetadataRequestWithoutTag() {
+        // given
+        TopicNameCacheFilter topicNameCacheFilter = new TopicNameCacheFilter(DEFAULT, Map.of(TOPIC_ID, TOPIC_NAME), CLUSTER_NAME);
+        RequestHeaderData header = new RequestHeaderData();
+        MetadataRequestData request = new MetadataRequestData();
+        MetadataRequestTopic topic = new MetadataRequestTopic();
+        topic.setTopicId(TOPIC_ID);
+        request.topics().add(topic);
+        CompletableFuture<RequestFilterResult> result = CompletableFuture.completedFuture(null);
+        when(filterContext.forwardRequest(header, request)).thenReturn(result);
+        // when
+        CompletionStage<RequestFilterResult> resultStage = topicNameCacheFilter.onMetadataRequest(ApiKeys.METADATA.latestVersion(), header,
+                request, filterContext);
+        // then
+        // request is forwarded upstream, we do not shortcircuit unless a specific tag is present on the request header
+        assertThat(resultStage).isSameAs(result);
+    }
+
+    @Test
+    void onMetadataRequestWithTagTopicsEmpty() {
+        // given
+        TopicNameCacheFilter topicNameCacheFilter = new TopicNameCacheFilter(DEFAULT, Map.of(TOPIC_ID, TOPIC_NAME), CLUSTER_NAME);
+        RequestHeaderData header = new RequestHeaderData();
+        RequestHeaderTagger.tag(header, RequestHeaderTagger.Tag.LEARN_TOPIC_NAMES);
+        MetadataRequestData request = new MetadataRequestData();
+        CompletableFuture<RequestFilterResult> result = CompletableFuture.completedFuture(null);
+        when(filterContext.requestFilterResultBuilder()).thenReturn(requestFilterResultBuilder);
+        when(requestFilterResultBuilder.errorResponse(Mockito.eq(header), Mockito.eq(request), Mockito.any())).thenReturn(closeOrTerminalStage);
+        when(closeOrTerminalStage.completed()).thenReturn(result);
+        // when
+        CompletionStage<RequestFilterResult> resultStage = topicNameCacheFilter.onMetadataRequest(ApiKeys.METADATA.latestVersion(), header,
+                request, filterContext);
+        // then
+        // we respond with an error as it's an illegal state for an internal topic name retrieval request to have an empty topics list
+        assertThat(resultStage).isSameAs(result);
+        ArgumentCaptor<ApiException> captor = ArgumentCaptor.forClass(ApiException.class);
+        Mockito.verify(requestFilterResultBuilder).errorResponse(Mockito.eq(header), Mockito.eq(request), captor.capture());
+        assertThat(captor.getValue()).isInstanceOf(UnknownServerException.class).hasMessage("received an internal topic name request with no topics");
+    }
+
+    @Test
+    void onMetadataRequestWithTagTopicsNull() {
+        // given
+        TopicNameCacheFilter topicNameCacheFilter = new TopicNameCacheFilter(DEFAULT, Map.of(TOPIC_ID, TOPIC_NAME), CLUSTER_NAME);
+        RequestHeaderData header = new RequestHeaderData();
+        RequestHeaderTagger.tag(header, RequestHeaderTagger.Tag.LEARN_TOPIC_NAMES);
+        MetadataRequestData request = new MetadataRequestData();
+        request.setTopics(null);
+        CompletableFuture<RequestFilterResult> result = CompletableFuture.completedFuture(null);
+        when(filterContext.requestFilterResultBuilder()).thenReturn(requestFilterResultBuilder);
+        when(requestFilterResultBuilder.errorResponse(Mockito.eq(header), Mockito.eq(request), Mockito.any())).thenReturn(closeOrTerminalStage);
+        when(closeOrTerminalStage.completed()).thenReturn(result);
+        // when
+        CompletionStage<RequestFilterResult> resultStage = topicNameCacheFilter.onMetadataRequest(ApiKeys.METADATA.latestVersion(), header,
+                request, filterContext);
+        // then
+        // we respond with an error as it's an illegal state for an internal topic name retrieval request to have an empty topics list
+        assertThat(resultStage).isSameAs(result);
+        ArgumentCaptor<ApiException> captor = ArgumentCaptor.forClass(ApiException.class);
+        Mockito.verify(requestFilterResultBuilder).errorResponse(Mockito.eq(header), Mockito.eq(request), captor.capture());
+        assertThat(captor.getValue()).isInstanceOf(UnknownServerException.class).hasMessage("received an internal topic name request with no topics");
+    }
+
+    @Test
+    void onMetadataRequestWithTagAndAllTopicIdsCached() {
+        // given
+        TopicNameCacheFilter topicNameCacheFilter = new TopicNameCacheFilter(DEFAULT, Map.of(TOPIC_ID, TOPIC_NAME), CLUSTER_NAME);
+        RequestHeaderData header = new RequestHeaderData();
+        RequestHeaderTagger.tag(header, RequestHeaderTagger.Tag.LEARN_TOPIC_NAMES);
+        MetadataRequestData request = new MetadataRequestData();
+        MetadataRequestTopic topic = new MetadataRequestTopic();
+        topic.setTopicId(TOPIC_ID);
+        request.topics().add(topic);
+        CompletableFuture<RequestFilterResult> result = CompletableFuture.completedFuture(null);
+        when(filterContext.requestFilterResultBuilder()).thenReturn(requestFilterResultBuilder);
+        when(requestFilterResultBuilder.shortCircuitResponse(Mockito.any())).thenReturn(closeOrTerminalStage);
+        when(closeOrTerminalStage.completed()).thenReturn(result);
+        // when
+        CompletionStage<RequestFilterResult> resultStage = topicNameCacheFilter.onMetadataRequest(ApiKeys.METADATA.latestVersion(), header,
+                request, filterContext);
+        // then
+        assertThat(resultStage).isSameAs(result);
+        ArgumentCaptor<ApiMessage> captor = ArgumentCaptor.forClass(ApiMessage.class);
+        Mockito.verify(requestFilterResultBuilder).shortCircuitResponse(captor.capture());
+        ApiMessage value = captor.getValue();
+        assertThat(value).isInstanceOfSatisfying(MetadataResponseData.class, metadataResponseData -> {
+            assertThat(metadataResponseData.topics()).isNotNull().singleElement().satisfies(metadataResponseTopic -> {
+                assertThat(metadataResponseTopic.topicId()).isEqualTo(TOPIC_ID);
+                assertThat(metadataResponseTopic.name()).isEqualTo(TOPIC_NAME);
+            });
+        });
+    }
+
+    @Test
+    void onMetadataRequestWithTagAndTopicIdsNotCached() {
+        // given
+        TopicNameCacheFilter topicNameCacheFilter = new TopicNameCacheFilter(DEFAULT, Map.of(), CLUSTER_NAME);
+        RequestHeaderData header = new RequestHeaderData();
+        RequestHeaderTagger.tag(header, RequestHeaderTagger.Tag.LEARN_TOPIC_NAMES);
+        MetadataRequestData request = new MetadataRequestData();
+        MetadataRequestTopic topic = new MetadataRequestTopic();
+        topic.setTopicId(TOPIC_ID);
+        request.topics().add(topic);
+        CompletableFuture<RequestFilterResult> result = CompletableFuture.completedFuture(null);
+        when(filterContext.forwardRequest(Mockito.any(), Mockito.any())).thenReturn(result);
+        // when
+        CompletionStage<RequestFilterResult> resultStage = topicNameCacheFilter.onMetadataRequest(ApiKeys.METADATA.latestVersion(), header,
+                request, filterContext);
+        // then
+        assertThat(resultStage).isSameAs(result);
+        ArgumentCaptor<RequestHeaderData> headerCaptor = ArgumentCaptor.forClass(RequestHeaderData.class);
+        ArgumentCaptor<ApiMessage> captor = ArgumentCaptor.forClass(ApiMessage.class);
+        Mockito.verify(filterContext).forwardRequest(headerCaptor.capture(), captor.capture());
+        ApiMessage value = captor.getValue();
+        assertThat(value).isInstanceOfSatisfying(MetadataRequestData.class, requestData -> {
+            assertThat(requestData).isSameAs(request);
+        });
+        RequestHeaderData sendHeader = headerCaptor.getValue();
+        assertThat(header).isSameAs(sendHeader);
+        // tag removed before forwarding upstream
+        assertThat(RequestHeaderTagger.containsTag(sendHeader, RequestHeaderTagger.Tag.LEARN_TOPIC_NAMES)).isFalse();
+    }
+
+    @Test
+    void onMetadataResponseWithNoTopics() {
+        // given
+        TopicNameCacheFilter topicNameCacheFilter = new TopicNameCacheFilter(DEFAULT, CLUSTER_NAME);
+        ResponseHeaderData header = new ResponseHeaderData();
+        MetadataResponseData response = new MetadataResponseData();
+        CompletableFuture<ResponseFilterResult> result = CompletableFuture.completedFuture(null);
+        when(filterContext.forwardResponse(header, response)).thenReturn(result);
+        // when
+        CompletionStage<ResponseFilterResult> responseFilterResultCompletionStage = topicNameCacheFilter.onMetadataResponse(ApiKeys.METADATA.latestVersion(), header,
+                response, filterContext);
+        // then
+        assertThat(responseFilterResultCompletionStage).isSameAs(result);
+    }
+
+    @Test
+    void onMetadataResponseWithTopics() {
+        // given
+        TopicNameCacheFilter topicNameCacheFilter = new TopicNameCacheFilter(DEFAULT, CLUSTER_NAME);
+        ResponseHeaderData header = new ResponseHeaderData();
+        MetadataResponseData response = new MetadataResponseData();
+        MetadataResponseData.MetadataResponseTopic topic = new MetadataResponseData.MetadataResponseTopic();
+        topic.setTopicId(TOPIC_ID);
+        topic.setName(TOPIC_NAME);
+        response.topics().add(topic);
+        CompletableFuture<ResponseFilterResult> result = CompletableFuture.completedFuture(null);
+        when(filterContext.forwardResponse(header, response)).thenReturn(result);
+        // when
+        CompletionStage<ResponseFilterResult> responseFilterResultCompletionStage = topicNameCacheFilter.onMetadataResponse(ApiKeys.METADATA.latestVersion(), header,
+                response, filterContext);
+        // then
+        assertThat(responseFilterResultCompletionStage).isSameAs(result);
+        assertThat(topicNameCacheFilter.topicName(TOPIC_ID)).contains(TOPIC_NAME);
+    }
+
+    public static Stream<Arguments> onMetadataResponseWithUnlearnableTopic() {
+        return Stream.of(Arguments.argumentSet("null topic name", TOPIC_ID, null),
+                Arguments.argumentSet("empty topic name", TOPIC_ID, ""),
+                Arguments.argumentSet("zero topic id", Uuid.ZERO_UUID, TOPIC_NAME),
+                Arguments.argumentSet("null topic id", null, TOPIC_NAME));
+    }
+
+    @Test
+    void onMetadataResponseWithNullTopics() {
+        // given
+        TopicNameCacheFilter topicNameCacheFilter = new TopicNameCacheFilter(DEFAULT, CLUSTER_NAME);
+        ResponseHeaderData header = new ResponseHeaderData();
+        MetadataResponseData response = new MetadataResponseData();
+        response.setTopics(null);
+        CompletableFuture<ResponseFilterResult> result = CompletableFuture.completedFuture(null);
+        when(filterContext.forwardResponse(header, response)).thenReturn(result);
+        // when
+        CompletionStage<ResponseFilterResult> responseFilterResultCompletionStage = topicNameCacheFilter.onMetadataResponse(ApiKeys.METADATA.latestVersion(), header,
+                response, filterContext);
+        // then
+        assertThat(responseFilterResultCompletionStage).isSameAs(result);
+        assertThat(topicNameCacheFilter.topicName(TOPIC_ID)).isEmpty();
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void onMetadataResponseWithUnlearnableTopic(@Nullable Uuid topicId, @Nullable String topicName) {
+        // given
+        TopicNameCacheFilter topicNameCacheFilter = new TopicNameCacheFilter(DEFAULT, CLUSTER_NAME);
+        ResponseHeaderData header = new ResponseHeaderData();
+        MetadataResponseData response = new MetadataResponseData();
+        MetadataResponseData.MetadataResponseTopic topic = new MetadataResponseData.MetadataResponseTopic();
+        topic.setTopicId(topicId);
+        topic.setName(topicName);
+        response.topics().add(topic);
+        CompletableFuture<ResponseFilterResult> result = CompletableFuture.completedFuture(null);
+        when(filterContext.forwardResponse(header, response)).thenReturn(result);
+        // when
+        CompletionStage<ResponseFilterResult> responseFilterResultCompletionStage = topicNameCacheFilter.onMetadataResponse(ApiKeys.METADATA.latestVersion(), header,
+                response, filterContext);
+        // then
+        assertThat(responseFilterResultCompletionStage).isSameAs(result);
+        assertThat(topicNameCacheFilter.topicName(TOPIC_ID)).isEmpty();
+    }
+
+    @Test
+    void defaultCacheConfig() {
+        // given
+        CacheConfiguration cacheConfig = DEFAULT;
+        // when
+        TopicNameCacheFilter filter = new TopicNameCacheFilter(cacheConfig, CLUSTER_NAME);
+        // then
+        assertThat(filter.topicNameCache.policy().eviction()).isEmpty();
+        assertThat(filter.topicNameCache.policy().expireAfterAccess()).hasValueSatisfying(expiratioon -> {
+            assertThat(expiratioon.getExpiresAfter()).isEqualTo(Duration.ofHours(1));
+        });
+        assertThat(filter.topicNameCache.policy().expireAfterWrite()).isEmpty();
+    }
+
+    @Test
+    void cacheStatsEnabled() {
+        // when
+        TopicNameCacheFilter filter = new TopicNameCacheFilter(DEFAULT, CLUSTER_NAME);
+        // then
+        assertThat(filter.topicNameCache.policy().isRecordingStats()).isTrue();
+    }
+
+    @Test
+    void expiryConfig() {
+        // given
+        CacheConfiguration cacheConfig = new CacheConfiguration(null, Duration.of(10L, ChronoUnit.SECONDS), Duration.of(10L, ChronoUnit.SECONDS));
+        // when
+        TopicNameCacheFilter filter = new TopicNameCacheFilter(cacheConfig, CLUSTER_NAME);
+        // then
+        assertThat(filter.topicNameCache.policy().expireAfterAccess()).hasValueSatisfying(expiratioon -> {
+            assertThat(expiratioon.getExpiresAfter()).isEqualTo(Duration.ofSeconds(10));
+        });
+        assertThat(filter.topicNameCache.policy().expireAfterWrite()).hasValueSatisfying(expiration -> {
+            assertThat(expiration.getExpiresAfter()).isEqualTo(Duration.ofSeconds(10));
+        });
+    }
+
+    @Test
+    void maxSizeConfig() {
+        // given
+        CacheConfiguration cacheConfig = new CacheConfiguration(5, null, null);
+        // when
+        TopicNameCacheFilter filter = new TopicNameCacheFilter(cacheConfig, CLUSTER_NAME);
+        // then
+        assertThat(filter.topicNameCache.policy().eviction()).hasValueSatisfying(eviction -> {
+            assertThat(eviction.getMaximum()).isEqualTo(5L);
+        });
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/util/RequestHeaderTaggerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/util/RequestHeaderTaggerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal.util;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.protocol.types.RawTaggedField;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RequestHeaderTaggerTest {
+
+    @Test
+    void testTag() {
+        // given
+        RequestHeaderData headerData = new RequestHeaderData();
+        // when
+        RequestHeaderTagger.tag(headerData, RequestHeaderTagger.Tag.LEARN_TOPIC_NAMES);
+        // then
+        RawTaggedField expected = new RawTaggedField(14343085, "kroxylicious.io/learn-topic-names".getBytes(StandardCharsets.UTF_8));
+        assertThat(headerData.unknownTaggedFields()).contains(expected);
+    }
+
+    @Test
+    void noTagsOnHeader() {
+        // given
+        RequestHeaderData headerData = new RequestHeaderData();
+        // when
+        boolean actual = RequestHeaderTagger.containsTag(headerData, RequestHeaderTagger.Tag.LEARN_TOPIC_NAMES);
+        // then
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    void tagOnHeader() {
+        // given
+        RequestHeaderData headerData = new RequestHeaderData();
+        RequestHeaderTagger.tag(headerData, RequestHeaderTagger.Tag.LEARN_TOPIC_NAMES);
+        // when
+        boolean actual = RequestHeaderTagger.containsTag(headerData, RequestHeaderTagger.Tag.LEARN_TOPIC_NAMES);
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    // this is to check that if a Filter mutates the tag data, the tag no longer matches.
+    @Test
+    void mutatingTagDataHasNoSideEffects() {
+        // given
+        byte[] originalData = RequestHeaderTagger.Tag.LEARN_TOPIC_NAMES.getRawTaggedField().data().clone();
+        RequestHeaderData headerData = new RequestHeaderData();
+        RequestHeaderTagger.tag(headerData, RequestHeaderTagger.Tag.LEARN_TOPIC_NAMES);
+        headerData.unknownTaggedFields().iterator().next().data()[0] = 5;
+        // when
+        boolean actual = RequestHeaderTagger.containsTag(headerData, RequestHeaderTagger.Tag.LEARN_TOPIC_NAMES);
+        // then
+        assertThat(actual).isFalse();
+        byte[] currentData = RequestHeaderTagger.Tag.LEARN_TOPIC_NAMES.getRawTaggedField().data().clone();
+        assertThat(currentData).isEqualTo(originalData);
+    }
+
+    @Test
+    void knownTagButUnknownData() {
+        // given
+        RequestHeaderData headerData = new RequestHeaderData();
+        headerData.unknownTaggedFields().add(new RawTaggedField(14343085, new byte[0]));
+        // when
+        boolean actual = RequestHeaderTagger.containsTag(headerData, RequestHeaderTagger.Tag.LEARN_TOPIC_NAMES);
+        // then
+        assertThat(actual).isFalse();
+    }
+
+    @Test
+    void knownDataButUnknownTag() {
+        // given
+        RequestHeaderData headerData = new RequestHeaderData();
+        headerData.unknownTaggedFields().add(new RawTaggedField(1, "kroxylicious.io/learn-topic-names".getBytes(StandardCharsets.UTF_8)));
+        // when
+        boolean actual = RequestHeaderTagger.containsTag(headerData, RequestHeaderTagger.Tag.LEARN_TOPIC_NAMES);
+        // then
+        assertThat(actual).isFalse();
+    }
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This is an alternative to #3099 which uses a different strategy.

1. We install a Filter right near the end of the chain, close to the upstream, responsible for learning topic names from any and all metadata it sees. This Filter is shared across all connections for a Virtual Cluster.
2. The TopicNameRetriver sets a tag on the MetadataRequest it makes, identifying it as an internal name learning request.
3. The TopicNameCache filter intercepts the tagged request, and if it knows all the topic names it will short-circuit respond. Any untagged metadata requests are forward on untouched.
4. We introduce a caffeine `Cache` so that we can expire unused entries some time after access. Note this is a reactive process driven by reading/writing the cache.
5. VirtualCluster now has a configuration object `topicNameCache` where you can configure:
  ```yaml
  topicNameCache:
    maxSize: 5
    expireAfterWrite: 60s
    expireAfterAccess: 60s
  ```
6. Micrometer metrics are wired up to the cache so we can get metrics emitted, tagged with the virtual_cluster name:
  ```
  # HELP cache_eviction_weight_total The sum of weights of evicted entries. This total does not include manual invalidations.
  # TYPE cache_eviction_weight_total counter
  cache_eviction_weight_total{cache="topicNames",virtual_cluster="demo"} 0.0
  # HELP cache_evictions_total The number of times the cache was evicted.
  # TYPE cache_evictions_total counter
  cache_evictions_total{cache="topicNames",virtual_cluster="demo"} 0.0
  # HELP cache_gets_total The number of times cache lookup methods have returned a cached (hit) or uncached (newly loaded or null) value (miss).
  # TYPE cache_gets_total counter
  cache_gets_total{cache="topicNames",result="hit",virtual_cluster="demo"} 0.0
  cache_gets_total{cache="topicNames",result="miss",virtual_cluster="demo"} 0.0
  # HELP cache_puts_total The number of entries added to the cache
  # TYPE cache_puts_total counter
  cache_puts_total{cache="topicNames",virtual_cluster="demo"} 0.0
  # HELP cache_size The number of entries in this cache. This may be an approximation, depending on the type of cache.
  # TYPE cache_size gauge
  cache_size{cache="topicNames",virtual_cluster="demo"} 2.0
  ```

Pros:
* Less caches involved than #3099, where we cache per Filter instance. Reduced memory usage.
* Prevents more Metadata requests being forwarded than #3099 in the case where multiple Filters in the chain need to look up the same topic names. This is because the Metadata request driven by the first topic id retrieval will have its result cached and the subsequent lookups from the upstream filters will hit the cache. Also the caching spans connections.
* A cache per virtual cluster will be easier to monitor.

Cons:
* More work required in the Proxy, a MetadataRequest/Response has to be fired up and down the Filter chain for every topic name lookup.
* The internal Tag will be visible to User Filters and could be modified/removed by a Filter, which would prevent the activation of the caching behaviour.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
