### PR TITLE
fix(quickstart test): Await vault pod readiness before enabling secrets engine.

### DIFF
--- a/kroxylicious-docs-tests/src/main/java/io/kroxylicious/doctools/asciidoc/BlockExtractor.java
+++ b/kroxylicious-docs-tests/src/main/java/io/kroxylicious/doctools/asciidoc/BlockExtractor.java
@@ -144,7 +144,8 @@ public class BlockExtractor implements AutoCloseable {
 
     private static String deHtmlEntities(String content) {
         return content.replace("&lt;", "<")
-                .replace("&gt;", ">");
+                .replace("&gt;", ">")
+                .replace("&amp;", "&");
     }
 
     /**

--- a/kroxylicious-docs-tests/src/test/java/io/kroxylicious/doctools/asciidoc/BlockExtractorTest.java
+++ b/kroxylicious-docs-tests/src/test/java/io/kroxylicious/doctools/asciidoc/BlockExtractorTest.java
@@ -106,6 +106,18 @@ class BlockExtractorTest {
                         (Consumer<List<Block>>) blocks -> assertThat(blocks)
                                 .singleElement()
                                 .satisfies(b -> assertThat(b.content()).isEqualTo("foo: {}"))),
+                Arguments.argumentSet("handles code blocks using characters that are commonly represented by HTML entities",
+                        """
+                                [source,shell]
+                                ----
+                                (echo hello && echo entity world) > /tmp/null
+                                ----
+                                """,
+                        (Predicate<StructuralNode>) sn -> true,
+                        (Consumer<List<Block>>) blocks -> assertThat(blocks)
+                                .singleElement()
+                                .satisfies(b -> assertThat(b.content()).isEqualTo("(echo hello && echo entity world) > /tmp/null"))),
+
                 Arguments.argumentSet("reports line number",
                         """
                                 Mary had a little lamb,

--- a/kroxylicious-docs/docs/record-encryption-quickstart/index.adoc
+++ b/kroxylicious-docs/docs/record-encryption-quickstart/index.adoc
@@ -102,7 +102,7 @@ And enable the Transit Secrets Engine.
 
 [source,terminal,kms="vault"]
 ----
-$ kubectl exec -n kms statefulsets/vault -- vault secrets enable transit
+$ kubectl wait -n kms --for=condition=Ready pod/vault-0 && kubectl exec -n kms statefulsets/vault -- vault secrets enable transit
 ----
 ====
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

why: as Vault uses a statefulset with OnDelete strategy, Helm's wait option is not applied to it. Adding an explict wait for the pod before enabling the transit engine with the goal of avoid the sporadic test failure affecting the Quickstart tests.


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
