### PR TITLE
Add DurationSpec to kroxylicious-api

### DIFF
--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/datetime/DurationSpec.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/config/datetime/DurationSpec.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config.datetime;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Duration specifier.
+ * We use this in configuration to represent durations because:
+ * 1. we want to preserve fidelity, that is it serializes to the exact same format.
+ * 2. we don't want to install custom deserialization logic for Duration as it could
+ *    collide with the jackson date time module in future.
+ * @param amount amount
+ * @param unit unit
+ */
+public record DurationSpec(long amount, ChronoUnit unit) {
+
+    private static final Map<String, ChronoUnit> SUFFIX_UNIT = Map.of(
+            "d", ChronoUnit.DAYS,
+            "h", ChronoUnit.HOURS,
+            "m", ChronoUnit.MINUTES,
+            "s", ChronoUnit.SECONDS,
+            "ms", ChronoUnit.MILLIS,
+            "us", ChronoUnit.MICROS,
+            "ns", ChronoUnit.NANOS);
+    private static final Map<ChronoUnit, String> UNIT_SUFFIX = SUFFIX_UNIT.entrySet()
+            .stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+    private static final List<String> ALL_SUPPORTED_SUFFIXES = SUFFIX_UNIT.keySet().stream().sorted().toList();
+    private static final List<ChronoUnit> ALL_SUPPORTED_UNITS = SUFFIX_UNIT.values().stream().sorted().toList();
+
+    public DurationSpec {
+        Objects.requireNonNull(unit);
+        if (!UNIT_SUFFIX.containsKey(unit)) {
+            throw new IllegalArgumentException("Unsupported unit " + unit + ". Must be one of " + ALL_SUPPORTED_UNITS);
+        }
+        if (amount < 0) {
+            throw new IllegalArgumentException("Amount must be greater than or equal to zero");
+        }
+    }
+
+    public Duration duration() {
+        return Duration.of(amount, unit);
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return amount + UNIT_SUFFIX.get(unit);
+    }
+
+    /**
+     * Parse string form like '10s' into a DurationSpec
+     * @param durationSpec string specifier
+     * @throws IllegalArgumentException if durationSpec cannot be parsed
+     * @return duration spec
+     */
+    public static DurationSpec parse(String durationSpec) {
+        Objects.requireNonNull(durationSpec);
+        if (durationSpec.length() < 2) {
+            throw invalidDurationSpec(durationSpec, "Must be at least 2 characters long");
+        }
+        int firstNonNumeric = -1;
+        int lastInvalidCharacter = -1;
+        for (int i = 0; i < durationSpec.length(); i++) {
+            if (!Character.isDigit(durationSpec.charAt(i)) && firstNonNumeric == -1) {
+                firstNonNumeric = i;
+            }
+            if (!Character.isLetterOrDigit(durationSpec.charAt(i))) {
+                lastInvalidCharacter = i;
+            }
+        }
+        if (firstNonNumeric == -1) {
+            throw invalidDurationSpec(durationSpec, "No unit discovered");
+        }
+        if (lastInvalidCharacter != -1) {
+            throw invalidDurationSpec(durationSpec, "Invalid character '" + durationSpec.charAt(lastInvalidCharacter) + "' at index " + lastInvalidCharacter);
+        }
+        String unitSpecifier = durationSpec.substring(firstNonNumeric).toLowerCase(Locale.ROOT);
+        if (!SUFFIX_UNIT.containsKey(unitSpecifier)) {
+            throw invalidDurationSpec(durationSpec, "Unknown unit '" + unitSpecifier + "'. Must be one of " + ALL_SUPPORTED_SUFFIXES);
+        }
+        ChronoUnit unit = SUFFIX_UNIT.get(unitSpecifier);
+        String amountSpec = durationSpec.substring(0, firstNonNumeric);
+        try {
+            long amount = Long.parseLong(amountSpec);
+            return new DurationSpec(amount, unit);
+        }
+        catch (NumberFormatException e) {
+            throw invalidDurationSpec(durationSpec, "Could not parse '" + amountSpec + "' as long. Must be an integer between 0 and " + Long.MAX_VALUE);
+        }
+    }
+
+    @NonNull
+    private static IllegalArgumentException invalidDurationSpec(String durationSpec, String reason) {
+        return new IllegalArgumentException("Invalid duration spec: '" + durationSpec + "'. " + reason + ".");
+    }
+}

--- a/kroxylicious-api/src/test/java/io/kroxylicious/proxy/config/datetime/DurationSpecTest.java
+++ b/kroxylicious-api/src/test/java/io/kroxylicious/proxy/config/datetime/DurationSpecTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config.datetime;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+class DurationSpecTest {
+
+    public static Stream<Arguments> parseValid() {
+        return Stream.of(argumentSet("days", "5d", new DurationSpec(5L, ChronoUnit.DAYS)),
+                argumentSet("hours", "44h", new DurationSpec(44L, ChronoUnit.HOURS)),
+                argumentSet("0 amount", "0h", new DurationSpec(0L, ChronoUnit.HOURS)),
+                argumentSet("long max amount", Long.MAX_VALUE + "h", new DurationSpec(Long.MAX_VALUE, ChronoUnit.HOURS)),
+                argumentSet("minutes", "3m", new DurationSpec(3L, ChronoUnit.MINUTES)),
+                argumentSet("seconds", "6s", new DurationSpec(6L, ChronoUnit.SECONDS)),
+                argumentSet("milliseconds", "85ms", new DurationSpec(85L, ChronoUnit.MILLIS)),
+                argumentSet("microseconds", "25us", new DurationSpec(25L, ChronoUnit.MICROS)),
+                argumentSet("nanoseconds", "1ns", new DurationSpec(1L, ChronoUnit.NANOS)));
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void parseValid(String input, DurationSpec expected) {
+        DurationSpec parse = DurationSpec.parse(input);
+        assertThat(parse).isEqualTo(expected);
+        assertThat(parse.toString()).isEqualTo(input);
+    }
+
+    public static Stream<Arguments> parseInvalid() {
+        return Stream.of(argumentSet("unknown unit", "5z", "Unknown unit 'z'. Must be one of [d, h, m, ms, ns, s, us]"),
+                argumentSet("shorter than minimum", "5", "Must be at least 2 characters long"),
+                argumentSet("no unit", "500", "No unit discovered"),
+                argumentSet("preceding whitespace", " 500", "Invalid character ' ' at index 0"),
+                argumentSet("trailing whitespace", "500 ", "Invalid character ' ' at index 3"),
+                argumentSet("intervening whitespace", "500 m", "Invalid character ' ' at index 3"),
+                argumentSet("larger than max long", Long.MAX_VALUE + "1m",
+                        "Could not parse '92233720368547758071' as long. Must be an integer between 0 and 9223372036854775807"),
+                argumentSet("negative amount", "-5m", "Invalid character '-' at index 0"));
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void parseInvalid(@Nullable String input, String reason) {
+        assertThatThrownBy(() -> DurationSpec.parse(input)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Invalid duration spec: '" + input + "'. " + reason + ".");
+    }
+
+    @Test
+    void duration() {
+        DurationSpec spec = new DurationSpec(5, ChronoUnit.HOURS);
+        assertThat(spec.duration()).isEqualTo(Duration.of(5, ChronoUnit.HOURS));
+    }
+
+    @Test
+    void durationAmountMustBePositive() {
+        assertThatThrownBy(() -> new DurationSpec(-1, ChronoUnit.SECONDS)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Amount must be greater than or equal to zero");
+    }
+
+    @Test
+    void durationUnitMustBeKnown() {
+        assertThatThrownBy(() -> new DurationSpec(-1, ChronoUnit.MONTHS)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Unsupported unit Months. Must be one of [Nanos, Micros, Millis, Seconds, Minutes, Hours, Days]");
+    }
+
+    @Test
+    void durationUnitMustBeNonNull() {
+        assertThatThrownBy(() -> new DurationSpec(-1, null)).isInstanceOf(NullPointerException.class);
+    }
+
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/ConfigParser.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/ConfigParser.java
@@ -41,6 +41,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 
+import io.kroxylicious.proxy.config.datetime.DurationSpec;
 import io.kroxylicious.proxy.plugin.PluginImplConfig;
 import io.kroxylicious.proxy.plugin.PluginImplName;
 import io.kroxylicious.proxy.service.HostPort;
@@ -102,6 +103,7 @@ public class ConfigParser implements PluginFactoryRegistry {
         return new ObjectMapper(yamlFactory)
                 .registerModule(new ParameterNamesModule())
                 .registerModule(new Jdk8Module())
+                .registerModule(durationModule())
                 .registerModule(new SimpleModule().addSerializer(HostPort.class, new ToStringSerializer()))
                 .setVisibility(PropertyAccessor.ALL, Visibility.NONE)
                 .setVisibility(PropertyAccessor.FIELD, Visibility.ANY)
@@ -112,6 +114,13 @@ public class ConfigParser implements PluginFactoryRegistry {
                 .disable(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY)
                 .enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION)
                 .setSerializationInclusion(JsonInclude.Include.NON_DEFAULT);
+    }
+
+    private static SimpleModule durationModule() {
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(DurationSpec.class, new ToStringSerializer());
+        module.addDeserializer(DurationSpec.class, DurationSpecDeserializer.INSTANCE);
+        return module;
     }
 
     private static class PluginModule extends SimpleModule {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/DurationSpecDeserializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/DurationSpecDeserializer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
+
+import io.kroxylicious.proxy.config.datetime.DurationSpec;
+
+public class DurationSpecDeserializer extends StdScalarDeserializer<DurationSpec> {
+
+    public static final JsonDeserializer<DurationSpec> INSTANCE = new DurationSpecDeserializer();
+
+    private DurationSpecDeserializer() {
+        super(DurationSpec.class);
+    }
+
+    @Override
+    public DurationSpec deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
+        if (p.hasToken(JsonToken.VALUE_STRING)) {
+            return DurationSpec.parse(p.getText());
+        }
+        else {
+            throw new JsonParseException(p, "Expected a string value");
+        }
+    }
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This enables our configuration to consistently use a readable String format for durations. We have chosen to go with a suffix-style format often seen in k8s technology, like '7m' for 7 minutes. See https://pkg.go.dev/time#Duration

The should be familiar to our devops type audience, and generally be easy to read.

Supported units:

- '1d' -> 1 day
- '2h' -> 2 hours
- '3m' -> 3 minutes
- '4s' -> 4 seconds
- '5ms' -> 5 milliseconds
- '6us' -> 6 microseconds
- '7ns' -> 7 nanoseconds

Zero of each unit is allowed.

Rejected alternatives:
1. using milliseconds or seconds as a consistent unit in configuration. unreadable once the numbers get large
2. ISO8601 duration strings like 'PT5M'. Would be surprising and unintuitive to many users.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
