### PR TITLE
feat: add suffix-based Duration jackson serializer/deserializer

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/DurationArithmeticException.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/DurationArithmeticException.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config;
+
+/**
+ * Thrown if there is some arithmetic exception constructing or operating on a {@link java.time.Duration}
+ */
+public class DurationArithmeticException extends RuntimeException {
+
+    public DurationArithmeticException(String message, ArithmeticException cause) {
+        super(message, cause);
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/DurationSerde.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/DurationSerde.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
+import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
+
+public class DurationSerde {
+
+    /**
+     * Prevent construction of utility class
+     */
+    private DurationSerde() {
+        // prevent construction
+    }
+
+    private record Unit(ChronoUnit unit, String groupName, String serializedUnit) {
+
+        public Duration duration(long amount) {
+            try {
+                return Duration.of(amount, unit);
+            }
+            catch (ArithmeticException e) {
+                throw new DurationArithmeticException(amount + " " + unit + " could not be converted to a Duration", e);
+            }
+        }
+    }
+
+    private static final List<Unit> UNITS = List.of(new Unit(ChronoUnit.DAYS, "days", "d"),
+            new Unit(ChronoUnit.HOURS, "hours", "h"),
+            new Unit(ChronoUnit.MINUTES, "minutes", "m"),
+            new Unit(ChronoUnit.SECONDS, "seconds", "s"),
+            new Unit(ChronoUnit.MILLIS, "millis", "ms"),
+            new Unit(ChronoUnit.MICROS, "micros", "μs"),
+            new Unit(ChronoUnit.NANOS, "nanos", "ns"));
+
+    public static class Deserializer extends StdScalarDeserializer<Duration> {
+
+        // note that micros is special, allowing μs or us
+        private static final Pattern PATTERN = Pattern.compile("(?<sign>-)?(?:(?<days>\\d+)d)?(?:(?<hours>\\d+)h)?(?:(?<minutes>\\d+)m)?"
+                + "(?:(?<seconds>\\d+)s)?(?:(?<millis>\\d+)ms)?(?:(?<micros>\\d+)[μu]s)?(?:(?<nanos>\\d+)ns)?");
+
+        private static final String USAGE = "Expected a string time duration such as \"1h30m\", or \"120s\"; supported units are d, h, m, s, ms, μs (or us) and ns.";
+
+        public Deserializer() {
+            super(Duration.class);
+        }
+
+        @Override
+        public Duration deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            if (p.hasToken(JsonToken.VALUE_STRING)) {
+                String text = p.getText();
+                Matcher matcher = getMatcherIfValid(p, text);
+                boolean negated = matcher.group("sign") != null;
+                try {
+                    return UNITS.stream().flatMap(unit -> Optional.ofNullable(matcher.group(unit.groupName()))
+                            .stream()
+                            .map(maybeLong -> {
+                                try {
+                                    long parsedLong = Long.parseLong(maybeLong);
+                                    return unit.duration(parsedLong);
+                                }
+                                catch (NumberFormatException e) {
+                                    throw new NumberFormatException("Invalid duration string: '" + maybeLong + "', could not be parsed as long");
+                                }
+                            })).reduce(Duration.ZERO, negated ? DurationSerde::minus : DurationSerde::plus);
+                }
+                catch (DurationArithmeticException e) {
+                    throw new JsonParseException(p, "Invalid duration string: '" + text + "'. Likely it is too large to be converted to Duration: " + e.getMessage(), e);
+                }
+            }
+            else {
+                throw new JsonParseException(p, "Invalid serialized duration. Expected a string value, but was " + p.currentToken());
+            }
+        }
+
+        private Matcher getMatcherIfValid(JsonParser p, String text) throws JsonParseException {
+            if (text.isBlank()) {
+                throw patternMismatchException(p, text);
+            }
+            if (text.equals("-")) {
+                throw patternMismatchException(p, text);
+            }
+            Matcher matcher = PATTERN.matcher(text);
+            if (!matcher.matches()) {
+                throw patternMismatchException(p, text);
+            }
+            return matcher;
+        }
+
+        private JsonParseException patternMismatchException(JsonParser p, String text) {
+            return new JsonParseException(p, "Invalid duration string: '" + text + "'. " + USAGE);
+        }
+    }
+
+    private static Duration minus(Duration a, Duration b) {
+        try {
+            return a.minus(b);
+        }
+        catch (ArithmeticException e) {
+            throw new DurationArithmeticException(a + " minus " + b + " failed", e);
+        }
+    }
+
+    private static Duration plus(Duration a, Duration b) {
+        try {
+            return a.plus(b);
+        }
+        catch (ArithmeticException e) {
+            throw new DurationArithmeticException(a + " plus " + b + " failed", e);
+        }
+    }
+
+    public static class Serializer extends StdScalarSerializer<Duration> {
+
+        public Serializer() {
+            super(Duration.class);
+        }
+
+        @Override
+        public void serialize(Duration value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            if (value.isZero()) {
+                gen.writeString("0ms");
+            }
+            else {
+                StringBuilder result = new StringBuilder();
+                Duration temp = value;
+                if (temp.isNegative()) {
+                    result.append("-");
+                }
+                for (Unit unit : UNITS) {
+                    Duration oneUnit = unit.duration(1);
+                    long wholeUnits = temp.dividedBy(oneUnit);
+                    temp = temp.minus(wholeUnits, unit.unit());
+                    if (wholeUnits != 0) {
+                        result.append(Math.abs(wholeUnits));
+                        result.append(unit.serializedUnit());
+                    }
+                }
+                gen.writeString(result.toString());
+            }
+        }
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/DurationSerdeTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/config/DurationSerdeTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.config;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+class DurationSerdeTest {
+
+    private static final Duration ONE_OF_EACH_UNIT = Duration.ofDays(1).plusHours(1).plusMinutes(1).plusSeconds(1).plusMillis(1).plus(1, ChronoUnit.MICROS).plusNanos(1);
+    private static final Duration NEGATIVE_ONE_OF_EACH_UNIT = Duration.ofDays(-1).plusHours(-1).plusMinutes(-1).plusSeconds(-1).plusMillis(-1).plus(-1, ChronoUnit.MICROS)
+            .plusNanos(-1);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    public static final String EXPECTED_USAGE = "Expected a string time duration such as \"1h30m\", or \"120s\"; supported units are d, h, m, s, ms, μs (or us) and ns.";
+
+    static Stream<Arguments> deserializeValid() {
+        return Stream.of(argumentSet("days", "8d", Duration.ofDays(8)),
+                argumentSet("hours", "1h", Duration.ofHours(1)),
+                argumentSet("minutes", "5m", Duration.ofMinutes(5)),
+                argumentSet("seconds", "20s", Duration.ofSeconds(20)),
+                argumentSet("90 minutes", "90m", Duration.ofMinutes(90)),
+                argumentSet("3600 seconds", "3600s", Duration.ofHours(1)),
+                argumentSet("multiple units of same duration", "1h60m3600s", Duration.ofHours(3)),
+                argumentSet("milliseconds", "7ms", Duration.ofMillis(7)),
+                argumentSet("microseconds", "1μs", Duration.of(1, ChronoUnit.MICROS)),
+                argumentSet("microseconds (alternate)", "5us", Duration.of(5, ChronoUnit.MICROS)),
+                argumentSet("zeros", "0d0h0m0s0ms0us0ns", Duration.ZERO),
+                argumentSet("negative", "-1d1h1m1s1ms1us1ns",
+                        NEGATIVE_ONE_OF_EACH_UNIT),
+                argumentSet("complex", "1d1h1m1s1ms1us1ns",
+                        ONE_OF_EACH_UNIT),
+                argumentSet("nanoseconds", "3ns", Duration.ofNanos(3)),
+                argumentSet("max possible duration", "106751991167300d15h30m7s999ms999μs999ns", Duration.ofSeconds(Long.MAX_VALUE, 999_999_999)),
+                argumentSet("min possible duration", "-106751991167300d15h30m8s", Duration.ofSeconds(Long.MIN_VALUE, 0)));
+    }
+
+    private record TestRecord(@JsonDeserialize(using = DurationSerde.Deserializer.class) @JsonSerialize(using = DurationSerde.Serializer.class) Duration duration) {
+
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void deserializeValid(String durationString, Duration expected) throws IOException {
+        TestRecord testRecord = MAPPER.reader().readValue("""
+                {"duration": "%s"}
+                """.formatted(durationString), TestRecord.class);
+        assertThat(testRecord.duration()).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> deserializeInvalid() {
+        return Stream.of(argumentSet("number", "55", "Invalid serialized duration. Expected a string value, but was VALUE_NUMBER_INT"),
+                argumentSet("array", "[]", "Invalid serialized duration. Expected a string value, but was START_ARRAY"),
+                argumentSet("object", "{}", "Invalid serialized duration. Expected a string value, but was START_OBJECT"),
+                argumentSet("empty", "\"\"", "Invalid duration string: ''. " + EXPECTED_USAGE),
+                argumentSet("blank", "\" \"", "Invalid duration string: ' '. " + EXPECTED_USAGE),
+                argumentSet("larger than long max", "\"" + Long.MAX_VALUE + "1d\"",
+                        "Invalid duration string: '92233720368547758071', could not be parsed as long"),
+                argumentSet("overflow max duration", "\"106751991167301d\"",
+                        "Invalid duration string: '106751991167301d'. Likely it is too large to be converted to Duration: 106751991167301 Days could not be converted to a Duration"),
+                argumentSet("overflow max negative duration", "\"-106751991167301d\"",
+                        "Invalid duration string: '-106751991167301d'. Likely it is too large to be converted to Duration: 106751991167301 Days could not be converted to a Duration"),
+                argumentSet("overflow max duration during addition", "\"106751991167300d1000h\"",
+                        "Invalid duration string: '106751991167300d1000h'. Likely it is too large to be converted to Duration: PT2562047788015200H plus PT1000H failed"),
+                argumentSet("overflow max duration during subtraction", "\"-106751991167300d1000h\"",
+                        "Invalid duration string: '-106751991167300d1000h'. Likely it is too large to be converted to Duration: PT-2562047788015200H minus PT1000H failed"),
+                argumentSet("units not descending - seconds before hours", "\"1s1h\"", "Invalid duration string: '1s1h'. " + EXPECTED_USAGE),
+                argumentSet("units not descending - minutes before hours", "\"1m1h\"", "Invalid duration string: '1m1h'. " + EXPECTED_USAGE),
+                argumentSet("units not descending - hours before days", "\"1h1d\"", "Invalid duration string: '1h1d'. " + EXPECTED_USAGE),
+                argumentSet("units not descending - micros before millis", "\"1us1ms\"", "Invalid duration string: '1us1ms'. " + EXPECTED_USAGE),
+                argumentSet("sign only", "\"-\"", "Invalid duration string: '-'. " + EXPECTED_USAGE),
+                argumentSet("preceding whitespace", "\" 1d\"", "Invalid duration string: ' 1d'. " + EXPECTED_USAGE),
+                argumentSet("trailing whitespace", "\"1d \"", "Invalid duration string: '1d '. " + EXPECTED_USAGE),
+                argumentSet("intervening whitespace", "\"1 d\"", "Invalid duration string: '1 d'. " + EXPECTED_USAGE));
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void deserializeInvalid(String durationString, String expectedMessage) {
+        String input = """
+                {"duration": %s}
+                """.formatted(durationString);
+        ObjectReader reader = MAPPER.reader();
+        assertThatThrownBy(() -> {
+            reader.readValue(input, TestRecord.class);
+        }).isInstanceOf(JsonMappingException.class).hasMessageContaining(expectedMessage);
+    }
+
+    public static Stream<Arguments> serialize() {
+        return Stream.of(argumentSet("days", Duration.ofDays(8), """
+                {"duration":"8d"}\
+                """),
+                argumentSet("hours", Duration.ofHours(5), """
+                        {"duration":"5h"}\
+                        """),
+                argumentSet("minutes", Duration.ofMinutes(6), """
+                        {"duration":"6m"}\
+                        """),
+                argumentSet("seconds", Duration.ofSeconds(7), """
+                        {"duration":"7s"}\
+                        """),
+                argumentSet("millis", Duration.ofMillis(9), """
+                        {"duration":"9ms"}\
+                        """),
+                argumentSet("micros", Duration.of(7, ChronoUnit.MICROS), """
+                        {"duration":"7μs"}\
+                        """),
+                argumentSet("nanos", Duration.ofNanos(1), """
+                        {"duration":"1ns"}\
+                        """),
+                argumentSet("complex", ONE_OF_EACH_UNIT, """
+                        {"duration":"1d1h1m1s1ms1μs1ns"}\
+                        """),
+                argumentSet("complex negative", NEGATIVE_ONE_OF_EACH_UNIT, """
+                        {"duration":"-1d1h1m1s1ms1μs1ns"}\
+                        """),
+                argumentSet("zero", Duration.ZERO, """
+                        {"duration":"0ms"}\
+                        """),
+                argumentSet("max possible duration", Duration.ofSeconds(Long.MAX_VALUE, 999_999_999), """
+                        {"duration":"106751991167300d15h30m7s999ms999μs999ns"}\
+                        """),
+                argumentSet("min possible duration", Duration.ofSeconds(Long.MIN_VALUE, 0), """
+                        {"duration":"-106751991167300d15h30m8s"}\
+                        """),
+                argumentSet("uses largest units", Duration.ofSeconds(60), """
+                        {"duration":"1m"}\
+                        """));
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void serialize(Duration duration, String expectedSerialized) throws IOException {
+        String serialized = MAPPER.writeValueAsString(new TestRecord(duration));
+        assertThat(serialized).isEqualTo(expectedSerialized);
+    }
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

- Adds DurationSerde.Serializer and DurationSerde.Deserializer
- it is expected fields using this serialization scheme will initially be annotated explicitly with @JsonSerialize and @JsonDeserialize from jackson-databind.

We want some way to represent Duration in our YAML configuration that is easily understood. This introduces a custom serializer/deserializer that uses a suffix-style format that will be familiar to golang/k8s users. Examples include:

- '1d' -> one day (not supported by golang Duration)
- '1h' -> one hour
- '1m' -> one minute
- '1s' -> one second
- '1ms' -> one millisecond
- '1μs' -> one microsecond
- '1us' -> one microsecond (alternative unit)
- '1ns' -> one nanosecond
- '1d1h' -> one day and one hour
- '0s' -> zero seconds (equivalent to Duration.ZERO)
- '-1d' -> negative one day (all units may be negative)

Complex constructions must be in descending-unit-order, ie '1s1m' is invalid, but '1m1s' is valid.

Whitespace anywhere in the serialized form is invalid.

We chose to use explicit annotations so that it will work with any ObjectMapper without having to install custom modules, and to reduce the chance of any future conflict with the jackson java8 datetime module.

An alternative to #3163 this backs off adding anything to kroxylicious-api, we could consider that if we start accumulating usages in Filter configuration of durations, which hasn't happened yet. It also removes the additional layer of a DurationSpec record, with the consequence that we lose serialization roundtrip fidelity, ie "24h" deserialized then serialized would result in "1d".

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
