### PR TITLE
Improve Integration test action

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -85,9 +85,25 @@ jobs:
     runs-on: ubuntu-latest
     needs: run_integration_tests
     if: always()
+    permissions:
+      actions: read
     steps:
     - name: 'Check all matrix builds'
-      run: ${{!contains(needs.*.result, 'failure')}}
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        FAILED_JSON=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
+          --jq '.jobs[] | select(.conclusion=="failure") | {name: .name, url: .html_url}')
+        if [ -z "$FAILED_JSON" ]; then
+          echo "All jobs passed!" >> $GITHUB_STEP_SUMMARY
+          echo "No failures detected."
+          exit 0
+        fi
+        echo "Failed Matrix Jobs" >> $GITHUB_STEP_SUMMARY
+        echo "The following instances failed:"
+        echo "$FAILED_JSON" | jq -r '"* [\(.name)](\(.url))"' >> $GITHUB_STEP_SUMMARY
+        echo "$FAILED_JSON" | jq -r '"\(.name): \(.url)"'
+        exit 1
   integration_test_filter_archetype:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

* let all integration test jobs run to completion
* improve failure message in the aggregator job, include details about which matrix jobs failed

To explain a bit, we use a job to check if all the matrix jobs succeeded, if not fail. This is so there is a single job we can point the branch protection rules at, we don't want to configure the branch to require each matrix job to succeed because there are many of them and they're dynamically generated.

This is improving the message users see in this aggregate job in the github UI, to link off to the failed matrix builds.

Resolves #3178 

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
