### PR TITLE
Fix: shouldFailToStartIfIouUringConfiguredAndUnavailable

### DIFF
--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/KafkaProxyTest.java
@@ -451,7 +451,7 @@ class KafkaProxyTest {
                 """), Features.defaultFeatures())) {
             // When
             // Then
-            assertThatThrownBy(proxy::startup).isInstanceOf(IllegalStateException.class).hasMessageStartingWith("io_uring not available due to: ");
+            assertThatThrownBy(proxy::startup).isInstanceOf(LifecycleException.class).hasMessageStartingWith("io_uring not available due to: ");
         }
     }
 }


### PR DESCRIPTION

### Type of change

- Bugfix

### Description

Fix failing test on main

### Additional Context

Test is disabled on platforms where IOUring is available which means it generally doesn't run on Linux (and thus CI) but does fail execute on MacOS

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
