### PR TITLE
Remove iouring support from simple test client

### DIFF
--- a/kroxylicious-integration-test-support/pom.xml
+++ b/kroxylicious-integration-test-support/pom.xml
@@ -103,10 +103,6 @@
             <artifactId>netty-transport-classes-kqueue</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-classes-io_uring</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/EventGroupConfig.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/EventGroupConfig.java
@@ -22,10 +22,6 @@ import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.channel.uring.IoUring;
-import io.netty.channel.uring.IoUringIoHandler;
-import io.netty.channel.uring.IoUringServerSocketChannel;
-import io.netty.channel.uring.IoUringSocketChannel;
 
 public record EventGroupConfig(
                                Class<? extends SocketChannel> clientChannelClass,
@@ -35,11 +31,7 @@ public record EventGroupConfig(
         final Class<? extends SocketChannel> clientChannelClass;
         final Class<? extends ServerSocketChannel> serverChannelClass;
 
-        if (IoUring.isAvailable()) {
-            clientChannelClass = IoUringSocketChannel.class;
-            serverChannelClass = IoUringServerSocketChannel.class;
-        }
-        else if (Epoll.isAvailable()) {
+        if (Epoll.isAvailable()) {
             clientChannelClass = EpollSocketChannel.class;
             serverChannelClass = EpollServerSocketChannel.class;
         }
@@ -56,10 +48,7 @@ public record EventGroupConfig(
 
     private static EventLoopGroup newGroup() {
         final IoHandlerFactory ioHandlerFactory;
-        if (IoUring.isAvailable()) {
-            ioHandlerFactory = IoUringIoHandler.newFactory();
-        }
-        else if (Epoll.isAvailable()) {
+        if (Epoll.isAvailable()) {
             ioHandlerFactory = EpollIoHandler.newFactory();
         }
         else if (KQueue.isAvailable()) {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Resolves #3188 
Resolves #3120

Integration tests on corretto 25 on main push are currently failing reliably. Debugging showed that netty threads were piling up, stuck trying to teardown IOUring resources. IOUring is the default implementation picked by the `io.kroxylicious.test.client.KafkaClient` test client we use to send single RPCs at the proxy and these new AuthZ tests started creating many of these throwaway clients, causing big growth in threads over time.

This was a copy-paste job from the production event group config. We never really cared about IOUring for this integration test client and have talked about removing it before.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
