### PR TITLE
Document KROXYLICIOUS_SLACK_WEBHOOK secret

### DIFF
--- a/.github/AUTOMATION_README.md
+++ b/.github/AUTOMATION_README.md
@@ -59,6 +59,10 @@ found on this page https://uk.smartkey.io/#/settings.
 In order to be able to run the system and performance tests for our Pull Requests (PR) using Jenkins, we have defined the following Personal Access Token (PAT) 
 `KROXYLICIOUS_JENKINS_TOKEN` to allow `kroxylicious-robot` writing comments with the results of the test execution and adding a new status check in the PR.
 
+## Slack Integration
+
+We use a slack webhook to send messages to the `#kroxylicious-bots` channel on slack. The webhook is stored in an organization secret called `KROXYLICIOUS_SLACK_WEBHOOK`.
+
 ## Deploying the Snapshot Website to GitHub Pages on a Fork
 
 We have automation to deploy a snapshot version of the website (source at https://github.com/kroxylicious/kroxylicious.github.io) with the latest documentation


### PR DESCRIPTION
### Type of change

- Documentation

### Description

We want to send messages to a slack channel when our automation driven by `main` push fails, as it is currently invisible.

I've added a `KROXYLICIOUS_SLACK_WEBHOOK` secret to the org containing the hook URL. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
