### PR TITLE
fix(tests): stablise sporadically failing OperatorChangeDetectionST

### DIFF
--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/OperatorChangeDetectionST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/OperatorChangeDetectionST.java
@@ -42,14 +42,13 @@ import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.common.FilterRef;
 import io.kroxylicious.kubernetes.api.common.FilterRefBuilder;
 import io.kroxylicious.kubernetes.api.common.Protocol;
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProtocolFilter;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProtocolFilterBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngressBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
+import io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyspec.InfrastructureBuilder;
 import io.kroxylicious.kubernetes.operator.assertj.OperatorAssertions;
 import io.kroxylicious.systemtests.installation.kroxylicious.CertManager;
 import io.kroxylicious.systemtests.installation.kroxylicious.Kroxylicious;
@@ -184,31 +183,23 @@ class OperatorChangeDetectionST extends AbstractST {
     void shouldUpdateWhenFilterConfigurationChanges(String namespace) {
         // Given
         // @formatter:off
-        KafkaProtocolFilterBuilder arbitraryFilter = KroxyliciousFilterTemplates.baseFilterDeployment(namespace, "arbitrary-filter")
+        var arbitraryFilterBuilder = KroxyliciousFilterTemplates.baseFilterDeployment(namespace, "arbitrary-filter")
                 .withNewSpec()
                     .withType("io.kroxylicious.filter.simpletransform.ProduceRequestTransformation")
                     .withConfigTemplate(Map.of("transformation", "Replacing", "transformationConfig",  Map.of("findPattern", "foo", "replacementValue", "bar")))
                 .endSpec();
         // @formatter:on
-        KubeClient kubeClient = kubeClient(namespace);
-        resourceManager.createOrUpdateResourceWithWait(arbitraryFilter);
+        resourceManager.createOrUpdateResourceWithWait(arbitraryFilterBuilder);
         kroxylicious.deployPortIdentifiesNodeWithFilters(kafkaClusterName, List.of("arbitrary-filter"));
 
-        String originalChecksum = getInitialChecksum(namespace);
-
-        // @formatter:off
-        KafkaProtocolFilterBuilder updatedProtocolFilter = kubeClient.getClient().resources(KafkaProtocolFilter.class)
-                .inNamespace(namespace)
-                .withName("arbitrary-filter")
-                .get()
-                .edit()
-                    .editSpec()
-                    .withConfigTemplate(Map.of("transformation", "Replacing", "transformationConfig",  Map.of("findPattern", "foo", "replacementValue", "updated")))
-                .endSpec();
-        // @formatter:on
+        var originalChecksum = getInitialChecksum(namespace);
+        var arbitraryFilter = arbitraryFilterBuilder.build();
+        var replacementConfig = Map.of("transformation", "Replacing", "transformationConfig", Map.of("findPattern", "foo", "replacementValue", "updated"));
 
         // When
-        resourceManager.createOrUpdateResourceWithWait(updatedProtocolFilter);
+        resourceManager.replaceResourceWithRetries(arbitraryFilter, current -> {
+            current.getSpec().setConfigTemplate(replacementConfig);
+        });
         LOGGER.info("Kafka proxy filter updated");
 
         // Then
@@ -227,21 +218,20 @@ class OperatorChangeDetectionST extends AbstractST {
         var customResourceRequests = Map.of("cpu", Quantity.parse("599m"), "memory", Quantity.parse("515Mi"));
 
         // @formatter:off
-        KafkaProxyBuilder updatedKafkaProxy = kafkaProxy.edit()
-                .editOrNewSpec()
-                .withNewInfrastructure()
+        var infra = new InfrastructureBuilder()
                 .withNewProxyContainer()
                 .withResources(new ResourceRequirementsBuilder()
-                        .withLimits(customResourceLimits)
-                        .withRequests(customResourceRequests)
-                        .build())
-                .endProxyContainer()
-                .endInfrastructure()
-                .endSpec();
+                    .withLimits(customResourceLimits)
+                    .withRequests(customResourceRequests)
+                    .build())
+            .endProxyContainer()
+            .build();
         // @formatter:on
 
         // When
-        resourceManager.createOrUpdateResourceWithWait(updatedKafkaProxy);
+        resourceManager.replaceResourceWithRetries(kafkaProxy, current -> {
+            current.getSpec().setInfrastructure(infra);
+        });
         LOGGER.info("Kafka proxy updated");
 
         // Then
@@ -275,15 +265,10 @@ class OperatorChangeDetectionST extends AbstractST {
         KafkaProxy kafkaProxy = kubeClient.getClient().resources(KafkaProxy.class).inNamespace(namespace)
                 .withName(Constants.KROXYLICIOUS_PROXY_SIMPLE_NAME).get();
 
-        // @formatter:off
-        KafkaProxyBuilder updatedKafkaProxy = kafkaProxy.edit()
-                .editOrNewSpec()
-                .withReplicas(2)
-                .endSpec();
-        // @formatter:on
-
         // When
-        resourceManager.createOrUpdateResourceWithWait(updatedKafkaProxy);
+        resourceManager.replaceResourceWithRetries(kafkaProxy, current -> {
+            current.getSpec().setReplicas(2);
+        });
         LOGGER.info("Kafka proxy updated");
 
         // Then


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

why: the test's attempt to update the CR raced with the operator's update to the same resource's status section.  This meant the optimistic lock (resourceVersion) used during the update could fail with Conflict, leading to the sporadically failing test.

Refactoring the test to use `replaceResourceWithRetries`  rather than `createOrUpdateResourceWithWait` with should resolve the issue.  This is already the approach taken by several other tests in the same suite.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
