### PR TITLE
fix(tests): speculative fix for unstable ListOffsetsAuthzIT

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/AuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/AuthzIT.java
@@ -26,8 +26,10 @@ import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicCollection;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
@@ -657,6 +659,11 @@ public abstract class AuthzIT extends BaseIT {
     }
 
     private static boolean topicPartitionsHaveALeader(TopicDescription td) {
-        return td.partitions().stream().allMatch(p -> p.leader() != null);
+        return td.partitions().stream().allMatch(AuthzIT::partitionHasLeaderAssigned);
+    }
+
+    private static boolean partitionHasLeaderAssigned(TopicPartitionInfo p) {
+        var leader = p.leader();
+        return leader != null && leader.id() != Node.noNode().id();
     }
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/ListOffsetsAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/ListOffsetsAuthzIT.java
@@ -39,8 +39,9 @@ import io.kroxylicious.testing.kafka.junit5ext.Name;
 class ListOffsetsAuthzIT extends AuthzIT {
 
     public static final String EXISTING_TOPIC_NAME = "other-topic";
-    public static final IntStream SUPPORTED_API_VERSIONS = IntStream.rangeClosed(ApiKeys.LIST_OFFSETS.oldestVersion(), ApiKeys.LIST_OFFSETS.latestVersion(true));
-    public static final int NON_EXISTANT_PARTITION = 20;
+    public static final List<Short> SUPPORTED_API_VERSIONS = IntStream.rangeClosed(ApiKeys.LIST_OFFSETS.oldestVersion(), ApiKeys.LIST_OFFSETS.latestVersion(true)).boxed()
+            .map(Integer::shortValue).toList();
+    public static final int NON_EXISTENT_PARTITION = 20;
     private Path rulesFile;
 
     private static final String ALICE_TO_DESCRIBE_TOPIC_NAME = "alice-new-topic";
@@ -87,8 +88,8 @@ class ListOffsetsAuthzIT extends AuthzIT {
     }
 
     List<Arguments> shouldEnforceAccessToTopics() {
-        return SUPPORTED_API_VERSIONS.<Arguments> mapToObj(
-                apiVersion -> Arguments.argumentSet("list offsets version " + apiVersion, new ListOffsetsEquivalence((short) apiVersion))).toList();
+        return SUPPORTED_API_VERSIONS.stream().<Arguments> map(
+                apiVersion -> Arguments.argumentSet("list offsets version " + apiVersion, new ListOffsetsEquivalence(apiVersion))).toList();
     }
 
     @ParameterizedTest
@@ -124,9 +125,9 @@ class ListOffsetsAuthzIT extends AuthzIT {
         @Override
         public ListOffsetsRequestData requestData(String user, BaseClusterFixture clusterFixture) {
             ListOffsetsRequestData listOffsetsRequestData = new ListOffsetsRequestData();
-            ListOffsetsRequestData.ListOffsetsTopic topicA = createListOffsetsTopic(ALICE_TO_DESCRIBE_TOPIC_NAME, 0, NON_EXISTANT_PARTITION);
-            ListOffsetsRequestData.ListOffsetsTopic topicB = createListOffsetsTopic(BOB_TO_DESCRIBE_TOPIC_NAME, 0, NON_EXISTANT_PARTITION);
-            ListOffsetsRequestData.ListOffsetsTopic topicC = createListOffsetsTopic(EXISTING_TOPIC_NAME, 0, NON_EXISTANT_PARTITION);
+            ListOffsetsRequestData.ListOffsetsTopic topicA = createListOffsetsTopic(ALICE_TO_DESCRIBE_TOPIC_NAME, 0, NON_EXISTENT_PARTITION);
+            ListOffsetsRequestData.ListOffsetsTopic topicB = createListOffsetsTopic(BOB_TO_DESCRIBE_TOPIC_NAME, 0, NON_EXISTENT_PARTITION);
+            ListOffsetsRequestData.ListOffsetsTopic topicC = createListOffsetsTopic(EXISTING_TOPIC_NAME, 0, NON_EXISTENT_PARTITION);
             listOffsetsRequestData.setTopics(List.of(topicA, topicB, topicC));
             return listOffsetsRequestData;
         }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Speculative fix for unstable `ListOffsetsAuthzIT`.  My theory is that our logic for assessing if a topic partition has a leader is incomplete.

I haven't been able to reproduce the issue locally, but figure this change a worth a punt.

_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
