### PR TITLE
docs(filters): illustrate and describe the filterRef array in the VKC resource

### DIFF
--- a/kroxylicious-docs/docs/_modules/configuring/con-virtualkafkacluster-overview.adoc
+++ b/kroxylicious-docs/docs/_modules/configuring/con-virtualkafkacluster-overview.adoc
@@ -15,10 +15,11 @@ The virtual cluster references the following resources, which must be in the sam
 * A `KafkaProxy` resource that the proxy is part of.
 * One or more `KafkaProxyIngress` resources that expose the virtual cluster to Kafka clients and provide virtual-cluster-specific configuration to the ingress (such as TLS certificates and other parameters).
 * A `KafkaService` resource that defines the backend Kafka cluster.
-* Zero or more `KafkaProtocolFilter` resources define the filters applied to Kafka protocol traffic between clients and the backend Kafka cluster.
+* One or more `KafkaProtocolFilter` resources that filter the Kafka protocol traffic between clients and the backend Kafka cluster.
 The order of the filters in the `filterRefs` array defines the order that the filters are applied.
 Client requests pass through the filters starting at index `0`, then `1`, and continuing to index `n`.
 Broker responses pass through the same filters in the reverse order.
+If the `filterRefs` array is empty (or null), the traffic will pass through the cluster unchanged.
 
 The following example shows configuration for a `VirtualKafkaCluster` that is exposed it to Kafka clients running on the same Kubernetes cluster.
 Protocol traffic is filtered by the `my-filter` filter.


### PR DESCRIPTION
### Type of change


- Documentation

### Description

The operator documentation does not adequately describe the role of the `filterRefs` field in the VKC resource.  It should  tell the reader that the list governs the order the filters are applied to the protocol trafiic.


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [x] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
