### PR TITLE
ListOffsetsAuthzIT ought to test as a client (rather than a broker)

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/ListOffsetsAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/ListOffsetsAuthzIT.java
@@ -39,8 +39,9 @@ import io.kroxylicious.testing.kafka.junit5ext.Name;
 class ListOffsetsAuthzIT extends AuthzIT {
 
     public static final String EXISTING_TOPIC_NAME = "other-topic";
-    public static final IntStream SUPPORTED_API_VERSIONS = IntStream.rangeClosed(ApiKeys.LIST_OFFSETS.oldestVersion(), ApiKeys.LIST_OFFSETS.latestVersion(true));
-    public static final int NON_EXISTANT_PARTITION = 20;
+    public static final List<Short> SUPPORTED_API_VERSIONS = IntStream.rangeClosed(ApiKeys.LIST_OFFSETS.oldestVersion(), ApiKeys.LIST_OFFSETS.latestVersion(true)).boxed()
+            .map(Integer::shortValue).toList();
+    public static final int NON_EXISTENT_PARTITION = 20;
     private Path rulesFile;
 
     private static final String ALICE_TO_DESCRIBE_TOPIC_NAME = "alice-new-topic";
@@ -87,8 +88,8 @@ class ListOffsetsAuthzIT extends AuthzIT {
     }
 
     List<Arguments> shouldEnforceAccessToTopics() {
-        return SUPPORTED_API_VERSIONS.<Arguments> mapToObj(
-                apiVersion -> Arguments.argumentSet("list offsets version " + apiVersion, new ListOffsetsEquivalence((short) apiVersion))).toList();
+        return SUPPORTED_API_VERSIONS.stream().<Arguments> map(
+                apiVersion -> Arguments.argumentSet("list offsets version " + apiVersion, new ListOffsetsEquivalence(apiVersion))).toList();
     }
 
     @ParameterizedTest
@@ -127,9 +128,9 @@ class ListOffsetsAuthzIT extends AuthzIT {
             // Field doc for ReplicaId says "The broker ID of the requester, or -1 if this request is being made by a normal consumer."
             // our use-case is a client use-case, so we must use -1.
             listOffsetsRequestData.setReplicaId(-1);
-            ListOffsetsRequestData.ListOffsetsTopic topicA = createListOffsetsTopic(ALICE_TO_DESCRIBE_TOPIC_NAME, 0, NON_EXISTANT_PARTITION);
-            ListOffsetsRequestData.ListOffsetsTopic topicB = createListOffsetsTopic(BOB_TO_DESCRIBE_TOPIC_NAME, 0, NON_EXISTANT_PARTITION);
-            ListOffsetsRequestData.ListOffsetsTopic topicC = createListOffsetsTopic(EXISTING_TOPIC_NAME, 0, NON_EXISTANT_PARTITION);
+            ListOffsetsRequestData.ListOffsetsTopic topicA = createListOffsetsTopic(ALICE_TO_DESCRIBE_TOPIC_NAME, 0, NON_EXISTENT_PARTITION);
+            ListOffsetsRequestData.ListOffsetsTopic topicB = createListOffsetsTopic(BOB_TO_DESCRIBE_TOPIC_NAME, 0, NON_EXISTENT_PARTITION);
+            ListOffsetsRequestData.ListOffsetsTopic topicC = createListOffsetsTopic(EXISTING_TOPIC_NAME, 0, NON_EXISTENT_PARTITION);
             listOffsetsRequestData.setTopics(List.of(topicA, topicB, topicC));
             return listOffsetsRequestData;
         }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

The LIST_OFFSETS API has a duality - it can be invoked from the client or the broker.  The proxy is proxying the client, rather than the broker, so the test-case should make the LIST_OFFSETS request as if it were a client.  It currently fails to set the `replicaId` field, so the request is be interpreted as if it were from a broker.

I don't know if this has a bearing on #3207.  I haven't been able to reproduce the issue since making this change.
The test code is certainly wrong, so it needs fixing whatever.  Suggest we suck it and see.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
