### PR TITLE
Update System Tests to KRaft-only

### DIFF
--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/strimzi/KafkaTemplates.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/strimzi/KafkaTemplates.java
@@ -6,7 +6,6 @@
 
 package io.kroxylicious.systemtests.templates.strimzi;
 
-import io.strimzi.api.ResourceAnnotations;
 import io.strimzi.api.kafka.model.common.template.ExternalTrafficPolicy;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.entityoperator.EntityOperatorSpec;
@@ -18,7 +17,6 @@ import io.strimzi.api.kafka.model.kafka.listener.KafkaListenerType;
 import io.kroxylicious.systemtests.Constants;
 import io.kroxylicious.systemtests.Environment;
 import io.kroxylicious.systemtests.enums.LogLevel;
-import io.kroxylicious.systemtests.utils.KafkaVersionUtils;
 
 /**
  * The type Kafka templates.
@@ -29,43 +27,15 @@ public class KafkaTemplates {
     }
 
     /**
-     * Kafka persistent kafka builder.
+     * Kafka with external ip kafka builder.
      *
      * @param namespaceName the namespace name
      * @param clusterName the cluster name
      * @param kafkaReplicas the kafka replicas
-     * @param zkReplicas the zk replicas
      * @return the kafka builder
      */
-    public static KafkaBuilder kafkaPersistent(String namespaceName, String clusterName, int kafkaReplicas, int zkReplicas) {
-        return defaultKafka(namespaceName, clusterName, kafkaReplicas, zkReplicas)
-                .editSpec()
-                .editKafka()
-                .withNewPersistentClaimStorage()
-                .withSize("1Gi")
-                .withDeleteClaim(true)
-                .endPersistentClaimStorage()
-                .endKafka()
-                .editZookeeper()
-                .withNewPersistentClaimStorage()
-                .withSize("1Gi")
-                .withDeleteClaim(true)
-                .endPersistentClaimStorage()
-                .endZookeeper()
-                .endSpec();
-    }
-
-    /**
-     * Kafka persistent with external ip kafka builder.
-     *
-     * @param namespaceName the namespace name
-     * @param clusterName the cluster name
-     * @param kafkaReplicas the kafka replicas
-     * @param zkReplicas the zk replicas
-     * @return the kafka builder
-     */
-    public static KafkaBuilder kafkaPersistentWithExternalIp(String namespaceName, String clusterName, int kafkaReplicas, int zkReplicas) {
-        return kafkaPersistent(namespaceName, clusterName, kafkaReplicas, zkReplicas)
+    public static KafkaBuilder kafkaWithExternalIp(String namespaceName, String clusterName, int kafkaReplicas) {
+        return defaultKafka(namespaceName, clusterName, kafkaReplicas)
                 .editSpec()
                 .editKafka()
                 .addToListeners(new GenericKafkaListenerBuilder()
@@ -82,34 +52,17 @@ public class KafkaTemplates {
     }
 
     /**
-     * Kafka persistent with KRaft annotations.
-     *
-     * @param namespaceName the namespace name
-     * @param clusterName the cluster name
-     * @param kafkaReplicas the kafka replicas
-     * @return the kafka builder
-     */
-    public static KafkaBuilder kafkaPersistentWithKRaftAnnotations(String namespaceName, String clusterName, int kafkaReplicas) {
-        return kafkaPersistent(namespaceName, clusterName, kafkaReplicas, kafkaReplicas)
-                .editMetadata()
-                .addToAnnotations(ResourceAnnotations.ANNO_STRIMZI_IO_NODE_POOLS, "enabled")
-                .addToAnnotations(ResourceAnnotations.ANNO_STRIMZI_IO_KRAFT, "enabled")
-                .endMetadata();
-    }
-
-    /**
-     * Kafka persistent with authentication kafka builder.
+     * Kafka with authentication kafka builder.
      *
      * @param namespaceName the namespace name
      * @param clusterName the cluster name
      * @param kafkaReplicas the kafka replicas
      * @return  the kafka builder
      */
-    public static KafkaBuilder kafkaPersistentWithAuthentication(String namespaceName, String clusterName, int kafkaReplicas) {
+    public static KafkaBuilder kafkaWithAuthentication(String namespaceName, String clusterName, int kafkaReplicas) {
         EntityOperatorSpec entityOperatorSpec = new EntityOperatorSpec();
         entityOperatorSpec.setUserOperator(new EntityUserOperatorSpec());
-
-        return kafkaPersistentWithKRaftAnnotations(namespaceName, clusterName, kafkaReplicas)
+        return defaultKafka(namespaceName, clusterName, kafkaReplicas)
                 .editSpec()
                 .editKafka()
                 .withListeners(new GenericKafkaListenerBuilder()
@@ -131,7 +84,7 @@ public class KafkaTemplates {
                 .endSpec();
     }
 
-    private static KafkaBuilder defaultKafka(String namespaceName, String clusterName, int kafkaReplicas, int zkReplicas) {
+    public static KafkaBuilder defaultKafka(String namespaceName, String clusterName, int kafkaReplicas) {
         // @formatter:off
         return new KafkaBuilder()
                 .withApiVersion(Constants.KAFKA_API_VERSION_V1BETA2)
@@ -143,9 +96,6 @@ public class KafkaTemplates {
                 .editSpec()
                     .editKafka()
                         .withVersion(Environment.KAFKA_VERSION)
-                        .withReplicas(kafkaReplicas)
-                        .addToConfig("log.message.format.version", KafkaVersionUtils.getKafkaProtocolVersion(Environment.KAFKA_VERSION))
-                        .addToConfig("inter.broker.protocol.version", KafkaVersionUtils.getKafkaProtocolVersion(Environment.KAFKA_VERSION))
                         .addToConfig("offsets.topic.replication.factor", Math.min(kafkaReplicas, 3))
                         .addToConfig("transaction.state.log.min.isr", Math.min(kafkaReplicas, 2))
                         .addToConfig("transaction.state.log.replication.factor", Math.min(kafkaReplicas, 3))
@@ -169,12 +119,6 @@ public class KafkaTemplates {
                             .addToLoggers("rootLogger.level", LogLevel.INFO.name())
                         .endInlineLogging()
                     .endKafka()
-                    .editZookeeper()
-                        .withReplicas(zkReplicas)
-                        .withNewInlineLogging()
-                            .addToLoggers("zookeeper.root.logger", LogLevel.INFO.name())
-                        .endInlineLogging()
-                    .endZookeeper()
                 .endSpec();
         // @formatter:on
     }

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/KroxyliciousAppST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/KroxyliciousAppST.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.kroxylicious.systemtests.installation.kroxylicious.KroxyliciousApp;
+import io.kroxylicious.systemtests.templates.strimzi.KafkaNodePoolTemplates;
 import io.kroxylicious.systemtests.templates.strimzi.KafkaTemplates;
 import io.kroxylicious.systemtests.utils.DeploymentUtils;
 
@@ -53,7 +54,10 @@ class KroxyliciousAppST extends AbstractST {
         assumeTrue(DeploymentUtils.checkLoadBalancerIsWorking(Constants.KAFKA_DEFAULT_NAMESPACE), "Load balancer is not working fine, if you are using"
                 + "minikube please run 'minikube tunnel' before running the tests");
         LOGGER.info("Deploying Kafka in {} namespace", Constants.KAFKA_DEFAULT_NAMESPACE);
-        resourceManager.createResourceFromBuilderWithWait(KafkaTemplates.kafkaPersistentWithExternalIp(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName, 3, 3));
+        int kafkaReplicas = 3;
+        resourceManager.createResourceFromBuilderWithWait(
+                KafkaNodePoolTemplates.poolWithDualRoleAndPersistentStorage(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName, kafkaReplicas),
+                KafkaTemplates.kafkaWithExternalIp(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName, kafkaReplicas));
     }
 
     /**

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/KroxyliciousST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/KroxyliciousST.java
@@ -19,7 +19,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.Pod;
-import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 
 import io.kroxylicious.systemtests.clients.records.ConsumerRecord;
 import io.kroxylicious.systemtests.installation.kroxylicious.Kroxylicious;
@@ -41,7 +40,6 @@ class KroxyliciousST extends AbstractST {
     private static final Logger LOGGER = LoggerFactory.getLogger(KroxyliciousST.class);
     private static Kroxylicious kroxylicious;
     private final String clusterName = "kroxylicious-st-cluster";
-    protected static final String BROKER_NODE_NAME = "kafka";
     private static final String MESSAGE = "Hello-world";
     private KroxyliciousOperator kroxyliciousOperator;
 
@@ -257,12 +255,10 @@ class KroxyliciousST extends AbstractST {
         else {
             LOGGER.atInfo().setMessage("Deploying Kafka in {} namespace").addArgument(Constants.KAFKA_DEFAULT_NAMESPACE).log();
 
-            int numberOfBrokers = 1;
-            KafkaBuilder kafka = KafkaTemplates.kafkaPersistentWithKRaftAnnotations(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName, numberOfBrokers);
-
+            int kafkaReplicas = 1;
             resourceManager.createResourceFromBuilderWithWait(
-                    KafkaNodePoolTemplates.kafkaBasedNodePoolWithDualRole(BROKER_NODE_NAME, kafka.build(), numberOfBrokers),
-                    kafka);
+                    KafkaNodePoolTemplates.poolWithDualRoleAndPersistentStorage(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName, kafkaReplicas),
+                    KafkaTemplates.defaultKafka(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName, kafkaReplicas));
         }
 
         kroxyliciousOperator = new KroxyliciousOperator(Constants.KROXYLICIOUS_OPERATOR_NAMESPACE);

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/MetricsST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/MetricsST.java
@@ -20,7 +20,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.Pod;
-import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 
 import io.kroxylicious.systemtests.clients.records.ConsumerRecord;
 import io.kroxylicious.systemtests.enums.ComponentType;
@@ -190,12 +189,10 @@ class MetricsST extends AbstractST {
         else {
             LOGGER.atInfo().setMessage("Deploying Kafka in {} namespace").addArgument(Constants.KAFKA_DEFAULT_NAMESPACE).log();
 
-            int numberOfBrokers = 1;
-            KafkaBuilder kafka = KafkaTemplates.kafkaPersistentWithKRaftAnnotations(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName, numberOfBrokers);
-
+            int kafkaReplicas = 1;
             resourceManager.createResourceFromBuilderWithWait(
-                    KafkaNodePoolTemplates.kafkaBasedNodePoolWithDualRole(BROKER_NODE_NAME, kafka.build(), numberOfBrokers),
-                    kafka);
+                    KafkaNodePoolTemplates.poolWithDualRoleAndPersistentStorage(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName, kafkaReplicas),
+                    KafkaTemplates.defaultKafka(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName, kafkaReplicas));
         }
 
         kroxyliciousOperator = new KroxyliciousOperator(Constants.KROXYLICIOUS_OPERATOR_NAMESPACE);

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/NonJVMClientsST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/NonJVMClientsST.java
@@ -18,7 +18,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.Pod;
-import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 
 import io.kroxylicious.systemtests.clients.KafkaClients;
 import io.kroxylicious.systemtests.clients.records.ConsumerRecord;
@@ -40,7 +39,6 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 class NonJVMClientsST extends AbstractST {
     private static final Logger LOGGER = LoggerFactory.getLogger(NonJVMClientsST.class);
     private final String clusterName = "non-jvm-clients-cluster";
-    protected static final String BROKER_NODE_NAME = "kafka";
     private static final String MESSAGE = "Hello-world";
     private String bootstrap;
     private KroxyliciousOperator kroxyliciousOperator;
@@ -270,11 +268,10 @@ class NonJVMClientsST extends AbstractST {
         else {
             LOGGER.info("Deploying Kafka in {} namespace", Constants.KAFKA_DEFAULT_NAMESPACE);
 
-            KafkaBuilder kafka = KafkaTemplates.kafkaPersistentWithKRaftAnnotations(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName, 3);
-
+            int kafkaReplicas = 3;
             resourceManager.createResourceFromBuilderWithWait(
-                    KafkaNodePoolTemplates.kafkaBasedNodePoolWithDualRole(BROKER_NODE_NAME, kafka.build(), 3),
-                    kafka);
+                    KafkaNodePoolTemplates.poolWithDualRoleAndPersistentStorage(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName, kafkaReplicas),
+                    KafkaTemplates.defaultKafka(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName, kafkaReplicas));
         }
 
         kroxyliciousOperator = new KroxyliciousOperator(Constants.KROXYLICIOUS_OPERATOR_NAMESPACE);

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/filters/AuthorizationST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/filters/AuthorizationST.java
@@ -22,7 +22,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.Pod;
-import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 
 import io.kroxylicious.authorizer.service.Decision;
 import io.kroxylicious.systemtests.AbstractST;
@@ -44,7 +43,6 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 class AuthorizationST extends AbstractST {
-    protected static final String BROKER_NODE_NAME = "kafka";
     private static final Logger LOGGER = LoggerFactory.getLogger(AuthorizationST.class);
     private static final String MESSAGE = "Hello-world";
     private final String clusterName = "authorization-st-cluster";
@@ -63,12 +61,10 @@ class AuthorizationST extends AbstractST {
         else {
             LOGGER.atInfo().setMessage("Deploying Kafka in {} namespace").addArgument(Constants.KAFKA_DEFAULT_NAMESPACE).log();
 
-            int numberOfBrokers = 1;
-            KafkaBuilder kafka = KafkaTemplates.kafkaPersistentWithAuthentication(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName, numberOfBrokers);
-
+            int kafkaReplicas = 1;
             resourceManager.createResourceFromBuilderWithWait(
-                    KafkaNodePoolTemplates.kafkaBasedNodePoolWithDualRole(BROKER_NODE_NAME, kafka.build(), numberOfBrokers),
-                    kafka);
+                    KafkaNodePoolTemplates.poolWithDualRoleAndPersistentStorage(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName, kafkaReplicas),
+                    KafkaTemplates.kafkaWithAuthentication(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName, kafkaReplicas));
         }
 
         kroxyliciousOperator = new KroxyliciousOperator(Constants.KROXYLICIOUS_OPERATOR_NAMESPACE);

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/filters/RecordEncryptionST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/filters/RecordEncryptionST.java
@@ -21,7 +21,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.Pod;
-import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 
 import io.kroxylicious.kms.service.TestKekManager;
 import io.kroxylicious.kms.service.TestKmsFacade;
@@ -63,12 +62,10 @@ class RecordEncryptionST extends AbstractST {
         else {
             LOGGER.atInfo().setMessage("Deploying Kafka in {} namespace").addArgument(Constants.KAFKA_DEFAULT_NAMESPACE).log();
 
-            int numberOfBrokers = 1;
-            KafkaBuilder kafka = KafkaTemplates.kafkaPersistentWithKRaftAnnotations(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName, numberOfBrokers);
-
+            int kafkaReplicas = 1;
             resourceManager.createResourceFromBuilderWithWait(
-                    KafkaNodePoolTemplates.kafkaBasedNodePoolWithDualRole(BROKER_NODE_NAME, kafka.build(), numberOfBrokers),
-                    kafka);
+                    KafkaNodePoolTemplates.poolWithDualRoleAndPersistentStorage(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName, kafkaReplicas),
+                    KafkaTemplates.defaultKafka(Constants.KAFKA_DEFAULT_NAMESPACE, clusterName, kafkaReplicas));
         }
 
         kroxyliciousOperator = new KroxyliciousOperator(Constants.KROXYLICIOUS_OPERATOR_NAMESPACE);


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Align with Strimzi 0.48.0 KRaft-only architecture, shifting part of configuration to Node Pools, already causing warnings in current way of usage (https://github.com/kroxylicious/kroxylicious/issues/3081) 

### Additional Context

Configuration (Storage, Zookeeper, replicas, and some of additional kafka configs) set in Kafka custom resoruces is now deprecated/obsolete. Keeping setting it as it is now would result in failure to create Kafka in future Strimzi versions. 

**Changes Made**

`KafkaNodePoolTemplates.java` 
- stable node pool name to reduce passed params (were constant anyway)
- `EpehemeralStorage` assumed by default as it is no longer copied from Kafka custom resource
-  6 public methods to build node pools with Controller, Broker or dual roles  with/without persistent storage  repplaces mix of Kafka Based Nodepols, default builders and no longer depends on Kafka Build object but only kafka cluster name. 

`KafkaTemplates.java`
- `kafkaPersistent()` function removed as storage is no longer configured in kafka custom resource and prefix "kafkaPersistent" removed from rest of method as it should no longer implicate any storage related configuration
-  `kafkaPersistentWithKRaftAnnotations()` function removed as annotations to use kraft or node pools are no longer serving any purpose becasue kraft and node pools are implicit. 
- removal of setting of any other configs no longer to be set in kafka cr: Zookeeper, replicas, and some of additional kafka configs

`.*ST.java`
-  Updated 6 test classes to use new template API of creation of Kafka and KafkaNodePools according to changes made in templates. 

