### PR TITLE
chore: remove deprecated template kek selector brace style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
-build(deps): bump io.strimzi:api from 0.48.0 to 0.50.0 #3171
-
+* [#3242](https://github.com/kroxylicious/kroxylicious/pull/3242): chore: remove deprecated template kek selector brace style
 * [#3224](https://github.com/kroxylicious/kroxylicious/pull/3224): Add support for using Secret in `trustAnchorRef` field of the KafkaService and the VirtualKafkaCluster CRs.
 * [#3171](https://github.com/kroxylicious/kroxylicious/pull/3171): build(deps): bump io.strimzi:api from 0.48.0 to 0.50.0
 * [#3147](https://github.com/kroxylicious/kroxylicious/pull/3129): Deprecate Java 17. Upgrade to Java 21 in containers.
@@ -26,6 +25,8 @@ build(deps): bump io.strimzi:api from 0.48.0 to 0.50.0 #3171
 * The four argument forms of `RequestFilter#onRequest` and `ResponseFilter#onResponse` are deprecated and will be removed in a future release.
   Implement the five argument form, which includes the `apiVersion` instead.
 * A JSON Web Signature (JWS) Signature validator has been added. WARNING: This validator does NOT include JSON Web Token (JWT) validation (expiration, issuer, etc. are NOT checked).
+* Curly-brace style topicName tokens are no longer supported in the Record Encryption TemplateKekSelector template. `template` should use `$(topicName)` instead of `${topicName}`.
+  The was deprecated in version 0.11.0.
 
 ## 0.18.0
 

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/encrypt/TemplateKekSelectorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/encrypt/TemplateKekSelectorTest.java
@@ -50,33 +50,10 @@ class TemplateKekSelectorTest {
     }
 
     @Test
-    void shouldRejectUnknownPlaceholders_curly() {
-        assertThatThrownBy(() -> getSelector(null, "foo-${topicId}-bar"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Unknown template parameter: topicId");
-    }
-
-    @Test
     void shouldRejectUnknownPlaceholders() {
         assertThatThrownBy(() -> getSelector(null, "foo-$(topicId)-bar"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Unknown template parameter: topicId");
-    }
-
-    @Test
-    void shouldResolveWhenAliasExists_curly() {
-        kmsService.initialize(new UnitTestingKmsService.Config());
-        var kms = kmsService.buildKms();
-        var selector = getSelector(kms, "topic-${topicName}");
-
-        var kek = kms.generateKey();
-        kms.createAlias(kek, "topic-my-topic");
-        TopicNameKekSelection<UUID> selection = selector.selectKek(Set.of("my-topic")).toCompletableFuture().join();
-        var map = selection.topicNameToKekId();
-        assertThat(map)
-                .hasSize(1)
-                .containsEntry("my-topic", kek);
-        assertThat(selection.unresolvedTopicNames()).isEmpty();
     }
 
     @Test
@@ -93,21 +70,6 @@ class TemplateKekSelectorTest {
                 .hasSize(1)
                 .containsEntry("my-topic", kek);
         assertThat(selection.unresolvedTopicNames()).isEmpty();
-    }
-
-    @Test
-    void shouldNotThrowWhenAliasDoesNotExist_curly() {
-        kmsService.initialize(new UnitTestingKmsService.Config());
-        var kms = kmsService.buildKms();
-        var selector = getSelector(kms, "topic-${topicName}");
-
-        TopicNameKekSelection<UUID> selection = selector.selectKek(Set.of("my-topic")).toCompletableFuture().join();
-        var unresolvedTopicNames = selection.unresolvedTopicNames();
-        assertThat(unresolvedTopicNames)
-                .hasSize(1)
-                .containsExactly("my-topic");
-
-        assertThat(selection.topicNameToKekId()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Remove `${}` template style that was originally supported in the template kek selector. This was deprecated in v0.11.0.

Resolves #3241

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
