### PR TITLE
Require authorization for list transactions

### DIFF
--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/AuthorizationFilter.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/AuthorizationFilter.java
@@ -101,6 +101,7 @@ public class AuthorizationFilter implements RequestFilter, ResponseFilter {
         apiEnforcement.put(ApiKeys.CONSUMER_GROUP_DESCRIBE, new ConsumerGroupDescribeEnforcement());
         apiEnforcement.put(ApiKeys.DESCRIBE_GROUPS, new Passthrough<>(0, 6));
         apiEnforcement.put(ApiKeys.DESCRIBE_TRANSACTIONS, new DescribeTransactionsEnforcement());
+        apiEnforcement.put(ApiKeys.LIST_TRANSACTIONS, new ListTransactionsEnforcement());
     }
 
     @VisibleForTesting

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/ListTransactionsEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/ListTransactionsEnforcement.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.authorization;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.ListTransactionsRequestData;
+import org.apache.kafka.common.message.ListTransactionsResponseData;
+import org.apache.kafka.common.message.ListTransactionsResponseData.TransactionState;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+
+import io.kroxylicious.authorizer.service.Action;
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.RequestFilterResult;
+import io.kroxylicious.proxy.filter.ResponseFilterResult;
+
+class ListTransactionsEnforcement extends ApiEnforcement<ListTransactionsRequestData, ListTransactionsResponseData> {
+
+    short minSupportedVersion() {
+        return 0;
+    }
+
+    short maxSupportedVersion() {
+        return 2;
+    }
+
+    @Override
+    CompletionStage<RequestFilterResult> onRequest(RequestHeaderData header, ListTransactionsRequestData request, FilterContext context,
+                                                   AuthorizationFilter authorizationFilter) {
+        return context.forwardRequest(header, request);
+    }
+
+    @Override
+    CompletionStage<ResponseFilterResult> onResponse(ResponseHeaderData header, ListTransactionsResponseData response, FilterContext context,
+                                                     AuthorizationFilter authorizationFilter) {
+        List<Action> actions = Objects.requireNonNull(response.transactionStates()).stream().map(TransactionState::transactionalId)
+                .map(txnlId -> new Action(TransactionalIdResource.DESCRIBE, txnlId))
+                .toList();
+        return authorizationFilter.authorization(context, actions).thenCompose(authorizeResult -> {
+            List<String> deniedTxnlIds = authorizeResult.denied(TransactionalIdResource.DESCRIBE);
+            response.transactionStates().removeIf(transactionState -> deniedTxnlIds.contains(transactionState.transactionalId()));
+            return super.onResponse(header, response, context, authorizationFilter);
+        });
+    }
+}

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/AuthorizationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/AuthorizationFilterTest.java
@@ -322,7 +322,8 @@ class AuthorizationFilterTest {
                 ApiKeys.INCREMENTAL_ALTER_CONFIGS,
                 ApiKeys.CONSUMER_GROUP_DESCRIBE,
                 ApiKeys.DESCRIBE_GROUPS,
-                ApiKeys.DESCRIBE_TRANSACTIONS);
+                ApiKeys.DESCRIBE_TRANSACTIONS,
+                ApiKeys.LIST_TRANSACTIONS);
         EnumSet<ApiKeys> someVersionsSupported = of(ApiKeys.PRODUCE,
                 ApiKeys.FETCH,
                 ApiKeys.OFFSET_COMMIT,

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_TRANSACTIONS/0/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_TRANSACTIONS/0/baseline.yaml
@@ -1,0 +1,67 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "LIST_TRANSACTIONS"
+  apiVersion: 0
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "LIST_TRANSACTIONS"
+      expectedRequestVersion: 0
+      expectedRequestHeader:
+        requestApiKey: 66
+        requestApiVersion: 0
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        stateFilters:
+          - "random-string-329"
+        producerIdFilters:
+          - 918
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 91
+        errorCode: 168
+        unknownStateFilters:
+          - "random-string-610"
+        transactionStates:
+          - transactionalId: "my-transactional-id"
+            producerId: 667
+            transactionState: "random-string-35"
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-transactional-id"
+        resourceClass: "TRANSACTIONAL_ID"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 66
+    requestApiVersion: 0
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    stateFilters:
+      - "random-string-329"
+    producerIdFilters:
+      - 918
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 91
+    errorCode: 168
+    unknownStateFilters:
+      - "random-string-610"
+    transactionStates:
+      - transactionalId: "my-transactional-id"
+        producerId: 667
+        transactionState: "random-string-35"

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_TRANSACTIONS/1/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_TRANSACTIONS/1/baseline.yaml
@@ -1,0 +1,69 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "LIST_TRANSACTIONS"
+  apiVersion: 1
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "LIST_TRANSACTIONS"
+      expectedRequestVersion: 1
+      expectedRequestHeader:
+        requestApiKey: 66
+        requestApiVersion: 1
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        stateFilters:
+          - "random-string-1014"
+        producerIdFilters:
+          - 371
+        durationFilter: 105
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 773
+        errorCode: 602
+        unknownStateFilters:
+          - "random-string-746"
+        transactionStates:
+          - transactionalId: "my-transactional-id"
+            producerId: 442
+            transactionState: "random-string-556"
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-transactional-id"
+        resourceClass: "TRANSACTIONAL_ID"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 66
+    requestApiVersion: 1
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    stateFilters:
+      - "random-string-1014"
+    producerIdFilters:
+      - 371
+    durationFilter: 105
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 773
+    errorCode: 602
+    unknownStateFilters:
+      - "random-string-746"
+    transactionStates:
+      - transactionalId: "my-transactional-id"
+        producerId: 442
+        transactionState: "random-string-556"

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_TRANSACTIONS/2/all-transactional-ids-denied.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_TRANSACTIONS/2/all-transactional-ids-denied.yaml
@@ -1,0 +1,64 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "LIST_TRANSACTIONS"
+  apiVersion: 2
+  scenario: "all transactionalIds in the response are denied, causing their entries to be removed"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "LIST_TRANSACTIONS"
+      expectedRequestVersion: 2
+      expectedRequestHeader:
+        requestApiKey: 66
+        requestApiVersion: 2
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        stateFilters:
+          - "random-string-419"
+        producerIdFilters:
+          - 443
+        durationFilter: 906
+        transactionalIdPattern: "random-string-200"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 776
+        errorCode: 1003
+        unknownStateFilters:
+          - "random-string-936"
+        transactionStates:
+          - transactionalId: "my-transactional-id"
+            producerId: 913
+            transactionState: "random-string-578"
+  authorizerRules:
+    allowed: []
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 66
+    requestApiVersion: 2
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    stateFilters:
+      - "random-string-419"
+    producerIdFilters:
+      - 443
+    durationFilter: 906
+    transactionalIdPattern: "random-string-200"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 776
+    errorCode: 1003
+    unknownStateFilters:
+      - "random-string-936"
+    transactionStates: []

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_TRANSACTIONS/2/baseline.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_TRANSACTIONS/2/baseline.yaml
@@ -1,0 +1,71 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "LIST_TRANSACTIONS"
+  apiVersion: 2
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "LIST_TRANSACTIONS"
+      expectedRequestVersion: 2
+      expectedRequestHeader:
+        requestApiKey: 66
+        requestApiVersion: 2
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        stateFilters:
+          - "random-string-419"
+        producerIdFilters:
+          - 443
+        durationFilter: 906
+        transactionalIdPattern: "random-string-200"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 776
+        errorCode: 1003
+        unknownStateFilters:
+          - "random-string-936"
+        transactionStates:
+          - transactionalId: "my-transactional-id"
+            producerId: 913
+            transactionState: "random-string-578"
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-transactional-id"
+        resourceClass: "TRANSACTIONAL_ID"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 66
+    requestApiVersion: 2
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    stateFilters:
+      - "random-string-419"
+    producerIdFilters:
+      - 443
+    durationFilter: 906
+    transactionalIdPattern: "random-string-200"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 776
+    errorCode: 1003
+    unknownStateFilters:
+      - "random-string-936"
+    transactionStates:
+      - transactionalId: "my-transactional-id"
+        producerId: 913
+        transactionState: "random-string-578"

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_TRANSACTIONS/2/some-transactional-ids-denied.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/LIST_TRANSACTIONS/2/some-transactional-ids-denied.yaml
@@ -1,0 +1,74 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "LIST_TRANSACTIONS"
+  apiVersion: 2
+  scenario: "some transactionalIds in the response are denied, some are allowed, causing denied entries to be removed"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "LIST_TRANSACTIONS"
+      expectedRequestVersion: 2
+      expectedRequestHeader:
+        requestApiKey: 66
+        requestApiVersion: 2
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        stateFilters:
+          - "random-string-419"
+        producerIdFilters:
+          - 443
+        durationFilter: 906
+        transactionalIdPattern: "random-string-200"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 776
+        errorCode: 1003
+        unknownStateFilters:
+          - "random-string-936"
+        transactionStates:
+          - transactionalId: "my-transactional-id"
+            producerId: 913
+            transactionState: "random-string-578"
+          - transactionalId: "denied-transactional-id"
+            producerId: 913
+            transactionState: "random-string-578"
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-transactional-id"
+        resourceClass: "TRANSACTIONAL_ID"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 66
+    requestApiVersion: 2
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    stateFilters:
+      - "random-string-419"
+    producerIdFilters:
+      - 443
+    durationFilter: 906
+    transactionalIdPattern: "random-string-200"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 776
+    errorCode: 1003
+    unknownStateFilters:
+      - "random-string-936"
+    transactionStates:
+      - transactionalId: "my-transactional-id"
+        producerId: 913
+        transactionState: "random-string-578"

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/ListTransactionsAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/ListTransactionsAuthzIT.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.it.filter.authorization;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.common.acl.AccessControlEntry;
+import org.apache.kafka.common.acl.AclBinding;
+import org.apache.kafka.common.acl.AclOperation;
+import org.apache.kafka.common.acl.AclPermissionType;
+import org.apache.kafka.common.message.ListOffsetsRequestData;
+import org.apache.kafka.common.message.ListOffsetsResponseData;
+import org.apache.kafka.common.message.ListTransactionsRequestData;
+import org.apache.kafka.common.message.ListTransactionsResponseData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.requests.FindCoordinatorRequest;
+import org.apache.kafka.common.resource.PatternType;
+import org.apache.kafka.common.resource.ResourcePattern;
+import org.apache.kafka.common.resource.ResourceType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.kroxylicious.testing.kafka.junit5ext.Name;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ListTransactionsAuthzIT extends AuthzIT {
+
+    public static final List<Short> SUPPORTED_API_VERSIONS = IntStream
+            .rangeClosed(ApiKeys.LIST_TRANSACTIONS.oldestVersion(), ApiKeys.LIST_TRANSACTIONS.latestVersion(true)).boxed()
+            .map(Integer::shortValue).toList();
+    private Path rulesFile;
+
+    private static final String ALICE_TO_DESCRIBE_TRANSACTIONAL_ID_PREFIX = "alice-transaction";
+    private static final String BOB_TO_DESCRIBE_TRANSACTIONAL_ID_PREFIX = "bob-transaction";
+    private static final List<String> ALL_TRANSACTIONAL_ID_PREFIXES = List.of(ALICE_TO_DESCRIBE_TRANSACTIONAL_ID_PREFIX, BOB_TO_DESCRIBE_TRANSACTIONAL_ID_PREFIX);
+    private static List<AclBinding> aclBindings;
+
+    @Name("kafkaClusterWithAuthz")
+    static Admin kafkaClusterWithAuthzAdmin;
+    @Name("kafkaClusterNoAuthz")
+    static Admin kafkaClusterNoAuthzAdmin;
+
+    @BeforeAll
+    void beforeAll() throws IOException {
+        rulesFile = Files.createTempFile(getClass().getName(), ".aclRules");
+        Files.writeString(rulesFile, """
+                from io.kroxylicious.filter.authorization import TransactionalIdResource as TxnlId;
+                allow User with name = "alice" to * TxnlId with name like "%s*";
+                allow User with name = "bob" to DESCRIBE TxnlId with name like "%s*";
+                allow User with name = "super" to * TxnlId with name like "*";
+                otherwise deny;
+                """.formatted(ALICE_TO_DESCRIBE_TRANSACTIONAL_ID_PREFIX, BOB_TO_DESCRIBE_TRANSACTIONAL_ID_PREFIX));
+
+        aclBindings = List.of(
+                new AclBinding(
+                        new ResourcePattern(ResourceType.TRANSACTIONAL_ID, ALICE_TO_DESCRIBE_TRANSACTIONAL_ID_PREFIX, PatternType.PREFIXED),
+                        new AccessControlEntry("User:" + ALICE, "*",
+                                AclOperation.ALL, AclPermissionType.ALLOW)),
+                new AclBinding(
+                        new ResourcePattern(ResourceType.TRANSACTIONAL_ID, BOB_TO_DESCRIBE_TRANSACTIONAL_ID_PREFIX, PatternType.PREFIXED),
+                        new AccessControlEntry("User:" + BOB, "*",
+                                AclOperation.DESCRIBE, AclPermissionType.ALLOW)));
+    }
+
+    @BeforeEach
+    void prepClusters() {
+        this.topicIdsInUnproxiedCluster = ClusterPrepUtils.createTopicsAndAcls(kafkaClusterWithAuthzAdmin, List.of(), aclBindings);
+        this.topicIdsInProxiedCluster = ClusterPrepUtils.createTopicsAndAcls(kafkaClusterNoAuthzAdmin, List.of(), List.of());
+    }
+
+    @AfterEach
+    void tidyClusters() {
+        ClusterPrepUtils.deleteTopicsAndAcls(kafkaClusterWithAuthzAdmin, List.of(), aclBindings);
+        ClusterPrepUtils.deleteTopicsAndAcls(kafkaClusterNoAuthzAdmin, List.of(), List.of());
+    }
+
+    List<Arguments> shouldEnforceAccessToTopics() {
+        return SUPPORTED_API_VERSIONS.stream().<Arguments> map(
+                apiVersion -> {
+                    List<String> transactionIds = ALL_TRANSACTIONAL_ID_PREFIXES.stream().map(s -> s + "-" + UUID.randomUUID()).toList();
+                    return Arguments.argumentSet("list offsets version " + apiVersion, new ListTransactionsEquivalence(apiVersion, transactionIds));
+                }).toList();
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void shouldEnforceAccessToTopics(VersionSpecificVerification<ListOffsetsRequestData, ListOffsetsResponseData> test) {
+        try (var referenceCluster = new ReferenceCluster(kafkaClusterWithAuthz, this.topicIdsInUnproxiedCluster);
+                var proxiedCluster = new ProxiedCluster(kafkaClusterNoAuthz, this.topicIdsInProxiedCluster, rulesFile)) {
+            test.verifyBehaviour(referenceCluster, proxiedCluster);
+        }
+    }
+
+    class ListTransactionsEquivalence extends Equivalence<ListTransactionsRequestData, ListTransactionsResponseData> {
+
+        private final List<String> transactionIds;
+
+        ListTransactionsEquivalence(short apiVersion, List<String> transactionIds) {
+            super(apiVersion);
+            this.transactionIds = transactionIds;
+        }
+
+        @Override
+        public String clobberResponse(BaseClusterFixture cluster, ObjectNode jsonResponse) {
+            return prettyJsonString(jsonResponse);
+        }
+
+        @Override
+        public ApiKeys apiKey() {
+            return ApiKeys.LIST_TRANSACTIONS;
+        }
+
+        @Override
+        public Map<String, String> passwords() {
+            return PASSWORDS;
+        }
+
+        @Override
+        public ListTransactionsRequestData requestData(String user, BaseClusterFixture clusterFixture) {
+            return new ListTransactionsRequestData();
+        }
+
+        @Override
+        public void assertUnproxiedResponses(Map<String, ListTransactionsResponseData> unproxiedResponsesByUser) {
+            assertThat(unproxiedResponsesByUser.get(ALICE).transactionStates())
+                    .isNotEmpty()
+                    .allSatisfy(transactionState -> assertThat(transactionState.transactionalId()).startsWith(ALICE_TO_DESCRIBE_TRANSACTIONAL_ID_PREFIX));
+            assertThat(unproxiedResponsesByUser.get(BOB).transactionStates())
+                    .isNotEmpty()
+                    .allSatisfy(transactionState -> assertThat(transactionState.transactionalId()).startsWith(BOB_TO_DESCRIBE_TRANSACTIONAL_ID_PREFIX));
+            assertThat(unproxiedResponsesByUser.get(EVE).transactionStates()).isEmpty();
+        }
+
+        @Override
+        public void prepareCluster(BaseClusterFixture cluster) {
+            KafkaDriver driver = new KafkaDriver(cluster, cluster.authenticatedClient(AuthzIT.SUPER, SUPER_PASSWORD), AuthzIT.SUPER);
+            for (String id : transactionIds) {
+                driver.findCoordinator(FindCoordinatorRequest.CoordinatorType.TRANSACTION, id);
+                driver.initProducerId(id);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Require authorization for list transactions

The user must have DESCRIBE permissions for each transactionalId in the list transactions response. All entries with a denied transactionalId are removed from the response.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
