### PR TITLE
Add documentation for `trustAnchorRef` stating that it supports Secrets too

### DIFF
--- a/kroxylicious-docs/docs/_modules/configuring/con-configuring-kafkaservice-trust.adoc
+++ b/kroxylicious-docs/docs/_modules/configuring/con-configuring-kafkaservice-trust.adoc
@@ -31,7 +31,7 @@ spec:
     # ...
 ----
 <1> The `trustAnchorRef` property references a separate Kubernetes resource which contains the CA certificates to be trusted
-<2> The `kind` is optional and defaults to `ConfigMap`. The users can also use the key from a Kubernetes secret by configuring `kind` as `Secret`. For example:
+<2> The `kind` is optional and defaults to `ConfigMap`. To reference a key in a `Secret`, set `kind` to `Secret`. For example:
 +
 [source,yaml]
 ----

--- a/kroxylicious-docs/docs/_modules/configuring/con-virtualkafkacluster-mtls.adoc
+++ b/kroxylicious-docs/docs/_modules/configuring/con-virtualkafkacluster-mtls.adoc
@@ -32,7 +32,7 @@ spec:
         tlsClientAuthentication: REQUIRED <5>
 ----
 <1> References a separate Kubernetes resource containing the trusted CA certificates.
-<2> The `kind` is optional and defaults to `ConfigMap`. The users can also use the key from a Kubernetes secret by configuring `kind` as `Secret`. For example:
+<2> The `kind` is optional and defaults to `ConfigMap`. To reference a key in a `Secret`, set `kind` to `Secret`. For example:
 +
 [source,yaml]
 ----


### PR DESCRIPTION
### Type of change

- Documentation

### Description

This PR add documentation for stating that the `trustAnchorRef`  supports using key from a Secret.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, [trigger the system test suite](../blob/main/DEV_GUIDE.md#jenkins-pipeline-for-system-tests).  Make sure tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
