### PR TITLE
fix(tests):  fix bad filter config data leading to operand crash-looping and  sporadic test failures.

### DIFF
--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
@@ -248,7 +248,7 @@ public class KafkaProxyReconcilerIT {
     void testCreateWithKafkaServiceTlsUsingTrustAnchorFromSecret() {
         // given
         testActor.create(tlsKeyAndCertSecret(UPSTREAM_TLS_CERTIFICATE_SECRET_NAME));
-        testActor.create(secretContainingTrustAnchor(CA_CERT_SECRET_NAME));
+        testActor.create(trustAnchorSecret(CA_CERT_SECRET_NAME));
         KafkaService kafkaService = kafkaServiceWithTlsWithTrustAnchorRefAsSecret();
 
         // when
@@ -1262,12 +1262,12 @@ public class KafkaProxyReconcilerIT {
                 .build();
     }
 
-    private Secret secretContainingTrustAnchor(String name) {
+    private Secret trustAnchorSecret(String name) {
         return new SecretBuilder()
                 .withNewMetadata()
                 .withName(name)
                 .endMetadata()
-                .addToData(TRUSTED_CAS_PEM, "aGVsbG93b3JsZA==")
+                .addToStringData(TRUSTED_CAS_PEM, TestKeyMaterial.TEST_CERT_PEM)
                 .build();
     }
 


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Bugfix

### Description

The filter config used by the test was leading to a crash-looping operand.  For reasons described on #3344, this sometimes lead to a test failure. #3345 is the reason why the issue went (mostly) unnoticed.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
