### PR TITLE
fix(authz): Use ConfigResource.Type enum in config enforcements

### DIFF
--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/AlterConfigsEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/AlterConfigsEnforcement.java
@@ -15,14 +15,13 @@ import org.apache.kafka.common.message.AlterConfigsRequestData.AlterConfigsResou
 import org.apache.kafka.common.message.AlterConfigsResponseData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.resource.ResourceType;
 
 import io.kroxylicious.authorizer.service.Action;
 import io.kroxylicious.authorizer.service.Decision;
 import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 
-import static org.apache.kafka.common.resource.ResourceType.TOPIC;
+import static org.apache.kafka.common.config.ConfigResource.Type.TOPIC;
 
 class AlterConfigsEnforcement extends ApiEnforcement<AlterConfigsRequestData, AlterConfigsResponseData> {
     @Override
@@ -38,8 +37,7 @@ class AlterConfigsEnforcement extends ApiEnforcement<AlterConfigsRequestData, Al
     @Override
     CompletionStage<RequestFilterResult> onRequest(RequestHeaderData header, AlterConfigsRequestData request, FilterContext context,
                                                    AuthorizationFilter authorizationFilter) {
-        List<AlterConfigsResource> topicRequests = request.resources().stream()
-                .filter(resource -> ResourceType.fromCode(resource.resourceType()) == TOPIC).toList();
+        List<AlterConfigsResource> topicRequests = ConfigResources.filter(request.resources().stream(), AlterConfigsResource::resourceType, TOPIC).toList();
         if (topicRequests.isEmpty()) {
             return context.forwardRequest(header, request);
         }

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/ConfigResources.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/ConfigResources.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.authorization;
+
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.apache.kafka.common.config.ConfigResource;
+
+/**
+ * Centralize handling of ConfigResources to ensure we have a tested facility for mapping all known ConfigResource types.
+ */
+public class ConfigResources {
+
+    /**
+     * Prevent construction of utility class
+     */
+    private ConfigResources() {
+        // Prevent construction
+    }
+
+    public static <T> Stream<T> filter(Stream<T> stream, Function<T, Byte> idByteFunction, ConfigResource.Type type) {
+        Objects.requireNonNull(stream);
+        Objects.requireNonNull(idByteFunction);
+        Objects.requireNonNull(type);
+        return stream.filter(t -> {
+            Byte configTypeIdByte = idByteFunction.apply(t);
+            return type == ConfigResource.Type.forId(configTypeIdByte);
+        });
+    }
+}

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/IncrementalAlterConfigsEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/IncrementalAlterConfigsEnforcement.java
@@ -15,14 +15,13 @@ import org.apache.kafka.common.message.IncrementalAlterConfigsRequestData.AlterC
 import org.apache.kafka.common.message.IncrementalAlterConfigsResponseData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.resource.ResourceType;
 
 import io.kroxylicious.authorizer.service.Action;
 import io.kroxylicious.authorizer.service.Decision;
 import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 
-import static org.apache.kafka.common.resource.ResourceType.TOPIC;
+import static org.apache.kafka.common.config.ConfigResource.Type.TOPIC;
 
 class IncrementalAlterConfigsEnforcement extends ApiEnforcement<IncrementalAlterConfigsRequestData, IncrementalAlterConfigsResponseData> {
     @Override
@@ -38,8 +37,7 @@ class IncrementalAlterConfigsEnforcement extends ApiEnforcement<IncrementalAlter
     @Override
     CompletionStage<RequestFilterResult> onRequest(RequestHeaderData header, IncrementalAlterConfigsRequestData request, FilterContext context,
                                                    AuthorizationFilter authorizationFilter) {
-        List<AlterConfigsResource> topicRequests = request.resources().stream()
-                .filter(resource -> ResourceType.fromCode(resource.resourceType()) == TOPIC).toList();
+        List<AlterConfigsResource> topicRequests = ConfigResources.filter(request.resources().stream(), AlterConfigsResource::resourceType, TOPIC).toList();
         if (topicRequests.isEmpty()) {
             return context.forwardRequest(header, request);
         }

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/ConfigResourcesTest.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/ConfigResourcesTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.authorization;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.apache.kafka.common.config.ConfigResource;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.apache.kafka.common.config.ConfigResource.Type.TOPIC;
+import static org.apache.kafka.common.config.ConfigResource.Type.UNKNOWN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfigResourcesTest {
+
+    // simulates a Future ConfigResource type unknown to proxy
+    public static final byte FUTURE_CONFIG_RESOURCE_TYPE = (byte) 256;
+
+    public static Stream<Arguments> filter() {
+        Stream<Byte> allKnownValues = Arrays.stream(ConfigResource.Type.values()).map(ConfigResource.Type::id);
+        Stream<Byte> unknownValue = Stream.of(FUTURE_CONFIG_RESOURCE_TYPE);
+        List<Byte> allValues = Stream.concat(allKnownValues, unknownValue).toList();
+        Stream<Arguments> filterKnownTypes = Arrays.stream(ConfigResource.Type.values()).filter(type -> type != UNKNOWN)
+                .map(type -> Arguments.argumentSet("filter " + type, allValues, type, List.of(type.id())));
+        Stream<Arguments> otherArguments = Stream.of(Arguments.argumentSet("filter UNKNOWN", allValues, UNKNOWN, List.of(UNKNOWN.id(), FUTURE_CONFIG_RESOURCE_TYPE)),
+                Arguments.argumentSet("filter empty list", List.of(), TOPIC, List.of()));
+        return Stream.concat(filterKnownTypes, otherArguments);
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void filter(List<Byte> input, ConfigResource.Type resource, List<Byte> expectedOutput) {
+        Stream<Byte> filtered = ConfigResources.filter(input.stream(), Function.identity(), resource);
+        assertThat(filtered).containsExactlyElementsOf(expectedOutput);
+    }
+
+}


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

We were filtering using the wrong enum
`org.apache.kafka.common.resource.ResourceType` when working with config resourceTypes.

This luckily didn't cause issues because TOPIC has the same byte value in both enums and all other bytes were mapped to a different enum values.

We introduce a shared util class for filtering to have a better place to unit-test that we understand ConfigResource.Type properly. Our AuthorizationFilter unit tests can't discover the problem because the Filter forwards on any value upstream.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
