### PR TITLE
fix(ci): repair Discover STs bash script in system-tests-merge workflow

### DIFF
--- a/.github/workflows/system-tests-merge.yaml
+++ b/.github/workflows/system-tests-merge.yaml
@@ -58,9 +58,11 @@ jobs:
         working-directory: kroxylicious-systemtests
         id: discover
         run: |
-          client_types=$(grep -oE '^\s+[A-Z][A-Z0-9_]+' ./src/main/java/io/kroxylicious/systemtests/enums/KafkaClientType.java | tr -d '[:space:]')
-          client_types="${client_types##*( )}"
-          TEST_CLIENTS="[$( echo $client_types | tr '[:upper:]' '[:lower:]' | sed 's/, */,/g' | sed 's/[^,]*/"&"/g')]"
+          client_types=$(grep -oE '^\s+[A-Z][A-Z0-9_]+' ./src/main/java/io/kroxylicious/systemtests/enums/KafkaClientType.java \
+            | tr -d ' ' \
+            | tr '[:upper:]' '[:lower:]' \
+            | paste -sd ',')
+          TEST_CLIENTS="[$(echo "$client_types" | sed 's/[^,]*/"&"/g')]"
           echo "test_clients=$TEST_CLIENTS" >> $GITHUB_OUTPUT
 
   # Then we run the tests that with the KAFKA_CLIENT selected


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes two bugs in the `discover_system_test_clients` job's `Discover STs` step introduced in #3332, which caused every post-merge system test run to fail immediately.

**Bug 1 — bash syntax error (immediate failure):**
The `tr` command ended with `'[:space:]'"))` — the stray `"` opened an unclosed double-quoted string inside the `$(...)` command substitution. Bash reported `unexpected EOF while looking for matching '"'` at parse time, failing the job before any work was done.

**Bug 2 — logic error (wrong matrix input):**
`tr -d '[:space:]'` removed all whitespace including newlines, concatenating all enum values from `KafkaClientType.java` into a single string (e.g. `STRIMZI_TEST_CLIENTKATKAFPYTHON_TEST_CLIENT`). The downstream `sed` pipeline expected comma-separated values, so the matrix would receive one incorrect item rather than four separate client names.

The fix strips only spaces (not newlines) with `tr -d ' '`, lowercases inline, then joins lines with `paste -sd ','` before quoting each value — producing the correct output:
```
["strimzi_test_client","kcat","kaf","python_test_client"]
```

### Additional Context

Observed failure: https://github.com/kroxylicious/kroxylicious/actions/runs/22374682932/job/64762440626

### Checklist

- [x] PR raised from a fork of this repository and made from a branch rather than main.
- [ ] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, trigger the performance test suite.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md