### PR TITLE
Add links from README.md to SECURITY.md and GOVERNANCE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,5 +49,8 @@ Run `mvn archetype:generate -DarchetypeGroupId=io.kroxylicious -DarchetypeArtifa
 
 ## Contributing
 
-
 We welcome contributions! Please see our [contributing guidelines](https://github.com/kroxylicious/.github/blob/main/CONTRIBUTING.md) to get started.
+
+If you think you have found a security-related issue with Kroxylicious then please follow the [SECURITY process](https://github.com/kroxylicious/.github/blob/main/SECURITY.md).
+
+Our [GOVERNANCE.md](https://github.com/kroxylicious/.github/blob/main/GOVERNANCE.md) document describes how the project is run, including how decisions are made, and by whom.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Adds some links from the README to files in the `.github` which might not otherwise be very discoverable.

