### PR TITLE
fix(test): trying to understand LocalStack issue during RecordEncryption  STs

### DIFF
--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kms/aws/LocalStack.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kms/aws/LocalStack.java
@@ -7,10 +7,15 @@
 package io.kroxylicious.systemtests.installation.kms.aws;
 
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
+import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,6 +71,34 @@ public class LocalStack implements AwsKmsClient {
                 Optional.empty(),
                 Optional.of(Path.of(TestUtils.getResourcesURI("helm_localstack_overrides.yaml"))),
                 Optional.of(Map.of("image.repository", Constants.DOCKER_REGISTRY_GCR_MIRROR + "/" + LOCALSTACK_HELM_CHART_NAME)));
+
+        pingLocalStackEndpoint();
+    }
+
+    // Experimental workaround for https://github.com/kroxylicious/kroxylicious/issues/3362
+    @SuppressWarnings("java:S2095") // try-with-resources for "HttpClient" is not available until we adopt JDK21
+    private void pingLocalStackEndpoint() {
+        var client = HttpClient.newHttpClient();
+        Awaitility.await()
+                .atMost(30, TimeUnit.SECONDS)
+                .until(() -> {
+                    LOGGER.info("Probing localstack endpoint for responsiveness.");
+                    var probeUri = getAwsKmsUrl().resolve("/notfound");
+                    var request = HttpRequest.newBuilder()
+                            .uri(probeUri) // Intent is to deliberately provoke a 404
+                            .GET()
+                            .build();
+
+                    var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+                    LOGGER.debug("Probe {} gave response {}/{}.", probeUri, response.body(), response.statusCode());
+                    if (response.statusCode() != 404) {
+                        throw new IllegalStateException("Localstack %s endpoint seems not to be responsive.".formatted(getAwsKmsUrl()));
+                    }
+                    else {
+                        LOGGER.info("Endpoint {} seems to be minimally responsive.", getAwsKmsUrl());
+                        return true;
+                    }
+                });
     }
 
     @Override


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Relates to #3362
Try probing the endpoint after the Helm Localstack install.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
