### PR TITLE
fix:(systemtests): make localstack probe ignore ConnectException

### DIFF
--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kms/aws/LocalStack.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kms/aws/LocalStack.java
@@ -81,6 +81,7 @@ public class LocalStack implements AwsKmsClient {
         var client = HttpClient.newHttpClient();
         Awaitility.await()
                 .atMost(30, TimeUnit.SECONDS)
+                .ignoreExceptions()
                 .until(() -> {
                     LOGGER.info("Probing localstack endpoint for responsiveness.");
                     var probeUri = getAwsKmsUrl().resolve("/notfound");


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

The RecordEncryptionST [failed](https://productionresultssa1.blob.core.windows.net/actions-results/15cd81f2-bc49-4b36-ad64-cb6581923b24/workflow-job-run-2041dcba-50f2-580b-ad69-4e877bcbaebc/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-03-03T14%3A17%3A19Z&sig=9N9tQ4xtSpxth%2FFOQ79Uh%2FU5DjF9FryYwMYL2uEJe6Q%3D&ske=2026-03-03T15%3A28%3A15Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-03-03T11%3A28%3A15Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-03-03T14%3A07%3A14Z&sv=2025-11-05) with a ConnectException during the new probe.

The intent of the probe added by #3370 was that ConnectExceptions would be ignored and Awaitility would keep trying until the endpoint is minimally available, but this is not happening.  The probe is failing on the first ConnectException.

This change tells Awaitility to swallow the exception.  If the timeout occurs, the stacktrace will be seen.

```
2026-03-03T13:26:53.4514648Z 2026-03-03 13:26:53 INFO  io.skodjob.testframe.utils.LoggerUtils:50 - ############################################################################
2026-03-03T13:26:53.5069135Z [ERROR] Tests run: 40, Failures: 0, Errors: 1, Skipped: 18, Time elapsed: 1507 s <<< FAILURE! -- in io.kroxylicious.systemtests.filters.RecordEncryptionST
2026-03-03T13:26:53.5071000Z [ERROR] io.kroxylicious.systemtests.filters.RecordEncryptionST.produceAndConsumeMessageWithRotatedKEK(String, TestKmsFacade)[2] -- Time elapsed: 63.71 s <<< ERROR!
2026-03-03T13:26:53.5071809Z java.net.ConnectException
2026-03-03T13:26:53.5072230Z 	at java.net.http/jdk.internal.net.http.HttpClientImpl.send(HttpClientImpl.java:955)
2026-03-03T13:26:53.5073464Z 	at java.net.http/jdk.internal.net.http.HttpClientFacade.send(HttpClientFacade.java:133)
2026-03-03T13:26:53.5074887Z 	at io.kroxylicious.systemtests.installation.kms.aws.LocalStack.lambda$pingLocalStackEndpoint$0(LocalStack.java:92)
2026-03-03T13:26:53.5076442Z 	at org.awaitility.core.CallableCondition$ConditionEvaluationWrapper.eval(CallableCondition.java:99)
2026-03-03T13:26:53.5077697Z 	at org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:248)
2026-03-03T13:26:53.5078786Z 	at org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:235)
2026-03-03T13:26:53.5079750Z 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
2026-03-03T13:26:53.5080936Z 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
2026-03-03T13:26:53.5082159Z 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
2026-03-03T13:26:53.5083071Z 	at java.base/java.lang.Thread.run(Thread.java:1583)
2026-03-03T13:26:53.5083434Z Caused by: java.net.ConnectException
2026-03-03T13:26:53.5083959Z 	at java.net.http/jdk.internal.net.http.common.Utils.toConnectException(Utils.java:1065)
2026-03-03T13:26:53.5085103Z 	at java.net.http/jdk.internal.net.http.PlainHttpConnection.connectAsync(PlainHttpConnection.java:227)
2026-03-03T13:26:53.5086459Z 	at java.net.http/jdk.internal.net.http.PlainHttpConnection.checkRetryConnect(PlainHttpConnection.java:280)
2026-03-03T13:26:53.5087822Z 	at java.net.http/jdk.internal.net.http.PlainHttpConnection.lambda$connectAsync$2(PlainHttpConnection.java:238)
2026-03-03T13:26:53.5089104Z 	at java.base/java.util.concurrent.CompletableFuture.uniHandle(CompletableFuture.java:934)
2026-03-03T13:26:53.5090342Z 	at java.base/java.util.concurrent.CompletableFuture$UniHandle.tryFire(CompletableFuture.java:911)
2026-03-03T13:26:53.5092129Z 	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
2026-03-03T13:26:53.5093344Z 	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1773)
2026-03-03T13:26:53.5094164Z 	... 3 more
2026-03-03T13:26:53.5094595Z Caused by: java.nio.channels.ClosedChannelException
2026-03-03T13:26:53.5095422Z 	at java.base/sun.nio.ch.SocketChannelImpl.ensureOpen(SocketChannelImpl.java:202)
2026-03-03T13:26:53.5096434Z 	at java.base/sun.nio.ch.SocketChannelImpl.beginConnect(SocketChannelImpl.java:786)
2026-03-03T13:26:53.5097426Z 	at java.base/sun.nio.ch.SocketChannelImpl.connect(SocketChannelImpl.java:874)
2026-03-03T13:26:53.5101748Z 	at java.net.http/jdk.internal.net.http.PlainHttpConnection.lambda$connectAsync$1(PlainHttpConnection.java:210)
2026-03-03T13:26:53.5103082Z 	at java.base/java.security.AccessController.doPrivileged(AccessController.java:571)
2026-03-03T13:26:53.5103802Z 	at java.net.http/jdk.internal.net.http.PlainHttpConnection.connectAsync(PlainHttpConnection.java:212)
2026-03-03T13:26:53.5104294Z 	... 9 more
2026-03-03T
```
_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
