### PR TITLE
feat(test): have kroxyliciousTester support sharegroups

### DIFF
--- a/kroxylicious-integration-test-support/pom.xml
+++ b/kroxylicious-integration-test-support/pom.xml
@@ -170,6 +170,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-group-coordinator</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/DefaultKroxyliciousTester.java
@@ -27,6 +27,8 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ShareConsumer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
@@ -181,6 +183,41 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     }
 
     @Override
+    public ShareConsumer<String, String> shareConsumer(String groupName) {
+        return clients().shareConsumer(Map.of(ConsumerConfig.GROUP_ID_CONFIG, groupName));
+    }
+
+    @Override
+    public ShareConsumer<String, String> shareConsumer(String groupName, String virtualCluster) {
+        return shareConsumer(groupName, virtualCluster, DEFAULT_GATEWAY_NAME);
+    }
+
+    @Override
+    public ShareConsumer<String, String> shareConsumer(String groupName, String virtualCluster, String gateway) {
+        return clients(virtualCluster, gateway).shareConsumer(Map.of(ConsumerConfig.GROUP_ID_CONFIG, groupName));
+    }
+
+    @Override
+    public ShareConsumer<String, String> shareConsumer(Map<String, Object> additionalConfig) {
+        return clients().shareConsumer(additionalConfig);
+    }
+
+    @Override
+    public ShareConsumer<String, String> shareConsumer(String virtualCluster, Map<String, Object> additionalConfig) {
+        return clients(virtualCluster, DEFAULT_GATEWAY_NAME).shareConsumer(additionalConfig);
+    }
+
+    @Override
+    public <U, V> ShareConsumer<U, V> shareConsumer(Serde<U> keySerde, Serde<V> valueSerde, Map<String, Object> additionalConfig) {
+        return clients().shareConsumer(keySerde, valueSerde, additionalConfig);
+    }
+
+    @Override
+    public <U, V> ShareConsumer<U, V> shareConsumer(String virtualCluster, Serde<U> keySerde, Serde<V> valueSerde, Map<String, Object> additionalConfig) {
+        return clients(virtualCluster, DEFAULT_GATEWAY_NAME).shareConsumer(keySerde, valueSerde, additionalConfig);
+    }
+
+    @Override
     public KafkaClient simpleTestClient() {
         return clients().simpleTestClient();
     }
@@ -201,8 +238,8 @@ public class DefaultKroxyliciousTester implements KroxyliciousTester {
     }
 
     @Override
-    public Admin admin(String virtualCluster, String gatewayName, Map<String, Object> additionalConfig) {
-        return clients(virtualCluster, gatewayName).admin(additionalConfig);
+    public Admin admin(String virtualCluster, String gateway, Map<String, Object> additionalConfig) {
+        return clients(virtualCluster, gateway).admin(additionalConfig);
     }
 
     @Override

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousClients.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousClients.java
@@ -19,6 +19,8 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.KafkaShareConsumer;
+import org.apache.kafka.clients.consumer.ShareConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
@@ -31,6 +33,7 @@ import io.kroxylicious.test.client.KafkaClient;
 import io.kroxylicious.testing.kafka.clients.CloseableAdmin;
 import io.kroxylicious.testing.kafka.clients.CloseableConsumer;
 import io.kroxylicious.testing.kafka.clients.CloseableProducer;
+import io.kroxylicious.testing.kafka.clients.CloseableShareConsumer;
 
 class KroxyliciousClients implements Closeable {
     private final Map<String, Object> defaultClientConfiguration;
@@ -38,6 +41,7 @@ class KroxyliciousClients implements Closeable {
     private final List<Admin> admins;
     private final List<Producer<?, ?>> producers;
     private final List<Consumer<?, ?>> consumers;
+    private final List<ShareConsumer<?, ?>> shareConsumers;
     private final ClientFactory clientFactory;
 
     KroxyliciousClients(Map<String, Object> defaultClientConfiguration) {
@@ -50,6 +54,7 @@ class KroxyliciousClients implements Closeable {
         this.admins = new ArrayList<>();
         this.producers = new ArrayList<>();
         this.consumers = new ArrayList<>();
+        this.shareConsumers = new ArrayList<>();
         this.clientFactory = clientFactory;
     }
 
@@ -94,6 +99,21 @@ class KroxyliciousClients implements Closeable {
         return consumer;
     }
 
+    public <U, V> ShareConsumer<U, V> shareConsumer(Serde<U> keySerde, Serde<V> valueSerde, Map<String, Object> additionalConfig) {
+        Map<String, Object> config = createClientConfig(additionalConfig);
+        ShareConsumer<U, V> shareConsumer = clientFactory.newShareConsumer(config, keySerde.deserializer(), valueSerde.deserializer());
+        shareConsumers.add(shareConsumer);
+        return shareConsumer;
+    }
+
+    public ShareConsumer<String, String> shareConsumer(Map<String, Object> additionalConfig) {
+        return shareConsumer(Serdes.String(), Serdes.String(), additionalConfig);
+    }
+
+    public ShareConsumer<String, String> shareConsumer() {
+        return shareConsumer(Map.of(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"));
+    }
+
     public KafkaClient simpleTestClient() {
         var bootstrap = defaultClientConfiguration.get(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG).toString();
         var securityProtocol = SecurityProtocol
@@ -114,6 +134,7 @@ class KroxyliciousClients implements Closeable {
             exceptions.addAll(batchClose(admins));
             exceptions.addAll(batchClose(producers));
             exceptions.addAll(batchClose(consumers));
+            exceptions.addAll(batchClose(shareConsumers));
             if (!exceptions.isEmpty()) {
                 // if we encountered any exceptions while closing, throw whichever one came first.
                 throw exceptions.get(0);
@@ -150,6 +171,10 @@ class KroxyliciousClients implements Closeable {
 
         default <K, V> Consumer<K, V> newConsumer(Map<String, Object> clientConfiguration, Deserializer<K> keyDeserializer, Deserializer<V> valueDeserializer) {
             return CloseableConsumer.wrap(new KafkaConsumer<>(clientConfiguration, keyDeserializer, valueDeserializer));
+        }
+
+        default <V, U> ShareConsumer<U, V> newShareConsumer(Map<String, Object> clientConfiguration, Deserializer<U> keyDeserializer, Deserializer<V> valueDeserializer) {
+            return new CloseableShareConsumer<>(new KafkaShareConsumer<>(clientConfiguration, keyDeserializer, valueDeserializer));
         }
 
         default <K, V> Producer<K, V> newProducer(Map<String, Object> clientConfiguration, Serializer<K> keySerializer, Serializer<V> valueSerializer) {

--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousTester.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousTester.java
@@ -12,6 +12,7 @@ import java.util.Set;
 
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ShareConsumer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.serialization.Serde;
 
@@ -49,12 +50,12 @@ public interface KroxyliciousTester extends Closeable {
      * Creates an Admin Client configured with the kroxylicious bootstrap server
      * for a specific virtual cluster.
      * @param virtualCluster the virtual cluster we want the client to connect to
-     * @param listenerName the listener we want the client to connect to
+     * @param gateway the gateway we want the client to connect to
      * @param additionalConfig additional configuration for the Admin client
      * @return Admin client
      * @throws IllegalArgumentException if the named virtual cluster is not part of the kroxylicious server
      */
-    Admin admin(String virtualCluster, String listenerName, Map<String, Object> additionalConfig);
+    Admin admin(String virtualCluster, String gateway, Map<String, Object> additionalConfig);
 
     /**
      * Creates an Admin Client configured with the kroxylicious bootstrap server
@@ -66,7 +67,7 @@ public interface KroxyliciousTester extends Closeable {
 
     /**
      * Creates an Admin Client configured with the kroxylicious bootstrap server
-     * for a specific virtual cluster with a single listener.
+     * for a specific virtual cluster with a single gateway.
      * @param virtualCluster the virtual cluster we want the client to connect to
      * @return Admin client
      * @throws IllegalArgumentException if the named virtual cluster is not part of the kroxylicious server
@@ -75,13 +76,13 @@ public interface KroxyliciousTester extends Closeable {
 
     /**
      * Creates an Admin Client configured with the kroxylicious bootstrap server
-     * for a specific listener on a specific virtual cluster
+     * for a specific gateway on a specific virtual cluster
      * @param virtualCluster the virtual cluster we want the client to connect to
-     * @param listener the listener we want the client to connect to
+     * @param gateway the gateway we want the client to connect to
      * @return Admin client
-     * @throws IllegalArgumentException if the named virtual cluster is not part of the kroxylicious server, or if the virtual cluster does not have a listener with this name
+     * @throws IllegalArgumentException if the named virtual cluster is not part of the kroxylicious server, or if the virtual cluster does not have a gateway with this name
      */
-    Admin admin(String virtualCluster, String listener);
+    Admin admin(String virtualCluster, String gateway);
 
     /**
      * Creates a Producer configured with the kroxylicious bootstrap server
@@ -112,7 +113,7 @@ public interface KroxyliciousTester extends Closeable {
 
     /**
      * Creates a Producer configured with the kroxylicious bootstrap server
-     * for a specific virtual cluster for the default listener.
+     * for a specific virtual cluster for the default gateway.
      * @param virtualCluster the virtual cluster we want the client to connect to
      * @return Producer
      * @throws IllegalArgumentException if the named virtual cluster is not part of the kroxylicious server
@@ -121,13 +122,13 @@ public interface KroxyliciousTester extends Closeable {
 
     /**
      * Creates a Producer configured with the kroxylicious bootstrap server
-     * for a specific virtual cluster for the default listener.
+     * for a specific virtual cluster for the default gateway.
      * @param virtualCluster the virtual cluster we want the client to connect to
-     * @param listener the listener we want the client to connect to
+     * @param gateway the gateway we want the client to connect to
      * @return Producer
-     * @throws IllegalArgumentException if the named virtual cluster is not part of the kroxylicious server or if the virtual cluster doesn't have the named listener
+     * @throws IllegalArgumentException if the named virtual cluster is not part of the kroxylicious server or if the virtual cluster doesn't have the named gateway
      */
-    Producer<String, String> producer(String virtualCluster, String listener);
+    Producer<String, String> producer(String virtualCluster, String gateway);
 
     /**
      * Creates a Producer configured with the kroxylicious bootstrap server
@@ -196,14 +197,14 @@ public interface KroxyliciousTester extends Closeable {
 
     /**
      * Creates a Consumer configured with the kroxylicious bootstrap server
-     * for a specific virtual cluster and listener. Also sets a random group id
+     * for a specific virtual cluster and gateway. Also sets a random group id
      * and sets auto offset reset to "earliest".
      * @param virtualCluster the virtual cluster we want the client to connect to
-     * @param listener the listener to connect to
+     * @param gateway the gateway to connect to
      * @return Consumer
-     * @throws IllegalArgumentException if the named virtual cluster is not part of the kroxylicious server or if the virtual cluster doesn't have the named listener
+     * @throws IllegalArgumentException if the named virtual cluster is not part of the kroxylicious server or if the virtual cluster doesn't have the named gateway
      */
-    Consumer<String, String> consumer(String virtualCluster, String listener);
+    Consumer<String, String> consumer(String virtualCluster, String gateway);
 
     /**
      * Creates a Consumer configured with the kroxylicious bootstrap server
@@ -213,7 +214,7 @@ public interface KroxyliciousTester extends Closeable {
      * @param keySerde key serde
      * @param valueSerde value serde
      * @param additionalConfig additional consumer config
-     * @return Admin client
+     * @return Consumer
      * @throws AmbiguousVirtualClusterException if this tester is for a Kroxylicious configured with multiple virtual clusters
      */
     <U, V> Consumer<U, V> consumer(Serde<U> keySerde, Serde<V> valueSerde, Map<String, Object> additionalConfig);
@@ -232,6 +233,86 @@ public interface KroxyliciousTester extends Closeable {
      * @throws IllegalArgumentException if the named virtual cluster is not part of the kroxylicious server
      */
     <U, V> Consumer<U, V> consumer(String virtualCluster, Serde<U> keySerde, Serde<V> valueSerde, Map<String, Object> additionalConfig);
+
+    /**
+     * Creates a ShareConsumer configured with the kroxylicious bootstrap server
+     * for the only virtual cluster configured. Also sets a random group id
+     * and sets auto offset reset to "earliest".
+     * @param groupName name of share group
+     * @return ShareConsumer
+     * @throws AmbiguousVirtualClusterException if this tester is for a Kroxylicious configured with multiple virtual clusters
+     */
+    ShareConsumer<String, String> shareConsumer(String groupName);
+
+    /**
+     * Creates a ShareConsumer configured with the kroxylicious bootstrap server
+     * for a specific virtual cluster. Also sets a random group id
+     * and sets auto offset reset to "earliest".
+     *
+     * @param groupName name of share group
+     * @param virtualCluster the virtual cluster we want the client to connect to
+     * @return ShareConsumer
+     * @throws IllegalArgumentException if the named virtual cluster is not part of the kroxylicious server
+     */
+    ShareConsumer<String, String> shareConsumer(String groupName, String virtualCluster);
+
+    /**
+     * Creates a ShareConsumer configured with the kroxylicious bootstrap server
+     * for a specific virtual cluster. Also sets auto offset reset to "earliest".
+     *
+     * @param groupName name of share group
+     * @param virtualCluster the virtual cluster we want the client to connect to
+     * @return ShareConsumer
+     * @throws IllegalArgumentException if the named virtual cluster is not part of the kroxylicious server
+     */
+    ShareConsumer<String, String> shareConsumer(String groupName, String virtualCluster, String gatewayName);
+
+    /**
+     * Creates a ShareConsumer configured with the kroxylicious bootstrap server
+     * for the only virtual cluster configured.
+     * @param additionalConfig additional consumer config
+     * @return ShareConsumer
+     * @throws AmbiguousVirtualClusterException if this tester is for a Kroxylicious configured with multiple virtual clusters
+     */
+    ShareConsumer<String, String> shareConsumer(Map<String, Object> additionalConfig);
+
+    /**
+     * Creates a ShareConsumer configured with the kroxylicious bootstrap server
+     * for a specific virtual cluster.
+     * @param additionalConfig additional consumer config
+     * @param virtualCluster the virtual cluster we want the client to connect to
+     * @return ShareConsumer
+     * @throws IllegalArgumentException if the named virtual cluster is not part of the kroxylicious server
+     */
+    ShareConsumer<String, String> shareConsumer(String virtualCluster, Map<String, Object> additionalConfig);
+
+    /**
+     * Creates a ShareConsumer configured with the kroxylicious bootstrap server
+     * for the only virtual cluster configured.
+     * @param <U> key type
+     * @param <V> value type
+     * @param keySerde key serde
+     * @param valueSerde value serde
+     * @param additionalConfig additional consumer config
+     * @return ShareConsumer
+     * @throws AmbiguousVirtualClusterException if this tester is for a Kroxylicious configured with multiple virtual clusters
+     */
+    <U, V> ShareConsumer<U, V> shareConsumer(Serde<U> keySerde, Serde<V> valueSerde, Map<String, Object> additionalConfig);
+
+    /**
+     * Creates a ShareConsumer configured with the kroxylicious bootstrap server
+     * for a specific virtual cluster. Also sets a random group id
+     * and sets auto offset reset to "earliest".
+     * @param <U> key type
+     * @param <V> value type
+     * @param keySerde key serde
+     * @param valueSerde value serde
+     * @param additionalConfig additional consumer config
+     * @param virtualCluster the virtual cluster we want the client to connect to
+     * @return ShareConsumer
+     * @throws IllegalArgumentException if the named virtual cluster is not part of the kroxylicious server
+     */
+    <U, V> ShareConsumer<U, V> shareConsumer(String virtualCluster, Serde<U> keySerde, Serde<V> valueSerde, Map<String, Object> additionalConfig);
 
     /**
      * Creates a Mock Request client configured with the kroxylicious bootstrap server
@@ -308,11 +389,12 @@ public interface KroxyliciousTester extends Closeable {
     /**
      * @return the bootstrap address of the named virtual cluster
      */
-    String getBootstrapAddress(String clusterName, String listener);
+    String getBootstrapAddress(String clusterName, String gateway);
 
     /**
      * @return the Admin Http Client
      * @throws IllegalStateException admin interface not available
      */
     ManagementClient getManagementClient();
+
 }

--- a/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
+++ b/kroxylicious-integration-test-support/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
@@ -14,13 +14,19 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AlterConfigOp;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.KafkaAdminClient;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.ShareConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.message.DescribeAclsRequestData;
 import org.apache.kafka.common.message.DescribeAclsResponseData;
 import org.apache.kafka.common.message.ListTransactionsRequestData;
@@ -32,6 +38,7 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.coordinator.group.GroupConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -45,12 +52,14 @@ import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.clients.CloseableAdmin;
 import io.kroxylicious.testing.kafka.clients.CloseableConsumer;
 import io.kroxylicious.testing.kafka.clients.CloseableProducer;
+import io.kroxylicious.testing.kafka.clients.CloseableShareConsumer;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 import io.kroxylicious.testing.kafka.junit5ext.Name;
 import io.kroxylicious.testing.kafka.junit5ext.Topic;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.DEFAULT_GATEWAY_NAME;
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.DEFAULT_VIRTUAL_CLUSTER;
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.defaultPortIdentifiesNodeGatewayBuilder;
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
@@ -150,6 +159,7 @@ class KroxyliciousTestersTest {
             // Then
             assertClientIsInstanceOf(CloseableConsumer.class, tester::consumer);
             assertClientIsInstanceOf(CloseableConsumer.class, () -> tester.consumer(DEFAULT_VIRTUAL_CLUSTER));
+            assertClientIsInstanceOf(CloseableConsumer.class, () -> tester.consumer(DEFAULT_VIRTUAL_CLUSTER, DEFAULT_GATEWAY_NAME));
             assertClientIsInstanceOf(CloseableConsumer.class, () -> tester.consumer(Map.of()));
             assertClientIsInstanceOf(CloseableConsumer.class, () -> tester.consumer(DEFAULT_VIRTUAL_CLUSTER, Map.of()));
             assertClientIsInstanceOf(CloseableConsumer.class, () -> tester.consumer(Serdes.String(), Serdes.String(), Map.of()));
@@ -158,10 +168,28 @@ class KroxyliciousTestersTest {
     }
 
     @Test
+    void shouldReturnClosableShareConsumer() {
+        // Given
+        var groupName = "mygroup";
+        var config = Map.<String, Object> of(ConsumerConfig.GROUP_ID_CONFIG, groupName);
+        try (var tester = kroxyliciousTester(proxy(kafkaCluster))) {
+            // Then
+            assertClientIsInstanceOf(CloseableShareConsumer.class, () -> tester.shareConsumer(groupName));
+            assertClientIsInstanceOf(CloseableShareConsumer.class, () -> tester.shareConsumer(groupName, DEFAULT_VIRTUAL_CLUSTER));
+            assertClientIsInstanceOf(CloseableShareConsumer.class, () -> tester.shareConsumer(groupName, DEFAULT_VIRTUAL_CLUSTER, DEFAULT_GATEWAY_NAME));
+            assertClientIsInstanceOf(CloseableShareConsumer.class, () -> tester.shareConsumer(config));
+            assertClientIsInstanceOf(CloseableShareConsumer.class, () -> tester.shareConsumer(DEFAULT_VIRTUAL_CLUSTER, config));
+            assertClientIsInstanceOf(CloseableShareConsumer.class, () -> tester.shareConsumer(Serdes.String(), Serdes.String(), config));
+            assertClientIsInstanceOf(CloseableShareConsumer.class, () -> tester.shareConsumer(DEFAULT_VIRTUAL_CLUSTER, Serdes.String(), Serdes.String(), config));
+        }
+    }
+
+    @Test
     void testConsumerMethods(@Name("underlyingCluster") Topic topic) throws Exception {
-        KafkaProducer<String, String> producer = new KafkaProducer<>(kafkaCluster.getKafkaClientConfiguration(), new StringSerializer(), new StringSerializer());
         String topicName = topic.name();
-        producer.send(new ProducerRecord<>(topicName, "key", "value")).get(10, TimeUnit.SECONDS);
+        try (KafkaProducer<String, String> producer = new KafkaProducer<>(kafkaCluster.getKafkaClientConfiguration(), new StringSerializer(), new StringSerializer())) {
+            producer.send(new ProducerRecord<>(topicName, "key", "value")).get(10, TimeUnit.SECONDS);
+        }
         try (var tester = kroxyliciousTester(proxy(kafkaCluster))) {
             withConsumer(tester::consumer, consumer -> assertOneRecordConsumedFrom(consumer, topicName));
             withConsumer(() -> tester.consumer(randomGroupIdAndEarliestReset()), consumer -> assertOneRecordConsumedFrom(consumer, topicName));
@@ -174,8 +202,40 @@ class KroxyliciousTestersTest {
         }
     }
 
+    @Test
+    void testShareConsumerMethods(@Name("underlyingCluster") Topic topic) {
+        String topicName = topic.name();
+        var groupName = "mygroup";
+        var config = Map.<String, Object> of(ConsumerConfig.GROUP_ID_CONFIG, groupName);
+        try (var producer = new KafkaProducer<>(kafkaCluster.getKafkaClientConfiguration(), new StringSerializer(), new StringSerializer())) {
+            assertThat(producer.send(new ProducerRecord<>(topicName, "key", "value"))).succeedsWithin(Duration.ofSeconds(10));
+        }
+        try (var admin = KafkaAdminClient.create(kafkaCluster.getKafkaClientConfiguration())) {
+            prepareClusterForShareGroups(admin, groupName);
+
+            try (var tester = kroxyliciousTester(proxy(kafkaCluster))) {
+                withShareConsumer(() -> tester.shareConsumer(groupName), shareConsumer -> assertOneRecordConsumedFrom(shareConsumer, topicName));
+                withShareConsumer(() -> tester.shareConsumer(groupName, DEFAULT_VIRTUAL_CLUSTER), shareConsumer -> assertOneRecordConsumedFrom(shareConsumer, topicName));
+                withShareConsumer(() -> tester.shareConsumer(DEFAULT_VIRTUAL_CLUSTER, config), shareConsumer -> assertOneRecordConsumedFrom(shareConsumer, topicName));
+                withShareConsumer(() -> tester.shareConsumer(Serdes.String(), Serdes.String(), config),
+                        shareConsumer -> assertOneRecordConsumedFrom(shareConsumer, topicName));
+                withShareConsumer(() -> tester.shareConsumer(DEFAULT_VIRTUAL_CLUSTER, Serdes.String(), Serdes.String(), config),
+                        shareConsumer -> assertOneRecordConsumedFrom(shareConsumer, topicName));
+            }
+            finally {
+                removeShareGroup(admin, groupName);
+            }
+        }
+    }
+
     private void withConsumer(Supplier<Consumer<String, String>> supplier, java.util.function.Consumer<Consumer<String, String>> consumerFunc) {
         try (Consumer<String, String> consumer = supplier.get()) {
+            consumerFunc.accept(consumer);
+        }
+    }
+
+    private void withShareConsumer(Supplier<ShareConsumer<String, String>> supplier, java.util.function.Consumer<ShareConsumer<String, String>> consumerFunc) {
+        try (ShareConsumer<String, String> consumer = supplier.get()) {
             consumerFunc.accept(consumer);
         }
     }
@@ -296,6 +356,7 @@ class KroxyliciousTestersTest {
             assertThrows(IllegalArgumentException.class, () -> tester.consumer("NON_EXIST"));
             assertThrows(IllegalArgumentException.class, () -> tester.consumer("NON_EXIST", emptyMap));
             assertThrows(IllegalArgumentException.class, () -> tester.consumer("NON_EXIST", stringSerde, stringSerde, emptyMap));
+            assertThrows(IllegalArgumentException.class, () -> tester.shareConsumer("mygroup", "NON_EXIST"));
             assertThrows(IllegalArgumentException.class, () -> tester.producer("NON_EXIST"));
             assertThrows(IllegalArgumentException.class, () -> tester.producer("NON_EXIST", emptyMap));
             assertThrows(IllegalArgumentException.class, () -> tester.producer("NON_EXIST", stringSerde, stringSerde, emptyMap));
@@ -381,6 +442,12 @@ class KroxyliciousTestersTest {
         assertEquals(1, records.count());
     }
 
+    private static void assertOneRecordConsumedFrom(ShareConsumer<String, String> consumer, String topicName) {
+        consumer.subscribe(List.of(topicName));
+        ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(10));
+        assertEquals(1, records.count());
+    }
+
     private <T> void assertClientIsInstanceOf(Class<? extends T> expectedClass, Supplier<? extends T> clientSupplier) {
         final T client = clientSupplier.get();
         assertThat(client).isInstanceOf(expectedClass);
@@ -391,5 +458,18 @@ class KroxyliciousTestersTest {
         final T otherClient = clientSupplier.get();
         assertThat(otherClient).isNotNull();
         assertThat(client).isNotNull().isNotSameAs(otherClient);
+    }
+
+    private static void prepareClusterForShareGroups(Admin admin, String groupName) {
+        ConfigResource configResource = new ConfigResource(ConfigResource.Type.GROUP, groupName);
+        ConfigEntry autoOffsetReset = new ConfigEntry(GroupConfig.SHARE_AUTO_OFFSET_RESET_CONFIG, "earliest");
+        List<AlterConfigOp> alterConfig = List.of(new AlterConfigOp(autoOffsetReset, AlterConfigOp.OpType.SET));
+        assertThat(admin.incrementalAlterConfigs(Map.of(configResource, alterConfig)).all())
+                .succeedsWithin(Duration.ofSeconds(10));
+    }
+
+    private static void removeShareGroup(Admin admin, String groupName) {
+        assertThat(admin.deleteConsumerGroups(List.of(groupName)).all())
+                .succeedsWithin(Duration.ofSeconds(10));
     }
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/encryption/RecordEncryptionFilterIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/encryption/RecordEncryptionFilterIT.java
@@ -42,8 +42,6 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.consumer.KafkaShareConsumer;
-import org.apache.kafka.clients.consumer.ShareConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -54,7 +52,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.header.Header;
-import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.coordinator.group.GroupConfig;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.ThrowingConsumer;
@@ -80,7 +77,6 @@ import io.kroxylicious.kms.service.TestKmsFacade;
 import io.kroxylicious.kms.service.TestKmsFacadeInvocationContextProvider;
 import io.kroxylicious.proxy.config.NamedFilterDefinition;
 import io.kroxylicious.proxy.config.NamedFilterDefinitionBuilder;
-import io.kroxylicious.test.tester.KroxyliciousTester;
 import io.kroxylicious.test.tester.SimpleMetricAssert;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.common.BrokerConfig;
@@ -160,7 +156,7 @@ class RecordEncryptionFilterIT {
         try (var tester = kroxyliciousTester(builder);
                 var producer = tester.producer();
                 var admin = tester.admin();
-                ShareConsumer<String, String> shareConsumer = new KafkaShareConsumer<>(shareConsumerConfig(tester))) {
+                var shareConsumer = tester.shareConsumer(ENCRYPTION_SHARE_CONSUMER)) {
             prepareClusterForShareGroups(admin);
             shareConsumer.subscribe(List.of(topic.name()));
             producer.send(new ProducerRecord<>(topic.name(), HELLO_WORLD)).get(5, TimeUnit.SECONDS);
@@ -175,19 +171,11 @@ class RecordEncryptionFilterIT {
         }
     }
 
-    private static void prepareClusterForShareGroups(Admin admin) throws InterruptedException, ExecutionException {
+    private static void prepareClusterForShareGroups(Admin admin) {
         ConfigResource configResource = new ConfigResource(ConfigResource.Type.GROUP, ENCRYPTION_SHARE_CONSUMER);
         ConfigEntry autoOffsetReset = new ConfigEntry(GroupConfig.SHARE_AUTO_OFFSET_RESET_CONFIG, "earliest");
         List<AlterConfigOp> alterConfig = List.of(new AlterConfigOp(autoOffsetReset, AlterConfigOp.OpType.SET));
-        admin.incrementalAlterConfigs(Map.of(configResource, alterConfig)).all().get();
-    }
-
-    private static Map<String, Object> shareConsumerConfig(KroxyliciousTester tester) {
-        Map<String, Object> clientConfig = tester.clientConfiguration();
-        clientConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        clientConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        clientConfig.put(ConsumerConfig.GROUP_ID_CONFIG, ENCRYPTION_SHARE_CONSUMER);
-        return clientConfig;
+        assertThat(admin.incrementalAlterConfigs(Map.of(configResource, alterConfig)).all()).succeedsWithin(Duration.ofSeconds(10));
     }
 
     // Covers a bug, #2504, where large record batches failed to be encrypted. This occurred when the encrypted output for a record batch exceeded
@@ -604,7 +592,7 @@ class RecordEncryptionFilterIT {
         try (var tester = kroxyliciousTester(builder);
                 var producer = tester.producer();
                 var admin = tester.admin();
-                var consumer = new KafkaShareConsumer<>(shareConsumerConfig(tester))) {
+                var shareConsumer = tester.shareConsumer(ENCRYPTION_SHARE_CONSUMER)) {
             prepareClusterForShareGroups(admin);
 
             // messages produced via Kroxylicious will be encrypted
@@ -613,9 +601,9 @@ class RecordEncryptionFilterIT {
             // messages produced direct will be plain
             directProducer.send(new ProducerRecord<>(topic.name(), HELLO_WORLD)).get(5, TimeUnit.SECONDS);
 
-            consumer.subscribe(List.of(topic.name()));
+            shareConsumer.subscribe(List.of(topic.name()));
             Awaitility.await().untilAsserted(() -> {
-                var records = consumer.poll(Duration.ofSeconds(2));
+                var records = shareConsumer.poll(Duration.ofSeconds(2));
                 assertThat(records.iterator()).toIterable()
                         .hasSize(2)
                         .map(ConsumerRecord::value)
@@ -669,12 +657,12 @@ class RecordEncryptionFilterIT {
         try (var tester = kroxyliciousTester(builder);
                 var producer = tester.producer();
                 var admin = tester.admin();
-                var consumer = new KafkaShareConsumer<>(shareConsumerConfig(tester))) {
+                var shareConsumer = tester.shareConsumer(ENCRYPTION_SHARE_CONSUMER)) {
             prepareClusterForShareGroups(admin);
             String message = null;
             producer.send(new ProducerRecord<>(topic.name(), message)).get(5, TimeUnit.SECONDS);
 
-            assertOnlyValueInTopicHasNullValue(topic.name(), consumer::subscribe, consumer::poll);
+            assertOnlyValueInTopicHasNullValue(topic.name(), shareConsumer::subscribe, shareConsumer::poll);
             // test that the null-value is preserved in Kafka to keep compaction tombstoning working
             assertOnlyValueInTopicHasNullValue(topic.name(), directConsumer::subscribe, directConsumer::poll);
         }
@@ -966,7 +954,7 @@ class RecordEncryptionFilterIT {
         try (var tester = kroxyliciousTester(builder);
                 var producer = tester.producer();
                 var admin = tester.admin();
-                var consumer = new KafkaShareConsumer<>(shareConsumerConfig(tester))) {
+                var shareConsumer = tester.shareConsumer(ENCRYPTION_SHARE_CONSUMER)) {
             prepareClusterForShareGroups(admin);
             var timeout = Duration.ofSeconds(5);
             assertThat(producer.send(new ProducerRecord<>(topic.name(), HELLO_WORLD)))
@@ -974,10 +962,10 @@ class RecordEncryptionFilterIT {
 
             testKekManager.deleteKek(topic.name());
 
-            consumer.subscribe(List.of(topic.name()));
+            shareConsumer.subscribe(List.of(topic.name()));
 
             Awaitility.await().untilAsserted(() -> {
-                assertThatThrownBy(() -> consumer.poll(timeout))
+                assertThatThrownBy(() -> shareConsumer.poll(timeout))
                         .isInstanceOf(IllegalStateException.class)
                         .hasMessageContaining("Unexpected error code 91 while fetching from topic-partition " + topic.name() + "-0");
             });


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Adds support for ShareConsumers to KroxyliciousTester.
 
### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
