### PR TITLE
fix: set githubToken on all minikube setup usages

### DIFF
--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -46,6 +46,8 @@ jobs:
         uses: ./.github/actions/common/setup-java
       - name: Setup Minikube
         uses: ./.github/actions/common/setup-minikube
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Set up Docker Buildx'
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
       - name: 'Cache Maven packages'

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -60,6 +60,8 @@ jobs:
           javaDistro: ${{ matrix.java.distro }}
       - name: Setup Minikube
         uses: ./.github/actions/common/setup-minikube
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Test for unpublished reference release (japicmp)'
         run: |
           REFERENCE_RELEASE=$(mvn --quiet -pl kroxylicious-api help:evaluate -Dexpression=ApiCompatability.ReferenceVersion -DforceStdout)

--- a/.github/workflows/operator-maven.yaml
+++ b/.github/workflows/operator-maven.yaml
@@ -51,6 +51,8 @@ jobs:
         uses: ./.github/actions/common/setup-java
       - name: Setup Minikube
         uses: ./.github/actions/common/setup-minikube
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Set up Docker Buildx'
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
       - name: 'Cache Maven packages'

--- a/.github/workflows/run-system-tests.yaml
+++ b/.github/workflows/run-system-tests.yaml
@@ -74,6 +74,8 @@ jobs:
         uses: ./.github/actions/common/setup-java
       - name: Setup Minikube
         uses: ./.github/actions/common/setup-minikube
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Set up Docker Buildx'
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
       - name: 'Cache Maven packages'


### PR DESCRIPTION

### Type of change

- Bugfix

### Description
We have upgraded to use a new kubernetes version that is not officially supported by minikube, so minikube uses the GitHub API to discover the details for that k8s version and we're hitting rate limits in our actions.

Fixes #3406 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
