### PR TITLE
refactor(operator): extract shared IT infrastructure into LocalKroxyliciousOperatorExtension

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -107,7 +107,7 @@ jobs:
         run: |
           mvn --batch-mode \
             --activate-profiles 'ci,!qa' \
-            --projects ''!:kroxylicious-operator'' \
+            --projects '!:kroxylicious-kubernetes-api,!:kroxylicious-operator,!:kroxylicious-operator-dist,!:kroxylicious-operator-test-support' \
             -Derrorprone.skip=true \
             -DskipITs=true \
             -Djapicmp.skip=${REFERENCE_RELEASE_UNPUBLISHED} \

--- a/.github/workflows/operator-maven.yaml
+++ b/.github/workflows/operator-maven.yaml
@@ -81,7 +81,7 @@ jobs:
         run: |
           mvn --batch-mode \
             --activate-profiles 'ci,!qa' \
-            --projects ':kroxylicious-operator,:kroxylicious-kubernetes-parent,:kroxylicious-parent' \
+            --projects ':kroxylicious-operator,:kroxylicious-operator-dist,:kroxylicious-kubernetes-api,:kroxylicious-operator-test-support,:kroxylicious-kubernetes-parent,:kroxylicious-parent' \
             -Derrorprone.skip=true \
             -Djapicmp.skip=true \
             -DskipITs=true \

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -105,7 +105,7 @@ jobs:
         run: |
           mvn --batch-mode \
             --activate-profiles 'ci,!qa' \
-            --projects ''!:kroxylicious-operator,!:kroxylicious-operator-dist'' \
+            --projects '!:kroxylicious-operator,!:kroxylicious-operator-dist,!:kroxylicious-kubernetes-api,!:kroxylicious-operator-test-support' \
             -Derrorprone.skip=true \
             -DskipITs=true \
             -Djapicmp.skip=true \
@@ -124,7 +124,7 @@ jobs:
         run: |
           mvn --batch-mode \
             --activate-profiles 'ci,!qa' \
-            --projects ':kroxylicious-operator,:kroxylicious-kubernetes-parent,:kroxylicious-parent,:kroxylicious-operator-dist' \
+            --projects ':kroxylicious-operator,:kroxylicious-operator-dist,:kroxylicious-kubernetes-api,:kroxylicious-operator-test-support,:kroxylicious-kubernetes-parent,:kroxylicious-parent' \
             -Derrorprone.skip=true \
             -DskipITs=true \
             -Djapicmp.skip=true \

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/pom.xml
@@ -111,5 +111,16 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-server-mock</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-httpclient-vertx</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 </project>

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/pom.xml
@@ -27,21 +27,62 @@
     </description>
 
     <properties>
+        <!-- TODO: centralise josdk.version in the parent pom -->
+        <josdk.version>5.2.3</josdk.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.javaoperatorsdk</groupId>
+                <artifactId>operator-framework-bom</artifactId>
+                <version>${josdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-client-bom</artifactId>
+                <version>${kubernetes-client.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
-        <dependency>
-            <groupId>io.kroxylicious</groupId>
-            <artifactId>kroxylicious-runtime</artifactId>
-        </dependency>
+        <!-- project dependencies -->
         <dependency>
             <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-kubernetes-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-runtime</artifactId>
+        </dependency>
+
+        <!-- third party dependencies - compile -->
+        <dependency>
+            <groupId>io.javaoperatorsdk</groupId>
+            <artifactId>operator-framework-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.javaoperatorsdk</groupId>
+            <artifactId>operator-framework-junit-5</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-model-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-rbac</artifactId>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
@@ -49,12 +90,25 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>
+
+        <!-- JUnit is compile-scope: we ship a JUnit extension -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- third party dependencies - test -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <!-- TODO: centralise josdk.version in the parent pom -->
-        <josdk.version>5.2.3</josdk.version>
+        <josdk.version>5.3.4</josdk.version>
     </properties>
 
     <dependencyManagement>
@@ -69,7 +69,7 @@
         </dependency>
         <dependency>
             <groupId>io.javaoperatorsdk</groupId>
-            <artifactId>operator-framework-junit-5</artifactId>
+            <artifactId>operator-framework-junit</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/ClusterUser.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/ClusterUser.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.testing.operator;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Represents a cluster user interacting with Kubernetes resources in a specific namespace.
+ * <p>
+ * This is distinct from the operator's own client: a {@code ClusterUser} holds a
+ * Kubernetes client scoped to the RBAC of a regular user, not the operator itself.
+ * Using this explicitly in tests makes clear which operations represent user actions
+ * and which represent operator reactions, which matters for reasoning about RBAC.
+ */
+public class ClusterUser {
+
+    private final KubernetesClient client;
+    private final String namespace;
+
+    ClusterUser(@NonNull KubernetesClient client, @NonNull String namespace) {
+        this.client = client;
+        this.namespace = namespace;
+    }
+
+    @NonNull
+    public <T extends HasMetadata> T create(@NonNull T resource) {
+        return client.resource(resource).inNamespace(namespace).create();
+    }
+
+    @Nullable
+    public <T extends HasMetadata> T get(@NonNull Class<T> type, @NonNull String name) {
+        return client.resources(type).inNamespace(namespace).withName(name).get();
+    }
+
+    @NonNull
+    public <T extends HasMetadata> T replace(@NonNull T resource) {
+        return client.resource(resource).inNamespace(namespace).update();
+    }
+
+    public <T extends HasMetadata> boolean delete(@NonNull T resource) {
+        var result = client.resource(resource).inNamespace(namespace).delete();
+        return result.size() == 1 && result.get(0).getCauses().isEmpty();
+    }
+
+    @NonNull
+    public <T extends HasMetadata> NonNamespaceOperation<T, KubernetesResourceList<T>, Resource<T>> resources(@NonNull Class<T> type) {
+        return client.resources(type).inNamespace(namespace);
+    }
+}

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/ClusterUser.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/ClusterUser.java
@@ -9,6 +9,7 @@ package io.kroxylicious.testing.operator;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 
@@ -22,6 +23,8 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * Kubernetes client scoped to the RBAC of a regular user, not the operator itself.
  * Using this explicitly in tests makes clear which operations represent user actions
  * and which represent operator reactions, which matters for reasoning about RBAC.
+ * <p>
+ * Obtain instances via {@link LocalKroxyliciousOperatorExtension#clusterUser()}.
  */
 public class ClusterUser {
 
@@ -35,22 +38,46 @@ public class ClusterUser {
 
     @NonNull
     public <T extends HasMetadata> T create(@NonNull T resource) {
-        return client.resource(resource).inNamespace(namespace).create();
+        try {
+            return client.resource(resource).inNamespace(namespace).create();
+        }
+        catch (KubernetesClientException e) {
+            throw new KubernetesClientException(
+                    "ClusterUser failed to create %s/%s".formatted(resource.getKind(), resource.getMetadata().getName()), e);
+        }
     }
 
     @Nullable
     public <T extends HasMetadata> T get(@NonNull Class<T> type, @NonNull String name) {
-        return client.resources(type).inNamespace(namespace).withName(name).get();
+        try {
+            return client.resources(type).inNamespace(namespace).withName(name).get();
+        }
+        catch (KubernetesClientException e) {
+            throw new KubernetesClientException(
+                    "ClusterUser failed to get %s/%s".formatted(type.getSimpleName(), name), e);
+        }
     }
 
     @NonNull
     public <T extends HasMetadata> T replace(@NonNull T resource) {
-        return client.resource(resource).inNamespace(namespace).update();
+        try {
+            return client.resource(resource).inNamespace(namespace).update();
+        }
+        catch (KubernetesClientException e) {
+            throw new KubernetesClientException(
+                    "ClusterUser failed to replace %s/%s".formatted(resource.getKind(), resource.getMetadata().getName()), e);
+        }
     }
 
     public <T extends HasMetadata> boolean delete(@NonNull T resource) {
-        var result = client.resource(resource).inNamespace(namespace).delete();
-        return result.size() == 1 && result.get(0).getCauses().isEmpty();
+        try {
+            var result = client.resource(resource).inNamespace(namespace).delete();
+            return result.size() == 1 && result.get(0).getCauses().isEmpty();
+        }
+        catch (KubernetesClientException e) {
+            throw new KubernetesClientException(
+                    "ClusterUser failed to delete %s/%s".formatted(resource.getKind(), resource.getMetadata().getName()), e);
+        }
     }
 
     @NonNull

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/ClusterUser.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/ClusterUser.java
@@ -16,6 +16,8 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+import static io.kroxylicious.testing.operator.KubernetesResourceUtil.name;
+
 /**
  * Represents a cluster user interacting with Kubernetes resources in a specific namespace.
  * <p>
@@ -43,7 +45,7 @@ public class ClusterUser {
         }
         catch (KubernetesClientException e) {
             throw new KubernetesClientException(
-                    "ClusterUser failed to create %s/%s".formatted(resource.getKind(), resource.getMetadata().getName()), e);
+                    "ClusterUser failed to create %s/%s".formatted(resource.getKind(), name(resource)), e);
         }
     }
 
@@ -65,7 +67,7 @@ public class ClusterUser {
         }
         catch (KubernetesClientException e) {
             throw new KubernetesClientException(
-                    "ClusterUser failed to replace %s/%s".formatted(resource.getKind(), resource.getMetadata().getName()), e);
+                    "ClusterUser failed to replace %s/%s".formatted(resource.getKind(), name(resource)), e);
         }
     }
 
@@ -76,7 +78,7 @@ public class ClusterUser {
         }
         catch (KubernetesClientException e) {
             throw new KubernetesClientException(
-                    "ClusterUser failed to delete %s/%s".formatted(resource.getKind(), resource.getMetadata().getName()), e);
+                    "ClusterUser failed to delete %s/%s".formatted(resource.getKind(), name(resource)), e);
         }
     }
 

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/KubernetesResourceUtil.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/KubernetesResourceUtil.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.testing.operator;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+
+/**
+ * Minimal accessors for Kubernetes resource metadata, avoiding the
+ * {@code .getMetadata().getName()} ceremony.
+ */
+public final class KubernetesResourceUtil {
+
+    private KubernetesResourceUtil() {
+    }
+
+    public static String name(HasMetadata resource) {
+        return resource.getMetadata().getName();
+    }
+}

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
@@ -264,6 +264,19 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
         return localOperatorExtension.getNamespace();
     }
 
+    /**
+     * Returns a {@link ClusterUser} backed by the admin Kubernetes client, scoped to the test namespace.
+     * <p>
+     * Use this to represent user-side interactions (creating CRs, reading state) as opposed to
+     * operator reactions. The operator is the system-under-test; the {@code ClusterUser} is the actor.
+     * <p>
+     * Must be called after {@code beforeAll}.
+     */
+    @NonNull
+    public ClusterUser clusterUser() {
+        return new ClusterUser(rbacHandler.userClient(), localOperatorExtension.getNamespace());
+    }
+
     // ---- resource operations ----
 
     @NonNull

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
@@ -11,10 +11,12 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.AfterAllCallback;
@@ -279,6 +281,25 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
     @NonNull
     public <T extends HasMetadata> T patchStatus(@NonNull T resource) {
         return testActor.patchStatus(resource);
+    }
+
+    /**
+     * Re-fetches the resource to get the latest {@code resourceVersion}, applies the given
+     * status mutator, then patches the status. This avoids 409 Conflict errors when the
+     * operator has reconciled (and bumped {@code resourceVersion}) between resource creation
+     * and status patching.
+     *
+     * @param type the resource class
+     * @param name the resource name
+     * @param statusMutator a function that sets the desired status on the fresh resource and returns it
+     * @return the resource after status patching
+     */
+    @NonNull
+    public <T extends HasMetadata> T updateStatus(@NonNull Class<T> type, @NonNull String name, @NonNull UnaryOperator<T> statusMutator) {
+        T fresh = Objects.requireNonNull(testActor.get(type, name),
+                () -> "expected %s '%s' to exist".formatted(type.getSimpleName(), name));
+        T mutated = statusMutator.apply(fresh);
+        return testActor.patchStatus(mutated);
     }
 
     public <T extends HasMetadata> boolean delete(@NonNull T resource) {

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
@@ -352,10 +352,10 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
         }
 
         /**
-         * Overrides the default cluster role glob(s) used to load RBAC rules.
-         * The default is {@value DEFAULT_CLUSTER_ROLE_GLOB}.
+         * Replaces all cluster role glob(s) used to load RBAC rules with the given values.
+         * If not called, the default is {@value DEFAULT_CLUSTER_ROLE_GLOB}.
          */
-        public Builder withClusterRoleGlobs(@NonNull String... globs) {
+        public Builder replaceClusterRoleGlobs(@NonNull String... globs) {
             this.clusterRoleGlobs.clear();
             this.clusterRoleGlobs.addAll(Arrays.asList(globs));
             return this;

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
@@ -29,10 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
-import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.readiness.Readiness;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
@@ -45,7 +42,6 @@ import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * A JUnit 5 extension that runs a Kroxylicious operator locally for integration testing.
@@ -277,23 +273,6 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
         return new ClusterUser(rbacHandler.userClient(), localOperatorExtension.getNamespace());
     }
 
-    // ---- resource operations ----
-
-    @NonNull
-    public <T extends HasMetadata> T create(@NonNull T resource) {
-        return testActor.create(resource);
-    }
-
-    @Nullable
-    public <T extends HasMetadata> T get(@NonNull Class<T> type, @NonNull String name) {
-        return testActor.get(type, name);
-    }
-
-    @NonNull
-    public <T extends HasMetadata> T replace(@NonNull T resource) {
-        return testActor.replace(resource);
-    }
-
     @NonNull
     public <T extends HasMetadata> T patchStatus(@NonNull T resource) {
         return testActor.patchStatus(resource);
@@ -318,14 +297,6 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
         return testActor.patchStatus(mutated);
     }
 
-    public <T extends HasMetadata> boolean delete(@NonNull T resource) {
-        return testActor.delete(resource);
-    }
-
-    @NonNull
-    public <T extends HasMetadata> NonNamespaceOperation<T, KubernetesResourceList<T>, Resource<T>> resources(@NonNull Class<T> type) {
-        return testActor.resources(type);
-    }
 
     public static Builder builder() {
         return new Builder();

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
@@ -39,6 +39,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
+import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -92,6 +93,7 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
                 LocalKroxyliciousOperatorExtension::preloadOperandImage);
     }
 
+    @VisibleForTesting
     LocalKroxyliciousOperatorExtension(Builder builder,
                                        Supplier<LocallyRunningOperatorRbacHandler> rbacHandlerFactory,
                                        Function<LocallyRunningOperatorRbacHandler, LocallyRunOperatorExtension> extensionFactory,

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
@@ -84,9 +84,12 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
     private final List<Class<? extends HasMetadata>> additionalCleanupTypes;
     private final Runnable imagePreloader;
 
-    // mutable per-class state
+    // mutable per-class state — set in beforeAll(), null before lifecycle starts
+    @Nullable
     private LocallyRunningOperatorRbacHandler rbacHandler;
+    @Nullable
     private LocallyRunOperatorExtension localOperatorExtension;
+    @Nullable
     private LocallyRunningOperatorRbacHandler.TestActor testActor;
 
     private LocalKroxyliciousOperatorExtension(Builder builder) {

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
@@ -78,6 +78,7 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
     private final List<Executable> setupActions;
     private final List<Executable> teardownActions;
     private final List<Class<? extends HasMetadata>> additionalCleanupTypes;
+    private final Runnable imagePreloader;
 
     // mutable per-class state
     private LocallyRunningOperatorRbacHandler rbacHandler;
@@ -87,12 +88,14 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
     private LocalKroxyliciousOperatorExtension(Builder builder) {
         this(builder,
                 () -> new LocallyRunningOperatorRbacHandler(builder.installManifestsDir, builder.clusterRoleGlobs.toArray(String[]::new)),
-                handler -> buildExtension(List.copyOf(builder.reconcilers), List.copyOf(builder.additionalCRDs), handler));
+                handler -> buildExtension(List.copyOf(builder.reconcilers), List.copyOf(builder.additionalCRDs), handler),
+                LocalKroxyliciousOperatorExtension::preloadOperandImage);
     }
 
     LocalKroxyliciousOperatorExtension(Builder builder,
                                        Supplier<LocallyRunningOperatorRbacHandler> rbacHandlerFactory,
-                                       Function<LocallyRunningOperatorRbacHandler, LocallyRunOperatorExtension> extensionFactory) {
+                                       Function<LocallyRunningOperatorRbacHandler, LocallyRunOperatorExtension> extensionFactory,
+                                       Runnable imagePreloader) {
         if (builder.reconcilers.isEmpty()) {
             throw new IllegalStateException("at least one reconciler must be set");
         }
@@ -101,6 +104,7 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
         this.setupActions = List.copyOf(builder.setupActions);
         this.teardownActions = List.copyOf(builder.teardownActions);
         this.additionalCleanupTypes = List.copyOf(builder.additionalCleanupTypes);
+        this.imagePreloader = imagePreloader;
     }
 
     @Override
@@ -108,7 +112,7 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
         rbacHandler = rbacHandlerFactory.get();
         rbacHandler.beforeEach(context);
 
-        preloadOperandImage();
+        imagePreloader.run();
 
         for (var action : setupActions) {
             try {

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
@@ -42,6 +42,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * A JUnit 5 extension that runs a Kroxylicious operator locally for integration testing.
@@ -296,7 +297,6 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
         T mutated = statusMutator.apply(fresh);
         return testActor.patchStatus(mutated);
     }
-
 
     public static Builder builder() {
         return new Builder();

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.testing.operator;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -195,18 +196,25 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
         }
     }
 
-    private static String sanitiseImageRef(String image) {
+    @VisibleForTesting
+    static String sanitiseImageRef(String image) {
         return image.replaceAll("[\r\n]", "");
     }
 
     private static String resolveOperandImage() {
-        var envImage = System.getenv(KROXYLICIOUS_IMAGE_ENV_VAR);
+        return resolveOperandImage(
+                System.getenv(KROXYLICIOUS_IMAGE_ENV_VAR),
+                () -> LocalKroxyliciousOperatorExtension.class.getResourceAsStream(KROXYLICIOUS_IMAGE_PROPERTIES));
+    }
+
+    @VisibleForTesting
+    static String resolveOperandImage(String envImage, Supplier<InputStream> propertiesSupplier) {
         if (envImage != null && !envImage.isBlank()) {
             envImage = sanitiseImageRef(envImage);
             LOGGER.info("Using Kroxylicious operand image ({}) from environment variable {}", envImage, KROXYLICIOUS_IMAGE_ENV_VAR);
             return envImage;
         }
-        try (var is = LocalKroxyliciousOperatorExtension.class.getResourceAsStream(KROXYLICIOUS_IMAGE_PROPERTIES)) {
+        try (var is = propertiesSupplier.get()) {
             if (is == null) {
                 throw new IllegalStateException(
                         "No %s env var set and %s not found on classpath".formatted(KROXYLICIOUS_IMAGE_ENV_VAR, KROXYLICIOUS_IMAGE_PROPERTIES));

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.readiness.Readiness;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
@@ -88,6 +89,9 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
     private LocallyRunOperatorExtension localOperatorExtension;
     @Nullable
     private LocallyRunningOperatorRbacHandler.TestActor testActor;
+    // Owned here so its lifecycle spans the full test class; closed last in afterAll().
+    @Nullable
+    private KubernetesClient clusterUserClient;
 
     private LocalKroxyliciousOperatorExtension(Builder builder) {
         this(builder,
@@ -116,6 +120,7 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
     public void beforeAll(ExtensionContext context) throws Exception {
         rbacHandler = rbacHandlerFactory.get();
         rbacHandler.beforeEach(context);
+        clusterUserClient = rbacHandler.userClient();
 
         imagePreloader.run();
 
@@ -138,7 +143,7 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
         localOperatorExtension = extensionFactory.apply(rbacHandler);
         localOperatorExtension.beforeAll(context);
 
-        testActor = rbacHandler.testActor(localOperatorExtension);
+        testActor = rbacHandler.testActor(clusterUserClient, localOperatorExtension);
     }
 
     @Override
@@ -156,7 +161,9 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
         }
         if (rbacHandler != null) {
             rbacHandler.afterEach(context);
-            rbacHandler.afterAll(context);
+        }
+        if (clusterUserClient != null) {
+            clusterUserClient.close();
         }
     }
 
@@ -271,7 +278,7 @@ public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, Af
      */
     @NonNull
     public ClusterUser clusterUser() {
-        return new ClusterUser(rbacHandler.userClient(), localOperatorExtension.getNamespace());
+        return new ClusterUser(clusterUserClient, localOperatorExtension.getNamespace());
     }
 
     @NonNull

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtension.java
@@ -1,0 +1,364 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.testing.operator;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.function.Executable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.readiness.Readiness;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProtocolFilter;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * A JUnit 5 extension that runs a Kroxylicious operator locally for integration testing.
+ * <p>
+ * It manages the full lifecycle per test class: RBAC setup, namespace creation, CRD application,
+ * operator startup, operator shutdown, and cleanup. It also exposes resource management methods
+ * so that tests do not need to interact with Kubernetes directly.
+ * <p>
+ * All standard Kroxylicious CRDs ({@link KafkaProxy}, {@link VirtualKafkaCluster},
+ * {@link KafkaService}, {@link KafkaProxyIngress}, {@link KafkaProtocolFilter}) are installed
+ * automatically — callers do not need to list them.
+ * <p>
+ * Declare as a static field:
+ * <pre>
+ * {@code
+ * @RegisterExtension
+ * static LocalKroxyliciousOperatorExtension operator = LocalKroxyliciousOperatorExtension.builder()
+ *         .withReconciler(new KafkaProxyReconciler(Clock.systemUTC(), SecureConfigInterpolator.DEFAULT_INTERPOLATOR))
+ *         .withReconciler(new VirtualKafkaClusterReconciler(Clock.systemUTC(), DependencyResolver.create()))
+ *         .build();
+ * }
+ * </pre>
+ */
+public class LocalKroxyliciousOperatorExtension implements BeforeAllCallback, AfterAllCallback, AfterEachCallback {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LocalKroxyliciousOperatorExtension.class);
+    private static final String DEFAULT_INSTALL_MANIFESTS_DIR = "packaging/install";
+    static final String DEFAULT_CLUSTER_ROLE_GLOB = "*.ClusterRole.*.yaml";
+    private static final String KROXYLICIOUS_IMAGE_ENV_VAR = "KROXYLICIOUS_IMAGE";
+    private static final String KROXYLICIOUS_IMAGE_PROPERTIES = "/kroxylicious-image.properties";
+
+    private final Supplier<LocallyRunningOperatorRbacHandler> rbacHandlerFactory;
+    private final Function<LocallyRunningOperatorRbacHandler, LocallyRunOperatorExtension> extensionFactory;
+    private final List<Executable> setupActions;
+    private final List<Executable> teardownActions;
+    private final List<Class<? extends HasMetadata>> additionalCleanupTypes;
+
+    // mutable per-class state
+    private LocallyRunningOperatorRbacHandler rbacHandler;
+    private LocallyRunOperatorExtension localOperatorExtension;
+    private LocallyRunningOperatorRbacHandler.TestActor testActor;
+
+    private LocalKroxyliciousOperatorExtension(Builder builder) {
+        this(builder,
+                () -> new LocallyRunningOperatorRbacHandler(builder.installManifestsDir, builder.clusterRoleGlobs.toArray(String[]::new)),
+                handler -> buildExtension(List.copyOf(builder.reconcilers), List.copyOf(builder.additionalCRDs), handler));
+    }
+
+    LocalKroxyliciousOperatorExtension(Builder builder,
+                                       Supplier<LocallyRunningOperatorRbacHandler> rbacHandlerFactory,
+                                       Function<LocallyRunningOperatorRbacHandler, LocallyRunOperatorExtension> extensionFactory) {
+        if (builder.reconcilers.isEmpty()) {
+            throw new IllegalStateException("at least one reconciler must be set");
+        }
+        this.rbacHandlerFactory = rbacHandlerFactory;
+        this.extensionFactory = extensionFactory;
+        this.setupActions = List.copyOf(builder.setupActions);
+        this.teardownActions = List.copyOf(builder.teardownActions);
+        this.additionalCleanupTypes = List.copyOf(builder.additionalCleanupTypes);
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        rbacHandler = rbacHandlerFactory.get();
+        rbacHandler.beforeEach(context);
+
+        preloadOperandImage();
+
+        for (var action : setupActions) {
+            try {
+                action.execute();
+            }
+            catch (Exception e) {
+                throw e;
+            }
+            catch (Throwable t) {
+                throw new AssertionError("Setup action failed", t);
+            }
+        }
+
+        // LocallyRunOperatorExtension is built with oneNamespacePerClass=true, meaning
+        // beforeAll/afterAll are the lifecycle methods that create and tear down the namespace
+        // and start/stop the operator. This avoids per-test CRD deletion and re-application,
+        // which is slow and can cause races when CRDs are still terminating.
+        localOperatorExtension = extensionFactory.apply(rbacHandler);
+        localOperatorExtension.beforeAll(context);
+
+        testActor = rbacHandler.testActor(localOperatorExtension);
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        if (localOperatorExtension != null) {
+            localOperatorExtension.afterAll(context);
+        }
+        for (var action : teardownActions) {
+            try {
+                action.execute();
+            }
+            catch (Throwable t) {
+                throw new AssertionError("Teardown action failed", t);
+            }
+        }
+        if (rbacHandler != null) {
+            rbacHandler.afterEach(context);
+            rbacHandler.afterAll(context);
+        }
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        if (testActor == null) {
+            return;
+        }
+        // Clean up all Kroxylicious CRs and test-created resources between tests.
+        // The namespace and CRDs are shared for the whole class and cleaned up in afterAll.
+        deleteAll(VirtualKafkaCluster.class);
+        deleteAll(KafkaProxy.class);
+        deleteAll(KafkaProxyIngress.class);
+        deleteAll(KafkaService.class);
+        deleteAll(KafkaProtocolFilter.class);
+        deleteAll(Secret.class);
+        deleteAll(ConfigMap.class);
+        additionalCleanupTypes.forEach(this::deleteAll);
+    }
+
+    private <T extends HasMetadata> void deleteAll(Class<T> type) {
+        testActor.resources(type).list().getItems().forEach(testActor::delete);
+    }
+
+    private static void preloadOperandImage() {
+        String image = resolveOperandImage();
+        try (var client = OperatorTestUtils.kubeClient()) {
+            var pod = client.run().withName("preload-operand-image")
+                    .withNewRunConfig()
+                    .withImage(image)
+                    .withRestartPolicy("Never")
+                    .withCommand("ls").done();
+            try {
+                client.resource(pod).waitUntilCondition(Readiness::isPodSucceeded, 2, TimeUnit.MINUTES);
+            }
+            finally {
+                client.resource(pod).delete();
+            }
+        }
+    }
+
+    private static String sanitiseImageRef(String image) {
+        return image.replaceAll("[\r\n]", "");
+    }
+
+    private static String resolveOperandImage() {
+        var envImage = System.getenv(KROXYLICIOUS_IMAGE_ENV_VAR);
+        if (envImage != null && !envImage.isBlank()) {
+            envImage = sanitiseImageRef(envImage);
+            LOGGER.info("Using Kroxylicious operand image ({}) from environment variable {}", envImage, KROXYLICIOUS_IMAGE_ENV_VAR);
+            return envImage;
+        }
+        try (var is = LocalKroxyliciousOperatorExtension.class.getResourceAsStream(KROXYLICIOUS_IMAGE_PROPERTIES)) {
+            if (is == null) {
+                throw new IllegalStateException(
+                        "No %s env var set and %s not found on classpath".formatted(KROXYLICIOUS_IMAGE_ENV_VAR, KROXYLICIOUS_IMAGE_PROPERTIES));
+            }
+            var props = new Properties();
+            props.load(is);
+            var image = props.getProperty("kroxylicious-image");
+            if (image == null || image.isEmpty()) {
+                throw new IllegalStateException("Property 'kroxylicious-image' not found in %s".formatted(KROXYLICIOUS_IMAGE_PROPERTIES));
+            }
+            image = sanitiseImageRef(image);
+            LOGGER.info("Using Kroxylicious operand image ({}) from properties file {}", image, KROXYLICIOUS_IMAGE_PROPERTIES);
+            return image;
+        }
+        catch (IOException e) {
+            throw new IllegalStateException("Failed to read %s".formatted(KROXYLICIOUS_IMAGE_PROPERTIES), e);
+        }
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static LocallyRunOperatorExtension buildExtension(List<Reconciler<?>> reconcilers,
+                                                              List<Class<?>> additionalCRDs,
+                                                              LocallyRunningOperatorRbacHandler rbacHandler) {
+        var builder = LocallyRunOperatorExtension.builder()
+                .withKubernetesClient(rbacHandler.operatorClient())
+                .waitForNamespaceDeletion(false)
+                .oneNamespacePerClass(true)
+                .withConfigurationService(x -> x.withCloseClientOnStop(false));
+        reconcilers.forEach(builder::withReconciler);
+        // Always install all standard Kroxylicious CRDs — applyCrd is idempotent (createOrReplace)
+        Stream.of(KafkaProxy.class, VirtualKafkaCluster.class, KafkaService.class,
+                KafkaProxyIngress.class, KafkaProtocolFilter.class)
+                .forEach(builder::withAdditionalCustomResourceDefinition);
+        additionalCRDs.forEach(crd -> builder.withAdditionalCustomResourceDefinition((Class) crd));
+        return builder.build();
+    }
+
+    /**
+     * @return the Kubernetes namespace created for this test.
+     */
+    public String getNamespace() {
+        return localOperatorExtension.getNamespace();
+    }
+
+    // ---- resource operations ----
+
+    @NonNull
+    public <T extends HasMetadata> T create(@NonNull T resource) {
+        return testActor.create(resource);
+    }
+
+    @Nullable
+    public <T extends HasMetadata> T get(@NonNull Class<T> type, @NonNull String name) {
+        return testActor.get(type, name);
+    }
+
+    @NonNull
+    public <T extends HasMetadata> T replace(@NonNull T resource) {
+        return testActor.replace(resource);
+    }
+
+    @NonNull
+    public <T extends HasMetadata> T patchStatus(@NonNull T resource) {
+        return testActor.patchStatus(resource);
+    }
+
+    public <T extends HasMetadata> boolean delete(@NonNull T resource) {
+        return testActor.delete(resource);
+    }
+
+    @NonNull
+    public <T extends HasMetadata> NonNamespaceOperation<T, KubernetesResourceList<T>, Resource<T>> resources(@NonNull Class<T> type) {
+        return testActor.resources(type);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private final List<Reconciler<?>> reconcilers = new ArrayList<>();
+        private final List<Class<?>> additionalCRDs = new ArrayList<>();
+        private final List<Executable> setupActions = new ArrayList<>();
+        private final List<Executable> teardownActions = new ArrayList<>();
+        private final List<Class<? extends HasMetadata>> additionalCleanupTypes = new ArrayList<>();
+        private String installManifestsDir = DEFAULT_INSTALL_MANIFESTS_DIR;
+        private final List<String> clusterRoleGlobs = new ArrayList<>(List.of(DEFAULT_CLUSTER_ROLE_GLOB));
+
+        private Builder() {
+        }
+
+        public Builder withReconciler(@NonNull Reconciler<?> reconciler) {
+            this.reconcilers.add(reconciler);
+            return this;
+        }
+
+        @SuppressWarnings("unused")
+        public Builder withAdditionalCRD(@NonNull Class<?> crd) {
+            this.additionalCRDs.add(crd);
+            return this;
+        }
+
+        @SuppressWarnings("unused")
+        public Builder withAdditionalCRDs(@NonNull Class<?>... crds) {
+            this.additionalCRDs.addAll(Arrays.asList(crds));
+            return this;
+        }
+
+        /**
+         * Registers an action to run after RBAC setup but before the operator starts.
+         * Useful for installing third-party CRDs that the operator watches.
+         */
+        @SuppressWarnings("unused")
+        public Builder withSetupAction(@NonNull Executable action) {
+            this.setupActions.add(action);
+            return this;
+        }
+
+        /**
+         * Registers an action to run after the operator stops.
+         * Useful for cleaning up third-party CRDs installed via {@link #withSetupAction}.
+         */
+        @SuppressWarnings("unused")
+        public Builder withTeardownAction(@NonNull Executable action) {
+            this.teardownActions.add(action);
+            return this;
+        }
+
+        /**
+         * Registers additional resource types to delete between tests (in {@code afterEach}).
+         * Use this for third-party CRD resources (e.g. Strimzi {@code Kafka}) that tests create
+         * and that the extension does not clean up automatically.
+         */
+        @SuppressWarnings("unused")
+        @SafeVarargs
+        public final Builder withAdditionalCleanupTypes(@NonNull Class<? extends HasMetadata>... types) {
+            this.additionalCleanupTypes.addAll(Arrays.asList(types));
+            return this;
+        }
+
+        @SuppressWarnings("unused")
+        public Builder withInstallManifestsDir(@NonNull String dir) {
+            this.installManifestsDir = dir;
+            return this;
+        }
+
+        /**
+         * Overrides the default cluster role glob(s) used to load RBAC rules.
+         * The default is {@value DEFAULT_CLUSTER_ROLE_GLOB}.
+         */
+        public Builder withClusterRoleGlobs(@NonNull String... globs) {
+            this.clusterRoleGlobs.clear();
+            this.clusterRoleGlobs.addAll(Arrays.asList(globs));
+            return this;
+        }
+
+        public LocalKroxyliciousOperatorExtension build() {
+            return new LocalKroxyliciousOperatorExtension(this);
+        }
+    }
+}

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -85,25 +86,31 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
     private final String impersonatedUser = UUID.randomUUID().toString();
 
     private final KubernetesClient testActorClient = OperatorTestUtils.kubeClient();
+    private final Supplier<KubernetesClient> adminClientFactory;
 
     private final List<ClusterRole> clusterRoles;
     private final List<ClusterRoleBinding> roleBindings;
 
     public LocallyRunningOperatorRbacHandler(String resourceDirectory, String... clusterRoleFileGlobs) {
-        this(Path.of(resourceDirectory), clusterRoleFileGlobs);
+        this(Path.of(resourceDirectory), OperatorTestUtils::kubeClient, clusterRoleFileGlobs);
     }
 
-    private LocallyRunningOperatorRbacHandler(Path resourceDirectory, String... clusterRoleFileGlobs) {
+    LocallyRunningOperatorRbacHandler(String resourceDirectory, Supplier<KubernetesClient> adminClientFactory, String... clusterRoleFileGlobs) {
+        this(Path.of(resourceDirectory), adminClientFactory, clusterRoleFileGlobs);
+    }
+
+    private LocallyRunningOperatorRbacHandler(Path resourceDirectory, Supplier<KubernetesClient> adminClientFactory, String... clusterRoleFileGlobs) {
         requireNonNull(resourceDirectory);
         verifyClusterGlobs(clusterRoleFileGlobs);
         verifyDirectoryExists(resourceDirectory);
+        this.adminClientFactory = adminClientFactory;
         clusterRoles = loadClusterRoles(resourceDirectory, clusterRoleFileGlobs);
         roleBindings = this.clusterRoles.stream().map(this::bindingForRole).toList();
     }
 
     private List<ClusterRole> loadClusterRoles(Path resourceDirectory, String[] clusterRoleFileGlobs) {
         var clusterRolePathMatchers = Arrays.stream(clusterRoleFileGlobs).map(g -> FileSystems.getDefault().getPathMatcher("glob:**/" + g)).toList();
-        try (var adminClient = OperatorTestUtils.kubeClient();
+        try (var adminClient = adminClientFactory.get();
                 var files = Files.list(resourceDirectory)) {
             // The test framework itself needs these roles.
             Stream<ClusterRole> frameworkClusterRoles = Stream.of(FRAMEWORK_CLUSTER_ROLE);
@@ -135,7 +142,7 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
 
     @Override
     public void beforeEach(ExtensionContext context) {
-        try (var adminClient = OperatorTestUtils.kubeClient()) {
+        try (var adminClient = adminClientFactory.get()) {
             // The test framework itself needs these roles.
             clusterRoles.forEach(r -> {
                 LOGGER.atTrace()
@@ -179,7 +186,7 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
 
     @Override
     public void afterEach(ExtensionContext context) {
-        try (var adminClient = OperatorTestUtils.kubeClient()) {
+        try (var adminClient = adminClientFactory.get()) {
             this.roleBindings.forEach(roleBinding -> {
                 LOGGER.trace("Deleting ClusterRoleBinding: {}", roleBinding.getMetadata().getName());
                 adminClient.resource(roleBinding).delete();

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
@@ -93,6 +93,7 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
     private final List<ClusterRoleBinding> roleBindings;
 
     // Lazily set when testActor() is called; closed in afterAll.
+    @Nullable
     private KubernetesClient testActorClient;
 
     public LocallyRunningOperatorRbacHandler(String resourceDirectory, String... clusterRoleFileGlobs) {

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
@@ -42,6 +42,8 @@ import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.javaoperatorsdk.operator.junit.AbstractOperatorExtension;
 
+import io.kroxylicious.proxy.tag.VisibleForTesting;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
@@ -95,6 +97,7 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
         this(Path.of(resourceDirectory), OperatorTestUtils::kubeClient, clusterRoleFileGlobs);
     }
 
+    @VisibleForTesting
     LocallyRunningOperatorRbacHandler(String resourceDirectory, Supplier<KubernetesClient> adminClientFactory, String... clusterRoleFileGlobs) {
         this(Path.of(resourceDirectory), adminClientFactory, clusterRoleFileGlobs);
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
@@ -79,7 +79,7 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
             .endRule()
             .addNewRule()
             .addToApiGroups("apiextensions.k8s.io")
-            .addToVerbs("get", "list", "watch", "create", "delete", "patch", "delete")
+            .addToVerbs("get", "list", "watch", "create", "delete", "patch")
             .addToResources("customresourcedefinitions")
             .endRule()
             .build();
@@ -97,12 +97,12 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
         this(Path.of(resourceDirectory), OperatorTestUtils::kubeClient, clusterRoleFileGlobs);
     }
 
-    @VisibleForTesting
-    LocallyRunningOperatorRbacHandler(String resourceDirectory, Supplier<KubernetesClient> adminClientFactory, String... clusterRoleFileGlobs) {
-        this(Path.of(resourceDirectory), adminClientFactory, clusterRoleFileGlobs);
+    public LocallyRunningOperatorRbacHandler(Path resourceDirectory, String... clusterRoleFileGlobs) {
+        this(resourceDirectory, OperatorTestUtils::kubeClient, clusterRoleFileGlobs);
     }
 
-    private LocallyRunningOperatorRbacHandler(Path resourceDirectory, Supplier<KubernetesClient> adminClientFactory, String... clusterRoleFileGlobs) {
+    @VisibleForTesting
+    LocallyRunningOperatorRbacHandler(Path resourceDirectory, Supplier<KubernetesClient> adminClientFactory, String... clusterRoleFileGlobs) {
         requireNonNull(resourceDirectory);
         verifyClusterGlobs(clusterRoleFileGlobs);
         verifyDirectoryExists(resourceDirectory);
@@ -249,7 +249,7 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
             @NonNull
             @Override
             public <T extends HasMetadata> NonNamespaceOperation<T, KubernetesResourceList<T>, Resource<T>> resources(
-                                                                                                                      Class<T> type) {
+                    @NonNull Class<T> type) {
                 return testActorClient.resources(type).inNamespace(operatorExtension.getNamespace());
             }
 

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
@@ -87,11 +87,13 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
 
     private final String impersonatedUser = UUID.randomUUID().toString();
 
-    private final KubernetesClient testActorClient = OperatorTestUtils.kubeClient();
     private final Supplier<KubernetesClient> adminClientFactory;
 
     private final List<ClusterRole> clusterRoles;
     private final List<ClusterRoleBinding> roleBindings;
+
+    // Lazily set when testActor() is called; closed in afterAll.
+    private KubernetesClient testActorClient;
 
     public LocallyRunningOperatorRbacHandler(String resourceDirectory, String... clusterRoleFileGlobs) {
         this(Path.of(resourceDirectory), OperatorTestUtils::kubeClient, clusterRoleFileGlobs);
@@ -211,18 +213,20 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
 
     @NonNull
     public TestActor testActor(@NonNull AbstractOperatorExtension operatorExtension) {
+        testActorClient = adminClientFactory.get();
+        var client = testActorClient;
         return new TestActor() {
 
             @NonNull
             @Override
             public <T extends HasMetadata> T create(@NonNull T resource) {
-                return testActorClient.resource(resource).inNamespace(operatorExtension.getNamespace()).create();
+                return client.resource(resource).inNamespace(operatorExtension.getNamespace()).create();
             }
 
             @Nullable
             @Override
             public <T extends HasMetadata> T get(@NonNull Class<T> type, @NonNull String name) {
-                return testActorClient.resources(type).inNamespace(operatorExtension.getNamespace()).withName(name).get();
+                return client.resources(type).inNamespace(operatorExtension.getNamespace()).withName(name).get();
             }
 
             @NonNull
@@ -232,25 +236,25 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
 
             @NonNull
             public <T extends HasMetadata> T replace(@NonNull T resource) {
-                return testActorClient.resource(resource).inNamespace(operatorExtension.getNamespace()).update();
+                return client.resource(resource).inNamespace(operatorExtension.getNamespace()).update();
             }
 
             @NonNull
             public <T extends HasMetadata> T patchStatus(@NonNull T resource) {
-                return testActorClient.resource(resource).inNamespace(operatorExtension.getNamespace()).patchStatus();
+                return client.resource(resource).inNamespace(operatorExtension.getNamespace()).patchStatus();
             }
 
             @Override
             public <T extends HasMetadata> boolean delete(@NonNull T resource) {
-                var res = testActorClient.resource(resource).inNamespace(operatorExtension.getNamespace()).delete();
+                var res = client.resource(resource).inNamespace(operatorExtension.getNamespace()).delete();
                 return res.size() == 1 && res.get(0).getCauses().isEmpty();
             }
 
             @NonNull
             @Override
             public <T extends HasMetadata> NonNamespaceOperation<T, KubernetesResourceList<T>, Resource<T>> resources(
-                    @NonNull Class<T> type) {
-                return testActorClient.resources(type).inNamespace(operatorExtension.getNamespace());
+                                                                                                                      @NonNull Class<T> type) {
+                return client.resources(type).inNamespace(operatorExtension.getNamespace());
             }
 
             public <T extends KubernetesResource> boolean supports(Class<T> type) {
@@ -262,7 +266,9 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
 
     @Override
     public void afterAll(ExtensionContext context) {
-        testActorClient.close();
+        if (testActorClient != null) {
+            testActorClient.close();
+        }
     }
 
     public interface TestActor {

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
@@ -209,7 +209,10 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
     @NonNull
     public KubernetesClient operatorClient() {
         return OperatorTestUtils.kubeClient(
-                new KubernetesClientBuilder().editOrNewConfig().withImpersonateUsername(impersonatedUser).endConfig());
+                new KubernetesClientBuilder().editOrNewConfig()
+                        .withImpersonateUsername(impersonatedUser)
+                        .withUserAgent("kroxylicious-operator/test")
+                        .endConfig());
     }
 
     /**

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
@@ -244,16 +244,19 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
             }
 
             @NonNull
+            @Override
             public <T extends HasMetadata> T getInNamespace(@NonNull Class<T> type, @NonNull String name, @NonNull String namespace) {
                 return testActorClient.resources(type).inNamespace(namespace).withName(name).get();
             }
 
             @NonNull
+            @Override
             public <T extends HasMetadata> T replace(@NonNull T resource) {
                 return client.resource(resource).inNamespace(operatorExtension.getNamespace()).update();
             }
 
             @NonNull
+            @Override
             public <T extends HasMetadata> T patchStatus(@NonNull T resource) {
                 return client.resource(resource).inNamespace(operatorExtension.getNamespace()).patchStatus();
             }
@@ -271,6 +274,7 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
                 return client.resources(type).inNamespace(operatorExtension.getNamespace());
             }
 
+            @Override
             public <T extends KubernetesResource> boolean supports(Class<T> type) {
                 return testActorClient.supports(type);
             }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
@@ -212,10 +212,23 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
                 new KubernetesClientBuilder().editOrNewConfig().withImpersonateUsername(impersonatedUser).endConfig());
     }
 
+    /**
+     * Returns the Kubernetes client used for user-level interactions.
+     * <p>
+     * This client has the RBAC rights of a cluster user (via the admin client), not the operator.
+     * The client is created lazily on first call and closed in {@link #afterAll}.
+     */
+    @NonNull
+    public KubernetesClient userClient() {
+        if (testActorClient == null) {
+            testActorClient = adminClientFactory.get();
+        }
+        return testActorClient;
+    }
+
     @NonNull
     public TestActor testActor(@NonNull AbstractOperatorExtension operatorExtension) {
-        testActorClient = adminClientFactory.get();
-        var client = testActorClient;
+        var client = userClient();
         return new TestActor() {
 
             @NonNull

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
@@ -59,7 +59,7 @@ import static java.util.Objects.requireNonNull;
  * in production.
  * <br/>
  * For the test's interactions with Kubernetes, where more privileges are required, use the operations
- * exposed by {@link #testActor(AbstractOperatorExtension)}.
+ * exposed by {@link #testActor(KubernetesClient, AbstractOperatorExtension)}.
  *
  */
 public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, AfterEachCallback {

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
@@ -47,6 +47,7 @@ import io.kroxylicious.proxy.tag.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+import static io.kroxylicious.testing.operator.KubernetesResourceUtil.name;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -152,14 +153,14 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
             // The test framework itself needs these roles.
             clusterRoles.forEach(r -> {
                 LOGGER.atTrace()
-                        .addKeyValue("resourceName", r.getMetadata().getName())
+                        .addKeyValue("resourceName", name(r))
                         .log("Creating/patching");
                 adminClient.resource(r).createOr(EditReplacePatchable::patch);
             });
 
             roleBindings.forEach(roleBinding -> {
                 LOGGER.atTrace()
-                        .addKeyValue("resourceName", roleBinding.getMetadata().getName())
+                        .addKeyValue("resourceName", name(roleBinding))
                         .log("Creating role binding");
                 adminClient.resource(roleBinding).createOr(EditReplacePatchable::patch);
             });
@@ -171,9 +172,9 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
     }
 
     private ClusterRoleBinding bindingForRole(ClusterRole clusterRole) {
-        return new ClusterRoleBindingBuilder().withNewMetadata().withName(clusterRole.getMetadata().getName() + "-" + impersonatedUser + "-binding").endMetadata()
+        return new ClusterRoleBindingBuilder().withNewMetadata().withName(name(clusterRole) + "-" + impersonatedUser + "-binding").endMetadata()
                 .addNewSubject().withKind("User").withName(impersonatedUser).withApiGroup("rbac.authorization.k8s.io").endSubject()
-                .withNewRoleRef().withKind("ClusterRole").withName(clusterRole.getMetadata().getName()).withApiGroup("rbac.authorization.k8s.io").endRoleRef().build();
+                .withNewRoleRef().withKind("ClusterRole").withName(name(clusterRole)).withApiGroup("rbac.authorization.k8s.io").endRoleRef().build();
     }
 
     private @NonNull Stream<ClusterRole> loadClusterRoles(Stream<Path> files, KubernetesClient adminClient, List<PathMatcher> clusterRolePathMatchers) {
@@ -194,12 +195,12 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
     public void afterEach(ExtensionContext context) {
         try (var adminClient = adminClientFactory.get()) {
             this.roleBindings.forEach(roleBinding -> {
-                LOGGER.trace("Deleting ClusterRoleBinding: {}", roleBinding.getMetadata().getName());
+                LOGGER.trace("Deleting ClusterRoleBinding: {}", name(roleBinding));
                 adminClient.resource(roleBinding).delete();
             });
 
             this.clusterRoles.forEach(clusterRole -> {
-                LOGGER.trace("Deleting ClusterRole: {}", clusterRole.getMetadata().getName());
+                LOGGER.trace("Deleting ClusterRole: {}", name(clusterRole));
                 adminClient.resource(clusterRole).delete();
             });
         }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
@@ -21,7 +21,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -64,7 +63,7 @@ import static java.util.Objects.requireNonNull;
  * exposed by {@link #testActor(AbstractOperatorExtension)}.
  *
  */
-public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, AfterEachCallback, AfterAllCallback {
+public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, AfterEachCallback {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LocallyRunningOperatorRbacHandler.class);
 
@@ -92,10 +91,6 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
 
     private final List<ClusterRole> clusterRoles;
     private final List<ClusterRoleBinding> roleBindings;
-
-    // Lazily set when testActor() is called; closed in afterAll.
-    @Nullable
-    private KubernetesClient testActorClient;
 
     public LocallyRunningOperatorRbacHandler(String resourceDirectory, String... clusterRoleFileGlobs) {
         this(Path.of(resourceDirectory), OperatorTestUtils::kubeClient, clusterRoleFileGlobs);
@@ -217,22 +212,16 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
     }
 
     /**
-     * Returns the Kubernetes client used for user-level interactions.
-     * <p>
-     * This client has the RBAC rights of a cluster user (via the admin client), not the operator.
-     * The client is created lazily on first call and closed in {@link #afterAll}.
+     * Creates and returns a new Kubernetes client with the RBAC rights of a cluster user (via the admin client).
+     * The caller is responsible for closing the returned client.
      */
     @NonNull
     public KubernetesClient userClient() {
-        if (testActorClient == null) {
-            testActorClient = adminClientFactory.get();
-        }
-        return testActorClient;
+        return adminClientFactory.get();
     }
 
     @NonNull
-    public TestActor testActor(@NonNull AbstractOperatorExtension operatorExtension) {
-        var client = userClient();
+    public TestActor testActor(@NonNull KubernetesClient client, @NonNull AbstractOperatorExtension operatorExtension) {
         return new TestActor() {
 
             @NonNull
@@ -250,7 +239,7 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
             @NonNull
             @Override
             public <T extends HasMetadata> T getInNamespace(@NonNull Class<T> type, @NonNull String name, @NonNull String namespace) {
-                return testActorClient.resources(type).inNamespace(namespace).withName(name).get();
+                return client.resources(type).inNamespace(namespace).withName(name).get();
             }
 
             @NonNull
@@ -280,17 +269,10 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
 
             @Override
             public <T extends KubernetesResource> boolean supports(Class<T> type) {
-                return testActorClient.supports(type);
+                return client.supports(type);
             }
 
         };
-    }
-
-    @Override
-    public void afterAll(ExtensionContext context) {
-        if (testActorClient != null) {
-            testActorClient.close();
-        }
     }
 
     public interface TestActor {

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-package io.kroxylicious.kubernetes.operator;
+package io.kroxylicious.testing.operator;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -44,7 +44,6 @@ import io.javaoperatorsdk.operator.junit.AbstractOperatorExtension;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
-import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -140,14 +139,14 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
             // The test framework itself needs these roles.
             clusterRoles.forEach(r -> {
                 LOGGER.atTrace()
-                        .addKeyValue("resourceName", name(r))
+                        .addKeyValue("resourceName", r.getMetadata().getName())
                         .log("Creating/patching");
                 adminClient.resource(r).createOr(EditReplacePatchable::patch);
             });
 
             roleBindings.forEach(roleBinding -> {
                 LOGGER.atTrace()
-                        .addKeyValue("resourceName", name(roleBinding))
+                        .addKeyValue("resourceName", roleBinding.getMetadata().getName())
                         .log("Creating role binding");
                 adminClient.resource(roleBinding).createOr(EditReplacePatchable::patch);
             });
@@ -159,9 +158,9 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
     }
 
     private ClusterRoleBinding bindingForRole(ClusterRole clusterRole) {
-        return new ClusterRoleBindingBuilder().withNewMetadata().withName(name(clusterRole) + "-" + impersonatedUser + "-binding").endMetadata()
+        return new ClusterRoleBindingBuilder().withNewMetadata().withName(clusterRole.getMetadata().getName() + "-" + impersonatedUser + "-binding").endMetadata()
                 .addNewSubject().withKind("User").withName(impersonatedUser).withApiGroup("rbac.authorization.k8s.io").endSubject()
-                .withNewRoleRef().withKind("ClusterRole").withName(name(clusterRole)).withApiGroup("rbac.authorization.k8s.io").endRoleRef().build();
+                .withNewRoleRef().withKind("ClusterRole").withName(clusterRole.getMetadata().getName()).withApiGroup("rbac.authorization.k8s.io").endRoleRef().build();
     }
 
     private @NonNull Stream<ClusterRole> loadClusterRoles(Stream<Path> files, KubernetesClient adminClient, List<PathMatcher> clusterRolePathMatchers) {
@@ -182,12 +181,12 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
     public void afterEach(ExtensionContext context) {
         try (var adminClient = OperatorTestUtils.kubeClient()) {
             this.roleBindings.forEach(roleBinding -> {
-                LOGGER.trace("Deleting ClusterRoleBinding: {}", name(roleBinding));
+                LOGGER.trace("Deleting ClusterRoleBinding: {}", roleBinding.getMetadata().getName());
                 adminClient.resource(roleBinding).delete();
             });
 
             this.clusterRoles.forEach(clusterRole -> {
-                LOGGER.trace("Deleting ClusterRole: {}", name(clusterRole));
+                LOGGER.trace("Deleting ClusterRole: {}", clusterRole.getMetadata().getName());
                 adminClient.resource(clusterRole).delete();
             });
         }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandler.java
@@ -6,7 +6,6 @@
 
 package io.kroxylicious.testing.operator;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.FileSystems;
@@ -175,7 +174,7 @@ public class LocallyRunningOperatorRbacHandler implements BeforeEachCallback, Af
     private @NonNull Stream<ClusterRole> loadClusterRoles(Stream<Path> files, KubernetesClient adminClient, List<PathMatcher> clusterRolePathMatchers) {
         return files.filter(Files::isRegularFile).filter(path -> clusterRolePathMatchers.stream().anyMatch(matcher -> matcher.matches(path))).sorted()
                 .flatMap(resourceFile -> {
-                    try (var resourceInputStream = new FileInputStream(resourceFile.toString())) {
+                    try (var resourceInputStream = Files.newInputStream(resourceFile)) {
                         var resources = adminClient.load(resourceInputStream).items();
                         List<ClusterRole> roles = resources.stream().filter(ClusterRole.class::isInstance).map(ClusterRole.class::cast).toList();
                         return roles.stream();

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/OperatorTestUtils.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/OperatorTestUtils.java
@@ -16,6 +16,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class OperatorTestUtils {
 
+    private OperatorTestUtils() {
+        // Static utils only
+    }
+
     /**
      * The timeouts etc of this client build are tuned to handle the case where Kubernetes isn't present.
      * As might be the case on a developer's machine where minikube isn't running.

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/OperatorTestUtils.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/OperatorTestUtils.java
@@ -6,13 +6,14 @@
 
 package io.kroxylicious.testing.operator;
 
+import java.util.Objects;
+
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
-import io.fabric8.kubernetes.client.KubernetesClientException;
+
+import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class OperatorTestUtils {
 
@@ -35,19 +36,25 @@ public class OperatorTestUtils {
     }
 
     public static @NonNull KubernetesClient kubeClient(KubernetesClientBuilder kubernetesClientBuilder) {
-        KubernetesClient kubernetesClient = kubernetesClientBuilder.build();
-        assertThat(kubernetesClient).isNotNull();
-        return kubernetesClient;
+        return Objects.requireNonNull(kubernetesClientBuilder.build(), "KubernetesClientBuilder.build() returned null");
     }
 
     public static boolean isKubeClientAvailable() {
-        var client = PRESENCE_PROBING_KUBE_CLIENT_BUILD.build();
+        return isKubeClientAvailable(PRESENCE_PROBING_KUBE_CLIENT_BUILD);
+    }
+
+    @VisibleForTesting
+    static boolean isKubeClientAvailable(KubernetesClientBuilder builder) {
+        KubernetesClient client = null;
         try {
+            client = builder.build();
             client.namespaces().list();
             return true;
         }
-        catch (KubernetesClientException e) {
-            client.close();
+        catch (RuntimeException e) {
+            if (client != null) {
+                client.close();
+            }
             return false;
         }
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/OperatorTestUtils.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/OperatorTestUtils.java
@@ -4,30 +4,17 @@
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-package io.kroxylicious.kubernetes.operator;
+package io.kroxylicious.testing.operator;
 
-import java.util.Objects;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.readiness.Readiness;
-
-import io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy.ProxyDeploymentDependentResource;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class OperatorTestUtils {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(OperatorTestUtils.class);
 
     /**
      * The timeouts etc of this client build are tuned to handle the case where Kubernetes isn't present.
@@ -58,29 +45,6 @@ public class OperatorTestUtils {
         catch (KubernetesClientException e) {
             client.close();
             return false;
-        }
-    }
-
-    public static void preloadOperandImage() {
-        try (var client = kubeClient()) {
-            String operandImage = ProxyDeploymentDependentResource.getOperandImage();
-            var pod = client.run().withName("preload-operand-image")
-                    .withNewRunConfig()
-                    .withImage(operandImage)
-                    .withRestartPolicy("Never")
-                    .withCommand("ls").done();
-            try {
-                client.resource(pod).waitUntilCondition(Readiness::isPodSucceeded, 2, TimeUnit.MINUTES);
-            }
-            finally {
-                var reread = client.resource(pod).get();
-                if (!Readiness.isPodSucceeded(reread)) {
-                    var reasons = reread.getStatus().getContainerStatuses().stream().map(ContainerStatus::getState).map(Objects::toString)
-                            .collect(Collectors.joining(","));
-                    LOGGER.error("Preloading operand image failed, phase: {}, container state: {}", reread.getStatus().getPhase(), reasons);
-                }
-                client.resource(pod).delete();
-            }
         }
     }
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/package-info.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/main/java/io/kroxylicious/testing/operator/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * JUnit 5 extensions and utilities for operator integration tests.
+ */
+@ReturnValuesAreNonnullByDefault
+@DefaultAnnotationForParameters(NonNull.class)
+@DefaultAnnotation(NonNull.class)
+package io.kroxylicious.testing.operator;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.DefaultAnnotationForParameters;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.ReturnValuesAreNonnullByDefault;

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/ClusterUserTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/ClusterUserTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.testing.operator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EnableKubernetesMockClient(crud = true)
+class ClusterUserTest {
+
+    private static final String NAMESPACE = "test-ns";
+
+    KubernetesClient client;
+
+    @BeforeEach
+    void createNamespace() {
+        client.namespaces().resource(new io.fabric8.kubernetes.api.model.NamespaceBuilder()
+                .withNewMetadata().withName(NAMESPACE).endMetadata().build()).create();
+    }
+
+    @Test
+    void createPersistsResourceInNamespace() {
+        var user = new ClusterUser(client, NAMESPACE);
+        KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName("my-proxy").endMetadata().build();
+
+        user.create(proxy);
+
+        assertThat(client.resources(KafkaProxy.class).inNamespace(NAMESPACE).withName("my-proxy").get())
+                .isNotNull();
+    }
+
+    @Test
+    void getReturnsResourceByName() {
+        var user = new ClusterUser(client, NAMESPACE);
+        KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName("my-proxy").endMetadata().build();
+        client.resource(proxy).inNamespace(NAMESPACE).create();
+
+        KafkaProxy result = user.get(KafkaProxy.class, "my-proxy");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getMetadata().getName()).isEqualTo("my-proxy");
+    }
+
+    @Test
+    void getMissingResourceReturnsNull() {
+        var user = new ClusterUser(client, NAMESPACE);
+
+        assertThat(user.get(KafkaProxy.class, "does-not-exist")).isNull();
+    }
+
+    @Test
+    void replaceUpdatesExistingResource() {
+        var user = new ClusterUser(client, NAMESPACE);
+        Secret secret = new SecretBuilder().withNewMetadata().withName("my-secret").endMetadata()
+                .addToStringData("key", "original").build();
+        client.resource(secret).inNamespace(NAMESPACE).create();
+
+        Secret updated = new SecretBuilder(secret).addToStringData("key", "updated").build();
+        user.replace(updated);
+
+        Secret fetched = client.resources(Secret.class).inNamespace(NAMESPACE).withName("my-secret").get();
+        assertThat(fetched.getStringData()).containsEntry("key", "updated");
+    }
+
+    @Test
+    void deleteRemovesResourceFromNamespace() {
+        var user = new ClusterUser(client, NAMESPACE);
+        KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName("my-proxy").endMetadata().build();
+        client.resource(proxy).inNamespace(NAMESPACE).create();
+
+        user.delete(proxy);
+
+        assertThat(client.resources(KafkaProxy.class).inNamespace(NAMESPACE).withName("my-proxy").get())
+                .isNull();
+    }
+
+    @Test
+    void resourcesReturnsNamespaceScopedOperation() {
+        var user = new ClusterUser(client, NAMESPACE);
+        KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName("my-proxy").endMetadata().build();
+        client.resource(proxy).inNamespace(NAMESPACE).create();
+
+        var items = user.resources(KafkaProxy.class).list().getItems();
+
+        assertThat(items).hasSize(1);
+        assertThat(items.get(0).getMetadata().getName()).isEqualTo("my-proxy");
+    }
+}

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/ClusterUserTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/ClusterUserTest.java
@@ -7,18 +7,26 @@
 package io.kroxylicious.testing.operator;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.NamespaceableResource;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+// No explicit namespace cleanup needed: each test instance gets a fresh in-memory mock client.
 @EnableKubernetesMockClient(crud = true)
 class ClusterUserTest {
 
@@ -98,5 +106,73 @@ class ClusterUserTest {
 
         assertThat(items).hasSize(1);
         assertThat(items.get(0).getMetadata().getName()).isEqualTo("my-proxy");
+    }
+
+    @Nested
+    class ErrorContextWrapping {
+
+        @SuppressWarnings("unchecked")
+        @Test
+        void createWrapsExceptionWithResourceContext() {
+            KubernetesClient mockClient = mock(KubernetesClient.class);
+            NamespaceableResource<KafkaProxy> mockResource = mock(NamespaceableResource.class);
+            when(mockClient.resource(any(KafkaProxy.class))).thenReturn(mockResource);
+            when(mockResource.inNamespace(NAMESPACE)).thenReturn(mockResource);
+            when(mockResource.create()).thenThrow(new KubernetesClientException("forbidden"));
+
+            var user = new ClusterUser(mockClient, NAMESPACE);
+            KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName("my-proxy").endMetadata().build();
+
+            assertThatThrownBy(() -> user.create(proxy))
+                    .isInstanceOf(KubernetesClientException.class)
+                    .hasMessageContaining("ClusterUser")
+                    .hasMessageContaining("create")
+                    .hasMessageContaining("KafkaProxy")
+                    .hasMessageContaining("my-proxy")
+                    .hasCauseInstanceOf(KubernetesClientException.class);
+        }
+
+        @SuppressWarnings("unchecked")
+        @Test
+        void replaceWrapsExceptionWithResourceContext() {
+            KubernetesClient mockClient = mock(KubernetesClient.class);
+            NamespaceableResource<KafkaProxy> mockResource = mock(NamespaceableResource.class);
+            when(mockClient.resource(any(KafkaProxy.class))).thenReturn(mockResource);
+            when(mockResource.inNamespace(NAMESPACE)).thenReturn(mockResource);
+            when(mockResource.update()).thenThrow(new KubernetesClientException("conflict"));
+
+            var user = new ClusterUser(mockClient, NAMESPACE);
+            KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName("my-proxy").endMetadata().build();
+
+            assertThatThrownBy(() -> user.replace(proxy))
+                    .isInstanceOf(KubernetesClientException.class)
+                    .hasMessageContaining("ClusterUser")
+                    .hasMessageContaining("replace")
+                    .hasMessageContaining("KafkaProxy")
+                    .hasMessageContaining("my-proxy")
+                    .hasCauseInstanceOf(KubernetesClientException.class);
+        }
+
+        @SuppressWarnings("unchecked")
+        @Test
+        void deleteWrapsExceptionWithResourceContext() {
+            KubernetesClient mockClient = mock(KubernetesClient.class);
+            NamespaceableResource<KafkaProxy> mockResource = mock(NamespaceableResource.class);
+            when(mockClient.resource(any(KafkaProxy.class))).thenReturn(mockResource);
+            when(mockResource.inNamespace(NAMESPACE)).thenReturn(mockResource);
+            when(mockResource.delete()).thenThrow(new KubernetesClientException("not found"));
+
+            var user = new ClusterUser(mockClient, NAMESPACE);
+            KafkaProxy proxy = new KafkaProxyBuilder().withNewMetadata().withName("my-proxy").endMetadata().build();
+
+            assertThatThrownBy(() -> user.delete(proxy))
+                    .isInstanceOf(KubernetesClientException.class)
+                    .hasMessageContaining("ClusterUser")
+                    .hasMessageContaining("delete")
+                    .hasMessageContaining("KafkaProxy")
+                    .hasMessageContaining("my-proxy")
+                    .hasCauseInstanceOf(KubernetesClientException.class);
+        }
+
     }
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/KubernetesResourceUtilTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/KubernetesResourceUtilTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.testing.operator;
+
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+
+import static io.kroxylicious.testing.operator.KubernetesResourceUtil.name;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KubernetesResourceUtilTest {
+
+    @Test
+    void shouldExtractName() {
+        ConfigMap configMap = new ConfigMapBuilder()
+                .withNewMetadata()
+                .withName("my-config")
+                .endMetadata()
+                .build();
+
+        assertThat(name(configMap)).isEqualTo("my-config");
+    }
+}

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtensionBuilderTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtensionBuilderTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.testing.operator;
+
+import org.junit.jupiter.api.Test;
+
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LocalKroxyliciousOperatorExtensionBuilderTest {
+
+    @Test
+    void buildWithNoReconcilerShouldThrow() {
+        var builder = LocalKroxyliciousOperatorExtension.builder();
+        assertThatThrownBy(builder::build)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("at least one reconciler");
+    }
+
+    @Test
+    void buildWithOneReconcilerShouldSucceed() {
+        assertThatCode(() -> LocalKroxyliciousOperatorExtension.builder()
+                .withReconciler((KafkaProxy resource, Context<KafkaProxy> context) -> UpdateControl.noUpdate())
+                .build()).doesNotThrowAnyException();
+    }
+
+    @Test
+    void withReconcilerAccumulatesMultipleReconcilers() {
+        assertThatCode(() -> LocalKroxyliciousOperatorExtension.builder()
+                .withReconciler((KafkaProxy resource, Context<KafkaProxy> context) -> UpdateControl.noUpdate())
+                .withReconciler((KafkaProxy resource, Context<KafkaProxy> context) -> UpdateControl.noUpdate())
+                .build()).doesNotThrowAnyException();
+    }
+}

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtensionImageResolutionTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtensionImageResolutionTest.java
@@ -142,7 +142,7 @@ class LocalKroxyliciousOperatorExtensionImageResolutionTest {
     // ---- helpers ----
 
     private static Supplier<InputStream> propertiesSupplier(String image) {
-        String content = "kroxylicious-image=%s\n".formatted(image);
+        String content = "kroxylicious-image=%s%n".formatted(image);
         return () -> new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtensionImageResolutionTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtensionImageResolutionTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.testing.operator;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LocalKroxyliciousOperatorExtensionImageResolutionTest {
+
+    // ---- sanitiseImageRef ----
+
+    @Test
+    void sanitiseImageRefStripsCarriageReturnAndNewline() {
+        assertThat(LocalKroxyliciousOperatorExtension.sanitiseImageRef("my-image:tag\r\n")).isEqualTo("my-image:tag");
+    }
+
+    @Test
+    void sanitiseImageRefLeavesCleanRefUnchanged() {
+        assertThat(LocalKroxyliciousOperatorExtension.sanitiseImageRef("my-image:tag")).isEqualTo("my-image:tag");
+    }
+
+    // ---- resolveOperandImage: env var branch ----
+
+    @Test
+    void resolveOperandImageReturnsEnvVarWhenSet() {
+        // Given
+        String envImage = "quay.io/kroxylicious/kroxylicious:latest";
+
+        // When
+        String result = LocalKroxyliciousOperatorExtension.resolveOperandImage(envImage, () -> null);
+
+        // Then
+        assertThat(result).isEqualTo(envImage);
+    }
+
+    @Test
+    void resolveOperandImageSanitisesEnvVarImage() {
+        // Given
+        String envImage = "quay.io/kroxylicious/kroxylicious:latest\r\n";
+
+        // When
+        String result = LocalKroxyliciousOperatorExtension.resolveOperandImage(envImage, () -> null);
+
+        // Then
+        assertThat(result).isEqualTo("quay.io/kroxylicious/kroxylicious:latest");
+    }
+
+    @Test
+    void resolveOperandImageIgnoresBlankEnvVar() {
+        // Given: blank env var, valid properties supplier
+        String expectedImage = "quay.io/kroxylicious/kroxylicious:from-props";
+        Supplier<InputStream> propsSupplier = propertiesSupplier(expectedImage);
+
+        // When
+        String result = LocalKroxyliciousOperatorExtension.resolveOperandImage("   ", propsSupplier);
+
+        // Then
+        assertThat(result).isEqualTo(expectedImage);
+    }
+
+    // ---- resolveOperandImage: properties file branch ----
+
+    @Test
+    void resolveOperandImageReadsImageFromPropertiesFileWhenEnvVarAbsent() {
+        // Given
+        String expectedImage = "quay.io/kroxylicious/kroxylicious:1.2.3";
+
+        // When
+        String result = LocalKroxyliciousOperatorExtension.resolveOperandImage(null, propertiesSupplier(expectedImage));
+
+        // Then
+        assertThat(result).isEqualTo(expectedImage);
+    }
+
+    @Test
+    void resolveOperandImageSanitisesPropertiesFileImage() {
+        // Given
+        String result = LocalKroxyliciousOperatorExtension.resolveOperandImage(null, propertiesSupplier("my-image:tag\r\n"));
+
+        // Then
+        assertThat(result).isEqualTo("my-image:tag");
+    }
+
+    // ---- resolveOperandImage: error branches ----
+
+    @Test
+    void resolveOperandImageThrowsWhenPropertiesFileNotFound() {
+        // Given: supplier returns null (resource not on classpath)
+        assertThatThrownBy(() -> LocalKroxyliciousOperatorExtension.resolveOperandImage(null, () -> null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("not found on classpath");
+    }
+
+    @Test
+    void resolveOperandImageThrowsWhenPropertyMissingFromFile() {
+        // Given: properties file with no kroxylicious-image entry
+        Supplier<InputStream> emptyProps = () -> new ByteArrayInputStream("other.property=value\n".getBytes(StandardCharsets.UTF_8));
+
+        assertThatThrownBy(() -> LocalKroxyliciousOperatorExtension.resolveOperandImage(null, emptyProps))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("'kroxylicious-image' not found");
+    }
+
+    @Test
+    void resolveOperandImageThrowsWhenPropertyIsEmpty() {
+        // Given: properties file with an empty kroxylicious-image value
+        Supplier<InputStream> emptyValueProps = () -> new ByteArrayInputStream("kroxylicious-image=\n".getBytes(StandardCharsets.UTF_8));
+
+        assertThatThrownBy(() -> LocalKroxyliciousOperatorExtension.resolveOperandImage(null, emptyValueProps))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("'kroxylicious-image' not found");
+    }
+
+    @Test
+    void resolveOperandImageWrapsIOExceptionAsIllegalStateException() {
+        // Given: supplier returns a stream that throws on read
+        Supplier<InputStream> brokenSupplier = () -> new InputStream() {
+            @Override
+            public int read() throws IOException {
+                throw new IOException("disk error");
+            }
+        };
+
+        assertThatThrownBy(() -> LocalKroxyliciousOperatorExtension.resolveOperandImage(null, brokenSupplier))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Failed to read")
+                .hasCauseInstanceOf(IOException.class);
+    }
+
+    // ---- helpers ----
+
+    private static Supplier<InputStream> propertiesSupplier(String image) {
+        String content = "kroxylicious-image=%s\n".formatted(image);
+        return () -> new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtensionLifecycleTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtensionLifecycleTest.java
@@ -31,7 +31,9 @@ class LocalKroxyliciousOperatorExtensionLifecycleTest {
             LocalKroxyliciousOperatorExtension.builder()
                     .withReconciler((KafkaProxy resource, Context<KafkaProxy> ctx) -> UpdateControl.noUpdate()),
             () -> rbacHandler,
-            handler -> locallyRunOperatorExtension);
+            handler -> locallyRunOperatorExtension,
+            () -> {
+            });
 
     @Test
     void beforeAllSetsUpRbacThenStartsOperator() throws Exception {

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtensionLifecycleTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtensionLifecycleTest.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
@@ -234,6 +235,16 @@ class LocalKroxyliciousOperatorExtensionLifecycleTest {
         verify(mutator).apply(fresh);
         verify(actor).patchStatus(fresh);
         assertThat(result).isSameAs(patched);
+    }
+
+    @Test
+    void clusterUserIsNonNullAfterBeforeAll() throws Exception {
+        when(locallyRunOperatorExtension.getNamespace()).thenReturn("test-ns");
+        when(rbacHandler.userClient()).thenReturn(mock(KubernetesClient.class));
+
+        extension.beforeAll(context);
+
+        assertThat(extension.clusterUser()).isNotNull();
     }
 
     // ---- helpers ----

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtensionLifecycleTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtensionLifecycleTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.function.Executable;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
@@ -156,6 +157,53 @@ class LocalKroxyliciousOperatorExtensionLifecycleTest {
 
         // Then
         verify(setup.actor()).resources(Namespace.class);
+    }
+
+    @Test
+    void beforeAllRunsSetupActionsAfterRbacAndBeforeOperator() throws Throwable {
+        // Given
+        var localRbac = mock(LocallyRunningOperatorRbacHandler.class);
+        var localOp = mock(LocallyRunOperatorExtension.class);
+        Executable setupAction = mock(Executable.class);
+        var ext = new LocalKroxyliciousOperatorExtension(
+                defaultBuilder().withSetupAction(setupAction),
+                () -> localRbac,
+                handler -> localOp,
+                () -> {
+                });
+
+        // When
+        ext.beforeAll(context);
+
+        // Then
+        InOrder order = inOrder(localRbac, setupAction, localOp);
+        order.verify(localRbac).beforeEach(context);
+        order.verify(setupAction).execute();
+        order.verify(localOp).beforeAll(context);
+    }
+
+    @Test
+    void afterAllRunsTeardownActionsAfterOperatorAndBeforeRbac() throws Throwable {
+        // Given
+        var localRbac = mock(LocallyRunningOperatorRbacHandler.class);
+        var localOp = mock(LocallyRunOperatorExtension.class);
+        Executable teardownAction = mock(Executable.class);
+        var ext = new LocalKroxyliciousOperatorExtension(
+                defaultBuilder().withTeardownAction(teardownAction),
+                () -> localRbac,
+                handler -> localOp,
+                () -> {
+                });
+        ext.beforeAll(context);
+
+        // When
+        ext.afterAll(context);
+
+        // Then
+        InOrder order = inOrder(localOp, teardownAction, localRbac);
+        order.verify(localOp).afterAll(context);
+        order.verify(teardownAction).execute();
+        order.verify(localRbac).afterEach(context);
     }
 
     // ---- helpers ----

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtensionLifecycleTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtensionLifecycleTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.testing.operator;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.InOrder;
+
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class LocalKroxyliciousOperatorExtensionLifecycleTest {
+
+    private final LocallyRunningOperatorRbacHandler rbacHandler = mock(LocallyRunningOperatorRbacHandler.class);
+    private final LocallyRunOperatorExtension locallyRunOperatorExtension = mock(LocallyRunOperatorExtension.class);
+    private final ExtensionContext context = mock(ExtensionContext.class);
+
+    private final LocalKroxyliciousOperatorExtension extension = new LocalKroxyliciousOperatorExtension(
+            LocalKroxyliciousOperatorExtension.builder()
+                    .withReconciler((KafkaProxy resource, Context<KafkaProxy> ctx) -> UpdateControl.noUpdate()),
+            () -> rbacHandler,
+            handler -> locallyRunOperatorExtension);
+
+    @Test
+    void beforeAllSetsUpRbacThenStartsOperator() throws Exception {
+        extension.beforeAll(context);
+
+        InOrder order = inOrder(rbacHandler, locallyRunOperatorExtension);
+        order.verify(rbacHandler).beforeEach(context);
+        order.verify(locallyRunOperatorExtension).beforeAll(context);
+    }
+
+    @Test
+    void afterAllStopsOperatorThenCleansUpRbac() throws Exception {
+        extension.beforeAll(context);
+
+        extension.afterAll(context);
+
+        InOrder order = inOrder(locallyRunOperatorExtension, rbacHandler);
+        order.verify(locallyRunOperatorExtension).afterAll(context);
+        order.verify(rbacHandler).afterEach(context);
+        order.verify(rbacHandler).afterAll(context);
+    }
+
+    @Test
+    void afterAllIsIdempotentIfBeforeAllWasNeverCalled() throws Exception {
+        extension.afterAll(context);
+
+        verify(locallyRunOperatorExtension, never()).afterAll(context);
+        verify(rbacHandler, never()).afterEach(context);
+    }
+
+    @Test
+    void afterEachIsSafeIfBeforeAllWasNeverCalled() throws Exception {
+        extension.afterEach(context);
+        // testActor is null — nothing to verify, just must not throw
+    }
+}

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtensionLifecycleTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtensionLifecycleTest.java
@@ -6,20 +6,40 @@
 
 package io.kroxylicious.testing.operator;
 
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProtocolFilter;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
+import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class LocalKroxyliciousOperatorExtensionLifecycleTest {
 
@@ -57,7 +77,7 @@ class LocalKroxyliciousOperatorExtensionLifecycleTest {
     }
 
     @Test
-    void afterAllIsIdempotentIfBeforeAllWasNeverCalled() throws Exception {
+    void afterAllIsIdempotentIfBeforeAllWasNeverCalled() {
         extension.afterAll(context);
 
         verify(locallyRunOperatorExtension, never()).afterAll(context);
@@ -65,8 +85,107 @@ class LocalKroxyliciousOperatorExtensionLifecycleTest {
     }
 
     @Test
-    void afterEachIsSafeIfBeforeAllWasNeverCalled() throws Exception {
-        extension.afterEach(context);
+    void afterEachIsSafeIfBeforeAllWasNeverCalled() {
+        assertThatNoException().isThrownBy(() -> extension.afterEach(context));
         // testActor is null — nothing to verify, just must not throw
     }
+
+    @Test
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    void afterEachCleansUpAllStandardResourceTypes() throws Exception {
+        // Given
+        var setup = extensionWithMockActor(defaultBuilder(), List.of());
+
+        // When
+        setup.extension().afterEach(context);
+
+        // Then
+        ArgumentCaptor<Class> captor = ArgumentCaptor.forClass(Class.class);
+        verify(setup.actor(), atLeastOnce()).resources(captor.capture());
+        assertThat(captor.getAllValues()).containsExactlyInAnyOrder(
+                VirtualKafkaCluster.class, KafkaProxy.class, KafkaProxyIngress.class,
+                KafkaService.class, KafkaProtocolFilter.class, Secret.class, ConfigMap.class);
+    }
+
+    @Test
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    void afterEachDeletesFoundResources() throws Exception {
+        // Given: each standard type has one uniquely named resource so failures identify the missing type
+        var localRbac = mock(LocallyRunningOperatorRbacHandler.class);
+        var localOp = mock(LocallyRunOperatorExtension.class);
+        var ext = new LocalKroxyliciousOperatorExtension(defaultBuilder(), () -> localRbac, handler -> localOp, () -> {
+        });
+
+        LocallyRunningOperatorRbacHandler.TestActor mockActor = mock(LocallyRunningOperatorRbacHandler.TestActor.class);
+        when(localRbac.testActor(any())).thenReturn(mockActor);
+
+        List<Class<? extends HasMetadata>> standardTypes = List.of(
+                VirtualKafkaCluster.class, KafkaProxy.class, KafkaProxyIngress.class,
+                KafkaService.class, KafkaProtocolFilter.class, Secret.class, ConfigMap.class);
+
+        Map<Class<? extends HasMetadata>, HasMetadata> itemsByType = new LinkedHashMap<>();
+        for (Class<? extends HasMetadata> type : standardTypes) {
+            HasMetadata item = mock(HasMetadata.class, type.getSimpleName() + "-item");
+            itemsByType.put(type, item);
+            NonNamespaceOperation mockOp = mock(NonNamespaceOperation.class);
+            KubernetesResourceList mockList = mock(KubernetesResourceList.class);
+            when(mockList.getItems()).thenReturn(List.of(item));
+            when(mockOp.list()).thenReturn(mockList);
+            when(mockActor.resources(type)).thenReturn(mockOp);
+        }
+
+        ext.beforeAll(context);
+
+        // When
+        ext.afterEach(context);
+
+        // Then: every found resource was deleted — named mocks identify the type in failure messages
+        ArgumentCaptor<HasMetadata> deleteCaptor = ArgumentCaptor.forClass(HasMetadata.class);
+        verify(mockActor, atLeastOnce()).delete(deleteCaptor.capture());
+        assertThat(deleteCaptor.getAllValues())
+                .containsExactlyInAnyOrder(itemsByType.values().toArray(HasMetadata[]::new));
+    }
+
+    @Test
+    void afterEachAlsoCleansUpAdditionalCleanupTypes() throws Exception {
+        // Given
+        var setup = extensionWithMockActor(defaultBuilder().withAdditionalCleanupTypes(Namespace.class), List.of());
+
+        // When
+        setup.extension().afterEach(context);
+
+        // Then
+        verify(setup.actor()).resources(Namespace.class);
+    }
+
+    // ---- helpers ----
+
+    private LocalKroxyliciousOperatorExtension.Builder defaultBuilder() {
+        return LocalKroxyliciousOperatorExtension.builder()
+                .withReconciler((KafkaProxy resource, Context<KafkaProxy> ctx) -> UpdateControl.noUpdate());
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private ExtensionWithActor extensionWithMockActor(LocalKroxyliciousOperatorExtension.Builder builder,
+                                                      List<? extends HasMetadata> itemsPerType)
+            throws Exception {
+        var localRbac = mock(LocallyRunningOperatorRbacHandler.class);
+        var localOp = mock(LocallyRunOperatorExtension.class);
+        var ext = new LocalKroxyliciousOperatorExtension(builder, () -> localRbac, handler -> localOp, () -> {
+        });
+
+        LocallyRunningOperatorRbacHandler.TestActor mockActor = mock(LocallyRunningOperatorRbacHandler.TestActor.class);
+        NonNamespaceOperation mockOp = mock(NonNamespaceOperation.class);
+        KubernetesResourceList mockList = mock(KubernetesResourceList.class);
+        when(mockList.getItems()).thenReturn(itemsPerType);
+        when(mockOp.list()).thenReturn(mockList);
+        when(mockActor.resources(any())).thenReturn(mockOp);
+        when(localRbac.testActor(any())).thenReturn(mockActor);
+
+        ext.beforeAll(context);
+        return new ExtensionWithActor(ext, mockActor);
+    }
+
+    private record ExtensionWithActor(LocalKroxyliciousOperatorExtension extension,
+                                      LocallyRunningOperatorRbacHandler.TestActor actor) {}
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtensionLifecycleTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtensionLifecycleTest.java
@@ -9,6 +9,7 @@ package io.kroxylicious.testing.operator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -204,6 +205,35 @@ class LocalKroxyliciousOperatorExtensionLifecycleTest {
         order.verify(localOp).afterAll(context);
         order.verify(teardownAction).execute();
         order.verify(localRbac).afterEach(context);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void updateStatusRefetchesBeforeApplyingMutator() throws Exception {
+        // Given
+        var setup = extensionWithMockActor(defaultBuilder(), List.of());
+        var actor = setup.actor();
+
+        KafkaProxy stale = mock(KafkaProxy.class);
+        when(stale.getMetadata()).thenReturn(new io.fabric8.kubernetes.api.model.ObjectMetaBuilder().withName("my-proxy").build());
+
+        KafkaProxy fresh = mock(KafkaProxy.class);
+        when(actor.get(KafkaProxy.class, "my-proxy")).thenReturn(fresh);
+
+        KafkaProxy patched = mock(KafkaProxy.class);
+        when(actor.patchStatus(fresh)).thenReturn(patched);
+
+        UnaryOperator<KafkaProxy> mutator = mock(UnaryOperator.class);
+        when(mutator.apply(fresh)).thenReturn(fresh);
+
+        // When
+        KafkaProxy result = setup.extension().updateStatus(KafkaProxy.class, "my-proxy", mutator);
+
+        // Then — mutator receives the re-fetched object, not the stale one
+        verify(actor).get(KafkaProxy.class, "my-proxy");
+        verify(mutator).apply(fresh);
+        verify(actor).patchStatus(fresh);
+        assertThat(result).isSameAs(patched);
     }
 
     // ---- helpers ----

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtensionLifecycleTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocalKroxyliciousOperatorExtensionLifecycleTest.java
@@ -69,14 +69,27 @@ class LocalKroxyliciousOperatorExtensionLifecycleTest {
 
     @Test
     void afterAllStopsOperatorThenCleansUpRbac() throws Exception {
+        var userClient = mock(KubernetesClient.class);
+        when(rbacHandler.userClient()).thenReturn(userClient);
         extension.beforeAll(context);
 
         extension.afterAll(context);
 
-        InOrder order = inOrder(locallyRunOperatorExtension, rbacHandler);
+        InOrder order = inOrder(locallyRunOperatorExtension, rbacHandler, userClient);
         order.verify(locallyRunOperatorExtension).afterAll(context);
         order.verify(rbacHandler).afterEach(context);
-        order.verify(rbacHandler).afterAll(context);
+        order.verify(userClient).close();
+    }
+
+    @Test
+    void afterAllClosesClusterUserClient() throws Exception {
+        var userClient = mock(KubernetesClient.class);
+        when(rbacHandler.userClient()).thenReturn(userClient);
+        extension.beforeAll(context);
+
+        extension.afterAll(context);
+
+        verify(userClient).close();
     }
 
     @Test
@@ -120,7 +133,7 @@ class LocalKroxyliciousOperatorExtensionLifecycleTest {
         });
 
         LocallyRunningOperatorRbacHandler.TestActor mockActor = mock(LocallyRunningOperatorRbacHandler.TestActor.class);
-        when(localRbac.testActor(any())).thenReturn(mockActor);
+        when(localRbac.testActor(any(), any())).thenReturn(mockActor);
 
         List<Class<? extends HasMetadata>> standardTypes = List.of(
                 VirtualKafkaCluster.class, KafkaProxy.class, KafkaProxyIngress.class,
@@ -269,7 +282,7 @@ class LocalKroxyliciousOperatorExtensionLifecycleTest {
         when(mockList.getItems()).thenReturn(itemsPerType);
         when(mockOp.list()).thenReturn(mockList);
         when(mockActor.resources(any())).thenReturn(mockOp);
-        when(localRbac.testActor(any())).thenReturn(mockActor);
+        when(localRbac.testActor(any(), any())).thenReturn(mockActor);
 
         ext.beforeAll(context);
         return new ExtensionWithActor(ext, mockActor);

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandlerTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandlerTest.java
@@ -36,19 +36,19 @@ class LocallyRunningOperatorRbacHandlerTest {
 
     @Test
     void shouldThrowWhenGlobsIsEmpty() {
-        assertThatThrownBy(() -> new LocallyRunningOperatorRbacHandler(tempDir.toString()))
+        assertThatThrownBy(() -> new LocallyRunningOperatorRbacHandler(tempDir))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void shouldThrowWhenGlobContainsNull() {
-        assertThatThrownBy(() -> new LocallyRunningOperatorRbacHandler(tempDir.toString(), (String) null))
+        assertThatThrownBy(() -> new LocallyRunningOperatorRbacHandler(tempDir, (String) null))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void shouldThrowWhenGlobContainsEmptyString() {
-        assertThatThrownBy(() -> new LocallyRunningOperatorRbacHandler(tempDir.toString(), ""))
+        assertThatThrownBy(() -> new LocallyRunningOperatorRbacHandler(tempDir, ""))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -61,7 +61,7 @@ class LocallyRunningOperatorRbacHandlerTest {
     @Test
     void shouldThrowWhenPathIsNotDirectory() throws IOException {
         Path file = Files.createFile(tempDir.resolve("notadir.txt"));
-        assertThatThrownBy(() -> new LocallyRunningOperatorRbacHandler(file.toString(), "*.yaml"))
+        assertThatThrownBy(() -> new LocallyRunningOperatorRbacHandler(file, "*.yaml"))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -71,7 +71,7 @@ class LocallyRunningOperatorRbacHandlerTest {
     void shouldCreateRolesAndBindingsForMatchingFiles() throws Exception {
         Files.writeString(tempDir.resolve("test.ClusterRole.yaml"), clusterRoleYaml("test-role"));
 
-        var handler = new LocallyRunningOperatorRbacHandler(tempDir.toString(), this::freshClient, "*.ClusterRole.yaml");
+        var handler = new LocallyRunningOperatorRbacHandler(tempDir, this::freshClient, "*.ClusterRole.yaml");
         handler.beforeEach(mock(ExtensionContext.class));
 
         var roleNames = kubeClient.rbac().clusterRoles().list().getItems().stream()
@@ -88,7 +88,7 @@ class LocallyRunningOperatorRbacHandlerTest {
         Files.writeString(tempDir.resolve("test.ClusterRole.yaml"), clusterRoleYaml("matched-role"));
         Files.writeString(tempDir.resolve("other.yaml"), clusterRoleYaml("unmatched-role"));
 
-        var handler = new LocallyRunningOperatorRbacHandler(tempDir.toString(), this::freshClient, "*.ClusterRole.yaml");
+        var handler = new LocallyRunningOperatorRbacHandler(tempDir, this::freshClient, "*.ClusterRole.yaml");
         handler.beforeEach(mock(ExtensionContext.class));
 
         var roleNames = kubeClient.rbac().clusterRoles().list().getItems().stream()
@@ -100,15 +100,15 @@ class LocallyRunningOperatorRbacHandlerTest {
     void shouldIgnoreNonClusterRoleResourcesInMatchedFiles() throws Exception {
         // A file matching the glob that contains both a ClusterRole and a ClusterRoleBinding
         Files.writeString(tempDir.resolve("test.ClusterRole.yaml"),
-                clusterRoleYaml("my-role") + "\n---\n" + clusterRoleBindingYaml("my-binding", "my-role"));
+                clusterRoleYaml("my-role") + "\n---\n" + clusterRoleBindingYaml());
 
-        var handler = new LocallyRunningOperatorRbacHandler(tempDir.toString(), this::freshClient, "*.ClusterRole.yaml");
+        var handler = new LocallyRunningOperatorRbacHandler(tempDir, this::freshClient, "*.ClusterRole.yaml");
         handler.beforeEach(mock(ExtensionContext.class));
 
         // The ClusterRoleBinding from the file should NOT have been created (only handler-generated bindings)
         var bindingNames = kubeClient.rbac().clusterRoleBindings().list().getItems().stream()
                 .map(b -> b.getMetadata().getName()).toList();
-        assertThat(bindingNames).doesNotContain("my-binding");
+        assertThat(bindingNames).isNotEmpty().doesNotContain("my-binding");
     }
 
     // ---- afterEach cleanup ----
@@ -117,7 +117,7 @@ class LocallyRunningOperatorRbacHandlerTest {
     void afterEachShouldDeleteCreatedRolesAndBindings() throws Exception {
         Files.writeString(tempDir.resolve("test.ClusterRole.yaml"), clusterRoleYaml("cleanup-role"));
 
-        var handler = new LocallyRunningOperatorRbacHandler(tempDir.toString(), this::freshClient, "*.ClusterRole.yaml");
+        var handler = new LocallyRunningOperatorRbacHandler(tempDir, this::freshClient, "*.ClusterRole.yaml");
         var context = mock(ExtensionContext.class);
         handler.beforeEach(context);
 
@@ -148,17 +148,17 @@ class LocallyRunningOperatorRbacHandlerTest {
                 """.formatted(name);
     }
 
-    private static String clusterRoleBindingYaml(String bindingName, String roleName) {
+    private static String clusterRoleBindingYaml() {
         return """
                 apiVersion: rbac.authorization.k8s.io/v1
                 kind: ClusterRoleBinding
                 metadata:
-                  name: %s
+                  name: my-binding
                 roleRef:
                   apiGroup: rbac.authorization.k8s.io
                   kind: ClusterRole
-                  name: %s
+                  name: my-role
                 subjects: []
-                """.formatted(bindingName, roleName);
+                """;
     }
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandlerTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandlerTest.java
@@ -244,6 +244,20 @@ class LocallyRunningOperatorRbacHandlerTest {
         Assertions.assertDoesNotThrow(() -> handler.afterAll(mock(ExtensionContext.class)));
     }
 
+    // ---- operatorClient userAgent ----
+
+    @Test
+    void operatorClientShouldHaveKroxyliciousUserAgent() throws Exception {
+        Files.writeString(tempDir.resolve("role.ClusterRole.yaml"), clusterRoleYaml("test-role"));
+        var handler = new LocallyRunningOperatorRbacHandler(tempDir, this::freshClient, "*.ClusterRole.yaml");
+        handler.beforeEach(mock(ExtensionContext.class));
+
+        try (var operatorClient = handler.operatorClient()) {
+            assertThat(operatorClient.getConfiguration().getUserAgent())
+                    .contains("kroxylicious-operator");
+        }
+    }
+
     // ---- helpers ----
 
     /** Returns a fresh client pointing at the same mock server each call, so try-with-resources in the handler doesn't close the shared {@link #kubeClient}. */

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandlerTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandlerTest.java
@@ -23,6 +23,7 @@ import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.javaoperatorsdk.operator.junit.AbstractOperatorExtension;
 
+import static io.kroxylicious.testing.operator.KubernetesResourceUtil.name;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
@@ -82,11 +83,11 @@ class LocallyRunningOperatorRbacHandlerTest {
         handler.beforeEach(mock(ExtensionContext.class));
 
         var roleNames = kubeClient.rbac().clusterRoles().list().getItems().stream()
-                .map(r -> r.getMetadata().getName()).toList();
+                .map(r -> name(r)).toList();
         assertThat(roleNames).contains("test-role");
 
         var bindingNames = kubeClient.rbac().clusterRoleBindings().list().getItems().stream()
-                .map(b -> b.getMetadata().getName()).toList();
+                .map(b -> name(b)).toList();
         assertThat(bindingNames).anyMatch(name -> name.contains("test-role"));
     }
 
@@ -99,7 +100,7 @@ class LocallyRunningOperatorRbacHandlerTest {
         handler.beforeEach(mock(ExtensionContext.class));
 
         var roleNames = kubeClient.rbac().clusterRoles().list().getItems().stream()
-                .map(r -> r.getMetadata().getName()).toList();
+                .map(r -> name(r)).toList();
         assertThat(roleNames).contains("matched-role").doesNotContain("unmatched-role");
     }
 
@@ -114,7 +115,7 @@ class LocallyRunningOperatorRbacHandlerTest {
 
         // The ClusterRoleBinding from the file should NOT have been created (only handler-generated bindings)
         var bindingNames = kubeClient.rbac().clusterRoleBindings().list().getItems().stream()
-                .map(b -> b.getMetadata().getName()).toList();
+                .map(b -> name(b)).toList();
         assertThat(bindingNames).isNotEmpty().doesNotContain("my-binding");
     }
 
@@ -129,12 +130,12 @@ class LocallyRunningOperatorRbacHandlerTest {
         handler.beforeEach(context);
 
         assertThat(kubeClient.rbac().clusterRoles().list().getItems().stream()
-                .map(r -> r.getMetadata().getName()).toList()).contains("cleanup-role");
+                .map(r -> name(r)).toList()).contains("cleanup-role");
 
         handler.afterEach(context);
 
         assertThat(kubeClient.rbac().clusterRoles().list().getItems().stream()
-                .map(r -> r.getMetadata().getName()).toList()).doesNotContain("cleanup-role");
+                .map(r -> name(r)).toList()).doesNotContain("cleanup-role");
         assertThat(kubeClient.rbac().clusterRoleBindings().list().getItems()).isEmpty();
     }
 
@@ -211,7 +212,7 @@ class LocallyRunningOperatorRbacHandlerTest {
         var items = actor.resources(ConfigMap.class).list().getItems();
 
         // Then
-        assertThat(items).extracting(cm -> cm.getMetadata().getName()).contains("my-map");
+        assertThat(items).extracting(cm -> name(cm)).contains("my-map");
     }
 
     // ---- afterAll ----

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandlerTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandlerTest.java
@@ -9,9 +9,7 @@ package io.kroxylicious.testing.operator;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.io.TempDir;
@@ -27,7 +25,6 @@ import static io.kroxylicious.testing.operator.KubernetesResourceUtil.name;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @EnableKubernetesMockClient(crud = true)
@@ -146,7 +143,7 @@ class LocallyRunningOperatorRbacHandlerTest {
     @Test
     void testActorCreateAddsResourceToNamespace() throws Exception {
         // Given
-        var actor = handlerForTestActor().testActor(operatorExtensionInNamespace(TEST_NS));
+        var actor = handlerForTestActor().testActor(kubeClient, operatorExtensionInNamespace(TEST_NS));
         var configMap = new ConfigMapBuilder().withNewMetadata().withName("my-map").endMetadata().build();
 
         // When
@@ -161,7 +158,7 @@ class LocallyRunningOperatorRbacHandlerTest {
         // Given
         kubeClient.configMaps().inNamespace(TEST_NS)
                 .resource(new ConfigMapBuilder().withNewMetadata().withName("my-map").endMetadata().build()).create();
-        var actor = handlerForTestActor().testActor(operatorExtensionInNamespace(TEST_NS));
+        var actor = handlerForTestActor().testActor(kubeClient, operatorExtensionInNamespace(TEST_NS));
 
         // When
         var result = actor.get(ConfigMap.class, "my-map");
@@ -176,7 +173,7 @@ class LocallyRunningOperatorRbacHandlerTest {
         // Given
         var created = kubeClient.configMaps().inNamespace(TEST_NS)
                 .resource(new ConfigMapBuilder().withNewMetadata().withName("my-map").endMetadata().build()).create();
-        var actor = handlerForTestActor().testActor(operatorExtensionInNamespace(TEST_NS));
+        var actor = handlerForTestActor().testActor(kubeClient, operatorExtensionInNamespace(TEST_NS));
 
         // When
         actor.replace(new ConfigMapBuilder(created).addToData("key", "value").build());
@@ -191,7 +188,7 @@ class LocallyRunningOperatorRbacHandlerTest {
         // Given
         var created = kubeClient.configMaps().inNamespace(TEST_NS)
                 .resource(new ConfigMapBuilder().withNewMetadata().withName("my-map").endMetadata().build()).create();
-        var actor = handlerForTestActor().testActor(operatorExtensionInNamespace(TEST_NS));
+        var actor = handlerForTestActor().testActor(kubeClient, operatorExtensionInNamespace(TEST_NS));
 
         // When
         boolean deleted = actor.delete(created);
@@ -206,43 +203,13 @@ class LocallyRunningOperatorRbacHandlerTest {
         // Given
         kubeClient.configMaps().inNamespace(TEST_NS)
                 .resource(new ConfigMapBuilder().withNewMetadata().withName("my-map").endMetadata().build()).create();
-        var actor = handlerForTestActor().testActor(operatorExtensionInNamespace(TEST_NS));
+        var actor = handlerForTestActor().testActor(kubeClient, operatorExtensionInNamespace(TEST_NS));
 
         // When
         var items = actor.resources(ConfigMap.class).list().getItems();
 
         // Then
         assertThat(items).extracting(cm -> name(cm)).contains("my-map");
-    }
-
-    // ---- afterAll ----
-
-    @Test
-    void afterAllClosesTestActorClient() throws Exception {
-        // Given: loadClusterRoles (in constructor) gets a real client; testActor() gets the mock
-        var mockClient = mock(KubernetesClient.class);
-        Files.writeString(tempDir.resolve("role.ClusterRole.yaml"), clusterRoleYaml("test-role"));
-        var callCount = new AtomicInteger();
-        var handler = new LocallyRunningOperatorRbacHandler(tempDir,
-                () -> callCount.getAndIncrement() == 0 ? freshClient() : mockClient,
-                "*.ClusterRole.yaml");
-        handler.testActor(operatorExtensionInNamespace(TEST_NS));
-
-        // When
-        handler.afterAll(mock(ExtensionContext.class));
-
-        // Then
-        verify(mockClient).close();
-    }
-
-    @Test
-    void afterAllIsNoOpIfTestActorWasNeverCalled() throws Exception {
-        // Given
-        Files.writeString(tempDir.resolve("role.ClusterRole.yaml"), clusterRoleYaml("test-role"));
-        var handler = new LocallyRunningOperatorRbacHandler(tempDir, this::freshClient, "*.ClusterRole.yaml");
-
-        // When / Then: must not throw
-        Assertions.assertDoesNotThrow(() -> handler.afterAll(mock(ExtensionContext.class)));
     }
 
     // ---- operatorClient userAgent ----

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandlerTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandlerTest.java
@@ -9,18 +9,25 @@ package io.kroxylicious.testing.operator;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.io.TempDir;
 
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.javaoperatorsdk.operator.junit.AbstractOperatorExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @EnableKubernetesMockClient(crud = true)
 class LocallyRunningOperatorRbacHandlerTest {
@@ -131,11 +138,128 @@ class LocallyRunningOperatorRbacHandlerTest {
         assertThat(kubeClient.rbac().clusterRoleBindings().list().getItems()).isEmpty();
     }
 
+    // ---- testActor ----
+
+    private static final String TEST_NS = "test-namespace";
+
+    @Test
+    void testActorCreateAddsResourceToNamespace() throws Exception {
+        // Given
+        var actor = handlerForTestActor().testActor(operatorExtensionInNamespace(TEST_NS));
+        var configMap = new ConfigMapBuilder().withNewMetadata().withName("my-map").endMetadata().build();
+
+        // When
+        actor.create(configMap);
+
+        // Then
+        assertThat(kubeClient.configMaps().inNamespace(TEST_NS).withName("my-map").get()).isNotNull();
+    }
+
+    @Test
+    void testActorGetReturnsResourceFromNamespace() throws Exception {
+        // Given
+        kubeClient.configMaps().inNamespace(TEST_NS)
+                .resource(new ConfigMapBuilder().withNewMetadata().withName("my-map").endMetadata().build()).create();
+        var actor = handlerForTestActor().testActor(operatorExtensionInNamespace(TEST_NS));
+
+        // When
+        var result = actor.get(ConfigMap.class, "my-map");
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.getMetadata().getName()).isEqualTo("my-map");
+    }
+
+    @Test
+    void testActorReplaceUpdatesResourceInNamespace() throws Exception {
+        // Given
+        var created = kubeClient.configMaps().inNamespace(TEST_NS)
+                .resource(new ConfigMapBuilder().withNewMetadata().withName("my-map").endMetadata().build()).create();
+        var actor = handlerForTestActor().testActor(operatorExtensionInNamespace(TEST_NS));
+
+        // When
+        actor.replace(new ConfigMapBuilder(created).addToData("key", "value").build());
+
+        // Then
+        assertThat(kubeClient.configMaps().inNamespace(TEST_NS).withName("my-map").get().getData())
+                .containsEntry("key", "value");
+    }
+
+    @Test
+    void testActorDeleteRemovesResourceFromNamespace() throws Exception {
+        // Given
+        var created = kubeClient.configMaps().inNamespace(TEST_NS)
+                .resource(new ConfigMapBuilder().withNewMetadata().withName("my-map").endMetadata().build()).create();
+        var actor = handlerForTestActor().testActor(operatorExtensionInNamespace(TEST_NS));
+
+        // When
+        boolean deleted = actor.delete(created);
+
+        // Then
+        assertThat(deleted).isTrue();
+        assertThat(kubeClient.configMaps().inNamespace(TEST_NS).withName("my-map").get()).isNull();
+    }
+
+    @Test
+    void testActorResourcesListsResourcesInNamespace() throws Exception {
+        // Given
+        kubeClient.configMaps().inNamespace(TEST_NS)
+                .resource(new ConfigMapBuilder().withNewMetadata().withName("my-map").endMetadata().build()).create();
+        var actor = handlerForTestActor().testActor(operatorExtensionInNamespace(TEST_NS));
+
+        // When
+        var items = actor.resources(ConfigMap.class).list().getItems();
+
+        // Then
+        assertThat(items).extracting(cm -> cm.getMetadata().getName()).contains("my-map");
+    }
+
+    // ---- afterAll ----
+
+    @Test
+    void afterAllClosesTestActorClient() throws Exception {
+        // Given: loadClusterRoles (in constructor) gets a real client; testActor() gets the mock
+        var mockClient = mock(KubernetesClient.class);
+        Files.writeString(tempDir.resolve("role.ClusterRole.yaml"), clusterRoleYaml("test-role"));
+        var callCount = new AtomicInteger();
+        var handler = new LocallyRunningOperatorRbacHandler(tempDir,
+                () -> callCount.getAndIncrement() == 0 ? freshClient() : mockClient,
+                "*.ClusterRole.yaml");
+        handler.testActor(operatorExtensionInNamespace(TEST_NS));
+
+        // When
+        handler.afterAll(mock(ExtensionContext.class));
+
+        // Then
+        verify(mockClient).close();
+    }
+
+    @Test
+    void afterAllIsNoOpIfTestActorWasNeverCalled() throws Exception {
+        // Given
+        Files.writeString(tempDir.resolve("role.ClusterRole.yaml"), clusterRoleYaml("test-role"));
+        var handler = new LocallyRunningOperatorRbacHandler(tempDir, this::freshClient, "*.ClusterRole.yaml");
+
+        // When / Then: must not throw
+        Assertions.assertDoesNotThrow(() -> handler.afterAll(mock(ExtensionContext.class)));
+    }
+
     // ---- helpers ----
 
     /** Returns a fresh client pointing at the same mock server each call, so try-with-resources in the handler doesn't close the shared {@link #kubeClient}. */
     private KubernetesClient freshClient() {
         return new KubernetesClientBuilder().withConfig(kubeClient.getConfiguration()).build();
+    }
+
+    private LocallyRunningOperatorRbacHandler handlerForTestActor() throws IOException {
+        Files.writeString(tempDir.resolve("role.ClusterRole.yaml"), clusterRoleYaml("test-role"));
+        return new LocallyRunningOperatorRbacHandler(tempDir, this::freshClient, "*.ClusterRole.yaml");
+    }
+
+    private static AbstractOperatorExtension operatorExtensionInNamespace(String namespace) {
+        var ext = mock(AbstractOperatorExtension.class);
+        when(ext.getNamespace()).thenReturn(namespace);
+        return ext;
     }
 
     private static String clusterRoleYaml(String name) {

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandlerTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/LocallyRunningOperatorRbacHandlerTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.testing.operator;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+@EnableKubernetesMockClient(crud = true)
+class LocallyRunningOperatorRbacHandlerTest {
+
+    // Injected by @EnableKubernetesMockClient — also intercepted by all internal
+    // OperatorTestUtils.kubeClient() calls made by the handler under test.
+    KubernetesClient kubeClient;
+
+    @TempDir
+    Path tempDir;
+
+    // ---- constructor validation ----
+
+    @Test
+    void shouldThrowWhenGlobsIsEmpty() {
+        assertThatThrownBy(() -> new LocallyRunningOperatorRbacHandler(tempDir.toString()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldThrowWhenGlobContainsNull() {
+        assertThatThrownBy(() -> new LocallyRunningOperatorRbacHandler(tempDir.toString(), (String) null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldThrowWhenGlobContainsEmptyString() {
+        assertThatThrownBy(() -> new LocallyRunningOperatorRbacHandler(tempDir.toString(), ""))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldThrowWhenDirectoryDoesNotExist() {
+        assertThatThrownBy(() -> new LocallyRunningOperatorRbacHandler("/nonexistent/path/xyz", "*.yaml"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldThrowWhenPathIsNotDirectory() throws IOException {
+        Path file = Files.createFile(tempDir.resolve("notadir.txt"));
+        assertThatThrownBy(() -> new LocallyRunningOperatorRbacHandler(file.toString(), "*.yaml"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // ---- YAML loading and glob matching ----
+
+    @Test
+    void shouldCreateRolesAndBindingsForMatchingFiles() throws Exception {
+        Files.writeString(tempDir.resolve("test.ClusterRole.yaml"), clusterRoleYaml("test-role"));
+
+        var handler = new LocallyRunningOperatorRbacHandler(tempDir.toString(), this::freshClient, "*.ClusterRole.yaml");
+        handler.beforeEach(mock(ExtensionContext.class));
+
+        var roleNames = kubeClient.rbac().clusterRoles().list().getItems().stream()
+                .map(r -> r.getMetadata().getName()).toList();
+        assertThat(roleNames).contains("test-role");
+
+        var bindingNames = kubeClient.rbac().clusterRoleBindings().list().getItems().stream()
+                .map(b -> b.getMetadata().getName()).toList();
+        assertThat(bindingNames).anyMatch(name -> name.contains("test-role"));
+    }
+
+    @Test
+    void shouldNotLoadFilesNotMatchingGlob() throws Exception {
+        Files.writeString(tempDir.resolve("test.ClusterRole.yaml"), clusterRoleYaml("matched-role"));
+        Files.writeString(tempDir.resolve("other.yaml"), clusterRoleYaml("unmatched-role"));
+
+        var handler = new LocallyRunningOperatorRbacHandler(tempDir.toString(), this::freshClient, "*.ClusterRole.yaml");
+        handler.beforeEach(mock(ExtensionContext.class));
+
+        var roleNames = kubeClient.rbac().clusterRoles().list().getItems().stream()
+                .map(r -> r.getMetadata().getName()).toList();
+        assertThat(roleNames).contains("matched-role").doesNotContain("unmatched-role");
+    }
+
+    @Test
+    void shouldIgnoreNonClusterRoleResourcesInMatchedFiles() throws Exception {
+        // A file matching the glob that contains both a ClusterRole and a ClusterRoleBinding
+        Files.writeString(tempDir.resolve("test.ClusterRole.yaml"),
+                clusterRoleYaml("my-role") + "\n---\n" + clusterRoleBindingYaml("my-binding", "my-role"));
+
+        var handler = new LocallyRunningOperatorRbacHandler(tempDir.toString(), this::freshClient, "*.ClusterRole.yaml");
+        handler.beforeEach(mock(ExtensionContext.class));
+
+        // The ClusterRoleBinding from the file should NOT have been created (only handler-generated bindings)
+        var bindingNames = kubeClient.rbac().clusterRoleBindings().list().getItems().stream()
+                .map(b -> b.getMetadata().getName()).toList();
+        assertThat(bindingNames).doesNotContain("my-binding");
+    }
+
+    // ---- afterEach cleanup ----
+
+    @Test
+    void afterEachShouldDeleteCreatedRolesAndBindings() throws Exception {
+        Files.writeString(tempDir.resolve("test.ClusterRole.yaml"), clusterRoleYaml("cleanup-role"));
+
+        var handler = new LocallyRunningOperatorRbacHandler(tempDir.toString(), this::freshClient, "*.ClusterRole.yaml");
+        var context = mock(ExtensionContext.class);
+        handler.beforeEach(context);
+
+        assertThat(kubeClient.rbac().clusterRoles().list().getItems().stream()
+                .map(r -> r.getMetadata().getName()).toList()).contains("cleanup-role");
+
+        handler.afterEach(context);
+
+        assertThat(kubeClient.rbac().clusterRoles().list().getItems().stream()
+                .map(r -> r.getMetadata().getName()).toList()).doesNotContain("cleanup-role");
+        assertThat(kubeClient.rbac().clusterRoleBindings().list().getItems()).isEmpty();
+    }
+
+    // ---- helpers ----
+
+    /** Returns a fresh client pointing at the same mock server each call, so try-with-resources in the handler doesn't close the shared {@link #kubeClient}. */
+    private KubernetesClient freshClient() {
+        return new KubernetesClientBuilder().withConfig(kubeClient.getConfiguration()).build();
+    }
+
+    private static String clusterRoleYaml(String name) {
+        return """
+                apiVersion: rbac.authorization.k8s.io/v1
+                kind: ClusterRole
+                metadata:
+                  name: %s
+                rules: []
+                """.formatted(name);
+    }
+
+    private static String clusterRoleBindingYaml(String bindingName, String roleName) {
+        return """
+                apiVersion: rbac.authorization.k8s.io/v1
+                kind: ClusterRoleBinding
+                metadata:
+                  name: %s
+                roleRef:
+                  apiGroup: rbac.authorization.k8s.io
+                  kind: ClusterRole
+                  name: %s
+                subjects: []
+                """.formatted(bindingName, roleName);
+    }
+}

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/OperatorTestUtilsTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/OperatorTestUtilsTest.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.testing.operator;
+
+class OperatorTestUtilsTest {
+
+}

--- a/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/OperatorTestUtilsTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator-test-support/src/test/java/io/kroxylicious/testing/operator/OperatorTestUtilsTest.java
@@ -6,6 +6,57 @@
 
 package io.kroxylicious.testing.operator;
 
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@EnableKubernetesMockClient(crud = true)
 class OperatorTestUtilsTest {
 
+    // Injected by @EnableKubernetesMockClient
+    KubernetesClient kubeClient;
+
+    @Test
+    void kubeClientShouldReturnNonNullClient() {
+        try (var client = OperatorTestUtils.kubeClient(new KubernetesClientBuilder().withConfig(kubeClient.getConfiguration()))) {
+            assertThat(client).isNotNull();
+        }
+    }
+
+    @Test
+    void isKubeClientAvailableShouldReturnTrueWhenServerResponds() {
+        var builder = new KubernetesClientBuilder().withConfig(kubeClient.getConfiguration());
+        assertThat(OperatorTestUtils.isKubeClientAvailable(builder)).isTrue();
+    }
+
+    @Test
+    void isKubeClientAvailableShouldReturnFalseWhenServerIsUnreachable() {
+        var builder = new KubernetesClientBuilder()
+                .editOrNewConfig()
+                .withMasterUrl("https://localhost:1") // nothing listening here
+                .withRequestRetryBackoffLimit(0)
+                .withConnectionTimeout(500)
+                .endConfig();
+        assertThat(OperatorTestUtils.isKubeClientAvailable(builder)).isFalse();
+    }
+
+    @Test
+    void isKubeClientAvailableShouldReturnFalseWhenBuildThrows() {
+        var builder = mock(KubernetesClientBuilder.class);
+        when(builder.build()).thenThrow(new RuntimeException("build failed"));
+        assertThat(OperatorTestUtils.isKubeClientAvailable(builder)).isFalse();
+    }
+
+    @Test
+    void isKubeClientAvailableShouldReturnFalseWhenBuildReturnsNull() {
+        var builder = mock(KubernetesClientBuilder.class);
+        when(builder.build()).thenReturn(null);
+        assertThat(OperatorTestUtils.isKubeClientAvailable(builder)).isFalse();
+    }
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
@@ -187,7 +187,7 @@ class AllReconcilersIT {
         // so we wait explicitly for the ingresses to be populated rather than checking the
         // snapshot returned when the accepted condition first became true.
         AWAIT.alias("cluster %s has ingresses with bootstrap servers".formatted(CLUSTER_FOO))
-                .untilAsserted(() -> assertThat(testActor.get(VirtualKafkaCluster.class, CLUSTER_FOO))
+                .untilAsserted(() -> assertThat(operator.get(VirtualKafkaCluster.class, CLUSTER_FOO))
                         .isNotNull()
                         .extracting(VirtualKafkaCluster::getStatus)
                         .satisfies(vcs -> assertThat(vcs)

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -112,6 +113,13 @@ class AllReconcilersIT {
             })
             .build();
 
+    private ClusterUser clusterUser;
+
+    @BeforeEach
+    void setUp() {
+        clusterUser = operator.clusterUser();
+    }
+
     @Test
     void emptyProxyIsAllowed() {
         // Given
@@ -127,13 +135,13 @@ class AllReconcilersIT {
 
     static Stream<Arguments> filterScenarios() {
         return Stream.of(
-                argumentSet("no filters", (Function<LocalKroxyliciousOperatorExtension, KafkaProtocolFilter>) (builder -> null)),
-                argumentSet("filter with simple config", (Function<LocalKroxyliciousOperatorExtension, KafkaProtocolFilter>) (actor -> {
+                argumentSet("no filters", (Function<ClusterUser, KafkaProtocolFilter>) (builder -> null)),
+                argumentSet("filter with simple config", (Function<ClusterUser, KafkaProtocolFilter>) (actor -> {
                     var filter = editableFilter(CLUSTER_FOO_FILTER).build();
                     actor.create(filter);
                     return filter;
                 })),
-                argumentSet("filter with config that refs a configmap", (Function<LocalKroxyliciousOperatorExtension, KafkaProtocolFilter>) (actor -> {
+                argumentSet("filter with config that refs a configmap", (Function<ClusterUser, KafkaProtocolFilter>) (actor -> {
                 // @formatter:off
                     var filterConfigMap = new ConfigMapBuilder()
                             .withNewMetadata()
@@ -155,7 +163,7 @@ class AllReconcilersIT {
 
     @ParameterizedTest
     @MethodSource("filterScenarios")
-    void singleVirtualCluster(Function<LocalKroxyliciousOperatorExtension, KafkaProtocolFilter> filterFunc) {
+    void singleVirtualCluster(Function<ClusterUser, KafkaProtocolFilter> filterFunc) {
         // Given
         var myProxy = editableProxy(PROXY_A).build();
         // @formatter:off
@@ -169,7 +177,7 @@ class AllReconcilersIT {
         // @formatter:on
         var myService = editableService(CLUSTER_FOO_SERVICE).build();
 
-        var myFilter = filterFunc.apply(operator);
+        var myFilter = filterFunc.apply(clusterUser);
 
         var myCluster = editableVirtualCluster(CLUSTER_FOO, myProxy, myService, List.of(myIngress), Optional.ofNullable(myFilter).stream().toList()).build();
 
@@ -187,7 +195,7 @@ class AllReconcilersIT {
         // so we wait explicitly for the ingresses to be populated rather than checking the
         // snapshot returned when the accepted condition first became true.
         AWAIT.alias("cluster %s has ingresses with bootstrap servers".formatted(CLUSTER_FOO))
-                .untilAsserted(() -> assertThat(operator.get(VirtualKafkaCluster.class, CLUSTER_FOO))
+                .untilAsserted(() -> assertThat(clusterUser.get(VirtualKafkaCluster.class, CLUSTER_FOO))
                         .isNotNull()
                         .extracting(VirtualKafkaCluster::getStatus)
                         .satisfies(vcs -> assertThat(vcs)
@@ -200,8 +208,8 @@ class AllReconcilersIT {
 
     static Stream<Arguments> upstreamTlsScenarios() {
         return Stream.of(
-                argumentSet("tls", (Function<LocalKroxyliciousOperatorExtension, Tls>) (builder -> new Tls())),
-                argumentSet("tls with trust from secret", (Function<LocalKroxyliciousOperatorExtension, Tls>) (actor -> {
+                argumentSet("tls", (Function<ClusterUser, Tls>) (builder -> new Tls())),
+                argumentSet("tls with trust from secret", (Function<ClusterUser, Tls>) (actor -> {
                 // @formatter:off
                     var trust = new SecretBuilder()
                             .withNewMetadata()
@@ -222,7 +230,7 @@ class AllReconcilersIT {
                     actor.create(trust);
                     return ref;
                 })),
-                argumentSet("tls with trust from secret with store type", (Function<LocalKroxyliciousOperatorExtension, Tls>) (actor -> {
+                argumentSet("tls with trust from secret with store type", (Function<ClusterUser, Tls>) (actor -> {
                 // @formatter:off
                     var trust = new SecretBuilder()
                             .withNewMetadata()
@@ -248,9 +256,9 @@ class AllReconcilersIT {
 
     @ParameterizedTest
     @MethodSource("upstreamTlsScenarios")
-    void upstreamTls(Function<LocalKroxyliciousOperatorExtension, io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.Tls> tlsFunc) {
+    void upstreamTls(Function<ClusterUser, io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.Tls> tlsFunc) {
         // Given
-        var tlsScenario = tlsFunc.apply(operator);
+        var tlsScenario = tlsFunc.apply(clusterUser);
 
         var myProxy = editableProxy(PROXY_A).build();
         // @formatter:off
@@ -298,12 +306,12 @@ class AllReconcilersIT {
 
         return Stream.of(
                 argumentSet("tls with platform trust",
-                        (Function<LocalKroxyliciousOperatorExtension, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
+                        (Function<ClusterUser, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
                             actor.create(downstreamCert);
                             return new io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.TlsBuilder(downstreamTls).build();
                         })),
                 argumentSet("tls with trust from configmap",
-                        (Function<LocalKroxyliciousOperatorExtension, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
+                        (Function<ClusterUser, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
 
                         // @formatter:off
                     var downstreamTrust = new ConfigMapBuilder()
@@ -326,7 +334,7 @@ class AllReconcilersIT {
                             return tls;
                         })),
                 argumentSet("tls with trust from secret",
-                        (Function<LocalKroxyliciousOperatorExtension, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
+                        (Function<ClusterUser, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
 
                         // @formatter:off
                     var downstreamTrust = new SecretBuilder()
@@ -350,7 +358,7 @@ class AllReconcilersIT {
                             return tls;
                         })),
                 argumentSet("tls with trust from configmap with new key of supported store type",
-                        (Function<LocalKroxyliciousOperatorExtension, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
+                        (Function<ClusterUser, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
 
                         // @formatter:off
                     var downstreamTrust = new ConfigMapBuilder()
@@ -377,9 +385,9 @@ class AllReconcilersIT {
 
     @ParameterizedTest
     @MethodSource("downstreamTlsScenarios")
-    void downstreamTls(Function<LocalKroxyliciousOperatorExtension, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls> tlsFunc) {
+    void downstreamTls(Function<ClusterUser, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls> tlsFunc) {
         // Given
-        var tlsScenario = tlsFunc.apply(operator);
+        var tlsScenario = tlsFunc.apply(clusterUser);
 
         var myProxy = editableProxy(PROXY_A).build();
         // @formatter:off
@@ -411,7 +419,7 @@ class AllReconcilersIT {
     }
 
     private void createAll(HasMetadata... resources) {
-        Arrays.stream(resources).sequential().forEach(operator::create);
+        Arrays.stream(resources).sequential().forEach(clusterUser::create);
     }
 
     private static KafkaProxyBuilder editableProxy(String name) {
@@ -434,7 +442,7 @@ class AllReconcilersIT {
         var name = name(resource);
         var clazz = resource.getClass();
         AWAIT.alias("resource %s (%s) meets predicate".formatted(name, clazz.getSimpleName()))
-                .untilAsserted(() -> operator.get(clazz, name),
+                .untilAsserted(() -> clusterUser.get(clazz, name),
                         actual -> {
                             assertThat(actual)
                                     .isNotNull()

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
@@ -56,14 +56,15 @@ import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.NodeIdRangesBuil
 import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.Tls;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressesBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterstatus.Ingresses;
+import io.kroxylicious.kubernetes.operator.informer.SharedInformerManager;
 import io.kroxylicious.kubernetes.operator.reconciler.kafkaprotocolfilter.KafkaProtocolFilterReconciler;
 import io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy.KafkaProxyReconciler;
 import io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy.KafkaProxyReconcilerIT;
 import io.kroxylicious.kubernetes.operator.reconciler.kafkaproxyingress.KafkaProxyIngressReconciler;
 import io.kroxylicious.kubernetes.operator.reconciler.kafkaservice.KafkaServiceReconciler;
 import io.kroxylicious.kubernetes.operator.reconciler.virtualkafkacluster.VirtualKafkaClusterReconciler;
-import io.kroxylicious.kubernetes.operator.informer.SharedInformerManager;
 import io.kroxylicious.kubernetes.operator.resolver.DependencyResolver;
+import io.kroxylicious.testing.operator.ClusterUser;
 import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
 import io.kroxylicious.testing.operator.OperatorTestUtils;
 

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
@@ -20,25 +20,20 @@ import java.util.stream.Stream;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.core.ConditionFactory;
-import org.awaitility.core.ConditionTimeoutException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.client.CustomResource;
-import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.Updatable;
 import io.strimzi.api.kafka.Crds;
-import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 
 import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.common.FilterRefBuilder;
@@ -60,15 +55,16 @@ import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.NodeIdRangesBuil
 import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.Tls;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressesBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterstatus.Ingresses;
-import io.kroxylicious.kubernetes.operator.LocallyRunningOperatorRbacHandler.TestActor;
-import io.kroxylicious.kubernetes.operator.informer.SharedInformerManager;
 import io.kroxylicious.kubernetes.operator.reconciler.kafkaprotocolfilter.KafkaProtocolFilterReconciler;
 import io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy.KafkaProxyReconciler;
 import io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy.KafkaProxyReconcilerIT;
 import io.kroxylicious.kubernetes.operator.reconciler.kafkaproxyingress.KafkaProxyIngressReconciler;
 import io.kroxylicious.kubernetes.operator.reconciler.kafkaservice.KafkaServiceReconciler;
 import io.kroxylicious.kubernetes.operator.reconciler.virtualkafkacluster.VirtualKafkaClusterReconciler;
+import io.kroxylicious.kubernetes.operator.informer.SharedInformerManager;
 import io.kroxylicious.kubernetes.operator.resolver.DependencyResolver;
+import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
+import io.kroxylicious.testing.operator.OperatorTestUtils;
 
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
 import static org.assertj.core.api.Assertions.as;
@@ -82,51 +78,39 @@ import static org.junit.jupiter.params.provider.Arguments.argumentSet;
  * For deeper concerns, see the individual ReconcilerITs ({@link KafkaProxyReconcilerIT} etc.)
  *
  */
-@EnabledIf(value = "io.kroxylicious.kubernetes.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
+@EnabledIf(value = "io.kroxylicious.testing.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
 class AllReconcilersIT {
-    private static final Logger LOGGER = LoggerFactory.getLogger(AllReconcilersIT.class);
     private static final String PROXY_A = "proxy-a";
     private static final String CLUSTER_FOO = "foo";
     private static final String CLUSTER_FOO_CLUSTER_IP_INGRESS = "foo-cluster-ip";
     private static final String CLUSTER_FOO_SERVICE = "foo-service";
     private static final String CLUSTER_FOO_FILTER = "foo-filter";
-    private static final String STRIMZI_TLS_LISTENER = "tls";
     private static final ConditionFactory AWAIT = await().timeout(Duration.ofSeconds(60));
 
     // the initial operator image pull can take a long time and interfere with the tests
-    @BeforeAll
-    static void preloadOperandImage() {
-        OperatorTestUtils.preloadOperandImage();
-    }
+    // KafkaServiceReconciler conditionally creates a Strimzi Kafka informer when it detects the
+    // Strimzi API group. The CRD must be installed before the operator starts — setup/teardown
+    // actions run at the right point in the extension lifecycle to guarantee this ordering.
+    private static final SharedInformerManager sharedInformerManager = new SharedInformerManager(OperatorTestUtils.kubeClient(), Set.of());
 
     @RegisterExtension
-    static LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler(TestFiles.INSTALL_MANIFESTS_DIR, "*.ClusterRole.*.yaml");
-
-    // Non-static so each test gets a fresh SharedInformerManager instance with its own informer caches
-    // This prevents handler accumulation across test methods
-    final SharedInformerManager sharedInformerManager = new SharedInformerManager(rbacHandler.operatorClient(), Set.of());
-
-    @RegisterExtension
-    @SuppressWarnings("JUnitMalformedDeclaration") // The beforeAll and beforeEach have the same effect, so we can use it as an instance field.
-    LocallyRunOperatorExtension extension = LocallyRunOperatorExtension.builder()
+    static LocalKroxyliciousOperatorExtension operator = LocalKroxyliciousOperatorExtension.builder()
             .withReconciler(new KafkaProxyReconciler(Clock.systemUTC(), SecureConfigInterpolator.DEFAULT_INTERPOLATOR))
             .withReconciler(new VirtualKafkaClusterReconciler(Clock.systemUTC(), DependencyResolver.create(), sharedInformerManager))
             .withReconciler(new KafkaProxyIngressReconciler(Clock.systemUTC()))
             .withReconciler(new KafkaServiceReconciler(Clock.systemUTC(), sharedInformerManager))
             .withReconciler(new KafkaProtocolFilterReconciler(Clock.systemUTC(), SecureConfigInterpolator.DEFAULT_INTERPOLATOR, sharedInformerManager))
-            .withKubernetesClient(rbacHandler.operatorClient())
-            .waitForNamespaceDeletion(false)
-            .withConfigurationService(x -> x.withCloseClientOnStop(false))
-            .withAdditionalCustomResourceDefinition(Crds.kafka())
+            .withSetupAction(() -> {
+                try (KubernetesClient client = OperatorTestUtils.kubeClient()) {
+                    client.apiextensions().v1().customResourceDefinitions().resource(Crds.kafka()).createOr(Updatable::update);
+                }
+            })
+            .withTeardownAction(() -> {
+                try (KubernetesClient client = OperatorTestUtils.kubeClient()) {
+                    client.apiextensions().v1().customResourceDefinitions().resource(Crds.kafka()).delete();
+                }
+            })
             .build();
-    private final TestActor testActor = rbacHandler.testActor(extension);
-
-    @AfterEach
-    void stopOperator() {
-        extension.getOperator().stop();
-        sharedInformerManager.stopAll();
-        LOGGER.atInfo().log("Test finished");
-    }
 
     @Test
     void emptyProxyIsAllowed() {
@@ -143,13 +127,13 @@ class AllReconcilersIT {
 
     static Stream<Arguments> filterScenarios() {
         return Stream.of(
-                argumentSet("no filters", (Function<TestActor, KafkaProtocolFilter>) (builder -> null)),
-                argumentSet("filter with simple config", (Function<TestActor, KafkaProtocolFilter>) (actor -> {
+                argumentSet("no filters", (Function<LocalKroxyliciousOperatorExtension, KafkaProtocolFilter>) (builder -> null)),
+                argumentSet("filter with simple config", (Function<LocalKroxyliciousOperatorExtension, KafkaProtocolFilter>) (actor -> {
                     var filter = editableFilter(CLUSTER_FOO_FILTER).build();
                     actor.create(filter);
                     return filter;
                 })),
-                argumentSet("filter with config that refs a configmap", (Function<TestActor, KafkaProtocolFilter>) (actor -> {
+                argumentSet("filter with config that refs a configmap", (Function<LocalKroxyliciousOperatorExtension, KafkaProtocolFilter>) (actor -> {
                 // @formatter:off
                     var filterConfigMap = new ConfigMapBuilder()
                             .withNewMetadata()
@@ -171,7 +155,7 @@ class AllReconcilersIT {
 
     @ParameterizedTest
     @MethodSource("filterScenarios")
-    void singleVirtualCluster(Function<TestActor, KafkaProtocolFilter> filterFunc) {
+    void singleVirtualCluster(Function<LocalKroxyliciousOperatorExtension, KafkaProtocolFilter> filterFunc) {
         // Given
         var myProxy = editableProxy(PROXY_A).build();
         // @formatter:off
@@ -185,7 +169,7 @@ class AllReconcilersIT {
         // @formatter:on
         var myService = editableService(CLUSTER_FOO_SERVICE).build();
 
-        var myFilter = filterFunc.apply(testActor);
+        var myFilter = filterFunc.apply(operator);
 
         var myCluster = editableVirtualCluster(CLUSTER_FOO, myProxy, myService, List.of(myIngress), Optional.ofNullable(myFilter).stream().toList()).build();
 
@@ -202,32 +186,22 @@ class AllReconcilersIT {
         // The accepted condition and ingresses may be set in separate reconciliation cycles,
         // so we wait explicitly for the ingresses to be populated rather than checking the
         // snapshot returned when the accepted condition first became true.
-        try {
-            AWAIT.alias("cluster %s has ingresses with bootstrap servers".formatted(CLUSTER_FOO))
-                    .untilAsserted(() -> assertThat(testActor.get(VirtualKafkaCluster.class, CLUSTER_FOO))
-                            .isNotNull()
-                            .extracting(VirtualKafkaCluster::getStatus)
-                            .satisfies(vcs -> assertThat(vcs)
-                                    .extracting(VirtualKafkaClusterStatus::getIngresses, as(InstanceOfAssertFactories.list(Ingresses.class)))
-                                    .singleElement()
-                                    .extracting(Ingresses::getBootstrapServer, as(InstanceOfAssertFactories.STRING))
-                                    .isNotEmpty()));
-        }
-        catch (ConditionTimeoutException e) {
-            // Dump the last observed status so an intermittent CI failure can be diagnosed without a local repro.
-            var lastObserved = testActor.get(VirtualKafkaCluster.class, CLUSTER_FOO);
-            LOGGER.atWarn()
-                    .addKeyValue("name", CLUSTER_FOO)
-                    .addKeyValue("status", lastObserved == null ? null : lastObserved.getStatus())
-                    .log("Timed out waiting for ingresses with bootstrap servers; dumping last observed cluster status");
-            throw e;
-        }
+        AWAIT.alias("cluster %s has ingresses with bootstrap servers".formatted(CLUSTER_FOO))
+                .untilAsserted(() -> assertThat(testActor.get(VirtualKafkaCluster.class, CLUSTER_FOO))
+                        .isNotNull()
+                        .extracting(VirtualKafkaCluster::getStatus)
+                        .satisfies(vcs -> assertThat(vcs)
+                                .extracting(VirtualKafkaClusterStatus::getIngresses, as(InstanceOfAssertFactories.list(Ingresses.class)))
+                                .singleElement()
+                                .extracting(Ingresses::getBootstrapServer, as(InstanceOfAssertFactories.STRING))
+                                .isNotEmpty()));
+
     }
 
     static Stream<Arguments> upstreamTlsScenarios() {
         return Stream.of(
-                argumentSet("tls", (Function<TestActor, Tls>) (builder -> new Tls())),
-                argumentSet("tls with trust from secret", (Function<TestActor, Tls>) (actor -> {
+                argumentSet("tls", (Function<LocalKroxyliciousOperatorExtension, Tls>) (builder -> new Tls())),
+                argumentSet("tls with trust from secret", (Function<LocalKroxyliciousOperatorExtension, Tls>) (actor -> {
                 // @formatter:off
                     var trust = new SecretBuilder()
                             .withNewMetadata()
@@ -248,7 +222,7 @@ class AllReconcilersIT {
                     actor.create(trust);
                     return ref;
                 })),
-                argumentSet("tls with trust from secret with store type", (Function<TestActor, Tls>) (actor -> {
+                argumentSet("tls with trust from secret with store type", (Function<LocalKroxyliciousOperatorExtension, Tls>) (actor -> {
                 // @formatter:off
                     var trust = new SecretBuilder()
                             .withNewMetadata()
@@ -274,9 +248,9 @@ class AllReconcilersIT {
 
     @ParameterizedTest
     @MethodSource("upstreamTlsScenarios")
-    void upstreamTls(Function<TestActor, io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.Tls> tlsFunc) {
+    void upstreamTls(Function<LocalKroxyliciousOperatorExtension, io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.Tls> tlsFunc) {
         // Given
-        var tlsScenario = tlsFunc.apply(testActor);
+        var tlsScenario = tlsFunc.apply(operator);
 
         var myProxy = editableProxy(PROXY_A).build();
         // @formatter:off
@@ -323,12 +297,13 @@ class AllReconcilersIT {
         // @formatter:on
 
         return Stream.of(
-                argumentSet("tls with platform trust", (Function<TestActor, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
-                    actor.create(downstreamCert);
-                    return new io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.TlsBuilder(downstreamTls).build();
-                })),
+                argumentSet("tls with platform trust",
+                        (Function<LocalKroxyliciousOperatorExtension, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
+                            actor.create(downstreamCert);
+                            return new io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.TlsBuilder(downstreamTls).build();
+                        })),
                 argumentSet("tls with trust from configmap",
-                        (Function<TestActor, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
+                        (Function<LocalKroxyliciousOperatorExtension, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
 
                         // @formatter:off
                     var downstreamTrust = new ConfigMapBuilder()
@@ -351,7 +326,7 @@ class AllReconcilersIT {
                             return tls;
                         })),
                 argumentSet("tls with trust from secret",
-                        (Function<TestActor, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
+                        (Function<LocalKroxyliciousOperatorExtension, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
 
                         // @formatter:off
                     var downstreamTrust = new SecretBuilder()
@@ -375,7 +350,7 @@ class AllReconcilersIT {
                             return tls;
                         })),
                 argumentSet("tls with trust from configmap with new key of supported store type",
-                        (Function<TestActor, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
+                        (Function<LocalKroxyliciousOperatorExtension, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls>) (actor -> {
 
                         // @formatter:off
                     var downstreamTrust = new ConfigMapBuilder()
@@ -402,9 +377,9 @@ class AllReconcilersIT {
 
     @ParameterizedTest
     @MethodSource("downstreamTlsScenarios")
-    void downstreamTls(Function<TestActor, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls> tlsFunc) {
+    void downstreamTls(Function<LocalKroxyliciousOperatorExtension, io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.ingresses.Tls> tlsFunc) {
         // Given
-        var tlsScenario = tlsFunc.apply(testActor);
+        var tlsScenario = tlsFunc.apply(operator);
 
         var myProxy = editableProxy(PROXY_A).build();
         // @formatter:off
@@ -435,89 +410,8 @@ class AllReconcilersIT {
         assertResourcesAttainCondition(AllReconcilersIT::refsResolved, myCluster, myIngress, myService);
     }
 
-    @Test
-    void upstreamTlsFromStrimziKafkaRef() {
-        // Given
-        String kafkaName = "my-cluster";
-        // @formatter:off
-        var kafka = testActor.create(new KafkaBuilder()
-                .withNewMetadata()
-                    .withName(kafkaName)
-                .endMetadata()
-                .withNewSpec()
-                    .withNewKafka()
-                        .addNewListener()
-                            .withName(STRIMZI_TLS_LISTENER)
-                            .withTls(true)
-                        .endListener()
-                    .endKafka()
-                .endSpec()
-                .build());
-
-        // Patch the Kafka status to simulate what the Strimzi operator would do.
-        // The Strimzi operator manages the status subresource of Kafka CRs, populating
-        // listener addresses and other runtime state. In tests, we must manually set
-        // this status since the Strimzi operator is not running.
-        testActor.patchStatus(new KafkaBuilder(kafka)
-                .withNewStatus()
-                    .addNewListener()
-                        .withName(STRIMZI_TLS_LISTENER)
-                        .addNewAddress()
-                                .withHost("kafka.example.com")
-                                .withPort(9093)
-                        .endAddress()
-                    .endListener()
-                .endStatus()
-                .build());
-
-        testActor.create(new SecretBuilder()
-                .withNewMetadata()
-                    .withName(kafkaName + ResourcesUtil.STRIMZI_CLUSTER_CA_CERT_SECRET_SUFFIX)
-                .endMetadata()
-                .addToData(ResourcesUtil.STRIMZI_CLUSTER_CA_BUNDLE, "dGVzdC1jYQ==")
-                .build());
-
-        var myService = editableStrimziService(CLUSTER_FOO_SERVICE, kafkaName, STRIMZI_TLS_LISTENER).build();
-        var myProxy = editableProxy(PROXY_A).build();
-        var myIngress = editableIngress(CLUSTER_FOO_CLUSTER_IP_INGRESS, myProxy)
-                .editOrNewSpec()
-                    .withNewClusterIP()
-                        .withProtocol(Protocol.TCP)
-                    .endClusterIP()
-                .endSpec()
-                .build();
-        // @formatter:on
-
-        var myCluster = editableVirtualCluster(CLUSTER_FOO, myProxy, myService, List.of(myIngress), List.of()).build();
-
-        // When
-        createAll(myProxy, myCluster, myIngress, myService);
-
-        // Then
-        assertResourcesAttainCondition(AllReconcilersIT::resourceReady, myProxy);
-        assertResourcesAttainCondition(AllReconcilersIT::refsResolved, myCluster, myIngress, myService);
-    }
-
-    private static KafkaServiceBuilder editableStrimziService(String name, String kafkaName, String listenerName) {
-        // @formatter:off
-        return new KafkaServiceBuilder()
-                .withNewMetadata()
-                    .withName(name)
-                .endMetadata()
-                .withNewSpec()
-                    .withNewStrimziKafkaRef()
-                        .withListenerName(listenerName)
-                        .withTrustStrimziCaCertificate(true)
-                        .withNewRef()
-                            .withName(kafkaName)
-                        .endRef()
-                    .endStrimziKafkaRef()
-                .endSpec();
-        // @formatter:on
-    }
-
     private void createAll(HasMetadata... resources) {
-        Arrays.stream(resources).sequential().forEach(testActor::create);
+        Arrays.stream(resources).sequential().forEach(operator::create);
     }
 
     private static KafkaProxyBuilder editableProxy(String name) {
@@ -540,7 +434,7 @@ class AllReconcilersIT {
         var name = name(resource);
         var clazz = resource.getClass();
         AWAIT.alias("resource %s (%s) meets predicate".formatted(name, clazz.getSimpleName()))
-                .untilAsserted(() -> testActor.get(clazz, name),
+                .untilAsserted(() -> operator.get(clazz, name),
                         actual -> {
                             assertThat(actual)
                                     .isNotNull()

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/CustomResourceValidationIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/CustomResourceValidationIT.java
@@ -41,11 +41,12 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
+import io.kroxylicious.testing.operator.OperatorTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
-@EnabledIf(value = "io.kroxylicious.kubernetes.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
+@EnabledIf(value = "io.kroxylicious.testing.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
 class CustomResourceValidationIT {
 
     public static final Namespace NAMESPACE = new NamespaceBuilder().withNewMetadata().withName("proxy-ns").endMetadata().build();

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
@@ -42,11 +42,12 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyStatus;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
+import io.kroxylicious.testing.operator.OperatorTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
-@EnabledIf(value = "io.kroxylicious.kubernetes.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
+@EnabledIf(value = "io.kroxylicious.testing.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
 class OperatorMainIT {
     // This is an IT because it depends on having a running Kube cluster
 

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconcilerIT.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -27,6 +28,7 @@ import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProtocolFilter;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProtocolFilterBuilder;
 import io.kroxylicious.kubernetes.operator.Annotations;
+import io.kroxylicious.testing.operator.ClusterUser;
 import io.kroxylicious.kubernetes.operator.assertj.KafkaProtocolFilterStatusAssert;
 import io.kroxylicious.kubernetes.operator.informer.SharedInformerManager;
 import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
@@ -56,38 +58,45 @@ class KafkaProtocolFilterReconcilerIT {
             .replaceClusterRoleGlobs("*.ClusterRole.kroxylicious-operator-watched.yaml")
             .build();
 
+    private ClusterUser clusterUser;
+
+    @BeforeEach
+    void setUp() {
+        clusterUser = operator.clusterUser();
+    }
+
     @Test
     void shouldEventuallyResolveWhenFilterCreatedFirst() {
         createFilterFirst();
     }
 
     private KafkaProtocolFilter createFilterFirst() {
-        KafkaProtocolFilter filterOne = operator.create(filter(FILTER_ONE,
+        KafkaProtocolFilter filterOne = clusterUser.create(filter(FILTER_ONE,
                 "${secret:" + A + ":foo}", "${configmap:" + B + ":foo}"));
         assertResolvedRefsFalse(filterOne, "Referenced Secrets [a] ConfigMaps [b] not found");
-        operator.create(secret(A));
+        clusterUser.create(secret(A));
         assertResolvedRefsFalse(filterOne, "Referenced ConfigMaps [b] not found");
-        operator.create(cm(B));
+        clusterUser.create(cm(B));
         assertAllConditionsTrue(filterOne);
         return filterOne;
     }
 
     @Test
     void shouldEventuallyResolveWhenASecretCreatedFirst() {
-        operator.create(secret(A));
-        KafkaProtocolFilter filterOne = operator.create(filter(FILTER_ONE,
+        clusterUser.create(secret(A));
+        KafkaProtocolFilter filterOne = clusterUser.create(filter(FILTER_ONE,
                 "${secret:" + A + ":foo}", "${secret:" + B + ":foo}"));
         assertResolvedRefsFalse(filterOne, "Referenced Secrets [b] not found");
-        operator.create(secret(B));
+        clusterUser.create(secret(B));
         assertAllConditionsTrue(filterOne);
     }
 
     @Test
     void shouldEventuallyResolveWhenAllSecretsCreatedFirst() {
-        operator.create(secret(A));
-        operator.create(secret(B));
-        operator.create(secret(C));
-        KafkaProtocolFilter filterOne = operator.create(filter(FILTER_ONE,
+        clusterUser.create(secret(A));
+        clusterUser.create(secret(B));
+        clusterUser.create(secret(C));
+        KafkaProtocolFilter filterOne = clusterUser.create(filter(FILTER_ONE,
                 "${secret:" + A + ":foo}",
                 "${secret:" + B + ":foo}"));
         assertAllConditionsTrue(filterOne);
@@ -95,7 +104,7 @@ class KafkaProtocolFilterReconcilerIT {
 
     private void assertAllConditionsTrue(KafkaProtocolFilter filterOne) {
         AWAIT.alias("FilterStatusResolvedRefs").untilAsserted(() -> {
-            var kpf = operator.resources(KafkaProtocolFilter.class)
+            var kpf = clusterUser.resources(KafkaProtocolFilter.class)
                     .withName(ResourcesUtil.name(filterOne)).get();
             assertThat(kpf.getStatus()).isNotNull();
             KafkaProtocolFilterStatusAssert
@@ -112,10 +121,10 @@ class KafkaProtocolFilterReconcilerIT {
 
     @Test
     void shouldEventuallyResolveWhenSecretsAndConfigMapsFirst() {
-        operator.create(secret(A));
-        operator.create(cm(B));
-        operator.create(secret(C));
-        KafkaProtocolFilter filterOne = operator.create(filter(FILTER_ONE,
+        clusterUser.create(secret(A));
+        clusterUser.create(cm(B));
+        clusterUser.create(secret(C));
+        KafkaProtocolFilter filterOne = clusterUser.create(filter(FILTER_ONE,
                 "${secret:" + A + ":foo}",
                 "${configmap:" + B + ":foo}"));
         assertAllConditionsTrue(filterOne);
@@ -125,11 +134,11 @@ class KafkaProtocolFilterReconcilerIT {
     void shouldUpdateStatusOnFilterModify() {
         shouldEventuallyResolveWhenFilterCreatedFirst();
 
-        KafkaProtocolFilter filterOne = operator.replace(filter(FILTER_ONE,
+        KafkaProtocolFilter filterOne = clusterUser.replace(filter(FILTER_ONE,
                 "${secret:" + C + ":foo}", "${configmap:" + B + ":foo}"));
         assertResolvedRefsFalse(filterOne, "Referenced Secrets [c] not found");
 
-        operator.create(secret(C));
+        clusterUser.create(secret(C));
         assertAllConditionsTrue(filterOne);
     }
 
@@ -137,7 +146,7 @@ class KafkaProtocolFilterReconcilerIT {
     void shouldUpdateStatusOnSecretModify() {
         var filterOne = createFilterFirst();
 
-        operator.resources(Secret.class).withName(A).edit(secret -> secret.edit()
+        clusterUser.resources(Secret.class).withName(A).edit(secret -> secret.edit()
                 .addToData("baz", Base64.getEncoder().encodeToString("".getBytes(StandardCharsets.UTF_8)))
                 .build());
         assertAllConditionsTrue(filterOne);
@@ -147,17 +156,17 @@ class KafkaProtocolFilterReconcilerIT {
     void shouldUpdateReferentAnnotationOnSecretModify() {
         // given
         var filterOne = createFilterFirst();
-        String checksum = operator.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
+        String checksum = clusterUser.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
                 .getOrDefault(Annotations.REFERENT_CHECKSUM_ANNOTATION_KEY, NO_CHECKSUM_SPECIFIED);
 
         // when
-        operator.resources(Secret.class).withName(A).edit(secret -> secret.edit()
+        clusterUser.resources(Secret.class).withName(A).edit(secret -> secret.edit()
                 .addToData("baz", Base64.getEncoder().encodeToString("".getBytes(StandardCharsets.UTF_8)))
                 .build());
 
         // then
         assertAllConditionsTrue(filterOne);
-        String newChecksum = operator.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
+        String newChecksum = clusterUser.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
                 .getOrDefault(Annotations.REFERENT_CHECKSUM_ANNOTATION_KEY, NO_CHECKSUM_SPECIFIED);
         assertThat(newChecksum).isNotEqualTo(checksum);
     }
@@ -166,17 +175,17 @@ class KafkaProtocolFilterReconcilerIT {
     void shouldUpdateReferentAnnotationOnConfigMapModify() {
         // given
         var filterOne = createFilterFirst();
-        String checksum = operator.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
+        String checksum = clusterUser.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
                 .getOrDefault(Annotations.REFERENT_CHECKSUM_ANNOTATION_KEY, NO_CHECKSUM_SPECIFIED);
 
         // when
-        operator.resources(ConfigMap.class).withName(B).edit(configMap -> configMap.edit()
+        clusterUser.resources(ConfigMap.class).withName(B).edit(configMap -> configMap.edit()
                 .addToData("baz", Base64.getEncoder().encodeToString("".getBytes(StandardCharsets.UTF_8)))
                 .build());
 
         // then
         assertAllConditionsTrue(filterOne);
-        String newChecksum = operator.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
+        String newChecksum = clusterUser.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
                 .getOrDefault(Annotations.REFERENT_CHECKSUM_ANNOTATION_KEY, NO_CHECKSUM_SPECIFIED);
         assertThat(newChecksum).isNotEqualTo(checksum);
     }
@@ -217,7 +226,7 @@ class KafkaProtocolFilterReconcilerIT {
     private void assertResolvedRefsFalse(KafkaProtocolFilter cr,
                                          String message) {
         AWAIT.alias("FilterStatusResolvedRefs").untilAsserted(() -> {
-            var kpf = operator.resources(KafkaProtocolFilter.class)
+            var kpf = clusterUser.resources(KafkaProtocolFilter.class)
                     .withName(ResourcesUtil.name(cr)).get();
             assertThat(kpf.getStatus()).isNotNull();
             KafkaProtocolFilterStatusAssert

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconcilerIT.java
@@ -28,13 +28,13 @@ import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProtocolFilter;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProtocolFilterBuilder;
 import io.kroxylicious.kubernetes.operator.Annotations;
-import io.kroxylicious.testing.operator.ClusterUser;
-import io.kroxylicious.kubernetes.operator.assertj.KafkaProtocolFilterStatusAssert;
-import io.kroxylicious.kubernetes.operator.informer.SharedInformerManager;
-import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
-import io.kroxylicious.testing.operator.OperatorTestUtils;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.SecureConfigInterpolator;
+import io.kroxylicious.kubernetes.operator.informer.SharedInformerManager;
+import io.kroxylicious.testing.operator.ClusterUser;
+import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
+import io.kroxylicious.testing.operator.OperatorTestUtils;
+import io.kroxylicious.testing.operator.assertj.KafkaProtocolFilterStatusAssert;
 
 import static io.kroxylicious.kubernetes.operator.checksum.MetadataChecksumGenerator.NO_CHECKSUM_SPECIFIED;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconcilerIT.java
@@ -53,7 +53,7 @@ class KafkaProtocolFilterReconcilerIT {
     @RegisterExtension
     static LocalKroxyliciousOperatorExtension operator = LocalKroxyliciousOperatorExtension.builder()
             .withReconciler(new KafkaProtocolFilterReconciler(Clock.systemUTC(), SecureConfigInterpolator.DEFAULT_INTERPOLATOR, sharedInformerManager))
-            .withClusterRoleGlobs("*.ClusterRole.kroxylicious-operator-watched.yaml")
+            .replaceClusterRoleGlobs("*.ClusterRole.kroxylicious-operator-watched.yaml")
             .build();
 
     @Test

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconcilerIT.java
@@ -194,7 +194,7 @@ class KafkaProtocolFilterReconcilerIT {
     void shouldUpdateStatusOnSecretDelete() {
         var filterOne = createFilterFirst();
 
-        operator.delete(secret(A));
+        clusterUser.delete(secret(A));
         assertResolvedRefsFalse(filterOne, "Referenced Secrets [a] not found");
     }
 
@@ -202,7 +202,7 @@ class KafkaProtocolFilterReconcilerIT {
     void shouldUpdateStatusOnConfigMapDelete() {
         var filterOne = createFilterFirst();
 
-        operator.delete(cm(B));
+        clusterUser.delete(cm(B));
         assertResolvedRefsFalse(filterOne, "Referenced ConfigMaps [b] not found");
     }
 

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterReconcilerIT.java
@@ -14,40 +14,32 @@ import java.util.Map;
 import java.util.Set;
 
 import org.awaitility.core.ConditionFactory;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
-import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 
 import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProtocolFilter;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProtocolFilterBuilder;
 import io.kroxylicious.kubernetes.operator.Annotations;
-import io.kroxylicious.kubernetes.operator.LocallyRunningOperatorRbacHandler;
-import io.kroxylicious.kubernetes.operator.OperatorTestUtils;
+import io.kroxylicious.kubernetes.operator.assertj.KafkaProtocolFilterStatusAssert;
+import io.kroxylicious.kubernetes.operator.informer.SharedInformerManager;
+import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
+import io.kroxylicious.testing.operator.OperatorTestUtils;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.SecureConfigInterpolator;
-import io.kroxylicious.kubernetes.operator.TestFiles;
-import io.kroxylicious.kubernetes.operator.informer.SharedInformerManager;
-import io.kroxylicious.testing.operator.assertj.KafkaProtocolFilterStatusAssert;
 
 import static io.kroxylicious.kubernetes.operator.checksum.MetadataChecksumGenerator.NO_CHECKSUM_SPECIFIED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-@EnabledIf(value = "io.kroxylicious.kubernetes.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
+@EnabledIf(value = "io.kroxylicious.testing.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
 class KafkaProtocolFilterReconcilerIT {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProtocolFilterReconcilerIT.class);
 
     private static final String A = "a";
     private static final String B = "b";
@@ -56,34 +48,13 @@ class KafkaProtocolFilterReconcilerIT {
 
     private static final ConditionFactory AWAIT = await().timeout(Duration.ofSeconds(60));
 
-    // the initial operator image pull can take a long time and interfere with the tests
-    @BeforeAll
-    static void preloadOperandImage() {
-        OperatorTestUtils.preloadOperandImage();
-    }
+    private static final SharedInformerManager sharedInformerManager = new SharedInformerManager(OperatorTestUtils.kubeClient(), Set.of());
 
     @RegisterExtension
-    static LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler(TestFiles.INSTALL_MANIFESTS_DIR,
-            "*.ClusterRole.kroxylicious-operator-watched.yaml");
-
-    @RegisterExtension
-    @SuppressWarnings("JUnitMalformedDeclaration") // The beforeAll and beforeEach have the same effect so we can use it as an instance field.
-    LocallyRunOperatorExtension extension = LocallyRunOperatorExtension.builder()
-            .withReconciler(new KafkaProtocolFilterReconciler(Clock.systemUTC(), SecureConfigInterpolator.DEFAULT_INTERPOLATOR,
-                    new SharedInformerManager(rbacHandler.operatorClient(), Set.of())))
-            .withAdditionalCustomResourceDefinition(KafkaProtocolFilter.class)
-            .withKubernetesClient(rbacHandler.operatorClient())
-            .waitForNamespaceDeletion(false)
-            .withConfigurationService(x -> x.withCloseClientOnStop(false))
+    static LocalKroxyliciousOperatorExtension operator = LocalKroxyliciousOperatorExtension.builder()
+            .withReconciler(new KafkaProtocolFilterReconciler(Clock.systemUTC(), SecureConfigInterpolator.DEFAULT_INTERPOLATOR, sharedInformerManager))
+            .withClusterRoleGlobs("*.ClusterRole.kroxylicious-operator-watched.yaml")
             .build();
-
-    private final LocallyRunningOperatorRbacHandler.TestActor testActor = rbacHandler.testActor(extension);
-
-    @AfterEach
-    void stopOperator() {
-        extension.getOperator().stop();
-        LOGGER.atInfo().log("Test finished");
-    }
 
     @Test
     void shouldEventuallyResolveWhenFilterCreatedFirst() {
@@ -91,32 +62,32 @@ class KafkaProtocolFilterReconcilerIT {
     }
 
     private KafkaProtocolFilter createFilterFirst() {
-        KafkaProtocolFilter filterOne = testActor.create(filter(FILTER_ONE,
+        KafkaProtocolFilter filterOne = operator.create(filter(FILTER_ONE,
                 "${secret:" + A + ":foo}", "${configmap:" + B + ":foo}"));
         assertResolvedRefsFalse(filterOne, "Referenced Secrets [a] ConfigMaps [b] not found");
-        testActor.create(secret(A));
+        operator.create(secret(A));
         assertResolvedRefsFalse(filterOne, "Referenced ConfigMaps [b] not found");
-        testActor.create(cm(B));
+        operator.create(cm(B));
         assertAllConditionsTrue(filterOne);
         return filterOne;
     }
 
     @Test
     void shouldEventuallyResolveWhenASecretCreatedFirst() {
-        testActor.create(secret(A));
-        KafkaProtocolFilter filterOne = testActor.create(filter(FILTER_ONE,
+        operator.create(secret(A));
+        KafkaProtocolFilter filterOne = operator.create(filter(FILTER_ONE,
                 "${secret:" + A + ":foo}", "${secret:" + B + ":foo}"));
         assertResolvedRefsFalse(filterOne, "Referenced Secrets [b] not found");
-        testActor.create(secret(B));
+        operator.create(secret(B));
         assertAllConditionsTrue(filterOne);
     }
 
     @Test
     void shouldEventuallyResolveWhenAllSecretsCreatedFirst() {
-        testActor.create(secret(A));
-        testActor.create(secret(B));
-        testActor.create(secret(C));
-        KafkaProtocolFilter filterOne = testActor.create(filter(FILTER_ONE,
+        operator.create(secret(A));
+        operator.create(secret(B));
+        operator.create(secret(C));
+        KafkaProtocolFilter filterOne = operator.create(filter(FILTER_ONE,
                 "${secret:" + A + ":foo}",
                 "${secret:" + B + ":foo}"));
         assertAllConditionsTrue(filterOne);
@@ -124,7 +95,7 @@ class KafkaProtocolFilterReconcilerIT {
 
     private void assertAllConditionsTrue(KafkaProtocolFilter filterOne) {
         AWAIT.alias("FilterStatusResolvedRefs").untilAsserted(() -> {
-            var kpf = testActor.resources(KafkaProtocolFilter.class)
+            var kpf = operator.resources(KafkaProtocolFilter.class)
                     .withName(ResourcesUtil.name(filterOne)).get();
             assertThat(kpf.getStatus()).isNotNull();
             KafkaProtocolFilterStatusAssert
@@ -141,10 +112,10 @@ class KafkaProtocolFilterReconcilerIT {
 
     @Test
     void shouldEventuallyResolveWhenSecretsAndConfigMapsFirst() {
-        testActor.create(secret(A));
-        testActor.create(cm(B));
-        testActor.create(secret(C));
-        KafkaProtocolFilter filterOne = testActor.create(filter(FILTER_ONE,
+        operator.create(secret(A));
+        operator.create(cm(B));
+        operator.create(secret(C));
+        KafkaProtocolFilter filterOne = operator.create(filter(FILTER_ONE,
                 "${secret:" + A + ":foo}",
                 "${configmap:" + B + ":foo}"));
         assertAllConditionsTrue(filterOne);
@@ -154,11 +125,11 @@ class KafkaProtocolFilterReconcilerIT {
     void shouldUpdateStatusOnFilterModify() {
         shouldEventuallyResolveWhenFilterCreatedFirst();
 
-        KafkaProtocolFilter filterOne = testActor.replace(filter(FILTER_ONE,
+        KafkaProtocolFilter filterOne = operator.replace(filter(FILTER_ONE,
                 "${secret:" + C + ":foo}", "${configmap:" + B + ":foo}"));
         assertResolvedRefsFalse(filterOne, "Referenced Secrets [c] not found");
 
-        testActor.create(secret(C));
+        operator.create(secret(C));
         assertAllConditionsTrue(filterOne);
     }
 
@@ -166,7 +137,7 @@ class KafkaProtocolFilterReconcilerIT {
     void shouldUpdateStatusOnSecretModify() {
         var filterOne = createFilterFirst();
 
-        testActor.resources(Secret.class).withName(A).edit(secret -> secret.edit()
+        operator.resources(Secret.class).withName(A).edit(secret -> secret.edit()
                 .addToData("baz", Base64.getEncoder().encodeToString("".getBytes(StandardCharsets.UTF_8)))
                 .build());
         assertAllConditionsTrue(filterOne);
@@ -176,17 +147,17 @@ class KafkaProtocolFilterReconcilerIT {
     void shouldUpdateReferentAnnotationOnSecretModify() {
         // given
         var filterOne = createFilterFirst();
-        String checksum = testActor.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
+        String checksum = operator.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
                 .getOrDefault(Annotations.REFERENT_CHECKSUM_ANNOTATION_KEY, NO_CHECKSUM_SPECIFIED);
 
         // when
-        testActor.resources(Secret.class).withName(A).edit(secret -> secret.edit()
+        operator.resources(Secret.class).withName(A).edit(secret -> secret.edit()
                 .addToData("baz", Base64.getEncoder().encodeToString("".getBytes(StandardCharsets.UTF_8)))
                 .build());
 
         // then
         assertAllConditionsTrue(filterOne);
-        String newChecksum = testActor.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
+        String newChecksum = operator.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
                 .getOrDefault(Annotations.REFERENT_CHECKSUM_ANNOTATION_KEY, NO_CHECKSUM_SPECIFIED);
         assertThat(newChecksum).isNotEqualTo(checksum);
     }
@@ -195,17 +166,17 @@ class KafkaProtocolFilterReconcilerIT {
     void shouldUpdateReferentAnnotationOnConfigMapModify() {
         // given
         var filterOne = createFilterFirst();
-        String checksum = testActor.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
+        String checksum = operator.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
                 .getOrDefault(Annotations.REFERENT_CHECKSUM_ANNOTATION_KEY, NO_CHECKSUM_SPECIFIED);
 
         // when
-        testActor.resources(ConfigMap.class).withName(B).edit(configMap -> configMap.edit()
+        operator.resources(ConfigMap.class).withName(B).edit(configMap -> configMap.edit()
                 .addToData("baz", Base64.getEncoder().encodeToString("".getBytes(StandardCharsets.UTF_8)))
                 .build());
 
         // then
         assertAllConditionsTrue(filterOne);
-        String newChecksum = testActor.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
+        String newChecksum = operator.get(KafkaProtocolFilter.class, ResourcesUtil.name(filterOne)).getMetadata().getAnnotations()
                 .getOrDefault(Annotations.REFERENT_CHECKSUM_ANNOTATION_KEY, NO_CHECKSUM_SPECIFIED);
         assertThat(newChecksum).isNotEqualTo(checksum);
     }
@@ -214,7 +185,7 @@ class KafkaProtocolFilterReconcilerIT {
     void shouldUpdateStatusOnSecretDelete() {
         var filterOne = createFilterFirst();
 
-        testActor.delete(secret(A));
+        operator.delete(secret(A));
         assertResolvedRefsFalse(filterOne, "Referenced Secrets [a] not found");
     }
 
@@ -222,7 +193,7 @@ class KafkaProtocolFilterReconcilerIT {
     void shouldUpdateStatusOnConfigMapDelete() {
         var filterOne = createFilterFirst();
 
-        testActor.delete(cm(B));
+        operator.delete(cm(B));
         assertResolvedRefsFalse(filterOne, "Referenced ConfigMaps [b] not found");
     }
 
@@ -246,7 +217,7 @@ class KafkaProtocolFilterReconcilerIT {
     private void assertResolvedRefsFalse(KafkaProtocolFilter cr,
                                          String message) {
         AWAIT.alias("FilterStatusResolvedRefs").untilAsserted(() -> {
-            var kpf = testActor.resources(KafkaProtocolFilter.class)
+            var kpf = operator.resources(KafkaProtocolFilter.class)
                     .withName(ResourcesUtil.name(cr)).get();
             assertThat(kpf.getStatus()).isNotNull();
             KafkaProtocolFilterStatusAssert

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
@@ -19,9 +19,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.core.ConditionFactory;
@@ -31,6 +28,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
@@ -1457,38 +1456,34 @@ public class KafkaProxyReconcilerIT {
         assertDeploymentBecomesReady(proxyA);
     }
 
-    // the KafkaProxyReconciler only operates on Clusters that have been reconciled, ie metadata.status == status.observedGeneration
-    private VirtualKafkaCluster updateStatusObservedGeneration(VirtualKafkaCluster clusterBar) {
-        // Re-fetch to get the latest resourceVersion - the operator may have reconciled since we created it
-        VirtualKafkaCluster fresh = operator.get(VirtualKafkaCluster.class, name(clusterBar));
-        fresh.setStatus(new VirtualKafkaClusterStatusBuilder().withObservedGeneration(generation(fresh)).build());
-        return operator.patchStatus(fresh);
+    private VirtualKafkaCluster updateStatusObservedGeneration(VirtualKafkaCluster cluster) {
+        return operator.updateStatus(VirtualKafkaCluster.class, name(cluster), fresh -> {
+            fresh.setStatus(new VirtualKafkaClusterStatusBuilder().withObservedGeneration(generation(fresh)).build());
+            return fresh;
+        });
     }
 
-    // the KafkaProxyReconciler only operates on KafkaProtocolFilters that have been reconciled, ie metadata.status == status.observedGeneration
     private KafkaProtocolFilter updateStatusObservedGeneration(KafkaProtocolFilter filter) {
-        // Re-fetch to get the latest resourceVersion - the operator may have reconciled since we created it
-        KafkaProtocolFilter fresh = operator.get(KafkaProtocolFilter.class, name(filter));
-        fresh.setStatus(new KafkaProtocolFilterStatusBuilder().withObservedGeneration(generation(fresh)).build());
-        return operator.patchStatus(fresh);
+        return operator.updateStatus(KafkaProtocolFilter.class, name(filter), fresh -> {
+            fresh.setStatus(new KafkaProtocolFilterStatusBuilder().withObservedGeneration(generation(fresh)).build());
+            return fresh;
+        });
     }
 
-    // the KafkaProxyReconciler only operates on KafkaServices that have been reconciled, ie metadata.status == status.observedGeneration
     private KafkaService updateStatusObservedGeneration(KafkaService service, String bootstrapServers) {
-        // Re-fetch to get the latest resourceVersion - the operator may have reconciled since we created it
-        KafkaService fresh = operator.get(KafkaService.class, name(service));
-        fresh.setStatus(new KafkaServiceStatusBuilder().withObservedGeneration(generation(fresh))
-                .withBootstrapServers(bootstrapServers)
-                .build());
-        return operator.patchStatus(fresh);
+        return operator.updateStatus(KafkaService.class, name(service), fresh -> {
+            fresh.setStatus(new KafkaServiceStatusBuilder().withObservedGeneration(generation(fresh))
+                    .withBootstrapServers(bootstrapServers)
+                    .build());
+            return fresh;
+        });
     }
 
-    // the KafkaProxyReconciler only operates on KafkaServices that have been reconciled, ie metadata.status == status.observedGeneration
     private KafkaProxyIngress updateStatusObservedGeneration(KafkaProxyIngress ingress) {
-        // Re-fetch to get the latest resourceVersion - the operator may have reconciled since we created it
-        KafkaProxyIngress fresh = operator.get(KafkaProxyIngress.class, name(ingress));
-        fresh.setStatus(new KafkaProxyIngressStatusBuilder().withObservedGeneration(generation(fresh)).build());
-        return operator.patchStatus(fresh);
+        return operator.updateStatus(KafkaProxyIngress.class, name(ingress), fresh -> {
+            fresh.setStatus(new KafkaProxyIngressStatusBuilder().withObservedGeneration(generation(fresh)).build());
+            return fresh;
+        });
     }
 
     private void assertDeploymentIsRemoved(KafkaProxy proxy) {

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
@@ -961,13 +961,13 @@ public class KafkaProxyReconcilerIT {
         String initialChecksum = deploymentPodTemplateChecksum(proxy);
 
         // When - OpenShift assigns a host to the bootstrap route
-        Route bootstrapRoute = clusterUser.get(Route.class, bootstrapRouteName);
-        Route routeWithHost = new RouteBuilder(bootstrapRoute)
+        // Use updateStatus to re-fetch the latest resourceVersion, because the OpenShift
+        // ingress controller may have modified the Route since we last read it.
+        operator.updateStatus(Route.class, bootstrapRouteName, route -> new RouteBuilder(route)
                 .withNewStatus()
                 .addNewIngress().withHost(bootstrapRouteName + ".apps-crc.testing").endIngress()
                 .endStatus()
-                .build();
-        operator.patchStatus(routeWithHost);
+                .build());
 
         // Then - deployment pod template checksum should change so the proxy is restarted
         AWAIT.alias("deployment checksum updated after route host assignment")

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
@@ -89,7 +89,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.NodeIdRangesBuil
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.Ingresses;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressesBuilder;
 import io.kroxylicious.kubernetes.operator.Annotations;
-import io.kroxylicious.testing.operator.ClusterUser
+import io.kroxylicious.testing.operator.ClusterUser;
 import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.SecureConfigInterpolator;

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -88,6 +89,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.NodeIdRangesBuil
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.Ingresses;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressesBuilder;
 import io.kroxylicious.kubernetes.operator.Annotations;
+import io.kroxylicious.testing.operator.ClusterUser
 import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.SecureConfigInterpolator;
@@ -154,6 +156,13 @@ public class KafkaProxyReconcilerIT {
     static LocalKroxyliciousOperatorExtension operator = LocalKroxyliciousOperatorExtension.builder()
             .withReconciler(new KafkaProxyReconciler(Clock.systemUTC(), SecureConfigInterpolator.DEFAULT_INTERPOLATOR))
             .build();
+
+    private ClusterUser clusterUser;
+
+    @BeforeEach
+    void setUp() {
+        clusterUser = operator.clusterUser();
+    }
 
     @Test
     void testCreate() {
@@ -338,7 +347,7 @@ public class KafkaProxyReconcilerIT {
         String namespace = operator.getNamespace();
         String resourceName = resourceNameFn.apply(proxy);
 
-        AWAIT.alias(resourceName + " to exist").untilAsserted(() -> assertThat(operator.get(resourceClass, resourceName)).isNotNull());
+        AWAIT.alias(resourceName + " to exist").untilAsserted(() -> assertThat(clusterUser.get(resourceClass, resourceName)).isNotNull());
 
         // when — an external tool applies an SSA patch with its own field manager
         try (var client = new KubernetesClientBuilder().build()) {
@@ -348,15 +357,15 @@ public class KafkaProxyReconcilerIT {
         }
 
         // when — trigger a reconcile by changing the replica count
-        KafkaProxy updatedProxy = Objects.requireNonNull(operator.get(KafkaProxy.class, name(proxy)))
+        KafkaProxy updatedProxy = Objects.requireNonNull(clusterUser.get(KafkaProxy.class, name(proxy)))
                 .edit().editSpec().withReplicas(2).endSpec().build();
-        operator.replace(updatedProxy);
+        clusterUser.replace(updatedProxy);
 
         // then — wait for reconcile to complete (observable via Deployment replica change)
         assertDeploymentReplicaCount(proxy, 2);
 
         // then — external annotation must still be present after the operator reconciled
-        assertThat(operator.get(resourceClass, resourceName))
+        assertThat(clusterUser.get(resourceClass, resourceName))
                 .isNotNull()
                 .extracting(r -> r.getMetadata().getAnnotations(),
                         InstanceOfAssertFactories.map(String.class, String.class))
@@ -413,8 +422,8 @@ public class KafkaProxyReconcilerIT {
     @Test
     void testCreateWithKafkaServiceTls() {
         // given
-        operator.create(tlsKeyAndCertSecret(UPSTREAM_TLS_CERTIFICATE_SECRET_NAME));
-        operator.create(trustAnchorConfigMap(CA_BUNDLE_CONFIG_MAP_NAME));
+        clusterUser.create(tlsKeyAndCertSecret(UPSTREAM_TLS_CERTIFICATE_SECRET_NAME));
+        clusterUser.create(trustAnchorConfigMap(CA_BUNDLE_CONFIG_MAP_NAME));
         KafkaService kafkaService = kafkaServiceWithTls();
 
         // when
@@ -435,8 +444,8 @@ public class KafkaProxyReconcilerIT {
     @Test
     void testCreateWithKafkaServiceTlsUsingTrustAnchorFromSecret() {
         // given
-        operator.create(tlsKeyAndCertSecret(UPSTREAM_TLS_CERTIFICATE_SECRET_NAME));
-        operator.create(trustAnchorSecret(CA_CERT_SECRET_NAME));
+        clusterUser.create(tlsKeyAndCertSecret(UPSTREAM_TLS_CERTIFICATE_SECRET_NAME));
+        clusterUser.create(trustAnchorSecret(CA_CERT_SECRET_NAME));
         KafkaService kafkaService = kafkaServiceWithTlsWithTrustAnchorRefAsSecret();
 
         // when
@@ -455,20 +464,20 @@ public class KafkaProxyReconcilerIT {
     @Test
     void virtualClusterWithClusterIpIngress() {
         // Given
-        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
 
-        KafkaService kafkaService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
-        KafkaProxyIngress ingress = updateStatusObservedGeneration(operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
+        KafkaProxyIngress ingress = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
 
         String downstreamCertSecretName = "downstream-tls-certificate";
-        Secret tlsCert = operator.create(tlsKeyAndCertSecret(downstreamCertSecretName));
+        Secret tlsCert = clusterUser.create(tlsKeyAndCertSecret(downstreamCertSecretName));
 
         Ingresses build = createIngressForCluster(ingress, tlsCert);
         VirtualKafkaCluster resource = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(build), Optional.empty());
 
         // When
-        updateStatusObservedGeneration(operator.create(resource));
+        updateStatusObservedGeneration(clusterUser.create(resource));
 
         // Then
         assertProxyConfigContents(proxy, Set.of(downstreamCertSecretName), Set.of());
@@ -478,15 +487,15 @@ public class KafkaProxyReconcilerIT {
     @Test
     void virtualClusterWithClusterIpIngressWithTrustAnchor() {
         // Given
-        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
 
-        KafkaService kafkaService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
-        KafkaProxyIngress ingress = updateStatusObservedGeneration(operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
+        KafkaProxyIngress ingress = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
 
-        Secret tlsServerCert = operator.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
+        Secret tlsServerCert = clusterUser.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
         String downstreamTrustAnchorName = "downstream-tls-trust-anchor";
-        ConfigMap trustAnchor = operator.create(trustAnchorConfigMap(downstreamTrustAnchorName));
+        ConfigMap trustAnchor = clusterUser.create(trustAnchorConfigMap(downstreamTrustAnchorName));
 
         Ingresses clusterIngress = new IngressesBuilder()
                 .withIngressRef(toIngressRef(ingress))
@@ -499,7 +508,7 @@ public class KafkaProxyReconcilerIT {
         VirtualKafkaCluster resource = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(clusterIngress), Optional.empty());
 
         // When
-        updateStatusObservedGeneration(operator.create(resource));
+        updateStatusObservedGeneration(clusterUser.create(resource));
 
         // Then
         int clientFacingPort = TlsClusterIPClusterIngressNetworkingModel.CLIENT_FACING_PORT;
@@ -529,16 +538,16 @@ public class KafkaProxyReconcilerIT {
     @Test
     void virtualClusterWithMultipleClusterIpIngressWithTrustAnchor() {
         // Given
-        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
 
-        KafkaService kafkaService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
-        KafkaProxyIngress ingress = updateStatusObservedGeneration(operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
-        KafkaProxyIngress ingress2 = updateStatusObservedGeneration(operator.create(clusterIpIngress("another-cluster-ip", proxy, TLS)));
+        KafkaProxyIngress ingress = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
+        KafkaProxyIngress ingress2 = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress("another-cluster-ip", proxy, TLS)));
 
-        Secret tlsServerCert = operator.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
+        Secret tlsServerCert = clusterUser.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
         String downstreamTrustAnchorName = "downstream-tls-trust-anchor";
-        ConfigMap trustAnchor = operator.create(trustAnchorConfigMap(downstreamTrustAnchorName));
+        ConfigMap trustAnchor = clusterUser.create(trustAnchorConfigMap(downstreamTrustAnchorName));
 
         Ingresses clusterIngress = new IngressesBuilder()
                 .withIngressRef(toIngressRef(ingress))
@@ -559,7 +568,7 @@ public class KafkaProxyReconcilerIT {
         VirtualKafkaCluster resource = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(clusterIngress, clusterIngress2), Optional.empty());
 
         // When
-        updateStatusObservedGeneration(operator.create(resource));
+        updateStatusObservedGeneration(clusterUser.create(resource));
 
         // Then
         int clientFacingPort = TlsClusterIPClusterIngressNetworkingModel.CLIENT_FACING_PORT;
@@ -598,7 +607,7 @@ public class KafkaProxyReconcilerIT {
     }
 
     private void assertTlsClusterIpServiceManifested(String serviceName, KafkaProxy proxy, int clientFacingPort, int proxyListenPort) {
-        var service = operator.get(Service.class, serviceName);
+        var service = clusterUser.get(Service.class, serviceName);
         assertThat(service).isNotNull()
                 .describedAs(
                         "Expect Service '" + serviceName + " to exist")
@@ -615,18 +624,18 @@ public class KafkaProxyReconcilerIT {
 
     @Test
     void virtualClusterWithLoadBalancerIngressWithTrustAnchor() {
-        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
-        KafkaService kafkaService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
+        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
         String loadbalancerBootstrap = "bootstrap.kafka";
         String loadbalancerBrokerAddressPattern = "broker-$(nodeId).kafka";
         KafkaProxyIngress loadBalancerIngress = updateStatusObservedGeneration(
-                operator.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS, proxy, loadbalancerBootstrap,
+                clusterUser.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS, proxy, loadbalancerBootstrap,
                         loadbalancerBrokerAddressPattern)));
 
-        Secret tlsServerCert = operator.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
+        Secret tlsServerCert = clusterUser.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
         String downstreamTrustAnchorName = "downstream-tls-trust-anchor";
-        ConfigMap trustAnchor = operator.create(trustAnchorConfigMap(downstreamTrustAnchorName));
+        ConfigMap trustAnchor = clusterUser.create(trustAnchorConfigMap(downstreamTrustAnchorName));
 
         Ingresses clusterIngress = new IngressesBuilder()
                 .withIngressRef(toIngressRef(loadBalancerIngress))
@@ -638,14 +647,14 @@ public class KafkaProxyReconcilerIT {
         VirtualKafkaCluster cluster = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(clusterIngress), Optional.empty());
 
         // when
-        updateStatusObservedGeneration(operator.create(cluster));
+        updateStatusObservedGeneration(clusterUser.create(cluster));
 
         int clientFacingPort = LoadBalancerClusterIngressNetworkingModel.DEFAULT_CLIENT_FACING_LOADBALANCER_PORT;
         int proxyListenPort = ProxyDeploymentDependentResource.SHARED_SNI_PORT;
 
         AWAIT.alias("shared sni service manifested").untilAsserted(() -> {
             String serviceName = name(proxy) + "-sni";
-            var service = operator.get(Service.class, serviceName);
+            var service = clusterUser.get(Service.class, serviceName);
             assertThat(service).isNotNull()
                     .describedAs(
                             "Expect shared SNI Service for proxy '" + name(proxy) + " to exist")
@@ -675,7 +684,7 @@ public class KafkaProxyReconcilerIT {
 
     private void assertSharedSniPortExposedOnProxyDeployment(KafkaProxy proxy, int proxyListenPort) {
         AWAIT.alias("proxy deployment exposes shared sni port").untilAsserted(() -> {
-            var deployment = operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
+            var deployment = clusterUser.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
             assertThat(deployment).isNotNull();
             List<Container> containers = deployment.getSpec().getTemplate().getSpec().getContainers();
             assertThat(containers).hasSize(1).singleElement().satisfies(container -> {
@@ -692,33 +701,33 @@ public class KafkaProxyReconcilerIT {
 
     @Test
     void virtualClusterWithLoadBalancerAndClusterIpIngress() {
-        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
-        KafkaService kafkaService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
+        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
-        KafkaProxyIngress loadBalancerIngress = updateStatusObservedGeneration(operator.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS, proxy,
+        KafkaProxyIngress loadBalancerIngress = updateStatusObservedGeneration(clusterUser.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS, proxy,
                 "bootstrap.kafka",
                 "broker-$(nodeId).kafka")));
 
-        Secret loadBalancerTlsServerCert = operator.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate"));
+        Secret loadBalancerTlsServerCert = clusterUser.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate"));
 
         Ingresses lbIngress = createIngressForCluster(loadBalancerIngress, loadBalancerTlsServerCert);
 
-        Secret clusterIpTlsServerCert = operator.create(tlsKeyAndCertSecret("clusterip-tls-certificate"));
+        Secret clusterIpTlsServerCert = clusterUser.create(tlsKeyAndCertSecret("clusterip-tls-certificate"));
 
-        KafkaProxyIngress clusterIpIngress = updateStatusObservedGeneration(operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
+        KafkaProxyIngress clusterIpIngress = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
 
         Ingresses cipIngress = createIngressForCluster(clusterIpIngress, clusterIpTlsServerCert);
 
         VirtualKafkaCluster cluster = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(lbIngress, cipIngress), Optional.empty());
 
         // when
-        updateStatusObservedGeneration(operator.create(cluster));
+        updateStatusObservedGeneration(clusterUser.create(cluster));
 
         // then
         AWAIT.alias("services manifested").untilAsserted(() -> {
             String sharedSniServiceName = name(proxy) + "-sni";
             String clusterIpServiceName = CLUSTER_BAR + "-" + clusterIpIngress.getMetadata().getName() + "-bootstrap";
-            var services = operator.resources(Service.class).list().getItems();
+            var services = clusterUser.resources(Service.class).list().getItems();
             assertThat(services)
                     .extracting(service -> service.getMetadata().getName())
                     .contains(sharedSniServiceName, clusterIpServiceName);
@@ -733,26 +742,26 @@ public class KafkaProxyReconcilerIT {
 
     @Test
     void twoVirtualClusterUsingLoadBalancer() {
-        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
-        KafkaService kafkaService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
+        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
-        KafkaProxyIngress loadBalancerIngressFoo = updateStatusObservedGeneration(operator.create(loadBalancerIngress(CLUSTER_FOO_LOADBALANCER_INGRESS, proxy,
+        KafkaProxyIngress loadBalancerIngressFoo = updateStatusObservedGeneration(clusterUser.create(loadBalancerIngress(CLUSTER_FOO_LOADBALANCER_INGRESS, proxy,
                 "bootstrap.foo.kafka",
                 "broker-$(nodeId).foo.kafka")));
 
-        KafkaProxyIngress loadBalancerIngressBar = updateStatusObservedGeneration(operator.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS, proxy,
+        KafkaProxyIngress loadBalancerIngressBar = updateStatusObservedGeneration(clusterUser.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS, proxy,
                 "bootstrap.bar.kafka",
                 "broker-$(nodeId).bar.kafka")));
 
-        Secret loadBalancerTlsServerCertFoo = operator.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate-foo"));
-        Secret loadBalancerTlsServerCertBar = operator.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate-bar"));
+        Secret loadBalancerTlsServerCertFoo = clusterUser.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate-foo"));
+        Secret loadBalancerTlsServerCertBar = clusterUser.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate-bar"));
 
         Ingresses lbIngressFoo = createIngressForCluster(loadBalancerIngressFoo, loadBalancerTlsServerCertFoo);
 
         Ingresses lbIngressBar = createIngressForCluster(loadBalancerIngressBar, loadBalancerTlsServerCertBar);
 
-        VirtualKafkaCluster fooCluster = operator.create(virtualKafkaCluster(CLUSTER_FOO, proxy, kafkaService, List.of(lbIngressFoo), Optional.empty()));
-        VirtualKafkaCluster barCluster = operator.create(virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(lbIngressBar), Optional.empty()));
+        VirtualKafkaCluster fooCluster = clusterUser.create(virtualKafkaCluster(CLUSTER_FOO, proxy, kafkaService, List.of(lbIngressFoo), Optional.empty()));
+        VirtualKafkaCluster barCluster = clusterUser.create(virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(lbIngressBar), Optional.empty()));
 
         // when
         List.of(fooCluster, barCluster).forEach(this::updateStatusObservedGeneration);
@@ -760,7 +769,7 @@ public class KafkaProxyReconcilerIT {
         // then
         AWAIT.alias("shared sni service manifested").untilAsserted(() -> {
             String sharedSniServiceName = name(proxy) + "-sni";
-            var services = operator.resources(Service.class).list().getItems();
+            var services = clusterUser.resources(Service.class).list().getItems();
             assertThat(services)
                     .extracting(service -> service.getMetadata().getName())
                     .containsExactly(sharedSniServiceName);
@@ -783,17 +792,17 @@ public class KafkaProxyReconcilerIT {
 
     @Test
     void clusterIpIngressUsesDeclaredNodeIdsOfService() {
-        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
-        KafkaProtocolFilter filter = operator.create(filter(FILTER_NAME));
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
+        KafkaProtocolFilter filter = clusterUser.create(filter(FILTER_NAME));
         filter = updateStatusObservedGeneration(filter);
-        KafkaService barService = operator.create(new KafkaServiceBuilder().withNewMetadata().withName(CLUSTER_BAR_REF).endMetadata()
+        KafkaService barService = clusterUser.create(new KafkaServiceBuilder().withNewMetadata().withName(CLUSTER_BAR_REF).endMetadata()
                 .withNewSpec()
                 .withBootstrapServers(CLUSTER_BAR_BOOTSTRAP)
                 .withNodeIdRanges(createNodeIdRanges("brokers", 3L, 4L), createNodeIdRanges("more-brokers", 10L, 10L))
                 .endSpec().build());
         barService = updateStatusObservedGeneration(barService, CLUSTER_BAR_BOOTSTRAP);
-        KafkaProxyIngress ingressBar = updateStatusObservedGeneration(operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TCP)));
-        VirtualKafkaCluster clusterBar = operator.create(virtualKafkaCluster(CLUSTER_BAR, proxy, barService,
+        KafkaProxyIngress ingressBar = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TCP)));
+        VirtualKafkaCluster clusterBar = clusterUser.create(virtualKafkaCluster(CLUSTER_BAR, proxy, barService,
                 List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressBar)).build()), Optional.of(filter)));
         updateStatusObservedGeneration(clusterBar);
         clusterBar.setStatus(new VirtualKafkaClusterStatusBuilder().withObservedGeneration(generation(clusterBar)).build());
@@ -803,7 +812,7 @@ public class KafkaProxyReconcilerIT {
             String clusterName = name(clusterBar);
             String ingressName = name(ingressBar);
             String serviceName = clusterName + "-" + ingressName + "-bootstrap";
-            var service = operator.get(Service.class, serviceName);
+            var service = clusterUser.get(Service.class, serviceName);
             assertThat(service).isNotNull()
                     .describedAs(
                             "Expect Service for cluster '" + clusterName + "' and ingress '" + ingressName + "' to still exist")
@@ -818,7 +827,7 @@ public class KafkaProxyReconcilerIT {
         });
 
         AWAIT.alias("deployment pod template configured to expose ports").untilAsserted(() -> {
-            var deployment = operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
+            var deployment = clusterUser.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
             assertThat(deployment).isNotNull();
             List<Container> containers = deployment.getSpec().getTemplate().getSpec().getContainers();
             assertThat(containers).hasSize(1).singleElement().satisfies(container -> {
@@ -862,8 +871,8 @@ public class KafkaProxyReconcilerIT {
 
         // Given
         var domain = getDefaultOpenShiftIngressControllerDomain();
-        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
-        KafkaService kafkaService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
+        KafkaService kafkaService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
         int proxyListenPort = ProxyDeploymentDependentResource.SHARED_SNI_PORT;
 
@@ -871,21 +880,21 @@ public class KafkaProxyReconcilerIT {
         String routeBootstrap = "$(virtualClusterName)-bootstrap." + domain;
         String routeBrokerAddressPattern = "$(virtualClusterName)-$(nodeId)." + domain;
         KafkaProxyIngress openshiftRouteIngress = updateStatusObservedGeneration(
-                operator.create(openshiftRouteIngress(ingressName, proxy)));
+                clusterUser.create(openshiftRouteIngress(ingressName, proxy)));
 
         String downstreamCertSecretName = "downstream-tls-certificate";
-        Secret tlsCert = operator.create(tlsKeyAndCertSecret(downstreamCertSecretName));
+        Secret tlsCert = clusterUser.create(tlsKeyAndCertSecret(downstreamCertSecretName));
 
         Ingresses clusterIngress = createIngressForCluster(openshiftRouteIngress, tlsCert);
         VirtualKafkaCluster cluster = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(clusterIngress), Optional.empty());
 
         // When
-        updateStatusObservedGeneration(operator.create(cluster));
+        updateStatusObservedGeneration(clusterUser.create(cluster));
 
         // Then
         String serviceName = name(cluster) + "-" + name(openshiftRouteIngress) + "-service";
         AWAIT.alias("shared sni service manifested").untilAsserted(() -> {
-            var service = operator.get(Service.class, serviceName);
+            var service = clusterUser.get(Service.class, serviceName);
             assertThat(service).isNotNull()
                     .describedAs(
                             "Expect shared SNI Service for proxy '" + name(proxy) + " to exist")
@@ -928,15 +937,15 @@ public class KafkaProxyReconcilerIT {
                 .withFailMessage("kubernetes server is missing support for resource kind Route").isTrue();
 
         // Given
-        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
         KafkaService kafkaService = updateStatusObservedGeneration(
-                operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+                clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
         String ingressName = "openshiftroute";
         KafkaProxyIngress openshiftRouteIngress = updateStatusObservedGeneration(
-                operator.create(openshiftRouteIngress(ingressName, proxy)));
+                clusterUser.create(openshiftRouteIngress(ingressName, proxy)));
 
-        Secret tlsCert = operator.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
+        Secret tlsCert = clusterUser.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
 
         Ingresses clusterIngress = new IngressesBuilder()
                 .withIngressRef(toIngressRef(openshiftRouteIngress))
@@ -944,15 +953,15 @@ public class KafkaProxyReconcilerIT {
                 .build();
         VirtualKafkaCluster cluster = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService,
                 List.of(clusterIngress), Optional.empty());
-        updateStatusObservedGeneration(operator.create(cluster));
+        updateStatusObservedGeneration(clusterUser.create(cluster));
 
         String bootstrapRouteName = name(cluster) + "-bootstrap";
-        AWAIT.alias("bootstrap route created").untilAsserted(() -> assertThat(operator.get(Route.class, bootstrapRouteName)).isNotNull());
+        AWAIT.alias("bootstrap route created").untilAsserted(() -> assertThat(clusterUser.get(Route.class, bootstrapRouteName)).isNotNull());
 
         String initialChecksum = deploymentPodTemplateChecksum(proxy);
 
         // When - OpenShift assigns a host to the bootstrap route
-        Route bootstrapRoute = operator.get(Route.class, bootstrapRouteName);
+        Route bootstrapRoute = clusterUser.get(Route.class, bootstrapRouteName);
         Route routeWithHost = new RouteBuilder(bootstrapRoute)
                 .withNewStatus()
                 .addNewIngress().withHost(bootstrapRouteName + ".apps-crc.testing").endIngress()
@@ -966,7 +975,7 @@ public class KafkaProxyReconcilerIT {
     }
 
     private String deploymentPodTemplateChecksum(KafkaProxy proxy) {
-        var deployment = operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
+        var deployment = clusterUser.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
         assertThat(deployment).isNotNull();
         return Optional.ofNullable(deployment.getSpec().getTemplate().getMetadata().getAnnotations())
                 .map(annotations -> annotations.get(Annotations.REFERENT_CHECKSUM_ANNOTATION_KEY))
@@ -974,7 +983,7 @@ public class KafkaProxyReconcilerIT {
     }
 
     private void assertRouteManifested(String routeName, boolean isBootstrap, KafkaProxy proxy, String serviceName, int targetPort) {
-        var openshiftRoute = operator.get(Route.class, routeName);
+        var openshiftRoute = clusterUser.get(Route.class, routeName);
         assertThat(openshiftRoute).isNotNull()
                 .describedAs(
                         "Expect Route for proxy '" + name(proxy) + " to exist")
@@ -1045,15 +1054,15 @@ public class KafkaProxyReconcilerIT {
     }
 
     CreatedResources doCreate(KafkaService kafkaService, KafkaProxy kafkaProxy) {
-        KafkaProxy proxy = operator.create(kafkaProxy);
-        KafkaProtocolFilter filter = operator.create(filter(FILTER_NAME));
+        KafkaProxy proxy = clusterUser.create(kafkaProxy);
+        KafkaProtocolFilter filter = clusterUser.create(filter(FILTER_NAME));
         filter = updateStatusObservedGeneration(filter);
-        KafkaService barService = operator.create(kafkaService);
+        KafkaService barService = clusterUser.create(kafkaService);
         barService = updateStatusObservedGeneration(barService, CLUSTER_BAR_BOOTSTRAP);
-        KafkaProxyIngress ingressBar = operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TCP));
+        KafkaProxyIngress ingressBar = clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TCP));
         ingressBar = updateStatusObservedGeneration(ingressBar);
         Set<KafkaService> kafkaServices = Set.of(barService);
-        VirtualKafkaCluster clusterBar = operator.create(virtualKafkaCluster(CLUSTER_BAR, proxy, barService,
+        VirtualKafkaCluster clusterBar = clusterUser.create(virtualKafkaCluster(CLUSTER_BAR, proxy, barService,
                 List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressBar)).build()), Optional.of(filter)));
         clusterBar = updateStatusObservedGeneration(clusterBar);
         Set<VirtualKafkaCluster> clusters = Set.of(clusterBar);
@@ -1077,7 +1086,7 @@ public class KafkaProxyReconcilerIT {
     }
 
     private ProxyConfigAssert assertProxyConfigInConfigMap(KafkaProxy proxy) {
-        var configMap = operator.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
+        var configMap = clusterUser.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
         return assertThat(configMap)
                 .isNotNull()
                 .extracting(ConfigMap::getData, InstanceOfAssertFactories.map(String.class, String.class))
@@ -1199,7 +1208,7 @@ public class KafkaProxyReconcilerIT {
     private void assertDeploymentBecomesReady(KafkaProxy proxy) {
         // wait longer for initial operator image download
         AWAIT.alias("Deployment as expected").untilAsserted(() -> {
-            var deployment = operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
+            var deployment = clusterUser.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
             assertThat(deployment)
                     .describedAs("All deployment replicas should become ready")
                     .returns(true, Readiness::isDeploymentReady);
@@ -1211,7 +1220,7 @@ public class KafkaProxyReconcilerIT {
             String clusterName = name(cluster);
             String ingressName = name(ingress);
             String serviceName = clusterName + "-" + ingressName + "-bootstrap";
-            var service = operator.get(Service.class, serviceName);
+            var service = clusterUser.get(Service.class, serviceName);
             assertThat(service).isNotNull()
                     .describedAs(
                             "Expect Service for cluster '" + clusterName + "' and ingress '" + ingressName + "' to still exist")
@@ -1236,7 +1245,7 @@ public class KafkaProxyReconcilerIT {
 
     private <T> void assertDeploymentMounts(KafkaProxy proxy, Function<Volume, T> volumeSourceExtractor, Predicate<T> volumeSourcePredicate) {
         AWAIT.alias("Deployment as expected").untilAsserted(() -> {
-            var deployment = operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
+            var deployment = clusterUser.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
             assertThat(deployment).isNotNull()
                     .extracting(dep -> dep.getSpec().getTemplate().getSpec().getVolumes(), InstanceOfAssertFactories.list(Volume.class))
                     .describedAs("Deployment template should mount the proxy config configmap")
@@ -1248,7 +1257,7 @@ public class KafkaProxyReconcilerIT {
 
     private Deployment assertDeploymentReplicaCount(KafkaProxy proxy, int expectedReplicaCount) {
         AtomicReference<Deployment> actualDeployment = new AtomicReference<>();
-        AWAIT.alias("Deployment as expected").untilAsserted(() -> operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy)),
+        AWAIT.alias("Deployment as expected").untilAsserted(() -> clusterUser.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy)),
                 deployment -> {
                     assertThat(deployment).isNotNull();
                     assertThat(deployment.getSpec())
@@ -1260,7 +1269,7 @@ public class KafkaProxyReconcilerIT {
     }
 
     private void assertDeploymentResourcesEqual(KafkaProxy proxy, ResourceRequirements resourceRequirements) {
-        AWAIT.alias("Deployment as expected").untilAsserted(() -> operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy)),
+        AWAIT.alias("Deployment as expected").untilAsserted(() -> clusterUser.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy)),
                 deployment -> {
                     assertThat(deployment).isNotNull();
                     assertThat(deployment.getSpec())
@@ -1273,7 +1282,7 @@ public class KafkaProxyReconcilerIT {
 
     private void assertStausReplicaCount(KafkaProxy proxy, int expectedReplicaCount) {
         AWAIT.alias("Deployment as expected").untilAsserted(() -> {
-            var deployment = operator.get(KafkaProxy.class, ResourcesUtil.name(proxy));
+            var deployment = clusterUser.get(KafkaProxy.class, ResourcesUtil.name(proxy));
             assertThat(deployment).isNotNull()
                     .extracting(KafkaProxy::getStatus, AssertFactory.status())
                     .isNotNull()
@@ -1297,19 +1306,19 @@ public class KafkaProxyReconcilerIT {
     void testDelete() {
         var createdResources = doCreate();
         KafkaProxy proxy = createdResources.proxy;
-        operator.delete(proxy);
+        clusterUser.delete(proxy);
 
         AWAIT.alias("ConfigMap was deleted").untilAsserted(() -> {
-            var configMap = operator.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
+            var configMap = clusterUser.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
             assertThat(configMap).isNull();
         });
         AWAIT.alias("Deployment was deleted").untilAsserted(() -> {
-            var deployment = operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
+            var deployment = clusterUser.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
             assertThat(deployment).isNull();
         });
         AWAIT.alias("Services were deleted").untilAsserted(() -> {
             for (var cluster : createdResources.clusters) {
-                var service = operator.get(Service.class, ClusterServiceDependentResource.serviceName(cluster));
+                var service = clusterUser.get(Service.class, ClusterServiceDependentResource.serviceName(cluster));
                 assertThat(service).isNull();
             }
         });
@@ -1320,7 +1329,7 @@ public class KafkaProxyReconcilerIT {
         final var createdResources = doCreate();
         KafkaProxy proxy = createdResources.proxy;
         var kafkaService = createdResources.kafkaService().edit().editSpec().withBootstrapServers(NEW_BOOTSTRAP).endSpec().build();
-        kafkaService = operator.replace(kafkaService);
+        kafkaService = clusterUser.replace(kafkaService);
         updateStatusObservedGeneration(kafkaService, NEW_BOOTSTRAP);
 
         assertDeploymentBecomesReady(proxy);
@@ -1338,13 +1347,13 @@ public class KafkaProxyReconcilerIT {
         KafkaProxy proxy = createdResources.proxy;
 
         String newClusterRefName = "new-cluster-ref";
-        updateStatusObservedGeneration(operator.create(kafkaService(newClusterRefName, NEW_BOOTSTRAP)), NEW_BOOTSTRAP);
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(newClusterRefName, NEW_BOOTSTRAP)), NEW_BOOTSTRAP);
 
         KafkaServiceRef newClusterRef = new KafkaServiceRefBuilder().withName(newClusterRefName).build();
         var cluster = createdResources.cluster().edit().editSpec().withTargetKafkaServiceRef(newClusterRef).endSpec().build();
 
         // when
-        cluster = operator.replace(cluster);
+        cluster = clusterUser.replace(cluster);
         updateStatusObservedGeneration(cluster);
 
         // then
@@ -1360,15 +1369,15 @@ public class KafkaProxyReconcilerIT {
     void testDeleteVirtualCluster() {
         final var createdResources = doCreate();
         KafkaProxy proxy = createdResources.proxy;
-        operator.delete(createdResources.cluster());
+        clusterUser.delete(createdResources.cluster());
 
         AWAIT.untilAsserted(() -> {
-            var configMap = operator.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
+            var configMap = clusterUser.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
             assertThat(configMap)
                     .describedAs("Expect ConfigMap for cluster 'bar' to have been deleted")
                     .isNull();
 
-            var service = operator.get(Service.class, CLUSTER_BAR);
+            var service = clusterUser.get(Service.class, CLUSTER_BAR);
             assertThat(service)
                     .describedAs("Expect Service for cluster 'bar' to have been deleted")
                     .isNull();
@@ -1378,19 +1387,19 @@ public class KafkaProxyReconcilerIT {
     @Test
     void moveVirtualKafkaClusterToAnotherKafkaProxy() {
         // given
-        KafkaProxy proxyA = operator.create(kafkaProxy(PROXY_A));
-        KafkaProxy proxyB = operator.create(kafkaProxy(PROXY_B));
-        KafkaProxyIngress ingressFoo = updateStatusObservedGeneration(operator.create(clusterIpIngress(CLUSTER_FOO_CLUSTERIP_INGRESS, proxyA, TCP)));
-        KafkaProxyIngress ingressBar = updateStatusObservedGeneration(operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxyB, TCP)));
+        KafkaProxy proxyA = clusterUser.create(kafkaProxy(PROXY_A));
+        KafkaProxy proxyB = clusterUser.create(kafkaProxy(PROXY_B));
+        KafkaProxyIngress ingressFoo = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_FOO_CLUSTERIP_INGRESS, proxyA, TCP)));
+        KafkaProxyIngress ingressBar = updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxyB, TCP)));
 
-        KafkaService fooService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_FOO_REF, CLUSTER_FOO_BOOTSTRAP)), CLUSTER_FOO_BOOTSTRAP);
-        KafkaService barService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
-        KafkaProtocolFilter filter = updateStatusObservedGeneration(operator.create(filter(FILTER_NAME)));
+        KafkaService fooService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_FOO_REF, CLUSTER_FOO_BOOTSTRAP)), CLUSTER_FOO_BOOTSTRAP);
+        KafkaService barService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        KafkaProtocolFilter filter = updateStatusObservedGeneration(clusterUser.create(filter(FILTER_NAME)));
 
-        VirtualKafkaCluster fooCluster = operator.create(virtualKafkaCluster(CLUSTER_FOO, proxyA, fooService,
+        VirtualKafkaCluster fooCluster = clusterUser.create(virtualKafkaCluster(CLUSTER_FOO, proxyA, fooService,
                 List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressFoo)).build()), Optional.of(filter)));
         updateStatusObservedGeneration(fooCluster);
-        VirtualKafkaCluster barCluster = operator.create(virtualKafkaCluster(CLUSTER_BAR, proxyB, barService,
+        VirtualKafkaCluster barCluster = clusterUser.create(virtualKafkaCluster(CLUSTER_BAR, proxyB, barService,
                 List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressBar)).build()), Optional.of(filter)));
         updateStatusObservedGeneration(barCluster);
 
@@ -1400,17 +1409,17 @@ public class KafkaProxyReconcilerIT {
         assertServiceTargetsProxyInstances(proxyB, barCluster, ingressBar);
 
         // must swap ingresses so both proxy instances have a single port-per-broker ingress
-        updateStatusObservedGeneration(operator.replace(clusterIpIngress(CLUSTER_FOO_CLUSTERIP_INGRESS, proxyB, TCP)));
-        updateStatusObservedGeneration(operator.replace(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxyA, TCP)));
-        var updatedFooCluster = new VirtualKafkaClusterBuilder(operator.get(VirtualKafkaCluster.class, CLUSTER_FOO)).editSpec().editProxyRef().withName(name(proxyB))
+        updateStatusObservedGeneration(clusterUser.replace(clusterIpIngress(CLUSTER_FOO_CLUSTERIP_INGRESS, proxyB, TCP)));
+        updateStatusObservedGeneration(clusterUser.replace(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxyA, TCP)));
+        var updatedFooCluster = new VirtualKafkaClusterBuilder(clusterUser.get(VirtualKafkaCluster.class, CLUSTER_FOO)).editSpec().editProxyRef().withName(name(proxyB))
                 .endProxyRef().endSpec()
                 .build();
-        updatedFooCluster = operator.replace(updatedFooCluster);
+        updatedFooCluster = clusterUser.replace(updatedFooCluster);
         updateStatusObservedGeneration(updatedFooCluster);
-        var updatedBarCluster = new VirtualKafkaClusterBuilder(operator.get(VirtualKafkaCluster.class, CLUSTER_BAR)).editSpec().editProxyRef().withName(name(proxyA))
+        var updatedBarCluster = new VirtualKafkaClusterBuilder(clusterUser.get(VirtualKafkaCluster.class, CLUSTER_BAR)).editSpec().editProxyRef().withName(name(proxyA))
                 .endProxyRef().endSpec()
                 .build();
-        updatedBarCluster = operator.replace(updatedBarCluster);
+        updatedBarCluster = clusterUser.replace(updatedBarCluster);
         updateStatusObservedGeneration(updatedBarCluster);
 
         // then
@@ -1427,30 +1436,30 @@ public class KafkaProxyReconcilerIT {
     @Test
     void deleteAndRestoreADependency() {
         // given
-        KafkaProxy proxyA = operator.create(kafkaProxy(PROXY_A));
+        KafkaProxy proxyA = clusterUser.create(kafkaProxy(PROXY_A));
 
         KafkaProxyIngress ingress = clusterIpIngress(CLUSTER_FOO_CLUSTERIP_INGRESS, proxyA, TCP);
-        KafkaProxyIngress ingressFoo = updateStatusObservedGeneration(operator.create(ingress.edit().build()));
+        KafkaProxyIngress ingressFoo = updateStatusObservedGeneration(clusterUser.create(ingress.edit().build()));
 
-        KafkaService fooService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_FOO_REF, CLUSTER_FOO_BOOTSTRAP)), CLUSTER_FOO_BOOTSTRAP);
-        KafkaProtocolFilter filter = updateStatusObservedGeneration(operator.create(filter(FILTER_NAME)));
+        KafkaService fooService = updateStatusObservedGeneration(clusterUser.create(kafkaService(CLUSTER_FOO_REF, CLUSTER_FOO_BOOTSTRAP)), CLUSTER_FOO_BOOTSTRAP);
+        KafkaProtocolFilter filter = updateStatusObservedGeneration(clusterUser.create(filter(FILTER_NAME)));
 
         VirtualKafkaCluster fooCluster = updateStatusObservedGeneration(
-                operator.create(virtualKafkaCluster(CLUSTER_FOO, proxyA, fooService, List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressFoo)).build()),
+                clusterUser.create(virtualKafkaCluster(CLUSTER_FOO, proxyA, fooService, List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressFoo)).build()),
                         Optional.of(filter))));
 
         assertProxyConfigContents(proxyA, Set.of(CLUSTER_FOO_BOOTSTRAP), Set.of());
         assertServiceTargetsProxyInstances(proxyA, fooCluster, ingressFoo);
 
         // when
-        operator.delete(ingressFoo);
+        clusterUser.delete(ingressFoo);
 
         // then
         assertDeploymentIsRemoved(proxyA);
 
         // and when
         // we need an ingress without uid/resourceVersion in its metadata, so we clone an unadulterated ingress
-        updateStatusObservedGeneration(operator.create(ingress.edit().build()));
+        updateStatusObservedGeneration(clusterUser.create(ingress.edit().build()));
 
         // and then
         assertDeploymentBecomesReady(proxyA);
@@ -1489,11 +1498,11 @@ public class KafkaProxyReconcilerIT {
     private void assertDeploymentIsRemoved(KafkaProxy proxy) {
         // wait longer for initial operator image download
         AWAIT.alias("Deployment is removed")
-                .untilAsserted(() -> assertThat(operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy))).isNull());
+                .untilAsserted(() -> assertThat(clusterUser.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy))).isNull());
     }
 
     private AbstractStringAssert<?> assertThatProxyConfigFor(KafkaProxy proxy) {
-        var configMap = operator.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
+        var configMap = clusterUser.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
         return assertThat(configMap)
                 .isNotNull()
                 .extracting(ConfigMap::getData, InstanceOfAssertFactories.map(String.class, String.class))

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
@@ -89,14 +89,9 @@ import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.NodeIdRangesBuil
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.Ingresses;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressesBuilder;
 import io.kroxylicious.kubernetes.operator.Annotations;
-import io.kroxylicious.testing.operator.ClusterUser;
-import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.SecureConfigInterpolator;
 import io.kroxylicious.kubernetes.operator.TestKeyMaterial;
-import io.kroxylicious.kubernetes.operator.assertj.AssertFactory;
-import io.kroxylicious.kubernetes.operator.assertj.OperatorAssertions;
-import io.kroxylicious.kubernetes.operator.assertj.ProxyConfigAssert;
 import io.kroxylicious.kubernetes.operator.model.RouteHostDetails;
 import io.kroxylicious.kubernetes.operator.model.networking.LoadBalancerClusterIngressNetworkingModel;
 import io.kroxylicious.kubernetes.operator.model.networking.RouteClusterIngressNetworkingModel;
@@ -108,6 +103,11 @@ import io.kroxylicious.proxy.config.NetworkDefinition;
 import io.kroxylicious.proxy.config.VirtualCluster;
 import io.kroxylicious.proxy.config.VirtualClusterGateway;
 import io.kroxylicious.proxy.service.HostPort;
+import io.kroxylicious.testing.operator.ClusterUser;
+import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
+import io.kroxylicious.testing.operator.assertj.AssertFactory;
+import io.kroxylicious.testing.operator.assertj.OperatorAssertions;
+import io.kroxylicious.testing.operator.assertj.ProxyConfigAssert;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
@@ -8,7 +8,6 @@ package io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy;
 
 import java.time.Clock;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -20,19 +19,18 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.core.ConditionFactory;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
@@ -61,11 +59,9 @@ import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
 import io.fabric8.openshift.api.model.operator.v1.IngressController;
 import io.fabric8.openshift.api.model.operator.v1.IngressControllerStatus;
-import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 
 import io.kroxylicious.kubernetes.api.common.CertificateRef;
 import io.kroxylicious.kubernetes.api.common.CertificateRefBuilder;
-import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.common.FilterRefBuilder;
 import io.kroxylicious.kubernetes.api.common.IngressRef;
 import io.kroxylicious.kubernetes.api.common.IngressRefBuilder;
@@ -84,7 +80,6 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngressBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngressStatusBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceBuilder;
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceSpec;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceStatusBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
@@ -94,12 +89,13 @@ import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicespec.NodeIdRangesBuil
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.Ingresses;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressesBuilder;
 import io.kroxylicious.kubernetes.operator.Annotations;
-import io.kroxylicious.kubernetes.operator.LocallyRunningOperatorRbacHandler;
-import io.kroxylicious.kubernetes.operator.OperatorTestUtils;
+import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.SecureConfigInterpolator;
-import io.kroxylicious.kubernetes.operator.TestFiles;
 import io.kroxylicious.kubernetes.operator.TestKeyMaterial;
+import io.kroxylicious.kubernetes.operator.assertj.AssertFactory;
+import io.kroxylicious.kubernetes.operator.assertj.OperatorAssertions;
+import io.kroxylicious.kubernetes.operator.assertj.ProxyConfigAssert;
 import io.kroxylicious.kubernetes.operator.model.RouteHostDetails;
 import io.kroxylicious.kubernetes.operator.model.networking.LoadBalancerClusterIngressNetworkingModel;
 import io.kroxylicious.kubernetes.operator.model.networking.RouteClusterIngressNetworkingModel;
@@ -111,16 +107,12 @@ import io.kroxylicious.proxy.config.NetworkDefinition;
 import io.kroxylicious.proxy.config.VirtualCluster;
 import io.kroxylicious.proxy.config.VirtualClusterGateway;
 import io.kroxylicious.proxy.service.HostPort;
-import io.kroxylicious.testing.operator.assertj.AssertFactory;
-import io.kroxylicious.testing.operator.assertj.OperatorAssertions;
-import io.kroxylicious.testing.operator.assertj.ProxyConfigAssert;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 import static io.kroxylicious.kubernetes.api.common.Protocol.TCP;
 import static io.kroxylicious.kubernetes.api.common.Protocol.TLS;
-import static io.kroxylicious.kubernetes.operator.Labels.standardLabels;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.findOnlyResourceNamed;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.generation;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
@@ -129,7 +121,7 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.list;
 import static org.awaitility.Awaitility.await;
 
-@EnabledIf(value = "io.kroxylicious.kubernetes.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
+@EnabledIf(value = "io.kroxylicious.testing.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
 public class KafkaProxyReconcilerIT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProxyReconcilerIT.class);
@@ -151,43 +143,18 @@ public class KafkaProxyReconcilerIT {
 
     private static final ConditionFactory AWAIT = await().timeout(Duration.ofSeconds(60));
     public static final String UPSTREAM_TLS_CERTIFICATE_SECRET_NAME = "upstream-tls-certificate";
-    public static final String CA_BUNDLE = "ca-bundle";
+    public static final String CA_BUNDLE_CONFIG_MAP_NAME = "ca-bundle";
+    public static final String CA_CERT_SECRET_NAME = "ca-secret";
     public static final String TRUSTED_CAS_PEM = "trusted-cas.pem";
     public static final String PROTOCOL_TLS_V1_3 = "TLSv1.3";
     public static final String TLS_CIPHER_SUITE_AES256GCM_SHA384 = "TLS_AES_256_GCM_SHA384";
     // Default ingress controller domain used if we can't detect it from the platform (CRC/MicroShift).
     public static final String DEFAULT_INGRESS_CONTROLLER_DOMAIN = "apps.crc.testing";
 
-    private static final String DEPRECATION_SPEC_MESSAGE = "No spec, please add an empty one. Support for spec-less KafkaProxy resources is deprecated and will be removed in a future release.";
-
-    // the initial operator image pull can take a long time and interfere with the tests
-    @BeforeAll
-    static void preloadOperandImage() {
-        OperatorTestUtils.preloadOperandImage();
-    }
-
     @RegisterExtension
-    static LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler(TestFiles.INSTALL_MANIFESTS_DIR, "*.ClusterRole.*.yaml");
-
-    @RegisterExtension
-    @SuppressWarnings("JUnitMalformedDeclaration") // The beforeAll and beforeEach have the same effect so we can use it as an instance field.
-    LocallyRunOperatorExtension extension = LocallyRunOperatorExtension.builder()
+    static LocalKroxyliciousOperatorExtension operator = LocalKroxyliciousOperatorExtension.builder()
             .withReconciler(new KafkaProxyReconciler(Clock.systemUTC(), SecureConfigInterpolator.DEFAULT_INTERPOLATOR))
-            .withKubernetesClient(rbacHandler.operatorClient())
-            .withAdditionalCustomResourceDefinition(VirtualKafkaCluster.class)
-            .withAdditionalCustomResourceDefinition(KafkaService.class)
-            .withAdditionalCustomResourceDefinition(KafkaProxyIngress.class)
-            .withAdditionalCustomResourceDefinition(KafkaProtocolFilter.class)
-            .waitForNamespaceDeletion(false)
-            .withConfigurationService(x -> x.withCloseClientOnStop(false))
             .build();
-    private final LocallyRunningOperatorRbacHandler.TestActor testActor = rbacHandler.testActor(extension);
-
-    @AfterEach
-    void stopOperator() {
-        extension.getOperator().stop();
-        LOGGER.atInfo().log("Test finished");
-    }
 
     @Test
     void testCreate() {
@@ -369,10 +336,10 @@ public class KafkaProxyReconcilerIT {
         // given — create a proxy with 1 replica and wait for the target resource to exist
         var created = doCreate(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP), kafkaProxy(PROXY_A, 1));
         KafkaProxy proxy = created.proxy();
-        String namespace = extension.getNamespace();
+        String namespace = operator.getNamespace();
         String resourceName = resourceNameFn.apply(proxy);
 
-        AWAIT.alias(resourceName + " to exist").untilAsserted(() -> assertThat(testActor.get(resourceClass, resourceName)).isNotNull());
+        AWAIT.alias(resourceName + " to exist").untilAsserted(() -> assertThat(operator.get(resourceClass, resourceName)).isNotNull());
 
         // when — an external tool applies an SSA patch with its own field manager
         try (var client = new KubernetesClientBuilder().build()) {
@@ -382,15 +349,15 @@ public class KafkaProxyReconcilerIT {
         }
 
         // when — trigger a reconcile by changing the replica count
-        KafkaProxy updatedProxy = Objects.requireNonNull(testActor.get(KafkaProxy.class, name(proxy)))
+        KafkaProxy updatedProxy = Objects.requireNonNull(operator.get(KafkaProxy.class, name(proxy)))
                 .edit().editSpec().withReplicas(2).endSpec().build();
-        testActor.replace(updatedProxy);
+        operator.replace(updatedProxy);
 
         // then — wait for reconcile to complete (observable via Deployment replica change)
         assertDeploymentReplicaCount(proxy, 2);
 
         // then — external annotation must still be present after the operator reconciled
-        assertThat(testActor.get(resourceClass, resourceName))
+        assertThat(operator.get(resourceClass, resourceName))
                 .isNotNull()
                 .extracting(r -> r.getMetadata().getAnnotations(),
                         InstanceOfAssertFactories.map(String.class, String.class))
@@ -445,40 +412,10 @@ public class KafkaProxyReconcilerIT {
     }
 
     @Test
-    void shouldNotIncludeDeprecationWarningInKafkaProxyStatus() {
-        // given
-        int desiredReplicaCount = 3;
-        KafkaService kafkaService = kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP);
-
-        // when
-        var created = doCreate(kafkaService, kafkaProxy(PROXY_A, desiredReplicaCount));
-        assertDeploymentReplicaCount(created.proxy(), desiredReplicaCount);
-
-        // then
-        assertStausReplicaCount(created.proxy(), desiredReplicaCount); // contains its own AWAIT
-        // assertStausReplicaCount already awaited reconciliation above, so the status is current here
-        assertThat(Collections.singleton(created.proxy())).noneSatisfy(this::assertStatusDeprecationWarning);
-    }
-
-    @Test
-    void shouldIncludeDeprecationWarningInKafkaProxyStatus() {
-        // given
-        KafkaService kafkaService = kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP);
-
-        // when
-        var created = doCreate(kafkaService, kafkaProxyNoSpec(PROXY_A));
-
-        // then
-        AWAIT.alias("DeprecationWarning condition present").untilAsserted(() -> {
-            assertThat(Collections.singleton(created.proxy())).allSatisfy(this::assertStatusDeprecationWarning);
-        });
-    }
-
-    @Test
     void testCreateWithKafkaServiceTls() {
         // given
-        testActor.create(tlsKeyAndCertSecret(UPSTREAM_TLS_CERTIFICATE_SECRET_NAME));
-        testActor.create(trustAnchorConfigMap(CA_BUNDLE));
+        operator.create(tlsKeyAndCertSecret(UPSTREAM_TLS_CERTIFICATE_SECRET_NAME));
+        operator.create(trustAnchorConfigMap(CA_BUNDLE_CONFIG_MAP_NAME));
         KafkaService kafkaService = kafkaServiceWithTls();
 
         // when
@@ -492,15 +429,15 @@ public class KafkaProxyReconcilerIT {
                         PROTOCOL_TLS_V1_3,
                         TLS_CIPHER_SUITE_AES256GCM_SHA384),
                 Set.of());
-        assertDeploymentMountsConfigMap(created.proxy(), CA_BUNDLE);
+        assertDeploymentMountsConfigMap(created.proxy(), CA_BUNDLE_CONFIG_MAP_NAME);
         assertDeploymentMountsSecret(created.proxy(), UPSTREAM_TLS_CERTIFICATE_SECRET_NAME);
     }
 
     @Test
     void testCreateWithKafkaServiceTlsUsingTrustAnchorFromSecret() {
         // given
-        testActor.create(tlsKeyAndCertSecret(UPSTREAM_TLS_CERTIFICATE_SECRET_NAME));
-        testActor.create(trustAnchorSecret(CA_BUNDLE));
+        operator.create(tlsKeyAndCertSecret(UPSTREAM_TLS_CERTIFICATE_SECRET_NAME));
+        operator.create(trustAnchorSecret(CA_CERT_SECRET_NAME));
         KafkaService kafkaService = kafkaServiceWithTlsWithTrustAnchorRefAsSecret();
 
         // when
@@ -512,27 +449,27 @@ public class KafkaProxyReconcilerIT {
                         UPSTREAM_TLS_CERTIFICATE_SECRET_NAME,
                         TRUSTED_CAS_PEM),
                 Set.of());
-        assertDeploymentMountsSecret(created.proxy(), CA_BUNDLE);
+        assertDeploymentMountsSecret(created.proxy(), CA_CERT_SECRET_NAME);
         assertDeploymentMountsSecret(created.proxy(), UPSTREAM_TLS_CERTIFICATE_SECRET_NAME);
     }
 
     @Test
     void virtualClusterWithClusterIpIngress() {
         // Given
-        KafkaProxy proxy = testActor.create(kafkaProxy(PROXY_A));
+        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
 
-        KafkaService kafkaService = updateStatusObservedGeneration(testActor.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)));
+        KafkaService kafkaService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
-        KafkaProxyIngress ingress = updateStatusObservedGeneration(testActor.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
+        KafkaProxyIngress ingress = updateStatusObservedGeneration(operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
 
         String downstreamCertSecretName = "downstream-tls-certificate";
-        Secret tlsCert = testActor.create(tlsKeyAndCertSecret(downstreamCertSecretName));
+        Secret tlsCert = operator.create(tlsKeyAndCertSecret(downstreamCertSecretName));
 
         Ingresses build = createIngressForCluster(ingress, tlsCert);
         VirtualKafkaCluster resource = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(build), Optional.empty());
 
         // When
-        updateStatusObservedGeneration(testActor.create(resource));
+        updateStatusObservedGeneration(operator.create(resource));
 
         // Then
         assertProxyConfigContents(proxy, Set.of(downstreamCertSecretName), Set.of());
@@ -542,15 +479,15 @@ public class KafkaProxyReconcilerIT {
     @Test
     void virtualClusterWithClusterIpIngressWithTrustAnchor() {
         // Given
-        KafkaProxy proxy = testActor.create(kafkaProxy(PROXY_A));
+        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
 
-        KafkaService kafkaService = updateStatusObservedGeneration(testActor.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)));
+        KafkaService kafkaService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
-        KafkaProxyIngress ingress = updateStatusObservedGeneration(testActor.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
+        KafkaProxyIngress ingress = updateStatusObservedGeneration(operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
 
-        Secret tlsServerCert = testActor.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
+        Secret tlsServerCert = operator.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
         String downstreamTrustAnchorName = "downstream-tls-trust-anchor";
-        ConfigMap trustAnchor = testActor.create(trustAnchorConfigMap(downstreamTrustAnchorName));
+        ConfigMap trustAnchor = operator.create(trustAnchorConfigMap(downstreamTrustAnchorName));
 
         Ingresses clusterIngress = new IngressesBuilder()
                 .withIngressRef(toIngressRef(ingress))
@@ -563,7 +500,7 @@ public class KafkaProxyReconcilerIT {
         VirtualKafkaCluster resource = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(clusterIngress), Optional.empty());
 
         // When
-        updateStatusObservedGeneration(testActor.create(resource));
+        updateStatusObservedGeneration(operator.create(resource));
 
         // Then
         int clientFacingPort = TlsClusterIPClusterIngressNetworkingModel.CLIENT_FACING_PORT;
@@ -571,8 +508,8 @@ public class KafkaProxyReconcilerIT {
         assertProxyConfigContents(proxy, Set.of(downstreamTrustAnchorName), Set.of());
         String baseServiceName = name(resource) + "-" + name(ingress);
 
-        String expectedBootstrapHost = baseServiceName + "-bootstrap." + extension.getNamespace() + ".svc.cluster.local";
-        String expectedAdvertisedBrokerAddressPattern = baseServiceName + "-$(nodeId)." + extension.getNamespace() + ".svc.cluster.local";
+        String expectedBootstrapHost = baseServiceName + "-bootstrap." + operator.getNamespace() + ".svc.cluster.local";
+        String expectedAdvertisedBrokerAddressPattern = baseServiceName + "-$(nodeId)." + operator.getNamespace() + ".svc.cluster.local";
         AWAIT.alias("proxy config - gateway configured for clusterIP SNI ingress").untilAsserted(() -> assertProxyConfigInConfigMap(proxy)
                 .cluster(name(resource))
                 .gateway(name(ingress))
@@ -593,16 +530,16 @@ public class KafkaProxyReconcilerIT {
     @Test
     void virtualClusterWithMultipleClusterIpIngressWithTrustAnchor() {
         // Given
-        KafkaProxy proxy = testActor.create(kafkaProxy(PROXY_A));
+        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
 
-        KafkaService kafkaService = updateStatusObservedGeneration(testActor.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)));
+        KafkaService kafkaService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
-        KafkaProxyIngress ingress = updateStatusObservedGeneration(testActor.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
-        KafkaProxyIngress ingress2 = updateStatusObservedGeneration(testActor.create(clusterIpIngress("another-cluster-ip", proxy, TLS)));
+        KafkaProxyIngress ingress = updateStatusObservedGeneration(operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
+        KafkaProxyIngress ingress2 = updateStatusObservedGeneration(operator.create(clusterIpIngress("another-cluster-ip", proxy, TLS)));
 
-        Secret tlsServerCert = testActor.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
+        Secret tlsServerCert = operator.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
         String downstreamTrustAnchorName = "downstream-tls-trust-anchor";
-        ConfigMap trustAnchor = testActor.create(trustAnchorConfigMap(downstreamTrustAnchorName));
+        ConfigMap trustAnchor = operator.create(trustAnchorConfigMap(downstreamTrustAnchorName));
 
         Ingresses clusterIngress = new IngressesBuilder()
                 .withIngressRef(toIngressRef(ingress))
@@ -623,7 +560,7 @@ public class KafkaProxyReconcilerIT {
         VirtualKafkaCluster resource = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(clusterIngress, clusterIngress2), Optional.empty());
 
         // When
-        updateStatusObservedGeneration(testActor.create(resource));
+        updateStatusObservedGeneration(operator.create(resource));
 
         // Then
         int clientFacingPort = TlsClusterIPClusterIngressNetworkingModel.CLIENT_FACING_PORT;
@@ -651,8 +588,8 @@ public class KafkaProxyReconcilerIT {
 
     private void assertProxyGatewayConfiguredForTlsClusterIP(String baseServiceName, KafkaProxy proxy, VirtualKafkaCluster resource, KafkaProxyIngress ingress,
                                                              int proxyListenPort, int clientFacingPort) {
-        String expectedBootstrapHost = baseServiceName + "-bootstrap." + extension.getNamespace() + ".svc.cluster.local";
-        String expectedAdvertisedBrokerAddressPattern = baseServiceName + "-$(nodeId)." + extension.getNamespace() + ".svc.cluster.local";
+        String expectedBootstrapHost = baseServiceName + "-bootstrap." + operator.getNamespace() + ".svc.cluster.local";
+        String expectedAdvertisedBrokerAddressPattern = baseServiceName + "-$(nodeId)." + operator.getNamespace() + ".svc.cluster.local";
         AWAIT.alias("proxy config - gateway configured for clusterIP SNI ingress").untilAsserted(() -> assertProxyConfigInConfigMap(proxy)
                 .cluster(name(resource))
                 .gateway(name(ingress))
@@ -662,13 +599,13 @@ public class KafkaProxyReconcilerIT {
     }
 
     private void assertTlsClusterIpServiceManifested(String serviceName, KafkaProxy proxy, int clientFacingPort, int proxyListenPort) {
-        var service = testActor.get(Service.class, serviceName);
+        var service = operator.get(Service.class, serviceName);
         assertThat(service).isNotNull()
                 .describedAs(
                         "Expect Service '" + serviceName + " to exist")
                 .extracting(svc -> svc.getSpec().getSelector())
                 .describedAs("Service's selector should select proxy pods")
-                .isEqualTo(standardLabels(proxy));
+                .isEqualTo(ProxyDeploymentDependentResource.podLabels(proxy));
         assertThat(service.getSpec().getType()).isEqualTo("ClusterIP");
         assertThat(service.getSpec().getPorts()).singleElement().satisfies(onlyPort -> {
             assertThat(onlyPort.getProtocol()).isEqualTo("TCP");
@@ -679,18 +616,18 @@ public class KafkaProxyReconcilerIT {
 
     @Test
     void virtualClusterWithLoadBalancerIngressWithTrustAnchor() {
-        KafkaProxy proxy = testActor.create(kafkaProxy(PROXY_A));
-        KafkaService kafkaService = updateStatusObservedGeneration(testActor.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)));
+        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
+        KafkaService kafkaService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
         String loadbalancerBootstrap = "bootstrap.kafka";
         String loadbalancerBrokerAddressPattern = "broker-$(nodeId).kafka";
         KafkaProxyIngress loadBalancerIngress = updateStatusObservedGeneration(
-                testActor.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS, proxy, loadbalancerBootstrap,
+                operator.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS, proxy, loadbalancerBootstrap,
                         loadbalancerBrokerAddressPattern)));
 
-        Secret tlsServerCert = testActor.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
+        Secret tlsServerCert = operator.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
         String downstreamTrustAnchorName = "downstream-tls-trust-anchor";
-        ConfigMap trustAnchor = testActor.create(trustAnchorConfigMap(downstreamTrustAnchorName));
+        ConfigMap trustAnchor = operator.create(trustAnchorConfigMap(downstreamTrustAnchorName));
 
         Ingresses clusterIngress = new IngressesBuilder()
                 .withIngressRef(toIngressRef(loadBalancerIngress))
@@ -702,20 +639,20 @@ public class KafkaProxyReconcilerIT {
         VirtualKafkaCluster cluster = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(clusterIngress), Optional.empty());
 
         // when
-        updateStatusObservedGeneration(testActor.create(cluster));
+        updateStatusObservedGeneration(operator.create(cluster));
 
         int clientFacingPort = LoadBalancerClusterIngressNetworkingModel.DEFAULT_CLIENT_FACING_LOADBALANCER_PORT;
         int proxyListenPort = ProxyDeploymentDependentResource.SHARED_SNI_PORT;
 
         AWAIT.alias("shared sni service manifested").untilAsserted(() -> {
             String serviceName = name(proxy) + "-sni";
-            var service = testActor.get(Service.class, serviceName);
+            var service = operator.get(Service.class, serviceName);
             assertThat(service).isNotNull()
                     .describedAs(
                             "Expect shared SNI Service for proxy '" + name(proxy) + " to exist")
                     .extracting(svc -> svc.getSpec().getSelector())
                     .describedAs("Service's selector should select proxy pods")
-                    .isEqualTo(standardLabels(proxy));
+                    .isEqualTo(ProxyDeploymentDependentResource.podLabels(proxy));
             assertThat(service.getSpec().getType()).isEqualTo("LoadBalancer");
             // cannot use equality because the ServicePort has a random nodePort assigned to it
             assertThat(service.getSpec().getPorts()).singleElement().satisfies(onlyPort -> {
@@ -739,7 +676,7 @@ public class KafkaProxyReconcilerIT {
 
     private void assertSharedSniPortExposedOnProxyDeployment(KafkaProxy proxy, int proxyListenPort) {
         AWAIT.alias("proxy deployment exposes shared sni port").untilAsserted(() -> {
-            var deployment = testActor.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
+            var deployment = operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
             assertThat(deployment).isNotNull();
             List<Container> containers = deployment.getSpec().getTemplate().getSpec().getContainers();
             assertThat(containers).hasSize(1).singleElement().satisfies(container -> {
@@ -756,33 +693,33 @@ public class KafkaProxyReconcilerIT {
 
     @Test
     void virtualClusterWithLoadBalancerAndClusterIpIngress() {
-        KafkaProxy proxy = testActor.create(kafkaProxy(PROXY_A));
-        KafkaService kafkaService = updateStatusObservedGeneration(testActor.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)));
+        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
+        KafkaService kafkaService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
-        KafkaProxyIngress loadBalancerIngress = updateStatusObservedGeneration(testActor.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS, proxy,
+        KafkaProxyIngress loadBalancerIngress = updateStatusObservedGeneration(operator.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS, proxy,
                 "bootstrap.kafka",
                 "broker-$(nodeId).kafka")));
 
-        Secret loadBalancerTlsServerCert = testActor.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate"));
+        Secret loadBalancerTlsServerCert = operator.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate"));
 
         Ingresses lbIngress = createIngressForCluster(loadBalancerIngress, loadBalancerTlsServerCert);
 
-        Secret clusterIpTlsServerCert = testActor.create(tlsKeyAndCertSecret("clusterip-tls-certificate"));
+        Secret clusterIpTlsServerCert = operator.create(tlsKeyAndCertSecret("clusterip-tls-certificate"));
 
-        KafkaProxyIngress clusterIpIngress = updateStatusObservedGeneration(testActor.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
+        KafkaProxyIngress clusterIpIngress = updateStatusObservedGeneration(operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TLS)));
 
         Ingresses cipIngress = createIngressForCluster(clusterIpIngress, clusterIpTlsServerCert);
 
         VirtualKafkaCluster cluster = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(lbIngress, cipIngress), Optional.empty());
 
         // when
-        updateStatusObservedGeneration(testActor.create(cluster));
+        updateStatusObservedGeneration(operator.create(cluster));
 
         // then
         AWAIT.alias("services manifested").untilAsserted(() -> {
             String sharedSniServiceName = name(proxy) + "-sni";
             String clusterIpServiceName = CLUSTER_BAR + "-" + clusterIpIngress.getMetadata().getName() + "-bootstrap";
-            var services = testActor.resources(Service.class).list().getItems();
+            var services = operator.resources(Service.class).list().getItems();
             assertThat(services)
                     .extracting(service -> service.getMetadata().getName())
                     .contains(sharedSniServiceName, clusterIpServiceName);
@@ -797,26 +734,26 @@ public class KafkaProxyReconcilerIT {
 
     @Test
     void twoVirtualClusterUsingLoadBalancer() {
-        KafkaProxy proxy = testActor.create(kafkaProxy(PROXY_A));
-        KafkaService kafkaService = updateStatusObservedGeneration(testActor.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)));
+        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
+        KafkaService kafkaService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
-        KafkaProxyIngress loadBalancerIngressFoo = updateStatusObservedGeneration(testActor.create(loadBalancerIngress(CLUSTER_FOO_LOADBALANCER_INGRESS, proxy,
+        KafkaProxyIngress loadBalancerIngressFoo = updateStatusObservedGeneration(operator.create(loadBalancerIngress(CLUSTER_FOO_LOADBALANCER_INGRESS, proxy,
                 "bootstrap.foo.kafka",
                 "broker-$(nodeId).foo.kafka")));
 
-        KafkaProxyIngress loadBalancerIngressBar = updateStatusObservedGeneration(testActor.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS, proxy,
+        KafkaProxyIngress loadBalancerIngressBar = updateStatusObservedGeneration(operator.create(loadBalancerIngress(CLUSTER_BAR_LOADBALANCER_INGRESS, proxy,
                 "bootstrap.bar.kafka",
                 "broker-$(nodeId).bar.kafka")));
 
-        Secret loadBalancerTlsServerCertFoo = testActor.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate-foo"));
-        Secret loadBalancerTlsServerCertBar = testActor.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate-bar"));
+        Secret loadBalancerTlsServerCertFoo = operator.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate-foo"));
+        Secret loadBalancerTlsServerCertBar = operator.create(tlsKeyAndCertSecret("loadbalancer-tls-certificate-bar"));
 
         Ingresses lbIngressFoo = createIngressForCluster(loadBalancerIngressFoo, loadBalancerTlsServerCertFoo);
 
         Ingresses lbIngressBar = createIngressForCluster(loadBalancerIngressBar, loadBalancerTlsServerCertBar);
 
-        VirtualKafkaCluster fooCluster = testActor.create(virtualKafkaCluster(CLUSTER_FOO, proxy, kafkaService, List.of(lbIngressFoo), Optional.empty()));
-        VirtualKafkaCluster barCluster = testActor.create(virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(lbIngressBar), Optional.empty()));
+        VirtualKafkaCluster fooCluster = operator.create(virtualKafkaCluster(CLUSTER_FOO, proxy, kafkaService, List.of(lbIngressFoo), Optional.empty()));
+        VirtualKafkaCluster barCluster = operator.create(virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(lbIngressBar), Optional.empty()));
 
         // when
         List.of(fooCluster, barCluster).forEach(this::updateStatusObservedGeneration);
@@ -824,7 +761,7 @@ public class KafkaProxyReconcilerIT {
         // then
         AWAIT.alias("shared sni service manifested").untilAsserted(() -> {
             String sharedSniServiceName = name(proxy) + "-sni";
-            var services = testActor.resources(Service.class).list().getItems();
+            var services = operator.resources(Service.class).list().getItems();
             assertThat(services)
                     .extracting(service -> service.getMetadata().getName())
                     .containsExactly(sharedSniServiceName);
@@ -847,17 +784,17 @@ public class KafkaProxyReconcilerIT {
 
     @Test
     void clusterIpIngressUsesDeclaredNodeIdsOfService() {
-        KafkaProxy proxy = testActor.create(kafkaProxy(PROXY_A));
-        KafkaProtocolFilter filter = testActor.create(filter(FILTER_NAME));
+        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
+        KafkaProtocolFilter filter = operator.create(filter(FILTER_NAME));
         filter = updateStatusObservedGeneration(filter);
-        KafkaService barService = testActor.create(new KafkaServiceBuilder().withNewMetadata().withName(CLUSTER_BAR_REF).endMetadata()
+        KafkaService barService = operator.create(new KafkaServiceBuilder().withNewMetadata().withName(CLUSTER_BAR_REF).endMetadata()
                 .withNewSpec()
                 .withBootstrapServers(CLUSTER_BAR_BOOTSTRAP)
                 .withNodeIdRanges(createNodeIdRanges("brokers", 3L, 4L), createNodeIdRanges("more-brokers", 10L, 10L))
                 .endSpec().build());
-        barService = updateStatusObservedGeneration(barService);
-        KafkaProxyIngress ingressBar = updateStatusObservedGeneration(testActor.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TCP)));
-        VirtualKafkaCluster clusterBar = testActor.create(virtualKafkaCluster(CLUSTER_BAR, proxy, barService,
+        barService = updateStatusObservedGeneration(barService, CLUSTER_BAR_BOOTSTRAP);
+        KafkaProxyIngress ingressBar = updateStatusObservedGeneration(operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TCP)));
+        VirtualKafkaCluster clusterBar = operator.create(virtualKafkaCluster(CLUSTER_BAR, proxy, barService,
                 List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressBar)).build()), Optional.of(filter)));
         updateStatusObservedGeneration(clusterBar);
         clusterBar.setStatus(new VirtualKafkaClusterStatusBuilder().withObservedGeneration(generation(clusterBar)).build());
@@ -867,13 +804,13 @@ public class KafkaProxyReconcilerIT {
             String clusterName = name(clusterBar);
             String ingressName = name(ingressBar);
             String serviceName = clusterName + "-" + ingressName + "-bootstrap";
-            var service = testActor.get(Service.class, serviceName);
+            var service = operator.get(Service.class, serviceName);
             assertThat(service).isNotNull()
                     .describedAs(
                             "Expect Service for cluster '" + clusterName + "' and ingress '" + ingressName + "' to still exist")
                     .extracting(svc -> svc.getSpec().getSelector())
                     .describedAs("Service's selector should select proxy pods")
-                    .isEqualTo(standardLabels(proxy));
+                    .isEqualTo(ProxyDeploymentDependentResource.podLabels(proxy));
             ServicePort bootstrapServicePort = clusterIpServicePort(expectedBootstrapPort);
             ServicePort node0ServicePort = clusterIpServicePort(expectedBootstrapPort + 1);
             ServicePort node1ServicePort = clusterIpServicePort(expectedBootstrapPort + 2);
@@ -882,7 +819,7 @@ public class KafkaProxyReconcilerIT {
         });
 
         AWAIT.alias("deployment pod template configured to expose ports").untilAsserted(() -> {
-            var deployment = testActor.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
+            var deployment = operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
             assertThat(deployment).isNotNull();
             List<Container> containers = deployment.getSpec().getTemplate().getSpec().getContainers();
             assertThat(containers).hasSize(1).singleElement().satisfies(container -> {
@@ -922,12 +859,12 @@ public class KafkaProxyReconcilerIT {
 
     @Test
     void virtualClusterWithOpenshiftRouteIngress() {
-        assumeThat(testActor.supports(Route.class)).withFailMessage("kubernetes server is missing support for resource kind Route").isTrue();
+        assumeThat(supportsRoute()).withFailMessage("kubernetes server is missing support for resource kind Route").isTrue();
 
         // Given
         var domain = getDefaultOpenShiftIngressControllerDomain();
-        KafkaProxy proxy = testActor.create(kafkaProxy(PROXY_A));
-        KafkaService kafkaService = updateStatusObservedGeneration(testActor.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)));
+        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
+        KafkaService kafkaService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
         int proxyListenPort = ProxyDeploymentDependentResource.SHARED_SNI_PORT;
 
@@ -935,27 +872,27 @@ public class KafkaProxyReconcilerIT {
         String routeBootstrap = "$(virtualClusterName)-bootstrap." + domain;
         String routeBrokerAddressPattern = "$(virtualClusterName)-$(nodeId)." + domain;
         KafkaProxyIngress openshiftRouteIngress = updateStatusObservedGeneration(
-                testActor.create(openshiftRouteIngress(ingressName, proxy)));
+                operator.create(openshiftRouteIngress(ingressName, proxy)));
 
         String downstreamCertSecretName = "downstream-tls-certificate";
-        Secret tlsCert = testActor.create(tlsKeyAndCertSecret(downstreamCertSecretName));
+        Secret tlsCert = operator.create(tlsKeyAndCertSecret(downstreamCertSecretName));
 
         Ingresses clusterIngress = createIngressForCluster(openshiftRouteIngress, tlsCert);
         VirtualKafkaCluster cluster = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService, List.of(clusterIngress), Optional.empty());
 
         // When
-        updateStatusObservedGeneration(testActor.create(cluster));
+        updateStatusObservedGeneration(operator.create(cluster));
 
         // Then
         String serviceName = name(cluster) + "-" + name(openshiftRouteIngress) + "-service";
         AWAIT.alias("shared sni service manifested").untilAsserted(() -> {
-            var service = testActor.get(Service.class, serviceName);
+            var service = operator.get(Service.class, serviceName);
             assertThat(service).isNotNull()
                     .describedAs(
                             "Expect shared SNI Service for proxy '" + name(proxy) + " to exist")
                     .extracting(svc -> svc.getSpec().getSelector())
                     .describedAs("Service's selector should select proxy pods")
-                    .isEqualTo(standardLabels(proxy));
+                    .isEqualTo(ProxyDeploymentDependentResource.podLabels(proxy));
             assertThat(service.getSpec().getType()).isEqualTo("ClusterIP");
 
             assertThat(service.getSpec().getPorts()).singleElement().satisfies(onlyPort -> {
@@ -988,19 +925,19 @@ public class KafkaProxyReconcilerIT {
 
     @Test
     void deploymentChecksumUpdatesWhenOpenshiftRouteHostAssigned() {
-        assumeThat(testActor.supports(Route.class))
+        assumeThat(supportsRoute())
                 .withFailMessage("kubernetes server is missing support for resource kind Route").isTrue();
 
         // Given
-        KafkaProxy proxy = testActor.create(kafkaProxy(PROXY_A));
+        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
         KafkaService kafkaService = updateStatusObservedGeneration(
-                testActor.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)));
+                operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
 
         String ingressName = "openshiftroute";
         KafkaProxyIngress openshiftRouteIngress = updateStatusObservedGeneration(
-                testActor.create(openshiftRouteIngress(ingressName, proxy)));
+                operator.create(openshiftRouteIngress(ingressName, proxy)));
 
-        Secret tlsCert = testActor.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
+        Secret tlsCert = operator.create(tlsKeyAndCertSecret("downstream-tls-certificate"));
 
         Ingresses clusterIngress = new IngressesBuilder()
                 .withIngressRef(toIngressRef(openshiftRouteIngress))
@@ -1008,45 +945,29 @@ public class KafkaProxyReconcilerIT {
                 .build();
         VirtualKafkaCluster cluster = virtualKafkaCluster(CLUSTER_BAR, proxy, kafkaService,
                 List.of(clusterIngress), Optional.empty());
-        updateStatusObservedGeneration(testActor.create(cluster));
+        updateStatusObservedGeneration(operator.create(cluster));
 
         String bootstrapRouteName = name(cluster) + "-bootstrap";
-        Route bootstrapRoute = AWAIT.alias("bootstrap route created").until(() -> testActor.get(Route.class, bootstrapRouteName), Objects::nonNull);
+        AWAIT.alias("bootstrap route created").untilAsserted(() -> assertThat(operator.get(Route.class, bootstrapRouteName)).isNotNull());
 
-        var observedChecksum = deploymentPodTemplateChecksum(proxy);
+        String initialChecksum = deploymentPodTemplateChecksum(proxy);
 
-        // When
-
-        // The test is racing with the Ingress controller. We don't know if the ingress
-        // controller will have updated the resource or not yet. We make an update to
-        // the Route that we are certain will be different to that made by the controller
-        // in order to be certain an update is made.
-        //
-        // editStatus() is a non-locking operation that does not retry on 409 Conflict.
-        // See fabric8 kubernetes-client CHANGELOG v5.4.0:
-        // "Added editStatus... to support non-locking status updates"
-        // https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md
-        // We must retry manually when concurrent modifications are expected.
-        AWAIT.alias("update route status")
-                .ignoreExceptionsMatching(e -> e instanceof io.fabric8.kubernetes.client.KubernetesClientException kce && kce.getCode() == 409)
-                .until(() -> {
-                    Route currentRoute = testActor.get(Route.class, bootstrapRouteName);
-                    testActor.resources(Route.class).resource(currentRoute).editStatus(r -> new RouteBuilder(r)
-                            .editOrNewStatus()
-                            .addNewIngress().withHost("different.invalid").endIngress()
-                            .endStatus()
-                            .build());
-                    return true;
-                });
+        // When - OpenShift assigns a host to the bootstrap route
+        Route bootstrapRoute = operator.get(Route.class, bootstrapRouteName);
+        Route routeWithHost = new RouteBuilder(bootstrapRoute)
+                .withNewStatus()
+                .addNewIngress().withHost(bootstrapRouteName + ".apps-crc.testing").endIngress()
+                .endStatus()
+                .build();
+        operator.patchStatus(routeWithHost);
 
         // Then - deployment pod template checksum should change so the proxy is restarted
         AWAIT.alias("deployment checksum updated after route host assignment")
-                .untilAsserted(() -> assertThat(deploymentPodTemplateChecksum(proxy)).isNotEqualTo(observedChecksum));
+                .untilAsserted(() -> assertThat(deploymentPodTemplateChecksum(proxy)).isNotEqualTo(initialChecksum));
     }
 
-    @Nullable
     private String deploymentPodTemplateChecksum(KafkaProxy proxy) {
-        var deployment = testActor.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
+        var deployment = operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
         assertThat(deployment).isNotNull();
         return Optional.ofNullable(deployment.getSpec().getTemplate().getMetadata().getAnnotations())
                 .map(annotations -> annotations.get(Annotations.REFERENT_CHECKSUM_ANNOTATION_KEY))
@@ -1054,7 +975,7 @@ public class KafkaProxyReconcilerIT {
     }
 
     private void assertRouteManifested(String routeName, boolean isBootstrap, KafkaProxy proxy, String serviceName, int targetPort) {
-        var openshiftRoute = testActor.get(Route.class, routeName);
+        var openshiftRoute = operator.get(Route.class, routeName);
         assertThat(openshiftRoute).isNotNull()
                 .describedAs(
                         "Expect Route for proxy '" + name(proxy) + " to exist")
@@ -1125,15 +1046,15 @@ public class KafkaProxyReconcilerIT {
     }
 
     CreatedResources doCreate(KafkaService kafkaService, KafkaProxy kafkaProxy) {
-        KafkaProxy proxy = testActor.create(kafkaProxy);
-        KafkaProtocolFilter filter = testActor.create(filter(FILTER_NAME));
+        KafkaProxy proxy = operator.create(kafkaProxy);
+        KafkaProtocolFilter filter = operator.create(filter(FILTER_NAME));
         filter = updateStatusObservedGeneration(filter);
-        KafkaService barService = testActor.create(kafkaService);
-        barService = updateStatusObservedGeneration(barService);
-        KafkaProxyIngress ingressBar = testActor.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TCP));
+        KafkaService barService = operator.create(kafkaService);
+        barService = updateStatusObservedGeneration(barService, CLUSTER_BAR_BOOTSTRAP);
+        KafkaProxyIngress ingressBar = operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxy, TCP));
         ingressBar = updateStatusObservedGeneration(ingressBar);
         Set<KafkaService> kafkaServices = Set.of(barService);
-        VirtualKafkaCluster clusterBar = testActor.create(virtualKafkaCluster(CLUSTER_BAR, proxy, barService,
+        VirtualKafkaCluster clusterBar = operator.create(virtualKafkaCluster(CLUSTER_BAR, proxy, barService,
                 List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressBar)).build()), Optional.of(filter)));
         clusterBar = updateStatusObservedGeneration(clusterBar);
         Set<VirtualKafkaCluster> clusters = Set.of(clusterBar);
@@ -1157,7 +1078,7 @@ public class KafkaProxyReconcilerIT {
     }
 
     private ProxyConfigAssert assertProxyConfigInConfigMap(KafkaProxy proxy) {
-        var configMap = testActor.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
+        var configMap = operator.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
         return assertThat(configMap)
                 .isNotNull()
                 .extracting(ConfigMap::getData, InstanceOfAssertFactories.map(String.class, String.class))
@@ -1255,7 +1176,11 @@ public class KafkaProxyReconcilerIT {
         // MicroShift has the IngressController API, but no instances of the API, or a namespace of that name.
         // Minikube has neither API nor namespace.
         // The Fabric8 #get API treats absence of resource/namespace/api in the same manner (all return null).
-        var defaultIngressController = testActor.getInNamespace(IngressController.class, ingressControllerName, ingressControllerNamespace);
+        IngressController defaultIngressController;
+        try (var client = new KubernetesClientBuilder().build()) {
+            defaultIngressController = client.resources(IngressController.class)
+                    .inNamespace(ingressControllerNamespace).withName(ingressControllerName).get();
+        }
 
         return Optional.ofNullable(defaultIngressController)
                 .map(IngressController::getStatus)
@@ -1266,10 +1191,16 @@ public class KafkaProxyReconcilerIT {
                 });
     }
 
+    private static boolean supportsRoute() {
+        try (var client = new KubernetesClientBuilder().build()) {
+            return client.supports(Route.class);
+        }
+    }
+
     private void assertDeploymentBecomesReady(KafkaProxy proxy) {
         // wait longer for initial operator image download
         AWAIT.alias("Deployment as expected").untilAsserted(() -> {
-            var deployment = testActor.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
+            var deployment = operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
             assertThat(deployment)
                     .describedAs("All deployment replicas should become ready")
                     .returns(true, Readiness::isDeploymentReady);
@@ -1281,13 +1212,13 @@ public class KafkaProxyReconcilerIT {
             String clusterName = name(cluster);
             String ingressName = name(ingress);
             String serviceName = clusterName + "-" + ingressName + "-bootstrap";
-            var service = testActor.get(Service.class, serviceName);
+            var service = operator.get(Service.class, serviceName);
             assertThat(service).isNotNull()
                     .describedAs(
                             "Expect Service for cluster '" + clusterName + "' and ingress '" + ingressName + "' to still exist")
                     .extracting(svc -> svc.getSpec().getSelector())
                     .describedAs("Service's selector should select proxy pods")
-                    .isEqualTo(standardLabels(proxy));
+                    .isEqualTo(ProxyDeploymentDependentResource.podLabels(proxy));
             assertThat(service.getSpec().getPorts()).describedAs("number of ports").hasSize(4);
         });
     }
@@ -1306,7 +1237,7 @@ public class KafkaProxyReconcilerIT {
 
     private <T> void assertDeploymentMounts(KafkaProxy proxy, Function<Volume, T> volumeSourceExtractor, Predicate<T> volumeSourcePredicate) {
         AWAIT.alias("Deployment as expected").untilAsserted(() -> {
-            var deployment = testActor.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
+            var deployment = operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
             assertThat(deployment).isNotNull()
                     .extracting(dep -> dep.getSpec().getTemplate().getSpec().getVolumes(), InstanceOfAssertFactories.list(Volume.class))
                     .describedAs("Deployment template should mount the proxy config configmap")
@@ -1318,7 +1249,7 @@ public class KafkaProxyReconcilerIT {
 
     private Deployment assertDeploymentReplicaCount(KafkaProxy proxy, int expectedReplicaCount) {
         AtomicReference<Deployment> actualDeployment = new AtomicReference<>();
-        AWAIT.alias("Deployment as expected").untilAsserted(() -> testActor.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy)),
+        AWAIT.alias("Deployment as expected").untilAsserted(() -> operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy)),
                 deployment -> {
                     assertThat(deployment).isNotNull();
                     assertThat(deployment.getSpec())
@@ -1330,7 +1261,7 @@ public class KafkaProxyReconcilerIT {
     }
 
     private void assertDeploymentResourcesEqual(KafkaProxy proxy, ResourceRequirements resourceRequirements) {
-        AWAIT.alias("Deployment as expected").untilAsserted(() -> testActor.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy)),
+        AWAIT.alias("Deployment as expected").untilAsserted(() -> operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy)),
                 deployment -> {
                     assertThat(deployment).isNotNull();
                     assertThat(deployment.getSpec())
@@ -1343,26 +1274,12 @@ public class KafkaProxyReconcilerIT {
 
     private void assertStausReplicaCount(KafkaProxy proxy, int expectedReplicaCount) {
         AWAIT.alias("Deployment as expected").untilAsserted(() -> {
-            var deployment = testActor.get(KafkaProxy.class, ResourcesUtil.name(proxy));
+            var deployment = operator.get(KafkaProxy.class, ResourcesUtil.name(proxy));
             assertThat(deployment).isNotNull()
                     .extracting(KafkaProxy::getStatus, AssertFactory.status())
                     .isNotNull()
                     .replicas(expectedReplicaCount);
         });
-    }
-
-    private void assertStatusDeprecationWarning(KafkaProxy proxy) {
-        var deployment = testActor.get(KafkaProxy.class, ResourcesUtil.name(proxy));
-        assertThat(deployment).isNotNull()
-                .extracting(KafkaProxy::getStatus, AssertFactory.status())
-                .isNotNull()
-                .conditionList()
-                .satisfiesOnlyOnce(condition -> {
-                    assertThat(condition.getType()).isEqualTo(Condition.Type.DeprecationWarning);
-                    assertThat(condition.getStatus()).isEqualTo(Condition.Status.TRUE);
-                    assertThat(condition.getReason()).isEqualTo(Condition.Type.DeprecationWarning.name());
-                    assertThat(condition.getMessage()).isEqualTo(DEPRECATION_SPEC_MESSAGE);
-                });
     }
 
     private void assertProxyConfigContents(KafkaProxy cr, Set<String> contains, Set<String> notContains) {
@@ -1381,19 +1298,19 @@ public class KafkaProxyReconcilerIT {
     void testDelete() {
         var createdResources = doCreate();
         KafkaProxy proxy = createdResources.proxy;
-        testActor.delete(proxy);
+        operator.delete(proxy);
 
         AWAIT.alias("ConfigMap was deleted").untilAsserted(() -> {
-            var configMap = testActor.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
+            var configMap = operator.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
             assertThat(configMap).isNull();
         });
         AWAIT.alias("Deployment was deleted").untilAsserted(() -> {
-            var deployment = testActor.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
+            var deployment = operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
             assertThat(deployment).isNull();
         });
         AWAIT.alias("Services were deleted").untilAsserted(() -> {
             for (var cluster : createdResources.clusters) {
-                var service = testActor.get(Service.class, ClusterServiceDependentResource.serviceName(cluster));
+                var service = operator.get(Service.class, ClusterServiceDependentResource.serviceName(cluster));
                 assertThat(service).isNull();
             }
         });
@@ -1404,8 +1321,8 @@ public class KafkaProxyReconcilerIT {
         final var createdResources = doCreate();
         KafkaProxy proxy = createdResources.proxy;
         var kafkaService = createdResources.kafkaService().edit().editSpec().withBootstrapServers(NEW_BOOTSTRAP).endSpec().build();
-        kafkaService = testActor.replace(kafkaService);
-        updateStatusObservedGeneration(kafkaService);
+        kafkaService = operator.replace(kafkaService);
+        updateStatusObservedGeneration(kafkaService, NEW_BOOTSTRAP);
 
         assertDeploymentBecomesReady(proxy);
         AWAIT.untilAsserted(() -> assertThatProxyConfigFor(proxy)
@@ -1422,13 +1339,13 @@ public class KafkaProxyReconcilerIT {
         KafkaProxy proxy = createdResources.proxy;
 
         String newClusterRefName = "new-cluster-ref";
-        updateStatusObservedGeneration(testActor.create(kafkaService(newClusterRefName, NEW_BOOTSTRAP)));
+        updateStatusObservedGeneration(operator.create(kafkaService(newClusterRefName, NEW_BOOTSTRAP)), NEW_BOOTSTRAP);
 
         KafkaServiceRef newClusterRef = new KafkaServiceRefBuilder().withName(newClusterRefName).build();
         var cluster = createdResources.cluster().edit().editSpec().withTargetKafkaServiceRef(newClusterRef).endSpec().build();
 
         // when
-        cluster = testActor.replace(cluster);
+        cluster = operator.replace(cluster);
         updateStatusObservedGeneration(cluster);
 
         // then
@@ -1444,15 +1361,15 @@ public class KafkaProxyReconcilerIT {
     void testDeleteVirtualCluster() {
         final var createdResources = doCreate();
         KafkaProxy proxy = createdResources.proxy;
-        testActor.delete(createdResources.cluster());
+        operator.delete(createdResources.cluster());
 
         AWAIT.untilAsserted(() -> {
-            var configMap = testActor.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
+            var configMap = operator.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
             assertThat(configMap)
                     .describedAs("Expect ConfigMap for cluster 'bar' to have been deleted")
                     .isNull();
 
-            var service = testActor.get(Service.class, CLUSTER_BAR);
+            var service = operator.get(Service.class, CLUSTER_BAR);
             assertThat(service)
                     .describedAs("Expect Service for cluster 'bar' to have been deleted")
                     .isNull();
@@ -1462,19 +1379,19 @@ public class KafkaProxyReconcilerIT {
     @Test
     void moveVirtualKafkaClusterToAnotherKafkaProxy() {
         // given
-        KafkaProxy proxyA = testActor.create(kafkaProxy(PROXY_A));
-        KafkaProxy proxyB = testActor.create(kafkaProxy(PROXY_B));
-        KafkaProxyIngress ingressFoo = updateStatusObservedGeneration(testActor.create(clusterIpIngress(CLUSTER_FOO_CLUSTERIP_INGRESS, proxyA, TCP)));
-        KafkaProxyIngress ingressBar = updateStatusObservedGeneration(testActor.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxyB, TCP)));
+        KafkaProxy proxyA = operator.create(kafkaProxy(PROXY_A));
+        KafkaProxy proxyB = operator.create(kafkaProxy(PROXY_B));
+        KafkaProxyIngress ingressFoo = updateStatusObservedGeneration(operator.create(clusterIpIngress(CLUSTER_FOO_CLUSTERIP_INGRESS, proxyA, TCP)));
+        KafkaProxyIngress ingressBar = updateStatusObservedGeneration(operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxyB, TCP)));
 
-        KafkaService fooService = updateStatusObservedGeneration(testActor.create(kafkaService(CLUSTER_FOO_REF, CLUSTER_FOO_BOOTSTRAP)));
-        KafkaService barService = updateStatusObservedGeneration(testActor.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)));
-        KafkaProtocolFilter filter = updateStatusObservedGeneration(testActor.create(filter(FILTER_NAME)));
+        KafkaService fooService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_FOO_REF, CLUSTER_FOO_BOOTSTRAP)), CLUSTER_FOO_BOOTSTRAP);
+        KafkaService barService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_BAR_REF, CLUSTER_BAR_BOOTSTRAP)), CLUSTER_BAR_BOOTSTRAP);
+        KafkaProtocolFilter filter = updateStatusObservedGeneration(operator.create(filter(FILTER_NAME)));
 
-        VirtualKafkaCluster fooCluster = testActor.create(virtualKafkaCluster(CLUSTER_FOO, proxyA, fooService,
+        VirtualKafkaCluster fooCluster = operator.create(virtualKafkaCluster(CLUSTER_FOO, proxyA, fooService,
                 List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressFoo)).build()), Optional.of(filter)));
         updateStatusObservedGeneration(fooCluster);
-        VirtualKafkaCluster barCluster = testActor.create(virtualKafkaCluster(CLUSTER_BAR, proxyB, barService,
+        VirtualKafkaCluster barCluster = operator.create(virtualKafkaCluster(CLUSTER_BAR, proxyB, barService,
                 List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressBar)).build()), Optional.of(filter)));
         updateStatusObservedGeneration(barCluster);
 
@@ -1484,17 +1401,17 @@ public class KafkaProxyReconcilerIT {
         assertServiceTargetsProxyInstances(proxyB, barCluster, ingressBar);
 
         // must swap ingresses so both proxy instances have a single port-per-broker ingress
-        updateStatusObservedGeneration(testActor.replace(clusterIpIngress(CLUSTER_FOO_CLUSTERIP_INGRESS, proxyB, TCP)));
-        updateStatusObservedGeneration(testActor.replace(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxyA, TCP)));
-        var updatedFooCluster = new VirtualKafkaClusterBuilder(testActor.get(VirtualKafkaCluster.class, CLUSTER_FOO)).editSpec().editProxyRef().withName(name(proxyB))
+        updateStatusObservedGeneration(operator.replace(clusterIpIngress(CLUSTER_FOO_CLUSTERIP_INGRESS, proxyB, TCP)));
+        updateStatusObservedGeneration(operator.replace(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, proxyA, TCP)));
+        var updatedFooCluster = new VirtualKafkaClusterBuilder(operator.get(VirtualKafkaCluster.class, CLUSTER_FOO)).editSpec().editProxyRef().withName(name(proxyB))
                 .endProxyRef().endSpec()
                 .build();
-        updatedFooCluster = testActor.replace(updatedFooCluster);
+        updatedFooCluster = operator.replace(updatedFooCluster);
         updateStatusObservedGeneration(updatedFooCluster);
-        var updatedBarCluster = new VirtualKafkaClusterBuilder(testActor.get(VirtualKafkaCluster.class, CLUSTER_BAR)).editSpec().editProxyRef().withName(name(proxyA))
+        var updatedBarCluster = new VirtualKafkaClusterBuilder(operator.get(VirtualKafkaCluster.class, CLUSTER_BAR)).editSpec().editProxyRef().withName(name(proxyA))
                 .endProxyRef().endSpec()
                 .build();
-        updatedBarCluster = testActor.replace(updatedBarCluster);
+        updatedBarCluster = operator.replace(updatedBarCluster);
         updateStatusObservedGeneration(updatedBarCluster);
 
         // then
@@ -1511,30 +1428,30 @@ public class KafkaProxyReconcilerIT {
     @Test
     void deleteAndRestoreADependency() {
         // given
-        KafkaProxy proxyA = testActor.create(kafkaProxy(PROXY_A));
+        KafkaProxy proxyA = operator.create(kafkaProxy(PROXY_A));
 
         KafkaProxyIngress ingress = clusterIpIngress(CLUSTER_FOO_CLUSTERIP_INGRESS, proxyA, TCP);
-        KafkaProxyIngress ingressFoo = updateStatusObservedGeneration(testActor.create(ingress.edit().build()));
+        KafkaProxyIngress ingressFoo = updateStatusObservedGeneration(operator.create(ingress.edit().build()));
 
-        KafkaService fooService = updateStatusObservedGeneration(testActor.create(kafkaService(CLUSTER_FOO_REF, CLUSTER_FOO_BOOTSTRAP)));
-        KafkaProtocolFilter filter = updateStatusObservedGeneration(testActor.create(filter(FILTER_NAME)));
+        KafkaService fooService = updateStatusObservedGeneration(operator.create(kafkaService(CLUSTER_FOO_REF, CLUSTER_FOO_BOOTSTRAP)), CLUSTER_FOO_BOOTSTRAP);
+        KafkaProtocolFilter filter = updateStatusObservedGeneration(operator.create(filter(FILTER_NAME)));
 
         VirtualKafkaCluster fooCluster = updateStatusObservedGeneration(
-                testActor.create(virtualKafkaCluster(CLUSTER_FOO, proxyA, fooService, List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressFoo)).build()),
+                operator.create(virtualKafkaCluster(CLUSTER_FOO, proxyA, fooService, List.of(new IngressesBuilder().withIngressRef(toIngressRef(ingressFoo)).build()),
                         Optional.of(filter))));
 
         assertProxyConfigContents(proxyA, Set.of(CLUSTER_FOO_BOOTSTRAP), Set.of());
         assertServiceTargetsProxyInstances(proxyA, fooCluster, ingressFoo);
 
         // when
-        testActor.delete(ingressFoo);
+        operator.delete(ingressFoo);
 
         // then
         assertDeploymentIsRemoved(proxyA);
 
         // and when
         // we need an ingress without uid/resourceVersion in its metadata, so we clone an unadulterated ingress
-        updateStatusObservedGeneration(testActor.create(ingress.edit().build()));
+        updateStatusObservedGeneration(operator.create(ingress.edit().build()));
 
         // and then
         assertDeploymentBecomesReady(proxyA);
@@ -1543,66 +1460,45 @@ public class KafkaProxyReconcilerIT {
     // the KafkaProxyReconciler only operates on Clusters that have been reconciled, ie metadata.status == status.observedGeneration
     private VirtualKafkaCluster updateStatusObservedGeneration(VirtualKafkaCluster clusterBar) {
         // Re-fetch to get the latest resourceVersion - the operator may have reconciled since we created it
-        VirtualKafkaCluster fresh = testActor.get(VirtualKafkaCluster.class, name(clusterBar));
+        VirtualKafkaCluster fresh = operator.get(VirtualKafkaCluster.class, name(clusterBar));
         fresh.setStatus(new VirtualKafkaClusterStatusBuilder().withObservedGeneration(generation(fresh)).build());
-        return testActor.patchStatus(fresh);
+        return operator.patchStatus(fresh);
     }
 
     // the KafkaProxyReconciler only operates on KafkaProtocolFilters that have been reconciled, ie metadata.status == status.observedGeneration
     private KafkaProtocolFilter updateStatusObservedGeneration(KafkaProtocolFilter filter) {
         // Re-fetch to get the latest resourceVersion - the operator may have reconciled since we created it
-        KafkaProtocolFilter fresh = testActor.get(KafkaProtocolFilter.class, name(filter));
+        KafkaProtocolFilter fresh = operator.get(KafkaProtocolFilter.class, name(filter));
         fresh.setStatus(new KafkaProtocolFilterStatusBuilder().withObservedGeneration(generation(fresh)).build());
-        return testActor.patchStatus(fresh);
+        return operator.patchStatus(fresh);
     }
 
     // the KafkaProxyReconciler only operates on KafkaServices that have been reconciled, ie metadata.status == status.observedGeneration
-    private KafkaService updateStatusObservedGeneration(KafkaService service) {
+    private KafkaService updateStatusObservedGeneration(KafkaService service, String bootstrapServers) {
         // Re-fetch to get the latest resourceVersion - the operator may have reconciled since we created it
-        KafkaService fresh = testActor.get(KafkaService.class, name(service));
-
-        String bootstrapServers = Optional.ofNullable(fresh.getSpec())
-                .map(KafkaServiceSpec::getBootstrapServers)
-                .orElseThrow(() -> new IllegalStateException("Expected bootstrapServers in spec"));
-
-        var statusBuilder = new KafkaServiceStatusBuilder().withObservedGeneration(generation(fresh))
-                .withBootstrapServers(bootstrapServers);
-
-        // If TLS is configured in spec, copy it to status (as the reconciler would)
-        Optional.ofNullable(fresh.getSpec())
-                .map(KafkaServiceSpec::getTls)
-                .ifPresent(tls -> {
-                    var tlsStatusBuilder = statusBuilder.withNewTls();
-
-                    // Copy trustAnchorRef, certificateRef, protocols, and cipherSuites from spec to status
-                    tlsStatusBuilder
-                            .withTrustAnchorRef(tls.getTrustAnchorRef())
-                            .withCertificateRef(tls.getCertificateRef())
-                            .withProtocols(tls.getProtocols())
-                            .withCipherSuites(tls.getCipherSuites())
-                            .endTls();
-                });
-
-        fresh.setStatus(statusBuilder.build());
-        return testActor.patchStatus(fresh);
+        KafkaService fresh = operator.get(KafkaService.class, name(service));
+        fresh.setStatus(new KafkaServiceStatusBuilder().withObservedGeneration(generation(fresh))
+                .withBootstrapServers(bootstrapServers)
+                .build());
+        return operator.patchStatus(fresh);
     }
 
     // the KafkaProxyReconciler only operates on KafkaServices that have been reconciled, ie metadata.status == status.observedGeneration
     private KafkaProxyIngress updateStatusObservedGeneration(KafkaProxyIngress ingress) {
         // Re-fetch to get the latest resourceVersion - the operator may have reconciled since we created it
-        KafkaProxyIngress fresh = testActor.get(KafkaProxyIngress.class, name(ingress));
+        KafkaProxyIngress fresh = operator.get(KafkaProxyIngress.class, name(ingress));
         fresh.setStatus(new KafkaProxyIngressStatusBuilder().withObservedGeneration(generation(fresh)).build());
-        return testActor.patchStatus(fresh);
+        return operator.patchStatus(fresh);
     }
 
     private void assertDeploymentIsRemoved(KafkaProxy proxy) {
         // wait longer for initial operator image download
         AWAIT.alias("Deployment is removed")
-                .untilAsserted(() -> assertThat(testActor.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy))).isNull());
+                .untilAsserted(() -> assertThat(operator.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy))).isNull());
     }
 
     private AbstractStringAssert<?> assertThatProxyConfigFor(KafkaProxy proxy) {
-        var configMap = testActor.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
+        var configMap = operator.get(ConfigMap.class, ProxyConfigDependentResource.configMapName(proxy));
         return assertThat(configMap)
                 .isNotNull()
                 .extracting(ConfigMap::getData, InstanceOfAssertFactories.map(String.class, String.class))
@@ -1643,7 +1539,7 @@ public class KafkaProxyReconcilerIT {
                         .endCertificateRef()
                         .withNewTrustAnchorRef()
                             .withNewRef()
-                                .withName(CA_BUNDLE)
+                                .withName(CA_BUNDLE_CONFIG_MAP_NAME)
                             .endRef()
                             .withKey(TRUSTED_CAS_PEM)
                         .endTrustAnchorRef()
@@ -1669,7 +1565,7 @@ public class KafkaProxyReconcilerIT {
                         .endCertificateRef()
                         .withNewTrustAnchorRef()
                             .withNewRef()
-                                .withName(CA_BUNDLE)
+                                .withName(CA_CERT_SECRET_NAME)
                                 .withKind("Secret")
                             .endRef()
                             .withKey(TRUSTED_CAS_PEM)
@@ -1717,16 +1613,6 @@ public class KafkaProxyReconcilerIT {
                 .withNewSpec()
                     .withReplicas(replicaCount)
                 .endSpec()
-                .build();
-        // @formatter:on
-    }
-
-    KafkaProxy kafkaProxyNoSpec(String name) {
-        // @formatter:off
-        return new KafkaProxyBuilder()
-                .withNewMetadata()
-                    .withName(name)
-                .endMetadata()
                 .build();
         // @formatter:on
     }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/OperatorSsaUpgradeIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/OperatorSsaUpgradeIT.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.readiness.Readiness;
 import io.javaoperatorsdk.operator.Operator;
@@ -49,11 +50,11 @@ import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterStatusBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressesBuilder;
-import io.kroxylicious.testing.operator.LocallyRunningOperatorRbacHandler;
-import io.kroxylicious.testing.operator.OperatorTestUtils;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.SecureConfigInterpolator;
 import io.kroxylicious.kubernetes.operator.TestFiles;
+import io.kroxylicious.testing.operator.LocallyRunningOperatorRbacHandler;
+import io.kroxylicious.testing.operator.OperatorTestUtils;
 
 import static io.kroxylicious.kubernetes.operator.Labels.standardLabels;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.generation;
@@ -115,11 +116,13 @@ class OperatorSsaUpgradeIT {
             .withConfigurationService(x -> x.withCloseClientOnStop(false))
             .build();
 
-    private final LocallyRunningOperatorRbacHandler.TestActor testActor = rbacHandler.testActor(legacyExtension);
+    private final KubernetesClient userClient = rbacHandler.userClient();
+    private final LocallyRunningOperatorRbacHandler.TestActor testActor = rbacHandler.testActor(userClient, legacyExtension);
 
     @AfterEach
     void stopLegacyOperator() {
         legacyExtension.getOperator().stop();
+        userClient.close();
     }
 
     @Test

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/OperatorSsaUpgradeIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/OperatorSsaUpgradeIT.java
@@ -10,6 +10,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterEach;
@@ -21,6 +22,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.readiness.Readiness;
 import io.javaoperatorsdk.operator.Operator;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
@@ -47,8 +49,8 @@ import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterStatusBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressesBuilder;
-import io.kroxylicious.kubernetes.operator.LocallyRunningOperatorRbacHandler;
-import io.kroxylicious.kubernetes.operator.OperatorTestUtils;
+import io.kroxylicious.testing.operator.LocallyRunningOperatorRbacHandler;
+import io.kroxylicious.testing.operator.OperatorTestUtils;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.SecureConfigInterpolator;
 import io.kroxylicious.kubernetes.operator.TestFiles;
@@ -66,7 +68,7 @@ import static org.awaitility.Awaitility.await;
  * This test has a short shelf life: once all users have migrated past the
  * non-SSA operator, the upgrade scenario no longer applies.
  */
-@EnabledIf(value = "io.kroxylicious.kubernetes.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
+@EnabledIf(value = "io.kroxylicious.testing.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
 class OperatorSsaUpgradeIT {
 
     private static final String PROXY_NAME = "proxy-a";
@@ -77,7 +79,20 @@ class OperatorSsaUpgradeIT {
 
     @BeforeAll
     static void preloadOperandImage() {
-        OperatorTestUtils.preloadOperandImage();
+        String image = ProxyDeploymentDependentResource.getOperandImage();
+        try (var client = OperatorTestUtils.kubeClient()) {
+            var pod = client.run().withName("preload-operand-image")
+                    .withNewRunConfig()
+                    .withImage(image)
+                    .withRestartPolicy("Never")
+                    .withCommand("ls").done();
+            try {
+                client.resource(pod).waitUntilCondition(Readiness::isPodSucceeded, 2, TimeUnit.MINUTES);
+            }
+            finally {
+                client.resource(pod).delete();
+            }
+        }
     }
 
     @RegisterExtension

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/OperatorSsaUpgradeIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/OperatorSsaUpgradeIT.java
@@ -67,6 +67,10 @@ import static org.awaitility.Awaitility.await;
  * <p>
  * This test has a short shelf life: once all users have migrated past the
  * non-SSA operator, the upgrade scenario no longer applies.
+ * <p>
+ * Not migrated to {@link io.kroxylicious.kubernetes.operator.LocalKroxyliciousOperatorExtension}:
+ * this test requires a dual-operator lifecycle (two operator instances started and stopped
+ * independently within a single test) which the extension does not support.
  */
 @EnabledIf(value = "io.kroxylicious.testing.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
 class OperatorSsaUpgradeIT {

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressReconcilerIT.java
@@ -39,7 +39,7 @@ class KafkaProxyIngressReconcilerIT {
     @RegisterExtension
     static LocalKroxyliciousOperatorExtension operator = LocalKroxyliciousOperatorExtension.builder()
             .withReconciler(new KafkaProxyIngressReconciler(Clock.systemUTC()))
-            .withClusterRoleGlobs("*.ClusterRole.kroxylicious-operator-watched.yaml")
+            .replaceClusterRoleGlobs("*.ClusterRole.kroxylicious-operator-watched.yaml")
             .build();
 
     @Test

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressReconcilerIT.java
@@ -10,6 +10,7 @@ import java.time.Clock;
 import java.time.Duration;
 
 import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -19,6 +20,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngressBuilder;
+import io.kroxylicious.testing.operator.ClusterUser;
 import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.assertj.KafkaProxyIngressStatusAssert;
@@ -42,39 +44,46 @@ class KafkaProxyIngressReconcilerIT {
             .replaceClusterRoleGlobs("*.ClusterRole.kroxylicious-operator-watched.yaml")
             .build();
 
+    private ClusterUser clusterUser;
+
+    @BeforeEach
+    void setUp() {
+        clusterUser = operator.clusterUser();
+    }
+
     @Test
     void testCreateIngressFirst() {
-        KafkaProxyIngress ingressBar = operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
+        KafkaProxyIngress ingressBar = clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
         assertResolvedRefsFalse(ingressBar);
-        operator.create(kafkaProxy(PROXY_A));
+        clusterUser.create(kafkaProxy(PROXY_A));
         assertAllConditionsTrue(ingressBar);
     }
 
     @Test
     void testCreateProxyFirst() {
-        operator.create(kafkaProxy(PROXY_A));
-        KafkaProxyIngress ingressBar = operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
+        clusterUser.create(kafkaProxy(PROXY_A));
+        KafkaProxyIngress ingressBar = clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
         assertAllConditionsTrue(ingressBar);
     }
 
     @Test
     void testDeleteProxy() {
-        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
-        KafkaProxyIngress ingressBar = operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
+        KafkaProxyIngress ingressBar = clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
         assertAllConditionsTrue(ingressBar);
 
-        operator.delete(proxy);
+        clusterUser.delete(proxy);
         assertResolvedRefsFalse(ingressBar);
     }
 
     @Test
     void testSwitchProxy() {
-        operator.create(kafkaProxy(PROXY_A));
-        operator.create(kafkaProxy(PROXY_B));
-        KafkaProxyIngress ingressBar = operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
+        clusterUser.create(kafkaProxy(PROXY_A));
+        clusterUser.create(kafkaProxy(PROXY_B));
+        KafkaProxyIngress ingressBar = clusterUser.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
         assertAllConditionsTrue(ingressBar);
 
-        operator.replace(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_B));
+        clusterUser.replace(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_B));
         assertAllConditionsTrue(ingressBar);
     }
 
@@ -86,7 +95,7 @@ class KafkaProxyIngressReconcilerIT {
 
     private void assertAllConditionsTrue(KafkaProxyIngress ingressBar) {
         AWAIT.alias("IngressStatusConditionsAllTrue").untilAsserted(() -> {
-            var kpi = operator.resources(KafkaProxyIngress.class)
+            var kpi = clusterUser.resources(KafkaProxyIngress.class)
                     .withName(ResourcesUtil.name(ingressBar)).get();
             assertThat(kpi.getStatus()).isNotNull();
             var conditionListAssert = KafkaProxyIngressStatusAssert
@@ -106,7 +115,7 @@ class KafkaProxyIngressReconcilerIT {
 
     private void assertResolvedRefsFalse(KafkaProxyIngress cr) {
         AWAIT.alias("IngressStatusResolvedRefs").untilAsserted(() -> {
-            var kpi = operator.resources(KafkaProxyIngress.class)
+            var kpi = clusterUser.resources(KafkaProxyIngress.class)
                     .withName(ResourcesUtil.name(cr)).get();
             assertThat(kpi.getStatus()).isNotNull();
             KafkaProxyIngressStatusAssert

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressReconcilerIT.java
@@ -20,10 +20,10 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngressBuilder;
+import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.testing.operator.ClusterUser;
 import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
-import io.kroxylicious.kubernetes.operator.ResourcesUtil;
-import io.kroxylicious.kubernetes.operator.assertj.KafkaProxyIngressStatusAssert;
+import io.kroxylicious.testing.operator.assertj.KafkaProxyIngressStatusAssert;
 
 import static io.kroxylicious.kubernetes.api.common.Protocol.TCP;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressReconcilerIT.java
@@ -10,35 +10,25 @@ import java.time.Clock;
 import java.time.Duration;
 
 import org.awaitility.core.ConditionFactory;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 
 import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngressBuilder;
-import io.kroxylicious.kubernetes.operator.LocallyRunningOperatorRbacHandler;
-import io.kroxylicious.kubernetes.operator.OperatorTestUtils;
+import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
-import io.kroxylicious.kubernetes.operator.TestFiles;
-import io.kroxylicious.testing.operator.assertj.KafkaProxyIngressStatusAssert;
+import io.kroxylicious.kubernetes.operator.assertj.KafkaProxyIngressStatusAssert;
 
 import static io.kroxylicious.kubernetes.api.common.Protocol.TCP;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-@EnabledIf(value = "io.kroxylicious.kubernetes.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
+@EnabledIf(value = "io.kroxylicious.testing.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
 class KafkaProxyIngressReconcilerIT {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(KafkaProxyIngressReconcilerIT.class);
 
     private static final String PROXY_A = "proxy-a";
     private static final String PROXY_B = "proxy-b";
@@ -46,66 +36,45 @@ class KafkaProxyIngressReconcilerIT {
 
     private static final ConditionFactory AWAIT = await().timeout(Duration.ofSeconds(60));
 
-    // the initial operator image pull can take a long time and interfere with the tests
-    @BeforeAll
-    static void preloadOperandImage() {
-        OperatorTestUtils.preloadOperandImage();
-    }
-
     @RegisterExtension
-    static LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler(TestFiles.INSTALL_MANIFESTS_DIR,
-            "*.ClusterRole.kroxylicious-operator-watched.yaml");
-
-    @RegisterExtension
-    @SuppressWarnings("JUnitMalformedDeclaration") // The beforeAll and beforeEach have the same effect so we can use it as an instance field.
-    LocallyRunOperatorExtension extension = LocallyRunOperatorExtension.builder()
+    static LocalKroxyliciousOperatorExtension operator = LocalKroxyliciousOperatorExtension.builder()
             .withReconciler(new KafkaProxyIngressReconciler(Clock.systemUTC()))
-            .withKubernetesClient(rbacHandler.operatorClient())
-            .withAdditionalCustomResourceDefinition(KafkaProxy.class)
-            .waitForNamespaceDeletion(false)
-            .withConfigurationService(x -> x.withCloseClientOnStop(false))
+            .withClusterRoleGlobs("*.ClusterRole.kroxylicious-operator-watched.yaml")
             .build();
-    private final LocallyRunningOperatorRbacHandler.TestActor testActor = rbacHandler.testActor(extension);
-
-    @AfterEach
-    void stopOperator() {
-        extension.getOperator().stop();
-        LOGGER.atInfo().log("Test finished");
-    }
 
     @Test
     void testCreateIngressFirst() {
-        KafkaProxyIngress ingressBar = testActor.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
+        KafkaProxyIngress ingressBar = operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
         assertResolvedRefsFalse(ingressBar);
-        testActor.create(kafkaProxy(PROXY_A));
+        operator.create(kafkaProxy(PROXY_A));
         assertAllConditionsTrue(ingressBar);
     }
 
     @Test
     void testCreateProxyFirst() {
-        testActor.create(kafkaProxy(PROXY_A));
-        KafkaProxyIngress ingressBar = testActor.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
+        operator.create(kafkaProxy(PROXY_A));
+        KafkaProxyIngress ingressBar = operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
         assertAllConditionsTrue(ingressBar);
     }
 
     @Test
     void testDeleteProxy() {
-        KafkaProxy proxy = testActor.create(kafkaProxy(PROXY_A));
-        KafkaProxyIngress ingressBar = testActor.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
+        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
+        KafkaProxyIngress ingressBar = operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
         assertAllConditionsTrue(ingressBar);
 
-        testActor.delete(proxy);
+        operator.delete(proxy);
         assertResolvedRefsFalse(ingressBar);
     }
 
     @Test
     void testSwitchProxy() {
-        testActor.create(kafkaProxy(PROXY_A));
-        testActor.create(kafkaProxy(PROXY_B));
-        KafkaProxyIngress ingressBar = testActor.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
+        operator.create(kafkaProxy(PROXY_A));
+        operator.create(kafkaProxy(PROXY_B));
+        KafkaProxyIngress ingressBar = operator.create(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_A));
         assertAllConditionsTrue(ingressBar);
 
-        testActor.replace(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_B));
+        operator.replace(clusterIpIngress(CLUSTER_BAR_CLUSTERIP_INGRESS, PROXY_B));
         assertAllConditionsTrue(ingressBar);
     }
 
@@ -117,7 +86,7 @@ class KafkaProxyIngressReconcilerIT {
 
     private void assertAllConditionsTrue(KafkaProxyIngress ingressBar) {
         AWAIT.alias("IngressStatusConditionsAllTrue").untilAsserted(() -> {
-            var kpi = testActor.resources(KafkaProxyIngress.class)
+            var kpi = operator.resources(KafkaProxyIngress.class)
                     .withName(ResourcesUtil.name(ingressBar)).get();
             assertThat(kpi.getStatus()).isNotNull();
             var conditionListAssert = KafkaProxyIngressStatusAssert
@@ -137,7 +106,7 @@ class KafkaProxyIngressReconcilerIT {
 
     private void assertResolvedRefsFalse(KafkaProxyIngress cr) {
         AWAIT.alias("IngressStatusResolvedRefs").untilAsserted(() -> {
-            var kpi = testActor.resources(KafkaProxyIngress.class)
+            var kpi = operator.resources(KafkaProxyIngress.class)
                     .withName(ResourcesUtil.name(cr)).get();
             assertThat(kpi.getStatus()).isNotNull();
             KafkaProxyIngressStatusAssert

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceBootstrapReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceBootstrapReconcilerIT.java
@@ -54,7 +54,7 @@ class KafkaServiceBootstrapReconcilerIT {
     @RegisterExtension
     static LocalKroxyliciousOperatorExtension operator = LocalKroxyliciousOperatorExtension.builder()
             .withReconciler(new KafkaServiceReconciler(Clock.systemUTC(), sharedInformerManager))
-            .withClusterRoleGlobs("*.ClusterRole.kroxylicious-operator-watched.yaml")
+            .replaceClusterRoleGlobs("*.ClusterRole.kroxylicious-operator-watched.yaml")
             .build();
 
     @Test

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceBootstrapReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceBootstrapReconcilerIT.java
@@ -12,6 +12,7 @@ import java.util.Set;
 
 import org.assertj.core.api.Assertions;
 import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -25,6 +26,7 @@ import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceBuilder;
 import io.kroxylicious.kubernetes.operator.Annotations;
+import io.kroxylicious.testing.operator.ClusterUser;
 import io.kroxylicious.kubernetes.operator.assertj.OperatorAssertions;
 import io.kroxylicious.kubernetes.operator.informer.SharedInformerManager;
 import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
@@ -57,13 +59,20 @@ class KafkaServiceBootstrapReconcilerIT {
             .replaceClusterRoleGlobs("*.ClusterRole.kroxylicious-operator-watched.yaml")
             .build();
 
+    private ClusterUser clusterUser;
+
+    @BeforeEach
+    void setUp() {
+        clusterUser = operator.clusterUser();
+    }
+
     @Test
     void shouldImmediatelyResolveWhenNoReferents() {
         // Given
         KafkaService resource = kafkaService(SERVICE_A, null, null, null);
 
         // When
-        operator.create(resource);
+        clusterUser.create(resource);
 
         // Then
         assertResolvedRefsTrue(resource, FOO_BOOTSTRAP_9090, false);
@@ -72,12 +81,12 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldResolveUpdateToKafkaService() {
         // Given
-        var kafkaService = operator.create(
+        var kafkaService = clusterUser.create(
                 new KafkaServiceBuilder().withNewMetadata().withName(SERVICE_A).endMetadata().withNewSpec().withBootstrapServers(FOO_BOOTSTRAP_9090).endSpec().build());
 
         // When
         final KafkaService updated = kafkaService.edit().editSpec().withBootstrapServers(BAR_BOOTSTRAP_9090).endSpec().build();
-        operator.replace(updated);
+        clusterUser.replace(updated);
 
         // Then
         assertResolvedRefsTrue(updated, BAR_BOOTSTRAP_9090, false);
@@ -89,13 +98,13 @@ class KafkaServiceBootstrapReconcilerIT {
         KafkaService resource = kafkaService(SERVICE_A, SECRET_X, null, null);
 
         // When
-        final KafkaService kafkaService = operator.create(resource);
+        final KafkaService kafkaService = clusterUser.create(resource);
 
         // Then
         assertResolvedRefsFalse(kafkaService, Condition.REASON_REFS_NOT_FOUND, "spec.tls.certificateRef: referenced secret not found");
 
         // And When
-        operator.create(tlsCertificateSecret(SECRET_X));
+        clusterUser.create(tlsCertificateSecret(SECRET_X));
 
         // Then
         assertResolvedRefsTrue(kafkaService, FOO_BOOTSTRAP_9090, true);
@@ -105,8 +114,8 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldUpdateStatusOnceTlsCertificateSecretDeleted() {
         // Given
-        var tlsCertSecret = operator.create(tlsCertificateSecret(SECRET_X));
-        KafkaService resource = operator.create(kafkaService(SERVICE_A, SECRET_X, null, null));
+        var tlsCertSecret = clusterUser.create(tlsCertificateSecret(SECRET_X));
+        KafkaService resource = clusterUser.create(kafkaService(SERVICE_A, SECRET_X, null, null));
         assertResolvedRefsTrue(resource, FOO_BOOTSTRAP_9090, true);
 
         // When
@@ -122,13 +131,13 @@ class KafkaServiceBootstrapReconcilerIT {
         KafkaService resource = kafkaService(SERVICE_A, null, CONFIG_MAP_T, null);
 
         // When
-        final KafkaService kafkaService = operator.create(resource);
+        final KafkaService kafkaService = clusterUser.create(resource);
 
         // Then
         assertResolvedRefsFalse(kafkaService, Condition.REASON_REFS_NOT_FOUND, "spec.tls.trustAnchorRef: referenced configmap not found");
 
         // And When
-        operator.create(trustAnchorConfigMap(CONFIG_MAP_T));
+        clusterUser.create(trustAnchorConfigMap(CONFIG_MAP_T));
 
         // Then
         assertResolvedRefsTrue(kafkaService, FOO_BOOTSTRAP_9090, true);
@@ -141,13 +150,13 @@ class KafkaServiceBootstrapReconcilerIT {
         KafkaService resource = kafkaService(SERVICE_A, null, SECRET_T, "Secret");
 
         // When
-        final KafkaService kafkaService = operator.create(resource);
+        final KafkaService kafkaService = clusterUser.create(resource);
 
         // Then
         assertResolvedRefsFalse(kafkaService, Condition.REASON_REFS_NOT_FOUND, "spec.tls.trustAnchorRef: referenced secret not found");
 
         // And When
-        operator.create(trustAnchorSecret(SECRET_T));
+        clusterUser.create(trustAnchorSecret(SECRET_T));
 
         // Then
         assertResolvedRefsTrue(kafkaService, FOO_BOOTSTRAP_9090, true);
@@ -157,13 +166,13 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldUpdateReferentAnnotationWhenTrustAnchorConfigMapModified() {
         // Given
-        operator.create(trustAnchorConfigMap(CONFIG_MAP_T));
+        clusterUser.create(trustAnchorConfigMap(CONFIG_MAP_T));
         KafkaService resource = kafkaService(SERVICE_A, null, CONFIG_MAP_T, null);
-        final KafkaService kafkaService = operator.create(resource);
+        final KafkaService kafkaService = clusterUser.create(resource);
         String checksum = awaitReferentsChecksumSpecified(resource);
 
         // When
-        operator.replace(trustAnchorConfigMap(CONFIG_MAP_T).edit().addToData("arbitrary", "arbitrary").build());
+        clusterUser.replace(trustAnchorConfigMap(CONFIG_MAP_T).edit().addToData("arbitrary", "arbitrary").build());
 
         // Then
         assertReferentsChecksumNotEqual(kafkaService, checksum);
@@ -172,12 +181,12 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldUpdateReferentAnnotationWhenCertificateSecretModified() {
         // Given
-        operator.create(tlsCertificateSecret(SECRET_X));
-        KafkaService resource = operator.create(kafkaService(SERVICE_A, SECRET_X, null, null));
+        clusterUser.create(tlsCertificateSecret(SECRET_X));
+        KafkaService resource = clusterUser.create(kafkaService(SERVICE_A, SECRET_X, null, null));
         String checksum = awaitReferentsChecksumSpecified(resource);
 
         // When
-        operator.replace(tlsCertificateSecret(SECRET_X).edit().addToData("arbitrary", "whatever").build());
+        clusterUser.replace(tlsCertificateSecret(SECRET_X).edit().addToData("arbitrary", "whatever").build());
 
         // Then
         assertReferentsChecksumNotEqual(resource, checksum);
@@ -186,8 +195,8 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldUpdateStatusOnceTrustAnchorConfigMapDeleted() {
         // Given
-        var trustedCaCerts = operator.create(trustAnchorConfigMap(CONFIG_MAP_T));
-        KafkaService resource = operator.create(kafkaService(SERVICE_A, null, CONFIG_MAP_T, null));
+        var trustedCaCerts = clusterUser.create(trustAnchorConfigMap(CONFIG_MAP_T));
+        KafkaService resource = clusterUser.create(kafkaService(SERVICE_A, null, CONFIG_MAP_T, null));
         assertResolvedRefsTrue(resource, FOO_BOOTSTRAP_9090, true);
 
         // When
@@ -274,7 +283,7 @@ class KafkaServiceBootstrapReconcilerIT {
 
     private void assertResolvedRefsTrue(KafkaService cr, String expectedBootstrap, boolean hasReferents) {
         AWAIT.untilAsserted(() -> {
-            final KafkaService kafkaService = operator.get(KafkaService.class, ResourcesUtil.name(cr));
+            final KafkaService kafkaService = clusterUser.get(KafkaService.class, ResourcesUtil.name(cr));
             Assertions.assertThat(kafkaService).isNotNull();
             Assertions.assertThat(kafkaService.getStatus().getBootstrapServers()).isEqualTo(expectedBootstrap);
             assertThat(kafkaService.getStatus())
@@ -294,14 +303,14 @@ class KafkaServiceBootstrapReconcilerIT {
 
     private String awaitReferentsChecksumSpecified(KafkaService cr) {
         return AWAIT.until(() -> {
-            final KafkaService kafkaService = operator.get(KafkaService.class, ResourcesUtil.name(cr));
+            final KafkaService kafkaService = clusterUser.get(KafkaService.class, ResourcesUtil.name(cr));
             return getReferentChecksum(kafkaService);
         }, s -> !s.equals(NO_CHECKSUM_SPECIFIED));
     }
 
     private void assertReferentsChecksumNotEqual(KafkaService cr, String checksum) {
         AWAIT.untilAsserted(() -> {
-            final KafkaService kafkaService = operator.get(KafkaService.class, ResourcesUtil.name(cr));
+            final KafkaService kafkaService = clusterUser.get(KafkaService.class, ResourcesUtil.name(cr));
             String actualChecksum = getReferentChecksum(kafkaService);
             Assertions.assertThat(actualChecksum).isNotEqualTo(checksum);
         });
@@ -316,7 +325,7 @@ class KafkaServiceBootstrapReconcilerIT {
                                          String reason,
                                          String message) {
         AWAIT.alias("KafkaServiceStatusResolvedRefs").untilAsserted(() -> {
-            var kafkaService = operator.resources(KafkaService.class)
+            var kafkaService = clusterUser.resources(KafkaService.class)
                     .withName(ResourcesUtil.name(cr)).get();
             Assertions.assertThat(kafkaService.getStatus()).isNotNull();
             OperatorAssertions

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceBootstrapReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceBootstrapReconcilerIT.java
@@ -119,7 +119,7 @@ class KafkaServiceBootstrapReconcilerIT {
         assertResolvedRefsTrue(resource, FOO_BOOTSTRAP_9090, true);
 
         // When
-        operator.delete(tlsCertSecret);
+        clusterUser.delete(tlsCertSecret);
 
         // Then
         assertResolvedRefsFalse(resource, Condition.REASON_REFS_NOT_FOUND, "spec.tls.certificateRef: referenced secret not found");
@@ -200,7 +200,7 @@ class KafkaServiceBootstrapReconcilerIT {
         assertResolvedRefsTrue(resource, FOO_BOOTSTRAP_9090, true);
 
         // When
-        operator.delete(trustedCaCerts);
+        clusterUser.delete(trustedCaCerts);
 
         // Then
         assertResolvedRefsFalse(resource, Condition.REASON_REFS_NOT_FOUND, "spec.tls.trustAnchorRef: referenced configmap not found");

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceBootstrapReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceBootstrapReconcilerIT.java
@@ -12,39 +12,34 @@ import java.util.Set;
 
 import org.assertj.core.api.Assertions;
 import org.awaitility.core.ConditionFactory;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
-import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 
 import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceBuilder;
 import io.kroxylicious.kubernetes.operator.Annotations;
-import io.kroxylicious.kubernetes.operator.LocallyRunningOperatorRbacHandler;
-import io.kroxylicious.kubernetes.operator.ResourcesUtil;
-import io.kroxylicious.kubernetes.operator.TestFiles;
+import io.kroxylicious.kubernetes.operator.assertj.OperatorAssertions;
 import io.kroxylicious.kubernetes.operator.informer.SharedInformerManager;
-import io.kroxylicious.testing.operator.assertj.OperatorAssertions;
+import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
+import io.kroxylicious.testing.operator.OperatorTestUtils;
+import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
+import static io.kroxylicious.kubernetes.operator.assertj.OperatorAssertions.assertThat;
 import static io.kroxylicious.kubernetes.operator.checksum.MetadataChecksumGenerator.NO_CHECKSUM_SPECIFIED;
-import static io.kroxylicious.testing.operator.assertj.OperatorAssertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-@EnabledIf(value = "io.kroxylicious.kubernetes.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
+@EnabledIf(value = "io.kroxylicious.testing.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
 class KafkaServiceBootstrapReconcilerIT {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(KafkaServiceBootstrapReconcilerIT.class);
     public static final String FOO_BOOTSTRAP_9090 = "foo.bootstrap:9090";
     private static final String BAR_BOOTSTRAP_9090 = "bar.bootstrap:9090";
     public static final String SERVICE_A = "service-a";
@@ -54,28 +49,13 @@ class KafkaServiceBootstrapReconcilerIT {
 
     private static final ConditionFactory AWAIT = await().timeout(Duration.ofSeconds(60));
 
-    @RegisterExtension
-    static LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler(TestFiles.INSTALL_MANIFESTS_DIR,
-            "*.ClusterRole.kroxylicious-operator-watched.yaml");
+    private static final SharedInformerManager sharedInformerManager = new SharedInformerManager(OperatorTestUtils.kubeClient(), Set.of());
 
-    static final SharedInformerManager sharedInformerManager = new SharedInformerManager(rbacHandler.operatorClient(), Set.of());
-
-    @SuppressWarnings("JUnitMalformedDeclaration") // The beforeAll and beforeEach have the same effect so we can use it as an instance field.
     @RegisterExtension
-    LocallyRunOperatorExtension extension = LocallyRunOperatorExtension.builder()
+    static LocalKroxyliciousOperatorExtension operator = LocalKroxyliciousOperatorExtension.builder()
             .withReconciler(new KafkaServiceReconciler(Clock.systemUTC(), sharedInformerManager))
-            .withKubernetesClient(rbacHandler.operatorClient())
-            .waitForNamespaceDeletion(false)
-            .withConfigurationService(x -> x.withCloseClientOnStop(false))
+            .withClusterRoleGlobs("*.ClusterRole.kroxylicious-operator-watched.yaml")
             .build();
-
-    private final LocallyRunningOperatorRbacHandler.TestActor testActor = rbacHandler.testActor(extension);
-
-    @AfterEach
-    void stopOperator() {
-        extension.getOperator().stop();
-        LOGGER.atInfo().log("Test finished");
-    }
 
     @Test
     void shouldImmediatelyResolveWhenNoReferents() {
@@ -83,7 +63,7 @@ class KafkaServiceBootstrapReconcilerIT {
         KafkaService resource = kafkaService(SERVICE_A, null, null, null);
 
         // When
-        testActor.create(resource);
+        operator.create(resource);
 
         // Then
         assertResolvedRefsTrue(resource, FOO_BOOTSTRAP_9090, false);
@@ -92,18 +72,15 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldResolveUpdateToKafkaService() {
         // Given
-        var kafkaService = testActor.create(
+        var kafkaService = operator.create(
                 new KafkaServiceBuilder().withNewMetadata().withName(SERVICE_A).endMetadata().withNewSpec().withBootstrapServers(FOO_BOOTSTRAP_9090).endSpec().build());
 
-        assertResolvedRefsTrue(kafkaService, FOO_BOOTSTRAP_9090, false);
-
         // When
-        testActor.resources(KafkaService.class)
-                .withName(SERVICE_A)
-                .edit(current -> new KafkaServiceBuilder(current).withNewSpec().withBootstrapServers(BAR_BOOTSTRAP_9090).endSpec().build());
+        final KafkaService updated = kafkaService.edit().editSpec().withBootstrapServers(BAR_BOOTSTRAP_9090).endSpec().build();
+        operator.replace(updated);
 
         // Then
-        assertResolvedRefsTrue(kafkaService, BAR_BOOTSTRAP_9090, false);
+        assertResolvedRefsTrue(updated, BAR_BOOTSTRAP_9090, false);
     }
 
     @Test
@@ -112,13 +89,13 @@ class KafkaServiceBootstrapReconcilerIT {
         KafkaService resource = kafkaService(SERVICE_A, SECRET_X, null, null);
 
         // When
-        final KafkaService kafkaService = testActor.create(resource);
+        final KafkaService kafkaService = operator.create(resource);
 
         // Then
         assertResolvedRefsFalse(kafkaService, Condition.REASON_REFS_NOT_FOUND, "spec.tls.certificateRef: referenced secret not found");
 
         // And When
-        testActor.create(tlsCertificateSecret(SECRET_X));
+        operator.create(tlsCertificateSecret(SECRET_X));
 
         // Then
         assertResolvedRefsTrue(kafkaService, FOO_BOOTSTRAP_9090, true);
@@ -128,12 +105,12 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldUpdateStatusOnceTlsCertificateSecretDeleted() {
         // Given
-        var tlsCertSecret = testActor.create(tlsCertificateSecret(SECRET_X));
-        KafkaService resource = testActor.create(kafkaService(SERVICE_A, SECRET_X, null, null));
+        var tlsCertSecret = operator.create(tlsCertificateSecret(SECRET_X));
+        KafkaService resource = operator.create(kafkaService(SERVICE_A, SECRET_X, null, null));
         assertResolvedRefsTrue(resource, FOO_BOOTSTRAP_9090, true);
 
         // When
-        testActor.delete(tlsCertSecret);
+        operator.delete(tlsCertSecret);
 
         // Then
         assertResolvedRefsFalse(resource, Condition.REASON_REFS_NOT_FOUND, "spec.tls.certificateRef: referenced secret not found");
@@ -145,13 +122,13 @@ class KafkaServiceBootstrapReconcilerIT {
         KafkaService resource = kafkaService(SERVICE_A, null, CONFIG_MAP_T, null);
 
         // When
-        final KafkaService kafkaService = testActor.create(resource);
+        final KafkaService kafkaService = operator.create(resource);
 
         // Then
         assertResolvedRefsFalse(kafkaService, Condition.REASON_REFS_NOT_FOUND, "spec.tls.trustAnchorRef: referenced configmap not found");
 
         // And When
-        testActor.create(trustAnchorConfigMap(CONFIG_MAP_T));
+        operator.create(trustAnchorConfigMap(CONFIG_MAP_T));
 
         // Then
         assertResolvedRefsTrue(kafkaService, FOO_BOOTSTRAP_9090, true);
@@ -164,13 +141,13 @@ class KafkaServiceBootstrapReconcilerIT {
         KafkaService resource = kafkaService(SERVICE_A, null, SECRET_T, "Secret");
 
         // When
-        final KafkaService kafkaService = testActor.create(resource);
+        final KafkaService kafkaService = operator.create(resource);
 
         // Then
         assertResolvedRefsFalse(kafkaService, Condition.REASON_REFS_NOT_FOUND, "spec.tls.trustAnchorRef: referenced secret not found");
 
         // And When
-        testActor.create(trustAnchorSecret(SECRET_T));
+        operator.create(trustAnchorSecret(SECRET_T));
 
         // Then
         assertResolvedRefsTrue(kafkaService, FOO_BOOTSTRAP_9090, true);
@@ -180,13 +157,13 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldUpdateReferentAnnotationWhenTrustAnchorConfigMapModified() {
         // Given
-        testActor.create(trustAnchorConfigMap(CONFIG_MAP_T));
+        operator.create(trustAnchorConfigMap(CONFIG_MAP_T));
         KafkaService resource = kafkaService(SERVICE_A, null, CONFIG_MAP_T, null);
-        final KafkaService kafkaService = testActor.create(resource);
+        final KafkaService kafkaService = operator.create(resource);
         String checksum = awaitReferentsChecksumSpecified(resource);
 
         // When
-        testActor.replace(trustAnchorConfigMap(CONFIG_MAP_T).edit().addToData("arbitrary", "arbitrary").build());
+        operator.replace(trustAnchorConfigMap(CONFIG_MAP_T).edit().addToData("arbitrary", "arbitrary").build());
 
         // Then
         assertReferentsChecksumNotEqual(kafkaService, checksum);
@@ -195,12 +172,12 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldUpdateReferentAnnotationWhenCertificateSecretModified() {
         // Given
-        testActor.create(tlsCertificateSecret(SECRET_X));
-        KafkaService resource = testActor.create(kafkaService(SERVICE_A, SECRET_X, null, null));
+        operator.create(tlsCertificateSecret(SECRET_X));
+        KafkaService resource = operator.create(kafkaService(SERVICE_A, SECRET_X, null, null));
         String checksum = awaitReferentsChecksumSpecified(resource);
 
         // When
-        testActor.replace(tlsCertificateSecret(SECRET_X).edit().addToData("arbitrary", "whatever").build());
+        operator.replace(tlsCertificateSecret(SECRET_X).edit().addToData("arbitrary", "whatever").build());
 
         // Then
         assertReferentsChecksumNotEqual(resource, checksum);
@@ -209,12 +186,12 @@ class KafkaServiceBootstrapReconcilerIT {
     @Test
     void shouldUpdateStatusOnceTrustAnchorConfigMapDeleted() {
         // Given
-        var trustedCaCerts = testActor.create(trustAnchorConfigMap(CONFIG_MAP_T));
-        KafkaService resource = testActor.create(kafkaService(SERVICE_A, null, CONFIG_MAP_T, null));
+        var trustedCaCerts = operator.create(trustAnchorConfigMap(CONFIG_MAP_T));
+        KafkaService resource = operator.create(kafkaService(SERVICE_A, null, CONFIG_MAP_T, null));
         assertResolvedRefsTrue(resource, FOO_BOOTSTRAP_9090, true);
 
         // When
-        testActor.delete(trustedCaCerts);
+        operator.delete(trustedCaCerts);
 
         // Then
         assertResolvedRefsFalse(resource, Condition.REASON_REFS_NOT_FOUND, "spec.tls.trustAnchorRef: referenced configmap not found");
@@ -297,12 +274,10 @@ class KafkaServiceBootstrapReconcilerIT {
 
     private void assertResolvedRefsTrue(KafkaService cr, String expectedBootstrap, boolean hasReferents) {
         AWAIT.untilAsserted(() -> {
-            final KafkaService kafkaService = testActor.get(KafkaService.class, ResourcesUtil.name(cr));
+            final KafkaService kafkaService = operator.get(KafkaService.class, ResourcesUtil.name(cr));
             Assertions.assertThat(kafkaService).isNotNull();
-            var status = kafkaService.getStatus();
-            Assertions.assertThat(status).isNotNull();
-            Assertions.assertThat(status.getBootstrapServers()).isEqualTo(expectedBootstrap);
-            assertThat(status)
+            Assertions.assertThat(kafkaService.getStatus().getBootstrapServers()).isEqualTo(expectedBootstrap);
+            assertThat(kafkaService.getStatus())
                     .isNotNull()
                     .conditionList()
                     .singleElement()
@@ -319,14 +294,14 @@ class KafkaServiceBootstrapReconcilerIT {
 
     private String awaitReferentsChecksumSpecified(KafkaService cr) {
         return AWAIT.until(() -> {
-            final KafkaService kafkaService = testActor.get(KafkaService.class, ResourcesUtil.name(cr));
+            final KafkaService kafkaService = operator.get(KafkaService.class, ResourcesUtil.name(cr));
             return getReferentChecksum(kafkaService);
         }, s -> !s.equals(NO_CHECKSUM_SPECIFIED));
     }
 
     private void assertReferentsChecksumNotEqual(KafkaService cr, String checksum) {
         AWAIT.untilAsserted(() -> {
-            final KafkaService kafkaService = testActor.get(KafkaService.class, ResourcesUtil.name(cr));
+            final KafkaService kafkaService = operator.get(KafkaService.class, ResourcesUtil.name(cr));
             String actualChecksum = getReferentChecksum(kafkaService);
             Assertions.assertThat(actualChecksum).isNotEqualTo(checksum);
         });
@@ -341,7 +316,7 @@ class KafkaServiceBootstrapReconcilerIT {
                                          String reason,
                                          String message) {
         AWAIT.alias("KafkaServiceStatusResolvedRefs").untilAsserted(() -> {
-            var kafkaService = testActor.resources(KafkaService.class)
+            var kafkaService = operator.resources(KafkaService.class)
                     .withName(ResourcesUtil.name(cr)).get();
             Assertions.assertThat(kafkaService.getStatus()).isNotNull();
             OperatorAssertions

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceBootstrapReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceBootstrapReconcilerIT.java
@@ -26,17 +26,17 @@ import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceBuilder;
 import io.kroxylicious.kubernetes.operator.Annotations;
-import io.kroxylicious.testing.operator.ClusterUser;
-import io.kroxylicious.kubernetes.operator.assertj.OperatorAssertions;
+import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.informer.SharedInformerManager;
+import io.kroxylicious.testing.operator.ClusterUser;
 import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
 import io.kroxylicious.testing.operator.OperatorTestUtils;
-import io.kroxylicious.kubernetes.operator.ResourcesUtil;
+import io.kroxylicious.testing.operator.assertj.OperatorAssertions;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
-import static io.kroxylicious.kubernetes.operator.assertj.OperatorAssertions.assertThat;
 import static io.kroxylicious.kubernetes.operator.checksum.MetadataChecksumGenerator.NO_CHECKSUM_SPECIFIED;
+import static io.kroxylicious.testing.operator.assertj.OperatorAssertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 @EnabledIf(value = "io.kroxylicious.testing.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
@@ -57,7 +57,7 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
     @RegisterExtension
     static LocalKroxyliciousOperatorExtension operator = LocalKroxyliciousOperatorExtension.builder()
             .withReconciler(new KafkaServiceReconciler(Clock.systemUTC(), sharedInformerManager))
-            .withClusterRoleGlobs("*.ClusterRole.kroxylicious-operator-watched.yaml")
+            .replaceClusterRoleGlobs("*.ClusterRole.kroxylicious-operator-watched.yaml")
             .withSetupAction(() -> {
                 try (KubernetesClient client = OperatorTestUtils.kubeClient()) {
                     client.apiextensions().v1().customResourceDefinitions().resource(Crds.kafka()).createOr(Updatable::update);

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
@@ -31,15 +31,15 @@ import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceBuilder;
 import io.kroxylicious.kubernetes.operator.Annotations;
-import io.kroxylicious.kubernetes.operator.assertj.OperatorAssertions;
-import io.kroxylicious.kubernetes.operator.informer.SharedInformerManager;
-import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
-import io.kroxylicious.testing.operator.ClusterUser;
-import io.kroxylicious.testing.operator.OperatorTestUtils;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
+import io.kroxylicious.kubernetes.operator.informer.SharedInformerManager;
+import io.kroxylicious.testing.operator.ClusterUser;
+import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
+import io.kroxylicious.testing.operator.OperatorTestUtils;
+import io.kroxylicious.testing.operator.assertj.OperatorAssertions;
 
-import static io.kroxylicious.kubernetes.operator.assertj.OperatorAssertions.assertThat;
 import static io.kroxylicious.kubernetes.operator.checksum.MetadataChecksumGenerator.NO_CHECKSUM_SPECIFIED;
+import static io.kroxylicious.testing.operator.assertj.OperatorAssertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 @EnabledIf(value = "io.kroxylicious.testing.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
@@ -8,125 +8,148 @@ package io.kroxylicious.kubernetes.operator.reconciler.kafkaservice;
 
 import java.time.Clock;
 import java.time.Duration;
+import java.util.List;
 import java.util.Set;
 
 import org.assertj.core.api.Assertions;
 import org.awaitility.core.ConditionFactory;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
-import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.api.model.SecretBuilder;
-import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.Updatable;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.kafka.Kafka;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.GenericKafkaListenerBuilder;
+import io.strimzi.api.kafka.model.kafka.listener.ListenerAddressBuilder;
 import io.strimzi.api.kafka.model.kafka.listener.ListenerStatusBuilder;
 
 import io.kroxylicious.kubernetes.api.common.Condition;
-import io.kroxylicious.kubernetes.api.common.TrustAnchorRef;
-import io.kroxylicious.kubernetes.api.common.TrustAnchorRefBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceBuilder;
-import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceStatus;
-import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicestatus.Tls;
 import io.kroxylicious.kubernetes.operator.Annotations;
-import io.kroxylicious.kubernetes.operator.LocallyRunningOperatorRbacHandler;
-import io.kroxylicious.kubernetes.operator.ResourcesUtil;
-import io.kroxylicious.kubernetes.operator.TestFiles;
+import io.kroxylicious.kubernetes.operator.assertj.OperatorAssertions;
 import io.kroxylicious.kubernetes.operator.informer.SharedInformerManager;
-import io.kroxylicious.testing.operator.assertj.OperatorAssertions;
+import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
+import io.kroxylicious.testing.operator.OperatorTestUtils;
+import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
-
-import static io.kroxylicious.kubernetes.operator.ResourcesUtil.STRIMZI_CLUSTER_CA_BUNDLE;
+import static io.kroxylicious.kubernetes.operator.assertj.OperatorAssertions.assertThat;
 import static io.kroxylicious.kubernetes.operator.checksum.MetadataChecksumGenerator.NO_CHECKSUM_SPECIFIED;
-import static io.kroxylicious.testing.operator.assertj.OperatorAssertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-@EnabledIf(value = "io.kroxylicious.kubernetes.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
+@EnabledIf(value = "io.kroxylicious.testing.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
 class KafkaServiceStrimziKafkaRefReconcilerIT {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(KafkaServiceStrimziKafkaRefReconcilerIT.class);
-    public static final String FOO_BOOTSTRAP = "foo.bootstrap";
-    public static final int FOO_BOOTSTRAP_PORT = 9090;
-    public static final String FOO_BOOTSTRAP_9090 = FOO_BOOTSTRAP + ":" + FOO_BOOTSTRAP_PORT;
+    public static final String FOO_BOOTSTRAP_9090 = "foo.bootstrap:9090";
     public static final String SERVICE_A = "service-a";
     public static final String KAFKA_RESOURCE_NAME = "my-cluster";
 
     private static final ConditionFactory AWAIT = await().timeout(Duration.ofSeconds(60));
 
-    @RegisterExtension
-    static LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler(TestFiles.INSTALL_MANIFESTS_DIR,
-            "*.ClusterRole.kroxylicious-operator-watched.yaml");
+    // The Strimzi Kafka CRD must be installed before the operator starts so that KafkaServiceReconciler
+    // can set up its Strimzi Kafka informer during prepareEventSources. Setup/teardown actions run at
+    // the right point in the extension lifecycle to guarantee this ordering.
+    private static final SharedInformerManager sharedInformerManager = new SharedInformerManager(OperatorTestUtils.kubeClient(), Set.of());
 
-    static final SharedInformerManager sharedInformerManager = new SharedInformerManager(rbacHandler.operatorClient(), Set.of());
-
-    @SuppressWarnings("JUnitMalformedDeclaration") // The beforeAll and beforeEach have the same effect so we can use it as an instance field.
     @RegisterExtension
-    LocallyRunOperatorExtension extension = LocallyRunOperatorExtension.builder()
+    static LocalKroxyliciousOperatorExtension operator = LocalKroxyliciousOperatorExtension.builder()
             .withReconciler(new KafkaServiceReconciler(Clock.systemUTC(), sharedInformerManager))
-            .withKubernetesClient(rbacHandler.operatorClient())
-            .waitForNamespaceDeletion(false)
-            .withConfigurationService(x -> x.withCloseClientOnStop(false))
-            .withAdditionalCustomResourceDefinition(Crds.kafka())
+            .withClusterRoleGlobs("*.ClusterRole.kroxylicious-operator-watched.yaml")
+            .withSetupAction(() -> {
+                try (KubernetesClient client = OperatorTestUtils.kubeClient()) {
+                    client.apiextensions().v1().customResourceDefinitions().resource(Crds.kafka()).createOr(Updatable::update);
+                }
+            })
+            .withTeardownAction(() -> {
+                try (KubernetesClient client = OperatorTestUtils.kubeClient()) {
+                    client.apiextensions().v1().customResourceDefinitions().resource(Crds.kafka()).delete();
+                }
+            })
+            .withAdditionalCleanupTypes(Kafka.class)
             .build();
 
-    private final LocallyRunningOperatorRbacHandler.TestActor testActor = rbacHandler.testActor(extension);
-
-    @AfterEach
-    void stopOperator() {
-        extension.getOperator().stop();
-        LOGGER.atInfo().log("Test finished");
-    }
-
     @Test
-    void shouldResolveStrimziKafkaWithPlainListener() {
+    void shouldResolveStrimziKafka() {
         // Given
-        var kafka = testActor.create(kafkaResource(KAFKA_RESOURCE_NAME));
-        reconcileStrimziResource(kafka);
+        var kafka = operator.create(kafkaResource(KAFKA_RESOURCE_NAME));
+        String listenerHost = "foo.bootstrap";
+        int listenerPort = 9090;
+        Kafka withStatus = new KafkaBuilder(kafka)
+                .withNewStatus()
+                .withListeners(
+                        new ListenerStatusBuilder()
+                                .withName("plain")
+                                .withAddresses(new ListenerAddressBuilder()
+                                        .withHost(listenerHost)
+                                        .withPort(listenerPort)
+                                        .build())
+                                .build())
+                .endStatus()
+                .build();
+        operator.patchStatus(withStatus);
 
         // When
-        KafkaService service = testActor.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
+        KafkaService service = operator.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
 
         // Then
         assertResolvedRefsTrue(service, FOO_BOOTSTRAP_9090, true);
     }
 
     @Test
-    void shouldResolveStrimziKafkaWithTlsListener() {
+    void shouldHandleStrimziKafkaWithNoPlainListeners() {
         // Given
-        var kafka = testActor.create(kafkaResourceWithTls(KAFKA_RESOURCE_NAME));
-        reconcileStrimziResource(kafka);
+        String listenerHost = "mylistener";
+        int listenerPort = 9092;
+        Kafka withTlsListener = new KafkaBuilder()
+                .withNewMetadata()
+                .withName(KAFKA_RESOURCE_NAME)
+                .endMetadata()
+                .withNewSpec()
+                .withNewKafka()
+                .withListeners(List.of(new GenericKafkaListenerBuilder()
+                        .withName("tls")
+                        .withTls(true)
+                        .build()))
+                .endKafka()
+                .endSpec()
+                .withNewStatus()
+                .withListeners(
+                        new ListenerStatusBuilder()
+                                .withName("tls")
+                                .withAddresses(new ListenerAddressBuilder()
+                                        .withHost(listenerHost)
+                                        .withPort(listenerPort)
+                                        .build())
+                                .build())
+                .endStatus()
+                .build();
+
+        operator.create(withTlsListener);
 
         // When
-        KafkaService service = testActor.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "tls", KAFKA_RESOURCE_NAME));
+        KafkaService service = operator.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "tls", KAFKA_RESOURCE_NAME));
 
         // Then
-        assertResolvedRefsTrue(service, FOO_BOOTSTRAP_9090, true);
+        assertResolvedRefsFalse(service, Condition.REASON_INVALID_REFERENCED_RESOURCE, "Referenced resource should have listener as `plain`");
     }
 
     @Test
-    void shouldHandleStrimziKafkaWithNoReconciledListeners() {
+    void shouldHandleStrimziKafkaWithNoListeners() {
         // Given
-        var kafka = testActor.create(kafkaResource(KAFKA_RESOURCE_NAME));
+        var kafka = operator.create(kafkaResource(KAFKA_RESOURCE_NAME));
 
         Kafka withNoListener = new KafkaBuilder(kafka)
                 .withNewStatus()
                 .endStatus()
                 .build();
 
-        testActor.patchStatus(withNoListener);
+        operator.patchStatus(withNoListener);
 
         // When
-        KafkaService service = testActor.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
+        KafkaService service = operator.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
 
         // Then
         assertResolvedRefsFalse(service, Condition.REASON_REFERENCED_RESOURCE_NOT_RECONCILED, "Referenced resource has not yet reconciled listener name: plain");
@@ -135,10 +158,11 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
     @Test
     void shouldHandleStrimziKafkaWithNoStatus() {
         // Given
-        testActor.create(kafkaResource(KAFKA_RESOURCE_NAME));
+        operator.create(kafkaResource(KAFKA_RESOURCE_NAME));
 
         // When
-        KafkaService service = testActor.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
+
+        KafkaService service = operator.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
 
         // Then
         assertResolvedRefsFalse(service, Condition.REASON_REFERENCED_RESOURCE_NOT_RECONCILED, "Referenced resource has not yet reconciled listener name: plain");
@@ -147,173 +171,32 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
     @Test
     void shouldUpdateStatusOnceStrimziKafkaResourceDeleted() {
         // Given
-        var kafka = testActor.create(kafkaResource(KAFKA_RESOURCE_NAME));
-        reconcileStrimziResource(kafka);
+        var kafka = operator.create(kafkaResource(KAFKA_RESOURCE_NAME));
+        String listenerHost = "foo.bootstrap";
+        int listenerPort = 9090;
+        Kafka withListeners = new KafkaBuilder(kafka)
+                .withNewStatus()
+                .withListeners(
+                        new ListenerStatusBuilder()
+                                .withName("plain")
+                                .withAddresses(new ListenerAddressBuilder()
+                                        .withHost(listenerHost)
+                                        .withPort(listenerPort)
+                                        .build())
+                                .build())
+                .endStatus()
+                .build();
+        operator.patchStatus(withListeners);
 
         // When
-        KafkaService updated = testActor.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
+        KafkaService updated = operator.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
         assertResolvedRefsTrue(updated, FOO_BOOTSTRAP_9090, true);
 
         // When
-        testActor.delete(kafka);
+        operator.delete(kafka);
 
         // Then
         assertResolvedRefsFalse(updated, Condition.REASON_REFS_NOT_FOUND, "spec.strimziKafkaRef: referenced Kafka resource not found");
-    }
-
-    /**
-     * Tests that when trustAnchorRef is present, it always takes precedence
-     * regardless of trustStrimziCaCertificate setting.
-     */
-    @Test
-    void trustAnchorRefAlwaysTakesPrecedenceWhenPresent() {
-        // Given
-        var kafka = testActor.create(kafkaResourceWithTls(KAFKA_RESOURCE_NAME));
-        reconcileStrimziResource(kafka);
-        createTrustAnchorSecret("explicit-trust", "ca-bundle.pem");
-
-        var tar = createTrustAnchorRef("explicit-trust", "Secret");
-
-        // When - Create KafkaService with trustAnchorRef AND trustStrimziCaCertificate=true
-        var service = testActor.create(kafkaServiceWithStrimziKafkaRefAndOptionalTrustAnchor("service-with-both-refs", "tls", true, tar));
-
-        // Then - Explicit trustAnchorRef should be used (not Strimzi CA)
-        assertResolvedRefsTrue(service, FOO_BOOTSTRAP_9090, true);
-        assertKafkaService("service-with-both-refs", "explicit-trust", "Secret");
-    }
-
-    /**
-     * Tests that trustAnchorRef is used even when trustStrimziCaCertificate is explicitly false.
-     */
-    @Test
-    void trustAnchorRefUsedWhenTrustStrimziCaDisabled() {
-        // Given
-        var kafka = testActor.create(kafkaResourceWithTls(KAFKA_RESOURCE_NAME));
-        reconcileStrimziResource(kafka);
-        createTrustAnchorConfigMap("explicit-trust");
-
-        var tar = createTrustAnchorRef("explicit-trust", "ConfigMap");
-
-        // When - Create KafkaService with trustAnchorRef AND trustStrimziCaCertificate=false
-        var service = testActor.create(kafkaServiceWithStrimziKafkaRefAndOptionalTrustAnchor("service-trust-anchor-only", "tls", false, tar));
-
-        // Then - Explicit trustAnchorRef should be used
-        assertResolvedRefsTrue(service, FOO_BOOTSTRAP_9090, true);
-        assertKafkaService("service-trust-anchor-only", "explicit-trust", "ConfigMap");
-    }
-
-    /**
-     * Tests that when trustAnchorRef is NOT present and trustStrimziCaCertificate is enabled,
-     * the Strimzi CA is used.
-     */
-    @Test
-    void strimziCaUsedWhenTrustAnchorRefNotPresent() {
-        // Given
-        var kafka = testActor.create(kafkaResourceWithTls(KAFKA_RESOURCE_NAME));
-        reconcileStrimziResource(kafka);
-        String clusterCaSecretName = KAFKA_RESOURCE_NAME + ResourcesUtil.STRIMZI_CLUSTER_CA_CERT_SECRET_SUFFIX;
-        createStrimziTrustAnchorSecret(clusterCaSecretName);
-
-        // When - Create KafkaService with trustStrimziCaCertificate=true but NO trustAnchorRef
-        KafkaService service = testActor.create(kafkaServiceWithStrimziKafkaRefAndOptionalTrustAnchor("service-strimzi-only", "tls", true, null));
-
-        // Then - Strimzi CA should be used
-        assertResolvedRefsTrue(service, FOO_BOOTSTRAP_9090, true);
-        assertKafkaService("service-strimzi-only", clusterCaSecretName, "Secret");
-
-    }
-
-    /**
-     * Tests that when spec.tls is completely null but trustStrimziCaCertificate is enabled,
-     * status.tls is correctly built with the auto-discovered trust anchor and all other
-     * TLS fields are null (demonstrating null-safe handling in the builder).
-     */
-    @Test
-    void shouldBuildStatusTlsWhenSpecTlsIsNullButTrustAnchorRefDiscovered() {
-        // Given
-        var kafka = testActor.create(kafkaResourceWithTls(KAFKA_RESOURCE_NAME));
-        reconcileStrimziResource(kafka);
-        String clusterCaSecretName = KAFKA_RESOURCE_NAME + ResourcesUtil.STRIMZI_CLUSTER_CA_CERT_SECRET_SUFFIX;
-        createStrimziTrustAnchorSecret(clusterCaSecretName);
-
-        // When - Create KafkaService with spec.tls=null and trustStrimziCaCertificate=true
-        KafkaService service = testActor.create(kafkaServiceWithStrimziKafkaRefAndNullTls("service-null-tls", "tls"));
-
-        // Then - status.tls should be built with Strimzi CA as trust anchor
-        assertResolvedRefsTrue(service, FOO_BOOTSTRAP_9090, true);
-        AWAIT.untilAsserted(() -> {
-            var kafkaService = testActor.get(KafkaService.class, "service-null-tls");
-            assertThat(kafkaService)
-                    .isNotNull()
-                    .extracting(KafkaService::getStatus)
-                    .isNotNull()
-                    .extracting(KafkaServiceStatus::getTls)
-                    .isNotNull();
-            var tls = kafkaService.getStatus().getTls();
-            Assertions.assertThat(tls.getTrustAnchorRef()).isNotNull();
-            Assertions.assertThat(tls.getTrustAnchorRef().getRef().getName()).isEqualTo(clusterCaSecretName);
-            Assertions.assertThat(tls.getTrustAnchorRef().getRef().getKind()).isEqualTo("Secret");
-            Assertions.assertThat(tls.getTrustAnchorRef().getKey()).isEqualTo(STRIMZI_CLUSTER_CA_BUNDLE);
-            Assertions.assertThat(tls.getTrustAnchorRef().getStoreType()).isEqualTo("PEM");
-            // Validate null-safe handling - these should all be null since spec.tls was null
-            Assertions.assertThat(tls.getCertificateRef()).isNull();
-            Assertions.assertThat(tls.getProtocols()).isNull();
-            Assertions.assertThat(tls.getCipherSuites()).isNull();
-        });
-    }
-
-    private ConfigMap createTrustAnchorConfigMap(String name) {
-        ConfigMap configMap = new ConfigMapBuilder()
-                .withNewMetadata()
-                .withName(name)
-                .endMetadata()
-                .addToData("ca-bundle.pem", "whatever")
-                .build();
-        testActor.create(configMap);
-        return configMap;
-    }
-
-    private Secret createTrustAnchorSecret(String name, String key) {
-        Secret secret = new SecretBuilder()
-                .withNewMetadata()
-                .withName(name)
-                .endMetadata()
-                .addToData(key, "whatever")
-                .build();
-        testActor.create(secret);
-        return secret;
-    }
-
-    private Secret createStrimziTrustAnchorSecret(String name) {
-        return createTrustAnchorSecret(name, STRIMZI_CLUSTER_CA_BUNDLE);
-    }
-
-    private KafkaService kafkaServiceWithStrimziKafkaRefAndOptionalTrustAnchor(String serviceName,
-                                                                               String listenerName,
-                                                                               boolean trustStrimziCa,
-                                                                               @Nullable TrustAnchorRef explictTrust) {
-        // @formatter:off
-        var builder = new KafkaServiceBuilder()
-                .withNewMetadata()
-                    .withName(serviceName)
-                .endMetadata()
-                .editOrNewSpec()
-                    .withNewStrimziKafkaRef()
-                        .withListenerName(listenerName)
-                        .withTrustStrimziCaCertificate(trustStrimziCa)
-                        .withNewRef()
-                            .withName(KAFKA_RESOURCE_NAME)
-                        .endRef()
-                    .endStrimziKafkaRef();
-
-        if (explictTrust != null) {
-            builder.withNewTls()
-                    .withTrustAnchorRef(explictTrust)
-                .endTls();
-        }
-
-        return builder.endSpec().build();
-        // @formatter:on
     }
 
     private Kafka kafkaResource(String resourceName) {
@@ -328,24 +211,6 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
                                 .withName("plain")
                                 .withTls(false)
                                 .build())
-                    .endKafka()
-                .endSpec()
-                .build();
-        // @formatter:on
-    }
-
-    private Kafka kafkaResourceWithTls(String resourceName) {
-        // @formatter:off
-        return new KafkaBuilder()
-                .withNewMetadata()
-                    .withName(resourceName)
-                .endMetadata()
-                .withNewSpec()
-                    .withNewKafka()
-                        .addNewListener()
-                            .withName("tls")
-                            .withTls(true)
-                        .endListener()
                     .endKafka()
                 .endSpec()
                 .build();
@@ -370,39 +235,16 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
         // @formatter:on
     }
 
-    private static KafkaService kafkaServiceWithStrimziKafkaRefAndNullTls(String resourceName, String listenerName) {
-        // @formatter:off
-        return new KafkaServiceBuilder()
-                .withNewMetadata()
-                    .withName(resourceName)
-                .endMetadata()
-                .editOrNewSpec()
-                    .withNewStrimziKafkaRef()
-                        .withListenerName(listenerName)
-                        .withTrustStrimziCaCertificate(true)
-                        .withNewRef()
-                            .withName(KAFKA_RESOURCE_NAME)
-                        .endRef()
-                    .endStrimziKafkaRef()
-                    .withTls(null)
-                .endSpec()
-                .build();
-        // @formatter:on
-    }
-
     private void assertResolvedRefsTrue(KafkaService cr, String expectedBootstrap, boolean hasReferents) {
         AWAIT.untilAsserted(() -> {
-            final KafkaService kafkaService = testActor.get(KafkaService.class, ResourcesUtil.name(cr));
+            final KafkaService kafkaService = operator.get(KafkaService.class, ResourcesUtil.name(cr));
             Assertions.assertThat(kafkaService).isNotNull();
+            Assertions.assertThat(kafkaService.getStatus().getBootstrapServers()).isEqualTo(expectedBootstrap);
             assertThat(kafkaService.getStatus())
                     .isNotNull()
-                    .satisfies(status -> {
-                        Assertions.assertThat(status.getBootstrapServers()).isEqualTo(expectedBootstrap);
-                        assertThat(status)
-                                .conditionList()
-                                .singleElement()
-                                .isResolvedRefsTrue();
-                    });
+                    .conditionList()
+                    .singleElement()
+                    .isResolvedRefsTrue();
             String checksum = getReferentChecksum(kafkaService);
             if (hasReferents) {
                 Assertions.assertThat(checksum).isNotEqualTo(NO_CHECKSUM_SPECIFIED);
@@ -422,7 +264,7 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
                                          String reason,
                                          String message) {
         AWAIT.alias("KafkaServiceStatusResolvedRefs").untilAsserted(() -> {
-            var kafkaService = testActor.resources(KafkaService.class)
+            var kafkaService = operator.resources(KafkaService.class)
                     .withName(ResourcesUtil.name(cr)).get();
             Assertions.assertThat(kafkaService.getStatus()).isNotNull();
             OperatorAssertions
@@ -433,59 +275,4 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
                     .isResolvedRefsFalse(reason, message);
         });
     }
-
-    private void assertKafkaService(String kafkaServiceName, String expectedResourceName, String expectedResourceType) {
-        AWAIT.untilAsserted(() -> {
-            var kafkaService = testActor.get(KafkaService.class, kafkaServiceName);
-            assertThat(kafkaService)
-                    .isNotNull()
-                    .extracting(KafkaService::getStatus)
-                    .isNotNull()
-                    .extracting(KafkaServiceStatus::getTls)
-                    .isNotNull();
-            var tls = kafkaService.getStatus().getTls();
-            Assertions.assertThat(tls)
-                    .extracting(Tls::getTrustAnchorRef)
-                    .satisfies(tar -> {
-                        Assertions.assertThat(tar.getRef().getName()).isEqualTo(expectedResourceName);
-                        Assertions.assertThat(tar.getRef().getKind()).isEqualTo(expectedResourceType);
-                    });
-        });
-    }
-
-    // simulates what the Strimzi operator would do
-    private void reconcileStrimziResource(Kafka kafka) {
-
-        // @formatter:off
-        var statusListeners= kafka.getSpec().getKafka().getListeners().stream().map(specListener ->
-                new ListenerStatusBuilder()
-                        .withName(specListener.getName())
-                        .addNewAddress()
-                            .withHost(FOO_BOOTSTRAP)
-                            .withPort(FOO_BOOTSTRAP_PORT)
-                        .endAddress()
-                .build()).toList();
-        // @formatter:on
-
-        // @formatter:off
-        testActor.patchStatus(new KafkaBuilder(kafka)
-                .withNewStatus()
-                    .addAllToListeners(statusListeners)
-                .endStatus()
-            .build());
-        // @formatter:on
-    }
-
-    private TrustAnchorRef createTrustAnchorRef(String name, String kind) {
-        // @formatter:off
-        return new TrustAnchorRefBuilder()
-                    .withNewRef()
-                        .withName(name)
-                      .withKind(kind)
-                    .endRef()
-                    .withKey("ca-bundle.pem")
-                .build();
-        // @formatter:off
-    }
-
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
@@ -202,7 +202,7 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
         assertResolvedRefsTrue(updated, FOO_BOOTSTRAP_9090, true);
 
         // When
-        operator.delete(kafka);
+        clusterUser.delete(kafka);
 
         // Then
         assertResolvedRefsFalse(updated, Condition.REASON_REFS_NOT_FOUND, "spec.strimziKafkaRef: referenced Kafka resource not found");

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
@@ -13,6 +13,7 @@ import java.util.Set;
 
 import org.assertj.core.api.Assertions;
 import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -33,6 +34,7 @@ import io.kroxylicious.kubernetes.operator.Annotations;
 import io.kroxylicious.kubernetes.operator.assertj.OperatorAssertions;
 import io.kroxylicious.kubernetes.operator.informer.SharedInformerManager;
 import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
+import io.kroxylicious.testing.operator.ClusterUser;
 import io.kroxylicious.testing.operator.OperatorTestUtils;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 
@@ -71,10 +73,17 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
             .withAdditionalCleanupTypes(Kafka.class)
             .build();
 
+    private ClusterUser clusterUser;
+
+    @BeforeEach
+    void setUp() {
+        clusterUser = operator.clusterUser();
+    }
+
     @Test
     void shouldResolveStrimziKafka() {
         // Given
-        var kafka = operator.create(kafkaResource(KAFKA_RESOURCE_NAME));
+        var kafka = clusterUser.create(kafkaResource(KAFKA_RESOURCE_NAME));
         String listenerHost = "foo.bootstrap";
         int listenerPort = 9090;
         Kafka withStatus = new KafkaBuilder(kafka)
@@ -92,7 +101,7 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
         operator.patchStatus(withStatus);
 
         // When
-        KafkaService service = operator.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
+        KafkaService service = clusterUser.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
 
         // Then
         assertResolvedRefsTrue(service, FOO_BOOTSTRAP_9090, true);
@@ -127,10 +136,10 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
                 .endStatus()
                 .build();
 
-        operator.create(withTlsListener);
+        clusterUser.create(withTlsListener);
 
         // When
-        KafkaService service = operator.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "tls", KAFKA_RESOURCE_NAME));
+        KafkaService service = clusterUser.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "tls", KAFKA_RESOURCE_NAME));
 
         // Then
         assertResolvedRefsFalse(service, Condition.REASON_INVALID_REFERENCED_RESOURCE, "Referenced resource should have listener as `plain`");
@@ -139,7 +148,7 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
     @Test
     void shouldHandleStrimziKafkaWithNoListeners() {
         // Given
-        var kafka = operator.create(kafkaResource(KAFKA_RESOURCE_NAME));
+        var kafka = clusterUser.create(kafkaResource(KAFKA_RESOURCE_NAME));
 
         Kafka withNoListener = new KafkaBuilder(kafka)
                 .withNewStatus()
@@ -149,7 +158,7 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
         operator.patchStatus(withNoListener);
 
         // When
-        KafkaService service = operator.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
+        KafkaService service = clusterUser.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
 
         // Then
         assertResolvedRefsFalse(service, Condition.REASON_REFERENCED_RESOURCE_NOT_RECONCILED, "Referenced resource has not yet reconciled listener name: plain");
@@ -158,11 +167,11 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
     @Test
     void shouldHandleStrimziKafkaWithNoStatus() {
         // Given
-        operator.create(kafkaResource(KAFKA_RESOURCE_NAME));
+        clusterUser.create(kafkaResource(KAFKA_RESOURCE_NAME));
 
         // When
 
-        KafkaService service = operator.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
+        KafkaService service = clusterUser.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
 
         // Then
         assertResolvedRefsFalse(service, Condition.REASON_REFERENCED_RESOURCE_NOT_RECONCILED, "Referenced resource has not yet reconciled listener name: plain");
@@ -171,7 +180,7 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
     @Test
     void shouldUpdateStatusOnceStrimziKafkaResourceDeleted() {
         // Given
-        var kafka = operator.create(kafkaResource(KAFKA_RESOURCE_NAME));
+        var kafka = clusterUser.create(kafkaResource(KAFKA_RESOURCE_NAME));
         String listenerHost = "foo.bootstrap";
         int listenerPort = 9090;
         Kafka withListeners = new KafkaBuilder(kafka)
@@ -189,7 +198,7 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
         operator.patchStatus(withListeners);
 
         // When
-        KafkaService updated = operator.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
+        KafkaService updated = clusterUser.create(kafkaServiceWithStrimziKafkaRef(SERVICE_A, "plain", KAFKA_RESOURCE_NAME));
         assertResolvedRefsTrue(updated, FOO_BOOTSTRAP_9090, true);
 
         // When
@@ -237,7 +246,7 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
 
     private void assertResolvedRefsTrue(KafkaService cr, String expectedBootstrap, boolean hasReferents) {
         AWAIT.untilAsserted(() -> {
-            final KafkaService kafkaService = operator.get(KafkaService.class, ResourcesUtil.name(cr));
+            final KafkaService kafkaService = clusterUser.get(KafkaService.class, ResourcesUtil.name(cr));
             Assertions.assertThat(kafkaService).isNotNull();
             Assertions.assertThat(kafkaService.getStatus().getBootstrapServers()).isEqualTo(expectedBootstrap);
             assertThat(kafkaService.getStatus())
@@ -264,7 +273,7 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
                                          String reason,
                                          String message) {
         AWAIT.alias("KafkaServiceStatusResolvedRefs").untilAsserted(() -> {
-            var kafkaService = operator.resources(KafkaService.class)
+            var kafkaService = clusterUser.resources(KafkaService.class)
                     .withName(ResourcesUtil.name(cr)).get();
             Assertions.assertThat(kafkaService.getStatus()).isNotNull();
             OperatorAssertions

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconcilerIT.java
@@ -81,7 +81,7 @@ class VirtualKafkaClusterReconcilerIT {
     static LocalKroxyliciousOperatorExtension operator = LocalKroxyliciousOperatorExtension.builder()
             .withReconciler(new VirtualKafkaClusterReconciler(Clock.systemUTC(), DependencyResolver.create(), sharedInformerManager))
             .withReconciler(new KafkaProxyReconciler(Clock.systemUTC(), SecureConfigInterpolator.DEFAULT_INTERPOLATOR))
-            .withClusterRoleGlobs("*.ClusterRole*.yaml")
+            .replaceClusterRoleGlobs("*.ClusterRole*.yaml")
             .build();
 
     @Test

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconcilerIT.java
@@ -41,8 +41,8 @@ import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterStatus;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressesBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterstatus.Ingresses;
-import io.kroxylicious.kubernetes.operator.assertj.ConditionListAssert;
-import io.kroxylicious.kubernetes.operator.assertj.VirtualKafkaClusterStatusAssert;
+import io.kroxylicious.kubernetes.operator.ResourcesUtil;
+import io.kroxylicious.kubernetes.operator.SecureConfigInterpolator;
 import io.kroxylicious.kubernetes.operator.informer.SharedInformerManager;
 import io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy.KafkaProxyReconciler;
 import io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy.ProxyConfigDependentResource;
@@ -50,8 +50,8 @@ import io.kroxylicious.kubernetes.operator.resolver.DependencyResolver;
 import io.kroxylicious.testing.operator.ClusterUser;
 import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
 import io.kroxylicious.testing.operator.OperatorTestUtils;
-import io.kroxylicious.kubernetes.operator.ResourcesUtil;
-import io.kroxylicious.kubernetes.operator.SecureConfigInterpolator;
+import io.kroxylicious.testing.operator.assertj.ConditionListAssert;
+import io.kroxylicious.testing.operator.assertj.VirtualKafkaClusterStatusAssert;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconcilerIT.java
@@ -14,6 +14,7 @@ import java.util.Set;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -46,6 +47,7 @@ import io.kroxylicious.kubernetes.operator.informer.SharedInformerManager;
 import io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy.KafkaProxyReconciler;
 import io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy.ProxyConfigDependentResource;
 import io.kroxylicious.kubernetes.operator.resolver.DependencyResolver;
+import io.kroxylicious.testing.operator.ClusterUser
 import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
 import io.kroxylicious.testing.operator.OperatorTestUtils;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
@@ -85,16 +87,23 @@ class VirtualKafkaClusterReconcilerIT {
             .replaceClusterRoleGlobs("*.ClusterRole*.yaml")
             .build();
 
+    private ClusterUser clusterUser;
+
+    @BeforeEach
+    void setUp() {
+        clusterUser = operator.clusterUser();
+    }
+
     @Test
     void shouldResolveWhenClusterCreatedAfterReferents() {
         // Given
-        operator.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        updateStatusObservedGeneration(operator.create(filter(FILTER_K)));
+        clusterUser.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        updateStatusObservedGeneration(clusterUser.create(filter(FILTER_K)));
 
         // When
-        VirtualKafkaCluster clusterBar = operator.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
+        VirtualKafkaCluster clusterBar = clusterUser.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -103,17 +112,17 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileProxyInitiallyAbsent() {
         // Given
-        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
 
         // When
-        VirtualKafkaCluster clusterBar = operator.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null));
+        VirtualKafkaCluster clusterBar = clusterUser.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null));
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_REFS_NOT_FOUND);
 
         // And When
-        operator.create(kafkaProxy(PROXY_A));
+        clusterUser.create(kafkaProxy(PROXY_A));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -122,17 +131,17 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileServiceInitiallyAbsent() {
         // Given
-        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        operator.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        clusterUser.create(kafkaProxy(PROXY_A));
 
         // When
-        VirtualKafkaCluster clusterBar = operator.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null));
+        VirtualKafkaCluster clusterBar = clusterUser.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null));
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_REFS_NOT_FOUND);
 
         // And When
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -141,18 +150,18 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileIngressInitiallyAbsent() {
         // Given
-        operator.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        clusterUser.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
 
         // When
         VirtualKafkaCluster resource = cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null);
-        VirtualKafkaCluster clusterBar = operator.create(resource);
+        VirtualKafkaCluster clusterBar = clusterUser.create(resource);
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_REFS_NOT_FOUND);
 
         // And When
-        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -161,18 +170,18 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileFilterInitiallyAbsent() {
         // Given
-        operator.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        clusterUser.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
 
         // When
-        VirtualKafkaCluster clusterBar = operator.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
+        VirtualKafkaCluster clusterBar = clusterUser.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_REFS_NOT_FOUND);
 
         // And When
-        updateStatusObservedGeneration(operator.create(filter(FILTER_K)));
+        updateStatusObservedGeneration(clusterUser.create(filter(FILTER_K)));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -181,11 +190,11 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhenProxyDeleted() {
         // Given
-        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        updateStatusObservedGeneration(operator.create(filter(FILTER_K)));
-        VirtualKafkaCluster clusterBar = operator.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
+        KafkaProxy proxy = clusterUser.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        updateStatusObservedGeneration(clusterUser.create(filter(FILTER_K)));
+        VirtualKafkaCluster clusterBar = clusterUser.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
         assertAllConditionsTrue(clusterBar);
 
         // When
@@ -198,11 +207,11 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhenFilterDeleted() {
         // Given
-        operator.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        var filter = updateStatusObservedGeneration(operator.create(filter(FILTER_K)));
-        VirtualKafkaCluster clusterBar = operator.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
+        clusterUser.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        var filter = updateStatusObservedGeneration(clusterUser.create(filter(FILTER_K)));
+        VirtualKafkaCluster clusterBar = clusterUser.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
         assertAllConditionsTrue(clusterBar);
 
         // When
@@ -215,20 +224,20 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileIngressRefersToOtherProxy() {
         // Given
-        operator.create(kafkaProxy(PROXY_A));
-        operator.create(kafkaProxy(PROXY_B));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_B, TCP))); // not A, which is what the VKC references
+        clusterUser.create(kafkaProxy(PROXY_A));
+        clusterUser.create(kafkaProxy(PROXY_B));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_B, TCP))); // not A, which is what the VKC references
 
         // When
         VirtualKafkaCluster resource = cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null);
-        VirtualKafkaCluster clusterBar = operator.create(resource);
+        VirtualKafkaCluster clusterBar = clusterUser.create(resource);
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_TRANSITIVE_REFS_NOT_FOUND);
 
         // And when
-        updateStatusObservedGeneration(operator.replace(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(clusterUser.replace(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -237,20 +246,20 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileTwoIpIngresses() {
         // Given
-        operator.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_E, PROXY_A, TCP)));
+        clusterUser.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(clusterUser.create(clusterIpIngress(INGRESS_E, PROXY_A, TCP)));
 
         // When
         VirtualKafkaCluster resource = cluster(CLUSTER_BAR, PROXY_A, List.of(INGRESS_D, INGRESS_E), SERVICE_H, null);
-        VirtualKafkaCluster clusterBar = operator.create(resource);
+        VirtualKafkaCluster clusterBar = clusterUser.create(resource);
 
         // Then
         assertClusterAcceptedFalse(clusterBar, ProxyConfigDependentResource.REASON_INVALID);
 
         // And when
-        operator.replace(cluster(CLUSTER_BAR, PROXY_A, List.of(INGRESS_D), SERVICE_H, null));
+        clusterUser.replace(cluster(CLUSTER_BAR, PROXY_A, List.of(INGRESS_D), SERVICE_H, null));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -259,14 +268,14 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldReportIngressClusterIpBootstrap() {
         // Given
-        operator.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        clusterUser.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
         var cluster = cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null);
         var ingress = clusterIpIngress(INGRESS_D, PROXY_A, TCP);
-        updateStatusObservedGeneration(operator.create(ingress));
+        updateStatusObservedGeneration(clusterUser.create(ingress));
 
         // When
-        VirtualKafkaCluster clusterBar = operator.create(cluster);
+        VirtualKafkaCluster clusterBar = clusterUser.create(cluster);
 
         // Then
         assertClusterIngressStatusPopulated(clusterBar, ingress, "bar-cluster-ingress-d-bootstrap.%s.svc.cluster.local:9292", Protocol.TCP);
@@ -275,8 +284,8 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldResolveWithSecretTrustAnchorRef() {
         // Given
-        operator.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        clusterUser.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
         // @formatter:off
         var ingresses = List.of(new IngressesBuilder()
                 .withNewIngressRef()
@@ -311,13 +320,13 @@ class VirtualKafkaClusterReconcilerIT {
         // @formatter:on
         var cluster = specBuilder.endSpec().build();
         var ingress = clusterIpIngress(INGRESS_D, PROXY_A, TLS);
-        operator.create(tlsKeyAndCertSecret(SECRET_NAME));
-        operator.create(secretTrustAnchorRef(SECRET_TRUST_ANCHOR_REF_NAME));
+        clusterUser.create(tlsKeyAndCertSecret(SECRET_NAME));
+        clusterUser.create(secretTrustAnchorRef(SECRET_TRUST_ANCHOR_REF_NAME));
 
-        updateStatusObservedGeneration(operator.create(ingress));
+        updateStatusObservedGeneration(clusterUser.create(ingress));
 
         // When
-        VirtualKafkaCluster clusterBar = operator.create(cluster);
+        VirtualKafkaCluster clusterBar = clusterUser.create(cluster);
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -327,8 +336,8 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldReportIngressTlsClusterIpBootstrap() {
         // Given
-        operator.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        clusterUser.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
         // @formatter:off
         var ingresses = List.of(new IngressesBuilder()
                         .withNewIngressRef()
@@ -355,11 +364,11 @@ class VirtualKafkaClusterReconcilerIT {
         // @formatter:on
         var cluster = specBuilder.endSpec().build();
         var ingress = clusterIpIngress(INGRESS_D, PROXY_A, TLS);
-        operator.create(tlsKeyAndCertSecret(SECRET_NAME));
-        updateStatusObservedGeneration(operator.create(ingress));
+        clusterUser.create(tlsKeyAndCertSecret(SECRET_NAME));
+        updateStatusObservedGeneration(clusterUser.create(ingress));
 
         // When
-        VirtualKafkaCluster clusterBar = operator.create(cluster);
+        VirtualKafkaCluster clusterBar = clusterUser.create(cluster);
 
         // Then
         assertClusterIngressStatusPopulated(clusterBar, ingress, "bar-cluster-ingress-d-bootstrap.%s.svc.cluster.local:9292", Protocol.TLS);
@@ -368,9 +377,9 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldReportIngressLoadBalancerBootstrap() {
         // Given
-        operator.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        operator.create(tlsKeyAndCertSecret(SECRET_NAME));
+        clusterUser.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        clusterUser.create(tlsKeyAndCertSecret(SECRET_NAME));
         // @formatter:off
         var ingresses = new IngressesBuilder()
                 .withNewIngressRef()
@@ -397,10 +406,10 @@ class VirtualKafkaClusterReconcilerIT {
         // @formatter:on
         var cluster = specBuilder.endSpec().build();
         var ingress = loadBalancerIngress(INGRESS_D, PROXY_A);
-        updateStatusObservedGeneration(operator.create(ingress));
+        updateStatusObservedGeneration(clusterUser.create(ingress));
 
         // When
-        VirtualKafkaCluster clusterBar = operator.create(cluster);
+        VirtualKafkaCluster clusterBar = clusterUser.create(cluster);
 
         // Then
         assertClusterIngressStatusPopulated(clusterBar, ingress, "bootstrap.kafka:9083", Protocol.TLS);
@@ -409,15 +418,15 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldReportIngressClusterIpBootstrapWhenIngressInitiallyAbsent() {
         // Given
-        operator.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        clusterUser.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(clusterUser.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
         var cluster = cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null);
         var ingress = clusterIpIngress(INGRESS_D, PROXY_A, TCP);
 
-        VirtualKafkaCluster clusterBar = operator.create(cluster);
+        VirtualKafkaCluster clusterBar = clusterUser.create(cluster);
 
         AWAIT.alias("ClusterStatusBootstrapNotPresent").untilAsserted(() -> {
-            var vkc = operator.resources(VirtualKafkaCluster.class)
+            var vkc = clusterUser.resources(VirtualKafkaCluster.class)
                     .withName(ResourcesUtil.name(clusterBar)).get();
             VirtualKafkaClusterStatus status = vkc.getStatus();
             assertThat(status)
@@ -427,7 +436,7 @@ class VirtualKafkaClusterReconcilerIT {
         });
 
         // When
-        updateStatusObservedGeneration(operator.create(ingress));
+        updateStatusObservedGeneration(clusterUser.create(ingress));
 
         // Then
         assertClusterIngressStatusPopulated(clusterBar, ingress, "bar-cluster-ingress-d-bootstrap.%s.svc.cluster.local:9292", Protocol.TCP);
@@ -464,7 +473,7 @@ class VirtualKafkaClusterReconcilerIT {
 
     private void assertClusterResolvedRefsFalse(VirtualKafkaCluster cr, String expectedReason) {
         AWAIT.alias("ClusterStatusResolvedRefs").untilAsserted(() -> {
-            var vkc = operator.resources(VirtualKafkaCluster.class)
+            var vkc = clusterUser.resources(VirtualKafkaCluster.class)
                     .withName(ResourcesUtil.name(cr)).get();
             assertThat(vkc.getStatus()).isNotNull();
             VirtualKafkaClusterStatusAssert
@@ -480,7 +489,7 @@ class VirtualKafkaClusterReconcilerIT {
 
     private void assertAllConditionsTrue(VirtualKafkaCluster cr) {
         AWAIT.alias("ClusterStatusResolvedRefs").untilAsserted(() -> {
-            var vkc = operator.resources(VirtualKafkaCluster.class)
+            var vkc = clusterUser.resources(VirtualKafkaCluster.class)
                     .withName(ResourcesUtil.name(cr)).get();
             assertThat(vkc.getStatus()).isNotNull();
             ConditionListAssert conditionListAssert = VirtualKafkaClusterStatusAssert
@@ -499,7 +508,7 @@ class VirtualKafkaClusterReconcilerIT {
     private void assertClusterAcceptedFalse(VirtualKafkaCluster cr,
                                             String expectedReason) {
         AWAIT.alias("ClusterStatusResolvedRefs").untilAsserted(() -> {
-            var vkc = operator.resources(VirtualKafkaCluster.class)
+            var vkc = clusterUser.resources(VirtualKafkaCluster.class)
                     .withName(ResourcesUtil.name(cr)).get();
             assertThat(vkc.getStatus()).isNotNull();
             VirtualKafkaClusterStatusAssert
@@ -515,7 +524,7 @@ class VirtualKafkaClusterReconcilerIT {
 
     private void assertClusterIngressStatusPopulated(VirtualKafkaCluster clusterBar, KafkaProxyIngress ingress, String expectedBootstrapServer, Protocol protocol) {
         AWAIT.alias("ClusterIngressStatus").untilAsserted(() -> {
-            var vkc = operator.resources(VirtualKafkaCluster.class)
+            var vkc = clusterUser.resources(VirtualKafkaCluster.class)
                     .withName(ResourcesUtil.name(clusterBar)).get();
             var status = vkc.getStatus();
             assertThat(status)

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconcilerIT.java
@@ -14,18 +14,13 @@ import java.util.Set;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.core.ConditionFactory;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
-import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 
 import io.kroxylicious.kubernetes.api.common.Condition;
 import io.kroxylicious.kubernetes.api.common.Protocol;
@@ -45,17 +40,16 @@ import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaClusterStatus;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterspec.IngressesBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterstatus.Ingresses;
-import io.kroxylicious.kubernetes.operator.LocallyRunningOperatorRbacHandler;
-import io.kroxylicious.kubernetes.operator.OperatorTestUtils;
-import io.kroxylicious.kubernetes.operator.ResourcesUtil;
-import io.kroxylicious.kubernetes.operator.SecureConfigInterpolator;
-import io.kroxylicious.kubernetes.operator.TestFiles;
+import io.kroxylicious.kubernetes.operator.assertj.ConditionListAssert;
+import io.kroxylicious.kubernetes.operator.assertj.VirtualKafkaClusterStatusAssert;
 import io.kroxylicious.kubernetes.operator.informer.SharedInformerManager;
 import io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy.KafkaProxyReconciler;
 import io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy.ProxyConfigDependentResource;
 import io.kroxylicious.kubernetes.operator.resolver.DependencyResolver;
-import io.kroxylicious.testing.operator.assertj.ConditionListAssert;
-import io.kroxylicious.testing.operator.assertj.VirtualKafkaClusterStatusAssert;
+import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
+import io.kroxylicious.testing.operator.OperatorTestUtils;
+import io.kroxylicious.kubernetes.operator.ResourcesUtil;
+import io.kroxylicious.kubernetes.operator.SecureConfigInterpolator;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
@@ -65,10 +59,8 @@ import static io.kroxylicious.kubernetes.operator.ResourcesUtil.generation;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-@EnabledIf(value = "io.kroxylicious.kubernetes.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
+@EnabledIf(value = "io.kroxylicious.testing.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
 class VirtualKafkaClusterReconcilerIT {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(VirtualKafkaClusterReconcilerIT.class);
 
     private static final String PROXY_A = "proxy-a";
     private static final String PROXY_B = "proxy-b";
@@ -83,46 +75,25 @@ class VirtualKafkaClusterReconcilerIT {
     public static final String SECRET_NAME = "cert";
     public static final String SECRET_TRUST_ANCHOR_REF_NAME = "my-secret";
 
-    @RegisterExtension
-    static LocallyRunningOperatorRbacHandler rbacHandler = new LocallyRunningOperatorRbacHandler(TestFiles.INSTALL_MANIFESTS_DIR, "*.ClusterRole*.yaml");
+    private static final SharedInformerManager sharedInformerManager = new SharedInformerManager(OperatorTestUtils.kubeClient(), Set.of());
 
     @RegisterExtension
-    LocallyRunOperatorExtension extension = LocallyRunOperatorExtension.builder()
-            .withReconciler(
-                    new VirtualKafkaClusterReconciler(Clock.systemUTC(), DependencyResolver.create(), new SharedInformerManager(rbacHandler.operatorClient(), Set.of())))
+    static LocalKroxyliciousOperatorExtension operator = LocalKroxyliciousOperatorExtension.builder()
+            .withReconciler(new VirtualKafkaClusterReconciler(Clock.systemUTC(), DependencyResolver.create(), sharedInformerManager))
             .withReconciler(new KafkaProxyReconciler(Clock.systemUTC(), SecureConfigInterpolator.DEFAULT_INTERPOLATOR))
-            .withKubernetesClient(rbacHandler.operatorClient())
-            .withAdditionalCustomResourceDefinition(KafkaProxyIngress.class)
-            .withAdditionalCustomResourceDefinition(KafkaService.class)
-            .withAdditionalCustomResourceDefinition(KafkaProtocolFilter.class)
-            .waitForNamespaceDeletion(false)
-            .withConfigurationService(x -> x.withCloseClientOnStop(false))
+            .withClusterRoleGlobs("*.ClusterRole*.yaml")
             .build();
-
-    private final LocallyRunningOperatorRbacHandler.TestActor testActor = rbacHandler.testActor(extension);
-
-    // the initial operator image pull can take a long time and interfere with the tests
-    @BeforeAll
-    static void preloadOperandImage() {
-        OperatorTestUtils.preloadOperandImage();
-    }
-
-    @AfterEach
-    void stopOperator() {
-        extension.getOperator().stop();
-        LOGGER.atInfo().log("Test finished");
-    }
 
     @Test
     void shouldResolveWhenClusterCreatedAfterReferents() {
         // Given
-        testActor.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(testActor.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(testActor.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        updateStatusObservedGeneration(testActor.create(filter(FILTER_K)));
+        operator.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        updateStatusObservedGeneration(operator.create(filter(FILTER_K)));
 
         // When
-        VirtualKafkaCluster clusterBar = testActor.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
+        VirtualKafkaCluster clusterBar = operator.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -131,17 +102,17 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileProxyInitiallyAbsent() {
         // Given
-        updateStatusObservedGeneration(testActor.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(testActor.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
 
         // When
-        VirtualKafkaCluster clusterBar = testActor.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null));
+        VirtualKafkaCluster clusterBar = operator.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null));
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_REFS_NOT_FOUND);
 
         // And When
-        testActor.create(kafkaProxy(PROXY_A));
+        operator.create(kafkaProxy(PROXY_A));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -150,17 +121,17 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileServiceInitiallyAbsent() {
         // Given
-        updateStatusObservedGeneration(testActor.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        testActor.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        operator.create(kafkaProxy(PROXY_A));
 
         // When
-        VirtualKafkaCluster clusterBar = testActor.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null));
+        VirtualKafkaCluster clusterBar = operator.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null));
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_REFS_NOT_FOUND);
 
         // And When
-        updateStatusObservedGeneration(testActor.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -169,18 +140,18 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileIngressInitiallyAbsent() {
         // Given
-        testActor.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(testActor.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        operator.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
 
         // When
         VirtualKafkaCluster resource = cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null);
-        VirtualKafkaCluster clusterBar = testActor.create(resource);
+        VirtualKafkaCluster clusterBar = operator.create(resource);
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_REFS_NOT_FOUND);
 
         // And When
-        updateStatusObservedGeneration(testActor.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -189,18 +160,18 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileFilterInitiallyAbsent() {
         // Given
-        testActor.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(testActor.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(testActor.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        operator.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
 
         // When
-        VirtualKafkaCluster clusterBar = testActor.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
+        VirtualKafkaCluster clusterBar = operator.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_REFS_NOT_FOUND);
 
         // And When
-        updateStatusObservedGeneration(testActor.create(filter(FILTER_K)));
+        updateStatusObservedGeneration(operator.create(filter(FILTER_K)));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -209,15 +180,15 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhenProxyDeleted() {
         // Given
-        KafkaProxy proxy = testActor.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(testActor.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(testActor.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        updateStatusObservedGeneration(testActor.create(filter(FILTER_K)));
-        VirtualKafkaCluster clusterBar = testActor.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
+        KafkaProxy proxy = operator.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        updateStatusObservedGeneration(operator.create(filter(FILTER_K)));
+        VirtualKafkaCluster clusterBar = operator.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
         assertAllConditionsTrue(clusterBar);
 
         // When
-        testActor.delete((HasMetadata) proxy);
+        operator.delete((HasMetadata) proxy);
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_REFS_NOT_FOUND);
@@ -226,15 +197,15 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhenFilterDeleted() {
         // Given
-        testActor.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(testActor.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(testActor.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        var filter = updateStatusObservedGeneration(testActor.create(filter(FILTER_K)));
-        VirtualKafkaCluster clusterBar = testActor.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
+        operator.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        var filter = updateStatusObservedGeneration(operator.create(filter(FILTER_K)));
+        VirtualKafkaCluster clusterBar = operator.create(cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, FILTER_K));
         assertAllConditionsTrue(clusterBar);
 
         // When
-        testActor.delete(filter);
+        operator.delete(filter);
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_REFS_NOT_FOUND);
@@ -243,20 +214,20 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileIngressRefersToOtherProxy() {
         // Given
-        testActor.create(kafkaProxy(PROXY_A));
-        testActor.create(kafkaProxy(PROXY_B));
-        updateStatusObservedGeneration(testActor.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        updateStatusObservedGeneration(testActor.create(clusterIpIngress(INGRESS_D, PROXY_B, TCP))); // not A, which is what the VKC references
+        operator.create(kafkaProxy(PROXY_A));
+        operator.create(kafkaProxy(PROXY_B));
+        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_B, TCP))); // not A, which is what the VKC references
 
         // When
         VirtualKafkaCluster resource = cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null);
-        VirtualKafkaCluster clusterBar = testActor.create(resource);
+        VirtualKafkaCluster clusterBar = operator.create(resource);
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_TRANSITIVE_REFS_NOT_FOUND);
 
         // And when
-        updateStatusObservedGeneration(testActor.replace(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(operator.replace(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -265,20 +236,20 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldNotResolveWhileTwoIpIngresses() {
         // Given
-        testActor.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(testActor.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        updateStatusObservedGeneration(testActor.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
-        updateStatusObservedGeneration(testActor.create(clusterIpIngress(INGRESS_E, PROXY_A, TCP)));
+        operator.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_D, PROXY_A, TCP)));
+        updateStatusObservedGeneration(operator.create(clusterIpIngress(INGRESS_E, PROXY_A, TCP)));
 
         // When
         VirtualKafkaCluster resource = cluster(CLUSTER_BAR, PROXY_A, List.of(INGRESS_D, INGRESS_E), SERVICE_H, null);
-        VirtualKafkaCluster clusterBar = testActor.create(resource);
+        VirtualKafkaCluster clusterBar = operator.create(resource);
 
         // Then
         assertClusterAcceptedFalse(clusterBar, ProxyConfigDependentResource.REASON_INVALID);
 
         // And when
-        testActor.replace(cluster(CLUSTER_BAR, PROXY_A, List.of(INGRESS_D), SERVICE_H, null));
+        operator.replace(cluster(CLUSTER_BAR, PROXY_A, List.of(INGRESS_D), SERVICE_H, null));
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -287,14 +258,14 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldReportIngressClusterIpBootstrap() {
         // Given
-        testActor.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(testActor.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        operator.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
         var cluster = cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null);
         var ingress = clusterIpIngress(INGRESS_D, PROXY_A, TCP);
-        updateStatusObservedGeneration(testActor.create(ingress));
+        updateStatusObservedGeneration(operator.create(ingress));
 
         // When
-        VirtualKafkaCluster clusterBar = testActor.create(cluster);
+        VirtualKafkaCluster clusterBar = operator.create(cluster);
 
         // Then
         assertClusterIngressStatusPopulated(clusterBar, ingress, "bar-cluster-ingress-d-bootstrap.%s.svc.cluster.local:9292", Protocol.TCP);
@@ -303,8 +274,8 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldResolveWithSecretTrustAnchorRef() {
         // Given
-        testActor.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(testActor.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        operator.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
         // @formatter:off
         var ingresses = List.of(new IngressesBuilder()
                 .withNewIngressRef()
@@ -339,13 +310,13 @@ class VirtualKafkaClusterReconcilerIT {
         // @formatter:on
         var cluster = specBuilder.endSpec().build();
         var ingress = clusterIpIngress(INGRESS_D, PROXY_A, TLS);
-        testActor.create(tlsKeyAndCertSecret(SECRET_NAME));
-        testActor.create(secretTrustAnchorRef(SECRET_TRUST_ANCHOR_REF_NAME));
+        operator.create(tlsKeyAndCertSecret(SECRET_NAME));
+        operator.create(secretTrustAnchorRef(SECRET_TRUST_ANCHOR_REF_NAME));
 
-        updateStatusObservedGeneration(testActor.create(ingress));
+        updateStatusObservedGeneration(operator.create(ingress));
 
         // When
-        VirtualKafkaCluster clusterBar = testActor.create(cluster);
+        VirtualKafkaCluster clusterBar = operator.create(cluster);
 
         // Then
         assertAllConditionsTrue(clusterBar);
@@ -355,8 +326,8 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldReportIngressTlsClusterIpBootstrap() {
         // Given
-        testActor.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(testActor.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        operator.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
         // @formatter:off
         var ingresses = List.of(new IngressesBuilder()
                         .withNewIngressRef()
@@ -383,11 +354,11 @@ class VirtualKafkaClusterReconcilerIT {
         // @formatter:on
         var cluster = specBuilder.endSpec().build();
         var ingress = clusterIpIngress(INGRESS_D, PROXY_A, TLS);
-        testActor.create(tlsKeyAndCertSecret(SECRET_NAME));
-        updateStatusObservedGeneration(testActor.create(ingress));
+        operator.create(tlsKeyAndCertSecret(SECRET_NAME));
+        updateStatusObservedGeneration(operator.create(ingress));
 
         // When
-        VirtualKafkaCluster clusterBar = testActor.create(cluster);
+        VirtualKafkaCluster clusterBar = operator.create(cluster);
 
         // Then
         assertClusterIngressStatusPopulated(clusterBar, ingress, "bar-cluster-ingress-d-bootstrap.%s.svc.cluster.local:9292", Protocol.TLS);
@@ -396,9 +367,9 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldReportIngressLoadBalancerBootstrap() {
         // Given
-        testActor.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(testActor.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
-        testActor.create(tlsKeyAndCertSecret(SECRET_NAME));
+        operator.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        operator.create(tlsKeyAndCertSecret(SECRET_NAME));
         // @formatter:off
         var ingresses = new IngressesBuilder()
                 .withNewIngressRef()
@@ -425,10 +396,10 @@ class VirtualKafkaClusterReconcilerIT {
         // @formatter:on
         var cluster = specBuilder.endSpec().build();
         var ingress = loadBalancerIngress(INGRESS_D, PROXY_A);
-        updateStatusObservedGeneration(testActor.create(ingress));
+        updateStatusObservedGeneration(operator.create(ingress));
 
         // When
-        VirtualKafkaCluster clusterBar = testActor.create(cluster);
+        VirtualKafkaCluster clusterBar = operator.create(cluster);
 
         // Then
         assertClusterIngressStatusPopulated(clusterBar, ingress, "bootstrap.kafka:9083", Protocol.TLS);
@@ -437,15 +408,15 @@ class VirtualKafkaClusterReconcilerIT {
     @Test
     void shouldReportIngressClusterIpBootstrapWhenIngressInitiallyAbsent() {
         // Given
-        testActor.create(kafkaProxy(PROXY_A));
-        updateStatusObservedGeneration(testActor.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
+        operator.create(kafkaProxy(PROXY_A));
+        updateStatusObservedGeneration(operator.create(kafkaService(SERVICE_H)), BOOTSTRAP_SERVERS);
         var cluster = cluster(CLUSTER_BAR, PROXY_A, INGRESS_D, SERVICE_H, null);
         var ingress = clusterIpIngress(INGRESS_D, PROXY_A, TCP);
 
-        VirtualKafkaCluster clusterBar = testActor.create(cluster);
+        VirtualKafkaCluster clusterBar = operator.create(cluster);
 
         AWAIT.alias("ClusterStatusBootstrapNotPresent").untilAsserted(() -> {
-            var vkc = testActor.resources(VirtualKafkaCluster.class)
+            var vkc = operator.resources(VirtualKafkaCluster.class)
                     .withName(ResourcesUtil.name(clusterBar)).get();
             VirtualKafkaClusterStatus status = vkc.getStatus();
             assertThat(status)
@@ -455,7 +426,7 @@ class VirtualKafkaClusterReconcilerIT {
         });
 
         // When
-        updateStatusObservedGeneration(testActor.create(ingress));
+        updateStatusObservedGeneration(operator.create(ingress));
 
         // Then
         assertClusterIngressStatusPopulated(clusterBar, ingress, "bar-cluster-ingress-d-bootstrap.%s.svc.cluster.local:9292", Protocol.TCP);
@@ -492,7 +463,7 @@ class VirtualKafkaClusterReconcilerIT {
 
     private void assertClusterResolvedRefsFalse(VirtualKafkaCluster cr, String expectedReason) {
         AWAIT.alias("ClusterStatusResolvedRefs").untilAsserted(() -> {
-            var vkc = testActor.resources(VirtualKafkaCluster.class)
+            var vkc = operator.resources(VirtualKafkaCluster.class)
                     .withName(ResourcesUtil.name(cr)).get();
             assertThat(vkc.getStatus()).isNotNull();
             VirtualKafkaClusterStatusAssert
@@ -508,7 +479,7 @@ class VirtualKafkaClusterReconcilerIT {
 
     private void assertAllConditionsTrue(VirtualKafkaCluster cr) {
         AWAIT.alias("ClusterStatusResolvedRefs").untilAsserted(() -> {
-            var vkc = testActor.resources(VirtualKafkaCluster.class)
+            var vkc = operator.resources(VirtualKafkaCluster.class)
                     .withName(ResourcesUtil.name(cr)).get();
             assertThat(vkc.getStatus()).isNotNull();
             ConditionListAssert conditionListAssert = VirtualKafkaClusterStatusAssert
@@ -527,7 +498,7 @@ class VirtualKafkaClusterReconcilerIT {
     private void assertClusterAcceptedFalse(VirtualKafkaCluster cr,
                                             String expectedReason) {
         AWAIT.alias("ClusterStatusResolvedRefs").untilAsserted(() -> {
-            var vkc = testActor.resources(VirtualKafkaCluster.class)
+            var vkc = operator.resources(VirtualKafkaCluster.class)
                     .withName(ResourcesUtil.name(cr)).get();
             assertThat(vkc.getStatus()).isNotNull();
             VirtualKafkaClusterStatusAssert
@@ -543,7 +514,7 @@ class VirtualKafkaClusterReconcilerIT {
 
     private void assertClusterIngressStatusPopulated(VirtualKafkaCluster clusterBar, KafkaProxyIngress ingress, String expectedBootstrapServer, Protocol protocol) {
         AWAIT.alias("ClusterIngressStatus").untilAsserted(() -> {
-            var vkc = testActor.resources(VirtualKafkaCluster.class)
+            var vkc = operator.resources(VirtualKafkaCluster.class)
                     .withName(ResourcesUtil.name(clusterBar)).get();
             var status = vkc.getStatus();
             assertThat(status)
@@ -552,7 +523,7 @@ class VirtualKafkaClusterReconcilerIT {
                     .singleElement()
                     .satisfies(i -> {
                         assertThat(i.getName()).isEqualTo(ResourcesUtil.name(ingress));
-                        assertThat(i.getBootstrapServer()).isEqualTo(expectedBootstrapServer.formatted(extension.getNamespace()));
+                        assertThat(i.getBootstrapServer()).isEqualTo(expectedBootstrapServer.formatted(operator.getNamespace()));
                         assertThat(i.getProtocol()).isEqualTo(protocol);
                     });
         });
@@ -655,27 +626,27 @@ class VirtualKafkaClusterReconcilerIT {
     // the KafkaProxyReconciler only operates on KafkaProtocolFilters that have been reconciled, ie metadata.status == status.observedGeneration
     private KafkaProtocolFilter updateStatusObservedGeneration(KafkaProtocolFilter filter) {
         // Re-fetch to get the latest resourceVersion - the operator may have reconciled since we created it
-        KafkaProtocolFilter fresh = testActor.get(KafkaProtocolFilter.class, ResourcesUtil.name(filter));
+        KafkaProtocolFilter fresh = operator.get(KafkaProtocolFilter.class, ResourcesUtil.name(filter));
         fresh.setStatus(new KafkaProtocolFilterStatusBuilder().withObservedGeneration(generation(fresh)).build());
-        return testActor.patchStatus(fresh);
+        return operator.patchStatus(fresh);
     }
 
     // the KafkaProxyReconciler only operates on KafkaServices that have been reconciled, ie metadata.status == status.observedGeneration
     private KafkaService updateStatusObservedGeneration(KafkaService service, String bootstrapServers) {
         // Re-fetch to get the latest resourceVersion - the operator may have reconciled since we created it
-        KafkaService fresh = testActor.get(KafkaService.class, ResourcesUtil.name(service));
+        KafkaService fresh = operator.get(KafkaService.class, ResourcesUtil.name(service));
         fresh.setStatus(new KafkaServiceStatusBuilder().withObservedGeneration(generation(fresh))
                 .withBootstrapServers(bootstrapServers)
                 .build());
-        return testActor.patchStatus(fresh);
+        return operator.patchStatus(fresh);
     }
 
     // the KafkaProxyReconciler only operates on KafkaServices that have been reconciled, ie metadata.status == status.observedGeneration
     private KafkaProxyIngress updateStatusObservedGeneration(KafkaProxyIngress ingress) {
         // Re-fetch to get the latest resourceVersion - the operator may have reconciled since we created it
-        KafkaProxyIngress fresh = testActor.get(KafkaProxyIngress.class, ResourcesUtil.name(ingress));
+        KafkaProxyIngress fresh = operator.get(KafkaProxyIngress.class, ResourcesUtil.name(ingress));
         fresh.setStatus(new KafkaProxyIngressStatusBuilder().withObservedGeneration(generation(fresh)).build());
-        return testActor.patchStatus(fresh);
+        return operator.patchStatus(fresh);
     }
 
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconcilerIT.java
@@ -47,7 +47,7 @@ import io.kroxylicious.kubernetes.operator.informer.SharedInformerManager;
 import io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy.KafkaProxyReconciler;
 import io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy.ProxyConfigDependentResource;
 import io.kroxylicious.kubernetes.operator.resolver.DependencyResolver;
-import io.kroxylicious.testing.operator.ClusterUser
+import io.kroxylicious.testing.operator.ClusterUser;
 import io.kroxylicious.testing.operator.LocalKroxyliciousOperatorExtension;
 import io.kroxylicious.testing.operator.OperatorTestUtils;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconcilerIT.java
@@ -56,6 +56,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import static io.kroxylicious.kubernetes.api.common.Protocol.TCP;
 import static io.kroxylicious.kubernetes.api.common.Protocol.TLS;
 import static io.kroxylicious.kubernetes.operator.ResourcesUtil.generation;
+import static io.kroxylicious.kubernetes.operator.ResourcesUtil.name;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -623,30 +624,27 @@ class VirtualKafkaClusterReconcilerIT {
         // @formatter:on
     }
 
-    // the KafkaProxyReconciler only operates on KafkaProtocolFilters that have been reconciled, ie metadata.status == status.observedGeneration
     private KafkaProtocolFilter updateStatusObservedGeneration(KafkaProtocolFilter filter) {
-        // Re-fetch to get the latest resourceVersion - the operator may have reconciled since we created it
-        KafkaProtocolFilter fresh = operator.get(KafkaProtocolFilter.class, ResourcesUtil.name(filter));
-        fresh.setStatus(new KafkaProtocolFilterStatusBuilder().withObservedGeneration(generation(fresh)).build());
-        return operator.patchStatus(fresh);
+        return operator.updateStatus(KafkaProtocolFilter.class, name(filter), fresh -> {
+            fresh.setStatus(new KafkaProtocolFilterStatusBuilder().withObservedGeneration(generation(fresh)).build());
+            return fresh;
+        });
     }
 
-    // the KafkaProxyReconciler only operates on KafkaServices that have been reconciled, ie metadata.status == status.observedGeneration
     private KafkaService updateStatusObservedGeneration(KafkaService service, String bootstrapServers) {
-        // Re-fetch to get the latest resourceVersion - the operator may have reconciled since we created it
-        KafkaService fresh = operator.get(KafkaService.class, ResourcesUtil.name(service));
-        fresh.setStatus(new KafkaServiceStatusBuilder().withObservedGeneration(generation(fresh))
-                .withBootstrapServers(bootstrapServers)
-                .build());
-        return operator.patchStatus(fresh);
+        return operator.updateStatus(KafkaService.class, name(service), fresh -> {
+            fresh.setStatus(new KafkaServiceStatusBuilder().withObservedGeneration(generation(fresh))
+                    .withBootstrapServers(bootstrapServers)
+                    .build());
+            return fresh;
+        });
     }
 
-    // the KafkaProxyReconciler only operates on KafkaServices that have been reconciled, ie metadata.status == status.observedGeneration
     private KafkaProxyIngress updateStatusObservedGeneration(KafkaProxyIngress ingress) {
-        // Re-fetch to get the latest resourceVersion - the operator may have reconciled since we created it
-        KafkaProxyIngress fresh = operator.get(KafkaProxyIngress.class, ResourcesUtil.name(ingress));
-        fresh.setStatus(new KafkaProxyIngressStatusBuilder().withObservedGeneration(generation(fresh)).build());
-        return operator.patchStatus(fresh);
+        return operator.updateStatus(KafkaProxyIngress.class, name(ingress), fresh -> {
+            fresh.setStatus(new KafkaProxyIngressStatusBuilder().withObservedGeneration(generation(fresh)).build());
+            return fresh;
+        });
     }
 
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterReconcilerIT.java
@@ -198,7 +198,7 @@ class VirtualKafkaClusterReconcilerIT {
         assertAllConditionsTrue(clusterBar);
 
         // When
-        operator.delete((HasMetadata) proxy);
+        clusterUser.delete((HasMetadata) proxy);
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_REFS_NOT_FOUND);
@@ -215,7 +215,7 @@ class VirtualKafkaClusterReconcilerIT {
         assertAllConditionsTrue(clusterBar);
 
         // When
-        operator.delete(filter);
+        clusterUser.delete(filter);
 
         // Then
         assertClusterResolvedRefsFalse(clusterBar, Condition.REASON_REFS_NOT_FOUND);


### PR DESCRIPTION
### Type of change

- Refactoring
- Bugfix

### Description

Extracts repeated operator integration test setup into a reusable JUnit 5 extension, `LocalKroxyliciousOperatorExtension`, living in the existing `kroxylicious-operator-test-support` module. Also introduces `ClusterUser` as an explicit abstraction for user-perspective Kubernetes operations in tests, and fixes several bugs discovered during the process.

**Infrastructure changes:**

- Moved `LocallyRunningOperatorRbacHandler` from `kroxylicious-operator` test sources into `kroxylicious-operator-test-support/src/main/java` so it can be unit-tested and depended on
- Added `LocalKroxyliciousOperatorExtension`: a `BeforeAllCallback`/`AfterAllCallback`/`AfterEachCallback` that handles the full per-class lifecycle (RBAC setup, namespace creation, CRD installation, operator start/stop, resource cleanup) with `clusterUser()`, `updateStatus()`, and `patchStatus()` APIs
- Added `ClusterUser`: an explicit type representing the user perspective (as opposed to the operator) in tests, wrapping CRUD operations with operation-context error messages
- Added `KubernetesResourceUtil.name()` to reduce `getMetadata().getName()` noise throughout the test code
- Added `updateStatus()` on the extension to re-fetch before patching, avoiding 409 Conflict errors when the operator has already reconciled
- All 5 Kroxylicious CRDs (`KafkaProxy`, `VirtualKafkaCluster`, `KafkaService`, `KafkaProxyIngress`, `KafkaProtocolFilter`) are installed automatically — callers no longer need `.withAdditionalCRD()`

**Bugs fixed:**

- Race condition in `LocallyRunningOperatorRbacHandler`: the shared `KubernetesClient` used by `testActor` was closed in `afterAll()` while still potentially in use. The client is now owned by `LocalKroxyliciousOperatorExtension`, created eagerly in `beforeAll()`, and closed last in `afterAll()` after the operator stops and RBAC is torn down
- Route re-fetch before status patch to avoid 409 Conflict errors
- `Files.newInputStream` instead of `FileInputStream(String)` to resolve SpotBugs `PATH_TRAVERSAL_IN` warning

**Migration:**

Migrated all reconciler ITs to use the new extension: `KafkaProxyReconcilerIT`, `VirtualKafkaClusterReconcilerIT`, `AllReconcilersIT`, `KafkaProxyIngressReconcilerIT`, `KafkaProtocolFilterReconcilerIT`, `KafkaServiceBootstrapReconcilerIT`, `KafkaServiceStrimziKafkaRefReconcilerIT`. `OperatorSsaUpgradeIT` intentionally keeps the old pattern (dual-operator test with complex lifecycle).

### Additional Context

Each reconciler IT previously declared three fields (`static rbacHandler`, `extension`, `testActor`) and an `@AfterEach stopOperator()`, plus needed to know which JOSDK internals to call. This was ~40 lines of boilerplate per test class. The new extension collapses it to a single `@RegisterExtension` field. The `ClusterUser` type makes it explicit which operations represent user actions vs. operator reactions, which matters for reasoning about RBAC.

### Checklist

- [x] New tests written (where applicable).
- [ ] If making a user-facing change, documentation is provided, or if the intent is to provide documentation in a follow up PR, an issue is raised tracking the need for the documentation update. Link the to issue in this checklist.
- [x] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).