### PR TITLE
Revert "chore(deps): update dependency kubernetes/kubernetes to v1.35.2

### DIFF
--- a/.github/actions/common/setup-minikube/action.yml
+++ b/.github/actions/common/setup-minikube/action.yml
@@ -31,6 +31,6 @@ runs:
       uses: manusa/actions-setup-minikube@b589f2d61bf96695c546929c72b38563e856059d
       with:
         "minikube version": "v1.38.1"
-        "kubernetes version": "v1.35.2"
+        "kubernetes version": "v1.35.1"
         "github token": ${{ inputs.githubToken }}
         driver: docker


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

This reverts commit ad137cc13139dbd45331a8e967affedc08e6ab08 from #3366

Resolves #3406
(hopefully)

We've observed some CI failures when `minikube start` is getting rate limited by github when obtaining information about kubernetes. 1.35.2 is higher than the max supported by minikube v1.38.1 so reverting to v1.35.1 puts us on the supported path.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
