### PR TITLE
fix(operator): fix flaky AllReconcilersIT.singleVirtualCluster[3] assertion

### DIFF
--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
@@ -186,16 +186,19 @@ class AllReconcilersIT {
 
         assertResourceAttainsCondition(AllReconcilersIT::resourceReady, myProxy);
 
-        var acceptedCluster = assertResourceAttainsCondition(AllReconcilersIT::resourceAccepted, myCluster);
-        assertThat(acceptedCluster)
-                .extracting(VirtualKafkaCluster::getStatus)
-                .satisfies(vcs -> {
-                    assertThat(vcs)
-                            .extracting(VirtualKafkaClusterStatus::getIngresses, as(InstanceOfAssertFactories.list(Ingresses.class)))
-                            .singleElement()
-                            .extracting(Ingresses::getBootstrapServer, as(InstanceOfAssertFactories.STRING))
-                            .isNotEmpty();
-                });
+        assertResourceAttainsCondition(AllReconcilersIT::resourceAccepted, myCluster);
+        // The accepted condition and ingresses may be set in separate reconciliation cycles,
+        // so we wait explicitly for the ingresses to be populated rather than checking the
+        // snapshot returned when the accepted condition first became true.
+        AWAIT.alias("cluster %s has ingresses with bootstrap servers".formatted(CLUSTER_FOO))
+                .untilAsserted(() -> assertThat(testActor.get(VirtualKafkaCluster.class, CLUSTER_FOO))
+                        .isNotNull()
+                        .extracting(VirtualKafkaCluster::getStatus)
+                        .satisfies(vcs -> assertThat(vcs)
+                                .extracting(VirtualKafkaClusterStatus::getIngresses, as(InstanceOfAssertFactories.list(Ingresses.class)))
+                                .singleElement()
+                                .extracting(Ingresses::getBootstrapServer, as(InstanceOfAssertFactories.STRING))
+                                .isNotEmpty()));
 
     }
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

`AllReconcilersIT.singleVirtualCluster[3]` (the "filter with config that refs a configmap" scenario) was failing because the test checked ingresses on a point-in-time snapshot of the `VirtualKafkaCluster` returned when the `accepted` condition first became true.

The reconciler can legitimately set `accepted=true` with an empty ingress list: `buildIngressStatus` reads Services from the informer cache, and when a filter has a configmap reference there is an extra reconciliation cycle needed to resolve it. During that cycle the Services may not yet be annotated with bootstrap server info, so the status patch is written with `accepted=true` and `ingresses=[]`. A subsequent reconciliation populates ingresses once the Services are annotated.

For the simpler filter scenarios ([1] no filter, [2] simple filter) the timing works out; [3] exposes the race because the configmap-ref resolution adds an additional reconciliation cycle.

Fix: replace the snapshot assertion with an explicit awaitility poll that waits until ingresses are populated, keeping the prior `assertResourceAttainsCondition` call for the accepted condition so we still get distinct failure messages for the two different failure modes.

### Additional Context

Failure observed on `main` at https://github.com/kroxylicious/kroxylicious/actions/runs/22854969758/job/66292767364

### Checklist

- [x] PR raised from a fork of this repository and made from a branch rather than main.
- [x] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, trigger the performance test suite.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md