### PR TITLE
[SystemTests] Add test reporter to the pipelines

### DIFF
--- a/.github/workflows/run-system-tests.yaml
+++ b/.github/workflows/run-system-tests.yaml
@@ -129,7 +129,8 @@ jobs:
           name: systemtest-logs-${{ matrix.tests }}-${{ inputs.kafkaClient }}
           path: kroxylicious-systemtests/target/logs
 
-      - uses: dorny/test-reporter@v2
+      - name: Test Reporter
+        uses: dorny/test-reporter@3d76b34a4535afbd0600d347b09a6ee5deb3ed7f
         if: ${{ !cancelled() }}
         with:
           artifact: junit-results-${{ matrix.tests }}-${{ inputs.kafkaClient }}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Currently find out which tests have failed is not an easy task because we need to look into the log and we can easily be lost.

Digging online, I have found this action [TestReporter](https://github.com/marketplace/actions/test-reporter) that allow us to have a summary per run where we can have a quick look of all the tests that have been passed/failed. Something like:

<img width="2013" height="1194" alt="image" src="https://github.com/user-attachments/assets/617b8bb3-c953-4510-adf4-8347a6de290f" />


### Additional Context

Closes #3438 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
