### PR TITLE
feat(authorization): support v13 Produce with topicIds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format `<github issue/pr number>: <short description>`.
 
 * [#2890](https://github.com/kroxylicious/kroxylicious/pull/2890) Update record-validation to Apicurio v3.
 * [#3383](https://github.com/kroxylicious/kroxylicious/pull/3383): fix(operator): the operator now uses Server-Side Apply for all dependent resources. This is a no-op change for users: existing deployments are unaffected and externally-applied SSA patches (e.g. annotations or env vars added by observability tooling) will now survive operator reconciles. Users upgrading from a prior release may observe one additional reconcile cycle as Kubernetes transfers field ownership to the SSA manager.
+* [#3444](https://github.com/kroxylicious/kroxylicious/pull/3444): feat(authorization): support v13 Produce with topicIds
 
 ### Changes, deprecations and removals
 

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/ProduceEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/ProduceEnforcement.java
@@ -6,24 +6,32 @@
 
 package io.kroxylicious.filter.authorization;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.protocol.Errors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.kroxylicious.authorizer.service.Action;
 import io.kroxylicious.authorizer.service.AuthorizeResult;
 import io.kroxylicious.authorizer.service.Decision;
 import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
+import io.kroxylicious.proxy.filter.metadata.TopicNameMapping;
 
 import static org.apache.kafka.common.protocol.Errors.TRANSACTIONAL_ID_AUTHORIZATION_FAILED;
+import static org.apache.kafka.common.protocol.Errors.UNKNOWN_TOPIC_ID;
 
 class ProduceEnforcement extends ApiEnforcement<ProduceRequestData, ProduceResponseData> {
+    private static final Logger log = LoggerFactory.getLogger(ProduceEnforcement.class);
+
     @Override
     short minSupportedVersion() {
         return 3;
@@ -31,7 +39,7 @@ class ProduceEnforcement extends ApiEnforcement<ProduceRequestData, ProduceRespo
 
     @Override
     short maxSupportedVersion() {
-        return 12;
+        return 13;
     }
 
     @Override
@@ -39,31 +47,68 @@ class ProduceEnforcement extends ApiEnforcement<ProduceRequestData, ProduceRespo
                                                    ProduceRequestData request,
                                                    FilterContext context,
                                                    AuthorizationFilter authorizationFilter) {
-        boolean requiresResponse = request.acks() != 0;
-        boolean hasTransactionalRecords = RequestDataUtils.hasTransactionalRecords(request);
-        String transactionalId = request.transactionalId();
-        // fail fast if records flagged as transactional but request has no transactionalId
-        if (hasTransactionalRecords && transactionalId == null) {
-            return transactionalIdErrorResponse(context, header, request, requiresResponse);
+        List<Uuid> topicIds = request.topicData().stream()
+                .map(ProduceRequestData.TopicProduceData::topicId)
+                .filter(uuid -> !Uuid.ZERO_UUID.equals(uuid))
+                .toList();
+        return context.topicNames(topicIds).thenCompose(topicNameMapping -> {
+            boolean requiresResponse = request.acks() != 0;
+            if (topicNameMapping.anyFailures()) {
+                return topicNameLookupFailure(header, request, context, requiresResponse, topicNameMapping);
+            }
+            boolean hasTransactionalRecords = RequestDataUtils.hasTransactionalRecords(request);
+            String transactionalId = request.transactionalId();
+            // fail fast if records flagged as transactional but request has no transactionalId
+            if (hasTransactionalRecords && transactionalId == null) {
+                return transactionalIdErrorResponse(context, header, request, requiresResponse);
+            }
+            else {
+                var topicWriteActions = request.topicData().stream()
+                        .map(t -> new Action(TopicResource.WRITE, getTopicName(t, topicNameMapping)));
+                var transactionalIdActions = Optional.ofNullable(transactionalId).stream().map(t -> new Action(TransactionalIdResource.WRITE, t));
+                return authorizationFilter.authorization(context, Stream.concat(topicWriteActions, transactionalIdActions).toList()).thenCompose(authorization -> {
+                    if (hasTransactionalRecords && authorization.denied(TransactionalIdResource.WRITE).contains(transactionalId)) {
+                        return transactionalIdErrorResponse(context, header, request, requiresResponse);
+                    }
+                    return authorizeTopics(header, request, context, authorizationFilter, authorization, requiresResponse, topicNameMapping);
+                });
+            }
+        });
+    }
+
+    private static String getTopicName(ProduceRequestData.TopicProduceData topicData, TopicNameMapping topicNameMapping) {
+        return Optional.ofNullable(topicData.name())
+                .filter(name -> !name.isEmpty())
+                .or(() -> Optional.ofNullable(topicNameMapping.topicNames().get(topicData.topicId())))
+                .orElseThrow(() -> new IllegalStateException(
+                        String.format("Topic name not found for TopicProduceData{%s, %s}", topicData.name(), topicData.topicId())));
+    }
+
+    private static CompletionStage<RequestFilterResult> topicNameLookupFailure(RequestHeaderData header,
+                                                                               ProduceRequestData request,
+                                                                               FilterContext context,
+                                                                               boolean requiresResponse,
+                                                                               TopicNameMapping topicNameMapping) {
+        if (requiresResponse) {
+            return context.requestFilterResultBuilder().errorResponse(header, request, UNKNOWN_TOPIC_ID.exception()).completed();
         }
         else {
-            var topicWriteActions = request.topicData().stream()
-                    .map(t -> new Action(TopicResource.WRITE, t.name()));
-            var transactionalIdActions = Optional.ofNullable(transactionalId).stream().map(t -> new Action(TransactionalIdResource.WRITE, t));
-            return authorizationFilter.authorization(context, Stream.concat(topicWriteActions, transactionalIdActions).toList()).thenCompose(authorization -> {
-                if (hasTransactionalRecords && authorization.denied(TransactionalIdResource.WRITE).contains(transactionalId)) {
-                    return transactionalIdErrorResponse(context, header, request, requiresResponse);
-                }
-                return authorizeTopics(header, request, context, authorizationFilter, authorization, requiresResponse);
-            });
+            log.atWarn()
+                    .setMessage("failed to map topic ids ({}) to names for acks=0 request, dropping request.")
+                    .addArgument(topicNameMapping::failures)
+                    .log();
+            return context.requestFilterResultBuilder().drop().completed();
         }
     }
 
-    private static CompletionStage<RequestFilterResult> authorizeTopics(RequestHeaderData header, ProduceRequestData request, FilterContext context,
-                                                                        AuthorizationFilter authorizationFilter, AuthorizeResult authorization,
-                                                                        boolean requiresResponse) {
+    private static CompletionStage<RequestFilterResult> authorizeTopics(RequestHeaderData header,
+                                                                        ProduceRequestData request,
+                                                                        FilterContext context,
+                                                                        AuthorizationFilter authorizationFilter,
+                                                                        AuthorizeResult authorization,
+                                                                        boolean requiresResponse, TopicNameMapping topicNameMapping) {
         var topicWriteDecisions = authorization.partition(request.topicData(),
-                TopicResource.WRITE, ProduceRequestData.TopicProduceData::name);
+                TopicResource.WRITE, topicData -> getTopicName(topicData, topicNameMapping));
 
         var allowedTopicWrites = topicWriteDecisions.get(Decision.ALLOW);
         if (allowedTopicWrites.isEmpty()) {
@@ -90,7 +135,7 @@ class ProduceEnforcement extends ApiEnforcement<ProduceRequestData, ProduceRespo
 
         var topicProduceResponses = deniedTopicWrites.stream()
                 .map(topicProduceData -> new ProduceResponseData.TopicProduceResponse()
-                        .setName(topicProduceData.name())
+                        .setName(getTopicName(topicProduceData, topicNameMapping))
                         .setPartitionResponses(topicProduceData.partitionData().stream()
                                 .map(partitionProduceData -> new ProduceResponseData.PartitionProduceResponse()
                                         .setIndex(partitionProduceData.index())

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/AuthorizationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/AuthorizationFilterTest.java
@@ -300,6 +300,7 @@ class AuthorizationFilterTest {
     @Test
     void shouldSupportApis() {
         EnumSet<ApiKeys> allVersionsSupported = of(ApiKeys.API_VERSIONS,
+                ApiKeys.PRODUCE,
                 ApiKeys.SASL_HANDSHAKE,
                 ApiKeys.SASL_AUTHENTICATE,
                 ApiKeys.METADATA,
@@ -332,8 +333,7 @@ class AuthorizationFilterTest {
                 ApiKeys.DESCRIBE_TRANSACTIONS,
                 ApiKeys.HEARTBEAT,
                 ApiKeys.LIST_TRANSACTIONS);
-        EnumSet<ApiKeys> someVersionsSupported = of(ApiKeys.PRODUCE,
-                ApiKeys.FETCH,
+        EnumSet<ApiKeys> someVersionsSupported = of(ApiKeys.FETCH,
                 ApiKeys.ADD_PARTITIONS_TO_TXN,
                 ApiKeys.INIT_PRODUCER_ID);
         EnumSet<ApiKeys> noVersionsSupported = complementOf(unionOf(allVersionsSupported, someVersionsSupported));

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/API_VERSIONS/4/produce-minVersion-not-manipulated.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/API_VERSIONS/4/produce-minVersion-not-manipulated.yaml
@@ -63,5 +63,5 @@ then:
         maxVersion: 13
       - apiKey: 0 # PRODUCE
         minVersion: 0 # unmodified despite filter not supporting v0-v2
-        maxVersion: 12 # max version supported by filter
+        maxVersion: 13 # max version supported by filter
     throttleTimeMs: 880

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/13/allowed-and-denied-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/13/allowed-and-denied-topic.yaml
@@ -1,0 +1,100 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "PRODUCE"
+  apiVersion: 13
+  scenario: "allowed topic is forwarded upstream"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "PRODUCE"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 0
+        requestApiVersion: 13
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-292"
+        acks: 1
+        timeoutMs: 141
+        topicData:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitionData:
+              - index: 134
+                records: !!binary ""
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        responses:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitionResponses:
+              - index: 969
+                errorCode: 51
+                baseOffset: 581
+                logAppendTimeMs: 693
+                logStartOffset: 269
+                recordErrors:
+                  - batchIndex: 164
+                    batchIndexErrorMessage: "random-string-410"
+                errorMessage: "random-string-667"
+        throttleTimeMs: 141
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "WRITE"
+  topicNames:
+    "6wZQe3j9QSO02xct4Ph0gA": "my-topic"
+    "2VJlngPmSGi69WMsWRVrOw": "unauthorized"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 0
+    requestApiVersion: 13
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-292"
+    acks: 1
+    timeoutMs: 141
+    topicData:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitionData:
+          - index: 134
+            records: !!binary ""
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitionData:
+          - index: 134
+            records: !!binary ""
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    responses:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitionResponses:
+          - index: 969
+            errorCode: 51
+            baseOffset: 581
+            logAppendTimeMs: 693
+            logStartOffset: 269
+            recordErrors:
+              - batchIndex: 164
+                batchIndexErrorMessage: "random-string-410"
+            errorMessage: "random-string-667"
+      - topicId: "AAAAAAAAAAAAAAAAAAAAAA"
+        partitionResponses:
+          - index: 134
+            errorCode: 29
+            baseOffset: 0
+            logAppendTimeMs: -1
+            logStartOffset: -1
+            recordErrors: [ ]
+            errorMessage: "Topic authorization failed."
+    throttleTimeMs: 141

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/13/allowed-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/13/allowed-topic.yaml
@@ -1,0 +1,86 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "PRODUCE"
+  apiVersion: 13
+  scenario: "allowed topic is forwarded upstream"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "PRODUCE"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 0
+        requestApiVersion: 13
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        transactionalId: "random-string-292"
+        acks: 1
+        timeoutMs: 141
+        topicData:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitionData:
+              - index: 134
+                records: !!binary ""
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        responses:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitionResponses:
+              - index: 969
+                errorCode: 51
+                baseOffset: 581
+                logAppendTimeMs: 693
+                logStartOffset: 269
+                recordErrors:
+                  - batchIndex: 164
+                    batchIndexErrorMessage: "random-string-410"
+                errorMessage: "random-string-667"
+        throttleTimeMs: 141
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "WRITE"
+  topicNames:
+    "6wZQe3j9QSO02xct4Ph0gA": "my-topic"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 0
+    requestApiVersion: 13
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-292"
+    acks: 1
+    timeoutMs: 141
+    topicData:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitionData:
+          - index: 134
+            records: !!binary ""
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    responses:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitionResponses:
+          - index: 969
+            errorCode: 51
+            baseOffset: 581
+            logAppendTimeMs: 693
+            logStartOffset: 269
+            recordErrors:
+              - batchIndex: 164
+                batchIndexErrorMessage: "random-string-410"
+            errorMessage: "random-string-667"
+    throttleTimeMs: 141

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/13/any-topic-id-lookup-fails-zero-ack.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/13/any-topic-id-lookup-fails-zero-ack.yaml
@@ -1,0 +1,39 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "PRODUCE"
+  apiVersion: 13
+  scenario: "allowed topic is forwarded upstream"
+given:
+  mockedUpstreamResponses: []
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "WRITE"
+  topicNames: null # no topic id name lookups succeed
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 0
+    requestApiVersion: 13
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-292"
+    acks: 0
+    timeoutMs: 141
+    topicData:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitionData:
+          - index: 134
+            records: !!binary ""
+then:
+  expectAuthorizationOutcomeLog: false # no authorization performed when topicName lookup fails
+  expectRequestDropped: true

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/13/any-topic-id-lookup-fails.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/13/any-topic-id-lookup-fails.yaml
@@ -1,0 +1,41 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "PRODUCE"
+  apiVersion: 13
+  scenario: "allowed topic is forwarded upstream"
+given:
+  mockedUpstreamResponses: []
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "WRITE"
+  topicNames: null # no topic id name lookups succeed
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 0
+    requestApiVersion: 13
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-292"
+    acks: 1
+    timeoutMs: 141
+    topicData:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitionData:
+          - index: 134
+            records: !!binary ""
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectAuthorizationOutcomeLog: false
+  expectedErrorResponse: UNKNOWN_TOPIC_ID

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/13/denied-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/13/denied-topic.yaml
@@ -1,0 +1,37 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "PRODUCE"
+  apiVersion: 13
+  scenario: "allowed topic is forwarded upstream"
+given:
+  mockedUpstreamResponses: []
+  authorizerRules:
+    allowed: [] # not authorized to WRITE to my-topic
+  topicNames:
+    "6wZQe3j9QSO02xct4Ph0gA": "my-topic"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 0
+    requestApiVersion: 13
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-292"
+    acks: 1
+    timeoutMs: 141
+    topicData:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitionData:
+          - index: 134
+            records: !!binary ""
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedErrorResponse: TOPIC_AUTHORIZATION_FAILED

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/13/zero-ack-denied-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/PRODUCE/13/zero-ack-denied-topic.yaml
@@ -1,0 +1,35 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "PRODUCE"
+  apiVersion: 13
+  scenario: "allowed topic is forwarded upstream"
+given:
+  mockedUpstreamResponses: []
+  authorizerRules:
+    allowed: [] # not authorized to WRITE to my-topic
+  topicNames:
+    "6wZQe3j9QSO02xct4Ph0gA": "my-topic"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 0
+    requestApiVersion: 13
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    transactionalId: "random-string-292"
+    acks: 0
+    timeoutMs: 141
+    topicData:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitionData:
+          - index: 134
+            records: !!binary ""
+then:
+  expectRequestDropped: true

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/ProduceAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/ProduceAuthzIT.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.kroxylicious.test.Request;
@@ -148,6 +149,14 @@ class ProduceAuthzIT extends AuthzIT {
 
         @Override
         public String clobberResponse(BaseClusterFixture cluster, ObjectNode jsonNodes) {
+            JsonNode topics = jsonNodes.get("responses");
+            if (topics.isArray()) {
+                for (JsonNode topic : topics) {
+                    if (topic instanceof ObjectNode objectNode) {
+                        replaceTopicIdWithName(cluster, objectNode, "topicId");
+                    }
+                }
+            }
             return prettyJsonString(jsonNodes);
         }
 
@@ -220,10 +229,6 @@ class ProduceAuthzIT extends AuthzIT {
         // Compute the n-fold Cartesian product of the tuples (except for pruning)
         List<Arguments> result = new ArrayList<>();
         for (var apiVersion : apiVersions) {
-            if (apiVersion >= 13) {
-                result.add(Arguments.of(new UnsupportedApiVersion<>(ApiKeys.PRODUCE, apiVersion)));
-                continue;
-            }
             for (String transactionalId : transactionalIds) {
                 result.add(
                         Arguments.of(new ProduceEquivalence(apiVersion,
@@ -235,6 +240,12 @@ class ProduceAuthzIT extends AuthzIT {
                                     var topicCollection = new ProduceRequestData.TopicProduceDataCollection();
                                     var t = new ProduceRequestData.TopicProduceData()
                                             .setPartitionData(partitionData(user, PASSWORDS.get(user)));
+                                    if (apiVersion >= 13) {
+                                        t.setTopicId(topicIds.topicIds().get(topicName));
+                                    }
+                                    else {
+                                        t.setName(topicName);
+                                    }
                                     t.setName(topicName);
                                     topicCollection.mustAdd(t);
                                     data.setTopicData(topicCollection);

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/ProduceAuthzTxnlIdIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/ProduceAuthzTxnlIdIT.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import io.kroxylicious.test.Request;
@@ -160,7 +161,12 @@ class ProduceAuthzTxnlIdIT extends AuthzIT {
             var topicCollection = new ProduceRequestData.TopicProduceDataCollection();
             var t = new ProduceRequestData.TopicProduceData()
                     .setPartitionData(partitionData(user, PASSWORDS.get(user), Objects.requireNonNull(producerIdAndEpoch)));
-            t.setName(getTopicName());
+            if (apiVersion() >= 13) {
+                t.setTopicId(clusterFixture.topicIds().get(topicName));
+            }
+            else {
+                t.setName(getTopicName());
+            }
             topicCollection.mustAdd(t);
             data.setTopicData(topicCollection);
             return data;
@@ -176,6 +182,14 @@ class ProduceAuthzTxnlIdIT extends AuthzIT {
 
         @Override
         public String clobberResponse(BaseClusterFixture cluster, ObjectNode jsonNodes) {
+            JsonNode topics = jsonNodes.get("responses");
+            if (topics.isArray()) {
+                for (JsonNode topic : topics) {
+                    if (topic instanceof ObjectNode objectNode) {
+                        replaceTopicIdWithName(cluster, objectNode, "topicId");
+                    }
+                }
+            }
             return prettyJsonString(jsonNodes);
         }
 
@@ -263,10 +277,6 @@ class ProduceAuthzTxnlIdIT extends AuthzIT {
         // Compute the n-fold Cartesian product of the tuples (except for pruning)
         List<Arguments> result = new ArrayList<>();
         for (var apiVersion : apiVersions) {
-            if (apiVersion >= 13) {
-                result.add(Arguments.argumentSet("unsupported version " + apiVersion, new UnsupportedApiVersion<>(ApiKeys.PRODUCE, apiVersion)));
-                continue;
-            }
             for (String transactionalIdPrefix : ALL_TRANSACTIONAL_ID_PREFIXES) {
                 String transactionalId = transactionalIdPrefix + "-" + UUID.randomUUID();
                 result.add(

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/ZeroAckProduceAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/ZeroAckProduceAuthzIT.java
@@ -12,11 +12,15 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.compress.Compression;
+import org.apache.kafka.common.message.MetadataResponseData;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.SaslAuthenticateResponseData;
 import org.apache.kafka.common.message.SaslHandshakeRequestData;
@@ -48,10 +52,12 @@ import io.kroxylicious.test.tester.MockServerKroxyliciousTester;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static io.kroxylicious.it.filter.authorization.AuthzIT.getRequest;
+import static io.kroxylicious.proxy.internal.TopicNameRetriever.METADATA_API_VER_WITH_TOPIC_ID_SUPPORT;
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
 import static io.kroxylicious.test.tester.MockServerKroxyliciousTester.zeroAckProduceRequestMatcher;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toSet;
+import static org.apache.kafka.common.protocol.ApiKeys.METADATA;
 import static org.apache.kafka.common.protocol.ApiKeys.PRODUCE;
 import static org.apache.kafka.common.protocol.ApiKeys.SASL_AUTHENTICATE;
 import static org.apache.kafka.common.protocol.ApiKeys.SASL_HANDSHAKE;
@@ -59,7 +65,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ZeroAckProduceAuthzIT {
     private static final String TOPIC_NAME_A = "topica";
+    private static final Uuid TOPIC_ID_A = Uuid.randomUuid();
     private static final String TOPIC_NAME_B = "topicb";
+    private static final Uuid TOPIC_ID_B = Uuid.randomUuid();
+    public static final Map<Uuid, String> TOPIC_ID_TO_NAME = Map.of(TOPIC_ID_A, TOPIC_NAME_A, TOPIC_ID_B, TOPIC_NAME_B);
+    public static final Map<String, Uuid> TOPIC_NAME_TO_ID = TOPIC_ID_TO_NAME.entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
     public static final String ALICE = "alice";
     public static final String BOB = "bob";
     public static final String EVE = "eve";
@@ -109,9 +119,9 @@ class ZeroAckProduceAuthzIT {
         try (MockServerKroxyliciousTester mockServerKroxyliciousTester = KroxyliciousTesters.mockKafkaKroxyliciousTester(
                 bootstrap -> proxyConfig(bootstrap, PASSWORDS, rulesFile));
                 KafkaClient kafkaClient = mockServerKroxyliciousTester.simpleTestClient()) {
-            givenMockSaslServer(mockServerKroxyliciousTester);
+            givenMockSaslServer(mockServerKroxyliciousTester, TOPIC_ID_TO_NAME);
             AuthzIT.authenticate(kafkaClient, expectation.user, PASSWORDS.get(expectation.user));
-            ProduceRequestData produceRequestData = getProduceRequestData(expectation.topicsInProduce());
+            ProduceRequestData produceRequestData = getProduceRequestData(expectation.topicsInProduce(), apiVersion);
             mockServerKroxyliciousTester.dropWhen(zeroAckProduceRequestMatcher());
             kafkaClient.get(new Request(PRODUCE, apiVersion, "client", produceRequestData)).get(5, SECONDS);
             // send another arbitrary message as a way of ensuring the produce has completed its fire and forget send on the same channel
@@ -124,12 +134,19 @@ class ZeroAckProduceAuthzIT {
                     assertThat(mockServerKroxyliciousTester.getRequestsForApiKey(PRODUCE)).hasSize(1)
                             .singleElement().satisfies(request -> {
                                 ProduceRequestData message = (ProduceRequestData) request.message();
-                                Set<String> forwardedTopics = message.topicData().stream().map(ProduceRequestData.TopicProduceData::name).collect(toSet());
+                                Set<String> forwardedTopics = message.topicData().stream().map(ZeroAckProduceAuthzIT::getName).collect(toSet());
                                 assertThat(forwardedTopics).containsExactlyInAnyOrderElementsOf(expectation.topicsForwarded());
                             });
                 });
             }
         }
+    }
+
+    private static String getName(ProduceRequestData.TopicProduceData topicProduceData) {
+        return Optional.ofNullable(topicProduceData.name())
+                .filter(s -> !s.isEmpty())
+                .or(() -> Optional.ofNullable(TOPIC_ID_TO_NAME.get(topicProduceData.topicId())))
+                .orElseThrow();
     }
 
     private static void sendArbitraryMessageExpectedResponse(KafkaClient kafkaClient) {
@@ -139,7 +156,7 @@ class ZeroAckProduceAuthzIT {
         assertThat(Errors.forCode(handshakeResponse.errorCode())).isEqualTo(Errors.NONE);
     }
 
-    private static void givenMockSaslServer(MockServerKroxyliciousTester mockServerKroxyliciousTester) {
+    private static void givenMockSaslServer(MockServerKroxyliciousTester mockServerKroxyliciousTester, Map<Uuid, String> topicNames) {
         SaslHandshakeResponseData handshakeResponse = new SaslHandshakeResponseData();
         handshakeResponse.setMechanisms(List.of(PlainSaslServer.PLAIN_MECHANISM));
         ResponsePayload handshakePayload = new ResponsePayload(SASL_HANDSHAKE, SASL_HANDSHAKE.latestVersion(), handshakeResponse);
@@ -149,6 +166,13 @@ class ZeroAckProduceAuthzIT {
         authResponse.setErrorCode(Errors.NONE.code());
         ResponsePayload authPayload = new ResponsePayload(SASL_AUTHENTICATE, SASL_AUTHENTICATE.latestVersion(), handshakeResponse);
         mockServerKroxyliciousTester.addMockResponseForApiKey(authPayload);
+        MetadataResponseData metadataResponseData = new MetadataResponseData();
+        topicNames.forEach((key, value) -> {
+            MetadataResponseData.MetadataResponseTopic topic = new MetadataResponseData.MetadataResponseTopic();
+            topic.setName(value).setTopicId(key);
+            metadataResponseData.topics().add(topic);
+        });
+        mockServerKroxyliciousTester.addMockResponseForApiKey(new ResponsePayload(METADATA, METADATA_API_VER_WITH_TOPIC_ID_SUPPORT, metadataResponseData));
     }
 
     record Expectation(String user, List<String> topicsInProduce, List<String> topicsForwarded) {
@@ -189,14 +213,21 @@ class ZeroAckProduceAuthzIT {
                         .map(expectation -> Arguments.argumentSet("api version " + apiVersion + " " + expectation, (short) (int) apiVersion, expectation)));
     }
 
-    private static ProduceRequestData getProduceRequestData(List<String> topicsToSendDataTo) {
+    private static ProduceRequestData getProduceRequestData(List<String> topicsToSendDataTo, short apiVersion) {
         ProduceRequestData data = new ProduceRequestData()
                 .setTimeoutMs(10_000)
                 .setAcks((short) 0);
         var topicCollection = new ProduceRequestData.TopicProduceDataCollection();
         for (String topic : topicsToSendDataTo) {
-            var t = new ProduceRequestData.TopicProduceData()
-                    .setPartitionData(partitionData()).setName(topic);
+            ProduceRequestData.TopicProduceData topicProduceData = new ProduceRequestData.TopicProduceData()
+                    .setPartitionData(partitionData());
+            ProduceRequestData.TopicProduceData t;
+            if (apiVersion >= 13) {
+                t = topicProduceData.setTopicId(TOPIC_NAME_TO_ID.get(topic));
+            }
+            else {
+                t = topicProduceData.setName(topic);
+            }
             topicCollection.mustAdd(t);
         }
         data.setTopicData(topicCollection);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Enhances the ProduceEnforcement to tolerate v13 Produce bearing topicIds. We request topicIds and if any names cannot be looked up we fail the whole request with an UNKNOWN_TOPIC_ID failure.

Implements part of #2930

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
