### PR TITLE
feat(authorization): support v13-v18 Fetch with topicIds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format `<github issue/pr number>: <short description>`.
 * [#2890](https://github.com/kroxylicious/kroxylicious/pull/2890) Update record-validation to Apicurio v3.
 * [#3383](https://github.com/kroxylicious/kroxylicious/pull/3383): fix(operator): the operator now uses Server-Side Apply for all dependent resources. This is a no-op change for users: existing deployments are unaffected and externally-applied SSA patches (e.g. annotations or env vars added by observability tooling) will now survive operator reconciles. Users upgrading from a prior release may observe one additional reconcile cycle as Kubernetes transfers field ownership to the SSA manager.
 * [#3444](https://github.com/kroxylicious/kroxylicious/pull/3444): feat(authorization): support v13 Produce with topicIds
+* [#3444](https://github.com/kroxylicious/kroxylicious/pull/3444): feat(authorization): support v13-v18 Fetch with topicIds
 
 ### Changes, deprecations and removals
 

--- a/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/metadata/TopicNameMapping.java
+++ b/kroxylicious-api/src/main/java/io/kroxylicious/proxy/filter/metadata/TopicNameMapping.java
@@ -21,6 +21,13 @@ public interface TopicNameMapping {
     boolean anyFailures();
 
     /**
+     * @return true if all name mappings failed
+     */
+    default boolean allFailures() {
+        return anyFailures() && topicNames().isEmpty();
+    }
+
+    /**
      * @return immutable map from topic id to successfully mapped topic name
      */
     Map<Uuid, String> topicNames();

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/FetchEnforcement.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/FetchEnforcement.java
@@ -8,8 +8,11 @@ package io.kroxylicious.filter.authorization;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
+import java.util.stream.Stream;
 
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.FetchRequestData;
 import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.RequestHeaderData;
@@ -19,12 +22,11 @@ import io.kroxylicious.authorizer.service.Action;
 import io.kroxylicious.authorizer.service.Decision;
 import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
+import io.kroxylicious.proxy.filter.metadata.TopicNameMapping;
+import io.kroxylicious.proxy.filter.metadata.TopicNameMappingException;
 
 import static org.apache.kafka.common.requests.FetchResponse.partitionResponse;
 
-/**
- * Initially no support for topic ids
- */
 class FetchEnforcement extends ApiEnforcement<FetchRequestData, FetchResponseData> {
 
     // lowest version supported by proxy
@@ -33,56 +35,108 @@ class FetchEnforcement extends ApiEnforcement<FetchRequestData, FetchResponseDat
     }
 
     short maxSupportedVersion() {
-        return 12;
+        return 18;
     }
 
     CompletionStage<RequestFilterResult> onRequest(RequestHeaderData header,
                                                    FetchRequestData request,
                                                    FilterContext context,
                                                    AuthorizationFilter authorizationFilter) {
-        var topicReadActions = request.topics().stream()
-                .map(t -> new Action(TopicResource.READ, t.topic()))
+        List<Uuid> topicIds = request.topics().stream()
+                .map(FetchRequestData.FetchTopic::topicId)
+                .filter(uuid -> !Uuid.ZERO_UUID.equals(uuid))
                 .toList();
-        return authorizationFilter.authorization(context, topicReadActions)
-                .thenCompose(authorization -> {
-                    var topicReadDecisions = authorization.partition(request.topics(),
-                            TopicResource.READ,
-                            FetchRequestData.FetchTopic::topic);
-                    List<FetchRequestData.FetchTopic> allowedTopics = topicReadDecisions.getOrDefault(Decision.ALLOW, List.of());
-                    if (allowedTopics.isEmpty()) {
-                        // Shortcircuit if there are no allowed topics
-                        FetchResponseData response = new FetchResponseData();
-                        response.setErrorCode(Errors.NONE.code());
-                        var fetchableTopicResponses = createDenyTopicResponses(topicReadDecisions);
-                        response.setResponses(fetchableTopicResponses);
-                        return context.requestFilterResultBuilder()
-                                .shortCircuitResponse(response)
-                                .completed();
-                    }
-                    else if (topicReadDecisions.getOrDefault(Decision.DENY, List.of()).isEmpty()) {
-                        // Just forward if there are no denied topics
-                        return context.forwardRequest(header, request);
-                    }
-                    else {
-                        request.setTopics(allowedTopics);
-                        var fetchableTopicResponses = createDenyTopicResponses(topicReadDecisions);
-                        authorizationFilter.pushInflightState(header, (FetchResponseData response) -> {
-                            response.responses().addAll(fetchableTopicResponses);
-                            return response;
-                        });
-                        return context.forwardRequest(header, request);
-                    }
-                });
+        return context.topicNames(topicIds).thenCompose(topicNameMapping -> {
+            if (topicNameMapping.allFailures()) {
+                return allTopicNameLookupsFailed(request, context, topicNameMapping);
+            }
+            List<FetchRequestData.FetchTopic> failedTopicIdLookups = request.topics().stream()
+                    .filter(fetchTopic -> topicNameMapping.failures().containsKey(fetchTopic.topicId()))
+                    .toList();
+            request.topics().removeAll(failedTopicIdLookups);
+            List<FetchResponseData.FetchableTopicResponse> failedTopicIdLookupResponses = failedTopicIdLookups.stream()
+                    .map(fetchTopic -> toTopicIdLookupFailureResponse(topicNameMapping, fetchTopic))
+                    .toList();
+            var topicReadActions = request.topics().stream()
+                    .map(t -> new Action(TopicResource.READ, getTopicName(t, topicNameMapping)))
+                    .toList();
+            return authorizationFilter.authorization(context, topicReadActions)
+                    .thenCompose(authorization -> {
+                        var topicReadDecisions = authorization.partition(request.topics(),
+                                TopicResource.READ,
+                                fetchTopic -> getTopicName(fetchTopic, topicNameMapping));
+                        List<FetchRequestData.FetchTopic> allowedTopics = topicReadDecisions.getOrDefault(Decision.ALLOW, List.of());
+                        if (allowedTopics.isEmpty()) {
+                            // Shortcircuit if there are no allowed topics
+                            FetchResponseData response = new FetchResponseData();
+                            response.setErrorCode(Errors.NONE.code());
+                            var fetchableTopicResponses = createFailedTopicResponses(topicReadDecisions, failedTopicIdLookupResponses);
+                            response.setResponses(fetchableTopicResponses);
+                            return context.requestFilterResultBuilder()
+                                    .shortCircuitResponse(response)
+                                    .completed();
+                        }
+                        else if (topicReadDecisions.getOrDefault(Decision.DENY, List.of()).isEmpty() && failedTopicIdLookupResponses.isEmpty()) {
+                            // Just forward if there are no denied topics and no failed topic lookup responses
+                            return context.forwardRequest(header, request);
+                        }
+                        else {
+                            request.setTopics(allowedTopics);
+                            var fetchableTopicResponses = createFailedTopicResponses(topicReadDecisions, failedTopicIdLookupResponses);
+                            authorizationFilter.pushInflightState(header, (FetchResponseData response) -> {
+                                response.responses().addAll(fetchableTopicResponses);
+                                return response;
+                            });
+                            return context.forwardRequest(header, request);
+                        }
+                    });
+        });
     }
 
-    private static List<FetchResponseData.FetchableTopicResponse> createDenyTopicResponses(
-                                                                                           Map<Decision, List<FetchRequestData.FetchTopic>> topicReadDecisions) {
+    private static String getTopicName(FetchRequestData.FetchTopic t, TopicNameMapping topicNameMapping) {
+        return Optional.ofNullable(t.topic())
+                .filter(s -> !s.isEmpty())
+                .or(() -> Optional.ofNullable(topicNameMapping.topicNames().get(t.topicId())))
+                // state should be impossible as we are operating on a FetchTopic that was not filtered due to missing topicName
+                .orElseThrow(() -> new IllegalStateException("Could not determine name for FetchTopic{topic='" + t.topic() + "', topicId:'" + t.topicId() + "}"));
+    }
+
+    private static CompletionStage<RequestFilterResult> allTopicNameLookupsFailed(FetchRequestData request, FilterContext context,
+                                                                                  TopicNameMapping topicNameMapping) {
+        FetchResponseData response = new FetchResponseData();
+        response.setErrorCode(Errors.NONE.code());
+        var fetchableTopicResponses = request.topics().stream()
+                .map(t -> toTopicIdLookupFailureResponse(topicNameMapping, t))
+                .toList();
+        response.setResponses(fetchableTopicResponses);
+        return context.requestFilterResultBuilder()
+                .shortCircuitResponse(response)
+                .completed();
+    }
+
+    private static FetchResponseData.FetchableTopicResponse toTopicIdLookupFailureResponse(TopicNameMapping topicNameMapping, FetchRequestData.FetchTopic t) {
+        return new FetchResponseData.FetchableTopicResponse()
+                .setTopic(t.topic())
+                .setTopicId(t.topicId())
+                .setPartitions(t.partitions().stream().map(p -> partitionResponse(p.partition(),
+                        Optional.ofNullable(topicNameMapping.failures().get(t.topicId())).map(TopicNameMappingException::getError)
+                                .orElse(Errors.NETWORK_EXCEPTION)))
+                        .toList());
+    }
+
+    private static List<FetchResponseData.FetchableTopicResponse> createFailedTopicResponses(
+                                                                                             Map<Decision, List<FetchRequestData.FetchTopic>> topicReadDecisions,
+                                                                                             List<FetchResponseData.FetchableTopicResponse> failedTopicIdLookupResponses) {
+        return Stream.concat(deniedTopicResponses(topicReadDecisions), failedTopicIdLookupResponses.stream())
+                .toList();
+    }
+
+    private static Stream<FetchResponseData.FetchableTopicResponse> deniedTopicResponses(Map<Decision, List<FetchRequestData.FetchTopic>> topicReadDecisions) {
         return topicReadDecisions.get(Decision.DENY)
                 .stream().map(t -> new FetchResponseData.FetchableTopicResponse()
                         .setTopic(t.topic())
                         .setTopicId(t.topicId())
-                        .setPartitions(t.partitions().stream().map(p -> partitionResponse(p.partition(), Errors.TOPIC_AUTHORIZATION_FAILED)).toList()))
-                .toList();
+                        .setPartitions(t.partitions().stream().map(p -> partitionResponse(p.partition(), Errors.TOPIC_AUTHORIZATION_FAILED)).toList()));
     }
 
 }

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/AuthorizationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/java/io/kroxylicious/filter/authorization/AuthorizationFilterTest.java
@@ -304,6 +304,7 @@ class AuthorizationFilterTest {
                 ApiKeys.SASL_HANDSHAKE,
                 ApiKeys.SASL_AUTHENTICATE,
                 ApiKeys.METADATA,
+                ApiKeys.FETCH,
                 ApiKeys.FIND_COORDINATOR,
                 ApiKeys.ADD_OFFSETS_TO_TXN,
                 ApiKeys.END_TXN,
@@ -333,8 +334,7 @@ class AuthorizationFilterTest {
                 ApiKeys.DESCRIBE_TRANSACTIONS,
                 ApiKeys.HEARTBEAT,
                 ApiKeys.LIST_TRANSACTIONS);
-        EnumSet<ApiKeys> someVersionsSupported = of(ApiKeys.FETCH,
-                ApiKeys.ADD_PARTITIONS_TO_TXN,
+        EnumSet<ApiKeys> someVersionsSupported = of(ApiKeys.ADD_PARTITIONS_TO_TXN,
                 ApiKeys.INIT_PRODUCER_ID);
         EnumSet<ApiKeys> noVersionsSupported = complementOf(unionOf(allVersionsSupported, someVersionsSupported));
         for (ApiKeys apiKey : allVersionsSupported) {

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/13/allowed-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/13/allowed-topic.yaml
@@ -1,0 +1,118 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 13
+  scenario: "all topics in request are allowed"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FETCH"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 1
+        requestApiVersion: 13
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 66
+        maxWaitMs: 631
+        minBytes: 576
+        maxBytes: 658
+        isolationLevel: 5
+        sessionId: 267
+        sessionEpoch: 603
+        topics:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partition: 549
+                currentLeaderEpoch: 609
+                fetchOffset: 402
+                lastFetchedEpoch: 645
+                logStartOffset: 742
+                partitionMaxBytes: 944
+        forgottenTopicsData:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - 563
+        rackId: "random-string-474"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 15
+        errorCode: 856
+        sessionId: 885
+        responses:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partitionIndex: 647
+                errorCode: 575
+                highWatermark: 339
+                lastStableOffset: 551
+                logStartOffset: 596
+                abortedTransactions:
+                  - producerId: 287
+                    firstOffset: 914
+                preferredReadReplica: 22
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames:
+    "6wZQe3j9QSO02xct4Ph0gA": "my-topic"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 13
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 66
+    maxWaitMs: 631
+    minBytes: 576
+    maxBytes: 658
+    isolationLevel: 5
+    sessionId: 267
+    sessionEpoch: 603
+    topics:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+    forgottenTopicsData:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - 563
+    rackId: "random-string-474"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 15
+    errorCode: 856
+    sessionId: 885
+    responses:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partitionIndex: 647
+            errorCode: 575
+            highWatermark: 339
+            lastStableOffset: 551
+            logStartOffset: 596
+            abortedTransactions:
+              - producerId: 287
+                firstOffset: 914
+            preferredReadReplica: 22
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/13/denied-and-allowed-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/13/denied-and-allowed-topic.yaml
@@ -1,0 +1,141 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 13
+  scenario: |
+    request contains some allowed topics and some denied
+    allowed topics are forwarded upstream
+    denied topics are not forwarded upstream
+    denied topic errors are augmented into response to client
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FETCH"
+      expectedRequestVersion: 13
+      expectedRequestHeader:
+        requestApiKey: 1
+        requestApiVersion: 13
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 66
+        maxWaitMs: 631
+        minBytes: 576
+        maxBytes: 658
+        isolationLevel: 5
+        sessionId: 267
+        sessionEpoch: 603
+        topics:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partition: 549
+                currentLeaderEpoch: 609
+                fetchOffset: 402
+                lastFetchedEpoch: 645
+                logStartOffset: 742
+                partitionMaxBytes: 944
+        forgottenTopicsData:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - 563
+        rackId: "random-string-474"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 15
+        errorCode: 856
+        sessionId: 885
+        responses:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partitionIndex: 647
+                errorCode: 575
+                highWatermark: 339
+                lastStableOffset: 551
+                logStartOffset: 596
+                abortedTransactions:
+                  - producerId: 287
+                    firstOffset: 914
+                preferredReadReplica: 22
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames:
+    "6wZQe3j9QSO02xct4Ph0gA": "my-topic"
+    "2VJlngPmSGi69WMsWRVrOw": "unauthorized"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 13
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 66
+    maxWaitMs: 631
+    minBytes: 576
+    maxBytes: 658
+    isolationLevel: 5
+    sessionId: 267
+    sessionEpoch: 603
+    topics:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+    forgottenTopicsData:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - 563
+    rackId: "random-string-474"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 15
+    errorCode: 856
+    sessionId: 885
+    responses:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partitionIndex: 647
+            errorCode: 575
+            highWatermark: 339
+            lastStableOffset: 551
+            logStartOffset: 596
+            abortedTransactions:
+              - producerId: 287
+                firstOffset: 914
+            preferredReadReplica: 22
+            records: !!binary ""
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partitionIndex: 549
+            errorCode: 29
+            highWatermark: -1
+            lastStableOffset: -1
+            logStartOffset: -1
+            abortedTransactions: [ ]
+            preferredReadReplica: -1
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/13/denied-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/13/denied-topic.yaml
@@ -1,0 +1,68 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 13
+  scenario: "all topics in request are denied. filter short circuit responds with error"
+given:
+  mockedUpstreamResponses: []
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames:
+    "2VJlngPmSGi69WMsWRVrOw": "unauthorized"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 13
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 66
+    maxWaitMs: 631
+    minBytes: 576
+    maxBytes: 658
+    isolationLevel: 5
+    sessionId: 267
+    sessionEpoch: 603
+    topics:
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+    forgottenTopicsData:
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - 563
+    rackId: "random-string-474"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 0
+    errorCode: 0
+    sessionId: 0
+    responses:
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partitionIndex: 549
+            errorCode: 29
+            highWatermark: -1
+            lastStableOffset: -1
+            logStartOffset: -1
+            abortedTransactions: [ ]
+            preferredReadReplica: -1
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/14/allowed-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/14/allowed-topic.yaml
@@ -1,0 +1,118 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 14
+  scenario: "all topics in request are allowed"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FETCH"
+      expectedRequestVersion: 14
+      expectedRequestHeader:
+        requestApiKey: 1
+        requestApiVersion: 14
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 66
+        maxWaitMs: 631
+        minBytes: 576
+        maxBytes: 658
+        isolationLevel: 5
+        sessionId: 267
+        sessionEpoch: 603
+        topics:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partition: 549
+                currentLeaderEpoch: 609
+                fetchOffset: 402
+                lastFetchedEpoch: 645
+                logStartOffset: 742
+                partitionMaxBytes: 944
+        forgottenTopicsData:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - 563
+        rackId: "random-string-474"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 15
+        errorCode: 856
+        sessionId: 885
+        responses:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partitionIndex: 647
+                errorCode: 575
+                highWatermark: 339
+                lastStableOffset: 551
+                logStartOffset: 596
+                abortedTransactions:
+                  - producerId: 287
+                    firstOffset: 914
+                preferredReadReplica: 22
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames:
+    "6wZQe3j9QSO02xct4Ph0gA": "my-topic"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 14
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 66
+    maxWaitMs: 631
+    minBytes: 576
+    maxBytes: 658
+    isolationLevel: 5
+    sessionId: 267
+    sessionEpoch: 603
+    topics:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+    forgottenTopicsData:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - 563
+    rackId: "random-string-474"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 15
+    errorCode: 856
+    sessionId: 885
+    responses:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partitionIndex: 647
+            errorCode: 575
+            highWatermark: 339
+            lastStableOffset: 551
+            logStartOffset: 596
+            abortedTransactions:
+              - producerId: 287
+                firstOffset: 914
+            preferredReadReplica: 22
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/14/denied-and-allowed-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/14/denied-and-allowed-topic.yaml
@@ -1,0 +1,141 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 14
+  scenario: |
+    request contains some allowed topics and some denied
+    allowed topics are forwarded upstream
+    denied topics are not forwarded upstream
+    denied topic errors are augmented into response to client
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FETCH"
+      expectedRequestVersion: 14
+      expectedRequestHeader:
+        requestApiKey: 1
+        requestApiVersion: 14
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        replicaId: 66
+        maxWaitMs: 631
+        minBytes: 576
+        maxBytes: 658
+        isolationLevel: 5
+        sessionId: 267
+        sessionEpoch: 603
+        topics:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partition: 549
+                currentLeaderEpoch: 609
+                fetchOffset: 402
+                lastFetchedEpoch: 645
+                logStartOffset: 742
+                partitionMaxBytes: 944
+        forgottenTopicsData:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - 563
+        rackId: "random-string-474"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 15
+        errorCode: 856
+        sessionId: 885
+        responses:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partitionIndex: 647
+                errorCode: 575
+                highWatermark: 339
+                lastStableOffset: 551
+                logStartOffset: 596
+                abortedTransactions:
+                  - producerId: 287
+                    firstOffset: 914
+                preferredReadReplica: 22
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames:
+    "6wZQe3j9QSO02xct4Ph0gA": "my-topic"
+    "2VJlngPmSGi69WMsWRVrOw": "unauthorized"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 14
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 66
+    maxWaitMs: 631
+    minBytes: 576
+    maxBytes: 658
+    isolationLevel: 5
+    sessionId: 267
+    sessionEpoch: 603
+    topics:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+    forgottenTopicsData:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - 563
+    rackId: "random-string-474"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 15
+    errorCode: 856
+    sessionId: 885
+    responses:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partitionIndex: 647
+            errorCode: 575
+            highWatermark: 339
+            lastStableOffset: 551
+            logStartOffset: 596
+            abortedTransactions:
+              - producerId: 287
+                firstOffset: 914
+            preferredReadReplica: 22
+            records: !!binary ""
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partitionIndex: 549
+            errorCode: 29
+            highWatermark: -1
+            lastStableOffset: -1
+            logStartOffset: -1
+            abortedTransactions: [ ]
+            preferredReadReplica: -1
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/14/denied-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/14/denied-topic.yaml
@@ -1,0 +1,68 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 14
+  scenario: "all topics in request are denied. filter short circuit responds with error"
+given:
+  mockedUpstreamResponses: []
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames:
+    "2VJlngPmSGi69WMsWRVrOw": "unauthorized"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 14
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    replicaId: 66
+    maxWaitMs: 631
+    minBytes: 576
+    maxBytes: 658
+    isolationLevel: 5
+    sessionId: 267
+    sessionEpoch: 603
+    topics:
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+    forgottenTopicsData:
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - 563
+    rackId: "random-string-474"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 0
+    errorCode: 0
+    sessionId: 0
+    responses:
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partitionIndex: 549
+            errorCode: 29
+            highWatermark: -1
+            lastStableOffset: -1
+            logStartOffset: -1
+            abortedTransactions: [ ]
+            preferredReadReplica: -1
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/15/allowed-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/15/allowed-topic.yaml
@@ -1,0 +1,116 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 15
+  scenario: "all topics in request are allowed"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FETCH"
+      expectedRequestVersion: 15
+      expectedRequestHeader:
+        requestApiKey: 1
+        requestApiVersion: 15
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        maxWaitMs: 631
+        minBytes: 576
+        maxBytes: 658
+        isolationLevel: 5
+        sessionId: 267
+        sessionEpoch: 603
+        topics:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partition: 549
+                currentLeaderEpoch: 609
+                fetchOffset: 402
+                lastFetchedEpoch: 645
+                logStartOffset: 742
+                partitionMaxBytes: 944
+        forgottenTopicsData:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - 563
+        rackId: "random-string-474"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 15
+        errorCode: 856
+        sessionId: 885
+        responses:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partitionIndex: 647
+                errorCode: 575
+                highWatermark: 339
+                lastStableOffset: 551
+                logStartOffset: 596
+                abortedTransactions:
+                  - producerId: 287
+                    firstOffset: 914
+                preferredReadReplica: 22
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames:
+    "6wZQe3j9QSO02xct4Ph0gA": "my-topic"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 15
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    maxWaitMs: 631
+    minBytes: 576
+    maxBytes: 658
+    isolationLevel: 5
+    sessionId: 267
+    sessionEpoch: 603
+    topics:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+    forgottenTopicsData:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - 563
+    rackId: "random-string-474"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 15
+    errorCode: 856
+    sessionId: 885
+    responses:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partitionIndex: 647
+            errorCode: 575
+            highWatermark: 339
+            lastStableOffset: 551
+            logStartOffset: 596
+            abortedTransactions:
+              - producerId: 287
+                firstOffset: 914
+            preferredReadReplica: 22
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/15/denied-and-allowed-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/15/denied-and-allowed-topic.yaml
@@ -1,0 +1,139 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 15
+  scenario: |
+    request contains some allowed topics and some denied
+    allowed topics are forwarded upstream
+    denied topics are not forwarded upstream
+    denied topic errors are augmented into response to client
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FETCH"
+      expectedRequestVersion: 15
+      expectedRequestHeader:
+        requestApiKey: 1
+        requestApiVersion: 15
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        maxWaitMs: 631
+        minBytes: 576
+        maxBytes: 658
+        isolationLevel: 5
+        sessionId: 267
+        sessionEpoch: 603
+        topics:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partition: 549
+                currentLeaderEpoch: 609
+                fetchOffset: 402
+                lastFetchedEpoch: 645
+                logStartOffset: 742
+                partitionMaxBytes: 944
+        forgottenTopicsData:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - 563
+        rackId: "random-string-474"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 15
+        errorCode: 856
+        sessionId: 885
+        responses:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partitionIndex: 647
+                errorCode: 575
+                highWatermark: 339
+                lastStableOffset: 551
+                logStartOffset: 596
+                abortedTransactions:
+                  - producerId: 287
+                    firstOffset: 914
+                preferredReadReplica: 22
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames:
+    "6wZQe3j9QSO02xct4Ph0gA": "my-topic"
+    "2VJlngPmSGi69WMsWRVrOw": "unauthorized"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 15
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    maxWaitMs: 631
+    minBytes: 576
+    maxBytes: 658
+    isolationLevel: 5
+    sessionId: 267
+    sessionEpoch: 603
+    topics:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+    forgottenTopicsData:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - 563
+    rackId: "random-string-474"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 15
+    errorCode: 856
+    sessionId: 885
+    responses:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partitionIndex: 647
+            errorCode: 575
+            highWatermark: 339
+            lastStableOffset: 551
+            logStartOffset: 596
+            abortedTransactions:
+              - producerId: 287
+                firstOffset: 914
+            preferredReadReplica: 22
+            records: !!binary ""
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partitionIndex: 549
+            errorCode: 29
+            highWatermark: -1
+            lastStableOffset: -1
+            logStartOffset: -1
+            abortedTransactions: [ ]
+            preferredReadReplica: -1
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/15/denied-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/15/denied-topic.yaml
@@ -1,0 +1,67 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 15
+  scenario: "all topics in request are denied. filter short circuit responds with error"
+given:
+  mockedUpstreamResponses: []
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames:
+    "2VJlngPmSGi69WMsWRVrOw": "unauthorized"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 15
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    maxWaitMs: 631
+    minBytes: 576
+    maxBytes: 658
+    isolationLevel: 5
+    sessionId: 267
+    sessionEpoch: 603
+    topics:
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+    forgottenTopicsData:
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - 563
+    rackId: "random-string-474"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 0
+    errorCode: 0
+    sessionId: 0
+    responses:
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partitionIndex: 549
+            errorCode: 29
+            highWatermark: -1
+            lastStableOffset: -1
+            logStartOffset: -1
+            abortedTransactions: [ ]
+            preferredReadReplica: -1
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/16/allowed-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/16/allowed-topic.yaml
@@ -1,0 +1,116 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 16
+  scenario: "all topics in request are allowed"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FETCH"
+      expectedRequestVersion: 16
+      expectedRequestHeader:
+        requestApiKey: 1
+        requestApiVersion: 16
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        maxWaitMs: 631
+        minBytes: 576
+        maxBytes: 658
+        isolationLevel: 5
+        sessionId: 267
+        sessionEpoch: 603
+        topics:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partition: 549
+                currentLeaderEpoch: 609
+                fetchOffset: 402
+                lastFetchedEpoch: 645
+                logStartOffset: 742
+                partitionMaxBytes: 944
+        forgottenTopicsData:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - 563
+        rackId: "random-string-474"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 16
+        errorCode: 856
+        sessionId: 885
+        responses:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partitionIndex: 647
+                errorCode: 575
+                highWatermark: 339
+                lastStableOffset: 551
+                logStartOffset: 596
+                abortedTransactions:
+                  - producerId: 287
+                    firstOffset: 914
+                preferredReadReplica: 22
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames:
+    "6wZQe3j9QSO02xct4Ph0gA": "my-topic"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 16
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    maxWaitMs: 631
+    minBytes: 576
+    maxBytes: 658
+    isolationLevel: 5
+    sessionId: 267
+    sessionEpoch: 603
+    topics:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+    forgottenTopicsData:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - 563
+    rackId: "random-string-474"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 16
+    errorCode: 856
+    sessionId: 885
+    responses:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partitionIndex: 647
+            errorCode: 575
+            highWatermark: 339
+            lastStableOffset: 551
+            logStartOffset: 596
+            abortedTransactions:
+              - producerId: 287
+                firstOffset: 914
+            preferredReadReplica: 22
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/16/denied-and-allowed-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/16/denied-and-allowed-topic.yaml
@@ -1,0 +1,139 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 16
+  scenario: |
+    request contains some allowed topics and some denied
+    allowed topics are forwarded upstream
+    denied topics are not forwarded upstream
+    denied topic errors are augmented into response to client
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FETCH"
+      expectedRequestVersion: 16
+      expectedRequestHeader:
+        requestApiKey: 1
+        requestApiVersion: 16
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        maxWaitMs: 631
+        minBytes: 576
+        maxBytes: 658
+        isolationLevel: 5
+        sessionId: 267
+        sessionEpoch: 603
+        topics:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partition: 549
+                currentLeaderEpoch: 609
+                fetchOffset: 402
+                lastFetchedEpoch: 645
+                logStartOffset: 742
+                partitionMaxBytes: 944
+        forgottenTopicsData:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - 563
+        rackId: "random-string-474"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 16
+        errorCode: 856
+        sessionId: 885
+        responses:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partitionIndex: 647
+                errorCode: 575
+                highWatermark: 339
+                lastStableOffset: 551
+                logStartOffset: 596
+                abortedTransactions:
+                  - producerId: 287
+                    firstOffset: 914
+                preferredReadReplica: 22
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames:
+    "6wZQe3j9QSO02xct4Ph0gA": "my-topic"
+    "2VJlngPmSGi69WMsWRVrOw": "unauthorized"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 16
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    maxWaitMs: 631
+    minBytes: 576
+    maxBytes: 658
+    isolationLevel: 5
+    sessionId: 267
+    sessionEpoch: 603
+    topics:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+    forgottenTopicsData:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - 563
+    rackId: "random-string-474"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 16
+    errorCode: 856
+    sessionId: 885
+    responses:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partitionIndex: 647
+            errorCode: 575
+            highWatermark: 339
+            lastStableOffset: 551
+            logStartOffset: 596
+            abortedTransactions:
+              - producerId: 287
+                firstOffset: 914
+            preferredReadReplica: 22
+            records: !!binary ""
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partitionIndex: 549
+            errorCode: 29
+            highWatermark: -1
+            lastStableOffset: -1
+            logStartOffset: -1
+            abortedTransactions: [ ]
+            preferredReadReplica: -1
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/16/denied-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/16/denied-topic.yaml
@@ -1,0 +1,67 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 16
+  scenario: "all topics in request are denied. filter short circuit responds with error"
+given:
+  mockedUpstreamResponses: []
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames:
+    "2VJlngPmSGi69WMsWRVrOw": "unauthorized"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 16
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    maxWaitMs: 631
+    minBytes: 576
+    maxBytes: 658
+    isolationLevel: 5
+    sessionId: 267
+    sessionEpoch: 603
+    topics:
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+    forgottenTopicsData:
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - 563
+    rackId: "random-string-474"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 0
+    errorCode: 0
+    sessionId: 0
+    responses:
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partitionIndex: 549
+            errorCode: 29
+            highWatermark: -1
+            lastStableOffset: -1
+            logStartOffset: -1
+            abortedTransactions: [ ]
+            preferredReadReplica: -1
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/17/allowed-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/17/allowed-topic.yaml
@@ -1,0 +1,116 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 17
+  scenario: "all topics in request are allowed"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FETCH"
+      expectedRequestVersion: 17
+      expectedRequestHeader:
+        requestApiKey: 1
+        requestApiVersion: 17
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        maxWaitMs: 631
+        minBytes: 576
+        maxBytes: 658
+        isolationLevel: 5
+        sessionId: 267
+        sessionEpoch: 603
+        topics:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partition: 549
+                currentLeaderEpoch: 609
+                fetchOffset: 402
+                lastFetchedEpoch: 645
+                logStartOffset: 742
+                partitionMaxBytes: 944
+        forgottenTopicsData:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - 563
+        rackId: "random-string-474"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 17
+        errorCode: 856
+        sessionId: 885
+        responses:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partitionIndex: 647
+                errorCode: 575
+                highWatermark: 339
+                lastStableOffset: 551
+                logStartOffset: 596
+                abortedTransactions:
+                  - producerId: 287
+                    firstOffset: 914
+                preferredReadReplica: 22
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames:
+    "6wZQe3j9QSO02xct4Ph0gA": "my-topic"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 17
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    maxWaitMs: 631
+    minBytes: 576
+    maxBytes: 658
+    isolationLevel: 5
+    sessionId: 267
+    sessionEpoch: 603
+    topics:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+    forgottenTopicsData:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - 563
+    rackId: "random-string-474"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 17
+    errorCode: 856
+    sessionId: 885
+    responses:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partitionIndex: 647
+            errorCode: 575
+            highWatermark: 339
+            lastStableOffset: 551
+            logStartOffset: 596
+            abortedTransactions:
+              - producerId: 287
+                firstOffset: 914
+            preferredReadReplica: 22
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/17/denied-and-allowed-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/17/denied-and-allowed-topic.yaml
@@ -1,0 +1,139 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 17
+  scenario: |
+    request contains some allowed topics and some denied
+    allowed topics are forwarded upstream
+    denied topics are not forwarded upstream
+    denied topic errors are augmented into response to client
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FETCH"
+      expectedRequestVersion: 17
+      expectedRequestHeader:
+        requestApiKey: 1
+        requestApiVersion: 17
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        maxWaitMs: 631
+        minBytes: 576
+        maxBytes: 658
+        isolationLevel: 5
+        sessionId: 267
+        sessionEpoch: 603
+        topics:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partition: 549
+                currentLeaderEpoch: 609
+                fetchOffset: 402
+                lastFetchedEpoch: 645
+                logStartOffset: 742
+                partitionMaxBytes: 944
+        forgottenTopicsData:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - 563
+        rackId: "random-string-474"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 17
+        errorCode: 856
+        sessionId: 885
+        responses:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partitionIndex: 647
+                errorCode: 575
+                highWatermark: 339
+                lastStableOffset: 551
+                logStartOffset: 596
+                abortedTransactions:
+                  - producerId: 287
+                    firstOffset: 914
+                preferredReadReplica: 22
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames:
+    "6wZQe3j9QSO02xct4Ph0gA": "my-topic"
+    "2VJlngPmSGi69WMsWRVrOw": "unauthorized"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 17
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    maxWaitMs: 631
+    minBytes: 576
+    maxBytes: 658
+    isolationLevel: 5
+    sessionId: 267
+    sessionEpoch: 603
+    topics:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+    forgottenTopicsData:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - 563
+    rackId: "random-string-474"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 17
+    errorCode: 856
+    sessionId: 885
+    responses:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partitionIndex: 647
+            errorCode: 575
+            highWatermark: 339
+            lastStableOffset: 551
+            logStartOffset: 596
+            abortedTransactions:
+              - producerId: 287
+                firstOffset: 914
+            preferredReadReplica: 22
+            records: !!binary ""
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partitionIndex: 549
+            errorCode: 29
+            highWatermark: -1
+            lastStableOffset: -1
+            logStartOffset: -1
+            abortedTransactions: [ ]
+            preferredReadReplica: -1
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/17/denied-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/17/denied-topic.yaml
@@ -1,0 +1,67 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 17
+  scenario: "all topics in request are denied. filter short circuit responds with error"
+given:
+  mockedUpstreamResponses: []
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames:
+    "2VJlngPmSGi69WMsWRVrOw": "unauthorized"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 17
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    maxWaitMs: 631
+    minBytes: 576
+    maxBytes: 658
+    isolationLevel: 5
+    sessionId: 267
+    sessionEpoch: 603
+    topics:
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+    forgottenTopicsData:
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - 563
+    rackId: "random-string-474"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 0
+    errorCode: 0
+    sessionId: 0
+    responses:
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partitionIndex: 549
+            errorCode: 29
+            highWatermark: -1
+            lastStableOffset: -1
+            logStartOffset: -1
+            abortedTransactions: [ ]
+            preferredReadReplica: -1
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/18/all-topic-id-lookups-fail.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/18/all-topic-id-lookups-fail.yaml
@@ -1,0 +1,69 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 18
+  scenario: |
+    when all topicIds in request cannot be mapped to names
+    then we short-circuit respond with error response
+given:
+  mockedUpstreamResponses: []
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames: null # no topic ids mapped
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 18
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    maxWaitMs: 631
+    minBytes: 576
+    maxBytes: 658
+    isolationLevel: 5
+    sessionId: 267
+    sessionEpoch: 603
+    topics:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # topic name mapping fails
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+    forgottenTopicsData:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA"
+        partitions:
+          - 563
+    rackId: "random-string-474"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectAuthorizationOutcomeLog: false
+  expectedResponse:
+    throttleTimeMs: 0
+    errorCode: 0
+    sessionId: 0
+    responses:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA"
+        partitions:
+          - partitionIndex: 549
+            errorCode: -1 # UNKNOWN_SERVER_ERROR, the code the test framework sets for the unmapped topic
+            highWatermark: -1
+            lastStableOffset: -1
+            logStartOffset: -1
+            abortedTransactions: [ ]
+            preferredReadReplica: -1
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/18/allowed-topic-and-lookup-failure.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/18/allowed-topic-and-lookup-failure.yaml
@@ -1,0 +1,139 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 18
+  scenario: |
+    request contains an allowed topics with a resolvable topicId
+    request contains a topic with no name resolvable for its topicId
+    allowed topics are forwarded upstream
+    topicId mapping failed topics are not forwarded upstream
+    topicId mapping failed errors are augmented into response to client
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FETCH"
+      expectedRequestVersion: 18
+      expectedRequestHeader:
+        requestApiKey: 1
+        requestApiVersion: 18
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        maxWaitMs: 631
+        minBytes: 576
+        maxBytes: 658
+        isolationLevel: 5
+        sessionId: 267
+        sessionEpoch: 603
+        topics:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partition: 549
+                currentLeaderEpoch: 609
+                fetchOffset: 402
+                lastFetchedEpoch: 645
+                logStartOffset: 742
+                partitionMaxBytes: 944
+        forgottenTopicsData:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - 563
+        rackId: "random-string-474"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 18
+        errorCode: 856
+        sessionId: 885
+        responses:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partitionIndex: 647
+                errorCode: 575
+                highWatermark: 339
+                lastStableOffset: 551
+                logStartOffset: 596
+                abortedTransactions:
+                  - producerId: 287
+                    firstOffset: 914
+                preferredReadReplica: 22
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames:
+    "6wZQe3j9QSO02xct4Ph0gA": "my-topic"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 18
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    maxWaitMs: 631
+    minBytes: 576
+    maxBytes: 658
+    isolationLevel: 5
+    sessionId: 267
+    sessionEpoch: 603
+    topics:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # has no topic name mapping
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+    forgottenTopicsData:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - 563
+    rackId: "random-string-474"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 18
+    errorCode: 856
+    sessionId: 885
+    responses:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partitionIndex: 647
+            errorCode: 575
+            highWatermark: 339
+            lastStableOffset: 551
+            logStartOffset: 596
+            abortedTransactions:
+              - producerId: 287
+                firstOffset: 914
+            preferredReadReplica: 22
+            records: !!binary ""
+      - topicId: "2VJlngPmSGi69WMsWRVrOw"
+        partitions:
+          - partitionIndex: 549
+            errorCode: -1 # UNKNOWN_SERVER_ERROR, the code the test framework sets for the unmapped topic
+            highWatermark: -1
+            lastStableOffset: -1
+            logStartOffset: -1
+            abortedTransactions: [ ]
+            preferredReadReplica: -1
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/18/allowed-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/18/allowed-topic.yaml
@@ -1,0 +1,116 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 18
+  scenario: "all topics in request are allowed"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FETCH"
+      expectedRequestVersion: 18
+      expectedRequestHeader:
+        requestApiKey: 1
+        requestApiVersion: 18
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        maxWaitMs: 631
+        minBytes: 576
+        maxBytes: 658
+        isolationLevel: 5
+        sessionId: 267
+        sessionEpoch: 603
+        topics:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partition: 549
+                currentLeaderEpoch: 609
+                fetchOffset: 402
+                lastFetchedEpoch: 645
+                logStartOffset: 742
+                partitionMaxBytes: 944
+        forgottenTopicsData:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - 563
+        rackId: "random-string-474"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 18
+        errorCode: 856
+        sessionId: 885
+        responses:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partitionIndex: 647
+                errorCode: 575
+                highWatermark: 339
+                lastStableOffset: 551
+                logStartOffset: 596
+                abortedTransactions:
+                  - producerId: 287
+                    firstOffset: 914
+                preferredReadReplica: 22
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames:
+    "6wZQe3j9QSO02xct4Ph0gA": "my-topic"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 18
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    maxWaitMs: 631
+    minBytes: 576
+    maxBytes: 658
+    isolationLevel: 5
+    sessionId: 267
+    sessionEpoch: 603
+    topics:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+    forgottenTopicsData:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - 563
+    rackId: "random-string-474"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 18
+    errorCode: 856
+    sessionId: 885
+    responses:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partitionIndex: 647
+            errorCode: 575
+            highWatermark: 339
+            lastStableOffset: 551
+            logStartOffset: 596
+            abortedTransactions:
+              - producerId: 287
+                firstOffset: 914
+            preferredReadReplica: 22
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/18/denied-and-allowed-topic-and-lookup-failure.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/18/denied-and-allowed-topic-and-lookup-failure.yaml
@@ -1,0 +1,160 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 18
+  scenario: |
+    request contains some allowed topics and some denied
+    request contains a topicId that cannot be mapped to a nme
+    allowed topics are forwarded upstream
+    denied topics are not forwarded upstream
+    topicId mapping failed topics are not forwarded upstream
+    denied topic errors are augmented into response to client
+    topicId mapping failure errors are augmented into response to client
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FETCH"
+      expectedRequestVersion: 18
+      expectedRequestHeader:
+        requestApiKey: 1
+        requestApiVersion: 18
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        maxWaitMs: 631
+        minBytes: 576
+        maxBytes: 658
+        isolationLevel: 5
+        sessionId: 267
+        sessionEpoch: 603
+        topics:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partition: 549
+                currentLeaderEpoch: 609
+                fetchOffset: 402
+                lastFetchedEpoch: 645
+                logStartOffset: 742
+                partitionMaxBytes: 944
+        forgottenTopicsData:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - 563
+        rackId: "random-string-474"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 18
+        errorCode: 856
+        sessionId: 885
+        responses:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partitionIndex: 647
+                errorCode: 575
+                highWatermark: 339
+                lastStableOffset: 551
+                logStartOffset: 596
+                abortedTransactions:
+                  - producerId: 287
+                    firstOffset: 914
+                preferredReadReplica: 22
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames:
+    "6wZQe3j9QSO02xct4Ph0gA": "my-topic"
+    "2VJlngPmSGi69WMsWRVrOw": "unauthorized"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 18
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    maxWaitMs: 631
+    minBytes: 576
+    maxBytes: 658
+    isolationLevel: 5
+    sessionId: 267
+    sessionEpoch: 603
+    topics:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+      - topicId: "sNxDYvXAQne6fpYrpGFsfQ" # has no topic name mapping
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+    forgottenTopicsData:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - 563
+    rackId: "random-string-474"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 18
+    errorCode: 856
+    sessionId: 885
+    responses:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partitionIndex: 647
+            errorCode: 575
+            highWatermark: 339
+            lastStableOffset: 551
+            logStartOffset: 596
+            abortedTransactions:
+              - producerId: 287
+                firstOffset: 914
+            preferredReadReplica: 22
+            records: !!binary ""
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partitionIndex: 549
+            errorCode: 29
+            highWatermark: -1
+            lastStableOffset: -1
+            logStartOffset: -1
+            abortedTransactions: [ ]
+            preferredReadReplica: -1
+            records: !!binary ""
+      - topicId: "sNxDYvXAQne6fpYrpGFsfQ" # has no topic name mapping
+        partitions:
+          - partitionIndex: 549
+            errorCode: -1 # UNKNOWN_SERVER_ERROR, the code the test framework sets for the unmapped topic
+            highWatermark: -1
+            lastStableOffset: -1
+            logStartOffset: -1
+            abortedTransactions: [ ]
+            preferredReadReplica: -1
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/18/denied-and-allowed-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/18/denied-and-allowed-topic.yaml
@@ -1,0 +1,139 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 18
+  scenario: |
+    request contains some allowed topics and some denied
+    allowed topics are forwarded upstream
+    denied topics are not forwarded upstream
+    denied topic errors are augmented into response to client
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "FETCH"
+      expectedRequestVersion: 18
+      expectedRequestHeader:
+        requestApiKey: 1
+        requestApiVersion: 18
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        maxWaitMs: 631
+        minBytes: 576
+        maxBytes: 658
+        isolationLevel: 5
+        sessionId: 267
+        sessionEpoch: 603
+        topics:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partition: 549
+                currentLeaderEpoch: 609
+                fetchOffset: 402
+                lastFetchedEpoch: 645
+                logStartOffset: 742
+                partitionMaxBytes: 944
+        forgottenTopicsData:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - 563
+        rackId: "random-string-474"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        throttleTimeMs: 18
+        errorCode: 856
+        sessionId: 885
+        responses:
+          - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+            partitions:
+              - partitionIndex: 647
+                errorCode: 575
+                highWatermark: 339
+                lastStableOffset: 551
+                logStartOffset: 596
+                abortedTransactions:
+                  - producerId: 287
+                    firstOffset: 914
+                preferredReadReplica: 22
+                records: !!binary ""
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames:
+    "6wZQe3j9QSO02xct4Ph0gA": "my-topic"
+    "2VJlngPmSGi69WMsWRVrOw": "unauthorized"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 18
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    maxWaitMs: 631
+    minBytes: 576
+    maxBytes: 658
+    isolationLevel: 5
+    sessionId: 267
+    sessionEpoch: 603
+    topics:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+    forgottenTopicsData:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - 563
+    rackId: "random-string-474"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 18
+    errorCode: 856
+    sessionId: 885
+    responses:
+      - topicId: "6wZQe3j9QSO02xct4Ph0gA" # maps to topic named 'my-topic'
+        partitions:
+          - partitionIndex: 647
+            errorCode: 575
+            highWatermark: 339
+            lastStableOffset: 551
+            logStartOffset: 596
+            abortedTransactions:
+              - producerId: 287
+                firstOffset: 914
+            preferredReadReplica: 22
+            records: !!binary ""
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partitionIndex: 549
+            errorCode: 29
+            highWatermark: -1
+            lastStableOffset: -1
+            logStartOffset: -1
+            abortedTransactions: [ ]
+            preferredReadReplica: -1
+            records: !!binary ""

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/18/denied-topic.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/FETCH/18/denied-topic.yaml
@@ -1,0 +1,67 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "FETCH"
+  apiVersion: 18
+  scenario: "all topics in request are denied. filter short circuit responds with error"
+given:
+  mockedUpstreamResponses: []
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "READ"
+  topicNames:
+    "2VJlngPmSGi69WMsWRVrOw": "unauthorized"
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 1
+    requestApiVersion: 18
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    maxWaitMs: 631
+    minBytes: 576
+    maxBytes: 658
+    isolationLevel: 5
+    sessionId: 267
+    sessionEpoch: 603
+    topics:
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partition: 549
+            currentLeaderEpoch: 609
+            fetchOffset: 402
+            lastFetchedEpoch: 645
+            logStartOffset: 742
+            partitionMaxBytes: 944
+    forgottenTopicsData:
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - 563
+    rackId: "random-string-474"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    throttleTimeMs: 0
+    errorCode: 0
+    sessionId: 0
+    responses:
+      - topicId: "2VJlngPmSGi69WMsWRVrOw" # maps to topic named 'unauthorized'
+        partitions:
+          - partitionIndex: 549
+            errorCode: 29
+            highWatermark: -1
+            lastStableOffset: -1
+            logStartOffset: -1
+            abortedTransactions: [ ]
+            preferredReadReplica: -1
+            records: !!binary ""

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/FetchAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/FetchAuthzIT.java
@@ -34,15 +34,18 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import io.kroxylicious.filter.authorization.AuthorizationFilter;
 import io.kroxylicious.testing.kafka.junit5ext.Name;
+
+import static java.util.stream.Stream.concat;
 
 class FetchAuthzIT extends AuthzIT {
 
     public static final String EXISTING_TOPIC_NAME = "other-topic";
-    public static final IntStream API_VERSIONS_WITHOUT_TOPIC_IDS = IntStream.rangeClosed(4, 12);
-    public static final IntStream API_VERSIONS_WITH_TOPIC_IDS = IntStream.rangeClosed(13, ApiKeys.FETCH.latestVersion(true));
+    private static final short MIN_VERSION_WITH_TOPIC_ID = 13;
     private Path rulesFile;
 
     private static final String ALICE_TO_READ_TOPIC_NAME = "alice-new-topic";
@@ -89,12 +92,16 @@ class FetchAuthzIT extends AuthzIT {
     }
 
     List<Arguments> shouldEnforceAccessToTopics() {
-        Stream<Arguments> supportedVersions = API_VERSIONS_WITHOUT_TOPIC_IDS.mapToObj(
-                apiVersion -> Arguments.argumentSet("fetch version " + apiVersion, new FetchEquivalence((short) apiVersion)));
-        Stream<Arguments> unsupportedVersions = API_VERSIONS_WITH_TOPIC_IDS
-                .mapToObj(apiVersion -> Arguments.argumentSet("unsupported version " + apiVersion, new UnsupportedApiVersion<>(ApiKeys.FETCH, (short) apiVersion)));
-        return Stream.concat(supportedVersions, unsupportedVersions)
-                .toList();
+        Stream<Arguments> supportedVersions = IntStream.rangeClosed(AuthorizationFilter.minSupportedApiVersion(ApiKeys.FETCH),
+                AuthorizationFilter.maxSupportedApiVersion(ApiKeys.FETCH))
+                .boxed().map(apiVersion -> Arguments.argumentSet("fetch version " + apiVersion, new FetchEquivalence((short) (int) apiVersion)));
+        Stream<Arguments> unsupportedVersions = IntStream
+                .rangeClosed(ApiKeys.FETCH.oldestVersion(), ApiKeys.FETCH.latestVersion(true))
+                .filter(version -> !AuthorizationFilter.isApiVersionSupported(ApiKeys.FETCH, (short) version))
+                .mapToObj(
+                        apiVersion -> Arguments.argumentSet("unsupported version " + apiVersion,
+                                new UnsupportedApiVersion<>(ApiKeys.FETCH, (short) apiVersion)));
+        return concat(supportedVersions, unsupportedVersions).toList();
     }
 
     @ParameterizedTest
@@ -114,6 +121,14 @@ class FetchAuthzIT extends AuthzIT {
 
         @Override
         public String clobberResponse(BaseClusterFixture cluster, ObjectNode jsonResponse) {
+            JsonNode responses = jsonResponse.get("responses");
+            if (responses.isArray()) {
+                for (JsonNode topic : responses) {
+                    if (topic instanceof ObjectNode objectNode) {
+                        replaceTopicIdWithName(cluster, objectNode, "topicId");
+                    }
+                }
+            }
             return prettyJsonString(jsonResponse);
         }
 
@@ -130,9 +145,9 @@ class FetchAuthzIT extends AuthzIT {
         @Override
         public FetchRequestData requestData(String user, BaseClusterFixture clusterFixture) {
             FetchRequestData fetchRequestData = new FetchRequestData();
-            FetchRequestData.FetchTopic topicA = createFetchTopic(ALICE_TO_READ_TOPIC_NAME, 0);
-            FetchRequestData.FetchTopic topicB = createFetchTopic(BOB_TO_READ_TOPIC_NAME, 0);
-            FetchRequestData.FetchTopic topicC = createFetchTopic(EXISTING_TOPIC_NAME, 0);
+            FetchRequestData.FetchTopic topicA = createFetchTopic(ALICE_TO_READ_TOPIC_NAME, clusterFixture, 0);
+            FetchRequestData.FetchTopic topicB = createFetchTopic(BOB_TO_READ_TOPIC_NAME, clusterFixture, 0);
+            FetchRequestData.FetchTopic topicC = createFetchTopic(EXISTING_TOPIC_NAME, clusterFixture, 0);
             fetchRequestData.setTopics(List.of(topicA, topicB, topicC));
             return fetchRequestData;
         }
@@ -143,17 +158,22 @@ class FetchAuthzIT extends AuthzIT {
                     .flatMap(topicData -> topicData.partitions().stream())
                     .anyMatch(partitionData -> partitionData.errorCode() == Errors.NOT_LEADER_OR_FOLLOWER.code());
         }
-    }
 
-    private static FetchRequestData.FetchTopic createFetchTopic(String topicName, int... partitions) {
-        FetchRequestData.FetchTopic fetchTopic = new FetchRequestData.FetchTopic();
-        fetchTopic.setTopic(topicName);
-        List<FetchRequestData.FetchPartition> fetchPartitions = Arrays.stream(partitions).mapToObj(partition -> {
-            FetchRequestData.FetchPartition fetchPartition = new FetchRequestData.FetchPartition();
-            fetchPartition.setPartition(partition);
-            return fetchPartition;
-        }).toList();
-        fetchTopic.setPartitions(fetchPartitions);
-        return fetchTopic;
+        private FetchRequestData.FetchTopic createFetchTopic(String topicName, BaseClusterFixture cluster, int... partitions) {
+            FetchRequestData.FetchTopic fetchTopic = new FetchRequestData.FetchTopic();
+            if (apiVersion() >= MIN_VERSION_WITH_TOPIC_ID) {
+                fetchTopic.setTopicId(cluster.topicIds().get(topicName));
+            }
+            else {
+                fetchTopic.setTopic(topicName);
+            }
+            List<FetchRequestData.FetchPartition> fetchPartitions = Arrays.stream(partitions).mapToObj(partition -> {
+                FetchRequestData.FetchPartition fetchPartition = new FetchRequestData.FetchPartition();
+                fetchPartition.setPartition(partition);
+                return fetchPartition;
+            }).toList();
+            fetchTopic.setPartitions(fetchPartitions);
+            return fetchTopic;
+        }
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

* If all topic id name lookups fail for the request, then we short-circuit respond with error.
* If a subset of topic id name lookups fail, those topics are removed from the request that may be forwarded (depending on authz outcome). 
* Then, regardless of authorization outcome or whether we forward the request on, we always include these topic failures in the response message.

Closes #2930

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
