### PR TITLE
feat(authorization): do not manipulate advertised Produce minVersion

### DIFF
--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/AuthorizationFilter.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/AuthorizationFilter.java
@@ -154,6 +154,11 @@ public class AuthorizationFilter implements RequestFilter, ResponseFilter {
     public AuthorizationFilter(Authorizer authorizer) {
         this.authorizer = authorizer;
         this.inflightState = new HashMap<>(10);
+        if (apiEnforcement.get(ApiKeys.PRODUCE).minSupportedVersion() != 3) {
+            // sanity check, see https://issues.apache.org/jira/browse/KAFKA-18659
+            // if we want to raise the minimum version, we must consciously decide to break older librdkafka clients
+            throw new IllegalStateException("To behave like an upstream Kafka 4+ cluster, we must support v3 despite presenting v0 as min supported version");
+        }
     }
 
     CompletionStage<AuthorizeResult> authorization(FilterContext context, List<Action> actions) {
@@ -342,9 +347,15 @@ public class AuthorizationFilter implements RequestFilter, ResponseFilter {
         var toRemove = new ArrayList<ApiVersionsResponseData.ApiVersion>();
         ApiVersionsResponseData.ApiVersionCollection apiVersions = response.apiKeys();
         for (var version : apiVersions) {
-            var enforcement = apiEnforcement.get(ApiKeys.forId(version.apiKey()));
+            ApiKeys key = ApiKeys.forId(version.apiKey());
+            var enforcement = apiEnforcement.get(key);
             if (enforcement != null) {
-                version.setMinVersion(Passthrough.asShort(Math.max(enforcement.minSupportedVersion(), version.minVersion())));
+                // Kafka 4.0 presents itself as supporting v0-v2 of Produce despite it not really supporting
+                // those versions. This is to maintain support for older librdkafka versions.
+                // see https://issues.apache.org/jira/browse/KAFKA-18659
+                if (key != ApiKeys.PRODUCE) {
+                    version.setMinVersion(Passthrough.asShort(Math.max(enforcement.minSupportedVersion(), version.minVersion())));
+                }
                 version.setMaxVersion(Passthrough.asShort(Math.min(enforcement.maxSupportedVersion(), version.maxVersion())));
             }
             else {

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/API_VERSIONS/4/produce-minVersion-not-manipulated.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/API_VERSIONS/4/produce-minVersion-not-manipulated.yaml
@@ -1,0 +1,67 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "API_VERSIONS"
+  apiVersion: 4
+  scenario: |
+    we leave the minimum produce version unmanipulated because of a Kafka quirk to support older librdkafka clients
+    see https://issues.apache.org/jira/browse/KAFKA-18659
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "API_VERSIONS"
+      expectedRequestVersion: 4
+      expectedRequestHeader:
+        requestApiKey: 18
+        requestApiVersion: 4
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        clientSoftwareName: "random-string-313"
+        clientSoftwareVersion: "random-string-234"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        errorCode: 45
+        apiKeys:
+          - apiKey: 3 # METADATA
+            minVersion: 0
+            maxVersion: 13
+          - apiKey: 0 # PRODUCE
+            minVersion: 0
+            maxVersion: 9999 # unrealistically large maxVersion
+        throttleTimeMs: 880
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 18
+    requestApiVersion: 4
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    clientSoftwareName: "random-string-313"
+    clientSoftwareVersion: "random-string-234"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    errorCode: 45
+    apiKeys:
+      - apiKey: 3 # METADATA
+        minVersion: 0
+        maxVersion: 13
+      - apiKey: 0 # PRODUCE
+        minVersion: 0 # unmodified despite filter not supporting v0-v2
+        maxVersion: 12 # max version supported by filter
+    throttleTimeMs: 880


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

There is a Quirk in Kafka 4.0+ that the broker presents v0-v2 of Produce as supported, but does not really support them. This is to support an older librdkafka version.

See https://issues.apache.org/jira/browse/KAFKA-18659

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
