### PR TITLE
docs(record-validation): documentation for the apicurio registry trust configuration.

### DIFF
--- a/kroxylicious-docs/docs/_modules/record-validation/proc-configuring-record-validation-filter.adoc
+++ b/kroxylicious-docs/docs/_modules/record-validation/proc-configuring-record-validation-filter.adoc
@@ -69,10 +69,10 @@ allowEmpty: true
   If the record key or value does not conform to the schema identified by this ID, the record is rejected.
   If a Kafka producer embeds a schema ID in the record (either in a header or _magic_ bytes at the start of the record's key or value), the filter validates it against this value. The record is rejected if the IDs do not match.
 * `apicurioRegistryUrl` specifies the endpoint URL for the Apicurio Registry.
-* `tls` optional TLS configuration to be used when connecting to the Apicurio Registry using a secure connection
-** `storeFile` provides a set of trust anchors used to validate the connection to the server.
-** `storePassword` the password used to protect the store (optional).
-** `storeType` supported values include `PKCS12`, `JKS` and `PEM`.
+* `tls` specifies the optional TLS configuration used when connecting securely to the Apicurio Registry.
+** `storeFile` path to the truststore file that contains the trust anchors used to validate the server connection.
+** `storePassword` (Optional) password used to protect the truststore.
+** `storeType` truststore type. Supported values include `PKCS12`, `JKS`, and `PEM`.
 * `wireFormatVersion` controls whether the Apicurio client operates in `V3` (default) or `V2` (deprecated).
    In `V3` mode, the `apicurioId` property identifies schema by content ID, and the filter expects the Kafka producer to use content IDs to identify schema.
    In `V2` mode, the `apicurioId` property identifies schema by global ID, and the filter expects the Kafka producer to use global IDs to identify schema.


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

Documentation change to accompany #3033.

In #3033, support has been enabled for connecting to Apicurio Registry servers that are using a private or corporate CA.  Trust can be provide as a PKCS#12, JKS, or PEM.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [x] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
