### PR TITLE
Add Flaky Test issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaky_test.md
+++ b/.github/ISSUE_TEMPLATE/flaky_test.md
@@ -1,0 +1,22 @@
+---
+name: Flaky Test
+about: Report a non-deterministic test failure in GitHub Actions
+title: 'bug: Non-Deterministic Test <InsertTestNameHere>'
+labels: kind/bug, test, triaged
+assignees: ''
+type: Bug
+
+---
+
+A test failed non-deterministically in GitHub Actions:
+
+## failed test
+
+<< insert test name>>
+<<insert link to failure>>
+
+## stack trace
+
+```
+<<insert stack trace if relevant>>
+```


### PR DESCRIPTION
This is a particular class of Issue that we don't need to spend time triaging. We link to a test failure in Github and resolve it, there is usually nothing much to discuss. If it points to a real issue in the code, a separate issue can be created.