### PR TITLE
feat(record-validation): add Avro and Protobuf schema validation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#3498](https://github.com/kroxylicious/kroxylicious/pull/3498): feat(record-validation): add Avro and Protobuf schema validation support
 * [#3769](https://github.com/kroxylicious/kroxylicious/pull/3769): fix(runtime): messages enter Filter chain before Transport Subject built
 * [#3757](https://github.com/kroxylicious/kroxylicious/issues/3757): fix(runtime): trigger read after HAProxy message to prevent deadlock when autoread disabled
 * [#1295](https://github.com/kroxylicious/kroxylicious/issues/1295): feat(aws-kms): add IRSA and EKS Pod Identity credential providers, and restructure AWS KMS credential configuration under a new `credentials` node (see [note](#note-021-aws-kms-credentials-restructure))

--- a/kroxylicious-docs/docs/_modules/record-validation/proc-configuring-record-validation-filter.adoc
+++ b/kroxylicious-docs/docs/_modules/record-validation/proc-configuring-record-validation-filter.adoc
@@ -60,6 +60,7 @@ Example schema validation rule:
 schemaValidationConfig:
   apicurioId: 1001
   apicurioRegistryUrl: http://registry.local:8080
+  schemaType: JSON_SCHEMA
   tls:
     trust:
       storeFile: /opt/proxy/trust/ca.p12
@@ -75,6 +76,10 @@ allowEmpty: true
   If the record key or value does not conform to the schema identified by this ID, the record is rejected.
   If a Kafka producer embeds a schema ID in the record (either in a header or _magic_ bytes at the start of the record's key or value), the filter validates it against this value. The record is rejected if the IDs do not match.
 * `apicurioRegistryUrl` specifies the endpoint URL for the Apicurio Registry.
+* `schemaType` specifies the type of schema to validate against. Supported values are:
+** `JSON_SCHEMA` — validates against a JSON Schema (default if not specified).
+** `AVRO` — validates against an Apache Avro schema.
+** `PROTOBUF` — validates against a Protocol Buffers schema.
 * `tls` specifies the optional TLS configuration used when connecting securely to the Apicurio Registry.
 ** `storeFile` path to the truststore file that contains the trust anchors used to validate the server connection.
 ** `storePassword` (Optional) password used to protect the truststore.
@@ -89,8 +94,6 @@ allowEmpty: true
 For more information about embedding the ID in a record, see the
   {apicurio-docs}/getting-started/assembly-using-kafka-client-serdes.html#_consumer_schema_configuration[Apicurio documentation^].
 --
-+
-NOTE: Schema validation currently supports enforcing JSON schemas only ({github-issues}/1431[issue]).
 +
 Example JSON syntax validation rule:
 +

--- a/kroxylicious-filters/kroxylicious-record-validation/pom.xml
+++ b/kroxylicious-filters/kroxylicious-record-validation/pom.xml
@@ -57,6 +57,14 @@
             <artifactId>apicurio-registry-schema-validation-jsonschema</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-schema-validation-avro</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-schema-validation-protobuf</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.bitbucket.b_c</groupId>
             <artifactId>jose4j</artifactId>
         </dependency>

--- a/kroxylicious-filters/kroxylicious-record-validation/pom.xml
+++ b/kroxylicious-filters/kroxylicious-record-validation/pom.xml
@@ -65,6 +65,18 @@
             <artifactId>apicurio-registry-schema-validation-protobuf</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-protobuf-schema-utilities</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.bitbucket.b_c</groupId>
             <artifactId>jose4j</artifactId>
         </dependency>

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/ProduceRequestValidatorBuilder.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/ProduceRequestValidatorBuilder.java
@@ -67,16 +67,22 @@ class ProduceRequestValidatorBuilder {
         var validators = new ArrayList<BytebufValidator>();
         valueRule.getSyntacticallyCorrectJsonConfig().ifPresent(config -> validators.add(BytebufValidators.jsonSyntaxValidator(config.isValidateObjectKeysUnique())));
         valueRule.getSchemaValidationConfig().ifPresent(
-                config -> validators.add(BytebufValidators.jsonSchemaValidator(
-                        buildSchemaResolverConfig(config),
-                        config.apicurioId(),
-                        config.wireFormatVersion())));
+                config -> validators.add(buildSchemaValidator(config)));
         valueRule.getJwsSignatureValidationConfig().ifPresent(
                 config -> validators
                         .add(BytebufValidators.jwsSignatureValidator(config.getJsonWebKeySet(), config.getAlgorithms(), config.getHeaderOptions(),
                                 config.getContentOptions())));
 
         return BytebufValidators.chainOf(validators);
+    }
+
+    private static BytebufValidator buildSchemaValidator(SchemaValidationConfig config) {
+        var schemaResolverConfig = buildSchemaResolverConfig(config);
+        return switch (config.schemaType()) {
+            case JSON_SCHEMA -> BytebufValidators.jsonSchemaValidator(schemaResolverConfig, config.apicurioId(), config.wireFormatVersion());
+            case AVRO -> BytebufValidators.avroSchemaValidator(schemaResolverConfig, config.apicurioId(), config.wireFormatVersion());
+            case PROTOBUF -> BytebufValidators.protobufSchemaValidator(schemaResolverConfig, config.apicurioId(), config.wireFormatVersion());
+        };
     }
 
     private static Map<String, Object> buildSchemaResolverConfig(SchemaValidationConfig config) {

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/RecordValidation.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/RecordValidation.java
@@ -6,8 +6,6 @@
 
 package io.kroxylicious.filter.validation;
 
-import javax.annotation.Nullable;
-
 import io.kroxylicious.filter.validation.config.ValidationConfig;
 import io.kroxylicious.filter.validation.validators.request.ProduceRequestValidator;
 import io.kroxylicious.proxy.filter.FilterFactory;
@@ -17,6 +15,7 @@ import io.kroxylicious.proxy.plugin.Plugin;
 import io.kroxylicious.proxy.plugin.Plugins;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 @Plugin(configType = ValidationConfig.class)
 @DeprecatedPluginName(oldName = "io.kroxylicious.proxy.filter.validation.RecordValidation", since = "0.19.0")

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/config/SchemaValidationConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/config/SchemaValidationConfig.java
@@ -27,7 +27,7 @@ public record SchemaValidationConfig(URL apicurioRegistryUrl,
                                      long apicurioId,
                                      WireFormatVersion wireFormatVersion,
                                      @Nullable Tls tls,
-                                     SchemaType schemaType) {
+                                     @Nullable SchemaType schemaType) {
 
     /**
      * The type of schema stored in Apicurio Registry to validate against.

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/config/SchemaValidationConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/config/SchemaValidationConfig.java
@@ -21,8 +21,29 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * @param apicurioId schema identifier - interpreted as contentId for V3 (default) or globalId for V2
  * @param wireFormatVersion wire format version (defaults to V3 if null)
  * @param tls optional TLS configuration for connecting to a schema registry protected by TLS
+ * @param schemaType the type of schema to validate against (defaults to JSON_SCHEMA if null)
  */
-public record SchemaValidationConfig(URL apicurioRegistryUrl, long apicurioId, WireFormatVersion wireFormatVersion, @Nullable Tls tls) {
+public record SchemaValidationConfig(URL apicurioRegistryUrl, long apicurioId, WireFormatVersion wireFormatVersion, @Nullable Tls tls, SchemaType schemaType) {
+
+    /**
+     * The type of schema stored in Apicurio Registry to validate against.
+     */
+    public enum SchemaType {
+        /**
+         * JSON Schema validation.
+         */
+        JSON_SCHEMA,
+
+        /**
+         * Apache Avro schema validation.
+         */
+        AVRO,
+
+        /**
+         * Protocol Buffers (Protobuf) schema validation.
+         */
+        PROTOBUF
+    }
 
     /**
      * Wire format versions for Apicurio Registry schema identifiers.
@@ -47,21 +68,24 @@ public record SchemaValidationConfig(URL apicurioRegistryUrl, long apicurioId, W
     }
 
     /**
-     * Construct SchemaValidationConfig with explicit wire format version and TLS configuration
+     * Construct SchemaValidationConfig with explicit wire format version, TLS configuration, and schema type
      * @param apicurioRegistryUrl Apicurio Registry instance url
      * @param apicurioId schema identifier - interpreted as contentId for V3 (default) or globalId for V2
      * @param wireFormatVersion wire format version (defaults to V3 if null)
      * @param tls optional TLS configuration for connecting to a schema registry protected by TLS with a custom trust store
+     * @param schemaType the type of schema to validate against (defaults to JSON_SCHEMA if null)
      */
     @JsonCreator
     public SchemaValidationConfig(@JsonProperty(value = "apicurioRegistryUrl", required = true) URL apicurioRegistryUrl,
                                   @JsonProperty(value = "apicurioId", required = true) long apicurioId,
                                   @Nullable @JsonProperty(value = "wireFormatVersion", required = false) WireFormatVersion wireFormatVersion,
-                                  @JsonProperty(value = "tls", required = false) @Nullable Tls tls) {
+                                  @JsonProperty(value = "tls", required = false) @Nullable Tls tls,
+                                  @Nullable @JsonProperty(value = "schemaType", required = false) SchemaType schemaType) {
         this.apicurioId = apicurioId;
         this.apicurioRegistryUrl = apicurioRegistryUrl;
         this.wireFormatVersion = wireFormatVersion != null ? wireFormatVersion : WireFormatVersion.V3;
         this.tls = tls;
+        this.schemaType = schemaType != null ? schemaType : SchemaType.JSON_SCHEMA;
     }
 
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/config/SchemaValidationConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/config/SchemaValidationConfig.java
@@ -78,9 +78,9 @@ public record SchemaValidationConfig(URL apicurioRegistryUrl, long apicurioId, W
     @JsonCreator
     public SchemaValidationConfig(@JsonProperty(value = "apicurioRegistryUrl", required = true) URL apicurioRegistryUrl,
                                   @JsonProperty(value = "apicurioId", required = true) long apicurioId,
-                                  @Nullable @JsonProperty(value = "wireFormatVersion", required = false) WireFormatVersion wireFormatVersion,
-                                  @JsonProperty(value = "tls", required = false) @Nullable Tls tls,
-                                  @Nullable @JsonProperty(value = "schemaType", required = false) SchemaType schemaType) {
+                                  @Nullable @JsonProperty(value = "wireFormatVersion") WireFormatVersion wireFormatVersion,
+                                  @JsonProperty(value = "tls") @Nullable Tls tls,
+                                  @Nullable @JsonProperty(value = "schemaType") SchemaType schemaType) {
         this.apicurioId = apicurioId;
         this.apicurioRegistryUrl = apicurioRegistryUrl;
         this.wireFormatVersion = wireFormatVersion != null ? wireFormatVersion : WireFormatVersion.V3;

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/config/SchemaValidationConfig.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/config/SchemaValidationConfig.java
@@ -23,7 +23,11 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * @param tls optional TLS configuration for connecting to a schema registry protected by TLS
  * @param schemaType the type of schema to validate against (defaults to JSON_SCHEMA if null)
  */
-public record SchemaValidationConfig(URL apicurioRegistryUrl, long apicurioId, WireFormatVersion wireFormatVersion, @Nullable Tls tls, SchemaType schemaType) {
+public record SchemaValidationConfig(URL apicurioRegistryUrl,
+                                     long apicurioId,
+                                     WireFormatVersion wireFormatVersion,
+                                     @Nullable Tls tls,
+                                     SchemaType schemaType) {
 
     /**
      * The type of schema stored in Apicurio Registry to validate against.

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AbstractSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AbstractSchemaBytebufValidator.java
@@ -25,6 +25,23 @@ import io.apicurio.registry.serde.kafka.headers.HeadersHandler;
 import io.kroxylicious.filter.validation.config.SchemaValidationConfig.WireFormatVersion;
 import io.kroxylicious.filter.validation.validators.Result;
 
+/**
+ * Base class for schema-based record validators that validate Kafka record values (or keys)
+ * against a schema stored in Apicurio Registry.
+ * <p>
+ * This class handles the Apicurio serde wire format, extracting the schema identifier from
+ * the record (either from Kafka headers or from a magic-byte prefix in the record body) and
+ * verifying it matches the expected schema. After stripping the serde envelope, it delegates
+ * actual schema validation to the subclass via {@link #doValidate(ByteBuffer)}.
+ * </p>
+ * <p>
+ * Subclasses must implement {@link #doValidate(ByteBuffer)} to perform schema-specific
+ * validation (e.g. JSON Schema, Avro, Protobuf). Subclasses may also override
+ * {@link #skipExtraSerdeBytes(ByteBuffer)} if the serde writes additional framing bytes
+ * between the schema identifier and the payload (e.g. the Protobuf serde writes a
+ * delimited Ref message).
+ * </p>
+ */
 abstract class AbstractSchemaBytebufValidator implements BytebufValidator {
     private final Long schemaId;
     private final WireFormatVersion wireFormatVersion;
@@ -79,18 +96,9 @@ abstract class AbstractSchemaBytebufValidator implements BytebufValidator {
     @SuppressWarnings("removal")
     private Optional<Long> extractSchemaIdFromRecord(ByteBuffer buffer, Record kafkaRecord, boolean isKey) {
         // Try headers first
-        if (kafkaRecord.headers().length > 0) {
-            var recordHeaders = new RecordHeaders(kafkaRecord.headers());
-            var headerHandler = isKey ? keyHeaderHandler : valueHeaderHandler;
-            var ref = headerHandler.readHeaders(recordHeaders);
-
-            Long id = switch (wireFormatVersion) {
-                case V2 -> ref.getGlobalId();
-                case V3 -> ref.getContentId();
-            };
-            if (id != null) {
-                return Optional.of(id);
-            }
+        var headerId = extractSchemaIdFromHeaders(kafkaRecord, isKey);
+        if (headerId.isPresent()) {
+            return headerId;
         }
 
         // Fall back to body prefix
@@ -104,6 +112,24 @@ abstract class AbstractSchemaBytebufValidator implements BytebufValidator {
                 case V3 -> ref.getContentId();
             };
             return Optional.ofNullable(id);
+        }
+        return Optional.empty();
+    }
+
+    @SuppressWarnings("removal")
+    private Optional<Long> extractSchemaIdFromHeaders(Record kafkaRecord, boolean isKey) {
+        if (kafkaRecord.headers().length > 0) {
+            var recordHeaders = new RecordHeaders(kafkaRecord.headers());
+            var headerHandler = isKey ? keyHeaderHandler : valueHeaderHandler;
+            var ref = headerHandler.readHeaders(recordHeaders);
+
+            Long id = switch (wireFormatVersion) {
+                case V2 -> ref.getGlobalId();
+                case V3 -> ref.getContentId();
+            };
+            if (id != null) {
+                return Optional.of(id);
+            }
         }
         return Optional.empty();
     }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AbstractSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AbstractSchemaBytebufValidator.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.validation.validators.bytebuf;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.Record;
+
+import io.apicurio.registry.serde.BaseSerde;
+import io.apicurio.registry.serde.Default4ByteIdHandler;
+import io.apicurio.registry.serde.IdHandler;
+import io.apicurio.registry.serde.Legacy8ByteIdHandler;
+import io.apicurio.registry.serde.kafka.headers.DefaultHeadersHandler;
+import io.apicurio.registry.serde.kafka.headers.HeadersHandler;
+
+import io.kroxylicious.filter.validation.config.SchemaValidationConfig.WireFormatVersion;
+import io.kroxylicious.filter.validation.validators.Result;
+
+abstract class AbstractSchemaBytebufValidator implements BytebufValidator {
+    private final Long schemaId;
+    private final WireFormatVersion wireFormatVersion;
+    private final HeadersHandler keyHeaderHandler;
+    private final HeadersHandler valueHeaderHandler;
+    private final IdHandler keyIdHandler;
+    private final IdHandler valueIdHandler;
+
+    protected AbstractSchemaBytebufValidator(Long schemaId, WireFormatVersion wireFormatVersion) {
+        this.schemaId = schemaId;
+        this.wireFormatVersion = wireFormatVersion;
+        this.keyHeaderHandler = buildHeaderHandler(true);
+        this.keyIdHandler = buildIdHandler(true, wireFormatVersion);
+        this.valueHeaderHandler = buildHeaderHandler(false);
+        this.valueIdHandler = buildIdHandler(false, wireFormatVersion);
+    }
+
+    @Override
+    public CompletionStage<Result> validate(ByteBuffer buffer, Record record, boolean isKey) {
+        try {
+            Optional<Long> extractedSchemaId = extractSchemaIdFromRecord(buffer, record, isKey);
+            if (extractedSchemaId.filter(e -> !e.equals(schemaId)).isPresent()) {
+                return CompletableFuture
+                        .completedStage(new Result(false, "Unexpected schema id in record (%d), expecting %d".formatted(extractedSchemaId.get(), schemaId)));
+            }
+
+            return doValidate(buffer);
+        }
+        catch (RuntimeException ex) {
+            return CompletableFuture.completedStage(new Result(false, ex.getMessage()));
+        }
+    }
+
+    protected abstract CompletionStage<Result> doValidate(ByteBuffer buffer);
+
+    @SuppressWarnings("removal")
+    private Optional<Long> extractSchemaIdFromRecord(ByteBuffer buffer, Record kafkaRecord, boolean isKey) {
+        if (kafkaRecord.headers().length > 0) {
+            var recordHeaders = new RecordHeaders(kafkaRecord.headers());
+            var headerHandler = isKey ? keyHeaderHandler : valueHeaderHandler;
+            var ref = headerHandler.readHeaders(recordHeaders);
+
+            Long id = switch (wireFormatVersion) {
+                case V2 -> ref.getGlobalId();
+                case V3 -> ref.getContentId();
+            };
+            if (id != null) {
+                return Optional.of(id);
+            }
+        }
+
+        var idHandler = isKey ? keyIdHandler : valueIdHandler;
+        var minBytes = 1 + idHandler.idSize();
+        if (buffer.remaining() > minBytes && buffer.get(buffer.position()) == BaseSerde.MAGIC_BYTE) {
+            buffer.get(); // ignore magic
+            var ref = idHandler.readId(buffer);
+            Long id = switch (wireFormatVersion) {
+                case V2 -> ref.getGlobalId();
+                case V3 -> ref.getContentId();
+            };
+            return Optional.ofNullable(id);
+        }
+        return Optional.empty();
+    }
+
+    private static DefaultHeadersHandler buildHeaderHandler(boolean isKey) {
+        var handler = new DefaultHeadersHandler();
+        handler.configure(Map.of(), isKey);
+        return handler;
+    }
+
+    @SuppressWarnings("removal")
+    private static IdHandler buildIdHandler(boolean isKey, WireFormatVersion wireFormatVersion) {
+        IdHandler handler = switch (wireFormatVersion) {
+            case V2 -> new Legacy8ByteIdHandler();
+            case V3 -> new Default4ByteIdHandler();
+        };
+        handler.configure(Map.of(), isKey);
+        return handler;
+    }
+}

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AbstractSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AbstractSchemaBytebufValidator.java
@@ -26,8 +26,9 @@ import io.kroxylicious.filter.validation.config.SchemaValidationConfig.WireForma
 import io.kroxylicious.filter.validation.validators.Result;
 
 /**
- * Base class for schema-based record validators that validate Kafka record values (or keys)
+ * Base class for schema-based record validators that validate Kafka record keys or values
  * against a schema stored in Apicurio Registry.
+ * This checks both that the record key or value has the expected schemaId, and that the key or value bytes validate against that schema.
  * <p>
  * This class handles the Apicurio serde wire format, extracting the schema identifier from
  * the record (either from Kafka headers or from a magic-byte prefix in the record body) and

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AbstractSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AbstractSchemaBytebufValidator.java
@@ -70,6 +70,10 @@ abstract class AbstractSchemaBytebufValidator implements BytebufValidator {
             }
 
             if (extractedSchemaId.isPresent()) {
+                // Some serdes write extra framing bytes after the schema ID (in both header and body modes).
+                // For example, Apicurio ProtobufSerde always writes a delimited Ref message containing the
+                // message type name before the protobuf payload — verified against Apicurio source where
+                // writeRef defaults to true and is never set to false in the body-mode code path.
                 skipExtraSerdeBytes(buffer);
             }
 

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AbstractSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AbstractSchemaBytebufValidator.java
@@ -48,7 +48,12 @@ abstract class AbstractSchemaBytebufValidator implements BytebufValidator {
             Optional<Long> extractedSchemaId = extractSchemaIdFromRecord(buffer, record, isKey);
             if (extractedSchemaId.filter(e -> !e.equals(schemaId)).isPresent()) {
                 return CompletableFuture
-                        .completedStage(new Result(false, "Unexpected schema id in record (%d), expecting %d".formatted(extractedSchemaId.get(), schemaId)));
+                        .completedStage(new Result(false,
+                                "Unexpected schema id in record (%d), expecting %d".formatted(extractedSchemaId.get(), schemaId)));
+            }
+
+            if (extractedSchemaId.isPresent()) {
+                skipExtraSerdeBytes(buffer);
             }
 
             return doValidate(buffer);
@@ -60,8 +65,20 @@ abstract class AbstractSchemaBytebufValidator implements BytebufValidator {
 
     protected abstract CompletionStage<Result> doValidate(ByteBuffer buffer);
 
+    /**
+     * Called when schema ID was found in the record (either in headers or body prefix).
+     * The body may contain serde-specific prefix bytes that need to be skipped before the
+     * actual schema data. For example, the Protobuf serde writes a Ref message before
+     * the protobuf payload in both header and body modes.
+     * Default implementation does nothing (JSON and Avro serdes have no extra prefix).
+     */
+    protected void skipExtraSerdeBytes(ByteBuffer buffer) {
+        // default: no extra bytes to skip
+    }
+
     @SuppressWarnings("removal")
     private Optional<Long> extractSchemaIdFromRecord(ByteBuffer buffer, Record kafkaRecord, boolean isKey) {
+        // Try headers first
         if (kafkaRecord.headers().length > 0) {
             var recordHeaders = new RecordHeaders(kafkaRecord.headers());
             var headerHandler = isKey ? keyHeaderHandler : valueHeaderHandler;
@@ -76,6 +93,7 @@ abstract class AbstractSchemaBytebufValidator implements BytebufValidator {
             }
         }
 
+        // Fall back to body prefix
         var idHandler = isKey ? keyIdHandler : valueIdHandler;
         var minBytes = 1 + idHandler.idSize();
         if (buffer.remaining() > minBytes && buffer.get(buffer.position()) == BaseSerde.MAGIC_BYTE) {

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AvroSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AvroSchemaBytebufValidator.java
@@ -38,7 +38,7 @@ import io.kroxylicious.filter.validation.validators.Result;
  * envelope (schema ID in headers or magic-byte body prefix).
  * </p>
  */
-public class AvroSchemaBytebufValidator extends AbstractSchemaBytebufValidator {
+class AvroSchemaBytebufValidator extends AbstractSchemaBytebufValidator {
     private final AvroValidator avroValidator;
     private final Schema avroSchema;
 

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AvroSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AvroSchemaBytebufValidator.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.filter.validation.validators.bytebuf;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Optional;
@@ -75,7 +76,7 @@ public class AvroSchemaBytebufValidator extends AbstractSchemaBytebufValidator {
             return schemaLookupResult.getParsedSchema().getParsedSchema();
         }
         catch (IOException e) {
-            throw new RuntimeException("Failed to resolve Avro schema", e);
+            throw new UncheckedIOException("Failed to resolve Avro schema", e);
         }
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AvroSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AvroSchemaBytebufValidator.java
@@ -60,9 +60,13 @@ public class AvroSchemaBytebufValidator extends AbstractSchemaBytebufValidator {
     }
 
     private static Schema resolveAvroSchema(Map<String, Object> schemaResolverConfig, Long schemaId) {
-        SchemaResolver<Schema, GenericRecord> resolver = new DefaultSchemaResolver<>();
-        resolver.configure(schemaResolverConfig, new AvroSchemaParser());
-        var schemaLookupResult = resolver.resolveSchemaByArtifactReference(ArtifactReference.fromContentId(schemaId));
-        return schemaLookupResult.getParsedSchema().getParsedSchema();
+        try (SchemaResolver<Schema, GenericRecord> resolver = new DefaultSchemaResolver<>()) {
+            resolver.configure(schemaResolverConfig, new AvroSchemaParser());
+            var schemaLookupResult = resolver.resolveSchemaByArtifactReference(ArtifactReference.fromContentId(schemaId));
+            return schemaLookupResult.getParsedSchema().getParsedSchema();
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to resolve Avro schema", e);
+        }
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AvroSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AvroSchemaBytebufValidator.java
@@ -42,7 +42,7 @@ class AvroSchemaBytebufValidator extends AbstractSchemaBytebufValidator {
     private final AvroValidator avroValidator;
     private final Schema avroSchema;
 
-    public AvroSchemaBytebufValidator(Map<String, Object> schemaResolverConfig, Long schemaId, WireFormatVersion wireFormatVersion) {
+    AvroSchemaBytebufValidator(Map<String, Object> schemaResolverConfig, Long schemaId, WireFormatVersion wireFormatVersion) {
         super(schemaId, wireFormatVersion);
         this.avroValidator = new AvroValidator(schemaResolverConfig, Optional.of(ArtifactReference.fromContentId(schemaId)));
         this.avroSchema = resolveAvroSchema(schemaResolverConfig, schemaId);

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AvroSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AvroSchemaBytebufValidator.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.validation.validators.bytebuf;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DecoderFactory;
+
+import io.apicurio.registry.resolver.DefaultSchemaResolver;
+import io.apicurio.registry.resolver.SchemaResolver;
+import io.apicurio.registry.resolver.strategy.ArtifactReference;
+import io.apicurio.schema.validation.avro.AvroSchemaParser;
+import io.apicurio.schema.validation.avro.AvroValidationResult;
+import io.apicurio.schema.validation.avro.AvroValidator;
+
+import io.kroxylicious.filter.validation.config.SchemaValidationConfig.WireFormatVersion;
+import io.kroxylicious.filter.validation.validators.Result;
+
+public class AvroSchemaBytebufValidator extends AbstractSchemaBytebufValidator {
+    private final AvroValidator avroValidator;
+    private final Schema avroSchema;
+
+    public AvroSchemaBytebufValidator(Map<String, Object> schemaResolverConfig, Long schemaId, WireFormatVersion wireFormatVersion) {
+        super(schemaId, wireFormatVersion);
+        this.avroValidator = new AvroValidator(schemaResolverConfig, Optional.of(ArtifactReference.fromContentId(schemaId)));
+        this.avroSchema = resolveAvroSchema(schemaResolverConfig, schemaId);
+    }
+
+    @Override
+    protected CompletionStage<Result> doValidate(ByteBuffer buffer) {
+        try {
+            GenericRecord record = deserialize(buffer);
+            AvroValidationResult avroValidationResult = avroValidator.validateByArtifactReference(record);
+            return avroValidationResult.success() ? Result.VALID_RESULT_STAGE
+                    : CompletableFuture.completedFuture(new Result(false, avroValidationResult.toString()));
+        }
+        catch (IOException e) {
+            return CompletableFuture.completedFuture(new Result(false, "Failed to deserialize Avro record: " + e.getMessage()));
+        }
+    }
+
+    private GenericRecord deserialize(ByteBuffer buffer) throws IOException {
+        byte[] bytes = new byte[buffer.remaining()];
+        buffer.get(bytes);
+        var decoder = DecoderFactory.get().binaryDecoder(bytes, null);
+        var reader = new GenericDatumReader<GenericRecord>(avroSchema);
+        return reader.read(null, decoder);
+    }
+
+    private static Schema resolveAvroSchema(Map<String, Object> schemaResolverConfig, Long schemaId) {
+        SchemaResolver<Schema, GenericRecord> resolver = new DefaultSchemaResolver<>();
+        resolver.configure(schemaResolverConfig, new AvroSchemaParser());
+        var schemaLookupResult = resolver.resolveSchemaByArtifactReference(ArtifactReference.fromContentId(schemaId));
+        return schemaLookupResult.getParsedSchema().getParsedSchema();
+    }
+}

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AvroSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/AvroSchemaBytebufValidator.java
@@ -28,6 +28,15 @@ import io.apicurio.schema.validation.avro.AvroValidator;
 import io.kroxylicious.filter.validation.config.SchemaValidationConfig.WireFormatVersion;
 import io.kroxylicious.filter.validation.validators.Result;
 
+/**
+ * Validates Kafka record values against an Apache Avro schema stored in Apicurio Registry.
+ * <p>
+ * Supports Avro Schema (JSON-based {@code .avsc}) format. Avro IDL ({@code .avdl}) is not
+ * directly supported; IDL must be compiled to Avro Schema before registration in the registry.
+ * The binary Avro payload is deserialized and validated after stripping any Apicurio serde
+ * envelope (schema ID in headers or magic-byte body prefix).
+ * </p>
+ */
 public class AvroSchemaBytebufValidator extends AbstractSchemaBytebufValidator {
     private final AvroValidator avroValidator;
     private final Schema avroSchema;

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/BytebufValidators.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/BytebufValidators.java
@@ -67,6 +67,28 @@ public class BytebufValidators {
     }
 
     /**
+     * get validator that validates if a non-null/non-empty buffer contains data that matches an Avro schema registered in the Schema Registry
+     * @param schemaResolverConfig schema resolver configuration
+     * @param contentId content ID to validate against
+     * @param wireFormatVersion wire format version (V2 or V3)
+     * @return validator
+     */
+    public static BytebufValidator avroSchemaValidator(Map<String, Object> schemaResolverConfig, Long contentId, WireFormatVersion wireFormatVersion) {
+        return new AvroSchemaBytebufValidator(schemaResolverConfig, contentId, wireFormatVersion);
+    }
+
+    /**
+     * get validator that validates if a non-null/non-empty buffer contains data that matches a Protobuf schema registered in the Schema Registry
+     * @param schemaResolverConfig schema resolver configuration
+     * @param contentId content ID to validate against
+     * @param wireFormatVersion wire format version (V2 or V3)
+     * @return validator
+     */
+    public static BytebufValidator protobufSchemaValidator(Map<String, Object> schemaResolverConfig, Long contentId, WireFormatVersion wireFormatVersion) {
+        return new ProtobufSchemaBytebufValidator(schemaResolverConfig, contentId, wireFormatVersion);
+    }
+
+    /**
      * Returns a validator that can validate whether a record contains a valid JWS (JSON Web Signature) Signature
      *
      * <p>

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/JsonSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/JsonSchemaBytebufValidator.java
@@ -20,7 +20,7 @@ import io.kroxylicious.filter.validation.config.SchemaValidationConfig.WireForma
 import io.kroxylicious.filter.validation.validators.Result;
 
 /**
- * Validates Kafka record values against a JSON Schema stored in Apicurio Registry.
+ * Validates Kafka record keys and values against a JSON Schema stored in Apicurio Registry.
  * <p>
  * Supports JSON Schema drafts as accepted by Apicurio Registry (Draft-04 through Draft 2020-12).
  * The JSON payload is validated after stripping any Apicurio serde envelope (schema ID in

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/JsonSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/JsonSchemaBytebufValidator.java
@@ -27,7 +27,7 @@ import io.kroxylicious.filter.validation.validators.Result;
  * headers or magic-byte body prefix).
  * </p>
  */
-public class JsonSchemaBytebufValidator extends AbstractSchemaBytebufValidator {
+class JsonSchemaBytebufValidator extends AbstractSchemaBytebufValidator {
     private final JsonValidator jsonValidator;
 
     public JsonSchemaBytebufValidator(Map<String, Object> schemaResolverConfig, Long schemaId, WireFormatVersion wireFormatVersion) {

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/JsonSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/JsonSchemaBytebufValidator.java
@@ -12,106 +12,25 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
-import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.apache.kafka.common.record.Record;
-
 import io.apicurio.registry.resolver.strategy.ArtifactReference;
-import io.apicurio.registry.serde.BaseSerde;
-import io.apicurio.registry.serde.Default4ByteIdHandler;
-import io.apicurio.registry.serde.IdHandler;
-import io.apicurio.registry.serde.Legacy8ByteIdHandler;
-import io.apicurio.registry.serde.kafka.headers.DefaultHeadersHandler;
-import io.apicurio.registry.serde.kafka.headers.HeadersHandler;
 import io.apicurio.schema.validation.json.JsonValidationResult;
 import io.apicurio.schema.validation.json.JsonValidator;
 
 import io.kroxylicious.filter.validation.config.SchemaValidationConfig.WireFormatVersion;
 import io.kroxylicious.filter.validation.validators.Result;
 
-public class JsonSchemaBytebufValidator implements BytebufValidator {
+public class JsonSchemaBytebufValidator extends AbstractSchemaBytebufValidator {
     private final JsonValidator jsonValidator;
-    private final Long schemaId;
-    private final WireFormatVersion wireFormatVersion;
-    private final HeadersHandler keyHeaderHandler;
-    private final HeadersHandler valueHeaderHandler;
-    private final IdHandler keyIdHandler;
-    private final IdHandler valueIdHandler;
 
     public JsonSchemaBytebufValidator(Map<String, Object> schemaResolverConfig, Long schemaId, WireFormatVersion wireFormatVersion) {
-        this.schemaId = schemaId;
-        this.wireFormatVersion = wireFormatVersion;
+        super(schemaId, wireFormatVersion);
         this.jsonValidator = new JsonValidator(schemaResolverConfig, Optional.of(ArtifactReference.fromContentId(schemaId)));
-        this.keyHeaderHandler = buildHeaderHandler(true);
-        this.keyIdHandler = buildIdHandler(true, wireFormatVersion);
-
-        this.valueHeaderHandler = buildHeaderHandler(false);
-        this.valueIdHandler = buildIdHandler(false, wireFormatVersion);
     }
 
     @Override
-    public CompletionStage<Result> validate(ByteBuffer buffer, Record record, boolean isKey) {
-        try {
-            // If the record includes a schema id, validate that it is consistent with the expected schemaId.
-            Optional<Long> extractedSchemaId = extractSchemaIdFromRecord(buffer, record, isKey);
-            if (extractedSchemaId.filter(e -> !e.equals(schemaId)).isPresent()) {
-                return CompletableFuture
-                        .completedStage(new Result(false, "Unexpected schema id in record (%d), expecting %d".formatted(extractedSchemaId.get(), schemaId)));
-            }
-
-            JsonValidationResult jsonValidationResult = jsonValidator.validateByArtifactReference(buffer);
-            return jsonValidationResult.success() ? Result.VALID_RESULT_STAGE
-                    : CompletableFuture.completedFuture(new Result(false, jsonValidationResult.toString()));
-        }
-        catch (RuntimeException ex) {
-            return CompletableFuture.completedStage(new Result(false, ex.getMessage()));
-        }
-    }
-
-    @SuppressWarnings("removal")
-    private Optional<Long> extractSchemaIdFromRecord(ByteBuffer buffer, Record kafkaRecord, boolean isKey) {
-        if (kafkaRecord.headers().length > 0) {
-            var recordHeaders = new RecordHeaders(kafkaRecord.headers());
-            var headerHandler = isKey ? keyHeaderHandler : valueHeaderHandler;
-            var ref = headerHandler.readHeaders(recordHeaders);
-
-            // V2 uses globalId in headers, V3 uses contentId
-            Long id = switch (wireFormatVersion) {
-                case V2 -> ref.getGlobalId();
-                case V3 -> ref.getContentId();
-            };
-            if (id != null) {
-                return Optional.of(id);
-            }
-        }
-
-        var idHandler = isKey ? keyIdHandler : valueIdHandler;
-        var minBytes = 1 + idHandler.idSize();
-        if (buffer.remaining() > minBytes && buffer.get(buffer.position()) == BaseSerde.MAGIC_BYTE) {
-            buffer.get(); // ignore magic
-            // V2 uses globalId in wire format, V3 uses contentId
-            var ref = idHandler.readId(buffer);
-            Long id = switch (wireFormatVersion) {
-                case V2 -> ref.getGlobalId();
-                case V3 -> ref.getContentId();
-            };
-            return Optional.ofNullable(id);
-        }
-        return Optional.empty();
-    }
-
-    private static DefaultHeadersHandler buildHeaderHandler(boolean isKey) {
-        var handler = new DefaultHeadersHandler();
-        handler.configure(Map.of(), isKey);
-        return handler;
-    }
-
-    @SuppressWarnings("removal")
-    private static IdHandler buildIdHandler(boolean isKey, WireFormatVersion wireFormatVersion) {
-        IdHandler handler = switch (wireFormatVersion) {
-            case V2 -> new Legacy8ByteIdHandler();
-            case V3 -> new Default4ByteIdHandler();
-        };
-        handler.configure(Map.of(), isKey);
-        return handler;
+    protected CompletionStage<Result> doValidate(ByteBuffer buffer) {
+        JsonValidationResult jsonValidationResult = jsonValidator.validateByArtifactReference(buffer);
+        return jsonValidationResult.success() ? Result.VALID_RESULT_STAGE
+                : CompletableFuture.completedFuture(new Result(false, jsonValidationResult.toString()));
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/JsonSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/JsonSchemaBytebufValidator.java
@@ -30,7 +30,7 @@ import io.kroxylicious.filter.validation.validators.Result;
 class JsonSchemaBytebufValidator extends AbstractSchemaBytebufValidator {
     private final JsonValidator jsonValidator;
 
-    public JsonSchemaBytebufValidator(Map<String, Object> schemaResolverConfig, Long schemaId, WireFormatVersion wireFormatVersion) {
+    JsonSchemaBytebufValidator(Map<String, Object> schemaResolverConfig, Long schemaId, WireFormatVersion wireFormatVersion) {
         super(schemaId, wireFormatVersion);
         this.jsonValidator = new JsonValidator(schemaResolverConfig, Optional.of(ArtifactReference.fromContentId(schemaId)));
     }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/JsonSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/JsonSchemaBytebufValidator.java
@@ -19,6 +19,14 @@ import io.apicurio.schema.validation.json.JsonValidator;
 import io.kroxylicious.filter.validation.config.SchemaValidationConfig.WireFormatVersion;
 import io.kroxylicious.filter.validation.validators.Result;
 
+/**
+ * Validates Kafka record values against a JSON Schema stored in Apicurio Registry.
+ * <p>
+ * Supports JSON Schema drafts as accepted by Apicurio Registry (Draft-04 through Draft 2020-12).
+ * The JSON payload is validated after stripping any Apicurio serde envelope (schema ID in
+ * headers or magic-byte body prefix).
+ * </p>
+ */
 public class JsonSchemaBytebufValidator extends AbstractSchemaBytebufValidator {
     private final JsonValidator jsonValidator;
 

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidator.java
@@ -40,6 +40,30 @@ public class ProtobufSchemaBytebufValidator extends AbstractSchemaBytebufValidat
     }
 
     @Override
+    protected void skipExtraSerdeBytes(ByteBuffer buffer) {
+        // The Apicurio ProtobufSerde writes a delimited Ref message (containing the protobuf
+        // message type name) before the actual protobuf payload in both header and body modes.
+        if (buffer.hasRemaining()) {
+            int refSize = readVarint(buffer);
+            for (int i = 0; i < refSize && buffer.hasRemaining(); i++) {
+                buffer.get();
+            }
+        }
+    }
+
+    private static int readVarint(ByteBuffer buffer) {
+        int value = 0;
+        int shift = 0;
+        byte b;
+        do {
+            b = buffer.get();
+            value |= (b & 0x7F) << shift;
+            shift += 7;
+        } while ((b & 0x80) != 0);
+        return value;
+    }
+
+    @Override
     protected CompletionStage<Result> doValidate(ByteBuffer buffer) {
         try {
             byte[] bytes = new byte[buffer.remaining()];

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidator.java
@@ -6,6 +6,7 @@
 
 package io.kroxylicious.filter.validation.validators.bytebuf;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Optional;
@@ -54,10 +55,14 @@ public class ProtobufSchemaBytebufValidator extends AbstractSchemaBytebufValidat
     }
 
     private static Descriptors.Descriptor resolveProtobufDescriptor(Map<String, Object> schemaResolverConfig, Long schemaId) {
-        SchemaResolver<ProtobufSchema, Message> resolver = new DefaultSchemaResolver<>();
-        resolver.configure(schemaResolverConfig, new ProtobufSchemaParser<>());
-        var schemaLookupResult = resolver.resolveSchemaByArtifactReference(ArtifactReference.fromContentId(schemaId));
-        var protobufSchema = schemaLookupResult.getParsedSchema().getParsedSchema();
-        return protobufSchema.getFileDescriptor().getMessageTypes().get(0);
+        try (SchemaResolver<ProtobufSchema, Message> resolver = new DefaultSchemaResolver<>()) {
+            resolver.configure(schemaResolverConfig, new ProtobufSchemaParser<>());
+            var schemaLookupResult = resolver.resolveSchemaByArtifactReference(ArtifactReference.fromContentId(schemaId));
+            var protobufSchema = schemaLookupResult.getParsedSchema().getParsedSchema();
+            return protobufSchema.getFileDescriptor().getMessageTypes().get(0);
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to resolve Protobuf schema", e);
+        }
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidator.java
@@ -51,7 +51,7 @@ class ProtobufSchemaBytebufValidator extends AbstractSchemaBytebufValidator {
     private final ProtobufValidator protobufValidator;
     private final Descriptors.Descriptor messageDescriptor;
 
-    public ProtobufSchemaBytebufValidator(Map<String, Object> schemaResolverConfig, Long schemaId, WireFormatVersion wireFormatVersion) {
+    ProtobufSchemaBytebufValidator(Map<String, Object> schemaResolverConfig, Long schemaId, WireFormatVersion wireFormatVersion) {
         super(schemaId, wireFormatVersion);
         this.protobufValidator = new ProtobufValidator(schemaResolverConfig, Optional.of(ArtifactReference.fromContentId(schemaId)));
         this.messageDescriptor = resolveProtobufDescriptor(schemaResolverConfig, schemaId);

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidator.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.validation.validators.bytebuf;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.Message;
+
+import io.apicurio.registry.resolver.DefaultSchemaResolver;
+import io.apicurio.registry.resolver.SchemaResolver;
+import io.apicurio.registry.resolver.strategy.ArtifactReference;
+import io.apicurio.registry.utils.protobuf.schema.ProtobufSchema;
+import io.apicurio.schema.validation.protobuf.ProtobufSchemaParser;
+import io.apicurio.schema.validation.protobuf.ProtobufValidationResult;
+import io.apicurio.schema.validation.protobuf.ProtobufValidator;
+
+import io.kroxylicious.filter.validation.config.SchemaValidationConfig.WireFormatVersion;
+import io.kroxylicious.filter.validation.validators.Result;
+
+public class ProtobufSchemaBytebufValidator extends AbstractSchemaBytebufValidator {
+    private final ProtobufValidator protobufValidator;
+    private final Descriptors.Descriptor messageDescriptor;
+
+    public ProtobufSchemaBytebufValidator(Map<String, Object> schemaResolverConfig, Long schemaId, WireFormatVersion wireFormatVersion) {
+        super(schemaId, wireFormatVersion);
+        this.protobufValidator = new ProtobufValidator(schemaResolverConfig, Optional.of(ArtifactReference.fromContentId(schemaId)));
+        this.messageDescriptor = resolveProtobufDescriptor(schemaResolverConfig, schemaId);
+    }
+
+    @Override
+    protected CompletionStage<Result> doValidate(ByteBuffer buffer) {
+        try {
+            byte[] bytes = new byte[buffer.remaining()];
+            buffer.get(bytes);
+            DynamicMessage message = DynamicMessage.parseFrom(messageDescriptor, bytes);
+            ProtobufValidationResult protobufValidationResult = protobufValidator.validateByArtifactReference(message);
+            return protobufValidationResult.success() ? Result.VALID_RESULT_STAGE
+                    : CompletableFuture.completedFuture(new Result(false, protobufValidationResult.toString()));
+        }
+        catch (InvalidProtocolBufferException e) {
+            return CompletableFuture.completedFuture(new Result(false, "Failed to parse Protobuf message: " + e.getMessage()));
+        }
+    }
+
+    private static Descriptors.Descriptor resolveProtobufDescriptor(Map<String, Object> schemaResolverConfig, Long schemaId) {
+        SchemaResolver<ProtobufSchema, Message> resolver = new DefaultSchemaResolver<>();
+        resolver.configure(schemaResolverConfig, new ProtobufSchemaParser<>());
+        var schemaLookupResult = resolver.resolveSchemaByArtifactReference(ArtifactReference.fromContentId(schemaId));
+        var protobufSchema = schemaLookupResult.getParsedSchema().getParsedSchema();
+        return protobufSchema.getFileDescriptor().getMessageTypes().get(0);
+    }
+}

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidator.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.filter.validation.validators.bytebuf;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.Optional;
@@ -98,7 +99,7 @@ public class ProtobufSchemaBytebufValidator extends AbstractSchemaBytebufValidat
             return protobufSchema.getFileDescriptor().getMessageTypes().get(0);
         }
         catch (IOException e) {
-            throw new RuntimeException("Failed to resolve Protobuf schema", e);
+            throw new UncheckedIOException("Failed to resolve Protobuf schema", e);
         }
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidator.java
@@ -37,12 +37,17 @@ import io.kroxylicious.filter.validation.validators.Result;
  * is not currently supported by Apicurio Registry.
  * </p>
  * <p>
+ * Only the first message type defined in the {@code .proto} file is used for validation.
+ * If the schema contains no message types, construction fails with an
+ * {@link IllegalArgumentException}.
+ * </p>
+ * <p>
  * The Apicurio ProtobufSerde writes a delimited Ref message (containing the protobuf message
  * type name) before the actual protobuf payload in both header and body modes. This class
  * overrides {@link #skipExtraSerdeBytes(ByteBuffer)} to skip that Ref prefix before validation.
  * </p>
  */
-public class ProtobufSchemaBytebufValidator extends AbstractSchemaBytebufValidator {
+class ProtobufSchemaBytebufValidator extends AbstractSchemaBytebufValidator {
     private final ProtobufValidator protobufValidator;
     private final Descriptors.Descriptor messageDescriptor;
 
@@ -69,6 +74,12 @@ public class ProtobufSchemaBytebufValidator extends AbstractSchemaBytebufValidat
         int shift = 0;
         byte b;
         do {
+            if (!buffer.hasRemaining()) {
+                throw new IllegalArgumentException("Truncated varint in Ref prefix");
+            }
+            if (shift >= 35) {
+                throw new IllegalArgumentException("Varint too long in Ref prefix");
+            }
             b = buffer.get();
             value |= (b & 0x7F) << shift;
             shift += 7;
@@ -96,7 +107,11 @@ public class ProtobufSchemaBytebufValidator extends AbstractSchemaBytebufValidat
             resolver.configure(schemaResolverConfig, new ProtobufSchemaParser<>());
             var schemaLookupResult = resolver.resolveSchemaByArtifactReference(ArtifactReference.fromContentId(schemaId));
             var protobufSchema = schemaLookupResult.getParsedSchema().getParsedSchema();
-            return protobufSchema.getFileDescriptor().getMessageTypes().get(0);
+            var messageTypes = protobufSchema.getFileDescriptor().getMessageTypes();
+            if (messageTypes.isEmpty()) {
+                throw new IllegalArgumentException("Protobuf schema has no message types defined");
+            }
+            return messageTypes.get(0);
         }
         catch (IOException e) {
             throw new UncheckedIOException("Failed to resolve Protobuf schema", e);

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidator.java
@@ -29,6 +29,18 @@ import io.apicurio.schema.validation.protobuf.ProtobufValidator;
 import io.kroxylicious.filter.validation.config.SchemaValidationConfig.WireFormatVersion;
 import io.kroxylicious.filter.validation.validators.Result;
 
+/**
+ * Validates Kafka record values against a Protocol Buffers schema stored in Apicurio Registry.
+ * <p>
+ * Supports proto2 and proto3 syntax. The proto editions syntax (introduced in protobuf v27)
+ * is not currently supported by Apicurio Registry.
+ * </p>
+ * <p>
+ * The Apicurio ProtobufSerde writes a delimited Ref message (containing the protobuf message
+ * type name) before the actual protobuf payload in both header and body modes. This class
+ * overrides {@link #skipExtraSerdeBytes(ByteBuffer)} to skip that Ref prefix before validation.
+ * </p>
+ */
 public class ProtobufSchemaBytebufValidator extends AbstractSchemaBytebufValidator {
     private final ProtobufValidator protobufValidator;
     private final Descriptors.Descriptor messageDescriptor;

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/ProduceRequestValidatorBuilderTlsTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/ProduceRequestValidatorBuilderTlsTest.java
@@ -141,7 +141,7 @@ class ProduceRequestValidatorBuilderTlsTest {
     }
 
     private SchemaValidationConfig schemaConfig(@Nullable Tls tls) {
-        return new SchemaValidationConfig(registryUrl, 1L, null, tls);
+        return new SchemaValidationConfig(registryUrl, 1L, null, tls, null);
     }
 
     private Object buildValidatorConfig(SchemaValidationConfig schemaConfig) {

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/ProduceRequestValidatorBuilderTlsTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/ProduceRequestValidatorBuilderTlsTest.java
@@ -6,13 +6,20 @@
 
 package io.kroxylicious.filter.validation;
 
+import java.io.FileOutputStream;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.util.Base64;
 import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import io.kroxylicious.filter.validation.config.BytebufValidation;
 import io.kroxylicious.filter.validation.config.SchemaValidationConfig;
@@ -37,10 +44,52 @@ class ProduceRequestValidatorBuilderTlsTest {
     private static final String PATH_TO_CLIENT_CERT_PEM = getResourceLocationOnFilesystem("client.pem");
     public static final String STORE_PASS = "storepass";
     private static URL registryUrl;
+    private static String jksTruststorePath;
+    private static String pkcs12TruststorePath;
+    private static String pemCertPath;
+    private static final String TRUSTSTORE_PASSWORD = "changeit";
+
+    @TempDir
+    private static Path tempDir;
 
     @BeforeAll
     static void init() throws Exception {
         registryUrl = URI.create("http://localhost:8080").toURL();
+        createTrustStoreFiles();
+    }
+
+    private static void createTrustStoreFiles() throws Exception {
+        // Generate a self-signed keystore using keytool, then extract the cert
+        var jksPath = tempDir.resolve("truststore.jks");
+        jksTruststorePath = jksPath.toString();
+
+        new ProcessBuilder("keytool", "-genkeypair", "-alias", "test", "-keyalg", "RSA", "-keysize", "2048",
+                "-validity", "1", "-dname", "CN=test", "-keystore", jksTruststorePath,
+                "-storepass", TRUSTSTORE_PASSWORD, "-keypass", TRUSTSTORE_PASSWORD, "-storetype", "JKS")
+                .inheritIO().start().waitFor();
+
+        // Load the certificate from JKS
+        var jksStore = KeyStore.getInstance("JKS");
+        try (var is = Files.newInputStream(jksPath)) {
+            jksStore.load(is, TRUSTSTORE_PASSWORD.toCharArray());
+        }
+        Certificate cert = jksStore.getCertificate("test");
+
+        // Create PKCS12 truststore with just the cert (no key)
+        var p12Store = KeyStore.getInstance("PKCS12");
+        p12Store.load(null, TRUSTSTORE_PASSWORD.toCharArray());
+        p12Store.setCertificateEntry("test", cert);
+        pkcs12TruststorePath = tempDir.resolve("truststore.p12").toString();
+        try (var fos = new FileOutputStream(pkcs12TruststorePath)) {
+            p12Store.store(fos, TRUSTSTORE_PASSWORD.toCharArray());
+        }
+
+        // Create PEM cert file
+        pemCertPath = tempDir.resolve("certs.pem").toString();
+        var pemContent = "-----BEGIN CERTIFICATE-----\n"
+                + Base64.getMimeEncoder(64, "\n".getBytes()).encodeToString(cert.getEncoded())
+                + "\n-----END CERTIFICATE-----\n";
+        Files.writeString(Path.of(pemCertPath), pemContent);
     }
 
     @Test

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/config/ValidationConfigTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/config/ValidationConfigTest.java
@@ -37,7 +37,7 @@ class ValidationConfigTest {
     private static ValidationConfig expectedApicurioTlsTrustStoreConfig() throws MalformedURLException {
         var tls = new Tls(null, new TrustStore("/path/to/truststore.jks", new InlinePassword("changeit"), "JKS"), null, null);
         TopicMatchingRecordValidationRule ruleOne = new TopicMatchingRecordValidationRule(Set.of("one"), null,
-                new BytebufValidation(null, new SchemaValidationConfig(URI.create("http://localhost:8080").toURL(), 1L, null, tls),
+                new BytebufValidation(null, new SchemaValidationConfig(URI.create("http://localhost:8080").toURL(), 1L, null, tls, null),
                         null, false, true));
         return new ValidationConfig(List.of(ruleOne), null);
     }
@@ -45,14 +45,14 @@ class ValidationConfigTest {
     private static ValidationConfig expectedApicurioTlsInsecureConfig() throws MalformedURLException {
         var tls = new Tls(null, new InsecureTls(true), null, null);
         TopicMatchingRecordValidationRule ruleOne = new TopicMatchingRecordValidationRule(Set.of("one"), null,
-                new BytebufValidation(null, new SchemaValidationConfig(URI.create("http://localhost:8080").toURL(), 1L, null, tls),
+                new BytebufValidation(null, new SchemaValidationConfig(URI.create("http://localhost:8080").toURL(), 1L, null, tls, null),
                         null, false, true));
         return new ValidationConfig(List.of(ruleOne), null);
     }
 
     private static ValidationConfig expectedApicurioConfig() throws MalformedURLException {
         TopicMatchingRecordValidationRule ruleOne = new TopicMatchingRecordValidationRule(Set.of("one"), null,
-                new BytebufValidation(new SyntacticallyCorrectJsonConfig(true), new SchemaValidationConfig(URI.create("http://localhost:8080").toURL(), 1L, null, null),
+                new BytebufValidation(new SyntacticallyCorrectJsonConfig(true), new SchemaValidationConfig(URI.create("http://localhost:8080").toURL(), 1L, null, null, null),
                         new JwsSignatureValidationConfig(ECDSA_VERIFY_JWKS, null, null, null), false,
                         true));
         TopicMatchingRecordValidationRule ruleTwo = new TopicMatchingRecordValidationRule(Set.of("two"), new BytebufValidation(null, null, null, false, true), null);

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/config/ValidationConfigTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/config/ValidationConfigTest.java
@@ -52,7 +52,8 @@ class ValidationConfigTest {
 
     private static ValidationConfig expectedApicurioConfig() throws MalformedURLException {
         TopicMatchingRecordValidationRule ruleOne = new TopicMatchingRecordValidationRule(Set.of("one"), null,
-                new BytebufValidation(new SyntacticallyCorrectJsonConfig(true), new SchemaValidationConfig(URI.create("http://localhost:8080").toURL(), 1L, null, null, null),
+                new BytebufValidation(new SyntacticallyCorrectJsonConfig(true),
+                        new SchemaValidationConfig(URI.create("http://localhost:8080").toURL(), 1L, null, null, null),
                         new JwsSignatureValidationConfig(ECDSA_VERIFY_JWKS, null, null, null), false,
                         true));
         TopicMatchingRecordValidationRule ruleTwo = new TopicMatchingRecordValidationRule(Set.of("two"), new BytebufValidation(null, null, null, false, true), null);

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/validators/bytebuf/AvroSchemaBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/validators/bytebuf/AvroSchemaBytebufValidatorTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.validation.validators.bytebuf;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.record.Record;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import io.apicurio.registry.serde.BaseSerde;
+import io.apicurio.registry.serde.kafka.headers.KafkaSerdeHeaders;
+
+import io.kroxylicious.filter.validation.config.SchemaValidationConfig.WireFormatVersion;
+import io.kroxylicious.filter.validation.validators.Result;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static io.kroxylicious.test.record.RecordTestUtils.record;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AvroSchemaBytebufValidatorTest {
+
+    private static final long CONTENT_ID = 1L;
+    private static final byte[] RECORD_KEY = "a".getBytes(StandardCharsets.UTF_8);
+
+    private static WireMockServer registryServer;
+    private static Map<String, Object> apicurioConfig;
+    private static Schema avroSchema;
+    private static byte[] validAvroBytes;
+
+    private static final String AVRO_SCHEMA_JSON = """
+            {
+              "type": "record",
+              "name": "Person",
+              "namespace": "io.kroxylicious.test",
+              "fields": [
+                {"name": "firstName", "type": "string"},
+                {"name": "lastName", "type": "string"},
+                {"name": "age", "type": "int"}
+              ]
+            }
+            """;
+
+    @BeforeAll
+    static void initMockRegistry() throws IOException {
+        avroSchema = new Schema.Parser().parse(AVRO_SCHEMA_JSON);
+
+        GenericRecord person = new GenericData.Record(avroSchema);
+        person.put("firstName", "John");
+        person.put("lastName", "Doe");
+        person.put("age", 25);
+        validAvroBytes = serializeAvro(avroSchema, person);
+
+        registryServer = new WireMockServer(
+                wireMockConfig()
+                        .dynamicPort());
+
+        registryServer.start();
+
+        registryServer.stubFor(
+                get(urlEqualTo("/apis/registry/v3/ids/contentIds/1"))
+                        .willReturn(WireMock.aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody(AVRO_SCHEMA_JSON)));
+
+        registryServer.stubFor(
+                get(urlEqualTo("/apis/registry/v3/ids/contentIds/1/references"))
+                        .willReturn(WireMock.aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("[]")));
+
+        apicurioConfig = Map.of(
+                "apicurio.registry.url", registryServer.baseUrl() + "/apis/registry/v3");
+    }
+
+    @AfterAll
+    static void shutdownMockRegistry() {
+        registryServer.shutdown();
+    }
+
+    @Test
+    void valuePassesSchemaValidation() {
+        Record record = record(RECORD_KEY, validAvroBytes);
+        BytebufValidator validator = BytebufValidators.avroSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        var future = validator.validate(record.value(), record, false);
+
+        assertThat(future)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .returns(true, Result::valid);
+    }
+
+    @Test
+    void nonAvroValueFailsDeserialization() {
+        Record record = record(RECORD_KEY, "not avro data".getBytes(StandardCharsets.UTF_8));
+        BytebufValidator validator = BytebufValidators.avroSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        var future = validator.validate(record.value(), record, false);
+
+        assertThat(future)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .satisfies(result -> {
+                    assertThat(result.valid()).isFalse();
+                    assertThat(result.errorMessage()).contains("Failed to deserialize Avro record");
+                });
+    }
+
+    @Test
+    void valueWithCorrectSchemaIdInHeaderPassesValidation() {
+        Header[] headers = new Header[]{ new RecordHeader(KafkaSerdeHeaders.HEADER_VALUE_CONTENT_ID, toByteArray(CONTENT_ID)) };
+        Record record = record(RECORD_KEY, validAvroBytes, headers);
+        BytebufValidator validator = BytebufValidators.avroSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        var future = validator.validate(record.value(), record, false);
+
+        assertThat(future)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .returns(true, Result::valid);
+    }
+
+    @Test
+    void valueWithWrongSchemaIdInHeaderRejected() {
+        Header[] headers = new Header[]{ new RecordHeader(KafkaSerdeHeaders.HEADER_VALUE_CONTENT_ID, toByteArray(CONTENT_ID + 1)) };
+        Record record = record(RECORD_KEY, validAvroBytes, headers);
+        BytebufValidator validator = BytebufValidators.avroSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        var future = validator.validate(record.value(), record, false);
+
+        assertThat(future)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .isEqualTo(new Result(false, "Unexpected schema id in record (2), expecting 1"));
+    }
+
+    @Test
+    void valueWithCorrectSchemaIdInBodyPassesValidation() {
+        var value = asV3SchemaIdPrefixBuf(CONTENT_ID, validAvroBytes);
+        Record record = record(RECORD_KEY, value);
+        BytebufValidator validator = BytebufValidators.avroSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        var future = validator.validate(record.value(), record, false);
+
+        assertThat(future)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .returns(true, Result::valid);
+    }
+
+    @Test
+    void valueWithUnexpectedSchemaIdInBodyRejected() {
+        var value = asV3SchemaIdPrefixBuf(CONTENT_ID + 1, validAvroBytes);
+        Record record = record(RECORD_KEY, value);
+        BytebufValidator validator = BytebufValidators.avroSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        var future = validator.validate(record.value(), record, false);
+
+        assertThat(future)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .isEqualTo(new Result(false, "Unexpected schema id in record (2), expecting 1"));
+    }
+
+    @Test
+    void schemaNotFoundThrows() {
+        long nonExistentContentId = 999L;
+        registryServer.stubFor(
+                get(urlEqualTo("/apis/registry/v3/ids/contentIds/999"))
+                        .willReturn(WireMock.aResponse()
+                                .withStatus(404)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\"message\":\"No artifact with ID '999' was found.\",\"error_code\":404}")));
+
+        registryServer.stubFor(
+                get(urlEqualTo("/apis/registry/v3/ids/contentIds/999/references"))
+                        .willReturn(WireMock.aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("[]")));
+
+        registryServer.stubFor(
+                get(urlEqualTo("/apis/registry/v3/ids/contentIds/999?dereference=false"))
+                        .willReturn(WireMock.aResponse()
+                                .withStatus(404)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\"message\":\"No artifact with ID '999' was found.\",\"error_code\":404}")));
+
+        assertThatThrownBy(() -> BytebufValidators.avroSchemaValidator(apicurioConfig, nonExistentContentId, WireFormatVersion.V3))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void bufferTooSmallForSchemaIdHandledGracefully() {
+        byte[] tinyBuffer = new byte[]{ BaseSerde.MAGIC_BYTE, 0x01 };
+        Record record = record(RECORD_KEY, tinyBuffer);
+        BytebufValidator validator = BytebufValidators.avroSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        var future = validator.validate(record.value(), record, false);
+
+        assertThat(future)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .returns(false, Result::valid);
+    }
+
+    private static byte[] serializeAvro(Schema schema, GenericRecord record) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        GenericDatumWriter<GenericRecord> writer = new GenericDatumWriter<>(schema);
+        var encoder = EncoderFactory.get().binaryEncoder(out, null);
+        writer.write(record, encoder);
+        encoder.flush();
+        return out.toByteArray();
+    }
+
+    private byte[] toByteArray(long contentId) {
+        var buf = ByteBuffer.allocate(Long.BYTES);
+        buf.putLong(contentId);
+        return buf.array();
+    }
+
+    private byte[] asV3SchemaIdPrefixBuf(long contentId, byte[] content) {
+        ByteBuffer buf = ByteBuffer.allocate(1 + Integer.BYTES + content.length);
+        buf.put(BaseSerde.MAGIC_BYTE);
+        buf.putInt((int) contentId);
+        buf.put(content);
+        return buf.array();
+    }
+}

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidatorTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.validation.validators.bytebuf;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.record.Record;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import io.apicurio.registry.serde.BaseSerde;
+import io.apicurio.registry.serde.kafka.headers.KafkaSerdeHeaders;
+
+import io.kroxylicious.filter.validation.config.SchemaValidationConfig.WireFormatVersion;
+import io.kroxylicious.filter.validation.validators.Result;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static io.kroxylicious.test.record.RecordTestUtils.record;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ProtobufSchemaBytebufValidatorTest {
+
+    private static final long CONTENT_ID = 1L;
+    private static final byte[] RECORD_KEY = "a".getBytes(StandardCharsets.UTF_8);
+
+    private static WireMockServer registryServer;
+    private static Map<String, Object> apicurioConfig;
+
+    private static final String PROTOBUF_SCHEMA = """
+            syntax = "proto3";
+
+            message Person {
+              string first_name = 1;
+              string last_name = 2;
+              int32 age = 3;
+            }
+            """;
+
+    // Valid protobuf encoding of Person{first_name="John", last_name="Doe", age=25}
+    // Field 1 (string): tag=0x0A, len=4, "John"
+    // Field 2 (string): tag=0x12, len=3, "Doe"
+    // Field 3 (int32): tag=0x18, varint=25
+    private static final byte[] VALID_PROTOBUF = new byte[]{
+            0x0A, 0x04, 'J', 'o', 'h', 'n',
+            0x12, 0x03, 'D', 'o', 'e',
+            0x18, 25
+    };
+
+    @BeforeAll
+    static void initMockRegistry() {
+        registryServer = new WireMockServer(
+                wireMockConfig()
+                        .dynamicPort());
+
+        registryServer.start();
+
+        registryServer.stubFor(
+                get(urlEqualTo("/apis/registry/v3/ids/contentIds/1"))
+                        .willReturn(WireMock.aResponse()
+                                .withHeader("Content-Type", "application/x-protobuf")
+                                .withBody(PROTOBUF_SCHEMA)));
+
+        registryServer.stubFor(
+                get(urlEqualTo("/apis/registry/v3/ids/contentIds/1/references"))
+                        .willReturn(WireMock.aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("[]")));
+
+        apicurioConfig = Map.of(
+                "apicurio.registry.url", registryServer.baseUrl() + "/apis/registry/v3");
+    }
+
+    @AfterAll
+    static void shutdownMockRegistry() {
+        registryServer.shutdown();
+    }
+
+    @Test
+    void valuePassesSchemaValidation() {
+        Record record = record(RECORD_KEY, VALID_PROTOBUF);
+        BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        var future = validator.validate(record.value(), record, false);
+
+        assertThat(future)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .returns(true, Result::valid);
+    }
+
+    @Test
+    void emptyMessagePassesValidation() {
+        // In proto3, all fields are optional, so an empty message is valid
+        Record record = record(RECORD_KEY, new byte[0]);
+        BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        var future = validator.validate(record.value(), record, false);
+
+        assertThat(future)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .returns(true, Result::valid);
+    }
+
+    @Test
+    void corruptProtobufFailsParsing() {
+        // Length-delimited field claims length 16 but only 1 byte follows
+        byte[] corruptData = new byte[]{ 0x0A, 0x10, 0x01 };
+        Record record = record(RECORD_KEY, corruptData);
+        BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        var future = validator.validate(record.value(), record, false);
+
+        assertThat(future)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .satisfies(result -> {
+                    assertThat(result.valid()).isFalse();
+                    assertThat(result.errorMessage()).contains("Failed to parse Protobuf message");
+                });
+    }
+
+    @Test
+    void valueWithCorrectSchemaIdInHeaderPassesValidation() {
+        Header[] headers = new Header[]{ new RecordHeader(KafkaSerdeHeaders.HEADER_VALUE_CONTENT_ID, toByteArray(CONTENT_ID)) };
+        Record record = record(RECORD_KEY, VALID_PROTOBUF, headers);
+        BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        var future = validator.validate(record.value(), record, false);
+
+        assertThat(future)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .returns(true, Result::valid);
+    }
+
+    @Test
+    void valueWithWrongSchemaIdInHeaderRejected() {
+        Header[] headers = new Header[]{ new RecordHeader(KafkaSerdeHeaders.HEADER_VALUE_CONTENT_ID, toByteArray(CONTENT_ID + 1)) };
+        Record record = record(RECORD_KEY, VALID_PROTOBUF, headers);
+        BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        var future = validator.validate(record.value(), record, false);
+
+        assertThat(future)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .isEqualTo(new Result(false, "Unexpected schema id in record (2), expecting 1"));
+    }
+
+    @Test
+    void valueWithCorrectSchemaIdInBodyPassesValidation() {
+        var value = asV3SchemaIdPrefixBuf(CONTENT_ID, VALID_PROTOBUF);
+        Record record = record(RECORD_KEY, value);
+        BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        var future = validator.validate(record.value(), record, false);
+
+        assertThat(future)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .returns(true, Result::valid);
+    }
+
+    @Test
+    void valueWithUnexpectedSchemaIdInBodyRejected() {
+        var value = asV3SchemaIdPrefixBuf(CONTENT_ID + 1, VALID_PROTOBUF);
+        Record record = record(RECORD_KEY, value);
+        BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
+        var future = validator.validate(record.value(), record, false);
+
+        assertThat(future)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .isEqualTo(new Result(false, "Unexpected schema id in record (2), expecting 1"));
+    }
+
+    @Test
+    void schemaNotFoundThrows() {
+        long nonExistentContentId = 999L;
+        registryServer.stubFor(
+                get(urlEqualTo("/apis/registry/v3/ids/contentIds/999"))
+                        .willReturn(WireMock.aResponse()
+                                .withStatus(404)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\"message\":\"No artifact with ID '999' was found.\",\"error_code\":404}")));
+
+        registryServer.stubFor(
+                get(urlEqualTo("/apis/registry/v3/ids/contentIds/999/references"))
+                        .willReturn(WireMock.aResponse()
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("[]")));
+
+        registryServer.stubFor(
+                get(urlEqualTo("/apis/registry/v3/ids/contentIds/999?dereference=false"))
+                        .willReturn(WireMock.aResponse()
+                                .withStatus(404)
+                                .withHeader("Content-Type", "application/json")
+                                .withBody("{\"message\":\"No artifact with ID '999' was found.\",\"error_code\":404}")));
+
+        assertThatThrownBy(() -> BytebufValidators.protobufSchemaValidator(apicurioConfig, nonExistentContentId, WireFormatVersion.V3))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    private byte[] toByteArray(long contentId) {
+        var buf = ByteBuffer.allocate(Long.BYTES);
+        buf.putLong(contentId);
+        return buf.array();
+    }
+
+    private byte[] asV3SchemaIdPrefixBuf(long contentId, byte[] content) {
+        ByteBuffer buf = ByteBuffer.allocate(1 + Integer.BYTES + content.length);
+        buf.put(BaseSerde.MAGIC_BYTE);
+        buf.putInt((int) contentId);
+        buf.put(content);
+        return buf.array();
+    }
+}

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidatorTest.java
@@ -133,7 +133,9 @@ class ProtobufSchemaBytebufValidatorTest {
     @Test
     void valueWithCorrectSchemaIdInHeaderPassesValidation() {
         Header[] headers = new Header[]{ new RecordHeader(KafkaSerdeHeaders.HEADER_VALUE_CONTENT_ID, toByteArray(CONTENT_ID)) };
-        Record record = record(RECORD_KEY, VALID_PROTOBUF, headers);
+        // When schema ID is in headers, the Apicurio ProtobufSerde writes a Ref delimited message
+        // before the protobuf payload in the body.
+        Record record = record(RECORD_KEY, withRefPrefix("Person", VALID_PROTOBUF), headers);
         BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
         var future = validator.validate(record.value(), record, false);
 
@@ -156,7 +158,8 @@ class ProtobufSchemaBytebufValidatorTest {
 
     @Test
     void valueWithCorrectSchemaIdInBodyPassesValidation() {
-        var value = asV3SchemaIdPrefixBuf(CONTENT_ID, VALID_PROTOBUF);
+        // Apicurio protobuf body wire format: magic + contentId + Ref + protobuf
+        var value = asV3SchemaIdPrefixBuf(CONTENT_ID, withRefPrefix("Person", VALID_PROTOBUF));
         Record record = record(RECORD_KEY, value);
         BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
         var future = validator.validate(record.value(), record, false);
@@ -168,7 +171,7 @@ class ProtobufSchemaBytebufValidatorTest {
 
     @Test
     void valueWithUnexpectedSchemaIdInBodyRejected() {
-        var value = asV3SchemaIdPrefixBuf(CONTENT_ID + 1, VALID_PROTOBUF);
+        var value = asV3SchemaIdPrefixBuf(CONTENT_ID + 1, withRefPrefix("Person", VALID_PROTOBUF));
         Record record = record(RECORD_KEY, value);
         BytebufValidator validator = BytebufValidators.protobufSchemaValidator(apicurioConfig, CONTENT_ID, WireFormatVersion.V3);
         var future = validator.validate(record.value(), record, false);
@@ -216,6 +219,23 @@ class ProtobufSchemaBytebufValidatorTest {
         buf.put(BaseSerde.MAGIC_BYTE);
         buf.putInt((int) contentId);
         buf.put(content);
+        return buf.array();
+    }
+
+    private byte[] withRefPrefix(String messageTypeName, byte[] protobufData) {
+        // Apicurio ProtobufSerde writes a delimited Ref message before protobuf data in headers mode.
+        // Ref proto: message Ref { string name = 1; }
+        // Encoded: tag(0x0A) + length + name_bytes
+        byte[] nameBytes = messageTypeName.getBytes(StandardCharsets.UTF_8);
+        byte[] refMessage = new byte[2 + nameBytes.length];
+        refMessage[0] = 0x0A; // field 1, wire type 2 (length-delimited)
+        refMessage[1] = (byte) nameBytes.length;
+        System.arraycopy(nameBytes, 0, refMessage, 2, nameBytes.length);
+        // Delimited format: varint size + ref message bytes
+        ByteBuffer buf = ByteBuffer.allocate(1 + refMessage.length + protobufData.length);
+        buf.put((byte) refMessage.length);
+        buf.put(refMessage);
+        buf.put(protobufData);
         return buf.array();
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/validators/bytebuf/ProtobufSchemaBytebufValidatorTest.java
@@ -52,10 +52,7 @@ class ProtobufSchemaBytebufValidatorTest {
             }
             """;
 
-    // Valid protobuf encoding of Person{first_name="John", last_name="Doe", age=25}
-    // Field 1 (string): tag=0x0A, len=4, "John"
-    // Field 2 (string): tag=0x12, len=3, "Doe"
-    // Field 3 (int32): tag=0x18, varint=25
+    // Valid protobuf encoding of Person with first_name="John", last_name="Doe", age=25
     private static final byte[] VALID_PROTOBUF = new byte[]{
             0x0A, 0x04, 'J', 'o', 'h', 'n',
             0x12, 0x03, 'D', 'o', 'e',
@@ -223,9 +220,8 @@ class ProtobufSchemaBytebufValidatorTest {
     }
 
     private byte[] withRefPrefix(String messageTypeName, byte[] protobufData) {
-        // Apicurio ProtobufSerde writes a delimited Ref message before protobuf data in headers mode.
-        // Ref proto: message Ref { string name = 1; }
-        // Encoded: tag(0x0A) + length + name_bytes
+        // Apicurio ProtobufSerde writes a delimited Ref message (containing the message type name)
+        // before protobuf data. The Ref is encoded as: tag(0x0A) + length + name_bytes
         byte[] nameBytes = messageTypeName.getBytes(StandardCharsets.UTF_8);
         byte[] refMessage = new byte[2 + nameBytes.length];
         refMessage[0] = 0x0A; // field 1, wire type 2 (length-delimited)

--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -309,6 +309,26 @@
         </dependency>
         <dependency>
             <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-avro-serde-kafka</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-protobuf-serde-kafka</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
             <artifactId>apicurio-registry-java-sdk</artifactId>
             <scope>test</scope>
         </dependency>

--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -347,12 +347,7 @@
             <artifactId>apicurio-registry-serde-common</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.github.docker-java</groupId>
-            <artifactId>docker-java-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
+<dependency>
             <groupId>net.javacrumbs.json-unit</groupId>
             <artifactId>json-unit-assertj</artifactId>
         </dependency>

--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -308,23 +308,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.apicurio</groupId>
-            <artifactId>apicurio-registry-avro-serde-kafka</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.apicurio</groupId>
-            <artifactId>apicurio-registry-protobuf-serde-kafka</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kroxylicious-integration-tests/pom.xml
+++ b/kroxylicious-integration-tests/pom.xml
@@ -308,8 +308,23 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-avro-serde-kafka</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-protobuf-serde-kafka</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/AvroRecordValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/AvroRecordValidationIT.java
@@ -26,12 +26,15 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.InvalidRecordException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -49,11 +52,15 @@ import io.apicurio.registry.rest.client.models.CreateArtifact;
 import io.apicurio.registry.rest.client.models.CreateVersion;
 import io.apicurio.registry.rest.client.models.VersionContent;
 import io.apicurio.registry.rest.client.models.VersionMetaData;
+import io.apicurio.registry.serde.avro.AvroSerde;
+import io.apicurio.registry.serde.config.SerdeConfig;
+import io.apicurio.registry.serde.kafka.config.KafkaSerdeConfig;
 
 import io.kroxylicious.filter.validation.RecordValidation;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.NamedFilterDefinition;
 import io.kroxylicious.proxy.config.NamedFilterDefinitionBuilder;
+import io.kroxylicious.test.tester.KroxyliciousTester;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 import io.kroxylicious.testing.kafka.junit5ext.Topic;
@@ -86,6 +93,7 @@ class AvroRecordValidationIT extends RecordValidationBaseIT {
     private static final String APICURIO_REGISTRY_API = "/apis/registry/v3";
     private static final String APICURIO_REGISTRY_URL = APICURIO_REGISTRY_HOST + ":" + APICURIO_REGISTRY_PORT + APICURIO_REGISTRY_API;
 
+    private static String artifactId;
     private static int contentId;
     private static GenericContainer<?> registryContainer;
     private static Schema parsedSchema;
@@ -119,6 +127,7 @@ class AvroRecordValidationIT extends RecordValidationBaseIT {
         createArtifact.setFirstVersion(version);
 
         VersionMetaData artifact = client.groups().byGroupId("default").artifacts().post(createArtifact).getVersion();
+        artifactId = artifact.getArtifactId();
         contentId = artifact.getContentId().intValue();
 
         parsedSchema = new Schema.Parser().parse(AVRO_SCHEMA);
@@ -179,6 +188,89 @@ class AvroRecordValidationIT extends RecordValidationBaseIT {
             var future = producer.send(new ProducerRecord<>(validatedTopic.name(), "my-key", invalidData));
             assertThatFutureFails(future, InvalidRecordException.class, "Failed to deserialize Avro record");
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void clientSideAvroSerdePassesValidation(boolean schemaIdInHeader, KafkaCluster cluster, Topic topic) {
+        var config = createAvroValidationConfig(cluster, topic, contentId);
+
+        var keySerde = new Serdes.StringSerde();
+        var producerValueSerde = createAvroProducerSerde(schemaIdInHeader);
+        var consumerValueSerde = createAvroConsumerSerde(schemaIdInHeader);
+
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer(keySerde, producerValueSerde, Map.of());
+                var consumer = consumeFromEarliestOffsets(tester, keySerde, consumerValueSerde)) {
+            GenericRecord person = new GenericData.Record(parsedSchema);
+            person.put("firstName", "John");
+            person.put("lastName", "Doe");
+            person.put("age", 30);
+
+            assertThat(producer.send(new ProducerRecord<>(topic.name(), "my-key", person)))
+                    .succeedsWithin(Duration.ofSeconds(10));
+            consumer.subscribe(Set.of(topic.name()));
+
+            var records = consumer.poll(Duration.ofSeconds(10));
+            assertThat(records.records(topic.name()))
+                    .hasSize(1)
+                    .extracting(ConsumerRecord::value)
+                    .first()
+                    .satisfies(value -> {
+                        GenericRecord received = (GenericRecord) value;
+                        assertThat(received.get("firstName").toString()).isEqualTo("John");
+                        assertThat(received.get("lastName").toString()).isEqualTo("Doe");
+                        assertThat(received.get("age")).isEqualTo(30);
+                    });
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void detectsClientProducingWithWrongAvroSchemaId(boolean schemaIdInHeader, KafkaCluster cluster, Topic topic) {
+        // Configure filter to expect a different contentId than the client sends
+        var config = createAvroValidationConfig(cluster, topic, contentId + 1);
+
+        var keySerde = new Serdes.StringSerde();
+        var valueSerde = createAvroProducerSerde(schemaIdInHeader);
+
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer(keySerde, valueSerde, Map.of())) {
+            GenericRecord person = new GenericData.Record(parsedSchema);
+            person.put("firstName", "John");
+            person.put("lastName", "Doe");
+            person.put("age", 30);
+
+            var future = producer.send(new ProducerRecord<>(topic.name(), "my-key", person));
+            assertThatFutureFails(future, InvalidRecordException.class, "Unexpected schema id in record");
+        }
+    }
+
+    private static AvroSerde<GenericRecord> createAvroProducerSerde(boolean schemaIdInHeader) {
+        var serde = new AvroSerde<GenericRecord>();
+        serde.configure(Map.of(
+                SerdeConfig.REGISTRY_URL, APICURIO_REGISTRY_URL,
+                SerdeConfig.EXPLICIT_ARTIFACT_ID, artifactId,
+                SerdeConfig.EXPLICIT_ARTIFACT_VERSION, "1",
+                KafkaSerdeConfig.ENABLE_HEADERS, schemaIdInHeader), false);
+        return serde;
+    }
+
+    private static AvroSerde<GenericRecord> createAvroConsumerSerde(boolean schemaIdInHeader) {
+        var serde = new AvroSerde<GenericRecord>();
+        serde.configure(Map.of(
+                SerdeConfig.REGISTRY_URL, APICURIO_REGISTRY_URL,
+                SerdeConfig.EXPLICIT_ARTIFACT_ID, artifactId,
+                SerdeConfig.EXPLICIT_ARTIFACT_VERSION, "1",
+                KafkaSerdeConfig.ENABLE_HEADERS, schemaIdInHeader), false);
+        return serde;
+    }
+
+    private static <T, S> org.apache.kafka.clients.consumer.Consumer<T, S> consumeFromEarliestOffsets(KroxyliciousTester tester, Serde<T> keySerde,
+                                                                                                      Serde<S> valueSerde) {
+        return tester.consumer(keySerde, valueSerde, Map.of(
+                GROUP_ID_CONFIG, UUID.randomUUID().toString(),
+                AUTO_OFFSET_RESET_CONFIG, "earliest"));
     }
 
     private static ConfigurationBuilder createAvroValidationConfig(KafkaCluster cluster, Topic topic, int avroContentId) {

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/AvroRecordValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/AvroRecordValidationIT.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.it.filter.validation;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.InvalidRecordException;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.HostConfig;
+import com.github.dockerjava.api.model.PortBinding;
+import com.github.dockerjava.api.model.Ports;
+
+import io.apicurio.registry.client.RegistryClientFactory;
+import io.apicurio.registry.client.common.RegistryClientOptions;
+import io.apicurio.registry.rest.client.models.CreateArtifact;
+import io.apicurio.registry.rest.client.models.CreateVersion;
+import io.apicurio.registry.rest.client.models.VersionContent;
+import io.apicurio.registry.rest.client.models.VersionMetaData;
+
+import io.kroxylicious.filter.validation.RecordValidation;
+import io.kroxylicious.proxy.config.ConfigurationBuilder;
+import io.kroxylicious.proxy.config.NamedFilterDefinition;
+import io.kroxylicious.proxy.config.NamedFilterDefinitionBuilder;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
+import io.kroxylicious.testing.kafka.junit5ext.Topic;
+
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
+import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(KafkaClusterExtension.class)
+@EnabledIf(value = "isDockerAvailable", disabledReason = "docker unavailable")
+class AvroRecordValidationIT extends RecordValidationBaseIT {
+
+    private static final String AVRO_SCHEMA = """
+            {
+              "type": "record",
+              "name": "Person",
+              "namespace": "io.kroxylicious.test",
+              "fields": [
+                {"name": "firstName", "type": "string"},
+                {"name": "lastName", "type": "string"},
+                {"name": "age", "type": "int"}
+              ]
+            }
+            """;
+
+    private static final String APICURIO_REGISTRY_HOST = "http://localhost";
+    private static final Integer APICURIO_REGISTRY_PORT = 8082;
+    private static final String APICURIO_REGISTRY_API = "/apis/registry/v3";
+    private static final String APICURIO_REGISTRY_URL = APICURIO_REGISTRY_HOST + ":" + APICURIO_REGISTRY_PORT + APICURIO_REGISTRY_API;
+
+    private static int contentId;
+    private static GenericContainer<?> registryContainer;
+    private static Schema parsedSchema;
+
+    @BeforeAll
+    static void init() {
+        String image = "quay.io/apicurio/apicurio-registry:3.1.6@sha256:d0625211cebb1f58a2982df29cb0945249d8f88f37ccce9e162c0c12c2aea89e";
+        DockerImageName dockerImageName = DockerImageName.parse(image)
+                .asCompatibleSubstituteFor(DockerImageName.parse(image.substring(0, image.indexOf("@"))));
+
+        Consumer<CreateContainerCmd> cmd = e -> e.withHostConfig(new HostConfig().withPortBindings(
+                new PortBinding(Ports.Binding.bindPort(APICURIO_REGISTRY_PORT), new ExposedPort(APICURIO_REGISTRY_PORT))));
+
+        registryContainer = new GenericContainer<>(dockerImageName)
+                .withEnv(Map.of("QUARKUS_HTTP_PORT", String.valueOf(APICURIO_REGISTRY_PORT)))
+                .withExposedPorts(APICURIO_REGISTRY_PORT)
+                .withCreateContainerCmdModifier(cmd)
+                .waitingFor(Wait.forHttp(APICURIO_REGISTRY_API + "/system/info").forStatusCode(200));
+
+        registryContainer.start();
+
+        var client = RegistryClientFactory.create(RegistryClientOptions.create(APICURIO_REGISTRY_URL));
+
+        CreateArtifact createArtifact = new CreateArtifact();
+        createArtifact.setArtifactType("AVRO");
+        CreateVersion version = new CreateVersion();
+        VersionContent content = new VersionContent();
+        content.setContent(AVRO_SCHEMA);
+        content.setContentType("application/json");
+        version.setContent(content);
+        createArtifact.setFirstVersion(version);
+
+        VersionMetaData artifact = client.groups().byGroupId("default").artifacts().post(createArtifact).getVersion();
+        contentId = artifact.getContentId().intValue();
+
+        parsedSchema = new Schema.Parser().parse(AVRO_SCHEMA);
+    }
+
+    @Test
+    void shouldAcceptValidAvroInProduceRequest(KafkaCluster cluster, Topic topic) throws IOException {
+        var config = createAvroValidationConfig(cluster, topic, contentId);
+        byte[] validAvro = serializeAvro(parsedSchema, "John", "Doe", 25);
+
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer(new Serdes.StringSerde(), Serdes.serdeFrom(new ByteArraySerializer(), new ByteArrayDeserializer()), Map.of())) {
+            assertThat(producer.send(new ProducerRecord<>(topic.name(), "my-key", validAvro)))
+                    .succeedsWithin(Duration.ofSeconds(10));
+
+            try (var consumer = tester.consumer(new Serdes.StringSerde(), Serdes.serdeFrom(new ByteArraySerializer(), new ByteArrayDeserializer()),
+                    Map.of(GROUP_ID_CONFIG, UUID.randomUUID().toString(), AUTO_OFFSET_RESET_CONFIG, "earliest"))) {
+                consumer.subscribe(Set.of(topic.name()));
+                var records = consumer.poll(Duration.ofSeconds(10));
+                assertThat(records.records(topic.name()))
+                        .hasSize(1)
+                        .extracting(ConsumerRecord::value)
+                        .first()
+                        .satisfies(bytes -> {
+                            GenericRecord deserialized = deserializeAvro(parsedSchema, (byte[]) bytes);
+                            assertThat(deserialized.get("firstName").toString()).isEqualTo("John");
+                            assertThat(deserialized.get("lastName").toString()).isEqualTo("Doe");
+                            assertThat(deserialized.get("age")).isEqualTo(25);
+                        });
+            }
+        }
+    }
+
+    @Test
+    void shouldRejectInvalidAvroInProduceRequest(KafkaCluster cluster, Topic topic) {
+        var config = createAvroValidationConfig(cluster, topic, contentId);
+        byte[] invalidData = "not avro data".getBytes();
+
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer(new Serdes.StringSerde(), Serdes.serdeFrom(new ByteArraySerializer(), new ByteArrayDeserializer()), Map.of())) {
+            var future = producer.send(new ProducerRecord<>(topic.name(), "my-key", invalidData));
+            assertThatFutureFails(future, InvalidRecordException.class, "Failed to deserialize Avro record");
+        }
+    }
+
+    @Test
+    void shouldAllowValidAvroOnUnvalidatedTopic(KafkaCluster cluster, Topic validatedTopic, Topic unvalidatedTopic) throws IOException {
+        var config = createAvroValidationConfig(cluster, validatedTopic, contentId);
+        byte[] invalidData = "not avro data".getBytes();
+
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer(new Serdes.StringSerde(), Serdes.serdeFrom(new ByteArraySerializer(), new ByteArrayDeserializer()), Map.of())) {
+            // Invalid data on unvalidated topic should succeed
+            assertThat(producer.send(new ProducerRecord<>(unvalidatedTopic.name(), "my-key", invalidData)))
+                    .succeedsWithin(Duration.ofSeconds(10));
+
+            // Invalid data on validated topic should fail
+            var future = producer.send(new ProducerRecord<>(validatedTopic.name(), "my-key", invalidData));
+            assertThatFutureFails(future, InvalidRecordException.class, "Failed to deserialize Avro record");
+        }
+    }
+
+    private static ConfigurationBuilder createAvroValidationConfig(KafkaCluster cluster, Topic topic, int avroContentId) {
+        String className = RecordValidation.class.getName();
+        NamedFilterDefinition namedFilterDefinition = new NamedFilterDefinitionBuilder(className, className).withConfig("rules",
+                List.of(Map.of("topicNames", List.of(topic.name()), "valueRule",
+                        Map.of("schemaValidationConfig",
+                                Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "apicurioId", avroContentId, "schemaType", "AVRO")))))
+                .build();
+        return proxy(cluster)
+                .addToFilterDefinitions(namedFilterDefinition)
+                .addToDefaultFilters(namedFilterDefinition.name());
+    }
+
+    private static byte[] serializeAvro(Schema schema, String firstName, String lastName, int age) throws IOException {
+        GenericRecord record = new GenericData.Record(schema);
+        record.put("firstName", firstName);
+        record.put("lastName", lastName);
+        record.put("age", age);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        GenericDatumWriter<GenericRecord> writer = new GenericDatumWriter<>(schema);
+        var encoder = EncoderFactory.get().binaryEncoder(out, null);
+        writer.write(record, encoder);
+        encoder.flush();
+        return out.toByteArray();
+    }
+
+    private static GenericRecord deserializeAvro(Schema schema, byte[] bytes) {
+        try {
+            var decoder = DecoderFactory.get().binaryDecoder(bytes, null);
+            var reader = new GenericDatumReader<GenericRecord>(schema);
+            return reader.read(null, decoder);
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to deserialize Avro", e);
+        }
+    }
+
+    @AfterAll
+    static void stopResources() {
+        if (registryContainer != null && registryContainer.isRunning()) {
+            registryContainer.stop();
+        }
+    }
+
+    static boolean isDockerAvailable() {
+        return DockerClientFactory.instance().isDockerAvailable();
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/AvroRecordValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/AvroRecordValidationIT.java
@@ -88,6 +88,18 @@ class AvroRecordValidationIT extends RecordValidationBaseIT {
             }
             """;
 
+    private static final String AVRO_SCHEMA_2 = """
+            {
+              "type": "record",
+              "name": "Person2",
+              "namespace": "io.kroxylicious.test",
+              "fields": [
+                {"name": "firstName", "type": "string"},
+                {"name": "lastName", "type": "string"}
+              ]
+            }
+            """;
+
     private static final String APICURIO_REGISTRY_HOST = "http://localhost";
     private static final Integer APICURIO_REGISTRY_PORT = 8082;
     private static final String APICURIO_REGISTRY_API = "/apis/registry/v3";
@@ -95,6 +107,7 @@ class AvroRecordValidationIT extends RecordValidationBaseIT {
 
     private static String artifactId;
     private static int contentId;
+    private static int secondContentId;
     private static GenericContainer<?> registryContainer;
     private static Schema parsedSchema;
 
@@ -129,6 +142,19 @@ class AvroRecordValidationIT extends RecordValidationBaseIT {
         VersionMetaData artifact = client.groups().byGroupId("default").artifacts().post(createArtifact).getVersion();
         artifactId = artifact.getArtifactId();
         contentId = artifact.getContentId().intValue();
+
+        // Register a second schema to get a different contentId for wrong-schema-id tests
+        CreateArtifact createSecondArtifact = new CreateArtifact();
+        createSecondArtifact.setArtifactType("AVRO");
+        CreateVersion secondVersion = new CreateVersion();
+        VersionContent secondContent = new VersionContent();
+        secondContent.setContent(AVRO_SCHEMA_2);
+        secondContent.setContentType("application/json");
+        secondVersion.setContent(secondContent);
+        createSecondArtifact.setFirstVersion(secondVersion);
+
+        VersionMetaData secondArtifact = client.groups().byGroupId("default").artifacts().post(createSecondArtifact).getVersion();
+        secondContentId = secondArtifact.getContentId().intValue();
 
         parsedSchema = new Schema.Parser().parse(AVRO_SCHEMA);
     }
@@ -229,7 +255,7 @@ class AvroRecordValidationIT extends RecordValidationBaseIT {
     @ValueSource(booleans = { true, false })
     void detectsClientProducingWithWrongAvroSchemaId(boolean schemaIdInHeader, KafkaCluster cluster, Topic topic) {
         // Configure filter to expect a different contentId than the client sends
-        var config = createAvroValidationConfig(cluster, topic, contentId + 1);
+        var config = createAvroValidationConfig(cluster, topic, secondContentId);
 
         var keySerde = new Serdes.StringSerde();
         var valueSerde = createAvroProducerSerde(schemaIdInHeader);

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/AvroRecordValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/AvroRecordValidationIT.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.Consumer;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -27,19 +26,8 @@ import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.DockerImageName;
 
-import com.github.dockerjava.api.command.CreateContainerCmd;
-import com.github.dockerjava.api.model.ExposedPort;
-import com.github.dockerjava.api.model.HostConfig;
-import com.github.dockerjava.api.model.PortBinding;
-import com.github.dockerjava.api.model.Ports;
-
-import io.apicurio.registry.client.RegistryClientFactory;
-import io.apicurio.registry.client.common.RegistryClientOptions;
 import io.apicurio.registry.rest.client.models.CreateArtifact;
 import io.apicurio.registry.rest.client.models.CreateVersion;
 import io.apicurio.registry.rest.client.models.VersionContent;
@@ -92,11 +80,7 @@ class AvroRecordValidationIT extends RecordValidationBaseIT {
             }
             """;
 
-    private static final String APICURIO_REGISTRY_HOST = "http://localhost";
-    private static final Integer APICURIO_REGISTRY_PORT = 8082;
-    private static final String APICURIO_REGISTRY_API = "/apis/registry/v3";
-    private static final String APICURIO_REGISTRY_URL = APICURIO_REGISTRY_HOST + ":" + APICURIO_REGISTRY_PORT + APICURIO_REGISTRY_API;
-
+    private static String apicurioRegistryUrl;
     private static String artifactId;
     private static int contentId;
     private static int secondContentId;
@@ -105,22 +89,10 @@ class AvroRecordValidationIT extends RecordValidationBaseIT {
 
     @BeforeAll
     static void init() {
-        String image = "quay.io/apicurio/apicurio-registry:3.1.6@sha256:d0625211cebb1f58a2982df29cb0945249d8f88f37ccce9e162c0c12c2aea89e";
-        DockerImageName dockerImageName = DockerImageName.parse(image)
-                .asCompatibleSubstituteFor(DockerImageName.parse(image.substring(0, image.indexOf("@"))));
+        registryContainer = startRegistryContainer();
+        apicurioRegistryUrl = registryUrl(registryContainer);
 
-        Consumer<CreateContainerCmd> cmd = e -> e.withHostConfig(new HostConfig().withPortBindings(
-                new PortBinding(Ports.Binding.bindPort(APICURIO_REGISTRY_PORT), new ExposedPort(APICURIO_REGISTRY_PORT))));
-
-        registryContainer = new GenericContainer<>(dockerImageName)
-                .withEnv(Map.of("QUARKUS_HTTP_PORT", String.valueOf(APICURIO_REGISTRY_PORT)))
-                .withExposedPorts(APICURIO_REGISTRY_PORT)
-                .withCreateContainerCmdModifier(cmd)
-                .waitingFor(Wait.forHttp(APICURIO_REGISTRY_API + "/system/info").forStatusCode(200));
-
-        registryContainer.start();
-
-        var client = RegistryClientFactory.create(RegistryClientOptions.create(APICURIO_REGISTRY_URL));
+        var client = registryClient(apicurioRegistryUrl);
 
         CreateArtifact createArtifact = new CreateArtifact();
         createArtifact.setArtifactType("AVRO");
@@ -271,7 +243,7 @@ class AvroRecordValidationIT extends RecordValidationBaseIT {
     private static AvroSerde<GenericRecord> createAvroSerde(boolean schemaIdInHeader) {
         var serde = new AvroSerde<GenericRecord>();
         serde.configure(Map.of(
-                SerdeConfig.REGISTRY_URL, APICURIO_REGISTRY_URL,
+                SerdeConfig.REGISTRY_URL, apicurioRegistryUrl,
                 SerdeConfig.EXPLICIT_ARTIFACT_ID, artifactId,
                 SerdeConfig.EXPLICIT_ARTIFACT_VERSION, "1",
                 KafkaSerdeConfig.ENABLE_HEADERS, schemaIdInHeader), false);
@@ -290,7 +262,7 @@ class AvroRecordValidationIT extends RecordValidationBaseIT {
         NamedFilterDefinition namedFilterDefinition = new NamedFilterDefinitionBuilder(className, className).withConfig("rules",
                 List.of(Map.of("topicNames", List.of(topic.name()), "valueRule",
                         Map.of("schemaValidationConfig",
-                                Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "apicurioId", avroContentId, "schemaType", "AVRO")))))
+                                Map.of("apicurioRegistryUrl", apicurioRegistryUrl, "apicurioId", avroContentId, "schemaType", "AVRO")))))
                 .build();
         return proxy(cluster)
                 .addToFilterDefinitions(namedFilterDefinition)
@@ -299,12 +271,6 @@ class AvroRecordValidationIT extends RecordValidationBaseIT {
 
     @AfterAll
     static void stopResources() {
-        if (registryContainer != null && registryContainer.isRunning()) {
-            registryContainer.stop();
-        }
-    }
-
-    static boolean isDockerAvailable() {
-        return DockerClientFactory.instance().isDockerAvailable();
+        stopContainer(registryContainer);
     }
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/AvroRecordValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/AvroRecordValidationIT.java
@@ -5,8 +5,6 @@
  */
 package io.kroxylicious.it.filter.validation;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -16,16 +14,10 @@ import java.util.function.Consumer;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericDatumReader;
-import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.io.DecoderFactory;
-import org.apache.avro.io.EncoderFactory;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.InvalidRecordException;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.junit.jupiter.api.AfterAll;
@@ -160,58 +152,62 @@ class AvroRecordValidationIT extends RecordValidationBaseIT {
     }
 
     @Test
-    void shouldAcceptValidAvroInProduceRequest(KafkaCluster cluster, Topic topic) throws IOException {
+    void shouldAcceptValidAvroInProduceRequest(KafkaCluster cluster, Topic topic) {
         var config = createAvroValidationConfig(cluster, topic, contentId);
-        byte[] validAvro = serializeAvro(parsedSchema, "John", "Doe", 25);
+
+        var keySerde = new Serdes.StringSerde();
+        var producerValueSerde = createAvroProducerSerde(false);
+        var consumerValueSerde = createAvroConsumerSerde(false);
 
         try (var tester = kroxyliciousTester(config);
-                var producer = tester.producer(new Serdes.StringSerde(), Serdes.serdeFrom(new ByteArraySerializer(), new ByteArrayDeserializer()), Map.of())) {
-            assertThat(producer.send(new ProducerRecord<>(topic.name(), "my-key", validAvro)))
+                var producer = tester.producer(keySerde, producerValueSerde, Map.of());
+                var consumer = consumeFromEarliestOffsets(tester, keySerde, consumerValueSerde)) {
+            GenericRecord person = new GenericData.Record(parsedSchema);
+            person.put("firstName", "John");
+            person.put("lastName", "Doe");
+            person.put("age", 25);
+
+            assertThat(producer.send(new ProducerRecord<>(topic.name(), "my-key", person)))
                     .succeedsWithin(Duration.ofSeconds(10));
 
-            try (var consumer = tester.consumer(new Serdes.StringSerde(), Serdes.serdeFrom(new ByteArraySerializer(), new ByteArrayDeserializer()),
-                    Map.of(GROUP_ID_CONFIG, UUID.randomUUID().toString(), AUTO_OFFSET_RESET_CONFIG, "earliest"))) {
-                consumer.subscribe(Set.of(topic.name()));
-                var records = consumer.poll(Duration.ofSeconds(10));
-                assertThat(records.records(topic.name()))
-                        .hasSize(1)
-                        .extracting(ConsumerRecord::value)
-                        .first()
-                        .satisfies(bytes -> {
-                            GenericRecord deserialized = deserializeAvro(parsedSchema, (byte[]) bytes);
-                            assertThat(deserialized.get("firstName").toString()).isEqualTo("John");
-                            assertThat(deserialized.get("lastName").toString()).isEqualTo("Doe");
-                            assertThat(deserialized.get("age")).isEqualTo(25);
-                        });
-            }
+            consumer.subscribe(Set.of(topic.name()));
+            var records = consumer.poll(Duration.ofSeconds(10));
+            assertThat(records.records(topic.name()))
+                    .hasSize(1)
+                    .extracting(ConsumerRecord::value)
+                    .first()
+                    .satisfies(value -> {
+                        GenericRecord received = (GenericRecord) value;
+                        assertThat(received.get("firstName").toString()).isEqualTo("John");
+                        assertThat(received.get("lastName").toString()).isEqualTo("Doe");
+                        assertThat(received.get("age")).isEqualTo(25);
+                    });
         }
     }
 
     @Test
     void shouldRejectInvalidAvroInProduceRequest(KafkaCluster cluster, Topic topic) {
         var config = createAvroValidationConfig(cluster, topic, contentId);
-        byte[] invalidData = "not avro data".getBytes();
 
         try (var tester = kroxyliciousTester(config);
-                var producer = tester.producer(new Serdes.StringSerde(), Serdes.serdeFrom(new ByteArraySerializer(), new ByteArrayDeserializer()), Map.of())) {
-            var future = producer.send(new ProducerRecord<>(topic.name(), "my-key", invalidData));
+                var producer = tester.producer()) {
+            var future = producer.send(new ProducerRecord<>(topic.name(), "my-key", "not avro data"));
             assertThatFutureFails(future, InvalidRecordException.class, "Failed to deserialize Avro record");
         }
     }
 
     @Test
-    void shouldAllowValidAvroOnUnvalidatedTopic(KafkaCluster cluster, Topic validatedTopic, Topic unvalidatedTopic) throws IOException {
+    void shouldAllowValidAvroOnUnvalidatedTopic(KafkaCluster cluster, Topic validatedTopic, Topic unvalidatedTopic) {
         var config = createAvroValidationConfig(cluster, validatedTopic, contentId);
-        byte[] invalidData = "not avro data".getBytes();
 
         try (var tester = kroxyliciousTester(config);
-                var producer = tester.producer(new Serdes.StringSerde(), Serdes.serdeFrom(new ByteArraySerializer(), new ByteArrayDeserializer()), Map.of())) {
+                var producer = tester.producer()) {
             // Invalid data on unvalidated topic should succeed
-            assertThat(producer.send(new ProducerRecord<>(unvalidatedTopic.name(), "my-key", invalidData)))
+            assertThat(producer.send(new ProducerRecord<>(unvalidatedTopic.name(), "my-key", "not avro data")))
                     .succeedsWithin(Duration.ofSeconds(10));
 
             // Invalid data on validated topic should fail
-            var future = producer.send(new ProducerRecord<>(validatedTopic.name(), "my-key", invalidData));
+            var future = producer.send(new ProducerRecord<>(validatedTopic.name(), "my-key", "not avro data"));
             assertThatFutureFails(future, InvalidRecordException.class, "Failed to deserialize Avro record");
         }
     }
@@ -309,30 +305,6 @@ class AvroRecordValidationIT extends RecordValidationBaseIT {
         return proxy(cluster)
                 .addToFilterDefinitions(namedFilterDefinition)
                 .addToDefaultFilters(namedFilterDefinition.name());
-    }
-
-    private static byte[] serializeAvro(Schema schema, String firstName, String lastName, int age) throws IOException {
-        GenericRecord record = new GenericData.Record(schema);
-        record.put("firstName", firstName);
-        record.put("lastName", lastName);
-        record.put("age", age);
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        GenericDatumWriter<GenericRecord> writer = new GenericDatumWriter<>(schema);
-        var encoder = EncoderFactory.get().binaryEncoder(out, null);
-        writer.write(record, encoder);
-        encoder.flush();
-        return out.toByteArray();
-    }
-
-    private static GenericRecord deserializeAvro(Schema schema, byte[] bytes) {
-        try {
-            var decoder = DecoderFactory.get().binaryDecoder(bytes, null);
-            var reader = new GenericDatumReader<GenericRecord>(schema);
-            return reader.read(null, decoder);
-        }
-        catch (IOException e) {
-            throw new RuntimeException("Failed to deserialize Avro", e);
-        }
     }
 
     @AfterAll

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/AvroRecordValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/AvroRecordValidationIT.java
@@ -156,8 +156,8 @@ class AvroRecordValidationIT extends RecordValidationBaseIT {
         var config = createAvroValidationConfig(cluster, topic, contentId);
 
         var keySerde = new Serdes.StringSerde();
-        var producerValueSerde = createAvroProducerSerde(false);
-        var consumerValueSerde = createAvroConsumerSerde(false);
+        var producerValueSerde = createAvroSerde(false);
+        var consumerValueSerde = createAvroSerde(false);
 
         try (var tester = kroxyliciousTester(config);
                 var producer = tester.producer(keySerde, producerValueSerde, Map.of());
@@ -178,8 +178,8 @@ class AvroRecordValidationIT extends RecordValidationBaseIT {
                     .first()
                     .satisfies(value -> {
                         GenericRecord received = (GenericRecord) value;
-                        assertThat(received.get("firstName").toString()).isEqualTo("John");
-                        assertThat(received.get("lastName").toString()).isEqualTo("Doe");
+                        assertThat(received.get("firstName")).hasToString("John");
+                        assertThat(received.get("lastName")).hasToString("Doe");
                         assertThat(received.get("age")).isEqualTo(25);
                     });
         }
@@ -218,8 +218,8 @@ class AvroRecordValidationIT extends RecordValidationBaseIT {
         var config = createAvroValidationConfig(cluster, topic, contentId);
 
         var keySerde = new Serdes.StringSerde();
-        var producerValueSerde = createAvroProducerSerde(schemaIdInHeader);
-        var consumerValueSerde = createAvroConsumerSerde(schemaIdInHeader);
+        var producerValueSerde = createAvroSerde(schemaIdInHeader);
+        var consumerValueSerde = createAvroSerde(schemaIdInHeader);
 
         try (var tester = kroxyliciousTester(config);
                 var producer = tester.producer(keySerde, producerValueSerde, Map.of());
@@ -240,8 +240,8 @@ class AvroRecordValidationIT extends RecordValidationBaseIT {
                     .first()
                     .satisfies(value -> {
                         GenericRecord received = (GenericRecord) value;
-                        assertThat(received.get("firstName").toString()).isEqualTo("John");
-                        assertThat(received.get("lastName").toString()).isEqualTo("Doe");
+                        assertThat(received.get("firstName")).hasToString("John");
+                        assertThat(received.get("lastName")).hasToString("Doe");
                         assertThat(received.get("age")).isEqualTo(30);
                     });
         }
@@ -254,7 +254,7 @@ class AvroRecordValidationIT extends RecordValidationBaseIT {
         var config = createAvroValidationConfig(cluster, topic, secondContentId);
 
         var keySerde = new Serdes.StringSerde();
-        var valueSerde = createAvroProducerSerde(schemaIdInHeader);
+        var valueSerde = createAvroSerde(schemaIdInHeader);
 
         try (var tester = kroxyliciousTester(config);
                 var producer = tester.producer(keySerde, valueSerde, Map.of())) {
@@ -268,17 +268,7 @@ class AvroRecordValidationIT extends RecordValidationBaseIT {
         }
     }
 
-    private static AvroSerde<GenericRecord> createAvroProducerSerde(boolean schemaIdInHeader) {
-        var serde = new AvroSerde<GenericRecord>();
-        serde.configure(Map.of(
-                SerdeConfig.REGISTRY_URL, APICURIO_REGISTRY_URL,
-                SerdeConfig.EXPLICIT_ARTIFACT_ID, artifactId,
-                SerdeConfig.EXPLICIT_ARTIFACT_VERSION, "1",
-                KafkaSerdeConfig.ENABLE_HEADERS, schemaIdInHeader), false);
-        return serde;
-    }
-
-    private static AvroSerde<GenericRecord> createAvroConsumerSerde(boolean schemaIdInHeader) {
+    private static AvroSerde<GenericRecord> createAvroSerde(boolean schemaIdInHeader) {
         var serde = new AvroSerde<GenericRecord>();
         serde.configure(Map.of(
                 SerdeConfig.REGISTRY_URL, APICURIO_REGISTRY_URL,

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/JsonSchemaRecordValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/JsonSchemaRecordValidationIT.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
-import java.util.function.Consumer;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -27,21 +26,13 @@ import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.DockerImageName;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.dockerjava.api.command.CreateContainerCmd;
-import com.github.dockerjava.api.model.ExposedPort;
-import com.github.dockerjava.api.model.HostConfig;
-import com.github.dockerjava.api.model.PortBinding;
-import com.github.dockerjava.api.model.Ports;
 
-import io.apicurio.registry.client.RegistryClientFactory;
-import io.apicurio.registry.client.common.RegistryClientOptions;
 import io.apicurio.registry.rest.client.models.CreateArtifact;
+import io.apicurio.registry.rest.client.models.CreateVersion;
+import io.apicurio.registry.rest.client.models.VersionContent;
 import io.apicurio.registry.rest.client.models.VersionMetaData;
 import io.apicurio.registry.serde.config.SerdeConfig;
 import io.apicurio.registry.serde.jsonschema.JsonSchemaSerde;
@@ -124,48 +115,27 @@ class JsonSchemaRecordValidationIT extends RecordValidationBaseIT {
             {"firstName":"json1","lastName":"json2"}""";
     private static final String INVALID_AGE_MESSAGE = """
             {"firstName":"json1","lastName":"json2","age":-3}""";
-    private static final String APICURIO_REGISTRY_HOST = "http://localhost";
-    private static final Integer APICURIO_REGISTRY_PORT = 8081;
-    private static final String APICURIO_REGISTRY_API = "/apis/registry/v3";
-    private static final String APICURIO_REGISTRY_URL = APICURIO_REGISTRY_HOST + ":" + APICURIO_REGISTRY_PORT + APICURIO_REGISTRY_API;
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     public static final PersonBean PERSON_BEAN = new PersonBean("john", "smith", 23);
 
-    public static String firstArtifactId;
-
-    public static int firstContentId;
-    public static int secondContentId;
-    private static GenericContainer registryContainer;
+    private static String apicurioRegistryUrl;
+    private static String firstArtifactId;
+    private static int firstContentId;
+    private static int secondContentId;
+    private static GenericContainer<?> registryContainer;
 
     @BeforeAll
     static void init() {
-        // An Apicurio Registry instance is required for this test to work, so we start one using a Generic Container
-        String image = "quay.io/apicurio/apicurio-registry:3.2.3@sha256:43f468182af66e083c2c97865109327503d74ece347e48987fb7165a27e77a62";
-        DockerImageName dockerImageName = DockerImageName.parse(image)
-                .asCompatibleSubstituteFor(DockerImageName.parse(image.substring(0, image.indexOf("@"))));
+        registryContainer = startRegistryContainer();
+        apicurioRegistryUrl = registryUrl(registryContainer);
 
-        Consumer<CreateContainerCmd> cmd = e -> e.withHostConfig(new HostConfig().withPortBindings(
-                new PortBinding(Ports.Binding.bindPort(APICURIO_REGISTRY_PORT), new ExposedPort(APICURIO_REGISTRY_PORT))));
-
-        registryContainer = new GenericContainer<>(dockerImageName)
-                .withEnv(Map.of(
-                        "QUARKUS_HTTP_PORT", String.valueOf(APICURIO_REGISTRY_PORT)))
-                .withExposedPorts(APICURIO_REGISTRY_PORT)
-                .withCreateContainerCmdModifier(cmd)
-                .waitingFor(Wait.forHttp(APICURIO_REGISTRY_API + "/system/info").forStatusCode(200));
-
-        registryContainer.start();
-
-        RegistryClientOptions.create(APICURIO_REGISTRY_URL);
-
-        // Preparation: In this test class, schemas are registered in Apicurio Registry v3 and their contentIds are stored for validation.
-        var client = RegistryClientFactory.create(RegistryClientOptions.create(APICURIO_REGISTRY_URL));
+        var client = registryClient(apicurioRegistryUrl);
 
         // Create first artifact with JSON_SCHEMA_TOPIC_1
         CreateArtifact createFirstArtifact = new CreateArtifact();
         createFirstArtifact.setArtifactType("JSON");
-        io.apicurio.registry.rest.client.models.CreateVersion firstVersion = new io.apicurio.registry.rest.client.models.CreateVersion();
-        io.apicurio.registry.rest.client.models.VersionContent firstContent = new io.apicurio.registry.rest.client.models.VersionContent();
+        CreateVersion firstVersion = new CreateVersion();
+        VersionContent firstContent = new VersionContent();
         firstContent.setContent(JSON_SCHEMA_TOPIC_1);
         firstContent.setContentType("application/json");
         firstVersion.setContent(firstContent);
@@ -174,8 +144,8 @@ class JsonSchemaRecordValidationIT extends RecordValidationBaseIT {
         // Create second artifact with JSON_SCHEMA_TOPIC_2 (different schema to get different contentId)
         CreateArtifact createSecondArtifact = new CreateArtifact();
         createSecondArtifact.setArtifactType("JSON");
-        io.apicurio.registry.rest.client.models.CreateVersion secondVersion = new io.apicurio.registry.rest.client.models.CreateVersion();
-        io.apicurio.registry.rest.client.models.VersionContent secondContent = new io.apicurio.registry.rest.client.models.VersionContent();
+        CreateVersion secondVersion = new CreateVersion();
+        VersionContent secondContent = new VersionContent();
         secondContent.setContent(JSON_SCHEMA_TOPIC_2);
         secondContent.setContentType("application/json");
         secondVersion.setContent(secondContent);
@@ -335,14 +305,14 @@ class JsonSchemaRecordValidationIT extends RecordValidationBaseIT {
                 SerdeConfig.EXPLICIT_ARTIFACT_ID, firstArtifactId,
                 SerdeConfig.EXPLICIT_ARTIFACT_VERSION, "1",
                 KafkaSerdeConfig.ENABLE_HEADERS, schemaIdInHeader,
-                SerdeConfig.REGISTRY_URL, APICURIO_REGISTRY_URL), isKey);
+                SerdeConfig.REGISTRY_URL, apicurioRegistryUrl), isKey);
         return consumerKeySerde;
     }
 
     private static @NonNull JsonSchemaSerde<PersonBean> createJsonSchemaProducerSerde(boolean schemaIdInHeader, boolean isKey) {
         var producerKeySerde = new JsonSchemaSerde<PersonBean>();
         producerKeySerde.configure(Map.of(
-                SerdeConfig.REGISTRY_URL, APICURIO_REGISTRY_URL,
+                SerdeConfig.REGISTRY_URL, apicurioRegistryUrl,
                 SerdeConfig.EXPLICIT_ARTIFACT_ID, firstArtifactId,
                 SerdeConfig.EXPLICIT_ARTIFACT_VERSION, "1",
                 KafkaSerdeConfig.ENABLE_HEADERS, schemaIdInHeader), isKey);
@@ -438,7 +408,7 @@ class JsonSchemaRecordValidationIT extends RecordValidationBaseIT {
         String className = RecordValidation.class.getName();
         NamedFilterDefinition namedFilterDefinition = new NamedFilterDefinitionBuilder(className, className).withConfig("rules",
                 List.of(Map.of("topicNames", List.of(topic.name()), ruleType,
-                        Map.of("schemaValidationConfig", Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "apicurioId", contentId)))))
+                        Map.of("schemaValidationConfig", Map.of("apicurioRegistryUrl", apicurioRegistryUrl, "apicurioId", contentId)))))
                 .build();
         return proxy(cluster)
                 .addToFilterDefinitions(namedFilterDefinition)
@@ -451,7 +421,7 @@ class JsonSchemaRecordValidationIT extends RecordValidationBaseIT {
         NamedFilterDefinition namedFilterDefinition = new NamedFilterDefinitionBuilder(className, className).withConfig("rules",
                 List.of(Map.of("topicNames", List.of(topic.name()), ruleType,
                         Map.of("schemaValidationConfig",
-                                Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "apicurioId", contentId, "wireFormatVersion", wireFormatVersion)))))
+                                Map.of("apicurioRegistryUrl", apicurioRegistryUrl, "apicurioId", contentId, "wireFormatVersion", wireFormatVersion)))))
                 .build();
         return proxy(cluster)
                 .addToFilterDefinitions(namedFilterDefinition)
@@ -462,7 +432,7 @@ class JsonSchemaRecordValidationIT extends RecordValidationBaseIT {
         // V2 wire format uses Legacy8ByteIdHandler
         var producerSerde = new JsonSchemaSerde<PersonBean>();
         producerSerde.configure(Map.of(
-                SerdeConfig.REGISTRY_URL, APICURIO_REGISTRY_URL,
+                SerdeConfig.REGISTRY_URL, apicurioRegistryUrl,
                 SerdeConfig.EXPLICIT_ARTIFACT_ID, firstArtifactId,
                 SerdeConfig.EXPLICIT_ARTIFACT_VERSION, "1",
                 KafkaSerdeConfig.ENABLE_HEADERS, schemaIdInHeader,
@@ -477,7 +447,7 @@ class JsonSchemaRecordValidationIT extends RecordValidationBaseIT {
                 SerdeConfig.EXPLICIT_ARTIFACT_ID, firstArtifactId,
                 SerdeConfig.EXPLICIT_ARTIFACT_VERSION, "1",
                 KafkaSerdeConfig.ENABLE_HEADERS, schemaIdInHeader,
-                SerdeConfig.REGISTRY_URL, APICURIO_REGISTRY_URL,
+                SerdeConfig.REGISTRY_URL, apicurioRegistryUrl,
                 SerdeConfig.ID_HANDLER, "io.apicurio.registry.serde.Legacy8ByteIdHandler"), false);
         return consumerSerde;
     }
@@ -491,12 +461,6 @@ class JsonSchemaRecordValidationIT extends RecordValidationBaseIT {
 
     @AfterAll
     static void stopResources() {
-        if (registryContainer != null && registryContainer.isRunning()) {
-            registryContainer.stop();
-        }
-    }
-
-    static boolean isDockerAvailable() {
-        return DockerClientFactory.instance().isDockerAvailable();
+        stopContainer(registryContainer);
     }
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/ProtobufRecordValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/ProtobufRecordValidationIT.java
@@ -17,12 +17,15 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.InvalidRecordException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -33,6 +36,9 @@ import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.HostConfig;
 import com.github.dockerjava.api.model.PortBinding;
 import com.github.dockerjava.api.model.Ports;
+import com.google.protobuf.DescriptorProtos;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
 
 import io.apicurio.registry.client.RegistryClientFactory;
 import io.apicurio.registry.client.common.RegistryClientOptions;
@@ -40,11 +46,15 @@ import io.apicurio.registry.rest.client.models.CreateArtifact;
 import io.apicurio.registry.rest.client.models.CreateVersion;
 import io.apicurio.registry.rest.client.models.VersionContent;
 import io.apicurio.registry.rest.client.models.VersionMetaData;
+import io.apicurio.registry.serde.config.SerdeConfig;
+import io.apicurio.registry.serde.kafka.config.KafkaSerdeConfig;
+import io.apicurio.registry.serde.protobuf.ProtobufSerde;
 
 import io.kroxylicious.filter.validation.RecordValidation;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.NamedFilterDefinition;
 import io.kroxylicious.proxy.config.NamedFilterDefinitionBuilder;
+import io.kroxylicious.test.tester.KroxyliciousTester;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 import io.kroxylicious.testing.kafka.junit5ext.Topic;
@@ -87,11 +97,13 @@ class ProtobufRecordValidationIT extends RecordValidationBaseIT {
     private static final String APICURIO_REGISTRY_API = "/apis/registry/v3";
     private static final String APICURIO_REGISTRY_URL = APICURIO_REGISTRY_HOST + ":" + APICURIO_REGISTRY_PORT + APICURIO_REGISTRY_API;
 
+    private static String artifactId;
     private static int contentId;
     private static GenericContainer<?> registryContainer;
+    private static Descriptors.Descriptor personDescriptor;
 
     @BeforeAll
-    static void init() {
+    static void init() throws Descriptors.DescriptorValidationException {
         String image = "quay.io/apicurio/apicurio-registry:3.1.6@sha256:d0625211cebb1f58a2982df29cb0945249d8f88f37ccce9e162c0c12c2aea89e";
         DockerImageName dockerImageName = DockerImageName.parse(image)
                 .asCompatibleSubstituteFor(DockerImageName.parse(image.substring(0, image.indexOf("@"))));
@@ -119,7 +131,23 @@ class ProtobufRecordValidationIT extends RecordValidationBaseIT {
         createArtifact.setFirstVersion(version);
 
         VersionMetaData artifact = client.groups().byGroupId("default").artifacts().post(createArtifact).getVersion();
+        artifactId = artifact.getArtifactId();
         contentId = artifact.getContentId().intValue();
+
+        // Build descriptor for creating DynamicMessage instances in tests
+        DescriptorProtos.FileDescriptorProto fileProto = DescriptorProtos.FileDescriptorProto.newBuilder()
+                .setSyntax("proto3")
+                .addMessageType(DescriptorProtos.DescriptorProto.newBuilder()
+                        .setName("Person")
+                        .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                                .setName("first_name").setNumber(1).setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING))
+                        .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                                .setName("last_name").setNumber(2).setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING))
+                        .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+                                .setName("age").setNumber(3).setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT32)))
+                .build();
+        Descriptors.FileDescriptor fileDesc = Descriptors.FileDescriptor.buildFrom(fileProto, new Descriptors.FileDescriptor[]{});
+        personDescriptor = fileDesc.findMessageTypeByName("Person");
     }
 
     @Test
@@ -181,6 +209,85 @@ class ProtobufRecordValidationIT extends RecordValidationBaseIT {
             var future = producer.send(new ProducerRecord<>(validatedTopic.name(), "my-key", CORRUPT_PROTOBUF));
             assertThatFutureFails(future, InvalidRecordException.class, "Failed to parse Protobuf message");
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void clientSideProtobufSerdePassesValidation(boolean schemaIdInHeader, KafkaCluster cluster, Topic topic) {
+        var config = createProtobufValidationConfig(cluster, topic, contentId);
+
+        var keySerde = new Serdes.StringSerde();
+        var producerValueSerde = createProtobufProducerSerde(schemaIdInHeader);
+        var consumerValueSerde = createProtobufConsumerSerde(schemaIdInHeader);
+
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer(keySerde, producerValueSerde, Map.of());
+                var consumer = consumeFromEarliestOffsets(tester, keySerde, consumerValueSerde)) {
+            DynamicMessage person = DynamicMessage.newBuilder(personDescriptor)
+                    .setField(personDescriptor.findFieldByName("first_name"), "John")
+                    .setField(personDescriptor.findFieldByName("last_name"), "Doe")
+                    .setField(personDescriptor.findFieldByName("age"), 25)
+                    .build();
+
+            assertThat(producer.send(new ProducerRecord<>(topic.name(), "my-key", person)))
+                    .succeedsWithin(Duration.ofSeconds(10));
+            consumer.subscribe(Set.of(topic.name()));
+
+            var records = consumer.poll(Duration.ofSeconds(10));
+            assertThat(records.records(topic.name()))
+                    .hasSize(1);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void detectsClientProducingWithWrongProtobufSchemaId(boolean schemaIdInHeader, KafkaCluster cluster, Topic topic) {
+        // Configure filter to expect a different contentId than the client sends
+        var config = createProtobufValidationConfig(cluster, topic, contentId + 1);
+
+        var keySerde = new Serdes.StringSerde();
+        var valueSerde = createProtobufProducerSerde(schemaIdInHeader);
+
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer(keySerde, valueSerde, Map.of())) {
+            DynamicMessage person = DynamicMessage.newBuilder(personDescriptor)
+                    .setField(personDescriptor.findFieldByName("first_name"), "John")
+                    .setField(personDescriptor.findFieldByName("last_name"), "Doe")
+                    .setField(personDescriptor.findFieldByName("age"), 25)
+                    .build();
+
+            var future = producer.send(new ProducerRecord<>(topic.name(), "my-key", person));
+            assertThatFutureFails(future, InvalidRecordException.class, "Unexpected schema id in record");
+        }
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static ProtobufSerde<DynamicMessage> createProtobufProducerSerde(boolean schemaIdInHeader) {
+        var serde = new ProtobufSerde();
+        serde.configure(Map.of(
+                SerdeConfig.REGISTRY_URL, APICURIO_REGISTRY_URL,
+                SerdeConfig.EXPLICIT_ARTIFACT_ID, artifactId,
+                SerdeConfig.EXPLICIT_ARTIFACT_VERSION, "1",
+                KafkaSerdeConfig.ENABLE_HEADERS, schemaIdInHeader), false);
+        return serde;
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static ProtobufSerde<DynamicMessage> createProtobufConsumerSerde(boolean schemaIdInHeader) {
+        var serde = new ProtobufSerde();
+        serde.configure(Map.of(
+                SerdeConfig.REGISTRY_URL, APICURIO_REGISTRY_URL,
+                SerdeConfig.EXPLICIT_ARTIFACT_ID, artifactId,
+                SerdeConfig.EXPLICIT_ARTIFACT_VERSION, "1",
+                KafkaSerdeConfig.ENABLE_HEADERS, schemaIdInHeader), false);
+        return serde;
+    }
+
+    private static <T, S> org.apache.kafka.clients.consumer.Consumer<T, S> consumeFromEarliestOffsets(KroxyliciousTester tester, Serde<T> keySerde,
+                                                                                                      Serde<S> valueSerde) {
+        return tester.consumer(keySerde, valueSerde, Map.of(
+                GROUP_ID_CONFIG, UUID.randomUUID().toString(),
+                AUTO_OFFSET_RESET_CONFIG, "earliest"));
     }
 
     private static ConfigurationBuilder createProtobufValidationConfig(KafkaCluster cluster, Topic topic, int protobufContentId) {

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/ProtobufRecordValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/ProtobufRecordValidationIT.java
@@ -86,6 +86,8 @@ class ProtobufRecordValidationIT extends RecordValidationBaseIT {
             }
             """;
 
+    private static final String PROTOBUF_CONTENT_TYPE = "application/x-protobuf";
+
     private static final String APICURIO_REGISTRY_HOST = "http://localhost";
     private static final Integer APICURIO_REGISTRY_PORT = 8083;
     private static final String APICURIO_REGISTRY_API = "/apis/registry/v3";
@@ -121,7 +123,7 @@ class ProtobufRecordValidationIT extends RecordValidationBaseIT {
         CreateVersion version = new CreateVersion();
         VersionContent content = new VersionContent();
         content.setContent(PROTOBUF_SCHEMA);
-        content.setContentType("application/x-protobuf");
+        content.setContentType(PROTOBUF_CONTENT_TYPE);
         version.setContent(content);
         createArtifact.setFirstVersion(version);
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/ProtobufRecordValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/ProtobufRecordValidationIT.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.Consumer;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -24,22 +23,12 @@ import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.DockerImageName;
 
-import com.github.dockerjava.api.command.CreateContainerCmd;
-import com.github.dockerjava.api.model.ExposedPort;
-import com.github.dockerjava.api.model.HostConfig;
-import com.github.dockerjava.api.model.PortBinding;
-import com.github.dockerjava.api.model.Ports;
 import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
 
-import io.apicurio.registry.client.RegistryClientFactory;
-import io.apicurio.registry.client.common.RegistryClientOptions;
 import io.apicurio.registry.rest.client.models.CreateArtifact;
 import io.apicurio.registry.rest.client.models.CreateVersion;
 import io.apicurio.registry.rest.client.models.VersionContent;
@@ -88,11 +77,7 @@ class ProtobufRecordValidationIT extends RecordValidationBaseIT {
 
     private static final String PROTOBUF_CONTENT_TYPE = "application/x-protobuf";
 
-    private static final String APICURIO_REGISTRY_HOST = "http://localhost";
-    private static final Integer APICURIO_REGISTRY_PORT = 8083;
-    private static final String APICURIO_REGISTRY_API = "/apis/registry/v3";
-    private static final String APICURIO_REGISTRY_URL = APICURIO_REGISTRY_HOST + ":" + APICURIO_REGISTRY_PORT + APICURIO_REGISTRY_API;
-
+    private static String apicurioRegistryUrl;
     private static String artifactId;
     private static int contentId;
     private static int secondContentId;
@@ -101,22 +86,10 @@ class ProtobufRecordValidationIT extends RecordValidationBaseIT {
 
     @BeforeAll
     static void init() throws Descriptors.DescriptorValidationException {
-        String image = "quay.io/apicurio/apicurio-registry:3.1.6@sha256:d0625211cebb1f58a2982df29cb0945249d8f88f37ccce9e162c0c12c2aea89e";
-        DockerImageName dockerImageName = DockerImageName.parse(image)
-                .asCompatibleSubstituteFor(DockerImageName.parse(image.substring(0, image.indexOf("@"))));
+        registryContainer = startRegistryContainer();
+        apicurioRegistryUrl = registryUrl(registryContainer);
 
-        Consumer<CreateContainerCmd> cmd = e -> e.withHostConfig(new HostConfig().withPortBindings(
-                new PortBinding(Ports.Binding.bindPort(APICURIO_REGISTRY_PORT), new ExposedPort(APICURIO_REGISTRY_PORT))));
-
-        registryContainer = new GenericContainer<>(dockerImageName)
-                .withEnv(Map.of("QUARKUS_HTTP_PORT", String.valueOf(APICURIO_REGISTRY_PORT)))
-                .withExposedPorts(APICURIO_REGISTRY_PORT)
-                .withCreateContainerCmdModifier(cmd)
-                .waitingFor(Wait.forHttp(APICURIO_REGISTRY_API + "/system/info").forStatusCode(200));
-
-        registryContainer.start();
-
-        var client = RegistryClientFactory.create(RegistryClientOptions.create(APICURIO_REGISTRY_URL));
+        var client = registryClient(apicurioRegistryUrl);
 
         CreateArtifact createArtifact = new CreateArtifact();
         createArtifact.setArtifactType("PROTOBUF");
@@ -137,7 +110,7 @@ class ProtobufRecordValidationIT extends RecordValidationBaseIT {
         CreateVersion secondVersion = new CreateVersion();
         VersionContent secondContent = new VersionContent();
         secondContent.setContent(PROTOBUF_SCHEMA_2);
-        secondContent.setContentType("application/x-protobuf");
+        secondContent.setContentType(PROTOBUF_CONTENT_TYPE);
         secondVersion.setContent(secondContent);
         createSecondArtifact.setFirstVersion(secondVersion);
 
@@ -286,7 +259,7 @@ class ProtobufRecordValidationIT extends RecordValidationBaseIT {
     private static ProtobufSerde<DynamicMessage> createProtobufProducerSerde(boolean schemaIdInHeader) {
         var serde = new ProtobufSerde();
         serde.configure(Map.of(
-                SerdeConfig.REGISTRY_URL, APICURIO_REGISTRY_URL,
+                SerdeConfig.REGISTRY_URL, apicurioRegistryUrl,
                 SerdeConfig.EXPLICIT_ARTIFACT_ID, artifactId,
                 SerdeConfig.EXPLICIT_ARTIFACT_VERSION, "1",
                 KafkaSerdeConfig.ENABLE_HEADERS, schemaIdInHeader), false);
@@ -300,7 +273,7 @@ class ProtobufRecordValidationIT extends RecordValidationBaseIT {
         // The deserializer falls back to Ref-based type detection in the body instead.
         var serde = new ProtobufSerde();
         serde.configure(Map.of(
-                SerdeConfig.REGISTRY_URL, APICURIO_REGISTRY_URL,
+                SerdeConfig.REGISTRY_URL, apicurioRegistryUrl,
                 SerdeConfig.EXPLICIT_ARTIFACT_ID, artifactId,
                 SerdeConfig.EXPLICIT_ARTIFACT_VERSION, "1",
                 KafkaSerdeConfig.ENABLE_HEADERS, schemaIdInHeader,
@@ -320,7 +293,7 @@ class ProtobufRecordValidationIT extends RecordValidationBaseIT {
         NamedFilterDefinition namedFilterDefinition = new NamedFilterDefinitionBuilder(className, className).withConfig("rules",
                 List.of(Map.of("topicNames", List.of(topic.name()), "valueRule",
                         Map.of("schemaValidationConfig",
-                                Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "apicurioId", protobufContentId, "schemaType", "PROTOBUF")))))
+                                Map.of("apicurioRegistryUrl", apicurioRegistryUrl, "apicurioId", protobufContentId, "schemaType", "PROTOBUF")))))
                 .build();
         return proxy(cluster)
                 .addToFilterDefinitions(namedFilterDefinition)
@@ -329,12 +302,6 @@ class ProtobufRecordValidationIT extends RecordValidationBaseIT {
 
     @AfterAll
     static void stopResources() {
-        if (registryContainer != null && registryContainer.isRunning()) {
-            registryContainer.stop();
-        }
-    }
-
-    static boolean isDockerAvailable() {
-        return DockerClientFactory.instance().isDockerAvailable();
+        stopContainer(registryContainer);
     }
 }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/ProtobufRecordValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/ProtobufRecordValidationIT.java
@@ -15,8 +15,7 @@ import java.util.function.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.InvalidRecordException;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -53,6 +52,7 @@ import io.kroxylicious.filter.validation.RecordValidation;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.NamedFilterDefinition;
 import io.kroxylicious.proxy.config.NamedFilterDefinitionBuilder;
+import io.kroxylicious.test.tester.KroxyliciousTester;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 import io.kroxylicious.testing.kafka.junit5ext.Topic;
@@ -85,19 +85,6 @@ class ProtobufRecordValidationIT extends RecordValidationBaseIT {
               string city = 2;
             }
             """;
-
-    // Valid protobuf encoding of Person{first_name="John", last_name="Doe", age=25}
-    // Field 1 (string): tag=0x0A, len=4, "John"
-    // Field 2 (string): tag=0x12, len=3, "Doe"
-    // Field 3 (int32): tag=0x18, varint=25
-    private static final byte[] VALID_PROTOBUF = new byte[]{
-            0x0A, 0x04, 'J', 'o', 'h', 'n',
-            0x12, 0x03, 'D', 'o', 'e',
-            0x18, 25
-    };
-
-    // Corrupt protobuf: length-delimited field claims length 16 but only 1 byte follows
-    private static final byte[] CORRUPT_PROTOBUF = new byte[]{ 0x0A, 0x10, 0x01 };
 
     private static final String APICURIO_REGISTRY_HOST = "http://localhost";
     private static final Integer APICURIO_REGISTRY_PORT = 8083;
@@ -175,21 +162,35 @@ class ProtobufRecordValidationIT extends RecordValidationBaseIT {
     void shouldAcceptValidProtobufInProduceRequest(KafkaCluster cluster, Topic topic) {
         var config = createProtobufValidationConfig(cluster, topic, contentId);
 
+        var keySerde = new Serdes.StringSerde();
+        var producerValueSerde = createProtobufProducerSerde(false);
+        var consumerValueSerde = createProtobufConsumerSerde(false);
+
         try (var tester = kroxyliciousTester(config);
-                var producer = tester.producer(new Serdes.StringSerde(), Serdes.serdeFrom(new ByteArraySerializer(), new ByteArrayDeserializer()), Map.of())) {
-            assertThat(producer.send(new ProducerRecord<>(topic.name(), "my-key", VALID_PROTOBUF)))
+                var producer = tester.producer(keySerde, producerValueSerde, Map.of());
+                var consumer = consumeFromEarliestOffsets(tester, keySerde, consumerValueSerde)) {
+            DynamicMessage person = DynamicMessage.newBuilder(personDescriptor)
+                    .setField(personDescriptor.findFieldByName("first_name"), "John")
+                    .setField(personDescriptor.findFieldByName("last_name"), "Doe")
+                    .setField(personDescriptor.findFieldByName("age"), 25)
+                    .build();
+
+            assertThat(producer.send(new ProducerRecord<>(topic.name(), "my-key", person)))
                     .succeedsWithin(Duration.ofSeconds(10));
 
-            try (var consumer = tester.consumer(new Serdes.StringSerde(), Serdes.serdeFrom(new ByteArraySerializer(), new ByteArrayDeserializer()),
-                    Map.of(GROUP_ID_CONFIG, UUID.randomUUID().toString(), AUTO_OFFSET_RESET_CONFIG, "earliest"))) {
-                consumer.subscribe(Set.of(topic.name()));
-                var records = consumer.poll(Duration.ofSeconds(10));
-                assertThat(records.records(topic.name()))
-                        .hasSize(1)
-                        .extracting(ConsumerRecord::value)
-                        .first()
-                        .isEqualTo(VALID_PROTOBUF);
-            }
+            consumer.subscribe(Set.of(topic.name()));
+            var records = consumer.poll(Duration.ofSeconds(10));
+            assertThat(records.records(topic.name()))
+                    .hasSize(1)
+                    .extracting(ConsumerRecord::value)
+                    .first()
+                    .satisfies(value -> {
+                        DynamicMessage received = (DynamicMessage) value;
+                        var desc = received.getDescriptorForType();
+                        assertThat(received.getField(desc.findFieldByName("first_name"))).isEqualTo("John");
+                        assertThat(received.getField(desc.findFieldByName("last_name"))).isEqualTo("Doe");
+                        assertThat(received.getField(desc.findFieldByName("age"))).isEqualTo(25);
+                    });
         }
     }
 
@@ -198,8 +199,8 @@ class ProtobufRecordValidationIT extends RecordValidationBaseIT {
         var config = createProtobufValidationConfig(cluster, topic, contentId);
 
         try (var tester = kroxyliciousTester(config);
-                var producer = tester.producer(new Serdes.StringSerde(), Serdes.serdeFrom(new ByteArraySerializer(), new ByteArrayDeserializer()), Map.of())) {
-            var future = producer.send(new ProducerRecord<>(topic.name(), "my-key", CORRUPT_PROTOBUF));
+                var producer = tester.producer()) {
+            var future = producer.send(new ProducerRecord<>(topic.name(), "my-key", "corrupt protobuf data"));
             assertThatFutureFails(future, InvalidRecordException.class, "Failed to parse Protobuf message");
         }
     }
@@ -209,14 +210,51 @@ class ProtobufRecordValidationIT extends RecordValidationBaseIT {
         var config = createProtobufValidationConfig(cluster, validatedTopic, contentId);
 
         try (var tester = kroxyliciousTester(config);
-                var producer = tester.producer(new Serdes.StringSerde(), Serdes.serdeFrom(new ByteArraySerializer(), new ByteArrayDeserializer()), Map.of())) {
+                var producer = tester.producer()) {
             // Corrupt data on unvalidated topic should succeed
-            assertThat(producer.send(new ProducerRecord<>(unvalidatedTopic.name(), "my-key", CORRUPT_PROTOBUF)))
+            assertThat(producer.send(new ProducerRecord<>(unvalidatedTopic.name(), "my-key", "corrupt protobuf data")))
                     .succeedsWithin(Duration.ofSeconds(10));
 
             // Corrupt data on validated topic should fail
-            var future = producer.send(new ProducerRecord<>(validatedTopic.name(), "my-key", CORRUPT_PROTOBUF));
+            var future = producer.send(new ProducerRecord<>(validatedTopic.name(), "my-key", "corrupt protobuf data"));
             assertThatFutureFails(future, InvalidRecordException.class, "Failed to parse Protobuf message");
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void clientSideProtobufSerdePassesValidation(boolean schemaIdInHeader, KafkaCluster cluster, Topic topic) {
+        var config = createProtobufValidationConfig(cluster, topic, contentId);
+
+        var keySerde = new Serdes.StringSerde();
+        var producerValueSerde = createProtobufProducerSerde(schemaIdInHeader);
+        var consumerValueSerde = createProtobufConsumerSerde(schemaIdInHeader);
+
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer(keySerde, producerValueSerde, Map.of());
+                var consumer = consumeFromEarliestOffsets(tester, keySerde, consumerValueSerde)) {
+            DynamicMessage person = DynamicMessage.newBuilder(personDescriptor)
+                    .setField(personDescriptor.findFieldByName("first_name"), "John")
+                    .setField(personDescriptor.findFieldByName("last_name"), "Doe")
+                    .setField(personDescriptor.findFieldByName("age"), 25)
+                    .build();
+
+            assertThat(producer.send(new ProducerRecord<>(topic.name(), "my-key", person)))
+                    .succeedsWithin(Duration.ofSeconds(10));
+            consumer.subscribe(Set.of(topic.name()));
+
+            var records = consumer.poll(Duration.ofSeconds(10));
+            assertThat(records.records(topic.name()))
+                    .hasSize(1)
+                    .extracting(ConsumerRecord::value)
+                    .first()
+                    .satisfies(value -> {
+                        DynamicMessage received = (DynamicMessage) value;
+                        var desc = received.getDescriptorForType();
+                        assertThat(received.getField(desc.findFieldByName("first_name"))).isEqualTo("John");
+                        assertThat(received.getField(desc.findFieldByName("last_name"))).isEqualTo("Doe");
+                        assertThat(received.getField(desc.findFieldByName("age"))).isEqualTo(25);
+                    });
         }
     }
 
@@ -251,6 +289,28 @@ class ProtobufRecordValidationIT extends RecordValidationBaseIT {
                 SerdeConfig.EXPLICIT_ARTIFACT_VERSION, "1",
                 KafkaSerdeConfig.ENABLE_HEADERS, schemaIdInHeader), false);
         return serde;
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static ProtobufSerde<DynamicMessage> createProtobufConsumerSerde(boolean schemaIdInHeader) {
+        // Override the message type header name to prevent the deserializer from using the
+        // Java class name header (which causes reflection failures with DynamicMessage).
+        // The deserializer falls back to Ref-based type detection in the body instead.
+        var serde = new ProtobufSerde();
+        serde.configure(Map.of(
+                SerdeConfig.REGISTRY_URL, APICURIO_REGISTRY_URL,
+                SerdeConfig.EXPLICIT_ARTIFACT_ID, artifactId,
+                SerdeConfig.EXPLICIT_ARTIFACT_VERSION, "1",
+                KafkaSerdeConfig.ENABLE_HEADERS, schemaIdInHeader,
+                KafkaSerdeConfig.HEADER_VALUE_MESSAGE_TYPE_OVERRIDE_NAME, "x-ignore-msg-type"), false);
+        return serde;
+    }
+
+    private static <T, S> org.apache.kafka.clients.consumer.Consumer<T, S> consumeFromEarliestOffsets(KroxyliciousTester tester, Serde<T> keySerde,
+                                                                                                      Serde<S> valueSerde) {
+        return tester.consumer(keySerde, valueSerde, Map.of(
+                GROUP_ID_CONFIG, UUID.randomUUID().toString(),
+                AUTO_OFFSET_RESET_CONFIG, "earliest"));
     }
 
     private static ConfigurationBuilder createProtobufValidationConfig(KafkaCluster cluster, Topic topic, int protobufContentId) {

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/ProtobufRecordValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/ProtobufRecordValidationIT.java
@@ -17,7 +17,6 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.InvalidRecordException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
-import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -54,7 +53,6 @@ import io.kroxylicious.filter.validation.RecordValidation;
 import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.NamedFilterDefinition;
 import io.kroxylicious.proxy.config.NamedFilterDefinitionBuilder;
-import io.kroxylicious.test.tester.KroxyliciousTester;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
 import io.kroxylicious.testing.kafka.junit5ext.Topic;
@@ -79,6 +77,15 @@ class ProtobufRecordValidationIT extends RecordValidationBaseIT {
             }
             """;
 
+    private static final String PROTOBUF_SCHEMA_2 = """
+            syntax = "proto3";
+
+            message Address {
+              string street = 1;
+              string city = 2;
+            }
+            """;
+
     // Valid protobuf encoding of Person{first_name="John", last_name="Doe", age=25}
     // Field 1 (string): tag=0x0A, len=4, "John"
     // Field 2 (string): tag=0x12, len=3, "Doe"
@@ -99,6 +106,7 @@ class ProtobufRecordValidationIT extends RecordValidationBaseIT {
 
     private static String artifactId;
     private static int contentId;
+    private static int secondContentId;
     private static GenericContainer<?> registryContainer;
     private static Descriptors.Descriptor personDescriptor;
 
@@ -133,6 +141,19 @@ class ProtobufRecordValidationIT extends RecordValidationBaseIT {
         VersionMetaData artifact = client.groups().byGroupId("default").artifacts().post(createArtifact).getVersion();
         artifactId = artifact.getArtifactId();
         contentId = artifact.getContentId().intValue();
+
+        // Register a second schema to get a different contentId for wrong-schema-id tests
+        CreateArtifact createSecondArtifact = new CreateArtifact();
+        createSecondArtifact.setArtifactType("PROTOBUF");
+        CreateVersion secondVersion = new CreateVersion();
+        VersionContent secondContent = new VersionContent();
+        secondContent.setContent(PROTOBUF_SCHEMA_2);
+        secondContent.setContentType("application/x-protobuf");
+        secondVersion.setContent(secondContent);
+        createSecondArtifact.setFirstVersion(secondVersion);
+
+        VersionMetaData secondArtifact = client.groups().byGroupId("default").artifacts().post(createSecondArtifact).getVersion();
+        secondContentId = secondArtifact.getContentId().intValue();
 
         // Build descriptor for creating DynamicMessage instances in tests
         DescriptorProtos.FileDescriptorProto fileProto = DescriptorProtos.FileDescriptorProto.newBuilder()
@@ -184,18 +205,6 @@ class ProtobufRecordValidationIT extends RecordValidationBaseIT {
     }
 
     @Test
-    void shouldAcceptEmptyProtobufMessage(KafkaCluster cluster, Topic topic) {
-        // In proto3, all fields are optional, so an empty message is valid
-        var config = createProtobufValidationConfig(cluster, topic, contentId);
-
-        try (var tester = kroxyliciousTester(config);
-                var producer = tester.producer(new Serdes.StringSerde(), Serdes.serdeFrom(new ByteArraySerializer(), new ByteArrayDeserializer()), Map.of())) {
-            assertThat(producer.send(new ProducerRecord<>(topic.name(), "my-key", new byte[0])))
-                    .succeedsWithin(Duration.ofSeconds(10));
-        }
-    }
-
-    @Test
     void shouldAllowAnyDataOnUnvalidatedTopic(KafkaCluster cluster, Topic validatedTopic, Topic unvalidatedTopic) {
         var config = createProtobufValidationConfig(cluster, validatedTopic, contentId);
 
@@ -213,37 +222,9 @@ class ProtobufRecordValidationIT extends RecordValidationBaseIT {
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
-    void clientSideProtobufSerdePassesValidation(boolean schemaIdInHeader, KafkaCluster cluster, Topic topic) {
-        var config = createProtobufValidationConfig(cluster, topic, contentId);
-
-        var keySerde = new Serdes.StringSerde();
-        var producerValueSerde = createProtobufProducerSerde(schemaIdInHeader);
-        var consumerValueSerde = createProtobufConsumerSerde(schemaIdInHeader);
-
-        try (var tester = kroxyliciousTester(config);
-                var producer = tester.producer(keySerde, producerValueSerde, Map.of());
-                var consumer = consumeFromEarliestOffsets(tester, keySerde, consumerValueSerde)) {
-            DynamicMessage person = DynamicMessage.newBuilder(personDescriptor)
-                    .setField(personDescriptor.findFieldByName("first_name"), "John")
-                    .setField(personDescriptor.findFieldByName("last_name"), "Doe")
-                    .setField(personDescriptor.findFieldByName("age"), 25)
-                    .build();
-
-            assertThat(producer.send(new ProducerRecord<>(topic.name(), "my-key", person)))
-                    .succeedsWithin(Duration.ofSeconds(10));
-            consumer.subscribe(Set.of(topic.name()));
-
-            var records = consumer.poll(Duration.ofSeconds(10));
-            assertThat(records.records(topic.name()))
-                    .hasSize(1);
-        }
-    }
-
-    @ParameterizedTest
-    @ValueSource(booleans = { true, false })
     void detectsClientProducingWithWrongProtobufSchemaId(boolean schemaIdInHeader, KafkaCluster cluster, Topic topic) {
         // Configure filter to expect a different contentId than the client sends
-        var config = createProtobufValidationConfig(cluster, topic, contentId + 1);
+        var config = createProtobufValidationConfig(cluster, topic, secondContentId);
 
         var keySerde = new Serdes.StringSerde();
         var valueSerde = createProtobufProducerSerde(schemaIdInHeader);
@@ -270,24 +251,6 @@ class ProtobufRecordValidationIT extends RecordValidationBaseIT {
                 SerdeConfig.EXPLICIT_ARTIFACT_VERSION, "1",
                 KafkaSerdeConfig.ENABLE_HEADERS, schemaIdInHeader), false);
         return serde;
-    }
-
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    private static ProtobufSerde<DynamicMessage> createProtobufConsumerSerde(boolean schemaIdInHeader) {
-        var serde = new ProtobufSerde();
-        serde.configure(Map.of(
-                SerdeConfig.REGISTRY_URL, APICURIO_REGISTRY_URL,
-                SerdeConfig.EXPLICIT_ARTIFACT_ID, artifactId,
-                SerdeConfig.EXPLICIT_ARTIFACT_VERSION, "1",
-                KafkaSerdeConfig.ENABLE_HEADERS, schemaIdInHeader), false);
-        return serde;
-    }
-
-    private static <T, S> org.apache.kafka.clients.consumer.Consumer<T, S> consumeFromEarliestOffsets(KroxyliciousTester tester, Serde<T> keySerde,
-                                                                                                      Serde<S> valueSerde) {
-        return tester.consumer(keySerde, valueSerde, Map.of(
-                GROUP_ID_CONFIG, UUID.randomUUID().toString(),
-                AUTO_OFFSET_RESET_CONFIG, "earliest"));
     }
 
     private static ConfigurationBuilder createProtobufValidationConfig(KafkaCluster cluster, Topic topic, int protobufContentId) {

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/ProtobufRecordValidationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/ProtobufRecordValidationIT.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.it.filter.validation;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.InvalidRecordException;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.HostConfig;
+import com.github.dockerjava.api.model.PortBinding;
+import com.github.dockerjava.api.model.Ports;
+
+import io.apicurio.registry.client.RegistryClientFactory;
+import io.apicurio.registry.client.common.RegistryClientOptions;
+import io.apicurio.registry.rest.client.models.CreateArtifact;
+import io.apicurio.registry.rest.client.models.CreateVersion;
+import io.apicurio.registry.rest.client.models.VersionContent;
+import io.apicurio.registry.rest.client.models.VersionMetaData;
+
+import io.kroxylicious.filter.validation.RecordValidation;
+import io.kroxylicious.proxy.config.ConfigurationBuilder;
+import io.kroxylicious.proxy.config.NamedFilterDefinition;
+import io.kroxylicious.proxy.config.NamedFilterDefinitionBuilder;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension;
+import io.kroxylicious.testing.kafka.junit5ext.Topic;
+
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
+import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(KafkaClusterExtension.class)
+@EnabledIf(value = "isDockerAvailable", disabledReason = "docker unavailable")
+class ProtobufRecordValidationIT extends RecordValidationBaseIT {
+
+    private static final String PROTOBUF_SCHEMA = """
+            syntax = "proto3";
+
+            message Person {
+              string first_name = 1;
+              string last_name = 2;
+              int32 age = 3;
+            }
+            """;
+
+    // Valid protobuf encoding of Person{first_name="John", last_name="Doe", age=25}
+    // Field 1 (string): tag=0x0A, len=4, "John"
+    // Field 2 (string): tag=0x12, len=3, "Doe"
+    // Field 3 (int32): tag=0x18, varint=25
+    private static final byte[] VALID_PROTOBUF = new byte[]{
+            0x0A, 0x04, 'J', 'o', 'h', 'n',
+            0x12, 0x03, 'D', 'o', 'e',
+            0x18, 25
+    };
+
+    // Corrupt protobuf: length-delimited field claims length 16 but only 1 byte follows
+    private static final byte[] CORRUPT_PROTOBUF = new byte[]{ 0x0A, 0x10, 0x01 };
+
+    private static final String APICURIO_REGISTRY_HOST = "http://localhost";
+    private static final Integer APICURIO_REGISTRY_PORT = 8083;
+    private static final String APICURIO_REGISTRY_API = "/apis/registry/v3";
+    private static final String APICURIO_REGISTRY_URL = APICURIO_REGISTRY_HOST + ":" + APICURIO_REGISTRY_PORT + APICURIO_REGISTRY_API;
+
+    private static int contentId;
+    private static GenericContainer<?> registryContainer;
+
+    @BeforeAll
+    static void init() {
+        String image = "quay.io/apicurio/apicurio-registry:3.1.6@sha256:d0625211cebb1f58a2982df29cb0945249d8f88f37ccce9e162c0c12c2aea89e";
+        DockerImageName dockerImageName = DockerImageName.parse(image)
+                .asCompatibleSubstituteFor(DockerImageName.parse(image.substring(0, image.indexOf("@"))));
+
+        Consumer<CreateContainerCmd> cmd = e -> e.withHostConfig(new HostConfig().withPortBindings(
+                new PortBinding(Ports.Binding.bindPort(APICURIO_REGISTRY_PORT), new ExposedPort(APICURIO_REGISTRY_PORT))));
+
+        registryContainer = new GenericContainer<>(dockerImageName)
+                .withEnv(Map.of("QUARKUS_HTTP_PORT", String.valueOf(APICURIO_REGISTRY_PORT)))
+                .withExposedPorts(APICURIO_REGISTRY_PORT)
+                .withCreateContainerCmdModifier(cmd)
+                .waitingFor(Wait.forHttp(APICURIO_REGISTRY_API + "/system/info").forStatusCode(200));
+
+        registryContainer.start();
+
+        var client = RegistryClientFactory.create(RegistryClientOptions.create(APICURIO_REGISTRY_URL));
+
+        CreateArtifact createArtifact = new CreateArtifact();
+        createArtifact.setArtifactType("PROTOBUF");
+        CreateVersion version = new CreateVersion();
+        VersionContent content = new VersionContent();
+        content.setContent(PROTOBUF_SCHEMA);
+        content.setContentType("application/x-protobuf");
+        version.setContent(content);
+        createArtifact.setFirstVersion(version);
+
+        VersionMetaData artifact = client.groups().byGroupId("default").artifacts().post(createArtifact).getVersion();
+        contentId = artifact.getContentId().intValue();
+    }
+
+    @Test
+    void shouldAcceptValidProtobufInProduceRequest(KafkaCluster cluster, Topic topic) {
+        var config = createProtobufValidationConfig(cluster, topic, contentId);
+
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer(new Serdes.StringSerde(), Serdes.serdeFrom(new ByteArraySerializer(), new ByteArrayDeserializer()), Map.of())) {
+            assertThat(producer.send(new ProducerRecord<>(topic.name(), "my-key", VALID_PROTOBUF)))
+                    .succeedsWithin(Duration.ofSeconds(10));
+
+            try (var consumer = tester.consumer(new Serdes.StringSerde(), Serdes.serdeFrom(new ByteArraySerializer(), new ByteArrayDeserializer()),
+                    Map.of(GROUP_ID_CONFIG, UUID.randomUUID().toString(), AUTO_OFFSET_RESET_CONFIG, "earliest"))) {
+                consumer.subscribe(Set.of(topic.name()));
+                var records = consumer.poll(Duration.ofSeconds(10));
+                assertThat(records.records(topic.name()))
+                        .hasSize(1)
+                        .extracting(ConsumerRecord::value)
+                        .first()
+                        .isEqualTo(VALID_PROTOBUF);
+            }
+        }
+    }
+
+    @Test
+    void shouldRejectCorruptProtobufInProduceRequest(KafkaCluster cluster, Topic topic) {
+        var config = createProtobufValidationConfig(cluster, topic, contentId);
+
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer(new Serdes.StringSerde(), Serdes.serdeFrom(new ByteArraySerializer(), new ByteArrayDeserializer()), Map.of())) {
+            var future = producer.send(new ProducerRecord<>(topic.name(), "my-key", CORRUPT_PROTOBUF));
+            assertThatFutureFails(future, InvalidRecordException.class, "Failed to parse Protobuf message");
+        }
+    }
+
+    @Test
+    void shouldAcceptEmptyProtobufMessage(KafkaCluster cluster, Topic topic) {
+        // In proto3, all fields are optional, so an empty message is valid
+        var config = createProtobufValidationConfig(cluster, topic, contentId);
+
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer(new Serdes.StringSerde(), Serdes.serdeFrom(new ByteArraySerializer(), new ByteArrayDeserializer()), Map.of())) {
+            assertThat(producer.send(new ProducerRecord<>(topic.name(), "my-key", new byte[0])))
+                    .succeedsWithin(Duration.ofSeconds(10));
+        }
+    }
+
+    @Test
+    void shouldAllowAnyDataOnUnvalidatedTopic(KafkaCluster cluster, Topic validatedTopic, Topic unvalidatedTopic) {
+        var config = createProtobufValidationConfig(cluster, validatedTopic, contentId);
+
+        try (var tester = kroxyliciousTester(config);
+                var producer = tester.producer(new Serdes.StringSerde(), Serdes.serdeFrom(new ByteArraySerializer(), new ByteArrayDeserializer()), Map.of())) {
+            // Corrupt data on unvalidated topic should succeed
+            assertThat(producer.send(new ProducerRecord<>(unvalidatedTopic.name(), "my-key", CORRUPT_PROTOBUF)))
+                    .succeedsWithin(Duration.ofSeconds(10));
+
+            // Corrupt data on validated topic should fail
+            var future = producer.send(new ProducerRecord<>(validatedTopic.name(), "my-key", CORRUPT_PROTOBUF));
+            assertThatFutureFails(future, InvalidRecordException.class, "Failed to parse Protobuf message");
+        }
+    }
+
+    private static ConfigurationBuilder createProtobufValidationConfig(KafkaCluster cluster, Topic topic, int protobufContentId) {
+        String className = RecordValidation.class.getName();
+        NamedFilterDefinition namedFilterDefinition = new NamedFilterDefinitionBuilder(className, className).withConfig("rules",
+                List.of(Map.of("topicNames", List.of(topic.name()), "valueRule",
+                        Map.of("schemaValidationConfig",
+                                Map.of("apicurioRegistryUrl", APICURIO_REGISTRY_URL, "apicurioId", protobufContentId, "schemaType", "PROTOBUF")))))
+                .build();
+        return proxy(cluster)
+                .addToFilterDefinitions(namedFilterDefinition)
+                .addToDefaultFilters(namedFilterDefinition.name());
+    }
+
+    @AfterAll
+    static void stopResources() {
+        if (registryContainer != null && registryContainer.isRunning()) {
+            registryContainer.stop();
+        }
+    }
+
+    static boolean isDockerAvailable() {
+        return DockerClientFactory.instance().isDockerAvailable();
+    }
+}

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/RecordValidationBaseIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/validation/RecordValidationBaseIT.java
@@ -14,6 +14,14 @@ import java.util.concurrent.Future;
 
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import io.apicurio.registry.client.RegistryClientFactory;
+import io.apicurio.registry.client.common.RegistryClientOptions;
+import io.apicurio.registry.rest.client.RegistryClient;
 
 import io.kroxylicious.it.BaseIT;
 import io.kroxylicious.test.tester.KroxyliciousTester;
@@ -24,6 +32,10 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class RecordValidationBaseIT extends BaseIT {
+
+    private static final String APICURIO_REGISTRY_IMAGE = "quay.io/apicurio/apicurio-registry:3.1.6@sha256:d0625211cebb1f58a2982df29cb0945249d8f88f37ccce9e162c0c12c2aea89e";
+    private static final String APICURIO_REGISTRY_API = "/apis/registry/v3";
+    private static final int CONTAINER_PORT = 8080;
 
     public void assertThatFutureSucceeds(Future<RecordMetadata> future) {
         assertThat(future)
@@ -44,5 +56,36 @@ public abstract class RecordValidationBaseIT extends BaseIT {
             consumer.subscribe(Set.of(topic.name()));
             return consumer.poll(Duration.ofSeconds(10));
         }
+    }
+
+    protected static GenericContainer<?> startRegistryContainer() {
+        String image = APICURIO_REGISTRY_IMAGE;
+        DockerImageName dockerImageName = DockerImageName.parse(image)
+                .asCompatibleSubstituteFor(DockerImageName.parse(image.substring(0, image.indexOf("@"))));
+
+        GenericContainer<?> container = new GenericContainer<>(dockerImageName)
+                .withExposedPorts(CONTAINER_PORT)
+                .waitingFor(Wait.forHttp(APICURIO_REGISTRY_API + "/system/info").forStatusCode(200));
+
+        container.start();
+        return container;
+    }
+
+    protected static String registryUrl(GenericContainer<?> container) {
+        return "http://" + container.getHost() + ":" + container.getMappedPort(CONTAINER_PORT) + APICURIO_REGISTRY_API;
+    }
+
+    protected static RegistryClient registryClient(String registryUrl) {
+        return RegistryClientFactory.create(RegistryClientOptions.create(registryUrl));
+    }
+
+    protected static void stopContainer(GenericContainer<?> container) {
+        if (container != null && container.isRunning()) {
+            container.stop();
+        }
+    }
+
+    static boolean isDockerAvailable() {
+        return DockerClientFactory.instance().isDockerAvailable();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -340,6 +340,16 @@
             </dependency>
             <dependency>
                 <groupId>io.apicurio</groupId>
+                <artifactId>apicurio-registry-avro-serde-kafka</artifactId>
+                <version>${apicurio-registry.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.apicurio</groupId>
+                <artifactId>apicurio-registry-protobuf-serde-kafka</artifactId>
+                <version>${apicurio-registry.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.apicurio</groupId>
                 <artifactId>apicurio-registry-serde-common</artifactId>
                 <version>${apicurio-registry.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,8 @@
         <apicurio-schema-validation.version>0.1.4</apicurio-schema-validation.version>
         <apicurio-registry.version>3.2.1</apicurio-registry.version>
         <kiota.version>0.0.34</kiota.version>
+        <avro.version>1.12.0</avro.version>
+        <protobuf-java.version>4.34.0</protobuf-java.version>
         <jose4j.version>0.9.6</jose4j.version>
 
         <!-- Test dependencies -->
@@ -315,6 +317,21 @@
                 <groupId>io.apicurio</groupId>
                 <artifactId>apicurio-registry-schema-validation-protobuf</artifactId>
                 <version>${apicurio-schema-validation.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.apicurio</groupId>
+                <artifactId>apicurio-registry-protobuf-schema-utilities</artifactId>
+                <version>${apicurio-registry.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro</artifactId>
+                <version>${avro.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>${protobuf-java.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.apicurio</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -349,6 +349,11 @@
                 <version>${apicurio-registry.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.kiota</groupId>
+                <artifactId>kiota-http-jdk</artifactId>
+                <version>${kiota.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>io.apicurio</groupId>
                 <artifactId>apicurio-registry-v2-java-sdk</artifactId>
                 <version>${apicurio-registry.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <zjsonpatch.version>0.4.16</zjsonpatch.version>
         <moby-names-generator.version>20.10.1-r0</moby-names-generator.version>
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
-        <apicurio-schema-validation.version>0.1.4-SNAPSHOT</apicurio-schema-validation.version>
+        <apicurio-schema-validation.version>0.1.4</apicurio-schema-validation.version>
         <apicurio-registry.version>3.2.1</apicurio-registry.version>
         <kiota.version>0.0.34</kiota.version>
         <jose4j.version>0.9.6</jose4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <zjsonpatch.version>0.4.16</zjsonpatch.version>
         <moby-names-generator.version>20.10.1-r0</moby-names-generator.version>
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
-        <apicurio-schema-validation.version>0.1.3</apicurio-schema-validation.version>
+        <apicurio-schema-validation.version>0.1.4-SNAPSHOT</apicurio-schema-validation.version>
         <apicurio-registry.version>3.2.1</apicurio-registry.version>
         <kiota.version>0.0.34</kiota.version>
         <jose4j.version>0.9.6</jose4j.version>
@@ -304,6 +304,16 @@
             <dependency>
                 <groupId>io.apicurio</groupId>
                 <artifactId>apicurio-registry-schema-validation-jsonschema</artifactId>
+                <version>${apicurio-schema-validation.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.apicurio</groupId>
+                <artifactId>apicurio-registry-schema-validation-avro</artifactId>
+                <version>${apicurio-schema-validation.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.apicurio</groupId>
+                <artifactId>apicurio-registry-schema-validation-protobuf</artifactId>
                 <version>${apicurio-schema-validation.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -340,16 +340,6 @@
             </dependency>
             <dependency>
                 <groupId>io.apicurio</groupId>
-                <artifactId>apicurio-registry-avro-serde-kafka</artifactId>
-                <version>${apicurio-registry.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.apicurio</groupId>
-                <artifactId>apicurio-registry-protobuf-serde-kafka</artifactId>
-                <version>${apicurio-registry.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.apicurio</groupId>
                 <artifactId>apicurio-registry-serde-common</artifactId>
                 <version>${apicurio-registry.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <apicurio-registry.version>3.2.1</apicurio-registry.version>
         <kiota.version>0.0.34</kiota.version>
         <avro.version>1.12.0</avro.version>
-        <protobuf-java.version>4.34.0</protobuf-java.version>
+        <protobuf-java.version>4.34.1</protobuf-java.version>
         <jose4j.version>0.9.6</jose4j.version>
 
         <!-- Test dependencies -->


### PR DESCRIPTION
## Summary

- Extend the record-validation filter to support **Avro** and **Protobuf** schema validation via Apicurio Registry, in addition to the existing JSON Schema support
- Add a `SchemaType` enum (`JSON_SCHEMA`, `AVRO`, `PROTOBUF`) to `SchemaValidationConfig`, defaulting to `JSON_SCHEMA` for full backward compatibility
- Bump `apicurio-schema-validation` to `0.1.4` which introduces Avro and Protobuf validation support
- Bump `apicurio-registry.version` to `3.2.0` and switch from Vert.x to JDK HTTP client for registry connections

### Key changes

- **`AbstractSchemaBytebufValidator`** — new base class extracting the shared schema ID extraction logic (headers + magic byte wire format) from `JsonSchemaBytebufValidator`
- **`AvroSchemaBytebufValidator`** — deserializes `ByteBuffer` to `GenericRecord` via `GenericDatumReader`, then validates using `AvroValidator`
- **`ProtobufSchemaBytebufValidator`** — parses `ByteBuffer` to `DynamicMessage` via the resolved Protobuf descriptor, then validates using `ProtobufValidator`
- **`BytebufValidators`** — new `avroSchemaValidator()` and `protobufSchemaValidator()` factory methods
- **`ProduceRequestValidatorBuilder`** — dispatches to the correct validator based on `SchemaType`; sets `HTTP_ADAPTER=JDK` on the schema resolver config
- **JDK HTTP client** — excludes `kiota-http-vertx` from `apicurio-registry-schema-resolver` and adds `kiota-http-jdk` as a runtime dependency, avoiding the Vert.x dependency tree
- **TLS tests** — updated to use real temporary keystores/PEM files since Apicurio 3.2.0 eagerly validates SSL contexts

### Configuration example

```yaml
rules:
  - topicNames:
      - my-avro-topic
    valueRule:
      schemaValidationConfig:
        apicurioRegistryUrl: http://apicurio-registry:8080
        apicurioId: 42
        schemaType: AVRO
  - topicNames:
      - my-protobuf-topic
    valueRule:
      schemaValidationConfig:
        apicurioRegistryUrl: http://apicurio-registry:8080
        apicurioId: 43
        schemaType: PROTOBUF
```

## Test plan

- [x] All 128 record-validation unit tests pass
- [x] Unit tests for `AvroSchemaBytebufValidator` with WireMock registry (valid data, invalid data, schema ID in header/body, schema not found)
- [x] Unit tests for `ProtobufSchemaBytebufValidator` with WireMock registry (valid data, empty message, corrupt data, schema ID in header/body, schema not found)
- [x] TLS tests updated for Apicurio 3.2.0 eager SSL context validation
- [x] Integration tests for Avro validation (`AvroRecordValidationIT`) with Testcontainers Apicurio Registry
- [x] Integration tests for Protobuf validation (`ProtobufRecordValidationIT`) with Testcontainers Apicurio Registry
- [x] Verify backward compatibility: existing configs without `schemaType` default to `JSON_SCHEMA`
- [x] Fix resource leak: `DefaultSchemaResolver` now properly closed after schema resolution