### PR TITLE
fix(entity-isolation): Fix naming inconsistency resourceTypes -> entityTypes

### DIFF
--- a/kroxylicious-filters/kroxylicious-entity-isolation/src/main/java/io/kroxylicious/filter/entityisolation/EntityIsolation.java
+++ b/kroxylicious-filters/kroxylicious-entity-isolation/src/main/java/io/kroxylicious/filter/entityisolation/EntityIsolation.java
@@ -65,7 +65,7 @@ public class EntityIsolation implements FilterFactory<EntityIsolation.Config, En
         if (mapper == null) {
             throw new IllegalStateException("filter factory has not been initialized");
         }
-        return new EntityIsolationFilter(configuration.resourceTypes, mapper);
+        return new EntityIsolationFilter(configuration.entityTypes, mapper);
     }
 
     /**
@@ -89,19 +89,19 @@ public class EntityIsolation implements FilterFactory<EntityIsolation.Config, En
     /**
      * Configuration for the {@link EntityIsolation}.
      *
-     * @param resourceTypes set of resource types to isolated.
+     * @param entityTypes set of resource types to isolated.
      * @param mapper mapper name
      * @param mapperConfig mapper config
      */
-    public record Config(@JsonProperty(required = true) Set<EntityType> resourceTypes,
+    public record Config(@JsonProperty(required = true) Set<EntityType> entityTypes,
                          @JsonProperty(required = true) @PluginImplName(EntityNameMapperService.class) String mapper,
                          @PluginImplConfig(implNameProperty = "mapper") Object mapperConfig) {
 
         public Config {
-            Objects.requireNonNull(resourceTypes);
+            Objects.requireNonNull(entityTypes);
             Objects.requireNonNull(mapper);
-            if (resourceTypes.contains(EntityType.TOPIC_NAME)) {
-                throw new IllegalArgumentException("Resource type TOPIC_NAME not yet supported by this filter");
+            if (entityTypes.contains(EntityType.TOPIC_NAME)) {
+                throw new IllegalArgumentException("Entity type TOPIC_NAME not yet supported by this filter");
             }
         }
     }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/entityisolation/EntityIsolationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/entityisolation/EntityIsolationIT.java
@@ -749,7 +749,7 @@ class EntityIsolationIT {
         }
     }
 
-    private static ConfigurationBuilder buildProxyConfig(KafkaCluster cluster, List<EntityIsolation.EntityType> resourcesTypes) {
+    private static ConfigurationBuilder buildProxyConfig(KafkaCluster cluster, List<EntityIsolation.EntityType> entityTypes) {
         var configBuilder = KroxyliciousConfigUtils.proxy(cluster);
 
         var saslInspectionFilter = new NamedFilterDefinitionBuilder(
@@ -763,7 +763,7 @@ class EntityIsolationIT {
                 EntityIsolation.class.getName(),
                 EntityIsolation.class.getName());
 
-        entityIsolationFilter.withConfig("resourceTypes", resourcesTypes,
+        entityIsolationFilter.withConfig("entityTypes", entityTypes,
                 "mapper", PrincipalEntityNameMapperService.class.getSimpleName(),
                 "mapperConfig", Map.of("principalType", User.class.getName()));
         var entityIsolation = entityIsolationFilter.build();

--- a/kroxylicious-operator/packaging/examples/entity-isolation/03.Filter.entity-isolation.yaml
+++ b/kroxylicious-operator/packaging/examples/entity-isolation/03.Filter.entity-isolation.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   type: EntityIsolation
   configTemplate:
-    resourceTypes:
+    entityTypes:
       - GROUP_ID
       - TRANSACTIONAL_ID
     mapper: PrincipalEntityNameMapperService


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

why: During #3467 review, there was review feedback given suggested a rename of `resourceTypes` -> `entityType`.  This was actioned.

 Unfortunately, I missed a reference of the top-level config object.

I spotted this whilst I wrote #3502. The open PR already factors this change in.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
