### PR TITLE
feat(validation): support v13+ Produce with topicId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Format `<github issue/pr number>: <short description>`.
 * [#3383](https://github.com/kroxylicious/kroxylicious/pull/3383): fix(operator): the operator now uses Server-Side Apply for all dependent resources. This is a no-op change for users: existing deployments are unaffected and externally-applied SSA patches (e.g. annotations or env vars added by observability tooling) will now survive operator reconciles. Users upgrading from a prior release may observe one additional reconcile cycle as Kubernetes transfers field ownership to the SSA manager.
 * [#3444](https://github.com/kroxylicious/kroxylicious/pull/3444): feat(authorization): support v13 Produce with topicIds
 * [#3444](https://github.com/kroxylicious/kroxylicious/pull/3444): feat(authorization): support v13-v18 Fetch with topicIds
+* [#3506](https://github.com/kroxylicious/kroxylicious/pull/3506): feat(validation): support v13+ Produce with topicIds
 
 ### Changes, deprecations and removals
 

--- a/kroxylicious-filters/kroxylicious-record-validation/pom.xml
+++ b/kroxylicious-filters/kroxylicious-record-validation/pom.xml
@@ -30,10 +30,6 @@
             <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.kroxylicious</groupId>
-            <artifactId>kroxylicious-kafka-message-tools</artifactId>
-        </dependency>
 
         <!-- third party dependencies - runtime and compile -->
         <dependency>

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/RecordValidationFilter.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/RecordValidationFilter.java
@@ -11,42 +11,37 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
-import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.message.ProduceRequestData.TopicProduceData;
 import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
-import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.kroxylicious.filter.validation.validators.request.ProduceRequestValidationResult;
 import io.kroxylicious.filter.validation.validators.request.ProduceRequestValidator;
+import io.kroxylicious.filter.validation.validators.request.ProduceRequestValidator.NamedTopicProduceData;
 import io.kroxylicious.filter.validation.validators.topic.PartitionValidationResult;
 import io.kroxylicious.filter.validation.validators.topic.RecordValidationFailure;
 import io.kroxylicious.filter.validation.validators.topic.TopicValidationResult;
-import io.kroxylicious.kafka.transform.ApiVersionsResponseTransformer;
-import io.kroxylicious.kafka.transform.ApiVersionsResponseTransformers;
-import io.kroxylicious.proxy.filter.ApiVersionsResponseFilter;
 import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
 import io.kroxylicious.proxy.filter.ProduceResponseFilter;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
+import io.kroxylicious.proxy.filter.metadata.TopicNameMapping;
 
 /**
  * The filter intercepts the produce requests and subject the records contained within them to validation. If the
  * validation fails, the whole produce request is rejected and the producing application receives an error
  * response {@link Errors#INVALID_RECORD}.  The broker does not receive rejected produce requests.
  */
-public class RecordValidationFilter implements ProduceRequestFilter, ProduceResponseFilter, ApiVersionsResponseFilter {
+class RecordValidationFilter implements ProduceRequestFilter, ProduceResponseFilter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RecordValidationFilter.class);
-    // currently we must downgrade to a produce request version that does not support topic ids, we rely on
-    // topic names in the messages when deciding what rules to apply.
-    // todo remove once we have a facility to look up the topic name for a topic id
-    private static final ApiVersionsResponseTransformer DOWNGRADE = ApiVersionsResponseTransformers.limitMaxVersionForApiKeys(Map.of(ApiKeys.PRODUCE, (short) 12));
     private final ProduceRequestValidator validator;
     private final Map<Integer, ProduceRequestValidationResult> correlatedResults = new HashMap<>();
 
@@ -55,51 +50,87 @@ public class RecordValidationFilter implements ProduceRequestFilter, ProduceResp
      *
      * @param validator validator to test ProduceRequests with
      */
-    public RecordValidationFilter(ProduceRequestValidator validator) {
+    RecordValidationFilter(ProduceRequestValidator validator) {
         if (validator == null) {
             throw new IllegalArgumentException("validator is null");
         }
         this.validator = validator;
     }
 
+    private static String topicName(TopicProduceData topicProduceData, Map<Uuid, String> topicNames) {
+        if (topicProduceData.name() != null && !topicProduceData.name().isEmpty()) {
+            return topicProduceData.name();
+        }
+        else {
+            String mappedName = topicNames.get(topicProduceData.topicId());
+            if (mappedName == null) {
+                throw new IllegalStateException(
+                        "topic name not found for TopicProduceData with name: '" + topicProduceData.name() + "' and topicId: '" + topicProduceData.topicId() + "'");
+            }
+            return mappedName;
+        }
+    }
+
     @Override
     public CompletionStage<RequestFilterResult> onProduceRequest(short apiVersion, RequestHeaderData header, ProduceRequestData request, FilterContext context) {
-        CompletionStage<ProduceRequestValidationResult> validationStage = validator.validateRequest(request);
-        return validationStage.thenCompose(result -> {
-            if (result.isAnyTopicPartitionInvalid()) {
-                return handleInvalidTopicPartitions(request, context, result);
+        List<Uuid> uuids = extractTopicIds(request);
+        return context.topicNames(uuids).thenCompose(topicNameMapping -> {
+            if (topicNameMapping.anyFailures()) {
+                return context.requestFilterResultBuilder().errorResponse(header, request, Errors.UNKNOWN_TOPIC_ID.exception()).completed();
             }
-            else {
-                return context.forwardRequest(header, request);
-            }
+            List<NamedTopicProduceData> namedTopicProduceData = request.topicData().stream()
+                    .map(data -> namedData(topicNameMapping, data)).toList();
+            CompletionStage<ProduceRequestValidationResult> validationStage = validator.validateRequest(namedTopicProduceData);
+            return validationStage.thenCompose(result -> {
+                if (result.isAnyTopicPartitionInvalid()) {
+                    return handleInvalidTopicPartitions(namedTopicProduceData, context, result);
+                }
+                else {
+                    return context.forwardRequest(header, request);
+                }
+            });
         });
     }
 
-    private CompletionStage<RequestFilterResult> handleInvalidTopicPartitions(ProduceRequestData request, FilterContext context,
+    private static NamedTopicProduceData namedData(TopicNameMapping topicNameMapping,
+                                                   TopicProduceData data) {
+        return new NamedTopicProduceData(topicName(data, topicNameMapping.topicNames()), data);
+    }
+
+    private static List<Uuid> extractTopicIds(ProduceRequestData request) {
+        return request.topicData().stream()
+                .map(TopicProduceData::topicId)
+                .filter(uuid -> !Uuid.ZERO_UUID.equals(uuid))
+                .toList();
+    }
+
+    private CompletionStage<RequestFilterResult> handleInvalidTopicPartitions(List<NamedTopicProduceData> requestTopicData,
+                                                                              FilterContext context,
                                                                               ProduceRequestValidationResult result) {
         LOGGER.debug("At least one topic-partitions with the request contained invalid records: {}. Produce request will be rejected.", result);
-        ProduceResponseData response = invalidateEntireRequest(request, result);
+        ProduceResponseData response = invalidateEntireRequest(requestTopicData, result);
         return context.requestFilterResultBuilder().shortCircuitResponse(response).completed();
     }
 
-    private static ProduceResponseData invalidateEntireRequest(ProduceRequestData request, ProduceRequestValidationResult produceRequestValidationResult) {
+    private static ProduceResponseData invalidateEntireRequest(List<NamedTopicProduceData> requestTopicData,
+                                                               ProduceRequestValidationResult produceRequestValidationResult) {
         ProduceResponseData response = new ProduceResponseData();
         ProduceResponseData.TopicProduceResponseCollection responseCollection = new ProduceResponseData.TopicProduceResponseCollection();
-        request.topicData().forEach(topicProduceData -> {
-            String topicName = topicProduceData.name();
-            TopicValidationResult topicValidationResult = produceRequestValidationResult.topicResult(topicName);
-            ProduceResponseData.TopicProduceResponse newElement = createInvalidatedTopicProduceResponse(topicName, topicProduceData, topicValidationResult);
+        requestTopicData.forEach(topicProduceData -> {
+            TopicValidationResult topicValidationResult = produceRequestValidationResult.topicResult(topicProduceData.topicName());
+            ProduceResponseData.TopicProduceResponse newElement = createInvalidatedTopicProduceResponse(topicProduceData.data(), topicValidationResult);
             responseCollection.add(newElement);
         });
         response.setResponses(responseCollection);
         return response;
     }
 
-    private static ProduceResponseData.TopicProduceResponse createInvalidatedTopicProduceResponse(String topicName,
-                                                                                                  ProduceRequestData.TopicProduceData topicProduceData,
+    private static ProduceResponseData.TopicProduceResponse createInvalidatedTopicProduceResponse(TopicProduceData topicProduceData,
                                                                                                   TopicValidationResult topicValidationResult) {
         ProduceResponseData.TopicProduceResponse response = new ProduceResponseData.TopicProduceResponse();
-        response.setName(topicName);
+        // we preserve the request topic identification mechanism here, one of name or topicId will be non-null
+        response.setName(topicProduceData.name());
+        response.setTopicId(topicProduceData.topicId());
         List<ProduceResponseData.PartitionProduceResponse> responses = topicProduceData.partitionData().stream().map(partitionProduceData -> {
             PartitionValidationResult partitionResult = topicValidationResult.getPartitionResult(partitionProduceData.index());
             return createInvalidatedPartitionProduceResponse(partitionProduceData, partitionResult);
@@ -169,11 +200,5 @@ public class RecordValidationFilter implements ProduceRequestFilter, ProduceResp
             response.setErrorMessage(toErrorString(partitionValidationResult.recordValidationFailures()));
             topicProduceResponse.partitionResponses().add(response);
         });
-    }
-
-    @Override
-    public CompletionStage<ResponseFilterResult> onApiVersionsResponse(short apiVersion, ResponseHeaderData header, ApiVersionsResponseData response,
-                                                                       FilterContext context) {
-        return context.forwardResponse(header, DOWNGRADE.transform(response));
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/request/ProduceRequestValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/request/ProduceRequestValidator.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.filter.validation.validators.request;
 
+import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletionStage;
 
 import org.apache.kafka.common.message.ProduceRequestData;
@@ -18,8 +20,18 @@ public interface ProduceRequestValidator {
 
     /**
      * Validate a request
-     * @param request the request
+     * @param namedTopicProduceDataList the named topic request data from a single request
      * @return result describing a validation outcome for all topic partitions and details of records that failed validation
      */
-    CompletionStage<ProduceRequestValidationResult> validateRequest(ProduceRequestData request);
+    CompletionStage<ProduceRequestValidationResult> validateRequest(List<NamedTopicProduceData> namedTopicProduceDataList);
+
+    record NamedTopicProduceData(String topicName, ProduceRequestData.TopicProduceData data) {
+        public NamedTopicProduceData {
+            Objects.requireNonNull(topicName);
+            Objects.requireNonNull(data);
+            if (topicName.isEmpty()) {
+                throw new IllegalStateException("topic name is empty");
+            }
+        }
+    }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/request/RoutingProduceRequestValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/request/RoutingProduceRequestValidator.java
@@ -18,8 +18,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import org.apache.kafka.common.message.ProduceRequestData;
-
 import io.kroxylicious.filter.validation.validators.topic.TopicValidationResult;
 import io.kroxylicious.filter.validation.validators.topic.TopicValidator;
 import io.kroxylicious.filter.validation.validators.topic.TopicValidators;
@@ -55,10 +53,9 @@ public class RoutingProduceRequestValidator implements ProduceRequestValidator {
         this.defaultValidator = defaultValidator;
     }
 
-    @Override
-    public CompletionStage<ProduceRequestValidationResult> validateRequest(ProduceRequestData request) {
-        CompletableFuture<TopicValidationResult>[] results = request.topicData().stream()
-                .map(topicProduceData -> getTopicValidator(topicProduceData).validateTopicData(topicProduceData).toCompletableFuture())
+    public CompletionStage<ProduceRequestValidationResult> validateRequest(List<NamedTopicProduceData> topicData) {
+        CompletableFuture<TopicValidationResult>[] results = topicData.stream()
+                .map(this::validateTopicProduceData)
                 .toArray(CompletableFuture[]::new);
         return CompletableFuture.allOf(results).thenApply(unused -> {
             Map<String, TopicValidationResult> result = Arrays.stream(results).map(CompletableFuture::join)
@@ -67,9 +64,14 @@ public class RoutingProduceRequestValidator implements ProduceRequestValidator {
         });
     }
 
-    private TopicValidator getTopicValidator(ProduceRequestData.TopicProduceData topicProduceData) {
-        return cache.computeIfAbsent(topicProduceData.name(), topicName -> {
-            Optional<RoutingRule> first = rules.stream().filter(routingRule -> routingRule.topicPredicate().test(topicName)).findFirst();
+    private CompletableFuture<TopicValidationResult> validateTopicProduceData(NamedTopicProduceData topicProduceData) {
+        TopicValidator topicValidator = getTopicValidator(topicProduceData.topicName());
+        return topicValidator.validateTopicData(topicProduceData.data(), topicProduceData.topicName()).toCompletableFuture();
+    }
+
+    private TopicValidator getTopicValidator(String topicName) {
+        return cache.computeIfAbsent(topicName, name -> {
+            Optional<RoutingRule> first = rules.stream().filter(routingRule -> routingRule.topicPredicate().test(name)).findFirst();
             return first.map(RoutingRule::validator).orElse(defaultValidator);
         });
     }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/topic/AllValidTopicValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/topic/AllValidTopicValidator.java
@@ -13,7 +13,7 @@ import org.apache.kafka.common.message.ProduceRequestData;
 
 class AllValidTopicValidator implements TopicValidator {
     @Override
-    public CompletionStage<TopicValidationResult> validateTopicData(ProduceRequestData.TopicProduceData request) {
-        return CompletableFuture.completedFuture(new AllValidTopicValidationResult(request.name()));
+    public CompletionStage<TopicValidationResult> validateTopicData(ProduceRequestData.TopicProduceData request, String topicName) {
+        return CompletableFuture.completedFuture(new AllValidTopicValidationResult(topicName));
     }
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/topic/PerRecordTopicValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/topic/PerRecordTopicValidator.java
@@ -33,14 +33,14 @@ class PerRecordTopicValidator implements TopicValidator {
     }
 
     @Override
-    public CompletionStage<TopicValidationResult> validateTopicData(ProduceRequestData.TopicProduceData topicProduceData) {
+    public CompletionStage<TopicValidationResult> validateTopicData(ProduceRequestData.TopicProduceData topicProduceData, String topicName) {
         CompletableFuture<PartitionValidationResult>[] result = topicProduceData.partitionData().stream().map(this::validateTopicPartition)
                 .map(CompletionStage::toCompletableFuture)
                 .toArray(CompletableFuture[]::new);
         return CompletableFuture.allOf(result).thenApply(unused -> {
             Map<Integer, PartitionValidationResult> collect = Arrays.stream(result).map(CompletableFuture::join)
                     .collect(Collectors.toMap(PartitionValidationResult::index, x -> x));
-            return new PerPartitionTopicValidationResult(topicProduceData.name(), collect);
+            return new PerPartitionTopicValidationResult(topicName, collect);
         });
     }
 

--- a/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/topic/TopicValidator.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/main/java/io/kroxylicious/filter/validation/validators/topic/TopicValidator.java
@@ -14,11 +14,13 @@ import org.apache.kafka.common.message.ProduceRequestData;
  * Validates {@link org.apache.kafka.common.message.ProduceRequestData.TopicProduceData}
  */
 public interface TopicValidator {
+
     /**
      * Validate topic produce data, returning details about which partitions/records were
      * invalid
      * @param request the request
+     * @param topicName the topic name
      * @return result describing whether any partitions were invalid, and details of any invalid partitions/records
      */
-    CompletionStage<TopicValidationResult> validateTopicData(ProduceRequestData.TopicProduceData request);
+    CompletionStage<TopicValidationResult> validateTopicData(ProduceRequestData.TopicProduceData request, String topicName);
 }

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/RecordValidationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/RecordValidationFilterTest.java
@@ -13,91 +13,43 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 
-import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.UnknownTopicIdException;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.message.RequestHeaderData;
-import org.apache.kafka.common.message.ResponseHeaderData;
-import org.apache.kafka.common.protocol.ApiKeys;
-import org.apache.kafka.common.protocol.ApiMessage;
 import org.apache.kafka.common.protocol.Errors;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.kroxylicious.filter.validation.validators.request.ProduceRequestValidationResult;
 import io.kroxylicious.filter.validation.validators.request.ProduceRequestValidator;
+import io.kroxylicious.filter.validation.validators.request.ProduceRequestValidator.NamedTopicProduceData;
 import io.kroxylicious.filter.validation.validators.topic.PartitionValidationResult;
 import io.kroxylicious.filter.validation.validators.topic.RecordValidationFailure;
 import io.kroxylicious.filter.validation.validators.topic.TopicValidationResult;
-import io.kroxylicious.proxy.filter.FilterContext;
-import io.kroxylicious.proxy.filter.RequestFilterResult;
-import io.kroxylicious.proxy.filter.RequestFilterResultBuilder;
-import io.kroxylicious.proxy.filter.ResponseFilterResult;
-import io.kroxylicious.proxy.filter.filterresultbuilder.CloseOrTerminalStage;
+import io.kroxylicious.test.assertj.MockFilterContextAssert;
+import io.kroxylicious.test.context.MockFilterContext;
 
 import static org.apache.kafka.common.message.ProduceRequestData.HIGHEST_SUPPORTED_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mock.Strictness.LENIENT;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class RecordValidationFilterTest {
 
     private static final String MY_TOPIC = "mytopic";
+    public static final Uuid TOPIC_ID = Uuid.randomUuid();
 
     @Mock
     private ProduceRequestValidator produceRequestValidator;
 
     @Mock
     private TopicValidationResult topicValidationResult;
-
-    @Mock(strictness = LENIENT)
-    private FilterContext context;
-
-    @Captor
-    private ArgumentCaptor<ApiMessage> apiMessageCaptor;
-
-    @BeforeEach
-    void setUp() {
-        when(context.forwardRequest(any(RequestHeaderData.class), apiMessageCaptor.capture())).then(invocationOnMock -> {
-            var filterResult = mock(RequestFilterResult.class);
-            lenient().when(filterResult.message()).thenReturn(apiMessageCaptor.getValue());
-            return CompletableFuture.completedFuture(filterResult);
-        });
-
-        when(context.forwardResponse(any(ResponseHeaderData.class), apiMessageCaptor.capture())).then(invocationOnMock -> {
-            var filterResult = mock(ResponseFilterResult.class);
-            lenient().when(filterResult.message()).thenReturn(apiMessageCaptor.getValue());
-            return CompletableFuture.completedFuture(filterResult);
-        });
-
-        when(context.requestFilterResultBuilder()).then(invocationOnMock -> {
-            var builder = mock(RequestFilterResultBuilder.class);
-            var filterResult = mock(RequestFilterResult.class);
-
-            var closeOrTerminalStage = mock(CloseOrTerminalStage.class);
-            lenient().when(closeOrTerminalStage.completed()).thenReturn(CompletableFuture.completedStage(filterResult));
-            lenient().when(closeOrTerminalStage.build()).thenReturn(filterResult);
-
-            when(builder.shortCircuitResponse(apiMessageCaptor.capture())).then(invocation -> {
-                lenient().when(filterResult.shortCircuitResponse()).thenReturn(true);
-                lenient().when(filterResult.message()).thenReturn(apiMessageCaptor.getValue());
-                return closeOrTerminalStage;
-            });
-            return builder;
-        });
-    }
 
     @SuppressWarnings("DataFlowIssue")
     @Test
@@ -107,22 +59,24 @@ class RecordValidationFilterTest {
     }
 
     @Test
-    void requestThatPassesValidationIsForwarded() {
+    void requestThatPassesValidationWithTopicNamesIsForwarded() {
         // Given
         var validator = new RecordValidationFilter(produceRequestValidator);
 
         when(topicValidationResult.isAnyPartitionInvalid()).thenReturn(false);
 
         var header = new RequestHeaderData();
-        var request = buildProduceRequestData(new ProduceRequestData.TopicProduceData()
+        ProduceRequestData.TopicProduceData produceData = new ProduceRequestData.TopicProduceData()
                 .setName(MY_TOPIC)
-                .setPartitionData(List.of(new ProduceRequestData.PartitionProduceData())));
+                .setPartitionData(List.of(new ProduceRequestData.PartitionProduceData()));
+        var request = buildProduceRequestData(produceData);
 
-        when(produceRequestValidator.validateRequest(request)).thenReturn(
+        when(produceRequestValidator.validateRequest(List.of(new NamedTopicProduceData(MY_TOPIC, produceData)))).thenReturn(
                 CompletableFuture.completedStage(new ProduceRequestValidationResult(Map.of(MY_TOPIC, topicValidationResult))));
 
+        MockFilterContext mockFilterContext = MockFilterContext.builder(header, request).build();
         // When
-        var result = validator.onProduceRequest(HIGHEST_SUPPORTED_VERSION, header, request, context);
+        var result = validator.onProduceRequest(HIGHEST_SUPPORTED_VERSION, header, request, mockFilterContext);
 
         // Then
         assertThat(result)
@@ -130,6 +84,59 @@ class RecordValidationFilterTest {
                 .satisfies(rfr -> {
                     assertThat(rfr.shortCircuitResponse()).isFalse();
                     assertThat(rfr.message()).isEqualTo(request);
+                });
+    }
+
+    @Test
+    void requestThatPassesValidationWithTopicIdsIsForwarded() {
+        // Given
+        var validator = new RecordValidationFilter(produceRequestValidator);
+
+        when(topicValidationResult.isAnyPartitionInvalid()).thenReturn(false);
+
+        var header = new RequestHeaderData();
+        ProduceRequestData.TopicProduceData produceData = new ProduceRequestData.TopicProduceData()
+                .setTopicId(TOPIC_ID)
+                .setPartitionData(List.of(new ProduceRequestData.PartitionProduceData()));
+        var request = buildProduceRequestData(produceData);
+
+        when(produceRequestValidator.validateRequest(List.of(new NamedTopicProduceData(MY_TOPIC, produceData)))).thenReturn(
+                CompletableFuture.completedStage(new ProduceRequestValidationResult(Map.of(MY_TOPIC, topicValidationResult))));
+
+        MockFilterContext mockFilterContext = MockFilterContext.builder(header, request).withTopicName(TOPIC_ID, MY_TOPIC).build();
+        // When
+        var result = validator.onProduceRequest(HIGHEST_SUPPORTED_VERSION, header, request, mockFilterContext);
+
+        // Then
+        assertThat(result)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .satisfies(rfr -> {
+                    assertThat(rfr.shortCircuitResponse()).isFalse();
+                    assertThat(rfr.message()).isEqualTo(request);
+                });
+    }
+
+    @Test
+    void topicIdLookupFailure() {
+        // Given
+        var validator = new RecordValidationFilter(produceRequestValidator);
+
+        var header = new RequestHeaderData();
+        var request = buildProduceRequestData(new ProduceRequestData.TopicProduceData()
+                .setTopicId(TOPIC_ID)
+                .setPartitionData(List.of(new ProduceRequestData.PartitionProduceData())));
+        // context will return mapping error as we have not configured topic ids
+        MockFilterContext mockFilterContext = MockFilterContext.builder(header, request).build();
+        // When
+        var result = validator.onProduceRequest(HIGHEST_SUPPORTED_VERSION, header, request, mockFilterContext);
+
+        // Then
+        assertThat(result)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .satisfies(rfr -> {
+                    MockFilterContextAssert.assertThat(rfr)
+                            .isErrorResponse()
+                            .errorResponse().isInstanceOf(UnknownTopicIdException.class);
                 });
     }
 
@@ -142,14 +149,16 @@ class RecordValidationFilterTest {
         when(topicValidationResult.getPartitionResult(0)).thenReturn(new PartitionValidationResult(0, List.of(new RecordValidationFailure(0, "record error"))));
 
         var header = new RequestHeaderData();
-        var request = buildProduceRequestData(new ProduceRequestData.TopicProduceData()
+        ProduceRequestData.TopicProduceData produceData = new ProduceRequestData.TopicProduceData()
                 .setName(MY_TOPIC)
-                .setPartitionData(List.of(new ProduceRequestData.PartitionProduceData())));
-        when(produceRequestValidator.validateRequest(request)).thenReturn(
+                .setPartitionData(List.of(new ProduceRequestData.PartitionProduceData()));
+        var request = buildProduceRequestData(produceData);
+        when(produceRequestValidator.validateRequest(List.of(new NamedTopicProduceData(MY_TOPIC, produceData)))).thenReturn(
                 CompletableFuture.completedStage(new ProduceRequestValidationResult(Map.of(MY_TOPIC, topicValidationResult))));
+        MockFilterContext mockFilterContext = MockFilterContext.builder(header, request).build();
 
         // When
-        var result = validator.onProduceRequest(HIGHEST_SUPPORTED_VERSION, header, request, context);
+        var result = validator.onProduceRequest(HIGHEST_SUPPORTED_VERSION, header, request, mockFilterContext);
 
         // Then
         assertThat(result)
@@ -184,17 +193,19 @@ class RecordValidationFilterTest {
         final ProduceRequestData.PartitionProduceData partition1 = new ProduceRequestData.PartitionProduceData();
         final ProduceRequestData.PartitionProduceData partition2 = new ProduceRequestData.PartitionProduceData();
         partition2.setIndex(1);
-        var request = buildProduceRequestData(new ProduceRequestData.TopicProduceData()
+        ProduceRequestData.TopicProduceData produceData = new ProduceRequestData.TopicProduceData()
                 .setName(MY_TOPIC)
                 .setPartitionData(
                         new ArrayList<>(List.of(
                                 partition1,
-                                partition2))));
-        when(produceRequestValidator.validateRequest(request)).thenReturn(
+                                partition2)));
+        var request = buildProduceRequestData(produceData);
+        when(produceRequestValidator.validateRequest(List.of(new NamedTopicProduceData(MY_TOPIC, produceData)))).thenReturn(
                 CompletableFuture.completedStage(new ProduceRequestValidationResult(Map.of(MY_TOPIC, topicValidationResult))));
+        MockFilterContext mockFilterContext = MockFilterContext.builder(header, request).build();
 
         // When
-        var result = validator.onProduceRequest(HIGHEST_SUPPORTED_VERSION, header, request, context);
+        var result = validator.onProduceRequest(HIGHEST_SUPPORTED_VERSION, header, request, mockFilterContext);
 
         // Then
         assertThat(result)
@@ -229,14 +240,16 @@ class RecordValidationFilterTest {
         when(topicValidationResult.getPartitionResult(0)).thenReturn(new PartitionValidationResult(0, List.of(new RecordValidationFailure(0, "record error"))));
 
         var header = new RequestHeaderData();
-        var request = buildProduceRequestData(Optional.of("testTransactionId"), new ProduceRequestData.TopicProduceData()
+        ProduceRequestData.TopicProduceData produceData = new ProduceRequestData.TopicProduceData()
                 .setName(MY_TOPIC)
-                .setPartitionData(List.of(new ProduceRequestData.PartitionProduceData())));
-        when(produceRequestValidator.validateRequest(request)).thenReturn(
+                .setPartitionData(List.of(new ProduceRequestData.PartitionProduceData()));
+        var request = buildProduceRequestData(Optional.of("testTransactionId"), produceData);
+        when(produceRequestValidator.validateRequest(List.of(new NamedTopicProduceData(MY_TOPIC, produceData)))).thenReturn(
                 CompletableFuture.completedStage(new ProduceRequestValidationResult(Map.of(MY_TOPIC, topicValidationResult))));
+        MockFilterContext mockFilterContext = MockFilterContext.builder(header, request).build();
 
         // When
-        var result = validator.onProduceRequest(HIGHEST_SUPPORTED_VERSION, header, request, context);
+        var result = validator.onProduceRequest(HIGHEST_SUPPORTED_VERSION, header, request, mockFilterContext);
 
         // Then
         assertThat(result)
@@ -259,38 +272,7 @@ class RecordValidationFilterTest {
     }
 
     @Test
-    void capsMaxProduceRequestVersionAt12() {
-        var validator = new RecordValidationFilter(produceRequestValidator);
-        ApiVersionsResponseData response = new ApiVersionsResponseData();
-        response.apiKeys().add(new ApiVersionsResponseData.ApiVersion().setApiKey(ApiKeys.PRODUCE.id).setMinVersion(ApiKeys.PRODUCE.id).setMaxVersion((short) 13));
-        CompletionStage<ResponseFilterResult> responseStage = validator.onApiVersionsResponse(ApiKeys.API_VERSIONS.latestVersion(), new ResponseHeaderData(), response,
-                context);
-        assertThat(responseStage).succeedsWithin(Duration.ofSeconds(1)).satisfies(responseFilterResult -> {
-            ApiMessage message = responseFilterResult.message();
-            assertThat(message).isInstanceOfSatisfying(ApiVersionsResponseData.class, apiVersionsResponseData -> {
-                assertThat(apiVersionsResponseData.apiKeys().find(ApiKeys.PRODUCE.id)).satisfies(apiKey -> {
-                    assertThat(apiKey.maxVersion()).isEqualTo((short) 12);
-                });
-            });
-        });
-    }
-
-    @Test
-    void handlesProduceVersionMissingInRespones() {
-        var validator = new RecordValidationFilter(produceRequestValidator);
-        ApiVersionsResponseData response = new ApiVersionsResponseData();
-        CompletionStage<ResponseFilterResult> responseStage = validator.onApiVersionsResponse(ApiKeys.API_VERSIONS.latestVersion(), new ResponseHeaderData(), response,
-                context);
-        assertThat(responseStage).succeedsWithin(Duration.ofSeconds(1)).satisfies(responseFilterResult -> {
-            ApiMessage message = responseFilterResult.message();
-            assertThat(message).isInstanceOfSatisfying(ApiVersionsResponseData.class, apiVersionsResponseData -> {
-                assertThat(apiVersionsResponseData.apiKeys()).isEmpty();
-            });
-        });
-    }
-
-    @Test
-    void requestWithSomePartitionsFailedIsRejectedWithShortCircuitResponseInTransaction() {
+    void requestUsingTopicNameWithSomePartitionsFailedIsRejectedWithShortCircuitResponseInTransaction() {
         // Given
         var validator = new RecordValidationFilter(produceRequestValidator);
 
@@ -298,15 +280,17 @@ class RecordValidationFilterTest {
         when(topicValidationResult.getPartitionResult(0)).thenReturn(new PartitionValidationResult(0, List.of(new RecordValidationFailure(0, "record error"))));
 
         var header = new RequestHeaderData();
-        var request = buildProduceRequestData(Optional.of("testTransactionId"), new ProduceRequestData.TopicProduceData()
+        ProduceRequestData.TopicProduceData produceData = new ProduceRequestData.TopicProduceData()
                 .setName(MY_TOPIC)
                 .setPartitionData(List.of(new ProduceRequestData.PartitionProduceData(),
-                        new ProduceRequestData.PartitionProduceData())));
-        when(produceRequestValidator.validateRequest(request)).thenReturn(
+                        new ProduceRequestData.PartitionProduceData()));
+        var request = buildProduceRequestData(Optional.of("testTransactionId"), produceData);
+        when(produceRequestValidator.validateRequest(List.of(new NamedTopicProduceData(MY_TOPIC, produceData)))).thenReturn(
                 CompletableFuture.completedStage(new ProduceRequestValidationResult(Map.of(MY_TOPIC, topicValidationResult))));
+        MockFilterContext mockFilterContext = MockFilterContext.builder(header, request).build();
 
         // When
-        var result = validator.onProduceRequest(HIGHEST_SUPPORTED_VERSION, header, request, context);
+        var result = validator.onProduceRequest(HIGHEST_SUPPORTED_VERSION, header, request, mockFilterContext);
 
         // Then
         assertThat(result)
@@ -321,6 +305,48 @@ class RecordValidationFilterTest {
                             .singleElement()
                             .satisfies(tpr -> {
                                 assertThat(tpr.name()).isEqualTo(MY_TOPIC);
+                                assertThat(tpr.topicId()).isEqualTo(Uuid.ZERO_UUID);
+                                assertThat(tpr.partitionResponses())
+                                        .allMatch(pr -> pr.errorCode() == Errors.INVALID_RECORD.code());
+                            });
+                });
+    }
+
+    @Test
+    void requestUsingTopicIdWithSomePartitionsFailedIsRejectedWithShortCircuitResponseInTransaction() {
+        // Given
+        var validator = new RecordValidationFilter(produceRequestValidator);
+
+        when(topicValidationResult.isAnyPartitionInvalid()).thenReturn(true);
+        when(topicValidationResult.getPartitionResult(0)).thenReturn(new PartitionValidationResult(0, List.of(new RecordValidationFailure(0, "record error"))));
+
+        var header = new RequestHeaderData();
+        ProduceRequestData.TopicProduceData produceData = new ProduceRequestData.TopicProduceData()
+                .setTopicId(TOPIC_ID)
+                .setPartitionData(List.of(new ProduceRequestData.PartitionProduceData(),
+                        new ProduceRequestData.PartitionProduceData()));
+        var request = buildProduceRequestData(Optional.of("testTransactionId"), produceData);
+        when(produceRequestValidator.validateRequest(List.of(new NamedTopicProduceData(MY_TOPIC, produceData)))).thenReturn(
+                CompletableFuture.completedStage(new ProduceRequestValidationResult(Map.of(MY_TOPIC, topicValidationResult))));
+        MockFilterContext mockFilterContext = MockFilterContext.builder(header, request).withTopicName(TOPIC_ID, MY_TOPIC).build();
+
+        // When
+        var result = validator.onProduceRequest(HIGHEST_SUPPORTED_VERSION, header, request, mockFilterContext);
+
+        // Then
+        assertThat(result)
+                .succeedsWithin(Duration.ofSeconds(1))
+                .satisfies(rfr -> {
+                    assertThat(rfr.shortCircuitResponse()).isTrue();
+                    assertThat(rfr.message())
+                            .isInstanceOf(ProduceResponseData.class);
+
+                    var prd = (ProduceResponseData) rfr.message();
+                    assertThat(prd.responses())
+                            .singleElement()
+                            .satisfies(tpr -> {
+                                assertThat(tpr.topicId()).isEqualTo(TOPIC_ID);
+                                assertThat(tpr.name()).isEmpty();
                                 assertThat(tpr.partitionResponses())
                                         .allMatch(pr -> pr.errorCode() == Errors.INVALID_RECORD.code());
                             });

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/validators/request/RoutingProduceRequestValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/validators/request/RoutingProduceRequestValidatorTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.filter.validation.validators.request;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Stream;
+
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.message.ProduceRequestData.TopicProduceData;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.kroxylicious.filter.validation.validators.request.ProduceRequestValidator.NamedTopicProduceData;
+import io.kroxylicious.filter.validation.validators.topic.TopicValidationResult;
+import io.kroxylicious.filter.validation.validators.topic.TopicValidator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RoutingProduceRequestValidatorTest {
+    public static final String TOPIC_NAME = "my_topic";
+    public static final Uuid TOPIC_ID = Uuid.randomUuid();
+    @Mock
+    TopicValidator validator;
+    @Mock
+    TopicValidationResult result;
+
+    public static Stream<Arguments> routeWithTopicIdInData() {
+        return Stream.of(Arguments.argumentSet("null name", new Object[]{ null }),
+                Arguments.argumentSet("empty name", ""));
+    }
+
+    @Test
+    void routeWithTopicNameInData() {
+        ProduceRequestValidator requestValidator = RoutingProduceRequestValidator.builder()
+                .appendValidatorForTopicPattern(Set.of(TOPIC_NAME), validator)
+                .build();
+        TopicProduceData produceData = new TopicProduceData();
+        produceData.setName(TOPIC_NAME);
+        CompletableFuture<TopicValidationResult> future = CompletableFuture.completedFuture(result);
+        when(validator.validateTopicData(produceData, TOPIC_NAME)).thenReturn(future);
+        when(result.topicName()).thenReturn(TOPIC_NAME);
+        CompletionStage<ProduceRequestValidationResult> stage = requestValidator.validateRequest(List.of(new NamedTopicProduceData(TOPIC_NAME, produceData)));
+        assertThat(stage).succeedsWithin(Duration.ZERO).satisfies(produceResult -> {
+            assertThat(produceResult.topicResult(TOPIC_NAME)).isSameAs(result);
+        });
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void routeWithTopicIdInData(String topicName) {
+        ProduceRequestValidator requestValidator = RoutingProduceRequestValidator.builder()
+                .appendValidatorForTopicPattern(Set.of(TOPIC_NAME), validator)
+                .build();
+        TopicProduceData produceData = new TopicProduceData();
+        produceData.setTopicId(TOPIC_ID);
+        produceData.setName(topicName);
+        CompletableFuture<TopicValidationResult> future = CompletableFuture.completedFuture(result);
+        when(validator.validateTopicData(produceData, TOPIC_NAME)).thenReturn(future);
+        when(result.topicName()).thenReturn(TOPIC_NAME);
+        CompletionStage<ProduceRequestValidationResult> stage = requestValidator.validateRequest(List.of(new NamedTopicProduceData(TOPIC_NAME, produceData)));
+        assertThat(stage).succeedsWithin(Duration.ZERO).satisfies(produceResult -> {
+            assertThat(produceResult.topicResult(TOPIC_NAME)).isSameAs(result);
+        });
+    }
+
+    @Test
+    void defaultIsAllValid() {
+        ProduceRequestValidator requestValidator = RoutingProduceRequestValidator.builder()
+                .build();
+        ProduceRequestData request = new ProduceRequestData();
+        TopicProduceData produceData = new TopicProduceData();
+        produceData.setName(TOPIC_NAME);
+        request.topicData().add(produceData);
+        ProduceRequestData.PartitionProduceData partitionData = new ProduceRequestData.PartitionProduceData();
+        partitionData.setIndex(0);
+        produceData.partitionData().add(partitionData);
+        CompletionStage<ProduceRequestValidationResult> stage = requestValidator.validateRequest(List.of(new NamedTopicProduceData(TOPIC_NAME, produceData)));
+        assertThat(stage).succeedsWithin(Duration.ZERO).satisfies(produceResult -> {
+            TopicValidationResult actual = produceResult.topicResult(TOPIC_NAME);
+            assertThat(actual.topicName()).isEqualTo(TOPIC_NAME);
+            assertThat(actual.isAnyPartitionInvalid()).isFalse();
+        });
+    }
+
+    @Test
+    void overrideDefault() {
+        ProduceRequestValidator requestValidator = RoutingProduceRequestValidator.builder()
+                .setDefaultValidator(validator)
+                .build();
+        ProduceRequestData request = new ProduceRequestData();
+        TopicProduceData produceData = new TopicProduceData();
+        produceData.setName(TOPIC_NAME);
+        request.topicData().add(produceData);
+        CompletableFuture<TopicValidationResult> future = CompletableFuture.completedFuture(result);
+        when(validator.validateTopicData(produceData, TOPIC_NAME)).thenReturn(future);
+        when(result.topicName()).thenReturn(TOPIC_NAME);
+        CompletionStage<ProduceRequestValidationResult> stage = requestValidator.validateRequest(List.of(new NamedTopicProduceData(TOPIC_NAME, produceData)));
+        assertThat(stage).succeedsWithin(Duration.ZERO).satisfies(produceResult -> {
+            assertThat(produceResult.topicResult(TOPIC_NAME)).isSameAs(result);
+        });
+    }
+
+}

--- a/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/validators/topic/PerRecordTopicValidatorTest.java
+++ b/kroxylicious-filters/kroxylicious-record-validation/src/test/java/io/kroxylicious/filter/validation/validators/topic/PerRecordTopicValidatorTest.java
@@ -43,7 +43,7 @@ class PerRecordTopicValidatorTest {
         var topicValidator = new PerRecordTopicValidator(validator);
 
         when(validator.validate(any(Record.class))).thenReturn(Result.VALID_RESULT_STAGE);
-        var result = topicValidator.validateTopicData(tpd);
+        var result = topicValidator.validateTopicData(tpd, tpd.name());
         assertThat(result)
                 .succeedsWithin(Duration.ofSeconds(1))
                 .returns(false, TopicValidationResult::isAnyPartitionInvalid)
@@ -59,7 +59,7 @@ class PerRecordTopicValidatorTest {
         var topicValidator = new PerRecordTopicValidator(validator);
 
         when(validator.validate(any(Record.class))).thenReturn(CompletableFuture.completedStage(new Result(false, "my bad record")));
-        var result = topicValidator.validateTopicData(tpd);
+        var result = topicValidator.validateTopicData(tpd, tpd.name());
         assertThat(result)
                 .succeedsWithin(Duration.ofSeconds(1))
                 .returns(true, TopicValidationResult::isAnyPartitionInvalid);
@@ -84,7 +84,7 @@ class PerRecordTopicValidatorTest {
 
         when(validator.validate(good)).thenReturn(Result.VALID_RESULT_STAGE);
         when(validator.validate(bad)).thenReturn(CompletableFuture.completedStage(new Result(false, "my bad record")));
-        var result = topicValidator.validateTopicData(tpd);
+        var result = topicValidator.validateTopicData(tpd, tpd.name());
 
         assertThat(result)
                 .succeedsWithin(Duration.ofSeconds(1))
@@ -112,7 +112,7 @@ class PerRecordTopicValidatorTest {
         when(validator.validate(bad)).thenReturn(CompletableFuture.completedStage(new Result(false, "my bad record")));
         when(validator.validate(ugly)).thenReturn(CompletableFuture.completedStage(new Result(false, "my ugly record")));
 
-        var result = topicValidator.validateTopicData(tpd);
+        var result = topicValidator.validateTopicData(tpd, tpd.name());
 
         assertThat(result)
                 .succeedsWithin(Duration.ofSeconds(1))
@@ -142,7 +142,7 @@ class PerRecordTopicValidatorTest {
         when(validator.validate(bad)).thenReturn(CompletableFuture.completedStage(new Result(false, "my bad record")));
         when(validator.validate(ugly)).thenReturn(CompletableFuture.completedStage(new Result(false, "my ugly record")));
 
-        var result = topicValidator.validateTopicData(tpd);
+        var result = topicValidator.validateTopicData(tpd, tpd.name());
 
         assertThat(result)
                 .succeedsWithin(Duration.ofSeconds(1))


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

We lookup all topicIds in the request and then translate them to the relevant topicName when applying validation. If any topicId lookup fails we fail the whole request with an error response.

The maximum Produce version is no longer constrained to 12.

Resolves #3040

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
