### PR TITLE
bugfix(test): stabilise non-deterministic produce authz tests

### DIFF
--- a/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/test/record/RecordTestUtils.java
+++ b/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/test/record/RecordTestUtils.java
@@ -302,6 +302,8 @@ public class RecordTestUtils {
      * Return a singleton RecordBatch containing a single Record with the given key, value and headers.
      * The batch will use the current magic.
      *
+     * @param recordTimestamp timestamp of the record, note that this can determine whether a segment
+     * is eligible for deletion, relative to the current system time. This depends on the TimestampType.
      * @param baseOffset baseOffset of the single batch and offset of the single record within it
      * @param compression
      * @return The record batch
@@ -319,9 +321,10 @@ public class RecordTestUtils {
                                                               int partitionLeaderEpoch,
                                                               byte[] key,
                                                               byte[] value,
+                                                              long recordTimestamp,
                                                               Header... headers) {
         MemoryRecords records = memoryRecordsWithoutCopy(magic, baseOffset, compression, timestampType, logAppendTime, producerId, producerEpoch, baseSequence,
-                isTransactional, isControlBatch, partitionLeaderEpoch, 0L, key, value, headers);
+                isTransactional, isControlBatch, partitionLeaderEpoch, recordTimestamp, key, value, headers);
         return records.batches().iterator().next();
     }
 

--- a/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/assertj/RecordBatchAssertTest.java
+++ b/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/assertj/RecordBatchAssertTest.java
@@ -179,7 +179,7 @@ class RecordBatchAssertTest {
                 false, 1,
                 "KEY".getBytes(
                         StandardCharsets.UTF_8),
-                "VALUE".getBytes(StandardCharsets.UTF_8), new RecordHeader[]{});
+                "VALUE".getBytes(StandardCharsets.UTF_8), 0L, new RecordHeader[]{});
         RecordBatchAssert batchAssert = KafkaAssertions.assertThat(batch);
         batchAssert.hasMetadataMatching(batch);
         batchAssert.hasMetadataMatching(batchSameMetadata);

--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/decrypt/InBandDecryptionManagerTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/decrypt/InBandDecryptionManagerTest.java
@@ -142,13 +142,13 @@ class InBandDecryptionManagerTest {
                 3L,
                 (short) 4, 5, false, false, 1, ARBITRARY_KEY.getBytes(
                         StandardCharsets.UTF_8),
-                ARBITRARY_VALUE.getBytes(StandardCharsets.UTF_8));
+                ARBITRARY_VALUE.getBytes(StandardCharsets.UTF_8), 0L);
 
         MutableRecordBatch secondBatch = RecordTestUtils.singleElementRecordBatch(RecordBatch.CURRENT_MAGIC_VALUE, 2L, Compression.NONE,
                 TimestampType.LOG_APPEND_TIME, 9L, 10L,
                 (short) 11, 12, false, false, 2, ARBITRARY_KEY_2.getBytes(
                         StandardCharsets.UTF_8),
-                ARBITRARY_VALUE_2.getBytes(StandardCharsets.UTF_8));
+                ARBITRARY_VALUE_2.getBytes(StandardCharsets.UTF_8), 0L);
         MemoryRecords records = RecordTestUtils.memoryRecords(firstBatch, secondBatch);
 
         // when
@@ -174,13 +174,13 @@ class InBandDecryptionManagerTest {
                 3L,
                 (short) 4, 5, false, false, 1, ARBITRARY_KEY.getBytes(
                         StandardCharsets.UTF_8),
-                ARBITRARY_VALUE.getBytes(StandardCharsets.UTF_8));
+                ARBITRARY_VALUE.getBytes(StandardCharsets.UTF_8), 0L);
 
         MutableRecordBatch secondBatch = RecordTestUtils.singleElementRecordBatch(RecordBatch.CURRENT_MAGIC_VALUE, 2L, Compression.NONE,
                 TimestampType.LOG_APPEND_TIME, 9L, 10L,
                 (short) 11, 12, false, false, 2, ARBITRARY_KEY_2.getBytes(
                         StandardCharsets.UTF_8),
-                ARBITRARY_VALUE_2.getBytes(StandardCharsets.UTF_8));
+                ARBITRARY_VALUE_2.getBytes(StandardCharsets.UTF_8), 0L);
         MemoryRecords records = RecordTestUtils.memoryRecords(firstBatch, secondBatch);
         MemoryRecords encrypted = assertImmediateSuccessAndGet(encrypt(encryptionManager, scheme, records));
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/ProduceAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/ProduceAuthzIT.java
@@ -201,19 +201,20 @@ class ProduceAuthzIT extends AuthzIT {
     private static List<ProduceRequestData.PartitionProduceData> partitionData(String key, String value) {
         // It's important to use different pid different client instances, else ProduceReequests will get fenced out
         long producerId = pid++;
+        long currentTimeMillis = System.currentTimeMillis();
         var mr = RecordTestUtils.memoryRecords(RecordTestUtils.singleElementRecordBatch(
                 RecordTestUtils.DEFAULT_MAGIC_VALUE,
                 RecordTestUtils.DEFAULT_OFFSET,
                 Compression.NONE,
                 TimestampType.CREATE_TIME,
-                156543L, // logAppendTime
+                currentTimeMillis, // logAppendTime
                 producerId, // producerId
                 (short) 0, // producerEpoch
                 4, // baseSequence
                 false, // isTransactional
                 false, // isControlBatch
                 0, // partitionLeaderEpoch
-                key.getBytes(StandardCharsets.UTF_8), value.getBytes(StandardCharsets.UTF_8)));
+                key.getBytes(StandardCharsets.UTF_8), value.getBytes(StandardCharsets.UTF_8), currentTimeMillis));
         assertThat(mr.firstBatchSize()).isGreaterThan(0);
         assertThat(mr.batches().iterator().next().iterator().hasNext()).isTrue();
         return List.of(new ProduceRequestData.PartitionProduceData()

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/ProduceAuthzTxnlIdIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/ProduceAuthzTxnlIdIT.java
@@ -250,19 +250,20 @@ class ProduceAuthzTxnlIdIT extends AuthzIT {
 
     @NonNull
     private static List<ProduceRequestData.PartitionProduceData> partitionData(String key, String value, ProducerIdAndEpoch idAndEpoch) {
+        long currentTimeMillis = System.currentTimeMillis();
         var mr = RecordTestUtils.memoryRecords(RecordTestUtils.singleElementRecordBatch(
                 RecordTestUtils.DEFAULT_MAGIC_VALUE,
                 RecordTestUtils.DEFAULT_OFFSET,
                 Compression.NONE,
                 TimestampType.CREATE_TIME,
-                156543L, // logAppendTime
+                currentTimeMillis, // logAppendTime
                 idAndEpoch.producerId, // producerId
                 idAndEpoch.epoch, // producerEpoch
                 0, // baseSequence
                 true, // isTransactional
                 false, // isControlBatch
                 0, // partitionLeaderEpoch
-                key.getBytes(StandardCharsets.UTF_8), value.getBytes(StandardCharsets.UTF_8)));
+                key.getBytes(StandardCharsets.UTF_8), value.getBytes(StandardCharsets.UTF_8), currentTimeMillis));
         assertThat(mr.firstBatchSize()).isGreaterThan(0);
         assertThat(mr.batches().iterator().next().iterator().hasNext()).isTrue();
         return List.of(new ProduceRequestData.PartitionProduceData()

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/ZeroAckProduceAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/ZeroAckProduceAuthzIT.java
@@ -235,19 +235,20 @@ class ZeroAckProduceAuthzIT {
     }
 
     private static List<ProduceRequestData.PartitionProduceData> partitionData() {
+        long currentTimeMillis = System.currentTimeMillis();
         var mr = RecordTestUtils.memoryRecords(RecordTestUtils.singleElementRecordBatch(
                 RecordTestUtils.DEFAULT_MAGIC_VALUE,
                 RecordTestUtils.DEFAULT_OFFSET,
                 Compression.NONE,
                 TimestampType.CREATE_TIME,
-                156543L, // logAppendTime
+                currentTimeMillis, // logAppendTime
                 1, // producerId
                 (short) 0, // producerEpoch
                 4, // baseSequence
                 false, // isTransactional
                 false, // isControlBatch
                 0, // partitionLeaderEpoch
-                "key".getBytes(StandardCharsets.UTF_8), "value".getBytes(StandardCharsets.UTF_8)));
+                "key".getBytes(StandardCharsets.UTF_8), "value".getBytes(StandardCharsets.UTF_8), currentTimeMillis));
         assertThat(mr.firstBatchSize()).isGreaterThan(0);
         assertThat(mr.batches().iterator().next().iterator().hasNext()).isTrue();
         return List.of(new ProduceRequestData.PartitionProduceData()


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Set batch logAppendTime and record timestamps to current epoch ms when generating test data.

Closes #3410

Why:
I noticed that the tests were failing about 30 seconds after the parameterized tests of `ProduceAuthzIT` and `ProduceAuthzTxnlIdIT` ran. I debugged this and found it failed at the same time as the LogManager `initialTaskDelayMs` of 30 seconds and by modifying the broker `log.initial.task.delay.ms` I could influence when the failure occured. Through some kafka debug logging I discovered that the segment was eligible for soft deletion because the max timestamp in the batch was 0, aka Jan 1st 1970. The test uses hand-rolled MemoryRecords and we had it hard-coded to 0.

So the flow was something like:
1. test creates topic
2. test sends MemoryRecords to topic with max timestamp 0
3. LogCleaner runs and soft-deletes the segment due to retention breach
4. test tries to consume and finds no records, retry until timeout

By setting up the append time and timestamp more realistically we should avoid the segment being eligible for deletion between Produce and Consume.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
