### PR TITLE
fix:(rec-enc-quickstart): Pin localstack image to specific tag (rather than allowing the default to latest).

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -91,11 +91,13 @@
       "customType": "regex",
       "managerFilePatterns": [
         "/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms-test-support/src/main/java/io/kroxylicious/kms/provider/aws/kms/AwsKmsTestKmsFacade.java/",
-        "/kroxylicious-systemtests/src/main/resources/helm_localstack_overrides.yaml/"
+        "/kroxylicious-systemtests/src/main/resources/helm_localstack_overrides.yaml/",
+        "/kroxylicious-docs/docs/record-encryption-quickstart/index.adoc/"
       ],
       "matchStrings": [
         "(?<depName>localstack/localstack):(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>.*)\"",
-        "tag:.*(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>.*)"
+        "tag:.*(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>.*)",
+        ":localstack-tag: *(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>.*)"
       ],
       "depNameTemplate": "localstack/localstack",
       "datasourceTemplate": "docker"
@@ -210,18 +212,6 @@
         ":vault-chart-version:.*(?<currentValue>\\d+\\.\\d+\\.\\d+)"
       ],
       "depNameTemplate": "hashicorp/vault-helm",
-      "datasourceTemplate": "github-releases"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/kroxylicious-docs/docs/record-encryption-quickstart/index.adoc/"
-      ],
-      "matchStrings": [
-        ":localstack-chart-version:.*(?<currentValue>\\d+\\.\\d+\\.\\d+)"
-      ],
-      "depNameTemplate": "localstack/helm-charts",
-      "extractVersionTemplate": "^localstack-(?<version>.*)$",
       "datasourceTemplate": "github-releases"
     },
     {

--- a/kroxylicious-docs/docs/record-encryption-quickstart/index.adoc
+++ b/kroxylicious-docs/docs/record-encryption-quickstart/index.adoc
@@ -1,6 +1,7 @@
 :experimental:
 :vault-chart-version: 0.32.0
 :localstack-chart-version: 0.6.27
+:localstack-tag: 4.14.0@sha256:3ebc37595918b8accb852f8048fef2aff047d465167edd655528065b07bc364a
 // A Renovate rule will update the strimzi-version but not kafka-version. Update the kafka-version to the point
 // at the latest kafka version supported by that strimzi.
 :strimzi-version: 0.51.0
@@ -79,7 +80,7 @@ It's intended for developing and testing cloud & Serverless apps offline.
 [source,terminal,subs="attributes",kms="localstack"]
 ----
 $ helm repo add --force-update localstack-repo https://helm.localstack.cloud
-$ helm upgrade --install localstack localstack-repo/localstack --namespace kms --create-namespace --version {localstack-chart-version} --set service.type=ClusterIP --wait
+$ helm upgrade --install localstack localstack-repo/localstack --namespace kms --create-namespace --version {localstack-chart-version} --set image.tag={localstack-tag} --set service.type=ClusterIP --wait
 ----
 
 NOTE: After installation, the LocalStack Helm chart prompts you to "Get the application URL". For this Quickstart, you can ignore these steps.


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Bugfix

### Description

why: previously the quickstart wasn't specifying a tag, so it [defaulted to latest ](https://github.com/localstack/helm-charts/blob/96d08c4c8a1bd0eac02c86aba6d8ac390ca58682/charts/localstack/values.yaml#L15).  Owing to policy changes at Localstack, `:latest` now requires authentication.  That policy is now in force, which explains the sudden CI error.

The use of `:latest` was always a mistake  as we value test repeatability.

```
LocalStack version: 2026.3.1.dev3
LocalStack build date: 2026-03-23
LocalStack build git hash: 6114fb260

Docker not available
Localstack returning with exit code 55. Reason:
===============================================
The license activation failed for the following reason:

No credentials were found in the environment. Please make sure to either set the LOCALSTACK_AUTH_TOKEN variable to a valid auth token. If you are using the CLI, you can also run `localstack auth set-token`.

LocalStack requires an account to run.

==> Have an account? Learn how to set LOCALSTACK_AUTH_TOKEN: https://app.localstack.cloud/settings/auth-tokens
==> Need an account? Get started: https://www.localstack.cloud/pricing
==> Want more time? Snooze until April 6, 2026 by setting LOCALSTACK_ACKNOWLEDGE_ACCOUNT_REQUIREMENT=1
```




### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
