### PR TITLE
fix(entity-isolation): validate that separator, principal name and generated upstream name are legal kafka resource names.

### DIFF
--- a/kroxylicious-filters/kroxylicious-entity-isolation/src/main/java/io/kroxylicious/filter/entityisolation/FindCoordinatorEntityIsolationProcessor.java
+++ b/kroxylicious-filters/kroxylicious-entity-isolation/src/main/java/io/kroxylicious/filter/entityisolation/FindCoordinatorEntityIsolationProcessor.java
@@ -21,7 +21,7 @@ import io.kroxylicious.proxy.filter.FilterContext;
 import io.kroxylicious.proxy.filter.RequestFilterResult;
 import io.kroxylicious.proxy.filter.ResponseFilterResult;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Entity isolation processor for FIND_COORDINATOR.
@@ -29,7 +29,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * from the request.
  */
 class FindCoordinatorEntityIsolationProcessor
-        implements EntityIsolationProcessor<FindCoordinatorRequestData, FindCoordinatorResponseData, EntityIsolation.EntityType> {
+        implements EntityIsolationProcessor<FindCoordinatorRequestData, FindCoordinatorResponseData, CoordinatorType> {
 
     private final Predicate<EntityIsolation.EntityType> shouldMap;
     private final EntityNameMapper mapper;
@@ -60,18 +60,33 @@ class FindCoordinatorEntityIsolationProcessor
                                                           FindCoordinatorRequestData request,
                                                           FilterContext filterContext,
                                                           MapperContext mapperContext) {
-        var entityType = getEntityType(request.keyType());
+        var coordinatorType = CoordinatorType.forId(request.keyType());
+        var entityType = convertCoordinatorType(coordinatorType);
         entityType.filter(shouldMap)
-                .ifPresent(rt -> {
+                .ifPresent(et -> {
                     if ((short) 0 <= header.requestApiVersion() && header.requestApiVersion() <= (short) 3) {
-                        request.setKey(mapper.map(mapperContext, rt, request.key()));
+                        request.setKey(doMap(mapperContext, coordinatorType, et, request.key()));
                     }
                     else {
-                        request.setCoordinatorKeys(request.coordinatorKeys().stream().map(k -> mapper.map(mapperContext, rt, k)).toList());
+                        request.setCoordinatorKeys(request.coordinatorKeys().stream().map(k -> doMap(mapperContext, coordinatorType, et, k)).toList());
                     }
                 });
 
         return filterContext.forwardRequest(header, request);
+    }
+
+    private String doMap(MapperContext mapperContext,
+                         CoordinatorType coordinatorType,
+                         EntityType entityType,
+                         String key) {
+        if (coordinatorType == CoordinatorType.SHARE) {
+            var split = splitShareGroupKey(key);
+            split[0] = mapper.map(mapperContext, entityType, split[0]);
+            return String.join(":", split);
+        }
+        else {
+            return mapper.map(mapperContext, entityType, key);
+        }
     }
 
     @Override
@@ -83,27 +98,37 @@ class FindCoordinatorEntityIsolationProcessor
     @SuppressWarnings("java:S2638") // Tightening UnknownNullness
     public CompletionStage<ResponseFilterResult> onResponse(ResponseHeaderData header,
                                                             short apiVersion,
-                                                            @Nullable EntityIsolation.EntityType requestedEntityType,
+                                                            @NonNull CoordinatorType requestedCoordinatorType,
                                                             FindCoordinatorResponseData response,
                                                             FilterContext filterContext,
                                                             MapperContext mapperContext) {
-        Optional.ofNullable(requestedEntityType)
+        var requestedEntityType = convertCoordinatorType(requestedCoordinatorType);
+        requestedEntityType
                 .filter(shouldMap)
-                .ifPresent(entityType -> response.coordinators()
-                        .forEach(coordinator -> coordinator.setKey(mapper.unmap(mapperContext, requestedEntityType, coordinator.key()))));
+                .ifPresent(et -> response.coordinators()
+                        .forEach(coordinator -> coordinator.setKey(doUnmap(et, requestedCoordinatorType, mapperContext, coordinator.key()))));
 
         return filterContext.forwardResponse(header, response);
     }
 
-    @Nullable
-    @Override
-    public EntityType createCorrelatedRequestContext(FindCoordinatorRequestData request) {
-        return getEntityType(request.keyType()).orElse(null);
+    private String doUnmap(EntityType requestedEntityType,
+                           CoordinatorType coordinatorType,
+                           MapperContext mapperContext,
+                           String key) {
+        if (coordinatorType == CoordinatorType.SHARE) {
+            // From FindCoordinatorRequest.json: For key type SHARE (2), the coordinator key format is "groupId:topicId:partition".
+            var split = splitShareGroupKey(key);
+            split[0] = mapper.unmap(mapperContext, requestedEntityType, split[0]);
+            return String.join(":", split);
+        }
+        else {
+            return mapper.unmap(mapperContext, requestedEntityType, key);
+        }
     }
 
-    private Optional<EntityType> getEntityType(byte id) {
-        var coordinatorType = CoordinatorType.forId(id);
-        return convertCoordinatorType(coordinatorType);
+    @Override
+    public CoordinatorType createCorrelatedRequestContext(FindCoordinatorRequestData request) {
+        return CoordinatorType.forId(request.keyType());
     }
 
     private Optional<EntityType> convertCoordinatorType(CoordinatorType coordinatorType) {
@@ -113,4 +138,12 @@ class FindCoordinatorEntityIsolationProcessor
         };
     }
 
+    private static String[] splitShareGroupKey(String key) {
+        // From FindCoordinatorRequest.json: For key type SHARE (2), the coordinator key format is "groupId:topicId:partition".
+        var split = key.split(":", 3);
+        if (split.length != 3) {
+            throw new IllegalStateException(String.format("Invalid formation of share group key '%s'", key));
+        }
+        return split;
+    }
 }

--- a/kroxylicious-filters/kroxylicious-entity-isolation/src/main/java/io/kroxylicious/filter/entityisolation/PrincipalEntityNameMapper.java
+++ b/kroxylicious-filters/kroxylicious-entity-isolation/src/main/java/io/kroxylicious/filter/entityisolation/PrincipalEntityNameMapper.java
@@ -6,9 +6,10 @@
 
 package io.kroxylicious.filter.entityisolation;
 
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 import io.kroxylicious.filter.entityisolation.EntityIsolation.EntityType;
 import io.kroxylicious.proxy.authentication.Principal;
@@ -31,14 +32,23 @@ class PrincipalEntityNameMapper implements EntityNameMapper {
     private final Class<? extends Principal> uniquePrincipalType;
     private final String separator;
 
+    /**
+     * Regular expression for what Kafka considers legal for topic and group id names.
+     * Kafka doesn't restrict transactionalId names,
+     */
+    static final Pattern KAFKA_RESOURCE_NAME_LEGAL_CHARS = Pattern.compile("[a-zA-Z0-9._\\-]+");
+
+    /** Maximum length of a Kafka topic or groupId */
+    static final int MAX_NAME_LENGTH = 249;
+
     PrincipalEntityNameMapper(Class<? extends Principal> uniquePrincipalType, String separator) {
         this.uniquePrincipalType = Objects.requireNonNull(uniquePrincipalType);
         this.separator = Objects.requireNonNull(separator);
         if (!uniquePrincipalType.isAnnotationPresent(Unique.class)) {
             throw new IllegalArgumentException(uniquePrincipalType.getName() + " is not a unique principal type.");
         }
-        if (separator.isEmpty()) {
-            throw new IllegalArgumentException(separator + " is an unacceptable separator.");
+        if (separator.isEmpty() || isIllegalKafkaName(separator)) {
+            throw new IllegalArgumentException("'%s' is an unacceptable separator.".formatted(separator));
         }
     }
 
@@ -49,13 +59,18 @@ class PrincipalEntityNameMapper implements EntityNameMapper {
         Objects.requireNonNull(downstreamEntityName);
 
         var validatedPrincipal = getValidatedPrincipal(mapperContext);
-        return doMap(validatedPrincipal.name(), downstreamEntityName);
+        return doMap(validatedPrincipal, downstreamEntityName, entityType);
     }
 
-    private String doMap(String principal, String downstreamEntityName) {
-        // Once we start mapping topic names, we must verify the length upstream name doesn't violate the topic naming org.apache.kafka.common.internals.Topic.isValid
-        // Also if https://cwiki.apache.org/confluence/display/KAFKA/KIP-1233%3A+Maximum+lengths+for+resource+names+and+IDs is accepted there may be rules to apply to groupIds/transactionalIds
-        return buildPrefix(principal) + downstreamEntityName;
+    private String doMap(Principal principal, String downstreamEntityName, EntityType entityType) {
+        // Note that there is a KIP proposed that will affect https://cwiki.apache.org/confluence/display/KAFKA/KIP-1233%3A+Maximum+lengths+for+resource+names+and+IDs resource name validations
+        var upstreamName = buildPrefix(principal.name()) + downstreamEntityName;
+        if (isIllegalKafkaName(upstreamName, entityType)) {
+            var pretty = entityType.name().toLowerCase(Locale.ROOT).replace("_", " ");
+            throw new EntityMapperException(String.format("Upstream name generated for principal '%s' for resource '%s' ('%s') is not a valid kafka %s.",
+                    downstreamEntityName, principal, upstreamName, pretty));
+        }
+        return upstreamName;
     }
 
     @Override
@@ -105,10 +120,29 @@ class PrincipalEntityNameMapper implements EntityNameMapper {
                         .formatted(
                                 uniquePrincipalType.getSimpleName(), mapperContext.authenticatedSubject())));
 
-        principalOpt.map(Principal::name)
-                .filter(Predicate.not(name -> name.contains(separator)))
-                .orElseThrow(() -> new EntityMapperException(
-                        "Principal '%s' is unacceptable as it contains the mapping separator '%s'".formatted(principalOpt.get(), separator)));
+        principalOpt.map(Principal::name).ifPresent(name -> {
+            if (name.contains(separator)) {
+                throw new EntityMapperException(
+                        "Principal '%s' is unacceptable as it contains the mapping separator '%s'".formatted(principalOpt.get(), separator));
+            }
+            if (isIllegalKafkaName(name)) {
+                throw new EntityMapperException(
+                        "Principal '%s' is unacceptable as it contains characters outside ASCII alphanumerics, '.', '_' and '-'".formatted(principalOpt.get()));
+            }
+        });
+
         return principalOpt.orElseThrow();
     }
+
+    private static boolean isIllegalKafkaName(String separator) {
+        return !KAFKA_RESOURCE_NAME_LEGAL_CHARS.matcher(separator).matches();
+    }
+
+    private static boolean isIllegalKafkaName(String upstreamName, EntityType entityType) {
+        return switch (entityType) {
+            case TOPIC_NAME, GROUP_ID -> isIllegalKafkaName(upstreamName) || upstreamName.length() > MAX_NAME_LENGTH;
+            case TRANSACTIONAL_ID -> false;
+        };
+    }
+
 }

--- a/kroxylicious-filters/kroxylicious-entity-isolation/src/test/java/io/kroxylicious/filter/entityisolation/EntityIsolationFilterTest.java
+++ b/kroxylicious-filters/kroxylicious-entity-isolation/src/test/java/io/kroxylicious/filter/entityisolation/EntityIsolationFilterTest.java
@@ -109,7 +109,7 @@ class EntityIsolationFilterTest {
         RequestHeaderData requestHeader = RequestHeaderDataJsonConverter.read(definition.when().requestHeader(), requestHeaderVersion);
 
         Map<Uuid, String> topicNames = Optional.ofNullable(definition.given().topicNames()).orElse(Map.of());
-        Subject subject = new Subject(new User(definition.when().subject()));
+        Subject subject = Optional.ofNullable(definition.when().subject()).map(User::new).map(Subject::new).orElse(Subject.anonymous());
         FilterContext context = new MockFilterContext(requestHeader, request, subject, topicNames, mockUpstream);
         CompletionStage<RequestFilterResult> stage = isolationFilter.onRequest(apiKeys, version, requestHeader, request, context);
         ScenarioDefinition.RequestError expectedRequestError = definition.then().expectedRequestError();

--- a/kroxylicious-filters/kroxylicious-entity-isolation/src/test/java/io/kroxylicious/filter/entityisolation/PrincipalEntityNameMapperTest.java
+++ b/kroxylicious-filters/kroxylicious-entity-isolation/src/test/java/io/kroxylicious/filter/entityisolation/PrincipalEntityNameMapperTest.java
@@ -7,10 +7,15 @@
 package io.kroxylicious.filter.entityisolation;
 
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -21,6 +26,7 @@ import io.kroxylicious.proxy.authentication.Subject;
 import io.kroxylicious.proxy.authentication.User;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -63,11 +69,19 @@ class PrincipalEntityNameMapperTest {
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
-    @Test
-    void shouldRejectEmptySeparator() {
+    @ParameterizedTest
+    @ValueSource(strings = { "", "*", "a*", " " })
+    void shouldRejectSeparatorsThatAreNotLegalKafkaResourceNames(String separator) {
         // Given/When/Then
-        assertThatThrownBy(() -> new PrincipalEntityNameMapper(User.class, ""))
+        assertThatThrownBy(() -> new PrincipalEntityNameMapper(User.class, separator))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "-", "_", ".", "--", "abc" })
+    void shouldAcceptSeparatorsThatAreLegalKafkaResourceNames(String separator) {
+        // Given/When/Then
+        assertThatNoException().isThrownBy(() -> new PrincipalEntityNameMapper(User.class, separator));
     }
 
     @Test
@@ -100,10 +114,49 @@ class PrincipalEntityNameMapperTest {
         var mapperContext = buildMapperContext(bobSubject);
 
         // When/Then
-        // When/Then
         assertThatThrownBy(() -> mapper.map(mapperContext, EntityType.TOPIC_NAME, "foo"))
                 .isInstanceOf(EntityMapperException.class)
                 .hasMessageContaining("Principal 'User[name=dash-boy]' is unacceptable as it contains the mapping separator '-'");
+    }
+
+    @Test
+    void mapShouldRejectPrincipalThatIsNotLegalKafkaResourceNames() {
+        // Given
+        when(bobSubject.uniquePrincipalOfType(User.class)).thenReturn(Optional.of(new User("bad*boy")));
+        var mapperContext = buildMapperContext(bobSubject);
+
+        // When/Then
+        assertThatThrownBy(() -> mapper.map(mapperContext, EntityType.TOPIC_NAME, "foo"))
+                .isInstanceOf(EntityMapperException.class)
+                .hasMessageContaining("Principal 'User[name=bad*boy]' is unacceptable as it contains characters outside ASCII alphanumerics, '.', '_' and '-'");
+    }
+
+    static Stream<Arguments> overlyLongKafkaResourceClusterNamesScenarios() {
+        var bob = new User("bob");
+        return Stream.of(
+                Arguments.argumentSet("upstream topic name too long by one", EntityType.TOPIC_NAME, bob,
+                        "t".repeat(PrincipalEntityNameMapper.MAX_NAME_LENGTH - 3 - 1 + 1), false),
+                Arguments.argumentSet("upstream topic name just fits", EntityType.TOPIC_NAME, bob, "t".repeat(PrincipalEntityNameMapper.MAX_NAME_LENGTH - 3 - 1), true),
+                Arguments.argumentSet("upstream group id just fits", EntityType.GROUP_ID, bob, "t".repeat(PrincipalEntityNameMapper.MAX_NAME_LENGTH - 3 - 1 + 1), false),
+                Arguments.argumentSet("upstream transactional id not unconstrained", EntityType.GROUP_ID, bob, "t".repeat(PrincipalEntityNameMapper.MAX_NAME_LENGTH * 2),
+                        false));
+    }
+
+    @ParameterizedTest
+    @MethodSource("overlyLongKafkaResourceClusterNamesScenarios")
+    void detectsOverlyLongKafkaResourceClusterNames(EntityType entityType, User principal, String resourceName, boolean isLegal) {
+        // Given
+        when(bobSubject.uniquePrincipalOfType(User.class)).thenReturn(Optional.of(principal));
+        var mapperContext = buildMapperContext(bobSubject);
+
+        // When/Then
+        if (isLegal) {
+            assertThatNoException().isThrownBy(() -> mapper.map(mapperContext, entityType, resourceName));
+        }
+        else {
+            assertThatThrownBy(() -> mapper.map(mapperContext, entityType, resourceName))
+                    .isInstanceOf(EntityMapperException.class);
+        }
     }
 
     @Test

--- a/kroxylicious-filters/kroxylicious-entity-isolation/src/test/java/io/kroxylicious/filter/entityisolation/ScenarioDefinition.java
+++ b/kroxylicious-filters/kroxylicious-entity-isolation/src/test/java/io/kroxylicious/filter/entityisolation/ScenarioDefinition.java
@@ -40,7 +40,7 @@ public record ScenarioDefinition(Metadata metadata, Given given, When when, Then
      * @param requestHeader header to send
      * @param request request to send
      */
-    public record When(String subject, JsonNode requestHeader, JsonNode request) {}
+    public record When(@Nullable String subject, JsonNode requestHeader, JsonNode request) {}
 
     /**
      * Expect request future to be completed exceptionally

--- a/kroxylicious-filters/kroxylicious-entity-isolation/src/test/resources/io/kroxylicious/filter/entityisolation/_NON-API-SPECIFIC/upstream-name-too-long.yaml
+++ b/kroxylicious-filters/kroxylicious-entity-isolation/src/test/resources/io/kroxylicious/filter/entityisolation/_NON-API-SPECIFIC/upstream-name-too-long.yaml
@@ -1,0 +1,35 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+metadata:
+  apiKeys: "JOIN_GROUP"
+  apiVersion: 9
+  scenario: "generated upstream name too long"
+given:
+  mockedUpstreamResponses: []
+  entityTypes: ["GROUP_ID"]
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 11
+    requestApiVersion: 9
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    groupId: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    sessionTimeoutMs: 0
+    rebalanceTimeoutMs: 0
+    memberId: mymemberid
+    groupInstanceId: mygroupinstanceid
+    protocolType: consumer
+    protocols:
+      - name: ""
+        metadata: !!binary |-
+          aGVsbG8K
+    reason: ""
+then:
+  expectedErrorResponse: "UNKNOWN_SERVER_ERROR"


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Bugfix

### Description

Fixes #3523: validate that separator, principal name and generated upstream name are legal kafka resource names. This change should means we fail early (in the proxy) rather than failing late (in the broker).

In Kafka, for topic names and group names, kafka resource names may contain only ASCII alphanumerics and `.`, `_`, and `-` and must be 249 characters or less.  Transactional ids must not be empty, but otherwise have no restrictions.
See `org.apache.kafka.common.internals.Topic`.

With this change:
* fail at startup if separator contains a characters that is not ASCII alphanumerics or `.`, `_`, and `-`.
* fail at runtime (`UNKNOWN_SERVER_ERROR`) if a principal is used that contains a characters that is not ASCII alphanumerics or `.`, `_`, and `-`.
* fail at runtime (`UNKNOWN_SERVER_ERROR`) if the generated upstream name violates the length restriction (topics and groupids only).

### Additional Context

There's https://cwiki.apache.org/confluence/display/KAFKA/KIP-1233%3A+Maximum+lengths+for+resource+names+and+IDs which is hoping to regularise Kafka resource name restrictions.  It also proposes error code `RESOURCE_IDENTIFIER_TOO_LARGE`  to be used when (non-topic) resource names are too large.  If that ever becomes reality, this filter should consider using it in place of `UNKNOWN_SERVER_ERROR` used today.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
