### PR TITLE
fix(ci): fix secrets context error in composite actions causing intermittent CI failures

### DIFF
--- a/.github/actions/common/setup-minikube/action.yml
+++ b/.github/actions/common/setup-minikube/action.yml
@@ -21,8 +21,7 @@ description: "Installs minikube"
 inputs:
   githubToken:
     description: "Github Token to be used"
-    required: false
-    default: ${{ secrets.GITHUB_TOKEN }}
+    required: true
 
 runs:
   using: "composite"

--- a/.github/actions/common/slack-notification/action.yml
+++ b/.github/actions/common/slack-notification/action.yml
@@ -21,8 +21,7 @@ description: "Slack Notification"
 inputs:
   slackWebhook:
     description: "Slack webhook"
-    required: false
-    default: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
+    required: true
   slackColor:
     description: "Color for the message"
     required: false

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -102,5 +102,6 @@ jobs:
         if: failure() && env.SLACK_WEBHOOK_SET == 'true'
         uses: ./.github/actions/common/slack-notification
         with:
+          slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
           slackTitle: 'Failure Alert: ${{ github.repository }}'
           slackMessage: 'The docker build workflow failed on branch ${{ github.ref_name }}.'

--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -46,6 +46,8 @@ jobs:
         uses: ./.github/actions/common/setup-java
       - name: Setup Minikube
         uses: ./.github/actions/common/setup-minikube
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Set up Docker Buildx'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
       - name: 'Cache Maven packages'
@@ -72,5 +74,6 @@ jobs:
         if: failure() && env.SLACK_WEBHOOK_SET == 'true'
         uses: ./.github/actions/common/slack-notification
         with:
+          slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
           slackTitle: 'Failure Alert: ${{ github.repository }}'
           slackMessage: 'The documentation tests workflow failed on branch ${{ github.ref_name }}.'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -61,5 +61,6 @@ jobs:
         if: failure() && env.SLACK_WEBHOOK_SET == 'true'
         uses: ./.github/actions/common/slack-notification
         with:
+          slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
           slackTitle: 'Failure Alert: ${{ github.repository }}'
           slackMessage: 'The lint workflow failed on branch ${{ github.ref_name }}.'

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -60,6 +60,8 @@ jobs:
           javaDistro: ${{ matrix.java.distro }}
       - name: Setup Minikube
         uses: ./.github/actions/common/setup-minikube
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Test for unpublished reference release (japicmp)'
         run: |
           REFERENCE_RELEASE=$(mvn --quiet -pl kroxylicious-api help:evaluate -Dexpression=ApiCompatability.ReferenceVersion -DforceStdout)
@@ -98,5 +100,6 @@ jobs:
         if: failure() && env.SLACK_WEBHOOK_SET == 'true'
         uses: ./.github/actions/common/slack-notification
         with:
+          slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
           slackTitle: 'Failure Alert: ${{ github.repository }}'
           slackMessage: 'The maven workflow failed on branch ${{ github.ref_name }}.'

--- a/.github/workflows/operator-maven.yaml
+++ b/.github/workflows/operator-maven.yaml
@@ -51,6 +51,8 @@ jobs:
         uses: ./.github/actions/common/setup-java
       - name: Setup Minikube
         uses: ./.github/actions/common/setup-minikube
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Set up Docker Buildx'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
       - name: 'Cache Maven packages'
@@ -98,5 +100,6 @@ jobs:
         if: failure() && env.SLACK_WEBHOOK_SET == 'true'
         uses: ./.github/actions/common/slack-notification
         with:
+          slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
           slackTitle: 'Failure Alert: ${{ github.repository }}'
           slackMessage: 'The operator maven workflow failed on branch ${{ github.ref_name }}.'

--- a/.github/workflows/publish-snapshot-docs-to-website.yaml
+++ b/.github/workflows/publish-snapshot-docs-to-website.yaml
@@ -118,6 +118,7 @@ jobs:
         if: failure() && env.SLACK_WEBHOOK_SET == 'true'
         uses: ./kroxylicious/.github/actions/common/slack-notification
         with:
+          slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
           slackTitle: 'Failure Alert: ${{ github.repository }}'
           slackMessage: 'The snapshot documentation build workflow failed.'
 
@@ -141,5 +142,6 @@ jobs:
         if: failure() && env.SLACK_WEBHOOK_SET == 'true'
         uses: ./kroxylicious/.github/actions/common/slack-notification
         with:
+          slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
           slackTitle: 'Failure Alert: ${{ github.repository }}'
           slackMessage: 'The snapshot documentation deployment workflow failed.'

--- a/.github/workflows/run-system-tests.yaml
+++ b/.github/workflows/run-system-tests.yaml
@@ -74,6 +74,8 @@ jobs:
         uses: ./.github/actions/common/setup-java
       - name: Setup Minikube
         uses: ./.github/actions/common/setup-minikube
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Set up Docker Buildx'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
       - name: 'Cache Maven packages'

--- a/.github/workflows/system-tests-merge.yaml
+++ b/.github/workflows/system-tests-merge.yaml
@@ -104,5 +104,6 @@ jobs:
         if: failure() && env.SLACK_WEBHOOK_SET == 'true'
         uses: ./.github/actions/common/slack-notification
         with:
+          slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
           slackTitle: 'Failure Alert: ${{ github.repository }}'
           slackMessage: 'The system tests workflow failed on branch ${{ github.ref_name }}.'


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

GitHub Actions composite actions cannot access the `secrets` context in input `default` values — this is a platform restriction. When a runner encounters `default: ${{ secrets.GITHUB_TOKEN }}` inside a composite action's input definition, it raises:

```
Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.GITHUB_TOKEN
```

**Why it is intermittent:** GitHub Actions runners are deployed across a fleet of machines running different versions of the runner software. Older runner versions do not validate `default` expressions strictly and silently treat the secret reference as an empty string. Newer runner versions fail fast with the error above. Whether a job passes or fails depends on which runner instance it is allocated to — meaning the same workflow can succeed and fail on different runs with no code changes.

Two composite actions had this problem:

- `.github/actions/common/setup-minikube/action.yml` — `default: ${{ secrets.GITHUB_TOKEN }}`
- `.github/actions/common/slack-notification/action.yml` — `default: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}`

The fix is to remove the invalid `default` from each composite action and pass the secret explicitly from each calling workflow. The `secrets` context is valid in regular workflow files — only composite action input defaults are restricted.

### Additional Context

Observed failure: https://github.com/kroxylicious/kroxylicious/actions/runs/23533912123/job/68505092504

### Checklist

- [x] PR raised from a fork of this repository and made from a branch rather than main.
- [ ] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).