### PR TITLE
refactor(operator): namespace route-for label

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/RouteHostDetails.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/model/RouteHostDetails.java
@@ -55,7 +55,7 @@ public record RouteHostDetails(
         BOOTSTRAP,
         NODE;
 
-        public static final String LABEL_KEY = "route-for";
+        public static final String LABEL_KEY = "kroxylicious.io/route-for";
 
         @Override
         public String toString() {

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress-hosts-ready/in-Route-one-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress-hosts-ready/in-Route-one-0.yaml
@@ -17,7 +17,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/component: "proxy"
     app.kubernetes.io/instance: "minimal"
-    route-for: "node"
+    kroxylicious.io/route-for: "node"
   name: "one-0"
   namespace: "proxy-ns"
   ownerReferences:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress-hosts-ready/in-Route-one-1.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress-hosts-ready/in-Route-one-1.yaml
@@ -17,7 +17,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/component: "proxy"
     app.kubernetes.io/instance: "minimal"
-    route-for: "node"
+    kroxylicious.io/route-for: "node"
   name: "one-1"
   namespace: "proxy-ns"
   ownerReferences:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress-hosts-ready/in-Route-one-2.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress-hosts-ready/in-Route-one-2.yaml
@@ -17,7 +17,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/component: "proxy"
     app.kubernetes.io/instance: "minimal"
-    route-for: "node"
+    kroxylicious.io/route-for: "node"
   name: "one-2"
   namespace: "proxy-ns"
   ownerReferences:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress-hosts-ready/in-Route-one-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress-hosts-ready/in-Route-one-bootstrap.yaml
@@ -17,7 +17,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/component: "proxy"
     app.kubernetes.io/instance: "minimal"
-    route-for: "bootstrap"
+    kroxylicious.io/route-for: "bootstrap"
   name: "one-bootstrap"
   namespace: "proxy-ns"
   ownerReferences:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress-hosts-ready/out-Route-one-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress-hosts-ready/out-Route-one-0.yaml
@@ -17,7 +17,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/component: "proxy"
     app.kubernetes.io/instance: "minimal"
-    route-for: "node"
+    kroxylicious.io/route-for: "node"
   name: "one-0"
   namespace: "proxy-ns"
   ownerReferences:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress-hosts-ready/out-Route-one-1.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress-hosts-ready/out-Route-one-1.yaml
@@ -17,7 +17,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/component: "proxy"
     app.kubernetes.io/instance: "minimal"
-    route-for: "node"
+    kroxylicious.io/route-for: "node"
   name: "one-1"
   namespace: "proxy-ns"
   ownerReferences:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress-hosts-ready/out-Route-one-2.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress-hosts-ready/out-Route-one-2.yaml
@@ -17,7 +17,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/component: "proxy"
     app.kubernetes.io/instance: "minimal"
-    route-for: "node"
+    kroxylicious.io/route-for: "node"
   name: "one-2"
   namespace: "proxy-ns"
   ownerReferences:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress-hosts-ready/out-Route-one-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress-hosts-ready/out-Route-one-bootstrap.yaml
@@ -17,7 +17,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/component: "proxy"
     app.kubernetes.io/instance: "minimal"
-    route-for: "bootstrap"
+    kroxylicious.io/route-for: "bootstrap"
   name: "one-bootstrap"
   namespace: "proxy-ns"
   ownerReferences:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress/out-Route-one-0.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress/out-Route-one-0.yaml
@@ -17,7 +17,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/component: "proxy"
     app.kubernetes.io/instance: "minimal"
-    route-for: "node"
+    kroxylicious.io/route-for: "node"
   name: "one-0"
   namespace: "proxy-ns"
   ownerReferences:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress/out-Route-one-1.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress/out-Route-one-1.yaml
@@ -17,7 +17,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/component: "proxy"
     app.kubernetes.io/instance: "minimal"
-    route-for: "node"
+    kroxylicious.io/route-for: "node"
   name: "one-1"
   namespace: "proxy-ns"
   ownerReferences:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress/out-Route-one-2.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress/out-Route-one-2.yaml
@@ -17,7 +17,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/component: "proxy"
     app.kubernetes.io/instance: "minimal"
-    route-for: "node"
+    kroxylicious.io/route-for: "node"
   name: "one-2"
   namespace: "proxy-ns"
   ownerReferences:

--- a/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress/out-Route-one-bootstrap.yaml
+++ b/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress/out-Route-one-bootstrap.yaml
@@ -17,7 +17,7 @@ metadata:
     app.kubernetes.io/name: "kroxylicious"
     app.kubernetes.io/component: "proxy"
     app.kubernetes.io/instance: "minimal"
-    route-for: "bootstrap"
+    kroxylicious.io/route-for: "bootstrap"
   name: "one-bootstrap"
   namespace: "proxy-ns"
   ownerReferences:


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Change the `openshiftRoute` ingress-related label key from `route-for` to `kroxylicious.io/route-for`.

### Additional Context

https://github.com/kroxylicious/kroxylicious/pull/3399#discussion_r2985368354
https://github.com/kroxylicious/kroxylicious/pull/3399#pullrequestreview-4010457971

### Checklist

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
