### PR TITLE
feat(operator): Allow env-var to restrict the operator to a set of namespaces

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
@@ -58,7 +58,7 @@ public class OperatorMain {
     private static final Logger LOGGER = LoggerFactory.getLogger(OperatorMain.class);
     private static final String BIND_ADDRESS_VAR_NAME = "BIND_ADDRESS";
     /**
-     * Name of an environment that specifies a comma separated list of namespaces that the operator will watch.
+     * Name of an environment variable specifing a comma separated list of Kubernetes namespaces that the operator will watch.
      * If the environment variable is not set, or is empty, the Operator will watch all namespaces.
      */
     static final String KROXYLICIOUS_WATCHED_NAMESPACES_VAR_NAME = "KROXYLICIOUS_WATCHED_NAMESPACES";

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
@@ -10,8 +10,14 @@ import java.net.InetSocketAddress;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.IntSupplier;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,8 +25,10 @@ import org.slf4j.LoggerFactory;
 import com.sun.net.httpserver.HttpContext;
 import com.sun.net.httpserver.HttpServer;
 
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.Operator;
+import io.javaoperatorsdk.operator.api.config.ControllerConfigurationOverrider;
 import io.javaoperatorsdk.operator.monitoring.micrometer.MicrometerMetrics;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Metrics;
@@ -39,6 +47,7 @@ import io.kroxylicious.proxy.VersionInfo;
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
@@ -48,6 +57,11 @@ public class OperatorMain {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OperatorMain.class);
     private static final String BIND_ADDRESS_VAR_NAME = "BIND_ADDRESS";
+    /**
+     * Name of an environment that specifies a comma separated list of namespaces that the operator will watch.
+     * If the environment variable is not set, is empty, or set to a value *, the Operator will watch all namespaces.
+     */
+    static final String KROXYLICIOUS_WATCHED_NAMESPACES_VAR_NAME = "KROXYLICIOUS_WATCHED_NAMESPACES";
     private static final int DEFAULT_MANAGEMENT_PORT = 8080;
     static final String HTTP_PATH_LIVEZ = "/livez";
     static final String HTTP_PATH_METRICS = "/metrics";
@@ -58,15 +72,21 @@ public class OperatorMain {
      * name emitted by Prometheus will be called {@code kroxylicious_operator_build_info}.
      */
     private static final String BUILD_INFO_METRIC_NAME = "kroxylicious_operator_build.info";
+    private static final Pattern WATCHED_NAMESPACE_SPLITTER = Pattern.compile(" *, *");
     private final Operator operator;
     private final HttpServer managementServer;
+    @Nullable
+    private final Set<String> watchedNamespaces;
 
     public OperatorMain() throws IOException {
-        this(null, createHttpServer());
+        this(createHttpServer(), null, null);
     }
 
     @VisibleForTesting
-    OperatorMain(@Nullable KubernetesClient kubeClient, HttpServer managementServer) {
+    OperatorMain(HttpServer managementServer,
+                 @Nullable KubernetesClient kubeClient,
+                 @Nullable Set<String> watchedNamespaces) {
+
         configurePrometheusMetrics(managementServer);
         // o.withMetrics is invoked multiple times so can cause issues with enabling metrics.
         operator = new Operator(o -> {
@@ -76,6 +96,7 @@ public class OperatorMain {
             }
         });
         this.managementServer = managementServer;
+        this.watchedNamespaces = Optional.ofNullable(watchedNamespaces).orElse(getWatchedNamespacesFromEnvironment());
     }
 
     public static void main(String[] args) {
@@ -93,11 +114,14 @@ public class OperatorMain {
      */
     void start() {
         operator.installShutdownHook(Duration.ofSeconds(10));
-        operator.register(new KafkaProxyReconciler(Clock.systemUTC(), SecureConfigInterpolator.DEFAULT_INTERPOLATOR));
-        operator.register(new VirtualKafkaClusterReconciler(Clock.systemUTC(), DependencyResolver.create()));
-        operator.register(new KafkaProxyIngressReconciler(Clock.systemUTC()));
-        operator.register(new KafkaServiceReconciler(Clock.systemUTC()));
-        operator.register(new KafkaProtocolFilterReconciler(Clock.systemUTC(), SecureConfigInterpolator.DEFAULT_INTERPOLATOR));
+
+        operator.register(new KafkaProxyReconciler(Clock.systemUTC(), SecureConfigInterpolator.DEFAULT_INTERPOLATOR), getNsOverriddingConfigurationOverriderConsumer());
+        operator.register(new VirtualKafkaClusterReconciler(Clock.systemUTC(), DependencyResolver.create()), getNsOverriddingConfigurationOverriderConsumer());
+        operator.register(new KafkaProxyIngressReconciler(Clock.systemUTC()), getNsOverriddingConfigurationOverriderConsumer());
+        operator.register(new KafkaServiceReconciler(Clock.systemUTC()), getNsOverriddingConfigurationOverriderConsumer());
+        operator.register(new KafkaProtocolFilterReconciler(Clock.systemUTC(), SecureConfigInterpolator.DEFAULT_INTERPOLATOR),
+                getNsOverriddingConfigurationOverriderConsumer());
+
         addHttpGetHandler("/", () -> 404);
         managementServer.start();
         addHttpGetHandler(HTTP_PATH_LIVEZ, this::livezStatusCode);
@@ -117,10 +141,16 @@ public class OperatorMain {
                 .log();
         versionInfoMetric(versionInfo);
 
+        Optional.ofNullable(watchedNamespaces)
+                .ifPresentOrElse(tns -> LOGGER.info("Watching namespaces: {}", tns), () -> LOGGER.info("Watching all namespaces."));
     }
 
-    private void addHttpGetHandler(
-                                   String path,
+    @NonNull
+    private <T extends HasMetadata> Consumer<ControllerConfigurationOverrider<T>> getNsOverriddingConfigurationOverriderConsumer() {
+        return configOverrider -> Optional.ofNullable(watchedNamespaces).filter(Predicate.not(Set::isEmpty)).ifPresent(configOverrider::settingNamespaces);
+    }
+
+    private void addHttpGetHandler(String path,
                                    IntSupplier statusCodeSupplier) {
         managementServer.createContext(path, exchange -> {
             try (exchange) {
@@ -213,6 +243,29 @@ public class OperatorMain {
                 .tag("commit_id", versionInfo.commitId())
                 .strongReference(true)
                 .register(Metrics.globalRegistry);
+    }
+
+    @Nullable
+    @VisibleForTesting
+    Set<String> getWatchedNamespaces() {
+        return watchedNamespaces;
+    }
+
+    @Nullable
+    private static Set<String> getWatchedNamespacesFromEnvironment() {
+        var targets = Optional.ofNullable(System.getenv().get(KROXYLICIOUS_WATCHED_NAMESPACES_VAR_NAME))
+                .map(String::trim)
+                .filter(Predicate.not(String::isEmpty))
+                .filter(Predicate.not("*"::equals));
+
+        if (targets.isEmpty()) {
+            return null;
+        }
+
+        return targets.stream()
+                .flatMap(WATCHED_NAMESPACE_SPLITTER::splitAsStream)
+                .map(String::trim)
+                .collect(Collectors.toSet());
     }
 
 }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/OperatorMain.java
@@ -59,7 +59,7 @@ public class OperatorMain {
     private static final String BIND_ADDRESS_VAR_NAME = "BIND_ADDRESS";
     /**
      * Name of an environment that specifies a comma separated list of namespaces that the operator will watch.
-     * If the environment variable is not set, is empty, or set to a value *, the Operator will watch all namespaces.
+     * If the environment variable is not set, or is empty, the Operator will watch all namespaces.
      */
     static final String KROXYLICIOUS_WATCHED_NAMESPACES_VAR_NAME = "KROXYLICIOUS_WATCHED_NAMESPACES";
     private static final int DEFAULT_MANAGEMENT_PORT = 8080;
@@ -255,8 +255,7 @@ public class OperatorMain {
     private static Set<String> getWatchedNamespacesFromEnvironment() {
         var targets = Optional.ofNullable(System.getenv().get(KROXYLICIOUS_WATCHED_NAMESPACES_VAR_NAME))
                 .map(String::trim)
-                .filter(Predicate.not(String::isEmpty))
-                .filter(Predicate.not("*"::equals));
+                .filter(Predicate.not(String::isEmpty));
 
         if (targets.isEmpty()) {
             return null;
@@ -265,6 +264,7 @@ public class OperatorMain {
         return targets.stream()
                 .flatMap(WATCHED_NAMESPACE_SPLITTER::splitAsStream)
                 .map(String::trim)
+                .filter(Predicate.not(String::isEmpty))
                 .collect(Collectors.toSet());
     }
 

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
@@ -13,6 +13,8 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
@@ -26,8 +28,8 @@ import org.junit.jupiter.api.condition.EnabledIf;
 
 import com.sun.net.httpserver.HttpServer;
 
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.javaoperatorsdk.operator.OperatorException;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
@@ -37,12 +39,13 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProtocolFilter;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyIngress;
+import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyStatus;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaService;
 import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 @EnabledIf(value = "io.kroxylicious.kubernetes.operator.OperatorTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
 class OperatorMainIT {
@@ -52,6 +55,7 @@ class OperatorMainIT {
     private static final String CLUSTER_FOO_BOOTSTRAP = "my-cluster-kafka-bootstrap.foo.svc.cluster.local:9092";
     private static final String CLUSTER_BAR_REF = "barref";
     private static final String CLUSTER_BAR_BOOTSTRAP = "my-cluster-kafka-bootstrap.bar.svc.cluster.local:9092";
+    private static final String FOO = UUID.randomUUID().toString();
 
     private HttpServer managementServer;
     private KafkaProxy kafkaProxy;
@@ -78,9 +82,9 @@ class OperatorMainIT {
     }
 
     @BeforeEach
-    void beforeEach() throws IOException {
-        managementServer = HttpServer.create(new InetSocketAddress("localhost", 0), 10);
-        operatorMain = new OperatorMain(null, managementServer);
+    void beforeEach() throws Exception {
+        managementServer = createManagementServer();
+        operatorMain = new OperatorMain(managementServer, null, null);
     }
 
     @AfterEach
@@ -98,13 +102,7 @@ class OperatorMainIT {
 
     @Test
     void start() {
-        try {
-            operatorMain.start();
-        }
-        catch (OperatorException e) {
-            fail("Exception occurred starting operator: " + e.getMessage());
-        }
-
+        assertThatNoException().isThrownBy(() -> operatorMain.start());
     }
 
     @Test
@@ -233,6 +231,50 @@ class OperatorMainIT {
         assertThat(response.body()).isEmpty();
     }
 
+    @Test
+    void shouldWatchOnlyConfiguredNamespace() throws Exception {
+        // Given
+        operatorMain.stop();
+        managementServer.stop(0);
+
+        var kc = Objects.requireNonNull(OperatorTestUtils.kubeClient());
+        var watchedNs = "watched-" + System.currentTimeMillis();
+        var unwatchedNs = "unwatched-" + System.currentTimeMillis();
+        var watched = kc.namespaces().resource(new NamespaceBuilder().withNewMetadata().withName(watchedNs).endMetadata().build()).create();
+        var unwatched = kc.namespaces().resource(new NamespaceBuilder().withNewMetadata().withName(unwatchedNs).endMetadata().build()).create();
+        var watchedKp = kc.resource(new KafkaProxyBuilder().withNewMetadata().withNamespace(watchedNs).withName("myproxy").endMetadata().withNewSpec().endSpec().build())
+                .create();
+        var unwatchedKp = kc
+                .resource(new KafkaProxyBuilder().withNewMetadata().withNamespace(unwatchedNs).withName("myproxy").endMetadata().withNewSpec().endSpec().build())
+                .create();
+
+        managementServer = createManagementServer();
+        operatorMain = new OperatorMain(managementServer, null, Set.of(watched.getMetadata().getName()));
+
+        // When
+        operatorMain.start();
+
+        // Then
+        Awaitility.await("reconcilesWatchedProxy")
+                .untilAsserted(() -> {
+                    var watchedProxy = kc.resource(watchedKp).get();
+                    assertThat(watchedProxy)
+                            .extracting(KafkaProxy::getStatus)
+                            .extracting(KafkaProxyStatus::getObservedGeneration)
+                            .withFailMessage("expecting watched proxy to have status with observed generation as operator should be reconciling it.")
+                            .isNotNull();
+                });
+
+        var unwatchedProxy = kc.resource(unwatchedKp).get();
+        assertThat(unwatchedProxy)
+                .isNotNull()
+                .extracting(KafkaProxy::getStatus)
+                .withFailMessage("expecting unwatched proxy to have no status object as operator should not be reconciling it.")
+                .isNull();
+
+        Set.of(watched, unwatched).forEach(r -> kc.resource(r).delete());
+    }
+
     private KafkaProxy createProxyInstance(KafkaProxyBuilder proxyBuilder) {
         final KubernetesClient kubernetesClient = Objects.requireNonNull(OperatorTestUtils.kubeClient());
         kubernetesClient.resource(clusterRef(CLUSTER_FOO_REF, CLUSTER_FOO_BOOTSTRAP)).create();
@@ -250,5 +292,9 @@ class OperatorMainIT {
 
     private String managementAddress() {
         return String.format("http://%s:%s", managementServer.getAddress().getHostString(), managementServer.getAddress().getPort());
+    }
+
+    private static HttpServer createManagementServer() throws IOException {
+        return HttpServer.create(new InetSocketAddress("localhost", 0), 10);
     }
 }

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainIT.java
@@ -14,7 +14,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
@@ -55,7 +54,6 @@ class OperatorMainIT {
     private static final String CLUSTER_FOO_BOOTSTRAP = "my-cluster-kafka-bootstrap.foo.svc.cluster.local:9092";
     private static final String CLUSTER_BAR_REF = "barref";
     private static final String CLUSTER_BAR_BOOTSTRAP = "my-cluster-kafka-bootstrap.bar.svc.cluster.local:9092";
-    private static final String FOO = UUID.randomUUID().toString();
 
     private HttpServer managementServer;
     private KafkaProxy kafkaProxy;

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
@@ -198,8 +198,8 @@ class OperatorMainTest {
     }
 
     @Test
-    @SetEnvironmentVariable(key = OperatorMain.KROXYLICIOUS_WATCHED_NAMESPACES_VAR_NAME, value = "*")
-    void shouldNotOverrideOperatorNamespaceWhenEnvVarWildcard() {
+    @SetEnvironmentVariable(key = OperatorMain.KROXYLICIOUS_WATCHED_NAMESPACES_VAR_NAME, value = "")
+    void shouldNotOverrideOperatorNamespaceWhenEnvVarEmpty() {
         doShouldNotOverrideOperatorNamespace();
     }
 
@@ -211,13 +211,43 @@ class OperatorMainTest {
     }
 
     @Test
-    @SetEnvironmentVariable(key = OperatorMain.KROXYLICIOUS_WATCHED_NAMESPACES_VAR_NAME, value = "abc,def, ghi ")
-    void shouldOverrideOperatorNamespaces() {
+    @SetEnvironmentVariable(key = OperatorMain.KROXYLICIOUS_WATCHED_NAMESPACES_VAR_NAME, value = "single")
+    void shouldOverrideOperatorNamespaceToSingletonNamespace() {
+        // When
+        operatorMain.start();
+
+        // Then
+        assertThat(operatorMain.getWatchedNamespaces()).containsExactly("single");
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = OperatorMain.KROXYLICIOUS_WATCHED_NAMESPACES_VAR_NAME, value = "abc,def,ghi")
+    void shouldOverrideOperatorNamespacesToManyNamespaces() {
         // When
         operatorMain.start();
 
         // Then
         assertThat(operatorMain.getWatchedNamespaces()).containsExactly("abc", "def", "ghi");
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = OperatorMain.KROXYLICIOUS_WATCHED_NAMESPACES_VAR_NAME, value = " abc ,def ")
+    void shouldTrimNamespaceNames() {
+        // When
+        operatorMain.start();
+
+        // Then
+        assertThat(operatorMain.getWatchedNamespaces()).containsExactly("abc", "def");
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = OperatorMain.KROXYLICIOUS_WATCHED_NAMESPACES_VAR_NAME, value = ",abc,")
+    void shouldIgnoreEmptyNamespaces() {
+        // When
+        operatorMain.start();
+
+        // Then
+        assertThat(operatorMain.getWatchedNamespaces()).containsExactly("abc");
     }
 
     private void shouldRespondWithStatusCode(ArgumentCaptor<HttpHandler> captor,

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/OperatorMainTest.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junitpioneer.jupiter.ClearEnvironmentVariable;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -78,7 +80,7 @@ class OperatorMainTest {
         when(managementServer.createContext(eq("/"), rootCaptor.capture())).thenReturn(rootHttpContext);
         when(managementServer.createContext(eq(OperatorMain.HTTP_PATH_METRICS), any(HttpHandler.class))).thenReturn(metricsHttpContext);
         when(managementServer.createContext(eq(OperatorMain.HTTP_PATH_LIVEZ), livezCaptor.capture())).thenReturn(livezHttpContext);
-        operatorMain = new OperatorMain(kubeClient, managementServer);
+        operatorMain = new OperatorMain(managementServer, kubeClient, null);
     }
 
     @AfterEach
@@ -187,6 +189,35 @@ class OperatorMainTest {
     void shouldRespondWith200ForRequestsLivez() throws IOException {
         // Given
         shouldRespondWithStatusCode(livezCaptor, 200);
+    }
+
+    @Test
+    @ClearEnvironmentVariable(key = OperatorMain.KROXYLICIOUS_WATCHED_NAMESPACES_VAR_NAME)
+    void shouldNotOverrideOperatorNamespaceWhenEnvVarNotSpecified() {
+        doShouldNotOverrideOperatorNamespace();
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = OperatorMain.KROXYLICIOUS_WATCHED_NAMESPACES_VAR_NAME, value = "*")
+    void shouldNotOverrideOperatorNamespaceWhenEnvVarWildcard() {
+        doShouldNotOverrideOperatorNamespace();
+    }
+
+    private void doShouldNotOverrideOperatorNamespace() {
+        // When
+        operatorMain.start();
+        // Then
+        assertThat(operatorMain.getWatchedNamespaces()).isNull();
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = OperatorMain.KROXYLICIOUS_WATCHED_NAMESPACES_VAR_NAME, value = "abc,def, ghi ")
+    void shouldOverrideOperatorNamespaces() {
+        // When
+        operatorMain.start();
+
+        // Then
+        assertThat(operatorMain.getWatchedNamespaces()).containsExactly("abc", "def", "ghi");
     }
 
     private void shouldRespondWithStatusCode(ArgumentCaptor<HttpHandler> captor,


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Relates to propsal: https://github.com/kroxylicious/design/pull/91


In issue #2246 we saw the operator go out of memory when run on a Kubernetes cluster that has many secrets/configmap.  I ran into a similar issue today.  Whilst you can give the operator more memory, it seems prudent to have an escape hatch.

Many Operators (Strimzi, Flink to name a few), let you restrict the Operator to a set of namespaces defined using an environment variable providing a comma-separated list of namespaces.  If provided the Operator restricts itself to that list namespaces.

This PR adds a new environment variable `KROXYLICIOUS_WATCHED_NAMESPACES` that can provide a (static) list of namespaces to watch.  If the environment variable is not set, the operator watches all namespaces as before.

### Additional Context

Whilst Kroxylicious Operator does not yet integrate with OLM, this feature should cooperate with OLM's [target-namespace-selection](https://olm.operatorframework.io/docs/concepts/crds/operatorgroup/#target-namespace-selection).  The CSV would need to express the env var like in the operator deployment like this:

```
                      - name: KROXYLICIOUS_WATCHED_NAMESPACES
                        valueFrom:
                          fieldRef:
                            fieldPath: metadata.annotations['olm.targetNamespaces']
```

The JOSDK offers lots of nice features that allow the operator to dynamically start watching new namespace, that say, match a patterned.  We could add that feature later, if we wished.

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
