### PR TITLE
fix(README.md): documentation and slack links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ Kroxylicious is a Kafka protocol proxy, addressing use cases such as encryption,
 
 ## Quick Links
 - [kroxylicious.io](https://www.kroxylicious.io)
-- [Documentation](https://www.kroxylicious.io/documentation)
+- [Documentation](https://www.kroxylicious.io/kroxylicious/documentation/)
 - [GitHub design and discussion](https://github.com/kroxylicious/design)
-- [Community Slack chat](https://kroxylicious.io/join-us/)
+- [Community Slack chat](https://kroxylicious.slack.com/)
+- [Join Slack](https://join.slack.com/t/kroxylicious/shared_invite/zt-1rzjijq6d-x7At3bfPiPqFEqc9RmNhYA)
 
 ## Build status
 ![Maven Central Version](https://img.shields.io/maven-central/v/io.kroxylicious/kroxylicious-parent)


### PR DESCRIPTION
### Type of change

- Documentation

### Description

* The https://www.kroxylicious.io/kroxylicious can access home page. However, the "What is it?" and "What can it do?" link to https://kroxylicious.io/kroxylicious/kroxylicious/overview/ and https://kroxylicious.io/kroxylicious/kroxylicious/use-cases/ which are 404.
  <img width="664" height="494" alt="Screenshot 2026-03-30 at 10 15 28 PM" src="https://github.com/user-attachments/assets/ec690fd9-3c96-41bc-99e9-d495b71de387" />
* For new joiner, https://kroxylicious.slack.com/ link cannot join the slack.


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [X] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [X] Update documentation
- [X] Make sure all unit/integration tests pass
- [X] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [X] If applicable to the change, make sure system tests pass.
- [X] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

