### PR TITLE
fix: release HAProxyMessage to prevent reference counting leak

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/HAProxyMessageHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/HAProxyMessageHandler.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.haproxy.HAProxyMessage;
+import io.netty.util.ReferenceCountUtil;
 
 /**
  * A channel handler that intercepts {@link HAProxyMessage} objects emitted by
@@ -46,8 +47,18 @@ public class HAProxyMessageHandler extends ChannelInboundHandlerAdapter {
                         haProxyMessage.destinationAddress(),
                         haProxyMessage.destinationPort());
             }
-            // Forward to state machine for processing - do not propagate to filters
-            proxyChannelStateMachine.onClientRequest(haProxyMessage);
+            // Forward to state machine for processing - do not propagate to filters.
+            // Release the message if the state machine throws before taking ownership of it.
+            boolean released = false;
+            try {
+                proxyChannelStateMachine.onClientRequest(haProxyMessage);
+                released = true;
+            }
+            finally {
+                if (!released) {
+                    ReferenceCountUtil.release(haProxyMessage);
+                }
+            }
         }
         else {
             // Pass all other messages (Kafka frames) to the next handler

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachine.java
@@ -23,6 +23,7 @@ import io.micrometer.core.instrument.Timer;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.haproxy.HAProxyMessage;
+import io.netty.util.ReferenceCountUtil;
 
 import io.kroxylicious.proxy.authentication.ClientSaslContext;
 import io.kroxylicious.proxy.authentication.Subject;
@@ -695,11 +696,29 @@ public class ProxyChannelStateMachine {
         toClosed(errorCodeEx, null);
     }
 
+    @Nullable
+    private static HAProxyMessage extractHaProxyMessage(ProxyChannelState state) {
+        if (state instanceof ProxyChannelState.HaProxy haProxy) {
+            return haProxy.haProxyMessage();
+        }
+        else if (state instanceof ProxyChannelState.SelectingServer ss) {
+            return ss.haProxyMessage();
+        }
+        else if (state instanceof ProxyChannelState.Connecting conn) {
+            return conn.haProxyMessage();
+        }
+        else if (state instanceof ProxyChannelState.Forwarding fwd) {
+            return fwd.haProxyMessage();
+        }
+        return null;
+    }
+
     private void toClosed(@Nullable Throwable errorCodeEx, @Nullable DisconnectCause disconnectCause) {
         if (state instanceof Closed) {
             return;
         }
 
+        ReferenceCountUtil.release(extractHaProxyMessage(state));
         setState(new Closed());
 
         incrementAppropriateDisconnectsMetric(disconnectCause);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/HAProxyMessageHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/HAProxyMessageHandlerTest.java
@@ -19,6 +19,8 @@ import io.netty.handler.codec.haproxy.HAProxyProxiedProtocol;
 
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -74,6 +76,22 @@ class HAProxyMessageHandlerTest {
         verifyNoInteractions(proxyChannelStateMachine);
         // Should propagate to next handler
         verify(ctx).fireChannelRead(kafkaFrame);
+    }
+
+    @Test
+    void shouldReleaseHaProxyMessageWhenStateMachineThrows() throws Exception {
+        // Given
+        HAProxyMessage mockHaProxyMessage = mock(HAProxyMessage.class);
+        doThrow(new RuntimeException("state machine error")).when(proxyChannelStateMachine).onClientRequest(mockHaProxyMessage);
+
+        // When
+        assertThatThrownBy(() -> handler.channelRead(ctx, mockHaProxyMessage))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("state machine error");
+
+        // Then
+        verify(mockHaProxyMessage).release();
+        verifyNoInteractions(ctx);
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
@@ -388,6 +388,74 @@ class ProxyChannelStateMachineTest {
     }
 
     @Test
+    void shouldReleaseHaProxyMessageWhenClosedFromHaProxyState() {
+        // Given
+        HAProxyMessage mockHaProxyMessage = mock(HAProxyMessage.class);
+        proxyChannelStateMachine.forceState(
+                new ProxyChannelState.HaProxy(mockHaProxyMessage),
+                frontendHandler,
+                null,
+                TEST_KAFKA_SESSION);
+
+        // When
+        proxyChannelStateMachine.onClientInactive();
+
+        // Then
+        verify(mockHaProxyMessage).release();
+    }
+
+    @Test
+    void shouldReleaseHaProxyMessageWhenClosedFromSelectingServerState() {
+        // Given
+        HAProxyMessage mockHaProxyMessage = mock(HAProxyMessage.class);
+        proxyChannelStateMachine.forceState(
+                new ProxyChannelState.SelectingServer(mockHaProxyMessage, null, null),
+                frontendHandler,
+                null,
+                TEST_KAFKA_SESSION);
+
+        // When
+        proxyChannelStateMachine.onClientInactive();
+
+        // Then
+        verify(mockHaProxyMessage).release();
+    }
+
+    @Test
+    void shouldReleaseHaProxyMessageWhenClosedFromConnectingState() {
+        // Given
+        HAProxyMessage mockHaProxyMessage = mock(HAProxyMessage.class);
+        proxyChannelStateMachine.forceState(
+                new ProxyChannelState.Connecting(mockHaProxyMessage, null, null, BROKER_ADDRESS),
+                frontendHandler,
+                backendHandler,
+                TEST_KAFKA_SESSION);
+
+        // When
+        proxyChannelStateMachine.onClientInactive();
+
+        // Then
+        verify(mockHaProxyMessage).release();
+    }
+
+    @Test
+    void shouldReleaseHaProxyMessageWhenClosedFromForwardingState() {
+        // Given
+        HAProxyMessage mockHaProxyMessage = mock(HAProxyMessage.class);
+        proxyChannelStateMachine.forceState(
+                new ProxyChannelState.Forwarding(mockHaProxyMessage, null, null),
+                frontendHandler,
+                backendHandler,
+                TEST_KAFKA_SESSION);
+
+        // When
+        proxyChannelStateMachine.onClientInactive();
+
+        // Then
+        verify(mockHaProxyMessage).release();
+    }
+
+    @Test
     void inHaProxyShouldBufferWhenOnClientMetadataRequest() {
         // Given
         stateMachineInHaProxy();
@@ -800,9 +868,14 @@ class ProxyChannelStateMachineTest {
                 TEST_KAFKA_SESSION);
     }
 
+    private static HAProxyMessage newHaProxyMessage() {
+        return new HAProxyMessage(HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, HAProxyProxiedProtocol.TCP4,
+                "1.1.1.1", "2.2.2.2", 46421, 9092);
+    }
+
     private void stateMachineInHaProxy() {
         proxyChannelStateMachine.forceState(
-                new ProxyChannelState.HaProxy(HA_PROXY_MESSAGE),
+                new ProxyChannelState.HaProxy(newHaProxyMessage()),
                 frontendHandler,
                 null,
                 TEST_KAFKA_SESSION);


### PR DESCRIPTION
## Summary

Fixes #3206 — `HAProxyMessage` implements Netty's `ReferenceCounted` but was never released after being stored in the proxy channel state machine, causing a memory leak for every connection using the PROXY protocol.

## Changes

### `ProxyChannelStateMachine.java`
- Added `extractHaProxyMessage(ProxyChannelState)` helper that pattern-matches against `HaProxy`, `SelectingServer`, `Connecting`, and `Forwarding` states to extract the held `HAProxyMessage`
- In `toClosed()`, releases the `HAProxyMessage` via `ReferenceCountUtil.release()` **before** transitioning to the `Closed` state

### `HAProxyMessageHandler.java`
- Wrapped `proxyChannelStateMachine.onClientRequest(haProxyMessage)` in a try-finally block so the message is released if the state machine throws before taking ownership

### Tests
- Added test in `HAProxyMessageHandlerTest` verifying release on state machine exception
- Added 4 tests in `ProxyChannelStateMachineTest` verifying `toClosed` releases the message from each state that can hold it (`HaProxy`, `SelectingServer`, `Connecting`, `Forwarding`)

All 97 existing + new tests pass.