### PR TITLE
chore(ci): run SpotBugs only in lint job, not build job

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -79,7 +79,7 @@ jobs:
           echo "KROXYLICIOUS_VERSION=${KROXYLICIOUS_VERSION}" >> "$GITHUB_ENV"
           # KROXYLICIOUS_IMAGE env var is used by the Operator ITs
           echo "KROXYLICIOUS_IMAGE=${KROXYLICIOUS_IMAGE}" >> "$GITHUB_ENV"
-          mvn -B install -DskipITs -Pci -Djapicmp.skip=${REFERENCE_RELEASE_UNPUBLISHED}
+          mvn -B install -DskipITs -Pci -Djapicmp.skip=${REFERENCE_RELEASE_UNPUBLISHED} -Dspotbugs.skip=true
       - name: Cache SonarCloud packages
         uses: actions/cache@v5
         if: github.ref_name == 'main' || env.SONAR_TOKEN_SET == 'true'

--- a/.github/workflows/operator-maven.yaml
+++ b/.github/workflows/operator-maven.yaml
@@ -80,7 +80,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mvn -B install -Pci -Djapicmp.skip=true -pl ':kroxylicious-operator' -am
+          mvn -B install -Pci -Djapicmp.skip=true -Dspotbugs.skip=true -pl ':kroxylicious-operator' -am
       - name: 'SonarCloud scan on main for the Operator'
         if: github.event_name == 'push' && github.ref_name == 'main' && env.SONAR_TOKEN_SET == 'true'
         env:


### PR DESCRIPTION
## Summary

- SpotBugs is a static analysis tool — it belongs in the lint job alongside checkstyle and other code quality checks
- Previously it ran redundantly in both the lint/build jobs and the dedicated lint job
- Adds `-Dspotbugs.skip=true` to the `maven.yaml` and `operator-maven.yaml` build invocations so SpotBugs failures fail fast in lint rather than blocking the full test matrix

## Additional context

Prompted by #3536 where a SpotBugs finding caused both the lint job and both build_proxy matrix jobs to fail simultaneously.

## Checklist

- [x] Relates to CI/build infrastructure only, no functional code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)