### PR TITLE
fix: microshift workflow should run on pushes to main too.

### DIFF
--- a/.github/workflows/operator-tests-microshift.yaml
+++ b/.github/workflows/operator-tests-microshift.yaml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: preflight
-    if: needs.preflight.outputs.pull-secret-check == 'true' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success')
+    if: needs.preflight.outputs.pull-secret-check == 'true' && (contains(fromJSON('["workflow_dispatch", "push"]'), github.event_name) || github.event.workflow_run.conclusion == 'success')
 
     steps:
       - name: 'Test for Slack secret'


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Bugfix

### Description
Update condition for operator tests on MicroShift workflow to run on push events too.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
