### PR TITLE
Fixes #3604 - Fix license checker warning for Dockerfile.operator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -654,6 +654,7 @@
                         <mapping>
                             <bicep>DOUBLESLASH_STYLE</bicep>
                             <g4>JAVADOC_STYLE</g4>
+                            <operator>SCRIPT_STYLE</operator>
                         </mapping>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

 The Maven license-checker plugin (com.mycila:license-maven-plugin) warns during builds because it doesn't recognize the .operator file extension used by Dockerfile.operator. This PR adds a mapping for .operator to SCRIPT_STYLE (hash # comments) in the plugin's configuration in pom.xml.

Fixes #3604

### Additional Context

During CI builds, the following warning is emitted:                                                                                                    
                                                                                                                                                         
Warning:  Unknown file extension: /home/runner/work/kroxylicious/kroxylicious/Dockerfile.operator                                                      
Warning:  Unable to find a comment style definition for some files.                                                                                    
                                                                                                                                                         
This is a clean build warning fix with no functional impact.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [x] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
