### PR TITLE
fix: resolve MathAbsoluteNegative ErrorProne warnings

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/MetricsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/MetricsIT.java
@@ -45,6 +45,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import com.google.common.math.LongMath;
+
 import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
 import io.micrometer.core.instrument.Metrics;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -920,7 +922,7 @@ class MetricsIT {
 
     @NonNull
     private String getRandomCounterName() {
-        return "test_metric_" + Math.abs(new Random().nextLong()) + "_total";
+        return "test_metric_" + LongMath.saturatedAbs(new Random().nextLong()) + "_total";
     }
 
     private ConfigurationBuilder configWithMetrics(KafkaCluster cluster) {

--- a/kroxylicious-kafka-message-tools/pom.xml
+++ b/kroxylicious-kafka-message-tools/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/kroxylicious-kafka-message-tools/src/test/java/io/kroxylicious/kafka/transform/RecordStreamTest.java
+++ b/kroxylicious-kafka-message-tools/src/test/java/io/kroxylicious/kafka/transform/RecordStreamTest.java
@@ -21,6 +21,8 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.common.utils.ByteBufferOutputStream;
 import org.junit.jupiter.api.Test;
 
+import com.google.common.math.IntMath;
+
 import io.kroxylicious.test.assertj.MemoryRecordsAssert;
 import io.kroxylicious.test.assertj.RecordBatchAssert;
 import io.kroxylicious.test.record.RecordTestUtils;
@@ -124,8 +126,8 @@ class RecordStreamTest {
                 .firstRecord()
                 .hasKeyEqualTo("prefixhello")
                 .hasValueEqualTo("prefixworld")
-                .hasOffsetEqualTo(Math.abs("prefix".hashCode()) + baseOffset)
-                .hasTimestampEqualTo(Math.abs("prefix".hashCode()) + 42L);
+                .hasOffsetEqualTo(IntMath.saturatedAbs("prefix".hashCode()) + baseOffset)
+                .hasTimestampEqualTo(IntMath.saturatedAbs("prefix".hashCode()) + 42L);
     }
 
     @Test
@@ -147,14 +149,14 @@ class RecordStreamTest {
         batch.firstRecord()
                 .hasKeyEqualTo(index + "hello")
                 .hasValueEqualTo(index + "world")
-                .hasOffsetEqualTo(Math.abs(Integer.hashCode(index)) + baseOffset)
-                .hasTimestampEqualTo(Math.abs(Integer.hashCode(index)) + 42L);
+                .hasOffsetEqualTo(IntMath.saturatedAbs(Integer.hashCode(index)) + baseOffset)
+                .hasTimestampEqualTo(IntMath.saturatedAbs(Integer.hashCode(index)) + 42L);
         index++;
         batch.lastRecord()
                 .hasKeyEqualTo(index + "HELLO")
                 .hasValueEqualTo(index + "WORLD")
-                .hasOffsetEqualTo(Math.abs(Integer.hashCode(index)) + baseOffset + 1)
-                .hasTimestampEqualTo(Math.abs(Integer.hashCode(index)) + 65L);
+                .hasOffsetEqualTo(IntMath.saturatedAbs(Integer.hashCode(index)) + baseOffset + 1)
+                .hasTimestampEqualTo(IntMath.saturatedAbs(Integer.hashCode(index)) + 65L);
     }
 
     @Test
@@ -176,14 +178,14 @@ class RecordStreamTest {
         batch.firstRecord()
                 .hasKeyEqualTo(index + "hello")
                 .hasValueEqualTo(index + "world")
-                .hasOffsetEqualTo(Math.abs(Integer.hashCode(index)) + baseOffset)
-                .hasTimestampEqualTo(Math.abs(Integer.hashCode(index)) + 42L);
+                .hasOffsetEqualTo(IntMath.saturatedAbs(Integer.hashCode(index)) + baseOffset)
+                .hasTimestampEqualTo(IntMath.saturatedAbs(Integer.hashCode(index)) + 42L);
         index++;
         batch.lastRecord()
                 .hasKeyEqualTo(index + "HELLO")
                 .hasValueEqualTo(index + "WORLD")
-                .hasOffsetEqualTo(Math.abs(Integer.hashCode(index)) + baseOffset + 1)
-                .hasTimestampEqualTo(Math.abs(Integer.hashCode(index)) + 65L);
+                .hasOffsetEqualTo(IntMath.saturatedAbs(Integer.hashCode(index)) + baseOffset + 1)
+                .hasTimestampEqualTo(IntMath.saturatedAbs(Integer.hashCode(index)) + 65L);
     }
 
     private static ByteBuffer prefix(String prefix, ByteBuffer buffer) {
@@ -214,12 +216,12 @@ class RecordStreamTest {
 
         @Override
         public long transformOffset(Record record) {
-            return Math.abs(state.hashCode()) + record.offset();
+            return IntMath.saturatedAbs(state.hashCode()) + record.offset();
         }
 
         @Override
         public long transformTimestamp(Record record) {
-            return Math.abs(state.hashCode()) + record.timestamp();
+            return IntMath.saturatedAbs(state.hashCode()) + record.timestamp();
         }
 
         @Nullable

--- a/pom.xml
+++ b/pom.xml
@@ -1346,7 +1346,7 @@
                                 <arg>-XDcompilePolicy=simple</arg>
                                 <arg>--should-stop=ifError=FLOW</arg>
                                 <!-- The following <arg> cannot be split over multiple lines :-( -->
-                                <arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode -XepExcludedPaths:.*/target/generated-sources/.* -Xep:MissingOverride:ERROR -Xep:MutablePublicArray:ERROR</arg>
+                                <arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode -XepExcludedPaths:.*/target/generated-sources/.* -Xep:MissingOverride:ERROR -Xep:MutablePublicArray:ERROR -Xep:MathAbsoluteNegative:ERROR</arg>
                                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
                                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>


### PR DESCRIPTION
### Type of change
- Bugfix

### Description

Replaces `Math.abs()` calls with Guava's `IntMath.saturatedAbs()` / `LongMath.saturatedAbs()` to resolve ErrorProne `MathAbsoluteNegative` warnings.

**Root cause:** `Math.abs(Integer.MIN_VALUE)` returns `Integer.MIN_VALUE` (still negative) due to two's complement overflow. ErrorProne correctly flags this as a potential bug.

**Fix:**
- `RecordStreamTest.java` — 12 occurrences: `Math.abs()` → `IntMath.saturatedAbs()` (clamps `MIN_VALUE` to `MAX_VALUE`)
- `MetricsIT.java` — 1 occurrence: `Math.abs()` → `LongMath.saturatedAbs()`
- Added Guava as explicit test-scoped dependency in `kroxylicious-kafka-message-tools/pom.xml` (was previously only available transitively)
- Promoted `MathAbsoluteNegative` to ERROR in root ErrorProne config (follows the same pattern as `MutablePublicArray:ERROR` in #3615)

### Checklist
- [x] PR raised from a fork of this repository and made from a branch rather than main.
- [x] Write tests — existing test suite covers all changed code (9 tests in RecordStreamTest, 32 in message-tools module, all passing)
- [x] Make sure all unit/integration tests pass — full `mvn clean install -DskipTests` succeeds, `kroxylicious-kafka-message-tools` test suite: 41 tests, 0 failures
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [x] Ensure the PR references relevant issue(s) so they are closed on merging.

Fixes #3628