### PR TITLE
refactor: Reduce cognitive complexity of FieldSpec constructor

### DIFF
--- a/kroxylicious-krpc-plugin/src/main/java/io/kroxylicious/krpccodegen/schema/FieldSpec.java
+++ b/kroxylicious-krpc-plugin/src/main/java/io/kroxylicious/krpccodegen/schema/FieldSpec.java
@@ -63,55 +63,84 @@ public final class FieldSpec {
                      @JsonProperty("flexibleVersions") String flexibleVersions,
                      @JsonProperty("tag") Integer tag,
                      @JsonProperty("zeroCopy") boolean zeroCopy) {
-        this.name = Objects.requireNonNull(name);
-        if (!VALID_FIELD_NAMES.matcher(this.name).matches()) {
-            throw new RuntimeException("Invalid field name " + this.name);
-        }
+        this.name = requireValidName(name);
         this.taggedVersions = Versions.parse(taggedVersions, Versions.NONE);
-        // If versions is not set, but taggedVersions is, default to taggedVersions.
-        this.versions = Versions.parse(versions, this.taggedVersions.empty() ? null : this.taggedVersions);
-        if (this.versions == null) {
-            throw new RuntimeException("You must specify the version of the " +
-                    name + " structure.");
-        }
-        this.fields = Collections.unmodifiableList(fields == null ? Collections.emptyList() : new ArrayList<>(fields));
+        this.versions = requireVersions(versions);
+        this.fields = parseFields(fields);
         this.type = FieldType.parse(Objects.requireNonNull(type));
         this.mapKey = mapKey;
         this.nullableVersions = Versions.parse(nullableVersions, Versions.NONE);
-        if (!this.nullableVersions.empty() && !this.type.canBeNullable()) {
-            throw new RuntimeException("Type " + this.type + " cannot be nullable.");
-        }
         this.fieldDefault = fieldDefault == null ? "" : fieldDefault;
         this.ignorable = ignorable;
         this.entityType = entityType == null ? EntityType.UNKNOWN : entityType;
-        this.entityType.verifyTypeMatches(name, this.type);
-
         this.about = about == null ? "" : about;
+        this.flexibleVersions = parseFlexibleVersions(flexibleVersions);
+        this.tag = Optional.ofNullable(tag);
+        this.zeroCopy = zeroCopy;
+
+        validateNullableVersions();
+        this.entityType.verifyTypeMatches(name, this.type);
+        validateSubFields();
+        validateTagNotMapKey();
+        checkTagInvariants();
+        validateZeroCopy();
+    }
+
+    private static String requireValidName(String name) {
+        Objects.requireNonNull(name);
+        if (!VALID_FIELD_NAMES.matcher(name).matches()) {
+            throw new RuntimeException("Invalid field name " + name);
+        }
+        return name;
+    }
+
+    // If versions is not set, but taggedVersions is, default to taggedVersions.
+    private Versions requireVersions(String versions) {
+        Versions v = Versions.parse(versions, this.taggedVersions.empty() ? null : this.taggedVersions);
+        if (v == null) {
+            throw new RuntimeException("You must specify the version of the " + name + " structure.");
+        }
+        return v;
+    }
+
+    private static List<FieldSpec> parseFields(List<FieldSpec> fields) {
+        return Collections.unmodifiableList(fields == null ? Collections.emptyList() : new ArrayList<>(fields));
+    }
+
+    private Optional<Versions> parseFlexibleVersions(String flexibleVersions) {
+        if (flexibleVersions == null || flexibleVersions.isEmpty()) {
+            return Optional.empty();
+        }
+        if (!(this.type.isString() || this.type.isBytes())) {
+            // For now, only allow flexibleVersions overrides for the string and bytes
+            // types. Overrides are only needed to keep compatibility with some old formats,
+            // so there isn't any need to support them for all types.
+            throw new RuntimeException("Invalid flexibleVersions override for " + name +
+                    ".  Only fields of type string or bytes can specify a flexibleVersions " +
+                    "override.");
+        }
+        return Optional.of(Versions.parse(flexibleVersions, null));
+    }
+
+    private void validateNullableVersions() {
+        if (!this.nullableVersions.empty() && !this.type.canBeNullable()) {
+            throw new RuntimeException("Type " + this.type + " cannot be nullable.");
+        }
+    }
+
+    private void validateSubFields() {
         if (!this.fields().isEmpty() && !this.type.isArray() && !this.type.isStruct()) {
             throw new RuntimeException("Non-array or Struct field " + name + " cannot have fields");
         }
+    }
 
-        if (flexibleVersions == null || flexibleVersions.isEmpty()) {
-            this.flexibleVersions = Optional.empty();
-        }
-        else {
-            this.flexibleVersions = Optional.of(Versions.parse(flexibleVersions, null));
-            if (!(this.type.isString() || this.type.isBytes())) {
-                // For now, only allow flexibleVersions overrides for the string and bytes
-                // types. Overrides are only needed to keep compatibility with some old formats,
-                // so there isn't any need to support them for all types.
-                throw new RuntimeException("Invalid flexibleVersions override for " + name +
-                        ".  Only fields of type string or bytes can specify a flexibleVersions " +
-                        "override.");
-            }
-        }
-        this.tag = Optional.ofNullable(tag);
+    private void validateTagNotMapKey() {
         if (this.tag.isPresent() && mapKey) {
             throw new RuntimeException("Tagged fields cannot be used as keys.");
         }
-        checkTagInvariants();
+    }
 
-        this.zeroCopy = zeroCopy;
+    private void validateZeroCopy() {
         if (this.zeroCopy && !this.type.isBytes()) {
             throw new RuntimeException("Invalid zeroCopy value for " + name +
                     ". Only fields of type bytes can use zeroCopy flag.");


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

Reduce cognitive complexity of FieldSpec constructor, extract some method to reduce the cognitive

### Additional Context

https://github.com/kroxylicious/kroxylicious/issues/3616

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
