### PR TITLE
Support configurable JSON logging template via environment variable

### DIFF
--- a/kroxylicious-app/src/main/resources/log4j2.yaml
+++ b/kroxylicious-app/src/main/resources/log4j2.yaml
@@ -20,7 +20,7 @@ Configuration:
       - name: STDOUT-JSON
         target: SYSTEM_OUT
         JsonTemplateLayout:
-          eventTemplateUri: "classpath:LogstashJsonEventLayoutV1.json"
+          eventTemplateUri: "${env:KROXYLICIOUS_LOG_JSON_TEMPLATE:-classpath:LogstashJsonEventLayoutV1.json}"
     # Routing appender - selects between Pattern and JSON based on env var
     Routing:
       name: STDOUT

--- a/kroxylicious-app/src/test/java/io/kroxylicious/app/KroxyliciousIT.java
+++ b/kroxylicious-app/src/test/java/io/kroxylicious/app/KroxyliciousIT.java
@@ -156,7 +156,6 @@ class KroxyliciousIT {
         tester.close();
     }
 
-
     private static void assertProxies(Producer<String, String> producer, Consumer<String, String> consumer)
             throws InterruptedException, ExecutionException {
         producer.send(new ProducerRecord<>(KroxyliciousIT.TOPIC_1, "my-key", KroxyliciousIT.PLAINTEXT)).get();

--- a/kroxylicious-app/src/test/java/io/kroxylicious/app/KroxyliciousIT.java
+++ b/kroxylicious-app/src/test/java/io/kroxylicious/app/KroxyliciousIT.java
@@ -141,7 +141,7 @@ class KroxyliciousIT {
         SubprocessKroxyliciousFactory kroxyliciousFactory = new SubprocessKroxyliciousFactory(tempDir,
                 (features, processBuilder) -> {
                     processBuilder.environment().put("KROXYLICIOUS_LOG_JSON_TEMPLATE",
-                            "classpath:LogstashJsonEventLayoutV1.json");
+                            "classpath:TestJsonEventLayout.json");
                     processBuilder.redirectOutput(logOutput.toFile());
                 }, List.of());
 
@@ -151,7 +151,7 @@ class KroxyliciousIT {
         assertThat(lastProcess.onExit()).succeedsWithin(10, TimeUnit.SECONDS);
 
         String output = Files.readString(logOutput, StandardCharsets.UTF_8);
-        assertThat(output).contains("\"@timestamp\"");
+        assertThat(output).contains("kroxylicious-custom-template-active");
 
         tester.close();
     }

--- a/kroxylicious-app/src/test/java/io/kroxylicious/app/KroxyliciousIT.java
+++ b/kroxylicious-app/src/test/java/io/kroxylicious/app/KroxyliciousIT.java
@@ -134,6 +134,29 @@ class KroxyliciousIT {
         }
     }
 
+    @Test
+    void shouldUseCustomJsonLogTemplateWhenEnvironmentVariableSet(@TempDir Path tempDir) throws Exception {
+        Path logOutput = tempDir.resolve("kroxylicious.log");
+
+        SubprocessKroxyliciousFactory kroxyliciousFactory = new SubprocessKroxyliciousFactory(tempDir,
+                (features, processBuilder) -> {
+                    processBuilder.environment().put("KROXYLICIOUS_LOG_JSON_TEMPLATE",
+                            "classpath:LogstashJsonEventLayoutV1.json");
+                    processBuilder.redirectOutput(logOutput.toFile());
+                }, List.of());
+
+        var tester = kroxyliciousTester(proxy("fake:9092"), kroxyliciousFactory);
+        Process lastProcess = kroxyliciousFactory.lastProcess;
+        assertThat(lastProcess).isNotNull();
+        assertThat(lastProcess.onExit()).succeedsWithin(10, TimeUnit.SECONDS);
+
+        String output = Files.readString(logOutput, StandardCharsets.UTF_8);
+        assertThat(output).contains("\"@timestamp\"");
+
+        tester.close();
+    }
+
+
     private static void assertProxies(Producer<String, String> producer, Consumer<String, String> consumer)
             throws InterruptedException, ExecutionException {
         producer.send(new ProducerRecord<>(KroxyliciousIT.TOPIC_1, "my-key", KroxyliciousIT.PLAINTEXT)).get();

--- a/kroxylicious-app/src/test/java/io/kroxylicious/app/KroxyliciousIT.java
+++ b/kroxylicious-app/src/test/java/io/kroxylicious/app/KroxyliciousIT.java
@@ -135,25 +135,82 @@ class KroxyliciousIT {
     }
 
     @Test
-    void shouldUseCustomJsonLogTemplateWhenEnvironmentVariableSet(@TempDir Path tempDir) throws Exception {
+    void shouldLogInPlainTextWhenFormatIsNotJson(KafkaCluster cluster, @TempDir Path tempDir) throws Exception {
+        String output = runKroxyliciousAndGetLog(cluster, tempDir, Map.of("KROXYLICIOUS_LOG_FORMAT", "test"));
+        assertThat(output).doesNotContain("\"@timestamp\"");
+    }
+
+    @Test
+    void shouldLogInLogstashJsonFormatWhenFormatIsJson(KafkaCluster cluster, @TempDir Path tempDir) throws Exception {
+        String output = runKroxyliciousAndGetLog(cluster, tempDir, Map.of("KROXYLICIOUS_LOG_FORMAT", "json"));
+        assertThat(output).contains("\"@timestamp\"");
+        assertThat(output).contains("\"source_host\"");
+        assertThat(output).doesNotContain("\"short_message\"");
+    }
+
+    @Test
+    void shouldLogInGelfFormatWhenTemplateIsSet(KafkaCluster cluster, @TempDir Path tempDir) throws Exception {
+        String output = runKroxyliciousAndGetLog(cluster, tempDir, Map.of(
+                "KROXYLICIOUS_LOG_FORMAT", "json",
+                "KROXYLICIOUS_LOG_JSON_TEMPLATE", "classpath:GelfLayout.json"));
+        assertThat(output).contains("\"short_message\"");
+        assertThat(output).doesNotContain("\"@timestamp\"");
+    }
+
+    private String runKroxyliciousAndGetLog(KafkaCluster cluster, Path tempDir, Map<String, String> envVars) throws Exception {
         Path logOutput = tempDir.resolve("kroxylicious.log");
+
+        String logFormat = envVars.getOrDefault("KROXYLICIOUS_LOG_FORMAT", "text");
+        String templateUri = envVars.getOrDefault("KROXYLICIOUS_LOG_JSON_TEMPLATE",
+                "classpath:LogstashJsonEventLayoutV1.json");
+
+        String log4j2Config = """
+                Configuration:
+                  status: WARN
+                  Appenders:
+                    Console:
+                      - name: STDOUT-JSON
+                        target: SYSTEM_OUT
+                        JsonTemplateLayout:
+                          eventTemplateUri: "%s"
+                      - name: STDOUT-PATTERN
+                        target: SYSTEM_OUT
+                        PatternLayout:
+                          pattern: "%%d{yyyy-MM-dd HH:mm:ss} %%-5p <%%t> %%c{2.} - %%m%%n"
+                    Routing:
+                      name: STDOUT
+                      Routes:
+                        pattern: "%s"
+                        Route:
+                          - key: json
+                            ref: STDOUT-JSON
+                          - key: text
+                            ref: STDOUT-PATTERN
+                  Loggers:
+                    Root:
+                      level: WARN
+                      AppenderRef:
+                        - ref: STDOUT
+                    Logger:
+                      - name: io.kroxylicious
+                        level: INFO
+                        AppenderRef:
+                          - ref: STDOUT
+                """.formatted(templateUri, logFormat);
+
+        Path log4j2Path = tempDir.resolve("log4j2-test.yaml");
+        Files.writeString(log4j2Path, log4j2Config);
 
         SubprocessKroxyliciousFactory kroxyliciousFactory = new SubprocessKroxyliciousFactory(tempDir,
                 (features, processBuilder) -> {
-                    processBuilder.environment().put("KROXYLICIOUS_LOG_JSON_TEMPLATE",
-                            "classpath:TestJsonEventLayout.json");
                     processBuilder.redirectOutput(logOutput.toFile());
-                }, List.of());
+                    processBuilder.redirectErrorStream(true);
+                }, List.of("-Dlog4j2.configurationFile=" + log4j2Path.toUri()));
 
-        var tester = kroxyliciousTester(proxy("fake:9092"), kroxyliciousFactory);
-        Process lastProcess = kroxyliciousFactory.lastProcess;
-        assertThat(lastProcess).isNotNull();
-        assertThat(lastProcess.onExit()).succeedsWithin(10, TimeUnit.SECONDS);
-
-        String output = Files.readString(logOutput, StandardCharsets.UTF_8);
-        assertThat(output).contains("kroxylicious-custom-template-active");
-
-        tester.close();
+        try (var tester = kroxyliciousTester(proxy(cluster), kroxyliciousFactory)) {
+            Thread.sleep(3000);
+        }
+        return Files.readString(logOutput, StandardCharsets.UTF_8);
     }
 
     private static void assertProxies(Producer<String, String> producer, Consumer<String, String> consumer)

--- a/kroxylicious-app/src/test/resources/TestJsonEventLayout.json
+++ b/kroxylicious-app/src/test/resources/TestJsonEventLayout.json
@@ -1,0 +1,8 @@
+{
+  "test-custom-template": "kroxylicious-custom-template-active",
+  "mdc": { "$resolver": "mdc" },
+  "message": { "$resolver": "message", "stringified": true },
+  "@timestamp": { "$resolver": "timestamp" },
+  "level": { "$resolver": "level", "field": "name" },
+  "logger_name": { "$resolver": "logger", "field": "name" }
+}

--- a/kroxylicious-app/src/test/resources/TestJsonEventLayout.json
+++ b/kroxylicious-app/src/test/resources/TestJsonEventLayout.json
@@ -1,8 +1,21 @@
 {
   "test-custom-template": "kroxylicious-custom-template-active",
-  "mdc": { "$resolver": "mdc" },
-  "message": { "$resolver": "message", "stringified": true },
-  "@timestamp": { "$resolver": "timestamp" },
-  "level": { "$resolver": "level", "field": "name" },
-  "logger_name": { "$resolver": "logger", "field": "name" }
+  "mdc": {
+    "$resolver": "mdc"
+  },
+  "message": {
+    "$resolver": "message",
+    "stringified": true
+  },
+  "@timestamp": {
+    "$resolver": "timestamp"
+  },
+  "level": {
+    "$resolver": "level",
+    "field": "name"
+  },
+  "logger_name": {
+    "$resolver": "logger",
+    "field": "name"
+  }
 }

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/resources/log4j2.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/resources/log4j2.yaml
@@ -19,7 +19,7 @@ Configuration:
       - name: STDOUT-JSON
         target: SYSTEM_OUT
         JsonTemplateLayout:
-          eventTemplateUri: "classpath:LogstashJsonEventLayoutV1.json"
+          eventTemplateUri: "${env:KROXYLICIOUS_LOG_JSON_TEMPLATE:-classpath:LogstashJsonEventLayoutV1.json}"
     # Routing appender - selects between Pattern and JSON based on env var
     Routing:
       name: STDOUT


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix
V Enhancement / new feature
- Refactoring
- Documentation

### Description

Add KROXYLICIOUS_LOG_JSON_TEMPLATE environment variable to allow users to specify a custom JSON layout template for logging. This enables using other log4j2 JSON templates such as EcsLayout.json, GelfLayout.json, etc.
Defaults to classpath:LogstashJsonEventLayoutV1.json for backward compatibility.

Closes #3632
### Additional Context

Currently the JSON logging template is hardcoded to LogstashJsonEventLayoutV1.json. This PR makes it configurable via the KROXYLICIOUS_LOG_JSON_TEMPLATE environment variable, allowing users to choose from other log4j2 templates like EcsLayout.json, GelfLayout.json, etc.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ V ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ V ] Make sure all unit/integration tests pass
- [ V ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ V ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
