### PR TITLE
refactor: Replace replaceAll() with replace() in KrpcGenerator (S5361)

### DIFF
--- a/kroxylicious-krpc-plugin/src/main/java/io/kroxylicious/krpccodegen/main/KrpcGenerator.java
+++ b/kroxylicious-krpc-plugin/src/main/java/io/kroxylicious/krpccodegen/main/KrpcGenerator.java
@@ -592,12 +592,12 @@ public class KrpcGenerator {
 
     private String outputFile(String pattern, String messageSpecName, String templateName) {
         if (messageSpecName != null) {
-            pattern = pattern.replaceAll("\\$\\{messageSpecName\\}", messageSpecName);
+            pattern = pattern.replace("${messageSpecName}", messageSpecName);
         }
 
         if (templateName != null) {
             templateName = templateName.substring(Math.max(0, templateName.lastIndexOf(File.separator) + 1), templateName.indexOf(".ftl"));
-            pattern = pattern.replaceAll("\\$\\{templateName\\}", templateName);
+            pattern = pattern.replace("${templateName}", templateName);
         }
 
         return pattern;


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

Replace unnecessary replaceAll() calls with replace() in `KrpcGenerator#outputFile`, since the patterns ${messageSpecName} and ${templateName} are plain literal strings that require no regex interpretation. 

### Additional Context

https://github.com/kroxylicious/kroxylicious/issues/3668

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
