### PR TITLE
refactor: Improve Test Assertions with AssertJ Chains in filter-test-support (S5853) 

### DIFF
--- a/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/jws/JwsTestUtilsTest.java
+++ b/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/jws/JwsTestUtilsTest.java
@@ -82,8 +82,9 @@ class JwsTestUtilsTest {
         first[0] = (byte) 0xFF;
 
         byte[] second = validJwsUsingEcdsaJwk();
-        assertThat(second).isEqualTo(originalCopy);
-        assertThat(second).isNotSameAs(first);
+        assertThat(second)
+                .isEqualTo(originalCopy)
+                .isNotSameAs(first);
     }
 
     @Test
@@ -96,8 +97,9 @@ class JwsTestUtilsTest {
         first[0] = (byte) 0xFF;
 
         byte[] second = validJwsUsingMissingEcdsaJwk();
-        assertThat(second).isEqualTo(originalCopy);
-        assertThat(second).isNotSameAs(first);
+        assertThat(second)
+                .isEqualTo(originalCopy)
+                .isNotSameAs(first);
     }
 
     @Test
@@ -110,8 +112,9 @@ class JwsTestUtilsTest {
         first[0] = (byte) 0xFF;
 
         byte[] second = validJwsUsingRsaJwk();
-        assertThat(second).isEqualTo(originalCopy);
-        assertThat(second).isNotSameAs(first);
+        assertThat(second)
+                .isEqualTo(originalCopy)
+                .isNotSameAs(first);
     }
 
     @Test
@@ -127,8 +130,9 @@ class JwsTestUtilsTest {
         first[0] = (byte) 0xFF;
 
         byte[] second = validJwsUsingEcdsaJwkAndContentDetached();
-        assertThat(second).isEqualTo(originalCopy);
-        assertThat(second).isNotSameAs(first);
+        assertThat(second)
+                .isEqualTo(originalCopy)
+                .isNotSameAs(first);
     }
 
     @Test
@@ -144,8 +148,9 @@ class JwsTestUtilsTest {
         first[0] = (byte) 0xFF;
 
         byte[] second = validJwsUsingEcdsaJwkAndUnencodedContentDetached();
-        assertThat(second).isEqualTo(originalCopy);
-        assertThat(second).isNotSameAs(first);
+        assertThat(second)
+                .isEqualTo(originalCopy)
+                .isNotSameAs(first);
     }
 
     @Test
@@ -160,8 +165,9 @@ class JwsTestUtilsTest {
         first[0] = (byte) 0xFF;
 
         byte[] second = invalidJws();
-        assertThat(second).isEqualTo(originalCopy);
-        assertThat(second).isNotSameAs(first);
+        assertThat(second)
+                .isEqualTo(originalCopy)
+                .isNotSameAs(first);
     }
 
     private boolean isJwsWithDetachedContent(String jws) {


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

Refactor test assertions in `JwsTestUtilsTest` to use AssertJ assertion chaining, joining multiple assertions on the same subject into a single chain to satisfy SonarQube rule S5853.
### Additional Context

https://github.com/kroxylicious/kroxylicious/issues/3669

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
