### PR TITLE
Refactor RecordEncryptionIT to use shared KMS instance for all tests (rather than once per test).

### DIFF
--- a/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/encrypt/InBandEncryptionManagerTest.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/test/java/io/kroxylicious/filter/encryption/encrypt/InBandEncryptionManagerTest.java
@@ -74,6 +74,35 @@ class InBandEncryptionManagerTest {
     }
 
     @Test
+    void shouldGenerateOneDekForMultipleBatchesToSameTopic() {
+        // Given
+        InMemoryKms kms = getInMemoryKms();
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+        final DekManager<UUID, InMemoryEdek> dekManager = new DekManager<>(new AsyncKms<>(kms, executor), 10000);
+        EncryptionDekCache<UUID, InMemoryEdek> cache = new EncryptionDekCache<>(dekManager, executor, EncryptionDekCache.NO_MAX_CACHE_SIZE, Duration.ofHours(1),
+                Duration.ofHours(1));
+        var encryptionManager = createEncryptionManager(dekManager, cache, executor);
+        var kekId = kms.generateKey();
+
+        var value = new byte[]{ 1, 2, 3 };
+        Record record = RecordTestUtils.record(value);
+        List<Record> batch = List.of(record);
+
+        // When - send two batches to the same topic
+        CompletionStage<Void> firstBatch = doEncrypt(encryptionManager, "topic", 0, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)), batch,
+                new ArrayList<>());
+        CompletionStage<Void> secondBatch = doEncrypt(encryptionManager, "topic", 0, new EncryptionScheme<>(kekId, EnumSet.of(RecordField.RECORD_VALUE)), batch,
+                new ArrayList<>());
+
+        // Then - both succeed
+        assertThat(firstBatch).succeedsWithin(10, TimeUnit.SECONDS);
+        assertThat(secondBatch).succeedsWithin(10, TimeUnit.SECONDS);
+
+        // And only one DEK was generated (reused for both batches)
+        assertThat(kms.numDeksGenerated()).isEqualTo(1);
+    }
+
+    @Test
     void testGrowBufferCannotGrowBeyondMaximum() {
         ByteBuffer priorBuffer = ByteBuffer.allocate(2);
         assertThatThrownBy(() -> InBandEncryptionManager.growBuffer(priorBuffer, 2)).isInstanceOf(EncryptionException.class)

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/encryption/RecordEncryptionFilterIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/encryption/RecordEncryptionFilterIT.java
@@ -52,10 +52,8 @@ import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.coordinator.group.GroupConfig;
-import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.ThrowingConsumer;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.Parameter;
@@ -73,7 +71,6 @@ import io.kroxylicious.filter.encryption.config.UnresolvedKeyPolicy;
 import io.kroxylicious.filter.encryption.crypto.Encryption;
 import io.kroxylicious.filter.encryption.crypto.EncryptionHeader;
 import io.kroxylicious.filter.encryption.crypto.EncryptionResolver;
-import io.kroxylicious.kms.provider.kroxylicious.inmemory.InMemoryKms;
 import io.kroxylicious.kms.provider.kroxylicious.inmemory.InMemoryTestKmsFacade;
 import io.kroxylicious.kms.service.TestKmsFacade;
 import io.kroxylicious.kms.service.TestKmsFacadeFactory;
@@ -98,7 +95,6 @@ import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
-import static org.assertj.core.api.Assumptions.assumeThatCode;
 import static org.assertj.core.api.InstanceOfAssertFactories.BYTE_ARRAY;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.contains;
@@ -794,56 +790,6 @@ class RecordEncryptionFilterIT {
         finally {
             consumer.assign(List.of());
         }
-    }
-
-    // TODO express this test as a unit test and consider doing away with the test as the IT level.
-    // yeah that ^^^^^
-    @Test
-    @Disabled
-    void shouldGenerateOneDek(@TopicNameMethodSource Topic topic)
-            throws Exception {
-        assumeThatCode(testKmsFacade::getKms).doesNotThrowAnyException();
-        assertThat(testKmsFacade.getKms()).isInstanceOf(InMemoryKms.class);
-
-        var testKekManager = testKmsFacade.getTestKekManager();
-        testKekManager.generateKek(topic.name());
-
-        var builder = proxy(cluster);
-        NamedFilterDefinition namedFilterDefinition = buildEncryptionFilterDefinition(testKmsFacade, UnresolvedKeyPolicy.PASSTHROUGH_UNENCRYPTED);
-        builder.addToFilterDefinitions(namedFilterDefinition);
-        builder.addToDefaultFilters(namedFilterDefinition.name());
-
-        try (var tester = kroxyliciousTester(builder);
-                var producer = tester.producer(Map.of(ProducerConfig.LINGER_MS_CONFIG, 0));
-                var consumer = tester.consumer()) {
-
-            producer.send(new ProducerRecord<>(topic.name(), HELLO_WORLD)).get(5, TimeUnit.SECONDS);
-
-            consumer.subscribe(List.of(topic.name()));
-            var records = consumer.poll(Duration.ofSeconds(2));
-            assertThat(records.iterator())
-                    .toIterable()
-                    .singleElement()
-                    .extracting(ConsumerRecord::value)
-                    .isEqualTo(HELLO_WORLD);
-
-            // Send two batches to the same topic
-            var message = "hello world #2";
-            producer.send(new ProducerRecord<>(topic.name(), message)).get(5, TimeUnit.SECONDS);
-
-            consumer.subscribe(List.of(topic.name()));
-            records = consumer.poll(Duration.ofSeconds(2));
-            assertThat(records.iterator())
-                    .toIterable()
-                    .singleElement()
-                    .extracting(ConsumerRecord::value)
-                    .isEqualTo(message);
-        }
-
-        assertThat(testKmsFacade.getKms())
-                .asInstanceOf(InstanceOfAssertFactories.type(InMemoryKms.class))
-                .extracting(InMemoryKms::numDeksGenerated).isEqualTo(1);
-
     }
 
     @Test

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/encryption/RecordEncryptionFilterIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/encryption/RecordEncryptionFilterIT.java
@@ -89,7 +89,6 @@ import io.kroxylicious.testing.kafka.junit5ext.TopicNameMethodSource;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static io.kroxylicious.filter.encryption.RecordEncryptionMetrics.TOPIC_NAME;
-import static io.kroxylicious.kms.service.TestKmsFacadeInvocationContextProvider.FACADE_CLASS_NAME_FILTER;
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -113,11 +112,7 @@ class RecordEncryptionFilterIT {
     static Stream<? extends TestKmsFacade<?, ?, ?>> facadesSource() {
         // We rely on the fact that streams are lazy so the facade isn't built
         // or started until the first test needs it.
-        return TestKmsFacadeFactory.getTestKmsFacadeFactories()
-                // filter based on env var
-                .map(TestKmsFacadeFactory::build)
-                .filter(f -> FACADE_CLASS_NAME_FILTER.matcher(f.getClass().getName()).matches())
-                .filter(TestKmsFacade::isAvailable)
+        return TestKmsFacadeFactory.getAvailableTestKmsFacades()
                 .peek(TestKmsFacade::start);
     }
 
@@ -865,14 +860,8 @@ class RecordEncryptionFilterIT {
         }
     }
 
-<<<<<<< HEAD
-    @TestTemplate
-    void shareGroupConsumeFailsAfterKekDeleted(@TopicNameMethodSource Topic topic,
-                                               TestKmsFacade<?, ?, ?> testKmsFacade) {
-=======
     @Test
     void shareGroupConsumeFailsAfterKekDeleted(@TopicNameMethodSource Topic topic) {
->>>>>>> a7dc8dcb4 (refactor(ITs): Have RecordEncryptionIT share a single KMS instance)
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
 

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/encryption/RecordEncryptionFilterIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/encryption/RecordEncryptionFilterIT.java
@@ -55,9 +55,12 @@ import org.apache.kafka.coordinator.group.GroupConfig;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.ThrowingConsumer;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.Parameter;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.google.common.base.Strings;
 
@@ -73,7 +76,7 @@ import io.kroxylicious.filter.encryption.crypto.EncryptionResolver;
 import io.kroxylicious.kms.provider.kroxylicious.inmemory.InMemoryKms;
 import io.kroxylicious.kms.provider.kroxylicious.inmemory.InMemoryTestKmsFacade;
 import io.kroxylicious.kms.service.TestKmsFacade;
-import io.kroxylicious.kms.service.TestKmsFacadeInvocationContextProvider;
+import io.kroxylicious.kms.service.TestKmsFacadeFactory;
 import io.kroxylicious.proxy.config.NamedFilterDefinition;
 import io.kroxylicious.proxy.config.NamedFilterDefinitionBuilder;
 import io.kroxylicious.test.tester.SimpleMetricAssert;
@@ -89,18 +92,21 @@ import io.kroxylicious.testing.kafka.junit5ext.TopicNameMethodSource;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static io.kroxylicious.filter.encryption.RecordEncryptionMetrics.TOPIC_NAME;
+import static io.kroxylicious.kms.service.TestKmsFacadeInvocationContextProvider.FACADE_CLASS_NAME_FILTER;
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.proxy;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.kroxyliciousTester;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.assertj.core.api.Assumptions.assumeThatCode;
 import static org.assertj.core.api.InstanceOfAssertFactories.BYTE_ARRAY;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.contains;
 
 @ExtendWith(KafkaClusterExtension.class)
-@ExtendWith(TestKmsFacadeInvocationContextProvider.class)
 @ExtendWith(NettyLeakDetectorExtension.class)
+@ParameterizedClass(autoCloseArguments = true /* relied upon to close the facade */)
+@MethodSource("facadesSource")
 class RecordEncryptionFilterIT {
 
     private static final String TEMPLATE_KEK_SELECTOR_PATTERN = "$(topicName)";
@@ -108,11 +114,24 @@ class RecordEncryptionFilterIT {
     private static final String HELLO_SECRET = "hello secret";
     public static final String ENCRYPTION_SHARE_CONSUMER = "encryption-share-consumer";
 
+    static Stream<? extends TestKmsFacade<?, ?, ?>> facadesSource() {
+        // We rely on the fact that streams are lazy so the facade isn't built
+        // or started until the first test needs it.
+        return TestKmsFacadeFactory.getTestKmsFacadeFactories()
+                // filter based on env var
+                .map(TestKmsFacadeFactory::build)
+                .filter(f -> FACADE_CLASS_NAME_FILTER.matcher(f.getClass().getName()).matches())
+                .filter(TestKmsFacade::isAvailable)
+                .peek(TestKmsFacade::start);
+    }
+
     static KafkaCluster cluster;
 
-    @TestTemplate
-    void roundTripSingleRecord(@TopicNameMethodSource Topic topic,
-                               TestKmsFacade<?, ?, ?> testKmsFacade)
+    @Parameter
+    TestKmsFacade<?, ?, ?> testKmsFacade;
+
+    @Test
+    void roundTripSingleRecord(@TopicNameMethodSource Topic topic)
             throws Exception {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
@@ -139,9 +158,8 @@ class RecordEncryptionFilterIT {
         }
     }
 
-    @TestTemplate
-    void roundTripShareGroup(@TopicNameMethodSource Topic topic,
-                             TestKmsFacade<?, ?, ?> testKmsFacade)
+    @Test
+    void roundTripShareGroup(@TopicNameMethodSource Topic topic)
             throws Exception {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
@@ -179,10 +197,9 @@ class RecordEncryptionFilterIT {
 
     // Covers a bug, #2504, where large record batches failed to be encrypted. This occurred when the encrypted output for a record batch exceeded
     // io.kroxylicious.filter.encryption.config.RecordEncryptionConfig#RECORD_BUFFER_DEFAULT_INITIAL_BYTES
-    @TestTemplate
+    @Test
     void roundTripBigRecord(@BrokerConfig(name = "message.max.bytes", value = "2000000") @Name("bigRecordCluster") KafkaCluster cluster,
-                            @Name("bigRecordCluster") @TopicNameMethodSource Topic topic,
-                            TestKmsFacade<?, ?, ?> testKmsFacade)
+                            @Name("bigRecordCluster") @TopicNameMethodSource Topic topic)
             throws Exception {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
@@ -210,9 +227,8 @@ class RecordEncryptionFilterIT {
         }
     }
 
-    @TestTemplate
-    void roundTripTransactional(@TopicNameMethodSource Topic topic,
-                                TestKmsFacade<?, ?, ?> testKmsFacade) {
+    @Test
+    void roundTripTransactional(@TopicNameMethodSource Topic topic) {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
 
@@ -242,9 +258,8 @@ class RecordEncryptionFilterIT {
     }
 
     // check that records from aborted transaction are not exposed to read_committed clients
-    @TestTemplate
-    void roundTripTransactionalAbort(@TopicNameMethodSource Topic topic,
-                                     TestKmsFacade<?, ?, ?> testKmsFacade) {
+    @Test
+    void roundTripTransactionalAbort(@TopicNameMethodSource Topic topic) {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
 
@@ -281,9 +296,8 @@ class RecordEncryptionFilterIT {
     }
 
     // check that records from uncommitted transaction are not exposed to read_committed clients
-    @TestTemplate
-    void roundTripTransactionalIsolation(@TopicNameMethodSource Topic topic,
-                                         TestKmsFacade<?, ?, ?> testKmsFacade) {
+    @Test
+    void roundTripTransactionalIsolation(@TopicNameMethodSource Topic topic) {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
 
@@ -322,9 +336,8 @@ class RecordEncryptionFilterIT {
         return producer;
     }
 
-    @TestTemplate
-    void roundTripManyRecordsFromDifferentProducers(@TopicNameMethodSource Topic topic,
-                                                    TestKmsFacade<?, ?, ?> testKmsFacade)
+    @Test
+    void roundTripManyRecordsFromDifferentProducers(@TopicNameMethodSource Topic topic)
             throws Exception {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
@@ -358,9 +371,8 @@ class RecordEncryptionFilterIT {
 
     // EDEKs can be configured with a time-based expiry. This gives us the nice property that after a KEK is rotated
     // in the external KMS a new EDEK will be generated using the new key.
-    @TestTemplate
+    @Test
     void edekExpiry(@TopicNameMethodSource Topic topic,
-                    TestKmsFacade<?, ?, ?> testKmsFacade,
                     @ClientConfig(name = ConsumerConfig.GROUP_ID_CONFIG, value = "rotation-test") KafkaConsumer<byte[], byte[]> directConsumer)
             throws Exception {
         var testKekManager = testKmsFacade.getTestKekManager();
@@ -397,10 +409,11 @@ class RecordEncryptionFilterIT {
     }
 
     @Test
-    void failedEncryptionRespondsWithError(@TopicNameMethodSource Topic topic,
-                                           InMemoryTestKmsFacade testKmsFacade)
+    void failedEncryptionRespondsWithError(@TopicNameMethodSource Topic topic)
             throws Exception {
-        var testKekManager = testKmsFacade.getTestKekManager();
+        assumeThat(testKmsFacade).isInstanceOf(InMemoryTestKmsFacade.class);
+        var inMemoryFacade = (InMemoryTestKmsFacade) testKmsFacade;
+        var testKekManager = inMemoryFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
 
         var builder = proxy(cluster);
@@ -408,8 +421,8 @@ class RecordEncryptionFilterIT {
         Duration edekExpiry = Duration.ofSeconds(1);
         NamedFilterDefinitionBuilder filterDefinitionBuilder = new NamedFilterDefinitionBuilder("encrypt", RecordEncryption.class.getSimpleName());
         builder.addToFilterDefinitions(filterDefinitionBuilder
-                .withConfig("kms", testKmsFacade.getKmsServiceClass().getSimpleName())
-                .withConfig("kmsConfig", testKmsFacade.getKmsServiceConfig())
+                .withConfig("kms", inMemoryFacade.getKmsServiceClass().getSimpleName())
+                .withConfig("kmsConfig", inMemoryFacade.getKmsServiceConfig())
                 .withConfig("experimental", Map.of(
                         "encryptionDekRefreshAfterWriteSeconds", edekExpiry.toSeconds(),
                         "maxEncryptionsPerDek", 1))
@@ -467,9 +480,8 @@ class RecordEncryptionFilterIT {
     }
 
     // This ensures the decrypt-ability guarantee, post kek rotation
-    @TestTemplate
-    void decryptionAfterKekRotation(@TopicNameMethodSource Topic topic,
-                                    TestKmsFacade<?, ?, ?> testKmsFacade)
+    @Test
+    void decryptionAfterKekRotation(@TopicNameMethodSource Topic topic)
             throws Exception {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
@@ -501,10 +513,9 @@ class RecordEncryptionFilterIT {
         }
     }
 
-    @TestTemplate
+    @Test
     void topicRecordsAreUnreadableOnServer(@TopicNameMethodSource Topic topic,
-                                           KafkaConsumer<String, String> directConsumer,
-                                           TestKmsFacade<?, ?, ?> testKmsFacade)
+                                           KafkaConsumer<String, String> directConsumer)
             throws Exception {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
@@ -532,10 +543,9 @@ class RecordEncryptionFilterIT {
         }
     }
 
-    @TestTemplate
+    @Test
     void unencryptedRecordsConsumable(KafkaProducer<String, String> directProducer,
-                                      @TopicNameMethodSource Topic topic,
-                                      TestKmsFacade<?, ?, ?> testKmsFacade)
+                                      @TopicNameMethodSource Topic topic)
             throws Exception {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
@@ -564,10 +574,9 @@ class RecordEncryptionFilterIT {
         }
     }
 
-    @TestTemplate
+    @Test
     void unencryptedRecordsConsumableByShareConsumer(KafkaProducer<String, String> directProducer,
-                                                     @TopicNameMethodSource Topic topic,
-                                                     TestKmsFacade<?, ?, ?> testKmsFacade)
+                                                     @TopicNameMethodSource Topic topic)
             throws Exception {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
@@ -600,10 +609,9 @@ class RecordEncryptionFilterIT {
         }
     }
 
-    @TestTemplate
+    @Test
     void nullValueRecordProducedAndConsumedSuccessfully(@ClientConfig(name = ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, value = "earliest") @ClientConfig(name = ConsumerConfig.GROUP_ID_CONFIG, value = "test") Consumer<String, String> directConsumer,
-                                                        @TopicNameMethodSource Topic topic,
-                                                        TestKmsFacade<?, ?, ?> testKmsFacade)
+                                                        @TopicNameMethodSource Topic topic)
             throws Exception {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
@@ -626,10 +634,9 @@ class RecordEncryptionFilterIT {
         }
     }
 
-    @TestTemplate
+    @Test
     void nullValueRecordProducedAndConsumedSuccessfullyByShareConsumer(@ClientConfig(name = ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, value = "earliest") @ClientConfig(name = ConsumerConfig.GROUP_ID_CONFIG, value = "test") Consumer<String, String> directConsumer,
-                                                                       @TopicNameMethodSource Topic topic,
-                                                                       TestKmsFacade<?, ?, ?> testKmsFacade)
+                                                                       @TopicNameMethodSource Topic topic)
             throws Exception {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
@@ -666,10 +673,9 @@ class RecordEncryptionFilterIT {
         });
     }
 
-    @TestTemplate
+    @Test
     void produceAndConsumeEncryptedAndPlainTopicsAtSameTime(@TopicNameMethodSource Topic encryptedTopic,
-                                                            @TopicNameMethodSource Topic plainTopic,
-                                                            TestKmsFacade<?, ?, ?> testKmsFacade) {
+                                                            @TopicNameMethodSource Topic plainTopic) {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(encryptedTopic.name());
 
@@ -695,10 +701,9 @@ class RecordEncryptionFilterIT {
         }
     }
 
-    @TestTemplate
+    @Test
     void userCanChooseToRejectRecordsWhichWeCannotResolveKeysFor(@TopicNameMethodSource Topic encryptedTopic,
-                                                                 @TopicNameMethodSource Topic plainTopic,
-                                                                 TestKmsFacade<?, ?, ?> testKmsFacade) {
+                                                                 @TopicNameMethodSource Topic plainTopic) {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(encryptedTopic.name());
 
@@ -724,15 +729,13 @@ class RecordEncryptionFilterIT {
      * @param cluster underlying kafka cluster
      * @param compactedTopic topic configured for compaction.
      * @param directConsumer consumer connected directly to the underlying kafka cluster
-     * @param testKmsFacade kms facade
      * @throws Exception exception
      */
-    @TestTemplate
+    @Test
     @SuppressWarnings("java:S2925")
     void offsetFidelity(@BrokerConfig(name = "log.cleaner.backoff.ms", value = "50") @Name("compactionCluster") KafkaCluster cluster,
                         @Name("compactionCluster") @TopicNameMethodSource @TopicConfig(name = "segment.ms", value = "125") @TopicConfig(name = "cleanup.policy", value = "compact") Topic compactedTopic,
-                        @Name("compactionCluster") Consumer<String, String> directConsumer,
-                        TestKmsFacade<?, ?, ?> testKmsFacade)
+                        @Name("compactionCluster") Consumer<String, String> directConsumer)
             throws Exception {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(compactedTopic.name());
@@ -794,9 +797,10 @@ class RecordEncryptionFilterIT {
     }
 
     // TODO express this test as a unit test and consider doing away with the test as the IT level.
-    @TestTemplate
-    void shouldGenerateOneDek(@TopicNameMethodSource Topic topic,
-                              TestKmsFacade<?, ?, ?> testKmsFacade)
+    // yeah that ^^^^^
+    @Test
+    @Disabled
+    void shouldGenerateOneDek(@TopicNameMethodSource Topic topic)
             throws Exception {
         assumeThatCode(testKmsFacade::getKms).doesNotThrowAnyException();
         assertThat(testKmsFacade.getKms()).isInstanceOf(InMemoryKms.class);
@@ -842,10 +846,9 @@ class RecordEncryptionFilterIT {
 
     }
 
-    @TestTemplate
+    @Test
     void checkMetricsIncrementedOnEncryptedAndPlainTopic(@TopicNameMethodSource Topic encryptedTopic,
-                                                         @TopicNameMethodSource Topic plainTopic,
-                                                         TestKmsFacade<?, ?, ?> testKmsFacade) {
+                                                         @TopicNameMethodSource Topic plainTopic) {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(encryptedTopic.name());
 
@@ -887,9 +890,8 @@ class RecordEncryptionFilterIT {
         }
     }
 
-    @TestTemplate
-    void consumeFailsAfterKekDeleted(@TopicNameMethodSource Topic topic,
-                                     TestKmsFacade<?, ?, ?> testKmsFacade) {
+    @Test
+    void consumeFailsAfterKekDeleted(@TopicNameMethodSource Topic topic) {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
 
@@ -917,9 +919,14 @@ class RecordEncryptionFilterIT {
         }
     }
 
+<<<<<<< HEAD
     @TestTemplate
     void shareGroupConsumeFailsAfterKekDeleted(@TopicNameMethodSource Topic topic,
                                                TestKmsFacade<?, ?, ?> testKmsFacade) {
+=======
+    @Test
+    void shareGroupConsumeFailsAfterKekDeleted(@TopicNameMethodSource Topic topic) {
+>>>>>>> a7dc8dcb4 (refactor(ITs): Have RecordEncryptionIT share a single KMS instance)
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(topic.name());
 
@@ -953,10 +960,9 @@ class RecordEncryptionFilterIT {
     /**
      * This test ensures that the topic that has suffered the failure to decrypt is the one reported to the client.
      */
-    @TestTemplate
+    @Test
     void consumeFailsForOneTopicOnlyAfterKekDeleted(@TopicNameMethodSource Topic lostKekTopic,
-                                                    @TopicNameMethodSource Topic otherTopic,
-                                                    TestKmsFacade<?, ?, ?> testKmsFacade) {
+                                                    @TopicNameMethodSource Topic otherTopic) {
         var testKekManager = testKmsFacade.getTestKekManager();
         testKekManager.generateKek(lostKekTopic.name());
         testKekManager.generateKek(otherTopic.name());

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/encryption/RecordEncryptionFilterIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/encryption/RecordEncryptionFilterIT.java
@@ -112,7 +112,9 @@ class RecordEncryptionFilterIT {
     static Stream<? extends TestKmsFacade<?, ?, ?>> facadesSource() {
         // We rely on the fact that streams are lazy so the facade isn't built
         // or started until the first test needs it.
-        return TestKmsFacadeFactory.getAvailableTestKmsFacades()
+        return TestKmsFacadeFactory.getTestKmsFacadeFactories()
+                .map(TestKmsFacadeFactory::build)
+                .filter(TestKmsFacade::isAvailable)
                 .peek(TestKmsFacade::start);
     }
 

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm/DEV_GUIDE.md
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-fortanix-dsm/DEV_GUIDE.md
@@ -15,7 +15,7 @@ If you don't have a Fortanix DSM SaaS account, create a trial account.   Create 
 It is the former that we use.   Copy the single string "API Key".  Use those values to set the two API_KEY environment variables.
 
 Once you've done these steps you can run the io.kroxylicious.it.kms.service.KmsIT and io.kroxylicious.it.filter.encryption.RecordEncryptionFilterIT.
-The integration test will execute the Fortanix KMS integration. You can set `KROXYLICIOUS_KMS_FACADE_CLASS_NAME_FILTER` to `.*Fortanix.*` so that
+The integration test will execute the Fortanix KMS integration. You can set `KROXYLICIOUS_KMS_FACADE_FACTORY_CLASS_NAME_FILTER` to `.*Fortanix.*` so that
 only the integrations for the other KMS providers are skipped.
 
 ## CLI

--- a/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKmsFacadeFactory.java
+++ b/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKmsFacadeFactory.java
@@ -6,16 +6,31 @@
 
 package io.kroxylicious.kms.service;
 
+import java.util.Optional;
 import java.util.ServiceLoader;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 /**
  * Factory for {@link TestKmsFacade}s.
+ * <br/>
+ * The {@code KROXYLICIOUS_KMS_FACADE_CLASS_NAME_FILTER} environment variable is a regular expression
+ * that limits the facades available to tests. It matches against the facade class name.
+ * If not set, all available facades are used.
+ *
  * @param <C> The config type
  * @param <K> The key reference
  * @param <E> The type of encrypted DEK
  */
 public interface TestKmsFacadeFactory<C, K, E> {
+
+    /**
+     * Pattern used to filter facades based on the {@code KROXYLICIOUS_KMS_FACADE_CLASS_NAME_FILTER} environment variable.
+     * Defaults to matching all class names if the environment variable is not set.
+     */
+    Pattern FACADE_CLASS_NAME_FILTER = Optional.ofNullable(System.getenv("KROXYLICIOUS_KMS_FACADE_CLASS_NAME_FILTER"))
+            .map(Pattern::compile)
+            .orElse(Pattern.compile(".*"));
 
     /**
      * Creates a TestKmsFacade instance
@@ -33,5 +48,18 @@ public interface TestKmsFacadeFactory<C, K, E> {
     static <C, K, E> Stream<TestKmsFacadeFactory<C, K, E>> getTestKmsFacadeFactories() {
         return ServiceLoader.load(TestKmsFacadeFactory.class).stream()
                 .map(ServiceLoader.Provider::get);
+    }
+
+    /**
+     * Discovers and builds available {@link TestKmsFacade}s, filtered by the
+     * {@code KROXYLICIOUS_KMS_FACADE_CLASS_NAME_FILTER} environment variable and availability.
+     *
+     * @return stream of available test KMS facades
+     */
+    static Stream<? extends TestKmsFacade<?, ?, ?>> getAvailableTestKmsFacades() {
+        return getTestKmsFacadeFactories()
+                .map(TestKmsFacadeFactory::build)
+                .filter(f -> FACADE_CLASS_NAME_FILTER.matcher(f.getClass().getName()).matches())
+                .filter(TestKmsFacade::isAvailable);
     }
 }

--- a/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKmsFacadeFactory.java
+++ b/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKmsFacadeFactory.java
@@ -14,8 +14,8 @@ import java.util.stream.Stream;
 /**
  * Factory for {@link TestKmsFacade}s.
  * <br/>
- * The {@code KROXYLICIOUS_KMS_FACADE_CLASS_NAME_FILTER} environment variable is a regular expression
- * that limits the facades available to tests. It matches against the facade class name.
+ * The {@code KROXYLICIOUS_KMS_FACADE_FACTORY_CLASS_NAME_FILTER} environment variable is a regular expression
+ * that limits the facades available to tests. It matches against the facade factory class name.
  * If not set, all available facades are used.
  *
  * @param <C> The config type
@@ -24,11 +24,13 @@ import java.util.stream.Stream;
  */
 public interface TestKmsFacadeFactory<C, K, E> {
 
+    /** Name of the environment variable used for facade factory filtering. */
+    String FACADE_FACTORY_CLASS_NAME_FILTER_ENV_VAR = "KROXYLICIOUS_KMS_FACADE_FACTORY_CLASS_NAME_FILTER";
     /**
-     * Pattern used to filter facades based on the {@code KROXYLICIOUS_KMS_FACADE_CLASS_NAME_FILTER} environment variable.
+     * Pattern used to filter facade factories based on the {@code KROXYLICIOUS_KMS_FACADE_FACTORY_CLASS_NAME_FILTER} environment variable.
      * Defaults to matching all class names if the environment variable is not set.
      */
-    Pattern FACADE_CLASS_NAME_FILTER = Optional.ofNullable(System.getenv("KROXYLICIOUS_KMS_FACADE_CLASS_NAME_FILTER"))
+    Pattern FACADE_FACTORY_CLASS_NAME_FILTER = Optional.ofNullable(System.getenv(FACADE_FACTORY_CLASS_NAME_FILTER_ENV_VAR))
             .map(Pattern::compile)
             .orElse(Pattern.compile(".*"));
 
@@ -46,20 +48,9 @@ public interface TestKmsFacadeFactory<C, K, E> {
      */
     @SuppressWarnings("unchecked")
     static <C, K, E> Stream<TestKmsFacadeFactory<C, K, E>> getTestKmsFacadeFactories() {
-        return ServiceLoader.load(TestKmsFacadeFactory.class).stream()
-                .map(ServiceLoader.Provider::get);
+        return (Stream<TestKmsFacadeFactory<C, K, E>>) (Stream<?>) ServiceLoader.load(TestKmsFacadeFactory.class).stream()
+                .map(ServiceLoader.Provider::get)
+                .filter(f -> FACADE_FACTORY_CLASS_NAME_FILTER.matcher(f.getClass().getName()).matches());
     }
 
-    /**
-     * Discovers and builds available {@link TestKmsFacade}s, filtered by the
-     * {@code KROXYLICIOUS_KMS_FACADE_CLASS_NAME_FILTER} environment variable and availability.
-     *
-     * @return stream of available test KMS facades
-     */
-    static Stream<? extends TestKmsFacade<?, ?, ?>> getAvailableTestKmsFacades() {
-        return getTestKmsFacadeFactories()
-                .map(TestKmsFacadeFactory::build)
-                .filter(f -> FACADE_CLASS_NAME_FILTER.matcher(f.getClass().getName()).matches())
-                .filter(TestKmsFacade::isAvailable);
-    }
 }

--- a/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKmsFacadeInvocationContextProvider.java
+++ b/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKmsFacadeInvocationContextProvider.java
@@ -8,9 +8,7 @@ package io.kroxylicious.kms.service;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -29,17 +27,11 @@ import org.junit.jupiter.api.extension.support.TypeBasedParameterResolver;
 
 /**
  * Junit Context Provider providing available {@link TestKmsFacade}s to integration tests.
- * <br/>
- * The variable {@code KROXYLICIOUS_KMS_FACADE_CLASS_NAME_FILTER} is a regular expression that limits the facades available
- * to the test.  It matches against the facade class name.
  */
 public class TestKmsFacadeInvocationContextProvider implements TestTemplateInvocationContextProvider, ParameterResolver {
 
     private static final ExtensionContext.Namespace STORE_NAMESPACE = ExtensionContext.Namespace.create("TEST_KMS");
     private static final String FACADE_FACTORIES = "KMS_FACADE_FACTORIES";
-
-    public static final Pattern FACADE_CLASS_NAME_FILTER = Optional.ofNullable(System.getenv("KROXYLICIOUS_KMS_FACADE_CLASS_NAME_FILTER")).map(Pattern::compile)
-            .orElse(Pattern.compile(".*"));
 
     @Override
     public boolean supportsTestTemplate(ExtensionContext context) {
@@ -51,7 +43,6 @@ public class TestKmsFacadeInvocationContextProvider implements TestTemplateInvoc
         return getTestKmsFacadeStream(context)
                 .values()
                 .stream()
-                .filter(f -> FACADE_CLASS_NAME_FILTER.matcher(f.getClass().getName()).matches())
                 .map(TemplateInvocationContext::new);
     }
 
@@ -77,14 +68,12 @@ public class TestKmsFacadeInvocationContextProvider implements TestTemplateInvoc
     @SuppressWarnings("unchecked")
     private static Map<Class<TestKmsFacade<?, ?, ?>>, TestKmsFacade<?, ?, ?>> getTestKmsFacadeStream(ExtensionContext extensionContext) {
         final ExtensionContext.Store store = extensionContext.getStore(STORE_NAMESPACE);
-        return store.getOrComputeIfAbsent(FACADE_FACTORIES, key -> TestKmsFacadeFactory.getTestKmsFacadeFactories()
-                .map(TestKmsFacadeFactory::build)
+        return store.getOrComputeIfAbsent(FACADE_FACTORIES, key -> TestKmsFacadeFactory.getAvailableTestKmsFacades()
                 .collect(
                         Collectors.toMap(
                                 Object::getClass,
-                                Function.identity()
-
-                        )), Map.class);
+                                Function.identity())),
+                Map.class);
     }
 
     private record TemplateInvocationContext(TestKmsFacade<?, ?, ?> kmsFacade) implements TestTemplateInvocationContext {

--- a/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKmsFacadeInvocationContextProvider.java
+++ b/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKmsFacadeInvocationContextProvider.java
@@ -38,7 +38,7 @@ public class TestKmsFacadeInvocationContextProvider implements TestTemplateInvoc
     private static final ExtensionContext.Namespace STORE_NAMESPACE = ExtensionContext.Namespace.create("TEST_KMS");
     private static final String FACADE_FACTORIES = "KMS_FACADE_FACTORIES";
 
-    private static final Pattern FACADE_CLASS_NAME_FILTER = Optional.ofNullable(System.getenv("KROXYLICIOUS_KMS_FACADE_CLASS_NAME_FILTER")).map(Pattern::compile)
+    public static final Pattern FACADE_CLASS_NAME_FILTER = Optional.ofNullable(System.getenv("KROXYLICIOUS_KMS_FACADE_CLASS_NAME_FILTER")).map(Pattern::compile)
             .orElse(Pattern.compile(".*"));
 
     @Override

--- a/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKmsFacadeInvocationContextProvider.java
+++ b/kroxylicious-kms-test-support/src/main/java/io/kroxylicious/kms/service/TestKmsFacadeInvocationContextProvider.java
@@ -68,7 +68,9 @@ public class TestKmsFacadeInvocationContextProvider implements TestTemplateInvoc
     @SuppressWarnings("unchecked")
     private static Map<Class<TestKmsFacade<?, ?, ?>>, TestKmsFacade<?, ?, ?>> getTestKmsFacadeStream(ExtensionContext extensionContext) {
         final ExtensionContext.Store store = extensionContext.getStore(STORE_NAMESPACE);
-        return store.getOrComputeIfAbsent(FACADE_FACTORIES, key -> TestKmsFacadeFactory.getAvailableTestKmsFacades()
+        return store.getOrComputeIfAbsent(FACADE_FACTORIES, key -> ((Stream<? extends TestKmsFacade<?, ?, ?>>) TestKmsFacadeFactory.getTestKmsFacadeFactories()
+                .map(TestKmsFacadeFactory::build)
+                .filter(TestKmsFacade::isAvailable))
                 .collect(
                         Collectors.toMap(
                                 Object::getClass,


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

Have RecordEncryptionITs share the KMS, rather creating a new KMS instance per test (creating a new KMS normally involves creating a KMS within a container (such as LocalStack)).  This approach save a significant amount of time.

On my box ~600 seconds (after #3678) -> ~180seconds

It does that that encryption keys may remain in the KMS between tests.  We tend to create key names based on topic names (which are randomized per test), so this shouldn't be problematic.


Tests run like this:

```
for all kms test facades
  start kms
  start broker
  run all tests
  stop broker
  stop kms
``` 

you can see that within the IDE:

<img width="1409" height="534" alt="Screenshot 2026-04-10 at 14 48 07" src="https://github.com/user-attachments/assets/dd642997-4e46-4a95-8f06-000ba8c04dbd" />



### Additional Context

The approach _should_ (unverified) apply to the KmsIT and the RecordEncryptionST too 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
