### PR TITLE
fix: combine AssertJ assertions into chains in JwsTestUtilsTest (S5853)

### DIFF
--- a/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/jws/JwsTestUtilsTest.java
+++ b/kroxylicious-filter-test-support/src/test/java/io/kroxylicious/test/jws/JwsTestUtilsTest.java
@@ -33,8 +33,9 @@ class JwsTestUtilsTest {
     void generateJwsGeneratesValidEcdsaJws() {
         String jws = generateJws(ECDSA_SIGN_JWKS, VALID_JWS_USING_ECDSA_JWK_PAYLOAD, false, false);
 
-        assertThat(jws).isNotEmpty();
-        assertThat(isJsonObject(jws)).isTrue();
+        assertThat(jws)
+                .isNotEmpty()
+                .matches(this::isJsonObject);
     }
 
     @Test
@@ -43,9 +44,10 @@ class JwsTestUtilsTest {
                 true,
                 false);
 
-        assertThat(jws).isNotEmpty();
-        assertThat(isJsonObject(jws)).isTrue();
-        assertThat(isJwsWithDetachedContent(jws)).isTrue();
+        assertThat(jws)
+                .isNotEmpty()
+                .matches(this::isJsonObject)
+                .matches(this::isJwsWithDetachedContent);
     }
 
     @Test
@@ -53,9 +55,10 @@ class JwsTestUtilsTest {
         String jws = generateJws(ECDSA_SIGN_JWKS,
                 VALID_JWS_USING_ECDSA_JWK_AND_UNENCODED_CONTENT_DETACHED_PAYLOAD, true, true);
 
-        assertThat(jws).isNotEmpty();
-        assertThat(isJsonObject(jws)).isTrue();
-        assertThat(isJwsWithDetachedContent(jws)).isTrue();
+        assertThat(jws)
+                .isNotEmpty()
+                .matches(this::isJsonObject)
+                .matches(this::isJwsWithDetachedContent);
     }
 
     @Test
@@ -123,8 +126,9 @@ class JwsTestUtilsTest {
         assertThat(first).isNotNull();
 
         String jwsString = new String(first, StandardCharsets.UTF_8);
-        assertThat(isJwsWithDetachedContent(jwsString)).isTrue();
-        assertThat(startsWithBase64JsonObject(jwsString)).isTrue();
+        assertThat(jwsString)
+                .matches(this::isJwsWithDetachedContent)
+                .matches(this::startsWithBase64JsonObject);
 
         byte[] originalCopy = first.clone();
         first[0] = (byte) 0xFF;
@@ -141,8 +145,9 @@ class JwsTestUtilsTest {
         assertThat(first).isNotNull();
 
         String jwsString = new String(first, StandardCharsets.UTF_8);
-        assertThat(isJwsWithDetachedContent(jwsString)).isTrue();
-        assertThat(startsWithBase64JsonObject(jwsString)).isTrue();
+        assertThat(jwsString)
+                .matches(this::isJwsWithDetachedContent)
+                .matches(this::startsWithBase64JsonObject);
 
         byte[] originalCopy = first.clone();
         first[0] = (byte) 0xFF;


### PR DESCRIPTION
## Summary

Combines multiple AssertJ assertions on the same subject into single assertion chains in `JwsTestUtilsTest`, resolving Sonar rule S5853.

## Changes

- `assertThat(jws)`: chained `.isNotEmpty().matches(this::isJsonObject)` (and `.matches(this::isJwsWithDetachedContent)` where applicable)
- `assertThat(jwsString)`: chained `.matches(this::isJwsWithDetachedContent).matches(this::startsWithBase64JsonObject)`
- `assertThat(second)`: chained `.isEqualTo(originalCopy).isNotSameAs(first)` across all defensive copy tests

## Why

Assertion chains:
- Provide better error messages when failures occur (the context is preserved)
- Make the logical relationship between assertions explicit
- Use AssertJ as intended per best practices

Closes #3669