### PR TITLE
fix(tests): remove superfluous throws declarations in integration tests (S1130)

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/FindCoordinatorGroupAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/FindCoordinatorGroupAuthzIT.java
@@ -12,7 +12,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.producer.Producer;
@@ -96,8 +95,7 @@ class FindCoordinatorGroupAuthzIT extends AuthzIT {
     void prepClusters(
                       @Name("kafkaClusterWithAuthz") @ClientConfig(name = ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, value = "org.apache.kafka.common.serialization.StringSerializer") @ClientConfig(name = ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, value = "org.apache.kafka.common.serialization.StringSerializer") Producer kafkaClusterWithAuthzProducer,
 
-                      @Name("kafkaClusterNoAuthz") @ClientConfig(name = ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, value = "org.apache.kafka.common.serialization.StringSerializer") @ClientConfig(name = ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, value = "org.apache.kafka.common.serialization.StringSerializer") Producer kafkaClusterNoAuthzProducer)
-            throws InterruptedException, ExecutionException {
+                      @Name("kafkaClusterNoAuthz") @ClientConfig(name = ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, value = "org.apache.kafka.common.serialization.StringSerializer") @ClientConfig(name = ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, value = "org.apache.kafka.common.serialization.StringSerializer") Producer kafkaClusterNoAuthzProducer) {
         prepCluster(kafkaClusterWithAuthz, ALL_TOPICS_IN_TEST, aclBindings);
         prepCluster(kafkaClusterNoAuthz, ALL_TOPICS_IN_TEST, List.of());
     }

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/FindCoordinatorTransactionalIdAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/FindCoordinatorTransactionalIdAuthzIT.java
@@ -12,7 +12,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.producer.Producer;
@@ -106,8 +105,7 @@ class FindCoordinatorTransactionalIdAuthzIT extends AuthzIT {
     void prepClusters(
                       @Name("kafkaClusterWithAuthz") @ClientConfig(name = ProducerConfig.TRANSACTIONAL_ID_CONFIG, value = TXN_COORDINATOR_OBSERVER) @ClientConfig(name = ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, value = "org.apache.kafka.common.serialization.StringSerializer") @ClientConfig(name = ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, value = "org.apache.kafka.common.serialization.StringSerializer") Producer kafkaClusterWithAuthzProducer,
 
-                      @Name("kafkaClusterNoAuthz") @ClientConfig(name = ProducerConfig.TRANSACTIONAL_ID_CONFIG, value = TXN_COORDINATOR_OBSERVER) @ClientConfig(name = ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, value = "org.apache.kafka.common.serialization.StringSerializer") @ClientConfig(name = ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, value = "org.apache.kafka.common.serialization.StringSerializer") Producer kafkaClusterNoAuthzProducer)
-            throws InterruptedException, ExecutionException {
+                      @Name("kafkaClusterNoAuthz") @ClientConfig(name = ProducerConfig.TRANSACTIONAL_ID_CONFIG, value = TXN_COORDINATOR_OBSERVER) @ClientConfig(name = ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, value = "org.apache.kafka.common.serialization.StringSerializer") @ClientConfig(name = ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, value = "org.apache.kafka.common.serialization.StringSerializer") Producer kafkaClusterNoAuthzProducer) {
         prepCluster(kafkaClusterWithAuthz, ALL_TOPICS_IN_TEST, aclBindings);
         prepCluster(kafkaClusterNoAuthz, ALL_TOPICS_IN_TEST, List.of());
         ensureCoordinators(kafkaClusterWithAuthzProducer, TXN_COORDINATOR_OBSERVER, kafkaClusterWithAuthzAdmin);

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/InitProducerIdAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/InitProducerIdAuthzIT.java
@@ -12,7 +12,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.producer.Producer;
@@ -96,8 +95,7 @@ class InitProducerIdAuthzIT extends AuthzIT {
     void prepClusters(
                       @Name("kafkaClusterWithAuthz") @ClientConfig(name = ProducerConfig.TRANSACTIONAL_ID_CONFIG, value = TXN_COORDINATOR_OBSERVER) @ClientConfig(name = ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, value = "org.apache.kafka.common.serialization.StringSerializer") @ClientConfig(name = ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, value = "org.apache.kafka.common.serialization.StringSerializer") Producer kafkaClusterWithAuthzProducer,
 
-                      @Name("kafkaClusterNoAuthz") @ClientConfig(name = ProducerConfig.TRANSACTIONAL_ID_CONFIG, value = TXN_COORDINATOR_OBSERVER) @ClientConfig(name = ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, value = "org.apache.kafka.common.serialization.StringSerializer") @ClientConfig(name = ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, value = "org.apache.kafka.common.serialization.StringSerializer") Producer kafkaClusterNoAuthzProducer)
-            throws InterruptedException, ExecutionException {
+                      @Name("kafkaClusterNoAuthz") @ClientConfig(name = ProducerConfig.TRANSACTIONAL_ID_CONFIG, value = TXN_COORDINATOR_OBSERVER) @ClientConfig(name = ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, value = "org.apache.kafka.common.serialization.StringSerializer") @ClientConfig(name = ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, value = "org.apache.kafka.common.serialization.StringSerializer") Producer kafkaClusterNoAuthzProducer) {
         prepCluster(kafkaClusterWithAuthz, ALL_TOPICS_IN_TEST, aclBindings);
         prepCluster(kafkaClusterNoAuthz, ALL_TOPICS_IN_TEST, List.of());
         ensureCoordinators(kafkaClusterWithAuthzProducer, TXN_COORDINATOR_OBSERVER, kafkaClusterWithAuthzAdmin);

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/ProduceAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/ProduceAuthzIT.java
@@ -259,7 +259,7 @@ class ProduceAuthzIT extends AuthzIT {
 
     @ParameterizedTest
     @MethodSource
-    void shouldEnforceAccessToTopics(VersionSpecificVerification<ProduceRequestData, ProduceResponseData> test) throws IOException {
+    void shouldEnforceAccessToTopics(VersionSpecificVerification<ProduceRequestData, ProduceResponseData> test) {
 
         try (var referenceCluster = new ReferenceCluster(kafkaClusterWithAuthz, this.topicIdsInUnproxiedCluster);
                 var proxiedCluster = new ProxiedCluster(kafkaClusterNoAuthz, this.topicIdsInProxiedCluster, rulesFile)) {


### PR DESCRIPTION
## Summary

Fixes #3670

Removes unnecessary checked exception declarations from test method signatures where those exceptions cannot actually be thrown, as flagged by SonarLint rule S1130.

**Changes:**

- `ProduceAuthzIT#shouldEnforceAccessToTopics` — removed `throws IOException`
- `FindCoordinatorGroupAuthzIT#prepClusters` — removed `throws InterruptedException, ExecutionException`
- `FindCoordinatorTransactionalIdAuthzIT#prepClusters` — same
- `InitProducerIdAuthzIT#prepClusters` — same

Also removed the now-unused `java.util.concurrent.ExecutionException` import from the three coordinator test files.

## Test plan

- [ ] Existing tests continue to pass (declaration-only cleanup, no functional change)
- [ ] `mvn verify -pl kroxylicious-integration-tests` passes
