### PR TITLE
perf(ci): eliminate redundant builds in integration test workflow

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -66,7 +66,7 @@ jobs:
         id: discover
         run: |
           TESTS_PER_CHUNK=15
-          TEST_CHUNKS="[$(find . -type f -name "*IT.java" -exec basename {} .java \; | xargs -L ${TESTS_PER_CHUNK} | tr ' ' , | sed 's/.*/"&"/' | sed -z 's/\n/,/g;s/,$/\n/')]"
+          TEST_CHUNKS="[$(find . -type f -name "*IT.java" -exec basename {} .java \; | shuf | xargs -L ${TESTS_PER_CHUNK} | tr ' ' , | sed 's/.*/"&"/' | sed -z 's/\n/,/g;s/,$/\n/')]"
           echo "test_chunks=$TEST_CHUNKS" >> $GITHUB_OUTPUT
   run_integration_tests:
     needs: [build_artifacts, discover_integration_test_chunks]

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -65,7 +65,7 @@ jobs:
         working-directory: kroxylicious-integration-tests
         id: discover
         run: |
-          TESTS_PER_CHUNK=5
+          TESTS_PER_CHUNK=15
           TEST_CHUNKS="[$(find . -type f -name "*IT.java" -exec basename {} .java \; | xargs -L ${TESTS_PER_CHUNK} | tr ' ' , | sed 's/.*/"&"/' | sed -z 's/\n/,/g;s/,$/\n/')]"
           echo "test_chunks=$TEST_CHUNKS" >> $GITHUB_OUTPUT
   run_integration_tests:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -25,6 +25,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build_artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+      - name: Setup Java
+        uses: ./.github/actions/common/setup-java
+      - name: 'Cache Maven packages'
+        uses: ./.github/actions/common/cache-maven-packages
+      - name: 'Build Kroxylicious proxy integration tests'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mvn -B install -DskipTests -Dmaven.javadoc.skip=true -DskipDocs=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Djapicmp.skip=true -pl :kroxylicious-bom,:kroxylicious-integration-tests,:kroxylicious-filter-archetype -am
+      - name: 'Package Kroxylicious Maven artifacts'
+        run: |
+          mkdir -p /tmp/kroxylicious-artifacts
+          cd "$HOME/.m2/repository"
+          tar czf /tmp/kroxylicious-artifacts/maven-repo.tar.gz io/kroxylicious
+      - name: 'Upload Kroxylicious Maven artifacts'
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874
+        with:
+          name: kroxylicious-maven-artifacts
+          path: /tmp/kroxylicious-artifacts/maven-repo.tar.gz
+          retention-days: 1
   discover_integration_test_chunks:
     runs-on: ubuntu-latest
     outputs:
@@ -42,7 +69,7 @@ jobs:
           TEST_CHUNKS="[$(find . -type f -name "*IT.java" -exec basename {} .java \; | xargs -L ${TESTS_PER_CHUNK} | tr ' ' , | sed 's/.*/"&"/' | sed -z 's/\n/,/g;s/,$/\n/')]"
           echo "test_chunks=$TEST_CHUNKS" >> $GITHUB_OUTPUT
   run_integration_tests:
-    needs: discover_integration_test_chunks
+    needs: [build_artifacts, discover_integration_test_chunks]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -59,11 +86,16 @@ jobs:
         uses: ./.github/actions/common/setup-java
       - name: 'Cache Maven packages'
         uses: ./.github/actions/common/cache-maven-packages
-      - name: 'Build Kroxylicious proxy integration tests'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Download Kroxylicious Maven artifacts'
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: kroxylicious-maven-artifacts
+          path: /tmp/kroxylicious-artifacts
+      - name: 'Extract Kroxylicious Maven artifacts'
         run: |
-          mvn -B install -DskipTests -Dmaven.javadoc.skip=true -DskipDocs=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Djapicmp.skip=true -pl :kroxylicious-bom,:kroxylicious-integration-tests,:kroxylicious-filter-archetype -am
+          mkdir -p "$HOME/.m2/repository"
+          cd "$HOME/.m2/repository"
+          tar xzf /tmp/kroxylicious-artifacts/maven-repo.tar.gz
       - name: 'Run proxy Kroxylicious integration tests'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -98,6 +130,7 @@ jobs:
         echo "$FAILED_JSON" | jq -r '"\(.name): \(.url)"'
         exit 1
   integration_test_filter_archetype:
+    needs: build_artifacts
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out repository'
@@ -108,11 +141,16 @@ jobs:
         uses: ./.github/actions/common/setup-java
       - name: 'Cache Maven packages'
         uses: ./.github/actions/common/cache-maven-packages
-      - name: 'Build Kroxylicious archetype'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Download Kroxylicious Maven artifacts'
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: kroxylicious-maven-artifacts
+          path: /tmp/kroxylicious-artifacts
+      - name: 'Extract Kroxylicious Maven artifacts'
         run: |
-          mvn -B install -DskipTests -Dmaven.javadoc.skip=true -DskipDocs=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Djapicmp.skip=true -pl :kroxylicious-bom,:kroxylicious-filter-archetype -am
+          mkdir -p "$HOME/.m2/repository"
+          cd "$HOME/.m2/repository"
+          tar xzf /tmp/kroxylicious-artifacts/maven-repo.tar.gz
       - name: 'run filter archetype integration tests'
         working-directory: kroxylicious-filter-archetype
         run: mvn -B verify


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

perf(ci): eliminate redundant builds in integration test workflow
    
### Additional Context

Previously, each of the 19 parallel integration test jobs independently
built Kroxylicious artifacts via 'mvn install', resulting in ~85 minutes
of cumulative redundant build time across all jobs.

This change introduces a single 'build_artifacts' job that builds once,
packages the io/kroxylicious Maven artifacts as a tarball, and uploads
them as a GitHub artifact. The parallel test jobs and archetype test job
now download and extract these pre-built artifacts instead of rebuilding.

Benefits:
- Eliminates 18 redundant builds (~4.5 minutes each)
- Reduces CI compute resource usage
- Each test job starts faster (artifact download vs full build)
- Clearer separation between build and test phases

The external Maven dependencies continue to be cached via the existing
cache-maven-packages action.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>

I've also increased the number of tests per chunk, and randomized which tests go into which chunk

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
