### PR TITLE
Fix UnnecessaryMethodReference warnings #3646

### DIFF
--- a/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/test/assertj/HeaderAssert.java
+++ b/kroxylicious-filter-test-support/src/main/java/io/kroxylicious/test/assertj/HeaderAssert.java
@@ -77,7 +77,7 @@ public class HeaderAssert extends AbstractAssert<HeaderAssert, Header> {
                 .asInstanceOf(InstanceOfAssertFactories.BYTE_ARRAY)
                 .asString(StandardCharsets.UTF_8)
                 .as(DESCRIBED_AS_PATTERN, existingDescription, VALUE_SUFFIX)
-                .satisfies(assertion::accept);
+                .satisfies(assertion);
 
         return this;
     }
@@ -87,7 +87,7 @@ public class HeaderAssert extends AbstractAssert<HeaderAssert, Header> {
         isNotNull().value()
                 .asInstanceOf(InstanceOfAssertFactories.BYTE_ARRAY)
                 .as(DESCRIBED_AS_PATTERN, existingDescription, VALUE_SUFFIX)
-                .satisfies(assertion::accept);
+                .satisfies(assertion);
 
         return this;
     }

--- a/kroxylicious-kms-tls-support/src/test/java/io/kroxylicious/proxy/tls/TlsHttpClientConfiguratorTest.java
+++ b/kroxylicious-kms-tls-support/src/test/java/io/kroxylicious/proxy/tls/TlsHttpClientConfiguratorTest.java
@@ -249,7 +249,7 @@ class TlsHttpClientConfiguratorTest {
         var tls = new TlsHttpClientConfigurator(new Tls(null, null, null, allowedDenied));
         tls.apply(builder);
 
-        assertThat(builder.build().sslParameters()).satisfies(assertSatisfies::accept);
+        assertThat(builder.build().sslParameters()).satisfies(assertSatisfies);
     }
 
     @Test
@@ -282,7 +282,7 @@ class TlsHttpClientConfiguratorTest {
         var tls = new TlsHttpClientConfigurator(new Tls(null, null, allowedDenied, null));
         tls.apply(builder);
 
-        assertThat(builder.build().sslParameters()).satisfies(assertSatisfies::accept);
+        assertThat(builder.build().sslParameters()).satisfies(assertSatisfies);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -1346,7 +1346,7 @@
                                 <arg>-XDcompilePolicy=simple</arg>
                                 <arg>--should-stop=ifError=FLOW</arg>
                                 <!-- The following <arg> cannot be split over multiple lines :-( -->
-                                <arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode -XepExcludedPaths:.*/target/generated-sources/.* -Xep:MissingOverride:ERROR -Xep:MutablePublicArray:ERROR -Xep:MathAbsoluteNegative:ERROR -Xep:EffectivelyPrivate:ERROR</arg>
+                                <arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode -XepExcludedPaths:.*/target/generated-sources/.* -Xep:MissingOverride:ERROR -Xep:MutablePublicArray:ERROR -Xep:MathAbsoluteNegative:ERROR -Xep:EffectivelyPrivate:ERROR -Xep:UnnecessaryMethodReference:ERROR</arg>
                                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
                                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>


### PR DESCRIPTION
### Type of change
- Refactoring

### Description
Replaces unnecessary method references `assertion::accept` and `assertSatisfies::accept` with direct variable references.

The Error Prone rule `UnnecessaryMethodReference` warns when a method reference to a functional interface's sole abstract method can be replaced by the functional interface itself. This PR fixes all occurrences in the project:

- `HeaderAssert.java` (2 places: `hasStringValueSatisfying` and `hasByteValueSatisfying`)
- `TlsHttpClientConfiguratorTest.java` (2 places: `restrictTlsProtocol` and `restrictTlsCipherSuites`)

After the change, `mvn clean compile` no longer shows any `UnnecessaryMethodReference` warnings.

### Additional Context
Fixes #3646