### PR TITLE
revert ITs path-ignore as ITs are required to be launched

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -19,18 +19,6 @@ name: "Run Kroxylicious Proxy Integration Tests"
 on:
   pull_request:
     types: [ opened, synchronize, reopened ]
-    paths-ignore:
-      - '**/**.md'
-      - '**/**.txt'
-      - '.github/**'
-      - '!.github/workflows/integration-tests.yaml'
-      - '!.github/actions/**'
-      - 'kroxylicious-docs/**'
-      - 'kroxylicious-operator/**'
-      - 'kroxylicious-operator-dist/**'
-      - 'kroxylicious-operator-test-support/**'
-      - 'kroxylicious-systemtests/**'
-      - 'kroxylicious-*benchmarks/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
### Description

Reverts #3694 

### Additional Context

Integration tests are `Required` to pass in order to merge the PR, so we cannot skip them for any reason.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
