### PR TITLE
fix: Update lowkey-vault image to use -ubi10-minimal suffix (why: arm64 availability)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -96,7 +96,7 @@
         "/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kms/azure/LowkeyVault.java/"
       ],
       "matchStrings": [
-        "(?<depName>nagyesta/lowkey-vault):(?<currentValue>\\d+\\.\\d+\\.\\d+)@(?<currentDigest>.*)\""
+        "(?<depName>nagyesta/lowkey-vault):(?<currentValue>\\d+\\.\\d+\\.\\d+(?:-[a-z0-9-]+)?)@(?<currentDigest>.*)\""
       ],
       "datasourceTemplate": "docker"
     },

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/src/main/java/io/kroxylicious/kms/provider/azure/kms/AzureKeyVaultKmsTestKmsFacade.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/src/main/java/io/kroxylicious/kms/provider/azure/kms/AzureKeyVaultKmsTestKmsFacade.java
@@ -80,7 +80,7 @@ public class AzureKeyVaultKmsTestKmsFacade extends AbstractAzureKeyVaultKmsTestK
 
     @VisibleForTesting
     static LowkeyVaultContainer createLowKeyContainer() {
-        String image = "nagyesta/lowkey-vault:7.1.61@sha256:0e5586bf5073eb0ef5358708961a03ae7fdbf0c9d2dbb522c60418ec28eb1764";
+        String image = "nagyesta/lowkey-vault:7.1.61-ubi10-minimal@sha256:f51b6781f0061a7c97dfeed54656e44dab5b572fe6304ec3a26ef652558b9007";
         final DockerImageName imageName = DockerImageName.parse("mirror.gcr.io/" + image)
                 .asCompatibleSubstituteFor(DockerImageName.parse(image.substring(0, image.indexOf("@"))));
         final LowkeyVaultContainer lowkeyVaultContainer = lowkeyVault(imageName)

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/test/java/io/kroxylicious/kms/provider/azure/keyvault/KeyVaultClientIT.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/test/java/io/kroxylicious/kms/provider/azure/keyvault/KeyVaultClientIT.java
@@ -58,7 +58,7 @@ class KeyVaultClientIT {
     BearerTokenService bearerTokenService;
 
     LowkeyVaultContainer startVault() {
-        String image = "nagyesta/lowkey-vault:7.1.61@sha256:0e5586bf5073eb0ef5358708961a03ae7fdbf0c9d2dbb522c60418ec28eb1764";
+        String image = "nagyesta/lowkey-vault:7.1.61-ubi10-minimal@sha256:f51b6781f0061a7c97dfeed54656e44dab5b572fe6304ec3a26ef652558b9007";
         final DockerImageName imageName = DockerImageName.parse("mirror.gcr.io/" + image)
                 .asCompatibleSubstituteFor(DockerImageName.parse(image.substring(0, image.indexOf("@"))));
         final LowkeyVaultContainer lowkeyVaultContainer = lowkeyVault(imageName)

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kms/azure/LowkeyVault.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/kms/azure/LowkeyVault.java
@@ -36,7 +36,7 @@ import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
 public class LowkeyVault implements AzureKmsClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(LowkeyVault.class);
     private static final String LOWKEY_VAULT_DEFAULT_NAMESPACE = "lowkey-vault";
-    private static final String IMAGE_NAME = "nagyesta/lowkey-vault:7.1.61@sha256:0e5586bf5073eb0ef5358708961a03ae7fdbf0c9d2dbb522c60418ec28eb1764";
+    private static final String IMAGE_NAME = "nagyesta/lowkey-vault:7.1.61-ubi10-minimal@sha256:f51b6781f0061a7c97dfeed54656e44dab5b572fe6304ec3a26ef652558b9007";
     @VisibleForTesting
     static final String LOWKEY_VAULT_IMAGE = Constants.DOCKER_REGISTRY_GCR_MIRROR + "/" + IMAGE_NAME;
     private final String deploymentNamespace;


### PR DESCRIPTION
## Summary
- Updates lowkey-vault image references to use the `-ubi10-minimal` suffix variant
- Updates Renovate regex pattern to handle version tags with optional suffixes

## Motivation
The lowkey-vault ARM64 image is only available with the `-ubi10-minimal` suffix. The suffixless version (`nagyesta/lowkey-vault:7.1.61`) does not include ARM64 architecture support, while the `-ubi10-minimal` variant (`nagyesta/lowkey-vault:7.1.61-ubi10-minimal`) does.

References:
- ARM64 with suffix: https://hub.docker.com/layers/nagyesta/lowkey-vault/7.1.61-ubi10-minimal/images/sha256-86205e568350c4223cbc8413e8c6a99437d49757c5bd156b4a0c73fab45d8bbf
- No ARM64 without suffix: https://hub.docker.com/layers/nagyesta/lowkey-vault/7.1.61/images/sha256-0e5586bf5073eb0ef5358708961a03ae7fdbf0c9d2dbb522c60418ec28eb1764

## Changes
- Updated image reference in `AzureKeyVaultKmsTestKmsFacade.java`
- Updated image reference in `KeyVaultClientIT.java`  
- Updated image reference in `LowkeyVault.java`
- Updated Renovate regex pattern in `.github/renovate.json` to match versions with optional suffixes: `\d+\.\d+\.\d+(?:-[a-z0-9-]+)?`

🤖 Generated with [Claude Code](https://claude.com/claude-code)