### PR TITLE
refactor: Share KMS instances across tests in KmsIT (77% faster)

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/kms/service/KmsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/kms/service/KmsIT.java
@@ -10,11 +10,14 @@ import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.TestTemplate;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.Parameter;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import io.kroxylicious.kms.service.DekPair;
 import io.kroxylicious.kms.service.DestroyableRawSecretKey;
@@ -23,7 +26,7 @@ import io.kroxylicious.kms.service.KmsService;
 import io.kroxylicious.kms.service.SecretKeyUtils;
 import io.kroxylicious.kms.service.TestKekManager;
 import io.kroxylicious.kms.service.TestKmsFacade;
-import io.kroxylicious.kms.service.TestKmsFacadeInvocationContextProvider;
+import io.kroxylicious.kms.service.TestKmsFacadeFactory;
 import io.kroxylicious.kms.service.UnknownAliasException;
 import io.kroxylicious.kms.service.UnknownKeyException;
 
@@ -36,8 +39,21 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @param <K> The key reference
  * @param <E> The type of encrypted DEK
  */
-@ExtendWith(TestKmsFacadeInvocationContextProvider.class)
+@ParameterizedClass(autoCloseArguments = true)
+@MethodSource("facadesSource")
 class KmsIT<C, K, E> {
+
+    static Stream<? extends TestKmsFacade<?, ?, ?>> facadesSource() {
+        // We rely on the fact that streams are lazy so the facade isn't built
+        // or started until the first test needs it.
+        return TestKmsFacadeFactory.getTestKmsFacadeFactories()
+                .map(TestKmsFacadeFactory::build)
+                .filter(TestKmsFacade::isAvailable)
+                .peek(TestKmsFacade::start);
+    }
+
+    @Parameter
+    TestKmsFacade<?, ?, ?> facade;
 
     private Kms<K, E> kms;
 
@@ -48,7 +64,7 @@ class KmsIT<C, K, E> {
 
     @BeforeEach
     @SuppressWarnings("unchecked")
-    void beforeEach(TestKmsFacade<?, ?, ?> facade) throws Exception {
+    void beforeEach() throws Exception {
         service = (KmsService<C, K, E>) facade.getKmsServiceClass().getDeclaredConstructor(new Class[]{}).newInstance();
         C kmsServiceConfig = (C) facade.getKmsServiceConfig();
         service.initialize(kmsServiceConfig);
@@ -61,20 +77,38 @@ class KmsIT<C, K, E> {
 
     @AfterEach
     void afterEach() {
+        // Clean up keys to keep the shared KMS environment clean
+        idempotentDeleteKek(alias);
         Optional.ofNullable(service).ifPresent(KmsService::close);
     }
 
-    @TestTemplate
-    void resolveKeyByName() {
-        String namedAlias = "my-key";
-        manager.generateKek(namedAlias);
-        var resolved = kms.resolveAlias(alias);
-        assertThat(resolved)
-                .succeedsWithin(Duration.ofSeconds(5))
-                .isNotNull();
+    private void idempotentDeleteKek(String kekAlias) {
+        if (manager != null && kekAlias != null) {
+            try {
+                manager.deleteKek(kekAlias);
+            }
+            catch (Exception e) {
+                // Ignore cleanup failures as key might already be deleted by the test or not exist
+            }
+        }
     }
 
-    @TestTemplate
+    @Test
+    void resolveKeyByName() {
+        String namedAlias = "my-key" + UUID.randomUUID();
+        try {
+            manager.generateKek(namedAlias);
+            var resolved = kms.resolveAlias(alias);
+            assertThat(resolved)
+                    .succeedsWithin(Duration.ofSeconds(5))
+                    .isNotNull();
+        }
+        finally {
+            idempotentDeleteKek(namedAlias);
+        }
+    }
+
+    @Test
     void resolveWithUnknownAlias() {
         var unknownAlias = "unknown";
         var resolved = kms.resolveAlias(unknownAlias);
@@ -84,7 +118,7 @@ class KmsIT<C, K, E> {
                 .withCauseInstanceOf(UnknownAliasException.class);
     }
 
-    @TestTemplate
+    @Test
     void generatedEncryptedDekDecryptsBackToPlain() {
         var pairStage = kms.generateDekPair(resolvedKekId);
         var pair = pairStage.toCompletableFuture().join();
@@ -95,7 +129,7 @@ class KmsIT<C, K, E> {
                 .matches(sk -> SecretKeyUtils.same((DestroyableRawSecretKey) sk, (DestroyableRawSecretKey) pair.dek()));
     }
 
-    @TestTemplate
+    @Test
     void generatedDekPairWithUnknownKeyId() {
         manager.deleteKek(alias);
 
@@ -106,7 +140,7 @@ class KmsIT<C, K, E> {
                 .withCauseInstanceOf(UnknownKeyException.class);
     }
 
-    @TestTemplate
+    @Test
     void decryptDekAfterRotate() {
 
         var pairStage = kms.generateDekPair(resolvedKekId);
@@ -121,7 +155,7 @@ class KmsIT<C, K, E> {
                 .matches(sk -> SecretKeyUtils.same((DestroyableRawSecretKey) sk, (DestroyableRawSecretKey) pair.dek()));
     }
 
-    @TestTemplate
+    @Test
     void failToDecryptEdekWithUnknownKeyId() {
 
         var dekPairStage = kms.generateDekPair(resolvedKekId);
@@ -138,7 +172,7 @@ class KmsIT<C, K, E> {
                 .withCauseInstanceOf(UnknownKeyException.class);
     }
 
-    @TestTemplate
+    @Test
     void edekSerdeRoundTrip() {
 
         var pairStage = kms.generateDekPair(resolvedKekId);


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Refactor KmsIT to use shared KMS instances rather than creating a new KMS instance per test. This approach saves significant time by avoiding repeated KMS container startup/shutdown cycles.

This applies the same technique successfully used in https://github.com/kroxylicious/kroxylicious/pull/3681 for RecordEncryptionFilterIT, where ~600 seconds was reduced to ~180 seconds.

#### Performance Improvement

**Before (baseline):**
- Total time: **64.0 seconds** (01:04 min)
- Test execution: 60.98 seconds
- Pattern: Each test method receives a fresh KMS facade instance (start → test → stop)
- Tests: 28 total (all passed)

**After (optimized):**
- Total time: **14.6 seconds** (average of 2 runs: 14.558s and 14.554s)
- Test execution: **3.99 seconds** for active tests (highly consistent: 3.890s and 4.089s)
- Pattern: KMS started once per facade type, all tests share it
- Tests: 28 total (all passed, 4 facades ran tests, 1 facade had no applicable tests)

**Time Savings:**
- **49.4 seconds saved** (77% faster overall)
- **93.5% faster** for actual test execution (3.99s vs 60.98s)
- Highly repeatable: 0.03% variance between runs (14.558s vs 14.554s)

**Breakdown by facade (run 1 / run 2):**
- InMemory facade: 7 tests in 0.198s / 0.195s
- Facade 2: 7 tests in 0.752s / 0.769s
- Facade 3: 7 tests in 0.478s / 0.455s
- Vault facade: 7 tests in 2.462s / 2.670s

#### How It Works

Tests now run like this:
```
for each kms facade type
  start kms once
  run all 7 tests
  stop kms once
```

Previously:
```
for each kms facade type
  for each of 7 tests
    start kms
    run test
    stop kms
```

#### Key Changes

1. **Class annotations**: Changed from `@ExtendWith(TestKmsFacadeInvocationContextProvider.class)` to `@ParameterizedClass(autoCloseArguments = true)` with `@MethodSource`
2. **Facade lifecycle**: Added `facadesSource()` static method that lazily builds and starts facades via `.peek(TestKmsFacade::start)`
3. **Test methods**: Changed all `@TestTemplate` to `@Test`
4. **Facade injection**: Added `@Parameter TestKmsFacade<?, ?, ?> facade` field
5. **Key cleanup**: Added `idempotentDeleteKek()` method to clean up keys between tests, maintaining test isolation in the shared KMS environment

### Additional Context

This optimization is particularly beneficial for:
- Container-based KMS providers (LocalStack, Vault, Azure Emulator) where startup is expensive
- Test suites with many test methods
- CI/CD pipelines where every second counts

Test isolation is maintained as each test generates unique key names (UUID-based), and the new `idempotentDeleteKek()` method ensures keys are cleaned up between tests to keep the shared KMS environment clean.

### Checklist

- [x] PR raised from a fork of this repository and made from a branch rather than main
- [x] Write tests (existing tests refactored)
- [ ] Update documentation (no user-facing changes)
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored
- [ ] If applicable to the change, make sure system tests pass
- [ ] If applicable to the change, trigger the performance test suite
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging
- [ ] For user facing changes, update CHANGELOG.md