### PR TITLE
refactor: Fix complie warning in kroxylicious-krpc-plugin module

### DIFF
--- a/kroxylicious-krpc-plugin/pom.xml
+++ b/kroxylicious-krpc-plugin/pom.xml
@@ -132,6 +132,11 @@
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/kroxylicious-krpc-plugin/src/main/java/io/kroxylicious/krpccodegen/maven/KrpcMultiGeneratorMojo.java
+++ b/kroxylicious-krpc-plugin/src/main/java/io/kroxylicious/krpccodegen/maven/KrpcMultiGeneratorMojo.java
@@ -9,7 +9,6 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
 import io.kroxylicious.krpccodegen.main.KrpcGenerator;
-import io.kroxylicious.krpccodegen.main.KrpcGenerator.Builder;
 
 /**
  * A Maven plugin capable of generating java source from Apache Kafka message
@@ -28,7 +27,7 @@ public class KrpcMultiGeneratorMojo extends AbstractKrpcGeneratorMojo {
     }
 
     @Override
-    protected Builder builder() {
+    protected KrpcGenerator.Builder builder() {
         return KrpcGenerator.multi();
     }
 }

--- a/kroxylicious-krpc-plugin/src/main/java/io/kroxylicious/krpccodegen/maven/KrpcSingleGeneratorMojo.java
+++ b/kroxylicious-krpc-plugin/src/main/java/io/kroxylicious/krpccodegen/maven/KrpcSingleGeneratorMojo.java
@@ -9,7 +9,6 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
 import io.kroxylicious.krpccodegen.main.KrpcGenerator;
-import io.kroxylicious.krpccodegen.main.KrpcGenerator.Builder;
 
 /**
  * A Maven plugin capable of generating java source from Apache Kafka message
@@ -28,7 +27,7 @@ public class KrpcSingleGeneratorMojo extends AbstractKrpcGeneratorMojo {
     }
 
     @Override
-    protected Builder builder() {
+    protected KrpcGenerator.Builder builder() {
         return KrpcGenerator.single();
     }
 }

--- a/kroxylicious-krpc-plugin/src/main/java/io/kroxylicious/krpccodegen/schema/FieldType.java
+++ b/kroxylicious-krpc-plugin/src/main/java/io/kroxylicious/krpccodegen/schema/FieldType.java
@@ -7,6 +7,9 @@ package io.kroxylicious.krpccodegen.schema;
 
 import java.util.Optional;
 
+import com.google.errorprone.annotations.Immutable;
+
+@Immutable
 public interface FieldType {
     String ARRAY_PREFIX = "[]";
 
@@ -285,30 +288,19 @@ public interface FieldType {
 
     static FieldType parse(String string) {
         string = string.trim();
-        switch (string) {
-            case BoolFieldType.NAME:
-                return BoolFieldType.INSTANCE;
-            case Int8FieldType.NAME:
-                return Int8FieldType.INSTANCE;
-            case Int16FieldType.NAME:
-                return Int16FieldType.INSTANCE;
-            case Uint16FieldType.NAME:
-                return Uint16FieldType.INSTANCE;
-            case Int32FieldType.NAME:
-                return Int32FieldType.INSTANCE;
-            case Int64FieldType.NAME:
-                return Int64FieldType.INSTANCE;
-            case UUIDFieldType.NAME:
-                return UUIDFieldType.INSTANCE;
-            case Float64FieldType.NAME:
-                return Float64FieldType.INSTANCE;
-            case StringFieldType.NAME:
-                return StringFieldType.INSTANCE;
-            case BytesFieldType.NAME:
-                return BytesFieldType.INSTANCE;
-            case RecordsFieldType.NAME:
-                return RecordsFieldType.INSTANCE;
-            default:
+        return switch (string) {
+            case BoolFieldType.NAME -> BoolFieldType.INSTANCE;
+            case Int8FieldType.NAME -> Int8FieldType.INSTANCE;
+            case Int16FieldType.NAME -> Int16FieldType.INSTANCE;
+            case Uint16FieldType.NAME -> Uint16FieldType.INSTANCE;
+            case Int32FieldType.NAME -> Int32FieldType.INSTANCE;
+            case Int64FieldType.NAME -> Int64FieldType.INSTANCE;
+            case UUIDFieldType.NAME -> UUIDFieldType.INSTANCE;
+            case Float64FieldType.NAME -> Float64FieldType.INSTANCE;
+            case StringFieldType.NAME -> StringFieldType.INSTANCE;
+            case BytesFieldType.NAME -> BytesFieldType.INSTANCE;
+            case RecordsFieldType.NAME -> RecordsFieldType.INSTANCE;
+            default -> {
                 if (string.startsWith(ARRAY_PREFIX)) {
                     String elementTypeString = string.substring(ARRAY_PREFIX.length());
                     if (elementTypeString.isEmpty()) {
@@ -320,15 +312,16 @@ public interface FieldType {
                         throw new IllegalArgumentException("Can't have an array of arrays.  " +
                                 "Use an array of structs containing an array instead.");
                     }
-                    return new ArrayType(elementType);
+                    yield new ArrayType(elementType);
                 }
                 else if (StructRegistry.firstIsCapitalized(string)) {
-                    return new StructType(string);
+                    yield new StructType(string);
                 }
                 else {
                     throw new IllegalArgumentException("Can't parse type " + string);
                 }
-        }
+            }
+        };
     }
 
     /**

--- a/kroxylicious-krpc-plugin/src/main/java/io/kroxylicious/krpccodegen/schema/MessageSpec.java
+++ b/kroxylicious-krpc-plugin/src/main/java/io/kroxylicious/krpccodegen/schema/MessageSpec.java
@@ -62,8 +62,8 @@ public final class MessageSpec implements Named {
             Objects.requireNonNull(flexibleVersions, "You must specify a value for flexibleVersions. " +
                     "Please use 0+ for all new messages.");
             this.flexibleVersions = Versions.parse(flexibleVersions, Versions.NONE);
-            if ((!this.flexibleVersions().empty()) &&
-                    (this.flexibleVersions.highest() < Short.MAX_VALUE)) {
+            if (!this.flexibleVersions().empty() &&
+                    this.flexibleVersions.highest() < Short.MAX_VALUE) {
                 throw new IllegalArgumentException("Field " + name + " specifies flexibleVersions " +
                         this.flexibleVersions + ", which is not open-ended.  flexibleVersions must " +
                         "be either none, or an open-ended range (that ends with a plus sign).");


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

There are still some warning when maven compile, we can fix it 
```
/kroxylicious/kroxylicious-krpc-plugin/src/main/java/io/kroxylicious/krpccodegen/schema/MessageSpec.java:[65,16]
[UnnecessaryParentheses] These parentheses are unnecessary; it is unlikely the code will be misinterpreted without them
    (see https://errorprone.info/bugpattern/UnnecessaryParentheses)
  Did you mean 'if ( !this.flexibleVersions().empty() &&'?
[WARNING]
/kroxylicious/kroxylicious-krpc-plugin/src/main/java/io/kroxylicious/krpccodegen/schema/FieldType.java:[288,8]
[StatementSwitchToExpressionSwitch] This statement switch can be converted to a new-style arrow switch
    (see https://errorprone.info/bugpattern/StatementSwitchToExpressionSwitch)
  Did you mean 'switch (string) {'?
[WARNING]
/kroxylicious/kroxylicious-krpc-plugin/src/main/java/io/kroxylicious/krpccodegen/schema/EntityType.java:[29,28]
[ImmutableEnumChecker] enums should be immutable: 'EntityType' has field 'baseType' of type 'io.kroxylicious.krpccodegen.schema.FieldType', the
declaration of type 'io.kroxylicious.krpccodegen.schema.FieldType' is not annotated with @com.google.errorprone.annotations.Immutable
    (see https://errorprone.info/bugpattern/ImmutableEnumChecker)
[WARNING] /kroxylicious/kroxylicious-krpc-plugin/src/main/java/io/kroxylicious/krpccodegen/maven/KrpcMultiGeneratorM
ojo.java:[31,14] [BadImport] Importing nested classes/static methods/static fields with commonly-used names can make code harder to read, because it
may not be clear from the context exactly which type is being referred to. Qualifying the name with that of the containing class can make the code
clearer. Here we recommend using qualified class: KrpcGenerator.
    (see https://errorprone.info/bugpattern/BadImport)
  Did you mean 'protected KrpcGenerator.Builder builder() {'?
[WARNING] /kroxylicious-krpc-plugin/src/main/java/io/kroxylicious/krpccodegen/maven/KrpcSingleGenerator
Mojo.java:[31,14] [BadImport] Importing nested classes/static methods/static fields with commonly-used names can make code harder to read, because it
 may not be clear from the context exactly which type is being referred to. Qualifying the name with that of the containing class can make the code
clearer. Here we recommend using qualified class: KrpcGenerator.
    (see https://errorprone.info/bugpattern/BadImport)
  Did you mean 'protected KrpcGenerator.Builder builder() {'?
```

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
