### PR TITLE
perf(ci): removed lint pipeline after merge

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,8 +17,6 @@
 name: "Lint Pull Request"
 
 on:
-  push:
-    branches: [ main, 'release/**' ]
   pull_request:
     types: [ opened, synchronize, reopened ]
 
@@ -49,18 +47,9 @@ jobs:
         run: |
           mvn -B -Pci -T1.5C verify -DskipTests -Djapicmp.skip=true
       - name: Save PR number to file
-        if: github.event_name == 'pull_request'
         run: echo ${{ github.event.number }} > PR_NUMBER.txt
       - name: Archive PR number
-        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: PR_NUMBER
           path: PR_NUMBER.txt
-      - name: Slack Notification on Failure
-        if: failure() && env.SLACK_WEBHOOK_SET == 'true' && github.event_name == 'push'
-        uses: ./.github/actions/common/slack-notification
-        with:
-          slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
-          slackTitle: 'Failure Alert: ${{ github.repository }}'
-          slackMessage: 'The lint workflow failed on branch ${{ github.ref_name }}.'


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

`Lint Pull Request` job does not make sense when pushing to main or release. Once the PR is merged, the lint is already done for the PR.

### Additional Context

Removing this will save one runner once the PR is merged.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
