### PR TITLE
fix: reduce cognitive complexity of ServiceBasedPluginFactoryRegistry#loadProviders (S3776)

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/ServiceBasedPluginFactoryRegistry.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/ServiceBasedPluginFactoryRegistry.java
@@ -60,11 +60,7 @@ public class ServiceBasedPluginFactoryRegistry implements PluginFactoryRegistry 
                 Collectors.partitioningBy(e -> e.getValue().size() == 1));
         var ambiguousEntries = partitioned.get(false);
         var unambiguousEntries = partitioned.get(true);
-        if (LOGGER.isWarnEnabled()) {
-            for (Map.Entry<String, Set<ProviderAndConfigType>> ambiguousEntry : ambiguousEntries) {
-                handleAmbiguousEntry(ambiguousEntry, pluginInterface);
-            }
-        }
+        ambiguousEntries.forEach(ambiguousEntry -> handleAmbiguousEntry(ambiguousEntry, pluginInterface));
         return unambiguousEntries.stream().collect(Collectors.toMap(
                 Map.Entry::getKey,
                 e -> e.getValue().iterator().next()));

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/ServiceBasedPluginFactoryRegistry.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/config/ServiceBasedPluginFactoryRegistry.java
@@ -60,7 +60,9 @@ public class ServiceBasedPluginFactoryRegistry implements PluginFactoryRegistry 
                 Collectors.partitioningBy(e -> e.getValue().size() == 1));
         var ambiguousEntries = partitioned.get(false);
         var unambiguousEntries = partitioned.get(true);
-        ambiguousEntries.forEach(ambiguousEntry -> handleAmbiguousEntry(ambiguousEntry, pluginInterface));
+        if (LOGGER.isWarnEnabled()) {
+            ambiguousEntries.forEach(ambiguousEntry -> handleAmbiguousEntry(ambiguousEntry, pluginInterface));
+        }
         return unambiguousEntries.stream().collect(Collectors.toMap(
                 Map.Entry::getKey,
                 e -> e.getValue().iterator().next()));


### PR DESCRIPTION
## Summary

Reduces the cognitive complexity of `loadProviders` by replacing the `if (LOGGER.isWarnEnabled())` guard + `for` loop with a single `forEach` call.

## Why

`LOGGER.atWarn()` (used inside `handleAmbiguousEntry`) is already lazy — it evaluates the log level internally before building the message. The `isWarnEnabled()` guard is therefore redundant and adds unnecessary nesting.

Removing the guard also fixes a subtle correctness issue: `handleAmbiguousEntry` can throw a `RuntimeException` on deprecated name collisions, but the old guard meant that exception would be silently suppressed whenever warn logging was disabled.

## Change

```java
// Before
if (LOGGER.isWarnEnabled()) {
    for (Map.Entry<String, Set<ProviderAndConfigType>> ambiguousEntry : ambiguousEntries) {
        handleAmbiguousEntry(ambiguousEntry, pluginInterface);
    }
}

// After
ambiguousEntries.forEach(ambiguousEntry -> handleAmbiguousEntry(ambiguousEntry, pluginInterface));
```

Closes #3618