### PR TITLE
refactor: Fix ErrorProne OperatorPrecedence warnings 

### DIFF
--- a/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/AtomicCryptorUsageCounter.java
+++ b/kroxylicious-filters/kroxylicious-record-encryption/src/main/java/io/kroxylicious/filter/encryption/dek/AtomicCryptorUsageCounter.java
@@ -109,7 +109,7 @@ class AtomicCryptorUsageCounter {
 
     /** Combine two int reference counts into a single long */
     private static long combine(int encryptors, int decryptors) {
-        return ((long) encryptors) << Integer.SIZE | 0xFFFFFFFFL & decryptors;
+        return (((long) encryptors) << Integer.SIZE) | (0xFFFFFFFFL & decryptors);
     }
 
     /** Extract the encryptor reference count from a long */

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/model/ErrorResponse.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-aws-kms/src/main/java/io/kroxylicious/kms/provider/aws/kms/model/ErrorResponse.java
@@ -31,7 +31,7 @@ public record ErrorResponse(@JsonProperty(value = "__type") String type,
 
     public boolean isNotFound() {
         return type().equalsIgnoreCase("NotFoundException") ||
-                type().equalsIgnoreCase("KMSInvalidStateException") && String.valueOf(message()).toLowerCase(Locale.ROOT).contains("is pending deletion");
+                (type().equalsIgnoreCase("KMSInvalidStateException") && String.valueOf(message()).toLowerCase(Locale.ROOT).contains("is pending deletion"));
     }
 
     @Override

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/AzureKeyVaultKms.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/src/main/java/io/kroxylicious/kms/provider/azure/AzureKeyVaultKms.java
@@ -115,8 +115,8 @@ public class AzureKeyVaultKms implements Kms<WrappingKey, AzureKeyVaultEdek> {
         return client.unwrap(new WrappingKey(edek.keyName(), edek.keyVersion(), edek.supportedKeyType(), edek.vaultName()), edek.edek())
                 .handle((bytes, throwable) -> {
                     if (throwable != null) {
-                        if (throwable instanceof UnexpectedHttpStatusCodeException e && e.getStatusCode() == 404
-                                || throwable.getCause() instanceof UnexpectedHttpStatusCodeException ex && ex.getStatusCode() == 404) {
+                        if ((throwable instanceof UnexpectedHttpStatusCodeException e && e.getStatusCode() == 404)
+                                || (throwable.getCause() instanceof UnexpectedHttpStatusCodeException ex && ex.getStatusCode() == 404)) {
                             throw new UnknownKeyException("key not found, key name: '" + edek.keyName() + "' version '" + edek.keyVersion() + "'");
                         }
                         else {

--- a/pom.xml
+++ b/pom.xml
@@ -1346,7 +1346,7 @@
                                 <arg>-XDcompilePolicy=simple</arg>
                                 <arg>--should-stop=ifError=FLOW</arg>
                                 <!-- The following <arg> cannot be split over multiple lines :-( -->
-                                <arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode -XepExcludedPaths:.*/target/generated-sources/.* -Xep:MissingOverride:ERROR -Xep:MutablePublicArray:ERROR -Xep:MathAbsoluteNegative:ERROR -Xep:EffectivelyPrivate:ERROR -Xep:ByteBufferBackingArray:ERROR -Xep:UnnecessaryMethodReference:ERROR</arg>
+                                <arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode -XepExcludedPaths:.*/target/generated-sources/.* -Xep:MissingOverride:ERROR -Xep:MutablePublicArray:ERROR -Xep:MathAbsoluteNegative:ERROR -Xep:EffectivelyPrivate:ERROR -Xep:ByteBufferBackingArray:ERROR -Xep:UnnecessaryMethodReference:ERROR -Xep:OperatorPrecedence:ERROR</arg>
                                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
                                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

Add explicit grouping parentheses to clarify operator precedence in three files, and promote OperatorPrecedence to a build error in the ErrorProne configuration so future violations fail the build.

### Additional Context

https://github.com/kroxylicious/kroxylicious/issues/3710

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
