### PR TITLE
Add plugins directory support to proxy classpath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ docs/*.html
 .claude/settings.local.json
 .claude/agent-memory
 .op/
+.claude/projects/

--- a/kroxylicious-app/src/assembly/kroxylicious-start.sh
+++ b/kroxylicious-app/src/assembly/kroxylicious-start.sh
@@ -21,6 +21,15 @@ script_dir() {
 classpath() {
   local class_path
   class_path="$(script_dir)/../libs/*"
+  # Scan plugins directory for subdirectories containing JARs
+  local plugins_dir="$(script_dir)/../plugins"
+  if [ -d "${plugins_dir}" ]; then
+    for dir in "${plugins_dir}"/*/; do
+      if [ -d "$dir" ]; then
+        class_path="$class_path:${dir}*"
+      fi
+    done
+  fi
   if [ -n "${KROXYLICIOUS_CLASSPATH:-}" ]; then
     class_path="$class_path:${KROXYLICIOUS_CLASSPATH}"
   fi

--- a/kroxylicious-app/src/assembly/kroxylicious-start.sh
+++ b/kroxylicious-app/src/assembly/kroxylicious-start.sh
@@ -21,14 +21,20 @@ script_dir() {
 classpath() {
   local class_path
   class_path="$(script_dir)/../libs/*"
-  # Scan plugins directory for subdirectories containing JARs
-  local plugins_dir="$(script_dir)/../plugins"
+  # Scan classpath-plugins directory for subdirectories containing JARs
+  local plugins_dir="$(script_dir)/../classpath-plugins"
   if [ -d "${plugins_dir}" ]; then
+    local found
+    found=""
     for dir in "${plugins_dir}"/*/; do
       if [ -d "$dir" ]; then
+        found="true"
         class_path="$class_path:${dir}*"
       fi
     done
+    if [ -n "${found}" ]; then
+      echo "WARNING: Loading Kroxylicious plugins from the 'classpath-plugins' directory is an Alpha feature: This feature may change, or be removed entirely, without warning in any future Kroxylicious release." >&2
+    fi
   fi
   if [ -n "${KROXYLICIOUS_CLASSPATH:-}" ]; then
     class_path="$class_path:${KROXYLICIOUS_CLASSPATH}"

--- a/kroxylicious-app/src/main/docker/proxy.dockerfile
+++ b/kroxylicious-app/src/main/docker/proxy.dockerfile
@@ -53,6 +53,8 @@ ENV JAVA_HOME=/usr/lib/jvm/jre-${JAVA_VERSION}
 
 COPY target/kroxylicious-app-${KROXYLICIOUS_VERSION}-bin/kroxylicious-app-${KROXYLICIOUS_VERSION}/ .
 
+RUN mkdir -p /opt/kroxylicious/plugins && chown ${CONTAINER_USER_UID}:${CONTAINER_USER_UID} /opt/kroxylicious/plugins
+
 USER ${CONTAINER_USER_UID}
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/opt/kroxylicious/bin/kroxylicious-start.sh" ]

--- a/kroxylicious-app/src/main/docker/proxy.dockerfile
+++ b/kroxylicious-app/src/main/docker/proxy.dockerfile
@@ -53,7 +53,7 @@ ENV JAVA_HOME=/usr/lib/jvm/jre-${JAVA_VERSION}
 
 COPY target/kroxylicious-app-${KROXYLICIOUS_VERSION}-bin/kroxylicious-app-${KROXYLICIOUS_VERSION}/ .
 
-RUN mkdir -p /opt/kroxylicious/plugins && chown ${CONTAINER_USER_UID}:${CONTAINER_USER_UID} /opt/kroxylicious/plugins
+RUN mkdir -p /opt/kroxylicious/classpath-plugins && chown ${CONTAINER_USER_UID}:${CONTAINER_USER_UID} /opt/kroxylicious/classpath-plugins
 
 USER ${CONTAINER_USER_UID}
 

--- a/kroxylicious-app/src/test/java/io/kroxylicious/app/StartScriptTest.java
+++ b/kroxylicious-app/src/test/java/io/kroxylicious/app/StartScriptTest.java
@@ -9,6 +9,7 @@ package io.kroxylicious.app;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
@@ -22,20 +23,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 class StartScriptTest {
 
     private static final Path START_SCRIPT = Path.of("src/assembly/kroxylicious-start.sh");
+    public static final String CLASSPATH_PLUGINS_WARNING = "WARNING: Loading Kroxylicious plugins from the 'classpath-plugins' directory is an Alpha feature: This feature may change, or be removed entirely, without warning in any future Kroxylicious release.";
 
     @Test
     void classpathIncludesPluginSubdirectories(@TempDir Path tempDir) throws Exception {
         Files.createDirectories(tempDir.resolve("bin"));
         Files.createDirectories(tempDir.resolve("libs"));
-        Files.createDirectories(tempDir.resolve("plugins/plugin-a"));
-        Files.createDirectories(tempDir.resolve("plugins/plugin-b"));
+        Files.createDirectories(tempDir.resolve("classpath-plugins/plugin-a"));
+        Files.createDirectories(tempDir.resolve("classpath-plugins/plugin-b"));
 
-        String output = runClasspathFunction(tempDir);
+        var stdStreams = runClasspathFunction(tempDir);
 
-        assertThat(output)
+        assertThat(stdStreams.standardError())
+                .isEqualTo(CLASSPATH_PLUGINS_WARNING);
+
+        assertThat(stdStreams.standardOutput())
                 .contains("/libs/*")
-                .contains("/plugins/plugin-a/")
-                .contains("/plugins/plugin-b/");
+                .contains("/classpath-plugins/plugin-a/")
+                .contains("/classpath-plugins/plugin-b/");
     }
 
     @Test
@@ -43,56 +48,74 @@ class StartScriptTest {
         Files.createDirectories(tempDir.resolve("bin"));
         Files.createDirectories(tempDir.resolve("libs"));
 
-        String output = runClasspathFunction(tempDir);
+        var stdStreams = runClasspathFunction(tempDir);
 
-        assertThat(output)
+        assertThat(stdStreams.standardError())
+                .as("No warning logged when directory is absent")
+                .isEmpty();
+
+        assertThat(stdStreams.standardOutput())
                 .contains("/libs/*")
-                .doesNotContain("plugins");
+                .doesNotContain("classpath-plugins");
+
     }
 
     @Test
     void classpathWorksWithEmptyPluginsDirectory(@TempDir Path tempDir) throws Exception {
         Files.createDirectories(tempDir.resolve("bin"));
         Files.createDirectories(tempDir.resolve("libs"));
-        Files.createDirectories(tempDir.resolve("plugins"));
+        Files.createDirectories(tempDir.resolve("classpath-plugins"));
 
-        String output = runClasspathFunction(tempDir);
+        var stdStreams = runClasspathFunction(tempDir);
 
-        assertThat(output)
+        assertThat(stdStreams.standardError())
+                .as("No warning logged when directory is present but empty")
+                .isEmpty();
+
+        assertThat(stdStreams.standardOutput())
                 .contains("/libs/*")
-                .doesNotContain("plugins");
+                .doesNotContain("classpath-plugins");
     }
 
     @Test
     void classpathPreservesKroxyliciousClasspathEnvVar(@TempDir Path tempDir) throws Exception {
         Files.createDirectories(tempDir.resolve("bin"));
         Files.createDirectories(tempDir.resolve("libs"));
-        Files.createDirectories(tempDir.resolve("plugins/my-plugin"));
+        Files.createDirectories(tempDir.resolve("classpath-plugins/my-plugin"));
 
-        String command = classpathTestCommand(tempDir);
-        var pb = new ProcessBuilder("bash", "-c", command);
-        pb.environment().put("KROXYLICIOUS_CLASSPATH", "/extra/jars/*");
-        pb.redirectErrorStream(true);
-        Process p = pb.start();
-        String output = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
-        assertThat(p.waitFor(5, TimeUnit.SECONDS)).isTrue();
-        assertThat(p.exitValue()).isZero();
+        var stdStreams = runClasspathFunction(tempDir, Map.of("KROXYLICIOUS_CLASSPATH", "/extra/jars/*"));
 
-        assertThat(output)
+        assertThat(stdStreams.standardError())
+                .isEqualTo(CLASSPATH_PLUGINS_WARNING);
+
+        assertThat(stdStreams.standardOutput())
                 .contains("/libs/*")
-                .contains("/plugins/my-plugin/")
+                .contains("/classpath-plugins/my-plugin/")
                 .contains("/extra/jars/*");
     }
 
-    private String runClasspathFunction(Path baseDir) throws Exception {
+    record StdStreams(String standardOutput, String standardError) {}
+
+    private StdStreams runClasspathFunction(Path baseDir) throws Exception {
+        return runClasspathFunction(baseDir, Map.of());
+    }
+
+    private StdStreams runClasspathFunction(Path baseDir, Map<String, String> env) throws Exception {
         String command = classpathTestCommand(baseDir);
-        Process p = new ProcessBuilder("bash", "-c", command)
-                .redirectErrorStream(true)
-                .start();
-        String output = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+        Path err = baseDir.resolve("err");
+        Path out = baseDir.resolve("out");
+
+        ProcessBuilder pb = new ProcessBuilder("bash", "-c", command)
+                .redirectError(err.toFile())
+                .redirectOutput(out.toFile());
+        pb.environment().putAll(env);
+        Process p = pb.start();
         assertThat(p.waitFor(5, TimeUnit.SECONDS)).isTrue();
         assertThat(p.exitValue()).isZero();
-        return output;
+        var error = Files.readString(err, StandardCharsets.UTF_8).trim();
+        var output = Files.readString(out, StandardCharsets.UTF_8).trim();
+        Files.delete(err);
+        return new StdStreams(output, error);
     }
 
     private static String classpathTestCommand(Path baseDir) {

--- a/kroxylicious-app/src/test/java/io/kroxylicious/app/StartScriptTest.java
+++ b/kroxylicious-app/src/test/java/io/kroxylicious/app/StartScriptTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.app;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the {@code classpath()} function in {@code kroxylicious-start.sh}.
+ */
+class StartScriptTest {
+
+    private static final Path START_SCRIPT = Path.of("src/assembly/kroxylicious-start.sh");
+
+    @Test
+    void classpathIncludesPluginSubdirectories(@TempDir Path tempDir) throws Exception {
+        Files.createDirectories(tempDir.resolve("bin"));
+        Files.createDirectories(tempDir.resolve("libs"));
+        Files.createDirectories(tempDir.resolve("plugins/plugin-a"));
+        Files.createDirectories(tempDir.resolve("plugins/plugin-b"));
+
+        String output = runClasspathFunction(tempDir);
+
+        assertThat(output)
+                .contains("/libs/*")
+                .contains("/plugins/plugin-a/")
+                .contains("/plugins/plugin-b/");
+    }
+
+    @Test
+    void classpathWorksWithoutPluginsDirectory(@TempDir Path tempDir) throws Exception {
+        Files.createDirectories(tempDir.resolve("bin"));
+        Files.createDirectories(tempDir.resolve("libs"));
+
+        String output = runClasspathFunction(tempDir);
+
+        assertThat(output)
+                .contains("/libs/*")
+                .doesNotContain("plugins");
+    }
+
+    @Test
+    void classpathWorksWithEmptyPluginsDirectory(@TempDir Path tempDir) throws Exception {
+        Files.createDirectories(tempDir.resolve("bin"));
+        Files.createDirectories(tempDir.resolve("libs"));
+        Files.createDirectories(tempDir.resolve("plugins"));
+
+        String output = runClasspathFunction(tempDir);
+
+        assertThat(output)
+                .contains("/libs/*")
+                .doesNotContain("plugins");
+    }
+
+    @Test
+    void classpathPreservesKroxyliciousClasspathEnvVar(@TempDir Path tempDir) throws Exception {
+        Files.createDirectories(tempDir.resolve("bin"));
+        Files.createDirectories(tempDir.resolve("libs"));
+        Files.createDirectories(tempDir.resolve("plugins/my-plugin"));
+
+        String command = classpathTestCommand(tempDir);
+        var pb = new ProcessBuilder("bash", "-c", command);
+        pb.environment().put("KROXYLICIOUS_CLASSPATH", "/extra/jars/*");
+        pb.redirectErrorStream(true);
+        Process p = pb.start();
+        String output = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+        assertThat(p.waitFor(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(p.exitValue()).isZero();
+
+        assertThat(output)
+                .contains("/libs/*")
+                .contains("/plugins/my-plugin/")
+                .contains("/extra/jars/*");
+    }
+
+    private String runClasspathFunction(Path baseDir) throws Exception {
+        String command = classpathTestCommand(baseDir);
+        Process p = new ProcessBuilder("bash", "-c", command)
+                .redirectErrorStream(true)
+                .start();
+        String output = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+        assertThat(p.waitFor(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(p.exitValue()).isZero();
+        return output;
+    }
+
+    private static String classpathTestCommand(Path baseDir) {
+        // Override script_dir() to point at our temp directory's bin/,
+        // then extract the real classpath() function from the production script via awk
+        return """
+                script_dir() { echo '%s'; }
+                eval "$(awk '/^classpath\\(\\)/,/^}/' '%s')"
+                classpath
+                """.formatted(
+                baseDir.resolve("bin"),
+                START_SCRIPT.toAbsolutePath());
+    }
+}

--- a/kroxylicious-docs/docs/_modules/con-custom-filters.adoc
+++ b/kroxylicious-docs/docs/_modules/con-custom-filters.adoc
@@ -469,3 +469,37 @@ Filters are packaged as standard `.jar` files. A typical Custom Filter jar conta
 
 1. Filter implementation classes
 2. A FilterFactory implementation per Filter and service metadata (see <<Filter Construction and Configuration>>)
+
+=== Deploying filters
+
+Third-party filter JARs can be deployed using the `plugins/` directory under the Kroxylicious installation directory.
+Each plugin should be placed in its own subdirectory:
+
+[source]
+----
+kroxylicious/
+  libs/          <1>
+  plugins/       <2>
+    my-filter/
+      my-filter-1.0.jar
+      my-dependency.jar
+    another-filter/
+      another-filter-2.1.jar
+----
+<1> Built-in Kroxylicious JARs (do not modify).
+<2> Third-party plugin JARs, organised by plugin name.
+
+The proxy startup script automatically scans `plugins/` subdirectories and adds their contents to the Java classpath.
+Plugins are then discovered via `ServiceLoader` alongside the built-in filters.
+
+If the `plugins/` directory does not exist, no plugin scanning is performed and the proxy starts normally.
+
+=== Dependency shading
+
+There is currently no classloader isolation between plugins.
+All plugins share a single classpath with the proxy itself.
+If a plugin bundles a library that is also used by the proxy or by another plugin (for example Jackson or Guava), the classpath ordering determines which version is used at runtime.
+This can cause subtle failures.
+
+To avoid dependency conflicts, plugin authors should shade (relocate) their transitive dependencies using the Maven Shade Plugin or an equivalent tool.
+Shading rewrites the package names of bundled libraries so they cannot collide with other versions on the classpath.

--- a/kroxylicious-docs/docs/_modules/con-custom-filters.adoc
+++ b/kroxylicious-docs/docs/_modules/con-custom-filters.adoc
@@ -470,16 +470,19 @@ Filters are packaged as standard `.jar` files. A typical Custom Filter jar conta
 1. Filter implementation classes
 2. A FilterFactory implementation per Filter and service metadata (see <<Filter Construction and Configuration>>)
 
-=== Deploying filters
+== Deploying filters
 
-Third-party filter JARs can be deployed using the `plugins/` directory under the Kroxylicious installation directory.
+Third-party filter JARs can be deployed using the `classpath-plugins/` directory under the Kroxylicious installation directory.
+
+WARNING: Loading Kroxylicious plugins from the `classpath-plugins/` directory is an Alpha feature: This feature may change, or be removed entirely, without warning in any future Kroxylicious release.
+
 Each plugin should be placed in its own subdirectory:
 
 [source]
 ----
 kroxylicious/
   libs/          <1>
-  plugins/       <2>
+  classpath-plugins/       <2>
     my-filter/
       my-filter-1.0.jar
       my-dependency.jar
@@ -489,14 +492,15 @@ kroxylicious/
 <1> Built-in Kroxylicious JARs (do not modify).
 <2> Third-party plugin JARs, organised by plugin name.
 
-The proxy startup script automatically scans `plugins/` subdirectories and adds their contents to the Java classpath.
+The proxy startup script automatically scans `classpath-plugins/` subdirectories and adds their contents to the Java classpath.
 Plugins are then discovered via `ServiceLoader` alongside the built-in filters.
 
-If the `plugins/` directory does not exist, no plugin scanning is performed and the proxy starts normally.
+If the `classpath-plugins/` directory does not exist, no plugin scanning is performed and the proxy starts normally.
 
 === Dependency shading
 
-There is currently no classloader isolation between plugins.
+CAUTION: There is currently no classloader isolation between plugins.
+
 All plugins share a single classpath with the proxy itself.
 If a plugin bundles a library that is also used by the proxy or by another plugin (for example Jackson or Guava), the classpath ordering determines which version is used at runtime.
 This can cause subtle failures.


### PR DESCRIPTION
The startup script now scans plugins/<name>/ subdirectories and adds their contents to the classpath, enabling 3rd party plugin JARs to be discovered by ServiceLoader. The Dockerfile creates the plugins directory with correct ownership. Backwards-compatible: if the directory is absent, behaviour is unchanged.

Document plugins directory and dependency shading

Add deployment and dependency shading guidance to the custom filters documentation, covering the plugins/ directory layout and the need to shade transitive dependencies to avoid classpath conflicts.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
