### PR TITLE
feat(omb): support arbitrary number of scenarios in run-all-scenarios.sh

### DIFF
--- a/kroxylicious-openmessaging-benchmarks/scripts/rate-sweep.sh
+++ b/kroxylicious-openmessaging-benchmarks/scripts/rate-sweep.sh
@@ -211,7 +211,7 @@ print_summary() {
     while IFS= read -r rate; do
         rates+=("${rate}")
     done < <(find "${ref_dir}" -maxdepth 1 -name 'rate-*' -type d 2>/dev/null \
-        | xargs -n1 basename | sed 's/^rate-//' | sort -n)
+        | xargs -r -n1 basename | sed 's/^rate-//' | sort -n)
 
     if [[ ${#rates[@]} -eq 0 ]]; then
         echo "No results found in ${ref_dir} — cannot produce summary" >&2

--- a/kroxylicious-openmessaging-benchmarks/scripts/run-all-scenarios.sh
+++ b/kroxylicious-openmessaging-benchmarks/scripts/run-all-scenarios.sh
@@ -14,20 +14,21 @@ WORKLOADS=(1topic-1kb 10topics-1kb 100topics-1kb)
 
 usage() {
     cat >&2 <<EOF
-Usage: $(basename "$0") [options] [<baseline> <candidate>] <output-dir>
+Usage: $(basename "$0") [options] [<scenario>...] <output-dir>
 
-Runs two benchmark scenarios across all workloads and produces a side-by-side
-comparison to quantify overhead.
+Runs one or more benchmark scenarios across all workloads and produces
+side-by-side comparisons against the first (baseline) scenario.
 
 For each scenario/workload combination, run-benchmark.sh is called.
 Each benchmark deploys fresh infrastructure, runs to completion, collects
 results, then tears down before the next run starts.
 
-After all runs complete, compare-results.sh is called for each workload.
+After all runs complete, compare-results.sh is called for each non-baseline
+scenario vs the baseline, for each workload.
 
 Arguments:
-  baseline   Baseline scenario name (default: baseline)
-  candidate  Candidate scenario name (default: proxy-no-filters)
+  scenario   Scenario names (default: baseline proxy-no-filters).
+             The first scenario is used as the baseline for comparisons.
   output-dir Root directory for all results. Results are organised as:
                <output-dir>/<scenario>/<workload>/
 
@@ -46,6 +47,7 @@ Environment:
 
 Examples:
   $(basename "$0") ./results/run-$(date +%Y%m%d-%H%M%S)/
+  $(basename "$0") baseline proxy-no-filters encryption ./results/run-$(date +%Y%m%d-%H%M%S)/
   $(basename "$0") baseline encryption \
     --cluster-overrides ~/my-cluster.yaml ./results/run-$(date +%Y%m%d-%H%M%S)/
 EOF
@@ -80,20 +82,19 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ ${#POSITIONAL[@]} -eq 1 ]]; then
-    BASELINE_SCENARIO="baseline"
-    CANDIDATE_SCENARIO="proxy-no-filters"
-    OUTPUT_DIR="${POSITIONAL[0]}"
-elif [[ ${#POSITIONAL[@]} -eq 3 ]]; then
-    BASELINE_SCENARIO="${POSITIONAL[0]}"
-    CANDIDATE_SCENARIO="${POSITIONAL[1]}"
-    OUTPUT_DIR="${POSITIONAL[2]}"
-else
-    echo "Error: expected 1 or 3 positional arguments, got ${#POSITIONAL[@]}" >&2
+if [[ ${#POSITIONAL[@]} -eq 0 ]]; then
+    echo "Error: output-dir is required" >&2
     usage
+elif [[ ${#POSITIONAL[@]} -eq 1 ]]; then
+    SCENARIOS=(baseline proxy-no-filters)
+    OUTPUT_DIR="${POSITIONAL[0]}"
+else
+    # Last positional arg is output-dir, everything before is a scenario
+    OUTPUT_DIR="${POSITIONAL[${#POSITIONAL[@]}-1]}"
+    SCENARIOS=("${POSITIONAL[@]:0:${#POSITIONAL[@]}-1}")
 fi
 
-SCENARIOS=("${BASELINE_SCENARIO}" "${CANDIDATE_SCENARIO}")
+BASELINE_SCENARIO="${SCENARIOS[0]}"
 
 for profile_file in ${PROFILE_VALUES[@]+"${PROFILE_VALUES[@]}"}; do
     if [[ ! -f "${profile_file}" ]]; then
@@ -108,9 +109,9 @@ if [[ -n "${CLUSTER_OVERRIDES}" && ! -f "${CLUSTER_OVERRIDES}" ]]; then
 fi
 
 echo "=== Running benchmark scenarios ==="
-echo "Baseline:  ${BASELINE_SCENARIO}"
-echo "Candidate: ${CANDIDATE_SCENARIO}"
-echo "Workloads: ${WORKLOADS[*]}"
+echo "Baseline:   ${BASELINE_SCENARIO}"
+echo "Candidates: ${SCENARIOS[*]:1}"
+echo "Workloads:  ${WORKLOADS[*]}"
 echo "Output:    ${OUTPUT_DIR}"
 if [[ ${#PROFILE_VALUES[@]} -gt 0 ]]; then
     echo "Profiles:  ${PROFILE_VALUES[*]}"
@@ -143,46 +144,48 @@ done
 echo "Generating result tooling sources..."
 mvn -q process-sources -pl kroxylicious-openmessaging-benchmarks -f "${SCRIPT_DIR}/../../pom.xml"
 
-# --- Compare baseline vs proxy-no-filters ---
-
-echo "=== Comparing ${BASELINE_SCENARIO} vs ${CANDIDATE_SCENARIO} ==="
-echo ""
+# --- Compare each candidate scenario against the baseline ---
 
 FILTERED="${SCRIPT_DIR}/../target/jbang/generated-sources/io/kroxylicious/benchmarks/results/cli/CompareResults.java"
 if [[ ! -f "${FILTERED}" ]]; then
     echo "Warning: comparison tooling not available after mvn process-sources, skipping." >&2
 else
-    for WORKLOAD in "${WORKLOADS[@]}"; do
-        # Filter out run-metadata.json — we want the OMB result files only
-        BASELINE_OMB=()
-        for f in "${OUTPUT_DIR}/${BASELINE_SCENARIO}/${WORKLOAD}/"*.json; do
-            [[ -f "${f}" && "$(basename "$f")" != "run-metadata.json" ]] && BASELINE_OMB+=("${f}")
-        done
-        CANDIDATE_OMB=()
-        for f in "${OUTPUT_DIR}/${CANDIDATE_SCENARIO}/${WORKLOAD}/"*.json; do
-            [[ -f "${f}" && "$(basename "$f")" != "run-metadata.json" ]] && CANDIDATE_OMB+=("${f}")
-        done
-
-        if [[ ${#BASELINE_OMB[@]} -eq 0 || ${#CANDIDATE_OMB[@]} -eq 0 ]]; then
-            echo "  ${WORKLOAD}: skipping (missing results for one or both scenarios)"
-            continue
-        fi
-
-        echo "--- ${WORKLOAD}: ${BASELINE_SCENARIO} vs ${CANDIDATE_SCENARIO} ---"
-        "${SCRIPT_DIR}/compare-results.sh" "${BASELINE_OMB[0]}" "${CANDIDATE_OMB[0]}"
+    for CANDIDATE_SCENARIO in "${SCENARIOS[@]:1}"; do
+        echo "=== Comparing ${BASELINE_SCENARIO} vs ${CANDIDATE_SCENARIO} ==="
         echo ""
 
-        # Check all scenarios for producer back-pressure and suggest a rate sweep if detected.
-        _BP_RESULTS=()
-        for _bp_scenario in "${SCENARIOS[@]}"; do
-            for _bp_f in "${OUTPUT_DIR}/${_bp_scenario}/${WORKLOAD}/"*.json; do
-                [[ -f "${_bp_f}" && "$(basename "${_bp_f}")" != "run-metadata.json" ]] && _BP_RESULTS+=("${_bp_f}")
+        for WORKLOAD in "${WORKLOADS[@]}"; do
+            # Filter out run-metadata.json — we want the OMB result files only
+            BASELINE_OMB=()
+            for f in "${OUTPUT_DIR}/${BASELINE_SCENARIO}/${WORKLOAD}/"*.json; do
+                [[ -f "${f}" && "$(basename "$f")" != "run-metadata.json" ]] && BASELINE_OMB+=("${f}")
             done
-        done
-        if [[ ${#_BP_RESULTS[@]} -gt 0 ]]; then
-            "${SCRIPT_DIR}/check-backpressure.sh" --workload "${WORKLOAD}" "${_BP_RESULTS[@]}" || true
+            CANDIDATE_OMB=()
+            for f in "${OUTPUT_DIR}/${CANDIDATE_SCENARIO}/${WORKLOAD}/"*.json; do
+                [[ -f "${f}" && "$(basename "$f")" != "run-metadata.json" ]] && CANDIDATE_OMB+=("${f}")
+            done
+
+            if [[ ${#BASELINE_OMB[@]} -eq 0 || ${#CANDIDATE_OMB[@]} -eq 0 ]]; then
+                echo "  ${WORKLOAD}: skipping (missing results for one or both scenarios)"
+                continue
+            fi
+
+            echo "--- ${WORKLOAD}: ${BASELINE_SCENARIO} vs ${CANDIDATE_SCENARIO} ---"
+            "${SCRIPT_DIR}/compare-results.sh" "${BASELINE_OMB[0]}" "${CANDIDATE_OMB[0]}"
             echo ""
-        fi
+
+            # Check all scenarios for producer back-pressure and suggest a rate sweep if detected.
+            _BP_RESULTS=()
+            for _bp_scenario in "${SCENARIOS[@]}"; do
+                for _bp_f in "${OUTPUT_DIR}/${_bp_scenario}/${WORKLOAD}/"*.json; do
+                    [[ -f "${_bp_f}" && "$(basename "${_bp_f}")" != "run-metadata.json" ]] && _BP_RESULTS+=("${_bp_f}")
+                done
+            done
+            if [[ ${#_BP_RESULTS[@]} -gt 0 ]]; then
+                "${SCRIPT_DIR}/check-backpressure.sh" --workload "${WORKLOAD}" "${_BP_RESULTS[@]}" || true
+                echo ""
+            fi
+        done
     done
 fi
 

--- a/kroxylicious-openmessaging-benchmarks/scripts/run-benchmark.sh
+++ b/kroxylicious-openmessaging-benchmarks/scripts/run-benchmark.sh
@@ -728,6 +728,17 @@ else
             echo "  ${SCENARIO}-${WORKLOAD}-flamegraph.html ($(du -h "${local_fg}" | cut -f1))"
         fi
     fi
+
+    # Generate run metadata for --skip-deploy probes (rate sweeps).
+    # Full deploys get metadata from collect-results.sh above.
+    FILTERED="${SCRIPT_DIR}/../target/jbang/generated-sources/io/kroxylicious/benchmarks/results/cli/CollectResults.java"
+    if [[ -f "${FILTERED}" ]]; then
+        JBANG_ARGS=(--generate-run-metadata "${OUTPUT_DIR}")
+        [[ -n "${SCENARIO}" ]]        && JBANG_ARGS+=(--scenario "${SCENARIO}")
+        [[ -n "${WORKLOAD}" ]]        && JBANG_ARGS+=(--workload "${WORKLOAD}")
+        [[ -n "${PRODUCER_RATE:-}" ]] && JBANG_ARGS+=(--target-rate "${PRODUCER_RATE}")
+        jbang "${FILTERED}" "${JBANG_ARGS[@]}"
+    fi
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

- `run-all-scenarios.sh` now accepts any number of scenario names instead of exactly two
- The first scenario is used as the baseline for comparisons; each subsequent scenario is compared against it
- Defaults to `baseline proxy-no-filters` when no scenarios are specified (preserves existing behaviour)

This allows running baseline, proxy-no-filters, and encryption in a single command:
```bash
./run-all-scenarios.sh baseline proxy-no-filters encryption ./results/
```

Or comparing proxy overhead against encryption directly:
```bash
./run-all-scenarios.sh proxy-no-filters encryption ./results/
```

## Test plan

- [ ] `./run-all-scenarios.sh ./results/` — defaults to baseline + proxy-no-filters (backwards compatible)
- [ ] `./run-all-scenarios.sh baseline proxy-no-filters encryption ./results/` — runs 3 scenarios, compares each candidate against baseline
- [ ] `./run-all-scenarios.sh proxy-no-filters encryption ./results/` — uses proxy-no-filters as baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)