### PR TITLE
Add claude rule for Java dependencies

### DIFF
--- a/.claude/rules/java-dependency-changes.md
+++ b/.claude/rules/java-dependency-changes.md
@@ -5,6 +5,8 @@ paths:
 
 # Java Dependency Change Requirements
 
+Follow this guidance when adding or changing Java dependencies.
+
 ## Open Source only
 
 This is a strictly open source project.
@@ -12,6 +14,10 @@ This extends to our direct and transitive dependencies.
 We can only add a new dependency (or upgrade an existing dependency) when the dependency, and all its transitive dependencies, have an open source license. 
 Open source license means a license that's approved but the OSI. 
 We prefer non-copyleft open source licenses. 
+
+## Adhere to the license conditions
+
+Evaluate what steps need to be taken to comply with the condition of the license, and follow them.
 
 ## Minimise the number of dependencies
 
@@ -21,13 +27,18 @@ We want to avoid having a larger set of dependencies than is strictly necessary,
 * The can also increase our users' exposure to security threats.
 * Even when a dependency's CVE is not expoitable in the proxy we have to fix it in practice because of false positives from security scanning software.
 
-In practice the standard is not quite as high for dependencies which will not made it into the production code.
+The following criteria should be considered:
 
-When there's a choice, our ordered preferences for production dependencies are:
+* Where functionality is simple we prefer to implement it in our own codebase, rather than using a dependency to provide it.
+* All else being equal, we prefer libraries that have no dependencies of their own.
+  Failing that, libraries that require few dependencies of their own are preferable.
+* Libraries that are well-known and/or obviously well-maintained are preferred.
+    * Regular releases are one signal of "well-maintained".
+* We prefer reusing an existing dependency over adding a new dependency with similar function.
+  For example, don't add a dependency on a YAML parser without a compelling reason;
+  you preferring that library over Jackson is not a compelling reason.
+* Dependencies with native code require special consideration: bring this up directly with the project managers.
+* Be extra cautious if a proposed dependency has a version clash with an existing dependenency.
+  There are few guardrails in this situation, so we need to evaluate how well the troublesome dependency manages binary compatibility.
 
-1. Implement simple functionality in our own codebase, rather than using a dependency to provide it.
-2. Prefer libraries that require no dependencies of their own.
-3. Prefer libraries that are well-known and/or well-maintained projects. Regular releases are one signal of "well-maintained".
-4. Prefer libraries that require few dependencies of their own.
-
-Please consider these requirements if you're suggesting to add or change a dependency.
+In practice the standard is not quite as high for dependencies which will not make it into the production code.

--- a/.claude/rules/java-dependency-changes.md
+++ b/.claude/rules/java-dependency-changes.md
@@ -1,0 +1,33 @@
+---
+paths:
+  - "**/pom.xml"
+---
+
+# Java Dependency Change Requirements
+
+## Open Source only
+
+This is a strictly open source project.
+This extends to our direct and transitive dependencies. 
+We can only add a new dependency (or upgrade an existing dependency) when the dependency, and all its transitive dependencies, have an open source license. 
+Open source license means a license that's approved but the OSI. 
+We prefer non-copyleft open source licenses. 
+
+## Minimise the number of dependencies
+
+We want to avoid having a larger set of dependencies than is strictly necessary, because:
+* Dependencies are a liability as much as an asset. 
+* They can increase our support burden by requiring dependency upgrades.
+* The can also increase our users' exposure to security threats.
+* Even when a dependency's CVE is not expoitable in the proxy we have to fix it in practice because of false positives from security scanning software.
+
+In practice the standard is not quite as high for dependencies which will not made it into the production code.
+
+When there's a choice, our ordered preferences for production dependencies are:
+
+1. Implement simple functionality in our own codebase, rather than using a dependency to provide it.
+2. Prefer libraries that require no dependencies of their own.
+3. Prefer libraries that are well-known and/or well-maintained projects. Regular releases are one signal of "well-maintained".
+4. Prefer libraries that require few dependencies of their own.
+
+Please consider these requirements if you're suggesting to add or change a dependency.


### PR DESCRIPTION
### Type of change

- Documentation

### Description

Adds claude rule for Java dependencies

### Additional Context

I think it's worth providing some guidance about what we consider acceptable. Being up-front avoids rework when bad choice are made initially.

Perhaps we can improve the wording. I didn't quite want to say: The AWS Java SDK is a great example of the kind of dependency we want to avoid, because it has a huge transitive dependency set. 