### PR TITLE
fix: add adoc mapping to license-maven-plugin configuration (#153)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -652,6 +652,7 @@
                             </licenseSet>
                         </licenseSets>
                         <mapping>
+                            <adoc>ASCIIDOC_STYLE</adoc>
                             <bicep>DOUBLESLASH_STYLE</bicep>
                             <g4>JAVADOC_STYLE</g4>
                             <operator>SCRIPT_STYLE</operator>


### PR DESCRIPTION
## Summary

The `license-maven-plugin` was emitting `Unknown file extension` warnings for `.adoc` files because no style mapping was configured for that extension.

Adds `ASCIIDOC_STYLE` to the plugin mapping so `.adoc` files are recognised and their license headers are validated as part of the build.

All 190 `.adoc` files in the project already carry the correct `////` block comment license header — this change simply ensures the plugin enforces that going forward.

## Testing

The `license:check` goal will now validate `.adoc` files rather than silently skipping them with an `Unknown file extension` warning.

Closes #153