### PR TITLE
perf(ci): speed up integration tests by skipping QA checks on shared pre-build step

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -40,7 +40,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mvn -B install -DskipTests -Dmaven.javadoc.skip=true -DskipDocs=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Djapicmp.skip=true -pl :kroxylicious-bom,:kroxylicious-integration-tests,:kroxylicious-filter-archetype -am
+          mvn -B install -P '!qa' -DskipTests -Dmaven.javadoc.skip=true -DskipDocs=true -Derrorprone.skip=true -pl :kroxylicious-bom,:kroxylicious-integration-tests,:kroxylicious-filter-archetype -am
       - name: 'Package Kroxylicious Maven artifacts'
         run: |
           mkdir -p /tmp/kroxylicious-artifacts
@@ -105,7 +105,7 @@ jobs:
           KROXYLICIOUS_KMS_FORTANIX_ADMIN_API_KEY: ${{ secrets.KROXYLICIOUS_KMS_FORTANIX_ADMIN_API_KEY }}
           KROXYLICIOUS_KMS_FORTANIX_API_KEY: ${{ secrets.KROXYLICIOUS_KMS_FORTANIX_API_KEY }}
         working-directory: kroxylicious-integration-tests
-        run: mvn -B verify -DskipUTs -Dit.test="${{ matrix.tests }}"
+        run: mvn -B verify -P '!qa' -DskipUTs -Derrorprone.skip=true -Dit.test="${{ matrix.tests }}"
   integration_test_proxy:
     runs-on: ubuntu-latest
     needs: run_integration_tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,16 @@ See [README.md](README.md) for comprehensive project documentation including:
 - API vs implementation distinctions
 - Testing guidance
 
+## Build and Development
+
+See [DEV_GUIDE.md](DEV_GUIDE.md) for:
+- Build commands and Maven properties/profiles
+- Maven profiles: `qa` (quality checks), `ci`, `dist`, `quick`, `systemtest`, `errorprone-jdk-compatible`
+- IDE setup and debugging
+- Running integration/system tests locally
+- Container image building and pushing
+- Continuous integration workflows
+
 ## Coding Rules
 
 When writing code, follow these prescriptive rules:

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -83,6 +83,18 @@ The running of the tests can be controlled with the following Maven properties:
 | `-DfailOnWarnings` | fail on javac warnings (ignored if `-Dquick`, see below)                                  |
 | `-Pdebug`          | enables logging so you can see what the Kafka clients, Proxy and in VM brokers are up to. |
 
+The build behavior can be controlled with the following Maven profiles:
+
+| profile                    | description                                                                                                                                                                                           |
+|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `-Pqa` (active by default) | Runs quality assurance checks: dependency analysis, code formatting, import sorting, license headers, checkstyle, spotbugs, japicmp API compatibility, and enforcer rules. Use `-P '!qa'` to disable. |
+| `-Pci`                     | CI-specific configuration: validates formatting instead of applying it, runs jacoco code coverage, switches license plugin to check mode instead of format mode.                                      |
+| `-Pdist`                   | Creates distribution artifacts including tarball, container images. Required for building deployable packages.                                                                                        |
+| `-Pquick`                  | Fast build mode: skips all tests, QA checks, javadoc, and documentation. Activates with `-Dquick`. Excludes integration/system test modules from reactor.                                             |
+| `-Psystemtest`             | Enables system test module and skips all other test types. Use with `-Pdist` to run Kubernetes-based system tests.                                                                                    |
+| `-P-withAdditionalFilters` | Excludes Kroxylicious-maintained filter implementations from the distribution. Only use with `-Pdist`.                                                                                                |
+| `errorprone-jdk-compatible` (auto-activated on JDK 17+) | Runs Error Prone static analysis during compilation to detect bug patterns. Adds ~15-30% to compilation time. Disable with `-Derrorprone.skip=true` for faster builds. |
+
 The kafka environment used by the integrations tests can be _defaulted_ with these two environment variables.
 
 | env var                       | default | description                                                                                                                             |

--- a/kroxylicious-api/pom.xml
+++ b/kroxylicious-api/pom.xml
@@ -143,47 +143,62 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>com.github.siom79.japicmp</groupId>
-                <artifactId>japicmp-maven-plugin</artifactId>
-                <version>0.25.5</version>
-                <configuration>
-                    <oldVersion>
-                        <!-- specify the old version directly so its deterministic -->
-                        <dependency>
-                            <groupId>${project.groupId}</groupId>
-                            <artifactId>${project.artifactId}</artifactId>
-                            <version>${ApiCompatability.ReferenceVersion}</version>
-                            <type>jar</type>
-                        </dependency>
-                    </oldVersion>
-                    <parameter>
-                        <accessModifier>public</accessModifier>
-                        <breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
-                        <breakBuildOnBinaryIncompatibleModifications>false</breakBuildOnBinaryIncompatibleModifications>
-                        <breakBuildBasedOnSemanticVersioningForMajorVersionZero>${ApiCompatability.EnforceForMajorVersionZero}</breakBuildBasedOnSemanticVersioningForMajorVersionZero>
-                        <excludes>
-                            <!-- The following filter exclusions relate to RPCs that were renamed in kafka-clients 4.1 -->
-                            <exclude>io.kroxylicious.proxy.filter.ListClientMetricsResourcesResponseFilter</exclude>
-                            <exclude>io.kroxylicious.proxy.filter.ListClientMetricsResourcesRequestFilter</exclude>
-                            <!-- The following methods become deprecated and are given a default implementation at 0.19.0 which throws UnsupportedOperationException -->
-                            <exclude>io.kroxylicious.proxy.filter.RequestFilter#onRequest(org.apache.kafka.common.protocol.ApiKeys, org.apache.kafka.common.message.RequestHeaderData, org.apache.kafka.common.protocol.ApiMessage, io.kroxylicious.proxy.filter.FilterContext)</exclude>
-                            <exclude>io.kroxylicious.proxy.filter.ResponseFilter#onResponse(org.apache.kafka.common.protocol.ApiKeys, org.apache.kafka.common.message.ResponseHeaderData, org.apache.kafka.common.protocol.ApiMessage, io.kroxylicious.proxy.filter.FilterContext)</exclude>
-                            <!-- The following method was deprecated since 0.18 and removed at 0.21.0, see https://github.com/kroxylicious/kroxylicious/issues/3620 -->
-                            <exclude>io.kroxylicious.proxy.filter.FilterContext#clientSaslAuthenticationSuccess(java.lang.String, java.lang.String)</exclude>
-                        </excludes>
-                        <!-- see documentation -->
-                    </parameter>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>cmp</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>qa</id>
+            <activation>
+                <property>
+                    <name>!quick</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.siom79.japicmp</groupId>
+                        <artifactId>japicmp-maven-plugin</artifactId>
+                        <version>0.25.5</version>
+                        <configuration>
+                            <oldVersion>
+                                <!-- specify the old version directly so its deterministic -->
+                                <dependency>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>${project.artifactId}</artifactId>
+                                    <version>${ApiCompatability.ReferenceVersion}</version>
+                                    <type>jar</type>
+                                </dependency>
+                            </oldVersion>
+                            <parameter>
+                                <accessModifier>public</accessModifier>
+                                <breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
+                                <breakBuildOnBinaryIncompatibleModifications>false</breakBuildOnBinaryIncompatibleModifications>
+                                <breakBuildBasedOnSemanticVersioningForMajorVersionZero>${ApiCompatability.EnforceForMajorVersionZero}</breakBuildBasedOnSemanticVersioningForMajorVersionZero>
+                                <excludes>
+                                    <!-- The following filter exclusions relate to RPCs that were renamed in kafka-clients 4.1 -->
+                                    <exclude>io.kroxylicious.proxy.filter.ListClientMetricsResourcesResponseFilter</exclude>
+                                    <exclude>io.kroxylicious.proxy.filter.ListClientMetricsResourcesRequestFilter</exclude>
+                                    <!-- The following methods become deprecated and are given a default implementation at 0.19.0 which throws UnsupportedOperationException -->
+                                    <exclude>io.kroxylicious.proxy.filter.RequestFilter#onRequest(org.apache.kafka.common.protocol.ApiKeys, org.apache.kafka.common.message.RequestHeaderData, org.apache.kafka.common.protocol.ApiMessage, io.kroxylicious.proxy.filter.FilterContext)</exclude>
+                                    <exclude>io.kroxylicious.proxy.filter.ResponseFilter#onResponse(org.apache.kafka.common.protocol.ApiKeys, org.apache.kafka.common.message.ResponseHeaderData, org.apache.kafka.common.protocol.ApiMessage, io.kroxylicious.proxy.filter.FilterContext)</exclude>
+                                    <!-- The following method was deprecated since 0.18 and removed at 0.21.0, see https://github.com/kroxylicious/kroxylicious/issues/3620 -->
+                                    <exclude>io.kroxylicious.proxy.filter.FilterContext#clientSaslAuthenticationSuccess(java.lang.String, java.lang.String)</exclude>
+                                </excludes>
+                                <!-- see documentation -->
+                            </parameter>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>cmp</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1058,72 +1058,6 @@
                             </rules>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>enforce-recommended-java</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireJavaVersion>
-                                    <version>[${java.recommended.version},)</version>
-                                    <message>
-                                        Use of JDK ${java.version} has been deprecated and will be removed in a future release. Please upgrade to JDK ${java.recommended.version} or later.
-                                    </message>
-                                </requireJavaVersion>
-                            </rules>
-                            <fail>false</fail>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>ban-build-time-dependencies-from-runtime</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <bannedDependencies>
-                                    <excludes>
-                                        <exclude>com.github.spotbugs:spotbugs-annotations:*:*:compile</exclude>
-                                        <exclude>com.github.spotbugs:spotbugs-annotations:*:*:runtime</exclude>
-                                    </excludes>
-                                </bannedDependencies>
-                            </rules>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <!--AssertJ will throw different exceptions than expected when JUnit 4 is on the classpath -->
-                        <!-- See: https://github.com/kroxylicious/kroxylicious/issues/2801-->
-                        <id>ban-junit-4</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <bannedDependencies>
-                                    <excludes>
-                                        <exclude>junit:junit</exclude>
-                                    </excludes>
-                                </bannedDependencies>
-                            </rules>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>project-metadata</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <requireProperty>
-                                    <!-- note Maven defaults project.name from project.artifactId if it is not specified -->
-                                    <property>project.name</property>
-                                    <regex>^((?!${project.artifactId}).)*$</regex>
-                                    <regexMessage>Module must define a explict project.name property</regexMessage>
-                                </requireProperty>
-                            </rules>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -1134,10 +1068,6 @@
                     <publishingServerId>central</publishingServerId>
                     <waitMaxTime>3600</waitMaxTime>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>
@@ -1324,7 +1254,77 @@
                                     </rules>
                                 </configuration>
                             </execution>
+                            <execution>
+                                <id>enforce-recommended-java</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireJavaVersion>
+                                            <version>[${java.recommended.version},)</version>
+                                            <message>
+                                                Use of JDK ${java.version} has been deprecated and will be removed in a future release. Please upgrade to JDK ${java.recommended.version} or later.
+                                            </message>
+                                        </requireJavaVersion>
+                                    </rules>
+                                    <fail>false</fail>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>ban-build-time-dependencies-from-runtime</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <bannedDependencies>
+                                            <excludes>
+                                                <exclude>com.github.spotbugs:spotbugs-annotations:*:*:compile</exclude>
+                                                <exclude>com.github.spotbugs:spotbugs-annotations:*:*:runtime</exclude>
+                                            </excludes>
+                                        </bannedDependencies>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <!--AssertJ will throw different exceptions than expected when JUnit 4 is on the classpath -->
+                                <!-- See: https://github.com/kroxylicious/kroxylicious/issues/2801-->
+                                <id>ban-junit-4</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <bannedDependencies>
+                                            <excludes>
+                                                <exclude>junit:junit</exclude>
+                                            </excludes>
+                                        </bannedDependencies>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>project-metadata</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireProperty>
+                                            <!-- note Maven defaults project.name from project.artifactId if it is not specified -->
+                                            <property>project.name</property>
+                                            <regex>^((?!${project.artifactId}).)*$</regex>
+                                            <regexMessage>Module must define a explict project.name property</regexMessage>
+                                        </requireProperty>
+                                    </rules>
+                                </configuration>
+                            </execution>
                         </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>
@@ -1527,13 +1527,7 @@
                 <skipTests>true</skipTests>
                 <maven.javadoc.skip>true</maven.javadoc.skip>
                 <archetype.test.skip>true</archetype.test.skip>
-                <mdep.analyze.skip>true</mdep.analyze.skip>
                 <skipDocs>true</skipDocs>
-                <checkstyle.skip>true</checkstyle.skip>
-                <spotbugs.skip>true</spotbugs.skip>
-                <enforcer.skip>true</enforcer.skip>
-                <formatter.skip>true</formatter.skip>
-                <impsort.skip>true</impsort.skip>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
## Summary

Optimize integration test workflow by disabling quality assurance checks and Error Prone static analysis, reducing build time by **68.7%**.

## Changes

### Maven Profile Reorganization

_(motivation - get all the checkers into a single profile, which is on by default, which can be toggled off easily)._

- **Moved spotbugs-maven-plugin** from main build to `qa` profile
- **Moved japicmp-maven-plugin** (in kroxylicious-api) to `qa` profile  
- **Moved 4 enforcer rules** to `qa` profile:
  - `enforce-recommended-java` (Java version warning)
  - `ban-build-time-dependencies-from-runtime` (spotbugs annotations scope check)
  - `ban-junit-4` (JUnit 4 classpath check)
  - `project-metadata` (explicit project.name validation)

### Integration Test Workflow Updates
- Added `-P '!qa'` to both build and test execution steps

_(it is the addition of the flag to build job that's the real win_

- Added `-Derrorprone.skip=true` to disable Error Prone static analysis
- Removed redundant `-Dcheckstyle.skip=true` (checkstyle only runs in qa profile)
- Removed redundant `-Dspotbugs.skip=true` (spotbugs now only in qa profile)
- Removed redundant `-Djapicmp.skip=true` (japicmp now only in qa profile)

### Documentation
- Added Maven profiles table to DEV_GUIDE.md documenting `qa`, `ci`, `dist`, `quick`, `systemtest`, and `errorprone-jdk-compatible` profiles
- Added "Build and Development" section to CLAUDE.md referencing DEV_GUIDE.md

## Performance Impact - ACTUAL RESULTS ✅

### Build Time for "Build Kroxylicious proxy integration tests" Step

| Metric | Before (main) | After (this PR) | Improvement |
|--------|---------------|-----------------|-------------|
| Build time | 4m 57s (297s) | **1m 33s (93s)** | **-204s (-68.7%)** |

### Baseline (main branch - average of 3 runs)
- Run 1 ([24519683004](https://github.com/kroxylicious/kroxylicious/actions/runs/24519683004)): 4m 52s (292s)
- Run 2 ([24519186987](https://github.com/kroxylicious/kroxylicious/actions/runs/24519186987)): 4m 50s (290s)
- Run 3 ([24514930010](https://github.com/kroxylicious/kroxylicious/actions/runs/24514930010)): 5m 8s (308s)
- **Average: 4m 57s (297s)**

### This PR
- Run ([24525226082](https://github.com/kroxylicious/kroxylicious/actions/runs/24525226082)): **1m 33s (93s)**

### Comparison to Estimates

| Metric | Estimated | Actual | Result |
|--------|-----------|--------|--------|
| Time saved | 80-125s | **204s** | ✨ **79-124s better than expected!** |
| % improvement | 27-42% | **68.7%** | ✨ **26-42% better than expected!** |

The combined effect of disabling QA checks, japicmp, enforcer rules, and Error Prone static analysis exceeded our conservative estimates significantly.

## Quality Assurance Preserved

All quality checks are still enforced:
- ✅ Run in other CI workflows (maven.yaml, sonar.yaml, etc.)
- ✅ Run in local development builds (qa profile active by default)
- ✅ Run when explicitly requested with `-Pqa`

Only the integration test workflow skips these checks for faster feedback on test results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)