### PR TITLE
perf(ci): optimize build pipeline efficiency by eliminating duplicate QA checks (including errorprone)

### DIFF
--- a/.github/workflows/build-kroxylicious-container-images.yaml
+++ b/.github/workflows/build-kroxylicious-container-images.yaml
@@ -36,7 +36,16 @@ jobs:
         uses: ./.github/actions/common/cache-maven-packages
       - name: 'Build Kroxylicious Operator/Operand Container Images & Operator Zip'
         run: |
-          mvn --quiet --batch-mode --activate-profiles dist --also-make --projects :kroxylicious-app,:kroxylicious-operator,:kroxylicious-operator-dist -Dquick package
+          mvn --quiet \
+            --batch-mode \
+            --activate-profiles 'dist,!qa' \
+            --also-make \
+            --projects :kroxylicious-app,:kroxylicious-operator,:kroxylicious-operator-dist \
+            -Derrorprone.skip=true \
+            -DskipTests \
+            -Dmaven.javadoc.skip=true \
+            -DskipDocs=true \
+            package
       - name: 'Archive kroxylicious proxy image'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -71,9 +71,17 @@ jobs:
 
       - name: Build Kroxylicious distribution artifacts
         run: |
-          mvn --quiet --batch-mode --activate-profiles dist \
-            --also-make --projects :kroxylicious-app,:kroxylicious-operator,:kroxylicious-operator-dist \
-            -Dquick -DskipContainerImageBuild=true package
+          mvn --quiet \
+            --batch-mode \
+            --activate-profiles 'dist,!qa' \
+            --also-make \
+            --projects :kroxylicious-app,:kroxylicious-operator,:kroxylicious-operator-dist \
+            -Derrorprone.skip=true \
+            -DskipTests \
+            -Dmaven.javadoc.skip=true \
+            -DskipDocs=true \
+            -DskipContainerImageBuild=true \
+            package
 
       - name: Login to container registry
         if: steps.build_configuration.outputs.push_images == 'true'

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -40,7 +40,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mvn -B install -P '!qa' -DskipTests -Dmaven.javadoc.skip=true -DskipDocs=true -Derrorprone.skip=true -pl :kroxylicious-bom,:kroxylicious-integration-tests,:kroxylicious-filter-archetype -am
+          mvn --batch-mode \
+            --activate-profiles '!qa' \
+            --projects :kroxylicious-bom,:kroxylicious-integration-tests,:kroxylicious-filter-archetype \
+            --also-make \
+            -DskipTests \
+            -Dmaven.javadoc.skip=true \
+            -DskipDocs=true \
+            -Derrorprone.skip=true \
+            install
       - name: 'Package Kroxylicious Maven artifacts'
         run: |
           mkdir -p /tmp/kroxylicious-artifacts
@@ -105,7 +113,13 @@ jobs:
           KROXYLICIOUS_KMS_FORTANIX_ADMIN_API_KEY: ${{ secrets.KROXYLICIOUS_KMS_FORTANIX_ADMIN_API_KEY }}
           KROXYLICIOUS_KMS_FORTANIX_API_KEY: ${{ secrets.KROXYLICIOUS_KMS_FORTANIX_API_KEY }}
         working-directory: kroxylicious-integration-tests
-        run: mvn -B verify -P '!qa' -DskipUTs -Derrorprone.skip=true -Dit.test="${{ matrix.tests }}"
+        run: |
+          mvn --batch-mode \
+            --activate-profiles '!qa' \
+            -DskipUTs \
+            -Derrorprone.skip=true \
+            -Dit.test="${{ matrix.tests }}" \
+            verify
   integration_test_proxy:
     runs-on: ubuntu-latest
     needs: run_integration_tests

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -45,7 +45,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mvn -B -Pci -T1.5C verify -DskipTests -Djapicmp.skip=true
+          # This is the authoritative QA check for all PRs. Explicitly enable the qa profile and errorprone
+          # to ensure all quality checks (formatting, licensing, checkstyle, spotbugs, dependency analysis, enforcer)
+          # run across all modules. Other workflows skip QA to avoid duplication.
+          mvn --batch-mode \
+            --activate-profiles ci,qa \
+            --threads 1.5C \
+            -Derrorprone.skip=false \
+            -DskipTests \
+            -Djapicmp.skip=true \
+            verify
       - name: Save PR number to file
         run: echo ${{ github.event.number }} > PR_NUMBER.txt
       - name: Archive PR number

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -45,13 +45,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # This is the authoritative QA check for all PRs. Explicitly enable the qa profile and errorprone
-          # to ensure all quality checks (formatting, licensing, checkstyle, spotbugs, dependency analysis, enforcer)
-          # run across all modules. Other workflows skip QA to avoid duplication.
+          # This is the authoritative QA check for all PRs. Explicitly enable the qa profile.
+          # ErrorProne automatically activates on JDK 17+ (errorprone-jdk-compatible profile).
+          # All quality checks run: formatting, licensing, checkstyle, spotbugs, dependency analysis, enforcer, errorprone.
+          # Other workflows skip QA to avoid duplication.
           mvn --batch-mode \
             --activate-profiles ci,qa \
             --threads 1.5C \
-            -Derrorprone.skip=false \
             -DskipTests \
             -Djapicmp.skip=true \
             verify

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -79,7 +79,14 @@ jobs:
           echo "KROXYLICIOUS_VERSION=${KROXYLICIOUS_VERSION}" >> "$GITHUB_ENV"
           # KROXYLICIOUS_IMAGE env var is used by the Operator ITs
           echo "KROXYLICIOUS_IMAGE=${KROXYLICIOUS_IMAGE}" >> "$GITHUB_ENV"
-          mvn -B install -DskipITs -Pci -Djapicmp.skip=${REFERENCE_RELEASE_UNPUBLISHED} -Dspotbugs.skip=true
+          # On PRs, skip QA checks (already run in lint.yaml). On push to main, run QA checks.
+          QA_OPTS="${{ github.event_name == 'pull_request' && '--activate-profiles !qa -Derrorprone.skip=true' || '' }}"
+          mvn --batch-mode \
+            --activate-profiles ci \
+            ${QA_OPTS} \
+            -DskipITs \
+            -Djapicmp.skip=${REFERENCE_RELEASE_UNPUBLISHED} \
+            install
       - name: Cache SonarCloud packages
         uses: actions/cache@v5
         if: github.ref_name == 'main' || env.SONAR_TOKEN_SET == 'true'
@@ -95,7 +102,14 @@ jobs:
           KROXYLICIOUS_KMS_FORTANIX_API_ENDPOINT: ${{ vars.KROXYLICIOUS_KMS_FORTANIX_API_ENDPOINT }}
           KROXYLICIOUS_KMS_FORTANIX_ADMIN_API_KEY: ${{ secrets.KROXYLICIOUS_KMS_FORTANIX_ADMIN_API_KEY }}
           KROXYLICIOUS_KMS_FORTANIX_API_KEY: ${{ secrets.KROXYLICIOUS_KMS_FORTANIX_API_KEY }}
-        run: mvn -B verify -Pci -Djapicmp.skip=${REFERENCE_RELEASE_UNPUBLISHED} org.sonarsource.scanner.maven:sonar-maven-plugin:5.5.0.6356:sonar  -pl ''!:kroxylicious-operator''
+        run: |
+          mvn --batch-mode \
+            --activate-profiles 'ci,!qa' \
+            --projects ''!:kroxylicious-operator'' \
+            -Derrorprone.skip=true \
+            -Djapicmp.skip=${REFERENCE_RELEASE_UNPUBLISHED} \
+            verify \
+            org.sonarsource.scanner.maven:sonar-maven-plugin:5.5.0.6356:sonar
       - name: Slack Notification on Failure
         if: failure() && env.SLACK_WEBHOOK_SET == 'true' && github.event_name == 'push'
         uses: ./.github/actions/common/slack-notification

--- a/.github/workflows/operator-maven.yaml
+++ b/.github/workflows/operator-maven.yaml
@@ -80,13 +80,28 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mvn -B install -Pci -Djapicmp.skip=true -Dspotbugs.skip=true -pl ':kroxylicious-operator' -am
+          mvn --batch-mode \
+            --activate-profiles 'ci,!qa' \
+            --projects ':kroxylicious-operator' \
+            --also-make \
+            -Derrorprone.skip=true \
+            -Djapicmp.skip=true \
+            install
       - name: 'SonarCloud scan on main for the Operator'
         if: github.event_name == 'push' && github.ref_name == 'main' && env.SONAR_TOKEN_SET == 'true'
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mvn -B verify -Pci -Djapicmp.skip=true org.sonarsource.scanner.maven:sonar-maven-plugin:5.5.0.6356:sonar -Dsonar.projectName='Kroxylicious Operator' -Dsonar.projectKey='kroxylicious_operator' -pl ':kroxylicious-operator,:kroxylicious-parent'
+        run: |
+          mvn --batch-mode \
+            --activate-profiles 'ci,!qa' \
+            --projects ':kroxylicious-operator,:kroxylicious-parent' \
+            -Derrorprone.skip=true \
+            -Djapicmp.skip=true \
+            -Dsonar.projectName='Kroxylicious Operator' \
+            -Dsonar.projectKey='kroxylicious_operator' \
+            verify \
+            org.sonarsource.scanner.maven:sonar-maven-plugin:5.5.0.6356:sonar
       - name: Save PR number to file
         if: github.event_name == 'pull_request'
         run: echo ${{ github.event.number }} > PR_NUMBER.txt

--- a/.github/workflows/operator-tests-microshift.yaml
+++ b/.github/workflows/operator-tests-microshift.yaml
@@ -123,10 +123,13 @@ jobs:
           KROXYLICIOUS_IMAGE=quay.io/kroxylicious/proxy:${KROXYLICIOUS_VERSION}-${GIT_HASH}
 
           mvn --batch-mode \
-              --activate-profiles dist \
+              --activate-profiles 'dist,!qa' \
               --also-make \
               --projects :kroxylicious-app,:kroxylicious-operator \
-              -Dquick \
+              -Derrorprone.skip=true \
+              -DskipTests \
+              -Dmaven.javadoc.skip=true \
+              -DskipDocs=true \
               -Dio.kroxylicious.proxy.image.name=${KROXYLICIOUS_IMAGE} \
               install
 
@@ -138,12 +141,12 @@ jobs:
           eval $(crc podman-env --root)
 
           mvn --batch-mode \
-            -pl kroxylicious-operator \
-            -Dcheckstyle.skip \
-            -Dspotbugs.skip \
+            --projects kroxylicious-operator \
+            --activate-profiles '!qa' \
+            -Derrorprone.skip=true \
             -Dmaven.javadoc.skip=true \
-            verify \
-            ${{ github.event.inputs.additionalMavenArguments }}
+            ${{ github.event.inputs.additionalMavenArguments }} \
+            verify
 
       - name: Upload Maven surefire / failsafe reports
         if: failure()

--- a/.github/workflows/run-system-tests.yaml
+++ b/.github/workflows/run-system-tests.yaml
@@ -57,8 +57,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # The dist' profile builds the kroxylicious-operator artefact.  This is needed by the systemtests.
-          mvn --batch-mode --activate-profiles 'dist,!qa' -DskipTests -Dmaven.javadoc.skip=true -DskipDocs=true -DskipContainerImageBuild -Derrorprone.skip=true install
+          # The 'dist' profile builds the kroxylicious-operator artefact. This is needed by the systemtests.
+          mvn --batch-mode \
+            --activate-profiles 'dist,!qa' \
+            -DskipTests \
+            -Dmaven.javadoc.skip=true \
+            -DskipDocs=true \
+            -DskipContainerImageBuild \
+            -Derrorprone.skip=true \
+            install
       - name: 'Package Kroxylicious Maven artifacts'
         run: |
           mkdir -p /tmp/kroxylicious-artifacts
@@ -166,7 +173,13 @@ jobs:
           # This avoids mvn compiling the other modules.
           # Dependencies (including Kroxylicious's own jars and operator artefact) will be got from .m2/repo
           # QA & errorprone are disabled to avoid any unnecessary work
-          mvn --batch-mode --activate-profiles 'systemtest,!qa' -Derrorprone.skip=true verify $TESTS_OPT $EXCLUDED_GROUPS_OPT $GROUPS_OPT
+          mvn --batch-mode \
+            --activate-profiles 'systemtest,!qa' \
+            -Derrorprone.skip=true \
+            $TESTS_OPT \
+            $EXCLUDED_GROUPS_OPT \
+            $GROUPS_OPT \
+            verify
 
       - name: Archive JUnit test results
         if: ${{ always() }}

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -86,18 +86,52 @@ jobs:
           restore-keys: ${{ runner.os }}-sonar
       - name: Preinstall prior to SonarCloud scan
         if: env.SONAR_TOKEN_SET == 'true'
-        run: mvn -B install -Pci -DskipITs=true -DskipTests
+        run: |
+          mvn --batch-mode \
+            --activate-profiles 'ci,!qa' \
+            -Derrorprone.skip=true \
+            -DskipITs=true \
+            -DskipTests \
+            install
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: SonarCloud scan on PR for the Proxy Runtime
         if: env.SONAR_TOKEN_SET == 'true'
-        run: mvn -B clean verify -Pci -DskipITs=true org.sonarsource.scanner.maven:sonar-maven-plugin:5.5.0.6356:sonar -Djapicmp.skip=true -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }} -Dsonar.pullrequest.key=${{ fromJson(steps.get_pr_data.outputs.data).number }} -Dsonar.pullrequest.branch=${{ fromJson(steps.get_pr_data.outputs.data).head.ref }} -Dsonar.pullrequest.base=${{ fromJson(steps.get_pr_data.outputs.data).base.ref }}  -pl ''!:kroxylicious-operator,!:kroxylicious-operator-dist''
+        run: |
+          mvn --batch-mode \
+            --activate-profiles 'ci,!qa' \
+            --projects ''!:kroxylicious-operator,!:kroxylicious-operator-dist'' \
+            -Derrorprone.skip=true \
+            -DskipITs=true \
+            -Djapicmp.skip=true \
+            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }} \
+            -Dsonar.pullrequest.key=${{ fromJson(steps.get_pr_data.outputs.data).number }} \
+            -Dsonar.pullrequest.branch=${{ fromJson(steps.get_pr_data.outputs.data).head.ref }} \
+            -Dsonar.pullrequest.base=${{ fromJson(steps.get_pr_data.outputs.data).base.ref }} \
+            clean \
+            verify \
+            org.sonarsource.scanner.maven:sonar-maven-plugin:5.5.0.6356:sonar
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: SonarCloud scan on PR for the Operator
         if: env.SONAR_TOKEN_SET == 'true'
-        run: mvn -B clean verify -Pci -DskipITs=true org.sonarsource.scanner.maven:sonar-maven-plugin:5.5.0.6356:sonar -Djapicmp.skip=true  -Dsonar.projectName='Kroxylicious Operator' -Dsonar.projectKey='kroxylicious_operator' -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }} -Dsonar.pullrequest.key=${{ fromJson(steps.get_pr_data.outputs.data).number }} -Dsonar.pullrequest.branch=${{ fromJson(steps.get_pr_data.outputs.data).head.ref }} -Dsonar.pullrequest.base=${{ fromJson(steps.get_pr_data.outputs.data).base.ref }} -pl ':kroxylicious-operator,:kroxylicious-parent,:kroxylicious-operator-dist'
+        run: |
+          mvn --batch-mode \
+            --activate-profiles 'ci,!qa' \
+            --projects ':kroxylicious-operator,:kroxylicious-parent,:kroxylicious-operator-dist' \
+            -Derrorprone.skip=true \
+            -DskipITs=true \
+            -Djapicmp.skip=true \
+            -Dsonar.projectName='Kroxylicious Operator' \
+            -Dsonar.projectKey='kroxylicious_operator' \
+            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }} \
+            -Dsonar.pullrequest.key=${{ fromJson(steps.get_pr_data.outputs.data).number }} \
+            -Dsonar.pullrequest.branch=${{ fromJson(steps.get_pr_data.outputs.data).head.ref }} \
+            -Dsonar.pullrequest.base=${{ fromJson(steps.get_pr_data.outputs.data).base.ref }} \
+            clean \
+            verify \
+            org.sonarsource.scanner.maven:sonar-maven-plugin:5.5.0.6356:sonar
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -72,16 +72,17 @@ mvn clean verify
 
 The running of the tests can be controlled with the following Maven properties:
 
-| property           | description                                                                               |
-|--------------------|-------------------------------------------------------------------------------------------|
-| `-DskipUTs=true`   | skip unit tests                                                                           |
-| `-DskipKTs=true`   | skip container image tests                                                                |
-| `-DskipITs=true`   | skip integration tests                                                                    |
-| `-DskipSTs=true`   | skip system tests                                                                         |
-| `-DskipDTs=true`   | skip documentation tests                                                                  |
-| `-DskipTests=true` | skip all tests                                                                            |
-| `-DfailOnWarnings` | fail on javac warnings (ignored if `-Dquick`, see below)                                  |
-| `-Pdebug`          | enables logging so you can see what the Kafka clients, Proxy and in VM brokers are up to. |
+| property                  | description                                                                                                                                                                                                               |
+|---------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `-DskipUTs=true`          | skip unit tests                                                                                                                                                                                                           |
+| `-DskipKTs=true`          | skip container image tests                                                                                                                                                                                                |
+| `-DskipITs=true`          | skip integration tests                                                                                                                                                                                                    |
+| `-DskipSTs=true`          | skip system tests                                                                                                                                                                                                         |
+| `-DskipDTs=true`          | skip documentation tests                                                                                                                                                                                                  |
+| `-DskipTests=true`        | skip all tests                                                                                                                                                                                                            |
+| `-DfailOnWarnings`        | fail on javac warnings (ignored if `-Dquick`, see below)                                                                                                                                                                  |
+| `-Derrorprone.skip=true`  | Disable ErrorProne static analysis. **Semantics:** Setting this property (even to `false`) disables the `errorprone-jdk-compatible` profile, which activates when the property is undefined (`<name>!errorprone.skip</name>`). To enable ErrorProne, omit this property entirely. |
+| `-Pdebug`                 | enables logging so you can see what the Kafka clients, Proxy and in VM brokers are up to.                                                                                                                                 |
 
 The build behavior can be controlled with the following Maven profiles:
 
@@ -93,7 +94,7 @@ The build behavior can be controlled with the following Maven profiles:
 | `-Pquick`                  | Fast build mode: skips all tests, QA checks, javadoc, and documentation. Activates with `-Dquick`. Excludes integration/system test modules from reactor.                                             |
 | `-Psystemtest`             | Enables system test module and skips all other test types. Use with `-Pdist` to run Kubernetes-based system tests.                                                                                    |
 | `-P-withAdditionalFilters` | Excludes Kroxylicious-maintained filter implementations from the distribution. Only use with `-Pdist`.                                                                                                |
-| `errorprone-jdk-compatible` (auto-activated on JDK 17+) | Runs Error Prone static analysis during compilation to detect bug patterns. Adds ~15-30% to compilation time. Disable with `-Derrorprone.skip=true` for faster builds. |
+| `errorprone-jdk-compatible` (auto-activated on JDK 17+) | Runs Error Prone static analysis during compilation to detect bug patterns. Adds ~15-30% to compilation time. Disable with `-Derrorprone.skip=true` for faster builds (see property table above for semantics). |
 
 The kafka environment used by the integrations tests can be _defaulted_ with these two environment variables.
 


### PR DESCRIPTION
## Motivation

This PR addresses two primary concerns:

1. **Build pipeline efficiency** - Currently, QA checks (formatting, licensing, checkstyle, spotbugs, dependency analysis, enforcer, ErrorProne) run redundantly across multiple workflows, wasting CI resources and developer time
2. **Uniformity of approach** - Inconsistent Maven command formatting and profile usage across workflows makes maintenance difficult

## Changes

### QA Check Optimization

- **lint.yaml** - Designated as the authoritative QA check for all PRs
  - Explicitly enables `qa` profile
  - ErrorProne automatically activates on JDK 17+ (errorprone-jdk-compatible profile)
  - Runs comprehensive quality checks across all modules
  - Added comment explaining its role to prevent future duplication
  
- **All other workflows** - Skip QA checks using `--activate-profiles '!qa'` and `-Derrorprone.skip=true`
  - maven.yaml: Conditional - skips QA on PRs (already run in lint), keeps QA on push to main
  - operator-maven.yaml: Skips QA (duplicates lint)
  - sonar.yaml: Skips QA (duplicates lint)
  - integration-tests.yaml: Skips QA
  - run-system-tests.yaml: Skips QA
  - operator-tests-microshift.yaml: Skips QA
  - docker.yaml: Replaces `-Dquick` with explicit profile exclusion
  - build-kroxylicious-container-images.yaml: Replaces `-Dquick` with explicit profile exclusion

### Maven Command Standardization

All Maven commands now follow a uniform format:
- **Long-form arguments** - `--batch-mode`, `--projects`, `--also-make`, `--threads`, `--activate-profiles` (except `-D` properties)
- **Multi-line formatting** - Backslash continuation with one argument per line for readability
- **Consistent ordering** - Switches → `-D` properties → lifecycle phases

### Documentation

- Added `-Derrorprone.skip=true` property to DEV_GUIDE.md with detailed semantics explanation

## Impact

### Measured Performance Improvements ✅

Actual results from this PR compared to baseline from earlier today:

| Workflow | Baseline | New Time | Time Saved | Improvement |
|----------|----------|----------|------------|-------------|
| **maven.yaml (temurin 21)** | 14m 49s | 10m 25s | 4m 24s | **29.7% faster** |
| **maven.yaml (corretto 25)** | 14m 36s | 10m 14s | 4m 22s | **29.9% faster** |
| **operator-maven.yaml** | 26m 1s | 25m 24s | 37s | **2.4% faster** |
| **TOTAL** | **55m 26s** | **46m 3s** | **9m 23s** | **~17% faster** |

**Per-PR savings: ~9 minutes** across these 3 key workflows. Additional workflows (integration-tests, system-tests, docker, etc.) also benefit from the optimizations.

**Note:** lint.yaml excluded from performance table because our changes didn't optimize it - it runs full QA both before and after. The observed time difference is normal build variance, not from our optimizations.

### QA Coverage Verification ✅

Comprehensive verification of lint workflow (run 24566155086):

**All QA plugins executing correctly:**
- ✅ checkstyle:3.6.0:check (0 violations found)
- ✅ formatter:2.29.0:validate (all sources validated)
- ✅ license:5.0.0:check (license headers verified)
- ✅ dependency:3.10.0:analyze-only (dependency analysis complete)
- ✅ enforcer:3.6.2:enforce (Maven version rules enforced)
- ✅ ErrorProne via maven-compiler-plugin (612 warnings reported)

**QA skip verification:**
- ✅ maven.yaml confirmed skipping QA on PRs (`--activate-profiles '!qa'` in logs)
- ✅ operator-maven.yaml confirmed skipping QA (`--activate-profiles 'ci,!qa'` in logs)
- ✅ Zero duplication - QA runs exactly once per PR

### Maintainability

- Uniform approach makes workflows easier to understand and maintain
- Clear separation of concerns - lint for QA, other workflows for testing
- Self-documenting command structure

## Testing

- [x] Verify lint.yaml runs all QA checks on PR ✅
- [x] Verify ErrorProne executes correctly (612 warnings) ✅
- [x] Verify other PR workflows skip QA checks ✅
- [x] Confirm CI pipeline completes successfully ✅
- [x] Measure performance improvements ✅

## Post-Merge Verification

- [ ] After merge: Verify maven.yaml runs QA checks on push to main (not testable until merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)