### PR TITLE
fix(runtime): ensure TransportSubjectBuilder callbacks run on Netty event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#3745](https://github.com/kroxylicious/kroxylicious/issues/3745): fix(runtime): ensure async TransportSubjectBuilder callbacks execute on Netty event loop to prevent race conditions
 * [#3620](https://github.com/kroxylicious/kroxylicious/issues/3620): Removed Deprecated clientSaslAuthenticationSuccess from FilterContext
 * [#3624](https://github.com/kroxylicious/kroxylicious/pull/3624): feat(operator): set Kubernetes client User-Agent to `kroxylicious-operator/<version>` for API server audit log identification
 * [#3565](https://github.com/kroxylicious/kroxylicious/pull/3514): build(deps): bump kubernetes-client.version from 7.5.2 to 7.6.1

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/MyTransportSubjectBuilderService.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/MyTransportSubjectBuilderService.java
@@ -9,6 +9,7 @@ package io.kroxylicious.it;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 
 import javax.security.auth.x500.X500Principal;
 
@@ -56,22 +57,15 @@ public class MyTransportSubjectBuilderService implements TransportSubjectBuilder
                 }
             }
             else {
-                var fut = new CompletableFuture<Subject>();
-                new Thread(() -> {
-                    try {
-                        Thread.sleep(delayMs);
-                    }
-                    catch (InterruptedException e) {
-                        throw new RuntimeException(e);
-                    }
-                    if (completeSuccessfully) {
-                        fut.complete(subject);
-                    }
-                    else {
-                        fut.completeExceptionally(new RuntimeException("Oops"));
-                    }
-                }).start();
-                return fut;
+                if (completeSuccessfully) {
+                    return CompletableFuture.supplyAsync(() -> subject,
+                            CompletableFuture.delayedExecutor(delayMs, TimeUnit.MILLISECONDS));
+                }
+                else {
+                    return CompletableFuture.supplyAsync(() -> {
+                        throw new RuntimeException("Oops");
+                    }, CompletableFuture.delayedExecutor(delayMs, TimeUnit.MILLISECONDS));
+                }
             }
         }
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientSubjectManager.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ClientSubjectManager.java
@@ -10,6 +10,7 @@ import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.Executor;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
@@ -86,10 +87,11 @@ public class ClientSubjectManager implements
 
     public void subjectFromTransport(@Nullable SSLSession session,
                                      TransportSubjectBuilder transportSubjectBuilder,
+                                     Executor eventLoopExecutor,
                                      Runnable whenDoneCallback) {
         this.clientCertificate = peerTlsCertificate(session);
         this.proxyCertificate = localTlsCertificate(session);
-        transportSubjectBuilder.buildTransportSubject(this).whenComplete((newSubject, error) -> {
+        transportSubjectBuilder.buildTransportSubject(this).whenCompleteAsync((newSubject, error) -> {
             if (error == null) {
                 this.subject = newSubject;
             }
@@ -101,7 +103,7 @@ public class ClientSubjectManager implements
             }
             this.mechanismName = null;
             whenDoneCallback.run();
-        });
+        }, eventLoopExecutor);
     }
 
     void clientSaslAuthenticationSuccess(

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLEngine;
@@ -556,6 +557,10 @@ public class KafkaProxyFrontendHandler
         var inboundChannel = clientCtx().channel();
         inboundChannel.config().setAutoRead(true);
         proxyChannelStateMachine.onClientWritable();
+    }
+
+    Executor eventLoopExecutor() {
+        return Objects.requireNonNull(clientCtx().executor(), "executor must not be null");
     }
 
     private ChannelHandlerContext clientCtx() {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachine.java
@@ -581,7 +581,8 @@ public class ProxyChannelStateMachine {
     }
 
     public void onClientTlsHandshakeSuccess(SSLSession sslSession) {
-        this.clientSubjectManager.subjectFromTransport(sslSession, transportSubjectBuilder, this::onTransportSubjectBuilt);
+        this.clientSubjectManager.subjectFromTransport(sslSession, transportSubjectBuilder,
+                Objects.requireNonNull(frontendHandler).eventLoopExecutor(), this::onTransportSubjectBuilt);
     }
 
     @SuppressWarnings("java:S5738")
@@ -596,7 +597,8 @@ public class ProxyChannelStateMachine {
         // these can happen in either order
         this.progressionLatch = 2;
         if (!this.isTlsListener()) {
-            this.clientSubjectManager.subjectFromTransport(null, this.transportSubjectBuilder, this::onTransportSubjectBuilt);
+            this.clientSubjectManager.subjectFromTransport(null, this.transportSubjectBuilder,
+                    frontendHandler.eventLoopExecutor(), this::onTransportSubjectBuilt);
         }
         frontendHandler.inClientActive();
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientSubjectManagerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ClientSubjectManagerTest.java
@@ -10,6 +10,7 @@ import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
@@ -108,7 +109,7 @@ class ClientSubjectManagerTest {
     void transitionInitialToAuthorized() {
         // Given
         ClientSubjectManager impl = new ClientSubjectManager();
-        impl.subjectFromTransport(null, context -> CompletableFuture.completedStage(Subject.anonymous()), () -> {
+        impl.subjectFromTransport(null, context -> CompletableFuture.completedStage(Subject.anonymous()), Runnable::run, () -> {
         });
         // When
         impl.clientSaslAuthenticationSuccess("FOO", new Subject(new User("bob")));
@@ -123,7 +124,7 @@ class ClientSubjectManagerTest {
     void transitionInitialToFailed() {
         // Given
         ClientSubjectManager impl = new ClientSubjectManager();
-        impl.subjectFromTransport(null, context -> CompletableFuture.completedStage(Subject.anonymous()), () -> {
+        impl.subjectFromTransport(null, context -> CompletableFuture.completedStage(Subject.anonymous()), Runnable::run, () -> {
         });
         // When
         impl.clientSaslAuthenticationFailure();
@@ -135,7 +136,7 @@ class ClientSubjectManagerTest {
     void transitionAuthorizedToAuthorized() {
         // Given
         ClientSubjectManager impl = new ClientSubjectManager();
-        impl.subjectFromTransport(null, context -> CompletableFuture.completedStage(Subject.anonymous()), () -> {
+        impl.subjectFromTransport(null, context -> CompletableFuture.completedStage(Subject.anonymous()), Runnable::run, () -> {
         });
         impl.clientSaslAuthenticationSuccess("FOO", new Subject(new User("bob")));
         // When
@@ -151,7 +152,7 @@ class ClientSubjectManagerTest {
     void transitionAuthorizedToFailed() {
         // Given
         ClientSubjectManager impl = new ClientSubjectManager();
-        impl.subjectFromTransport(null, context -> CompletableFuture.completedStage(Subject.anonymous()), () -> {
+        impl.subjectFromTransport(null, context -> CompletableFuture.completedStage(Subject.anonymous()), Runnable::run, () -> {
         });
         impl.clientSaslAuthenticationSuccess("FOO", new Subject(new User("bob")));
         // When
@@ -164,7 +165,7 @@ class ClientSubjectManagerTest {
     void transitionFailedToAuthorized() {
         // Given
         ClientSubjectManager impl = new ClientSubjectManager();
-        impl.subjectFromTransport(null, context -> CompletableFuture.completedStage(Subject.anonymous()), () -> {
+        impl.subjectFromTransport(null, context -> CompletableFuture.completedStage(Subject.anonymous()), Runnable::run, () -> {
         });
         impl.clientSaslAuthenticationFailure();
 
@@ -175,6 +176,73 @@ class ClientSubjectManagerTest {
             assertThat(csc.mechanismName()).isEqualTo("FOO");
             assertThat(csc.authorizationId()).isEqualTo("bob");
         });
+    }
+
+    @Test
+    void subjectFromTransportUsesProvidedExecutor() {
+        // Given
+        ClientSubjectManager impl = new ClientSubjectManager();
+        AtomicBoolean executorUsed = new AtomicBoolean(false);
+        AtomicBoolean callbackRan = new AtomicBoolean(false);
+
+        // When
+        impl.subjectFromTransport(
+                null,
+                context -> CompletableFuture.completedStage(Subject.anonymous()),
+                command -> {
+                    executorUsed.set(true);
+                    command.run();
+                },
+                () -> callbackRan.set(true));
+
+        // Then
+        assertThat(executorUsed).isTrue();
+        assertThat(callbackRan).isTrue();
+    }
+
+    @Test
+    void subjectFromTransportHandlesAsyncCompletion() {
+        // Given
+        ClientSubjectManager impl = new ClientSubjectManager();
+        CompletableFuture<Subject> asyncFuture = new CompletableFuture<>();
+        AtomicBoolean callbackRan = new AtomicBoolean(false);
+        Subject expectedSubject = new Subject(new User("alice"));
+
+        // When
+        impl.subjectFromTransport(
+                null,
+                context -> asyncFuture,
+                Runnable::run,
+                () -> callbackRan.set(true));
+
+        assertThat(callbackRan).isFalse(); // Not yet complete
+
+        asyncFuture.complete(expectedSubject);
+
+        // Then
+        assertThat(callbackRan).isTrue();
+        assertThat(impl.authenticatedSubject()).isEqualTo(expectedSubject);
+    }
+
+    @Test
+    void subjectFromTransportHandlesAsyncException() {
+        // Given
+        ClientSubjectManager impl = new ClientSubjectManager();
+        CompletableFuture<Subject> asyncFuture = new CompletableFuture<>();
+        AtomicBoolean callbackRan = new AtomicBoolean(false);
+
+        // When
+        impl.subjectFromTransport(
+                null,
+                context -> asyncFuture,
+                Runnable::run,
+                () -> callbackRan.set(true));
+
+        asyncFuture.completeExceptionally(new RuntimeException("Transport auth failed"));
+
+        // Then
+        assertThat(callbackRan).isTrue();
+        assertThat(impl.authenticatedSubject()).isEqualTo(Subject.anonymous());
     }
 
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerMockCollaboratorsTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerMockCollaboratorsTest.java
@@ -28,6 +28,7 @@ import io.netty.handler.codec.haproxy.HAProxyMessage;
 import io.netty.handler.codec.haproxy.HAProxyProtocolVersion;
 import io.netty.handler.codec.haproxy.HAProxyProxiedProtocol;
 import io.netty.handler.timeout.IdleStateHandler;
+import io.netty.util.concurrent.EventExecutor;
 
 import io.kroxylicious.proxy.authentication.Subject;
 import io.kroxylicious.proxy.authentication.TransportSubjectBuilder;
@@ -46,6 +47,7 @@ import io.kroxylicious.proxy.model.VirtualClusterModel;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -90,6 +92,9 @@ class KafkaProxyFrontendHandlerMockCollaboratorsTest {
     @Mock(strictness = Mock.Strictness.LENIENT)
     TransportSubjectBuilder subjectBuilder;
 
+    @Mock(strictness = Mock.Strictness.LENIENT)
+    EventExecutor executor;
+
     private KafkaProxyFrontendHandler handler;
 
     @BeforeEach
@@ -99,6 +104,14 @@ class KafkaProxyFrontendHandlerMockCollaboratorsTest {
         when(endpointBinding.endpointGateway()).thenReturn(endpointGateway);
         when(proxyChannelStateMachine.endpointBinding()).thenReturn(endpointBinding);
         when(proxyChannelStateMachine.virtualCluster()).thenReturn(virtualCluster);
+        // Make the executor run tasks synchronously
+        doAnswer(invocation -> {
+            Runnable runnable = invocation.getArgument(0);
+            runnable.run();
+            return null;
+        }).when(executor).execute(any(Runnable.class));
+        when(clientCtx.executor()).thenReturn(executor);
+
         handler = new KafkaProxyFrontendHandler(
                 pfr,
                 filterChainFactory,
@@ -338,5 +351,17 @@ class KafkaProxyFrontendHandlerMockCollaboratorsTest {
         // Then
         assertThat(pcsm.kafkaSession().currentState())
                 .isEqualTo(KafkaSessionState.ESTABLISHING);
+    }
+
+    @Test
+    void eventLoopExecutorReturnsContextExecutor() throws Exception {
+        // Given
+        handler.channelActive(clientCtx);
+
+        // When
+        var result = handler.eventLoopExecutor();
+
+        // Then
+        assertThat(result).isSameAs(executor);
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -588,6 +588,7 @@ class KafkaProxyFrontendHandlerTest {
         ChannelPipeline mockPipeline = mock(ChannelPipeline.class);
         doReturn(inboundChannel).when(mockChannelCtx).channel();
         doReturn(mockPipeline).when(mockChannelCtx).pipeline();
+        doReturn(inboundChannel.eventLoop()).when(mockChannelCtx).executor();
         return mockChannelCtx;
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
@@ -110,6 +110,8 @@ class ProxyChannelStateMachineTest {
         when(endpointGateway.virtualCluster()).thenReturn(VIRTUAL_CLUSTER_MODEL);
         proxyChannelStateMachine = new ProxyChannelStateMachine(endpointBinding, new DefaultSubjectBuilder(List.of()), new KafkaSession(KafkaSessionState.ESTABLISHING));
         when(frontendHandler.channelId()).thenReturn(DefaultChannelId.newInstance());
+        // Make the executor run tasks synchronously for tests
+        when(frontendHandler.eventLoopExecutor()).thenReturn(Runnable::run);
     }
 
     @AfterEach

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
@@ -8,9 +8,11 @@ package io.kroxylicious.proxy.internal;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
 import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSession;
 
 import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.errors.InvalidRequestException;
@@ -1015,6 +1017,24 @@ class ProxyChannelStateMachineTest {
 
     private int getVirtualNodeProxyToServerActiveConnections() {
         return io.kroxylicious.proxy.internal.util.Metrics.proxyToServerConnectionCounter(VIRTUAL_CLUSTER_NODE).get();
+    }
+
+    @Test
+    void onClientTlsHandshakeSuccessPassesExecutorToSubjectManager() {
+        // Given
+        proxyChannelStateMachine.onClientActive(frontendHandler);
+        SSLSession sslSession = mock(SSLSession.class);
+        AtomicBoolean executorUsed = new AtomicBoolean(false);
+        when(frontendHandler.eventLoopExecutor()).thenReturn(command -> {
+            executorUsed.set(true);
+            command.run();
+        });
+
+        // When
+        proxyChannelStateMachine.onClientTlsHandshakeSuccess(sslSession);
+
+        // Then - verify the executor was actually used, proving the new parameter is passed through correctly
+        assertThat(executorUsed).isTrue();
     }
 
     @org.junit.jupiter.api.Nested


### PR DESCRIPTION
_Relates to #3745, but as noted by @robobario below, this is not the complete story._

## Problem

When a `TransportSubjectBuilder` completes asynchronously on a non-Netty thread, the completion callback may update `ClientSubjectManager.subject` from a foreign thread, creating a race condition where the Netty event loop thread reads a stale value.

### Root Cause

The original code used `whenComplete()` without specifying an executor, allowing the callback to run on whichever thread completed the `CompletableFuture`. When a plugin's `TransportSubjectBuilder` completed on a different thread (e.g., from a thread pool or unmanaged thread), the subject field update would occur cross-thread without proper synchronization.

Test plugin `MyTransportSubjectBuilderService` created unmanaged threads that completed futures after delays, triggering cross-thread writes. The race became observable after commit 25aa9d9 introduced shared Kafka clusters across test parameters, tightening timing windows.

### Observable Symptom

The flaky test `PluginTlsApiIT.clientTlsContextMutualTls[3]` would occasionally observe `Subject[principals=[]]` instead of the expected authenticated subject containing the client certificate principal.

## Solution

Pass the Netty event loop executor to `ClientSubjectManager.subjectFromTransport()` and use `whenCompleteAsync(..., eventLoopExecutor)` to ensure callbacks always execute on the channel's event loop thread.

### Changes

**Production code:**
- `ClientSubjectManager.subjectFromTransport()`: Added `Executor eventLoopExecutor` parameter and changed `whenComplete()` to `whenCompleteAsync(..., eventLoopExecutor)`
- `KafkaProxyFrontendHandler`: Added `eventLoopExecutor()` method to expose the Netty executor
- `ProxyChannelStateMachine`: Updated both call sites to pass the event loop executor from the frontend handler

**Test code:**
- `MyTransportSubjectBuilderService`: Replaced unmanaged `Thread` with `CompletableFuture.delayedExecutor()` for cleaner async simulation (code quality improvement, not functionally required for the fix)
- `ClientSubjectManagerTest`: Updated test calls to use `Runnable::run` as a synchronous executor

### Benefits

This provides:
- **Thread affinity**: `ClientSubjectManager` state only modified on event loop
- **Happens-before guarantee**: Executor submission creates memory barrier  
- **Netty best practices**: Don't mutate channel state from foreign threads
- **No volatile needed**: Single-threaded access eliminates need for volatile

## Testing

Ran `PluginTlsApiIT.clientTlsContextMutualTls` multiple times with the fix applied - all tests pass consistently.

## Checklist

- [x] Production code change
- [x] CHANGELOG.md entry added
- [x] Tests updated
- [x] Commit signed-off (DCO)