### PR TITLE
fix(benchmarks): add cluster auth preflight check

### DIFF
--- a/kroxylicious-openmessaging-benchmarks/scripts/run-benchmark.sh
+++ b/kroxylicious-openmessaging-benchmarks/scripts/run-benchmark.sh
@@ -169,6 +169,12 @@ if [[ -n "${CLUSTER_OVERRIDES}" && ! -f "${CLUSTER_OVERRIDES}" ]]; then
     exit 1
 fi
 
+# Preflight: verify we can talk to the cluster
+if ! kubectl auth can-i get pods -n "${NAMESPACE}" &>/dev/null; then
+    echo "Error: not authenticated to cluster — check kubectl/oc login" >&2
+    exit 1
+fi
+
 METRICS_PID=""
 LOGS_PID=""
 


### PR DESCRIPTION
## Summary
- Adds a `kubectl auth can-i get pods` preflight check to `run-benchmark.sh` before any work begins
- Fails fast with a clear error message when not authenticated, instead of failing deep into the run with cryptic API errors

## Test plan
- [ ] Run `run-benchmark.sh` without being logged in — verify it fails immediately with `Error: not authenticated to cluster`
- [ ] Run `run-benchmark.sh` while logged in — verify it proceeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)