### PR TITLE
[Draft] prevent messages entering the Filter Handlers until TLS Subject created

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/BufferingGatewayHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/BufferingGatewayHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+/**
+ * This handler is installed directly after an SSLHandler. The intent is to buffer all channelRead data
+ * until a signal has been received that the Transport Subject has been built, at which point it will
+ * fire all its buffered objects into the channel and remove itself from the pipeline.
+ * This catches edge cases where messages traverse the Filter chain before the Transport Subject has been
+ * asynchronously computed.
+ */
+class BufferingGatewayHandler extends ChannelInboundHandlerAdapter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BufferingGatewayHandler.class);
+    private boolean gateOpen = false;
+    private final Queue<Object> buffer = new ArrayDeque<>();
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+        if (gateOpen) {
+            ctx.fireChannelRead(msg);
+        }
+        else {
+            LOGGER.atDebug()
+                    .addKeyValue("channelId", ctx.channel().id())
+                    .log("buffering event");
+            buffer.add(msg);
+        }
+    }
+
+    @Override
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) {
+        if (evt instanceof TransportSubjectBuilt) {
+            LOGGER.atDebug()
+                    .addArgument(buffer.size())
+                    .addKeyValue("channelId", ctx.channel().id())
+                    .log("Transport Subject Built, firing channel reads for {} buffered events");
+            gateOpen = true;
+            while (!buffer.isEmpty()) {
+                ctx.fireChannelRead(buffer.poll());
+            }
+            ctx.pipeline().remove(this);
+            ctx.read();
+        }
+        ctx.fireUserEventTriggered(evt);
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -639,4 +639,7 @@ public class KafkaProxyFrontendHandler
         return nettySettings.flatMap(NettySettings::authenticatedIdleTimeout).map(Duration::toMillis).orElse(NO_TIMEOUT);
     }
 
+    public void onTransportSubjectBuilt() {
+        Objects.requireNonNull(clientCtx).channel().pipeline().fireUserEventTriggered(new TransportSubjectBuilt());
+    }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -192,6 +192,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
 
             }
         });
+        ch.pipeline().addLast("buffering gateway", new BufferingGatewayHandler());
     }
 
     @VisibleForTesting
@@ -299,4 +300,5 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
                             cause.getClass().getSimpleName(), cause.getMessage());
         }
     }
+
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachine.java
@@ -603,6 +603,7 @@ public class ProxyChannelStateMachine {
             onSessionTransportAuthenticated();
         }
         maybeUnblock();
+        frontendHandler.onTransportSubjectBuilt();
     }
 
     Subject authenticatedSubject() {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/TransportSubjectBuilt.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/TransportSubjectBuilt.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+public record TransportSubjectBuilt() {}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/BufferingGatewayHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/BufferingGatewayHandlerTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BufferingGatewayHandlerTest {
+
+    private EmbeddedChannel channel;
+    private BufferingGatewayHandler handler;
+    private UserEventCollector userEventCollector;
+
+    @BeforeEach
+    void setUp() {
+        handler = new BufferingGatewayHandler();
+        userEventCollector = new UserEventCollector();
+        channel = new EmbeddedChannel(handler, userEventCollector);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (channel.isActive()) {
+            channel.finish();
+        }
+    }
+
+    @Test
+    void shouldBufferMessagesBeforeGateOpens() {
+        Object msg1 = new Object();
+        Object msg2 = new Object();
+
+        channel.writeInbound(msg1);
+        channel.writeInbound(msg2);
+
+        Object read = channel.readInbound();
+        assertThat(read).isNull();
+    }
+
+    @Test
+    void shouldForwardMessagesDirectlyAfterGateOpens() {
+        channel.pipeline().fireUserEventTriggered(new TransportSubjectBuilt());
+
+        Object msg = new Object();
+        channel.writeInbound(msg);
+
+        Object read = channel.readInbound();
+        assertThat(read).isSameAs(msg);
+    }
+
+    @Test
+    void shouldFlushBufferWhenTransportSubjectBuiltEventReceived() {
+        Object msg1 = new Object();
+        Object msg2 = new Object();
+        Object msg3 = new Object();
+
+        channel.writeInbound(msg1);
+        channel.writeInbound(msg2);
+        channel.writeInbound(msg3);
+
+        Object read = channel.readInbound();
+        assertThat(read).isNull();
+
+        channel.pipeline().fireUserEventTriggered(new TransportSubjectBuilt());
+
+        Object read1 = channel.readInbound();
+        assertThat(read1).isSameAs(msg1);
+        Object read2 = channel.readInbound();
+        assertThat(read2).isSameAs(msg2);
+        Object read3 = channel.readInbound();
+        assertThat(read3).isSameAs(msg3);
+    }
+
+    @Test
+    void shouldRemoveItselfFromPipelineAfterFlushingBuffer() {
+        channel.writeInbound(new Object());
+
+        assertThat(channel.pipeline().get(BufferingGatewayHandler.class)).isSameAs(handler);
+
+        channel.pipeline().fireUserEventTriggered(new TransportSubjectBuilt());
+
+        assertThat(channel.pipeline().get(BufferingGatewayHandler.class)).isNull();
+    }
+
+    @Test
+    void shouldForwardTransportSubjectBuiltEvent() {
+        TransportSubjectBuilt event = new TransportSubjectBuilt();
+
+        channel.pipeline().fireUserEventTriggered(event);
+
+        Object receivedEvent = userEventCollector.readUserEvent();
+        assertThat(receivedEvent).isSameAs(event);
+    }
+
+    @Test
+    void shouldForwardOtherUserEvents() {
+        Object customEvent = new Object();
+
+        channel.pipeline().fireUserEventTriggered(customEvent);
+
+        Object receivedEvent = userEventCollector.readUserEvent();
+        assertThat(receivedEvent).isSameAs(customEvent);
+    }
+
+    @Test
+    void shouldMaintainFifoOrderWhenFlushingBuffer() {
+        Object msg1 = new Object();
+        Object msg2 = new Object();
+        Object msg3 = new Object();
+
+        channel.writeInbound(msg1);
+        channel.writeInbound(msg2);
+        channel.writeInbound(msg3);
+
+        channel.pipeline().fireUserEventTriggered(new TransportSubjectBuilt());
+
+        Object read1 = channel.readInbound();
+        assertThat(read1).isSameAs(msg1);
+        Object read2 = channel.readInbound();
+        assertThat(read2).isSameAs(msg2);
+        Object read3 = channel.readInbound();
+        assertThat(read3).isSameAs(msg3);
+    }
+
+    @Test
+    void shouldHandleEmptyBufferWhenTransportSubjectBuiltReceived() {
+        channel.pipeline().fireUserEventTriggered(new TransportSubjectBuilt());
+
+        Object read = channel.readInbound();
+        assertThat(read).isNull();
+        assertThat(channel.pipeline().get(BufferingGatewayHandler.class)).isNull();
+    }
+
+    @Test
+    void shouldNotBufferAfterGateOpens() {
+        Object msg1 = new Object();
+        Object msg2 = new Object();
+
+        channel.writeInbound(msg1);
+        channel.pipeline().fireUserEventTriggered(new TransportSubjectBuilt());
+
+        Object read1 = channel.readInbound();
+        assertThat(read1).isSameAs(msg1);
+
+        channel.writeInbound(msg2);
+
+        Object read2 = channel.readInbound();
+        assertThat(read2).isSameAs(msg2);
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerMockCollaboratorsTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerMockCollaboratorsTest.java
@@ -337,4 +337,17 @@ class KafkaProxyFrontendHandlerMockCollaboratorsTest {
         assertThat(proxyChannelStateMachine.getKafkaSession().currentState())
                 .isEqualTo(KafkaSessionState.ESTABLISHING);
     }
+
+    @Test
+    void shouldFireTransportSubjectBuiltEventWhenOnTransportSubjectBuilt() throws Exception {
+        // Given
+        handler.channelActive(clientCtx);
+        when(clientCtx.channel().pipeline()).thenReturn(channelPipeline);
+
+        // When
+        handler.onTransportSubjectBuilt();
+
+        // Then
+        verify(channelPipeline).fireUserEventTriggered(any(TransportSubjectBuilt.class));
+    }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
@@ -754,6 +754,18 @@ class ProxyChannelStateMachineTest {
         verify(frontendHandler).onSessionAuthenticated();
     }
 
+    @Test
+    void shouldNotifyFrontendHandlerWhenTransportSubjectBuilt() {
+        // Given
+        stateMachineInClientActive();
+
+        // When
+        proxyChannelStateMachine.onTransportSubjectBuilt();
+
+        // Then
+        verify(frontendHandler).onTransportSubjectBuilt();
+    }
+
     public Stream<Arguments> clientErrorStates() {
         return Stream.of(
                 argumentSet("STARTING TLS on", (Runnable) () -> {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

https://github.com/kroxylicious/kroxylicious/issues/3745

After debugging this I found that it is possible for messages to be handled by Filters before the transport subject has been built.

Since we refactored Filters to be installed in the frontend channel, it is possible for the SslHandler to emit messages to the Filter pipeline before the asynchronous Transport Subject builder has finished its work. In the worst case we can see:
1. autoread disabled by `KafkaProxyFrontendHandler#inClientActive`
2. SslHandshakeCompletionEvent received by `KafkaProxyFrontendHandler` and deferred `subjectFromTransport` work kicked off by `PCSM`
3. ApiVersionsRequest read by proxy -> forward to upstream -> response forwarded to client
4. Produce request sent by client -> read by proxy
5. delayed subjectFromTransport work completed

So there are some nasty edge cases where autoread is false but multiple roundtrips can be read.

This is a brute force fix where we buffer all messages immediately after the SSLHandler, until the subjectFromTransport is computed and a user event is fired into the channel. At which point we can debuffer all the messages, remove the handler and continue.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
