### PR TITLE
Fix race where messages can enter Filter chain before Transport Subject is created

### DIFF
--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -15,9 +15,6 @@ import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLSession;
-
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +34,6 @@ import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SniCompletionEvent;
 import io.netty.handler.ssl.SslHandler;
-import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty.handler.timeout.IdleState;
 import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.handler.timeout.IdleStateHandler;
@@ -110,20 +106,6 @@ public class KafkaProxyFrontendHandler
     // once the outbound channel is active
     private boolean pendingReadComplete = true;
 
-    /**
-     * @return the SSL session, or null if a session does not (currently) exist.
-     */
-    @Nullable
-    SSLSession sslSession() {
-        // The SslHandler is added to the pipeline by the SniHandler (replacing it) after the ClientHello.
-        // It is added using the fully-qualified class name.
-        SslHandler sslHandler = (SslHandler) this.clientCtx().pipeline().get(SslHandler.class.getName());
-        return Optional.ofNullable(sslHandler)
-                .map(SslHandler::engine)
-                .map(SSLEngine::getSession)
-                .orElse(null);
-    }
-
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     KafkaProxyFrontendHandler(
                               PluginFactoryRegistry pfr,
@@ -183,10 +165,6 @@ public class KafkaProxyFrontendHandler
             else {
                 throw new IllegalStateException("SNI failed", sniCompletionEvent.cause());
             }
-        }
-        else if (event instanceof SslHandshakeCompletionEvent handshakeCompletionEvent
-                && handshakeCompletionEvent.isSuccess()) {
-            this.proxyChannelStateMachine.onClientTlsHandshakeSuccess(sslSession());
         }
         else if (event instanceof IdleStateEvent idleStateEvent && idleStateEvent.state() == IdleState.ALL_IDLE) {
             // No traffic has been observed on the channel for the configured period

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -15,15 +15,12 @@ import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.kafka.common.message.ResponseHeaderData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelId;
@@ -44,11 +41,7 @@ import io.kroxylicious.proxy.config.NamedFilterDefinition;
 import io.kroxylicious.proxy.config.NettySettings;
 import io.kroxylicious.proxy.config.PluginFactoryRegistry;
 import io.kroxylicious.proxy.filter.FilterAndInvoker;
-import io.kroxylicious.proxy.frame.DecodedRequestFrame;
-import io.kroxylicious.proxy.frame.DecodedResponseFrame;
-import io.kroxylicious.proxy.frame.ResponseFrame;
 import io.kroxylicious.proxy.internal.ProxyChannelState.ClientActive;
-import io.kroxylicious.proxy.internal.ProxyChannelState.Closed;
 import io.kroxylicious.proxy.internal.codec.CorrelationManager;
 import io.kroxylicious.proxy.internal.codec.DecodePredicate;
 import io.kroxylicious.proxy.internal.codec.KafkaMessageListener;
@@ -95,9 +88,6 @@ public class KafkaProxyFrontendHandler
     private final Long authenticatedIdleTimeMillis;
 
     private @Nullable ChannelHandlerContext clientCtx;
-    @VisibleForTesting
-    @Nullable
-    List<Object> bufferedMsgs;
     private boolean pendingClientFlushes;
     private @Nullable String sniHostname;
 
@@ -136,7 +126,6 @@ public class KafkaProxyFrontendHandler
         return "KafkaProxyFrontendHandler{"
                 + ", clientCtx=" + clientCtx
                 + ", proxyChannelState=" + this.proxyChannelStateMachine.currentState()
-                + ", number of bufferedMsgs=" + (bufferedMsgs == null ? 0 : bufferedMsgs.size())
                 + ", pendingClientFlushes=" + pendingClientFlushes
                 + ", sniHostname='" + sniHostname + '\''
                 + ", pendingReadComplete=" + pendingReadComplete
@@ -226,7 +215,7 @@ public class KafkaProxyFrontendHandler
     public void channelRead(
                             ChannelHandlerContext ctx,
                             Object msg) {
-        proxyChannelStateMachine.onClientRequest(msg);
+        proxyChannelStateMachine.onClientRequestTerminal(msg);
     }
 
     /**
@@ -433,37 +422,12 @@ public class KafkaProxyFrontendHandler
      * Called by the {@link ProxyChannelStateMachine} on entry to the {@link Forwarding} state.
      */
     void inForwarding() {
-        // connection is complete, so first forward the buffered message
-        if (bufferedMsgs != null) {
-            for (Object bufferedMsg : bufferedMsgs) {
-                proxyChannelStateMachine.messageFromClient(bufferedMsg);
-            }
-            bufferedMsgs = null;
-        }
 
         if (pendingReadComplete) {
             pendingReadComplete = false;
             channelReadComplete(this.clientCtx());
         }
 
-    }
-
-    /**
-     * Called by the {@link ProxyChannelStateMachine} on entry to the {@link Closed} state.
-     */
-    void inClosed(@Nullable Throwable errorCodeEx) {
-        Channel inboundChannel = clientCtx().channel();
-        if (inboundChannel.isActive()) {
-            Object msg = null;
-            if (errorCodeEx != null) {
-                msg = errorResponse(errorCodeEx);
-            }
-            if (msg == null) {
-                msg = Unpooled.EMPTY_BUFFER;
-            }
-            inboundChannel.writeAndFlush(msg)
-                    .addListener(ChannelFutureListener.CLOSE);
-        }
     }
 
     /**
@@ -495,18 +459,6 @@ public class KafkaProxyFrontendHandler
             // TODO does duplicate the writeability change notification from netty? If it does is that a problem?
             proxyChannelStateMachine.onClientUnwritable();
         }
-    }
-
-    /**
-     * Called by the {@link ProxyChannelStateMachine} when there is a requirement to buffer RPC's prior to forwarding to the upstream/server.
-     * Generally this is expected to be when client requests are received before we have a connection to the upstream node.
-     * @param msg the RPC to buffer.
-     */
-    void bufferMsg(Object msg) {
-        if (bufferedMsgs == null) {
-            bufferedMsgs = new ArrayList<>();
-        }
-        bufferedMsgs.add(msg);
     }
 
     private void addFiltersToPipeline(
@@ -543,33 +495,6 @@ public class KafkaProxyFrontendHandler
 
     private ChannelHandlerContext clientCtx() {
         return Objects.requireNonNull(this.clientCtx, "clientCtx was null while in state " + this.proxyChannelStateMachine.currentState());
-    }
-
-    private static ResponseFrame buildErrorResponseFrame(
-                                                         DecodedRequestFrame<?> triggerFrame,
-                                                         Throwable error) {
-        var responseData = KafkaProxyExceptionMapper.errorResponseMessage(triggerFrame, error);
-        final ResponseHeaderData responseHeaderData = new ResponseHeaderData();
-        responseHeaderData.setCorrelationId(triggerFrame.correlationId());
-        return new DecodedResponseFrame<>(triggerFrame.apiVersion(), triggerFrame.correlationId(), responseHeaderData, responseData);
-    }
-
-    /**
-     * Return an error response to send to the client, or null if no response should be sent.
-     * @param errorCodeEx The exception
-     * @return The response frame
-     */
-    private @Nullable ResponseFrame errorResponse(
-                                                  @Nullable Throwable errorCodeEx) {
-        ResponseFrame errorResponse;
-        final Object triggerMsg = bufferedMsgs != null && !bufferedMsgs.isEmpty() ? bufferedMsgs.get(0) : null;
-        if (errorCodeEx != null && triggerMsg instanceof final DecodedRequestFrame<?> triggerFrame) {
-            errorResponse = buildErrorResponseFrame(triggerFrame, errorCodeEx);
-        }
-        else {
-            errorResponse = null;
-        }
-        return errorResponse;
     }
 
     /**

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyGatewayHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyGatewayHandler.java
@@ -6,16 +6,28 @@
 
 package io.kroxylicious.proxy.internal;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSession;
 
+import org.apache.kafka.common.message.ResponseHeaderData;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
+
+import io.kroxylicious.proxy.frame.DecodedRequestFrame;
+import io.kroxylicious.proxy.frame.DecodedResponseFrame;
+import io.kroxylicious.proxy.frame.ResponseFrame;
+import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
@@ -24,6 +36,10 @@ public class KafkaProxyGatewayHandler extends ChannelInboundHandlerAdapter {
     private final ProxyChannelStateMachine proxyChannelStateMachine;
     @Nullable
     private ChannelHandlerContext clientCtx;
+
+    @VisibleForTesting
+    @Nullable
+    List<Object> bufferedMsgs;
 
     public KafkaProxyGatewayHandler(ProxyChannelStateMachine proxyChannelStateMachine) {
         Objects.requireNonNull(proxyChannelStateMachine, "state machine was null");
@@ -41,6 +57,18 @@ public class KafkaProxyGatewayHandler extends ChannelInboundHandlerAdapter {
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         proxyChannelStateMachine.onClientInactive();
         super.channelInactive(ctx);
+    }
+
+    /**
+     * Called by the {@link ProxyChannelStateMachine} when there is a requirement to buffer RPC's prior to forwarding to the upstream/server.
+     * Generally this is expected to be when client requests are received before we have a connection to the upstream node.
+     * @param msg the RPC to buffer.
+     */
+    void bufferMsg(Object msg) {
+        if (bufferedMsgs == null) {
+            bufferedMsgs = new ArrayList<>();
+        }
+        bufferedMsgs.add(msg);
     }
 
     /**
@@ -80,4 +108,82 @@ public class KafkaProxyGatewayHandler extends ChannelInboundHandlerAdapter {
         return Objects.requireNonNull(clientCtx);
     }
 
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        proxyChannelStateMachine.onClientRequestGateway(msg);
+    }
+
+    /**
+     * Called by the {@link ProxyChannelStateMachine} on entry to the {@link ProxyChannelState.Forwarding} state.
+     */
+    void inForwarding() {
+        // connection is complete, so first forward the buffered message
+        if (bufferedMsgs != null) {
+            for (Object bufferedMsg : bufferedMsgs) {
+                this.clientCtx().fireChannelRead(bufferedMsg);
+            }
+            bufferedMsgs = null;
+        }
+    }
+
+    public void forward(Object msg) {
+        clientCtx().fireChannelRead(msg);
+    }
+
+    private static ResponseFrame buildErrorResponseFrame(
+                                                         DecodedRequestFrame<?> triggerFrame,
+                                                         Throwable error) {
+        var responseData = KafkaProxyExceptionMapper.errorResponseMessage(triggerFrame, error);
+        final ResponseHeaderData responseHeaderData = new ResponseHeaderData();
+        responseHeaderData.setCorrelationId(triggerFrame.correlationId());
+        return new DecodedResponseFrame<>(triggerFrame.apiVersion(), triggerFrame.correlationId(), responseHeaderData, responseData);
+    }
+
+    /**
+     * Return an error response to send to the client, or null if no response should be sent.
+     * @param errorCodeEx The exception
+     * @return The response frame
+     */
+    private @Nullable ResponseFrame errorResponse(
+                                                  @Nullable Throwable errorCodeEx) {
+        ResponseFrame errorResponse;
+        final Object triggerMsg = ((bufferedMsgs != null) && !bufferedMsgs.isEmpty()) ? bufferedMsgs.get(0) : null;
+        if (errorCodeEx != null && triggerMsg instanceof final DecodedRequestFrame<?> triggerFrame) {
+            errorResponse = buildErrorResponseFrame(triggerFrame, errorCodeEx);
+        }
+        else {
+            errorResponse = null;
+        }
+        return errorResponse;
+    }
+
+    /**
+     * Called by the {@link ProxyChannelStateMachine} on entry to the {@link ProxyChannelState.Closed} state.
+     */
+    void inClosed(@Nullable Throwable errorCodeEx) {
+        Channel inboundChannel = clientCtx().channel();
+        if (inboundChannel.isActive()) {
+            Object msg = null;
+            if (errorCodeEx != null) {
+                msg = errorResponse(errorCodeEx);
+            }
+            if (msg == null) {
+                msg = Unpooled.EMPTY_BUFFER;
+            }
+            inboundChannel.writeAndFlush(msg)
+                    .addListener(ChannelFutureListener.CLOSE);
+        }
+    }
+
+    @Override
+    public String toString() {
+        // Don't include proxyChannelStateMachine's toString here
+        // because proxyChannelStateMachine's toString will include the gateway's toString
+        // and we don't want a SOE.
+        return "KafkaProxyFrontendHandler{"
+                + ", clientCtx=" + clientCtx
+                + ", proxyChannelState=" + this.proxyChannelStateMachine.currentState()
+                + ", number of bufferedMsgs=" + (bufferedMsgs == null ? 0 : bufferedMsgs.size())
+                + '}';
+    }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyGatewayHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyGatewayHandler.java
@@ -7,28 +7,77 @@
 package io.kroxylicious.proxy.internal;
 
 import java.util.Objects;
+import java.util.Optional;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSession;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.ssl.SslHandshakeCompletionEvent;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 public class KafkaProxyGatewayHandler extends ChannelInboundHandlerAdapter {
 
-    private final ProxyChannelStateMachine stateMachine;
+    private final ProxyChannelStateMachine proxyChannelStateMachine;
+    @Nullable
+    private ChannelHandlerContext clientCtx;
 
-    public KafkaProxyGatewayHandler(ProxyChannelStateMachine stateMachine) {
-        Objects.requireNonNull(stateMachine, "state machine was null");
-        this.stateMachine = stateMachine;
+    public KafkaProxyGatewayHandler(ProxyChannelStateMachine proxyChannelStateMachine) {
+        Objects.requireNonNull(proxyChannelStateMachine, "state machine was null");
+        this.proxyChannelStateMachine = proxyChannelStateMachine;
     }
 
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception {
-        stateMachine.onClientActive(this);
+        this.clientCtx = ctx;
+        proxyChannelStateMachine.onClientActive(this);
         super.channelActive(ctx);
     }
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-        stateMachine.onClientInactive();
+        proxyChannelStateMachine.onClientInactive();
         super.channelInactive(ctx);
     }
+
+    /**
+     * Netty callback. Used to notify us of custom events.
+     * Events such as ServerNameIndicator (SNI) resolution completing.
+     * <br>
+     * This method is called for <em>every</em> custom event, so its up to us to filter out the ones we care about.
+     *
+     * @param ctx the channel handler context on which the event was triggered.
+     * @param event the information being notified
+     * @throws Exception any errors in processing.
+     */
+    @Override
+    public void userEventTriggered(
+                                   ChannelHandlerContext ctx,
+                                   Object event)
+            throws Exception {
+        if (event instanceof SslHandshakeCompletionEvent handshakeCompletionEvent
+                && handshakeCompletionEvent.isSuccess()) {
+            this.proxyChannelStateMachine.onClientTlsHandshakeSuccess(sslSession());
+        }
+        super.userEventTriggered(ctx, event);
+    }
+
+    @Nullable
+    SSLSession sslSession() {
+        // The SslHandler is added to the pipeline by the SniHandler (replacing it) after the ClientHello.
+        // It is added using the fully-qualified class name.
+        SslHandler sslHandler = (SslHandler) clientCtx().pipeline().get(SslHandler.class.getName());
+        return Optional.ofNullable(sslHandler)
+                .map(SslHandler::engine)
+                .map(SSLEngine::getSession)
+                .orElse(null);
+    }
+
+    private ChannelHandlerContext clientCtx() {
+        return Objects.requireNonNull(clientCtx);
+    }
+
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyGatewayHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyGatewayHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import java.util.Objects;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+public class KafkaProxyGatewayHandler extends ChannelInboundHandlerAdapter {
+
+    private final ProxyChannelStateMachine stateMachine;
+
+    public KafkaProxyGatewayHandler(ProxyChannelStateMachine stateMachine) {
+        Objects.requireNonNull(stateMachine, "state machine was null");
+        this.stateMachine = stateMachine;
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        stateMachine.onClientActive(this);
+        super.channelActive(ctx);
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        stateMachine.onClientInactive();
+        super.channelInactive(ctx);
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -223,6 +223,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
 
         KafkaRequestDecoder decoder = new KafkaRequestDecoder(dp, virtualCluster.socketFrameMaxSizeBytes(), apiVersionsService, decoderListener);
         pipeline.addLast("requestDecoder", decoder);
+        pipeline.addLast("frontendGateway", new KafkaProxyGatewayHandler(proxyChannelStateMachine));
         pipeline.addLast("responseEncoder", new KafkaResponseEncoder(encoderListener));
         pipeline.addLast("saslV0Rejecter", new SaslV0RejectionHandler());
         pipeline.addLast("responseOrderer", new ResponseOrderer());

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachine.java
@@ -453,16 +453,31 @@ public class ProxyChannelStateMachine {
     }
 
     /**
-     * The proxy has received something from the client. The current state of the session determines what happens to it.
+     * The proxy has received something from the client that has been decoded then intercepted at the gateway. The current state of the session determines what happens to it.
+     *
      * @param msg the RPC received from the downstream client
      */
-    void onClientRequest(
-                         Object msg) {
+    void onClientRequestGateway(Object msg) {
+        Objects.requireNonNull(frontendGatewayHandler);
+        if (state() instanceof Forwarding) { // post-backend connection
+            frontendGatewayHandler.forward(msg);
+        }
+        else if (!onClientRequestBeforeForwarding(msg)) {
+            illegalState("Unexpected message received: " + (msg == null ? "null" : "message class=" + msg.getClass()));
+        }
+    }
+
+    /**
+     * The proxy has received something from the client that has reached the end of the frontend chain. The current state of the session determines what happens to it.
+     * @param msg the RPC received from the downstream client
+     */
+    void onClientRequestTerminal(
+                                 Object msg) {
         Objects.requireNonNull(frontendHandler);
         if (state() instanceof Forwarding) { // post-backend connection
             messageFromClient(msg);
         }
-        else if (!onClientRequestBeforeForwarding(msg)) {
+        else {
             illegalState("Unexpected message received: " + (msg == null ? "null" : "message class=" + msg.getClass()));
         }
     }
@@ -672,6 +687,7 @@ public class ProxyChannelStateMachine {
     private void toForwarding(Forwarding forwarding) {
         setState(forwarding);
         kafkaSession.transitionTo(KafkaSessionState.NOT_AUTHENTICATED);
+        Objects.requireNonNull(frontendGatewayHandler).inForwarding();
         Objects.requireNonNull(frontendHandler).inForwarding();
         // once buffered message has been forwarded we enable auto-read to start accepting further messages
         maybeUnblock();
@@ -684,7 +700,7 @@ public class ProxyChannelStateMachine {
      * @return <code>false</code> for unsupported message types
      */
     private boolean onClientRequestBeforeForwarding(Object msg) {
-        Objects.requireNonNull(frontendHandler).bufferMsg(msg);
+        Objects.requireNonNull(frontendGatewayHandler).bufferMsg(msg);
         if (state() instanceof ProxyChannelState.ClientActive clientActive) {
             return onClientRequestInClientActiveState(msg, clientActive);
         }
@@ -754,10 +770,10 @@ public class ProxyChannelStateMachine {
         }
 
         // Close the client connection with any error code
-        if (frontendHandler != null) { // Can be null if the error happens before clientActive (unlikely but possible)
-            frontendHandler.inClosed(errorCodeEx);
-            clientToProxyConnectionToken.release();
+        if (frontendGatewayHandler != null) { // Can be null if the error happens before clientActive (unlikely but possible)
+            frontendGatewayHandler.inClosed(errorCodeEx);
         }
+        clientToProxyConnectionToken.release();
     }
 
     private void incrementAppropriateDisconnectsMetric(@Nullable DisconnectCause disconnectCause) {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachine.java
@@ -175,6 +175,11 @@ public class ProxyChannelStateMachine {
      */
     @SuppressWarnings({ "java:S2637" })
     private @Nullable KafkaProxyFrontendHandler frontendHandler = null;
+    /**
+     * The frontend gateway handler. Non-null if we got as far as ClientActive.
+     */
+    @SuppressWarnings({ "java:S2637" })
+    private @Nullable KafkaProxyGatewayHandler frontendGatewayHandler = null;
 
     /**
      * The backend handler. Non-null if {@link #onInitiateConnect(HostPort)}
@@ -218,7 +223,11 @@ public class ProxyChannelStateMachine {
      * Sonar will complain if one uses this in prod code listen to it.
      */
     @VisibleForTesting
-    void forceState(ProxyChannelState state, KafkaProxyFrontendHandler frontendHandler, @Nullable KafkaProxyBackendHandler backendHandler, KafkaSession kafkaSession) {
+    void forceState(ProxyChannelState state,
+                    KafkaProxyFrontendHandler frontendHandler,
+                    @Nullable KafkaProxyBackendHandler backendHandler,
+                    KafkaSession kafkaSession,
+                    @Nullable KafkaProxyGatewayHandler frontendGatewayHandler) {
         LOGGER.atInfo()
                 .addKeyValue("state", state)
                 .addKeyValue("frontendHandler", frontendHandler)
@@ -228,6 +237,7 @@ public class ProxyChannelStateMachine {
         this.kafkaSession = kafkaSession;
         this.frontendHandler = frontendHandler;
         this.backendHandler = backendHandler;
+        this.frontendGatewayHandler = frontendGatewayHandler;
     }
 
     @Override
@@ -327,6 +337,15 @@ public class ProxyChannelStateMachine {
     void onClientActive(KafkaProxyFrontendHandler frontendHandler) {
         if (STARTING_STATE.equals(this.state)) {
             this.frontendHandler = frontendHandler;
+            maybeTransitionOutOfStarting();
+        }
+        else {
+            illegalState("Client frontend activation while not in the start state");
+        }
+    }
+
+    private void maybeTransitionOutOfStarting() {
+        if (frontendHandler != null && frontendGatewayHandler != null) {
             LOGGER.atDebug()
                     .addKeyValue("sessionId", kafkaSession.sessionId())
                     .addKeyValue("remoteHost", Objects.requireNonNull(this.frontendHandler).remoteHost())
@@ -340,8 +359,19 @@ public class ProxyChannelStateMachine {
                 toHaProxy(clientActive.toHaProxy());
             }
         }
+    }
+
+    /**
+     * Notify the statemachine that the client channel has an active TCP connection.
+     * @param kafkaProxyGatewayHandler with active connection
+     */
+    public void onClientActive(KafkaProxyGatewayHandler kafkaProxyGatewayHandler) {
+        if (STARTING_STATE.equals(this.state)) {
+            this.frontendGatewayHandler = kafkaProxyGatewayHandler;
+            maybeTransitionOutOfStarting();
+        }
         else {
-            illegalState("Client activation while not in the start state");
+            illegalState("Client gateway activation while not in the start state");
         }
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
@@ -102,7 +102,8 @@ public abstract class FilterHarness {
                 forwarding,
                 mock(KafkaProxyFrontendHandler.class),
                 mock(KafkaProxyBackendHandler.class),
-                kafkaSession);
+                kafkaSession,
+                null);
         var filterHandlers = Arrays.stream(filters)
                 .collect(Collector.of(ArrayDeque<Filter>::new, ArrayDeque::addLast, (d1, d2) -> {
                     d2.addAll(d1);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerMockCollaboratorsTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerMockCollaboratorsTest.java
@@ -309,6 +309,7 @@ class KafkaProxyFrontendHandlerMockCollaboratorsTest {
         when(subjectBuilder.buildTransportSubject(any())).thenReturn(CompletableFuture.completedStage(subject));
         var session = new KafkaSession(KafkaSessionState.ESTABLISHING);
         var pcsm = new ProxyChannelStateMachine(endpointBinding, subjectBuilder, session);
+        pcsm.onClientActive(new KafkaProxyGatewayHandler(pcsm));
         handler = new KafkaProxyFrontendHandler(
                 pfr,
                 filterChainFactory,

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerMockCollaboratorsTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerMockCollaboratorsTest.java
@@ -155,7 +155,7 @@ class KafkaProxyFrontendHandlerMockCollaboratorsTest {
         handler.channelRead(clientCtx, msg);
 
         // Then
-        verify(proxyChannelStateMachine).onClientRequest(msg);
+        verify(proxyChannelStateMachine).onClientRequestTerminal(msg);
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -233,11 +233,14 @@ class KafkaProxyFrontendHandlerTest {
         var proxyChannelStateMachine = this.proxyChannelStateMachine(endpointBinding);
 
         KafkaProxyFrontendHandler handler = handler(new DelegatingDecodePredicate(), proxyChannelStateMachine);
+        KafkaProxyGatewayHandler gatewayHandler = new KafkaProxyGatewayHandler(proxyChannelStateMachine);
         ChannelPipeline pipeline = inboundChannel.pipeline();
         pipeline.addLast(throwOnReadHandler(new DecoderException(new FrameOversizedException(5, 6))));
+        pipeline.addLast(gatewayHandler);
         pipeline.addLast(handler);
 
         ChannelHandlerContext mockChannelCtx = mockChannelContext();
+        gatewayHandler.channelActive(mockChannelCtx);
         handler.channelActive(mockChannelCtx);
 
         // when
@@ -261,11 +264,14 @@ class KafkaProxyFrontendHandlerTest {
         var proxyChannelStateMachine = this.proxyChannelStateMachine(endpointBinding);
 
         KafkaProxyFrontendHandler handler = handler(new DelegatingDecodePredicate(), proxyChannelStateMachine);
+        KafkaProxyGatewayHandler gatewayHandler = new KafkaProxyGatewayHandler(proxyChannelStateMachine);
         ChannelPipeline pipeline = inboundChannel.pipeline();
         pipeline.addLast(throwOnReadHandler(new DecoderException(new FrameOversizedException(5, 6))));
+        pipeline.addLast(gatewayHandler);
         pipeline.addLast(handler);
 
         ChannelHandlerContext mockChannelCtx = mockChannelContext();
+        gatewayHandler.channelActive(mockChannelCtx);
         handler.channelActive(mockChannelCtx);
 
         // when

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -479,6 +479,7 @@ class KafkaProxyFrontendHandlerTest {
             // Add HaProxyMessageHandler before the frontend handler to intercept HAProxyMessage
             // and prevent it from reaching FilterHandlers (which only expect Kafka protocol messages)
             pipeline.addLast(new HaProxyMessageHandler(proxyChannelStateMachine.kafkaSession()));
+            pipeline.addLast(new KafkaProxyGatewayHandler(proxyChannelStateMachine));
             pipeline.addLast(handler);
         }
         assertThat(proxyChannelStateMachine.state()).isExactlyInstanceOf(ProxyChannelState.Startup.class);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyGatewayHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyGatewayHandlerTest.java
@@ -110,8 +110,7 @@ class KafkaProxyGatewayHandlerTest {
 
         SSLSession session = kafkaProxyGatewayHandler.sslSession();
 
-        assertThat(session).isNotNull();
-        assertThat(session).isSameAs(sslHandler.engine().getSession());
+        assertThat(session).isNotNull().isSameAs(sslHandler.engine().getSession());
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyGatewayHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyGatewayHandlerTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import javax.net.ssl.SSLSession;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.ssl.SslHandshakeCompletionEvent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class KafkaProxyGatewayHandlerTest {
+
+    @Mock(strictness = Mock.Strictness.LENIENT)
+    ProxyChannelStateMachine proxyChannelStateMachine;
+
+    private KafkaProxyGatewayHandler kafkaProxyGatewayHandler;
+    private EmbeddedChannel clientChannel;
+    private ChannelHandlerContext clientContext;
+
+    @BeforeEach
+    void setUp() {
+        kafkaProxyGatewayHandler = new KafkaProxyGatewayHandler(proxyChannelStateMachine);
+        clientChannel = new EmbeddedChannel();
+        clientChannel.pipeline().addFirst(kafkaProxyGatewayHandler);
+        clientContext = clientChannel.pipeline().firstContext();
+    }
+
+    @Test
+    void shouldRejectNullStateMachineInConstructor() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> new KafkaProxyGatewayHandler(null))
+                .withMessage("state machine was null");
+    }
+
+    @Test
+    void shouldNotifyStateMachineOnChannelActive() throws Exception {
+        kafkaProxyGatewayHandler.channelActive(clientContext);
+
+        verify(proxyChannelStateMachine).onClientActive(kafkaProxyGatewayHandler);
+    }
+
+    @Test
+    void shouldNotifyStateMachineOnChannelInactive() throws Exception {
+        kafkaProxyGatewayHandler.channelActive(clientContext);
+        kafkaProxyGatewayHandler.channelInactive(clientContext);
+
+        verify(proxyChannelStateMachine).onClientInactive();
+    }
+
+    @Test
+    void shouldNotifyStateMachineOnSuccessfulSslHandshake() throws Exception {
+        SslHandler sslHandler = SslContextBuilder.forClient().build().newHandler(clientChannel.alloc());
+        clientChannel.pipeline().addFirst(SslHandler.class.getName(), sslHandler);
+
+        kafkaProxyGatewayHandler.channelActive(clientContext);
+        clearInvocations(proxyChannelStateMachine);
+
+        kafkaProxyGatewayHandler.userEventTriggered(clientContext, SslHandshakeCompletionEvent.SUCCESS);
+
+        SSLSession expectedSession = sslHandler.engine().getSession();
+        verify(proxyChannelStateMachine).onClientTlsHandshakeSuccess(expectedSession);
+    }
+
+    @Test
+    void shouldNotNotifyStateMachineOnFailedSslHandshake() throws Exception {
+        kafkaProxyGatewayHandler.channelActive(clientContext);
+        clearInvocations(proxyChannelStateMachine);
+
+        Exception handshakeFailure = new Exception("TLS handshake failed");
+        kafkaProxyGatewayHandler.userEventTriggered(clientContext, new SslHandshakeCompletionEvent(handshakeFailure));
+
+        verifyNoInteractions(proxyChannelStateMachine);
+    }
+
+    @Test
+    void shouldIgnoreNonSslHandshakeEvents() throws Exception {
+        kafkaProxyGatewayHandler.channelActive(clientContext);
+        clearInvocations(proxyChannelStateMachine);
+
+        kafkaProxyGatewayHandler.userEventTriggered(clientContext, new Object());
+
+        verifyNoInteractions(proxyChannelStateMachine);
+    }
+
+    @Test
+    void shouldReturnSslSessionWhenSslHandlerPresent() throws Exception {
+        SslHandler sslHandler = SslContextBuilder.forClient().build().newHandler(clientChannel.alloc());
+        clientChannel.pipeline().addFirst(SslHandler.class.getName(), sslHandler);
+
+        kafkaProxyGatewayHandler.channelActive(clientContext);
+
+        SSLSession session = kafkaProxyGatewayHandler.sslSession();
+
+        assertThat(session).isNotNull();
+        assertThat(session).isSameAs(sslHandler.engine().getSession());
+    }
+
+    @Test
+    void shouldReturnNullWhenSslHandlerNotPresent() throws Exception {
+        kafkaProxyGatewayHandler.channelActive(clientContext);
+
+        SSLSession session = kafkaProxyGatewayHandler.sslSession();
+
+        assertThat(session).isNull();
+    }
+
+    @Test
+    void shouldThrowWhenContextNotInitialized() {
+        KafkaProxyGatewayHandler uninitializedHandler = new KafkaProxyGatewayHandler(proxyChannelStateMachine);
+
+        assertThatNullPointerException()
+                .isThrownBy(uninitializedHandler::sslSession);
+    }
+}

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -381,7 +381,7 @@ class KafkaProxyInitializerTest {
     }
 
     @AfterEach
-    public void afterEach() {
+    void afterEach() {
         AbstractAssert.setDescriptionConsumer(null);
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -425,6 +425,7 @@ class KafkaProxyInitializerTest {
 
     private void verifyEncoderAndOrdererAdded(InOrder orderedVerifyer) {
         orderedVerifyer.verify(channelPipeline).addLast(eq("requestDecoder"), any(ByteToMessageDecoder.class));
+        orderedVerifyer.verify(channelPipeline).addLast(eq("frontendGateway"), any(KafkaProxyGatewayHandler.class));
         orderedVerifyer.verify(channelPipeline).addLast(eq("responseEncoder"), any(MessageToByteEncoder.class));
         orderedVerifyer.verify(channelPipeline).addLast(eq("saslV0Rejecter"), any(SaslV0RejectionHandler.class));
         orderedVerifyer.verify(channelPipeline).addLast(eq("responseOrderer"), any(ResponseOrderer.class));

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -17,6 +17,7 @@ import java.util.function.Consumer;
 
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.matcher.AssertionMatcher;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -379,6 +380,11 @@ class KafkaProxyInitializerTest {
         assertThatCode(embeddedChannel::checkException).doesNotThrowAnyException();
     }
 
+    @AfterEach
+    public void afterEach() {
+        AbstractAssert.setDescriptionConsumer(null);
+    }
+
     @SuppressWarnings("DataFlowIssue")
     private KafkaProxyInitializer createKafkaProxyInitializer(boolean tls,
                                                               EndpointBindingResolver bindingResolver) {
@@ -438,7 +444,7 @@ class KafkaProxyInitializerTest {
 
             @Override
             public void assertion(T actual) throws AssertionError {
-                AbstractAssert.setDescriptionConsumer(description -> underlyingDescription = description.value());
+                AbstractAssert.setDescriptionConsumer(description -> underlyingDescription = description == null ? null : description.value());
                 assertions.accept(actual);
             }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineEndToEndTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineEndToEndTest.java
@@ -102,6 +102,7 @@ class ProxyChannelStateMachineEndToEndTest {
 
     int correlationId = 0;
     private KafkaProxyFrontendHandler handler;
+    private KafkaProxyGatewayHandler gatewayHandler;
     private KafkaProxyBackendHandler backendHandler;
     private boolean activateOutboundChannelAutomatically = true;
 
@@ -128,7 +129,7 @@ class ProxyChannelStateMachineEndToEndTest {
         activateOutboundChannelAutomatically = false;
 
         // When
-        hClientConnect(proxyChannelStateMachine, handler);
+        hClientConnect(proxyChannelStateMachine, handler, gatewayHandler);
 
         // Then
         inboundChannel.checkException();
@@ -195,7 +196,7 @@ class ProxyChannelStateMachineEndToEndTest {
                     handler,
                     backendHandler,
                     TEST_SESSION,
-                    null);
+                    gatewayHandler);
         }
 
         // When
@@ -223,7 +224,7 @@ class ProxyChannelStateMachineEndToEndTest {
         var proxyChannelStateMachine = buildFrontendHandler(false);
         activateOutboundChannelAutomatically = false;
 
-        hClientConnect(proxyChannelStateMachine, handler);
+        hClientConnect(proxyChannelStateMachine, handler, gatewayHandler);
         assertThat(proxyChannelStateMachine.state()).isExactlyInstanceOf(ProxyChannelState.ClientActive.class);
         if (sni) {
             inboundChannel.pipeline().fireUserEventTriggered(new SniCompletionEvent(SNI_HOSTNAME));
@@ -253,7 +254,7 @@ class ProxyChannelStateMachineEndToEndTest {
                 .isNotNull();
 
         assertProxyActive(proxyChannelStateMachine);
-        assertThat(handler.bufferedMsgs).isNull();
+        assertThat(gatewayHandler.bufferedMsgs).isNull();
     }
 
     @ParameterizedTest
@@ -321,7 +322,7 @@ class ProxyChannelStateMachineEndToEndTest {
 
         assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Connecting.class);
 
-        assertThat(handler.bufferedMsgs)
+        assertThat(gatewayHandler.bufferedMsgs)
                 .asInstanceOf(InstanceOfAssertFactories.list(DecodedRequestFrame.class))
                 .singleElement()
                 .isEqualTo(firstRequest);
@@ -507,6 +508,7 @@ class ProxyChannelStateMachineEndToEndTest {
         var proxyChannelStateMachine = proxyChannelStateMachine(endpointBinding);
 
         this.handler = handler(proxyChannelStateMachine, dp);
+        this.gatewayHandler = new KafkaProxyGatewayHandler(proxyChannelStateMachine);
         this.inboundCtx = mock(ChannelHandlerContext.class);
         when(inboundCtx.channel()).thenReturn(inboundChannel);
         when(inboundCtx.pipeline()).thenReturn(inboundChannel.pipeline());
@@ -527,10 +529,12 @@ class ProxyChannelStateMachineEndToEndTest {
 
     // transitions from each state
     // each of the events that can happen in that state
-    private void hClientConnect(ProxyChannelStateMachine proxyChannelStateMachine, KafkaProxyFrontendHandler handler) {
+    private void hClientConnect(ProxyChannelStateMachine proxyChannelStateMachine,
+                                KafkaProxyFrontendHandler handler,
+                                KafkaProxyGatewayHandler gatewayHandler) {
         final ChannelPipeline pipeline = inboundChannel.pipeline();
         if (pipeline.get(KafkaProxyFrontendHandler.class) == null) {
-            pipeline.addLast(new KafkaProxyGatewayHandler(proxyChannelStateMachine));
+            pipeline.addLast(gatewayHandler);
             pipeline.addLast(handler);
         }
         assertThat(proxyChannelStateMachine.state()).isExactlyInstanceOf(ProxyChannelState.Startup.class);
@@ -620,7 +624,7 @@ class ProxyChannelStateMachineEndToEndTest {
                 .isEqualTo(expectedBufferedRequestTypes.contains(ApiKeys.API_VERSIONS) ? CLIENT_SOFTWARE_NAME : null);
         stateAssert.extracting(ProxyChannelState.Connecting::clientSoftwareVersion)
                 .isEqualTo(expectedBufferedRequestTypes.contains(ApiKeys.API_VERSIONS) ? CLIENT_SOFTWARE_VERSION : null);
-        assertThat(handler.bufferedMsgs).asInstanceOf(InstanceOfAssertFactories.list(DecodedRequestFrame.class))
+        assertThat(gatewayHandler.bufferedMsgs).asInstanceOf(InstanceOfAssertFactories.list(DecodedRequestFrame.class))
                 .map(DecodedRequestFrame::apiKey).isEqualTo(expectedBufferedRequestTypes);
     }
 
@@ -698,7 +702,7 @@ class ProxyChannelStateMachineEndToEndTest {
                                                                    ApiKeys firstMessage) {
         var proxyChannelStateMachine = buildFrontendHandler(tlsConfigured);
 
-        hClientConnect(proxyChannelStateMachine, handler);
+        hClientConnect(proxyChannelStateMachine, handler, gatewayHandler);
         if (sni) {
             inboundChannel.pipeline().fireUserEventTriggered(new SniCompletionEvent(SNI_HOSTNAME));
         }
@@ -709,7 +713,7 @@ class ProxyChannelStateMachineEndToEndTest {
                 handler,
                 backendHandler,
                 TEST_SESSION,
-                null);
+                gatewayHandler);
 
         inboundChannel.config().setAutoRead(false);
 
@@ -719,7 +723,7 @@ class ProxyChannelStateMachineEndToEndTest {
     @NonNull
     private DecodedRequestFrame<ApiMessage> firstRequest(ApiKeys firstMessage) {
         final DecodedRequestFrame<ApiMessage> firstRequest = apiKeyToMessage(firstMessage);
-        handler.bufferMsg(firstRequest);
+        gatewayHandler.bufferMsg(firstRequest);
 
         handler.inSelectingServer();
 
@@ -784,7 +788,7 @@ class ProxyChannelStateMachineEndToEndTest {
         var proxyChannelStateMachine = buildFrontendHandler(false);
 
         // When - Transition to ClientActive state (this installs filters in the pipeline)
-        hClientConnect(proxyChannelStateMachine, handler);
+        hClientConnect(proxyChannelStateMachine, handler, gatewayHandler);
 
         // Then - Verify the pipeline ordering
         ChannelPipeline pipeline = inboundChannel.pipeline();

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineEndToEndTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineEndToEndTest.java
@@ -194,7 +194,8 @@ class ProxyChannelStateMachineEndToEndTest {
                     new ProxyChannelState.HaProxy(),
                     handler,
                     backendHandler,
-                    TEST_SESSION);
+                    TEST_SESSION,
+                    null);
         }
 
         // When
@@ -529,6 +530,7 @@ class ProxyChannelStateMachineEndToEndTest {
     private void hClientConnect(ProxyChannelStateMachine proxyChannelStateMachine, KafkaProxyFrontendHandler handler) {
         final ChannelPipeline pipeline = inboundChannel.pipeline();
         if (pipeline.get(KafkaProxyFrontendHandler.class) == null) {
+            pipeline.addLast(new KafkaProxyGatewayHandler(proxyChannelStateMachine));
             pipeline.addLast(handler);
         }
         assertThat(proxyChannelStateMachine.state()).isExactlyInstanceOf(ProxyChannelState.Startup.class);
@@ -706,7 +708,8 @@ class ProxyChannelStateMachineEndToEndTest {
                         firstMessage == ApiKeys.API_VERSIONS ? CLIENT_SOFTWARE_VERSION : null),
                 handler,
                 backendHandler,
-                TEST_SESSION);
+                TEST_SESSION,
+                null);
 
         inboundChannel.config().setAutoRead(false);
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
@@ -70,6 +70,7 @@ import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -101,6 +102,10 @@ class ProxyChannelStateMachineTest {
 
     @Mock(strictness = Mock.Strictness.LENIENT)
     private KafkaProxyFrontendHandler frontendHandler;
+
+    @Mock(strictness = Mock.Strictness.LENIENT)
+    private KafkaProxyGatewayHandler frontendGatewayHandler;
+
     private SimpleMeterRegistry simpleMeterRegistry;
 
     @BeforeEach
@@ -130,6 +135,7 @@ class ProxyChannelStateMachineTest {
 
         // When
         proxyChannelStateMachine.onClientActive(frontendHandler);
+        proxyChannelStateMachine.onClientActive(frontendGatewayHandler);
 
         // Then
         assertThat(Metrics.globalRegistry.get("kroxylicious_client_to_proxy_connections").counter())
@@ -313,10 +319,28 @@ class ProxyChannelStateMachineTest {
     }
 
     @Test
-    void shouldNotifyHandlerOnTransitionFromStartToClientActive() {
+    void shouldNotifyHandlerOnTransitionFromStartToClientActiveWhenFrontendActiveFirst() {
         // Given
 
         // When
+        proxyChannelStateMachine.onClientActive(frontendHandler);
+        verify(frontendHandler, never()).inClientActive();
+        assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Startup.class);
+        proxyChannelStateMachine.onClientActive(frontendGatewayHandler);
+
+        // Then
+        assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.ClientActive.class);
+        verify(frontendHandler, times(1)).inClientActive();
+    }
+
+    @Test
+    void shouldNotifyHandlerOnTransitionFromStartToClientActiveWhenGatewayActiveFirst() {
+        // Given
+
+        // When
+        proxyChannelStateMachine.onClientActive(frontendGatewayHandler);
+        verify(frontendHandler, never()).inClientActive();
+        assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Startup.class);
         proxyChannelStateMachine.onClientActive(frontendHandler);
 
         // Then
@@ -331,6 +355,7 @@ class ProxyChannelStateMachineTest {
 
         // When
         proxyChannelStateMachine.onClientActive(frontendHandler);
+        proxyChannelStateMachine.onClientActive(frontendGatewayHandler);
 
         // Then - state machine transitions through ClientActive → HaProxy
         assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.HaProxy.class);
@@ -796,7 +821,8 @@ class ProxyChannelStateMachineTest {
                 new ProxyChannelState.ClientActive(),
                 frontendHandler,
                 null,
-                TEST_KAFKA_SESSION);
+                TEST_KAFKA_SESSION,
+                frontendGatewayHandler);
     }
 
     private void stateMachineInHaProxy() {
@@ -804,7 +830,8 @@ class ProxyChannelStateMachineTest {
                 new ProxyChannelState.HaProxy(),
                 frontendHandler,
                 null,
-                TEST_KAFKA_SESSION);
+                TEST_KAFKA_SESSION,
+                frontendGatewayHandler);
     }
 
     private void stateMachineInSelectingServer() {
@@ -812,7 +839,8 @@ class ProxyChannelStateMachineTest {
                 new ProxyChannelState.SelectingServer(null, null),
                 frontendHandler,
                 null,
-                TEST_KAFKA_SESSION);
+                TEST_KAFKA_SESSION,
+                frontendGatewayHandler);
     }
 
     private void stateMachineInConnecting() {
@@ -820,7 +848,8 @@ class ProxyChannelStateMachineTest {
                 new ProxyChannelState.Connecting(null, null, new HostPort("localhost", 9089)),
                 frontendHandler,
                 backendHandler,
-                TEST_KAFKA_SESSION);
+                TEST_KAFKA_SESSION,
+                frontendGatewayHandler);
     }
 
     private ProxyChannelState.Forwarding stateMachineInForwarding() {
@@ -829,7 +858,8 @@ class ProxyChannelStateMachineTest {
                 forwarding,
                 frontendHandler,
                 backendHandler,
-                TEST_KAFKA_SESSION);
+                TEST_KAFKA_SESSION,
+                frontendGatewayHandler);
         return forwarding;
     }
 
@@ -838,7 +868,8 @@ class ProxyChannelStateMachineTest {
                 new ProxyChannelState.Closed(),
                 frontendHandler,
                 backendHandler,
-                TEST_KAFKA_SESSION);
+                TEST_KAFKA_SESSION,
+                frontendGatewayHandler);
     }
 
     private static DecodedRequestFrame<ApiVersionsRequestData> apiVersionsRequest() {
@@ -876,6 +907,7 @@ class ProxyChannelStateMachineTest {
 
         // When
         proxyChannelStateMachine.onClientActive(frontendHandler);
+        proxyChannelStateMachine.onClientActive(frontendGatewayHandler);
 
         // Then
         assertThat(getVirtualNodeClientToProxyActiveConnections())
@@ -900,6 +932,7 @@ class ProxyChannelStateMachineTest {
     void shouldDecrementActiveConnectionsOnClosed() {
         // Given - establish both client and server connections
         proxyChannelStateMachine.onClientActive(frontendHandler);
+        proxyChannelStateMachine.onClientActive(frontendGatewayHandler);
         stateMachineInConnecting();
         proxyChannelStateMachine.onServerActive();
 
@@ -920,6 +953,7 @@ class ProxyChannelStateMachineTest {
     void shouldDecrementActiveConnectionsOnServerInactive() {
         // Given - establish both client and server connections
         proxyChannelStateMachine.onClientActive(frontendHandler);
+        proxyChannelStateMachine.onClientActive(frontendGatewayHandler);
         stateMachineInConnecting();
         proxyChannelStateMachine.onServerActive();
 
@@ -940,6 +974,7 @@ class ProxyChannelStateMachineTest {
     void shouldDecrementActiveConnectionsOnClientException() {
         // Given - establish client connection
         proxyChannelStateMachine.onClientActive(frontendHandler);
+        proxyChannelStateMachine.onClientActive(frontendGatewayHandler);
         int initialClientCount = getVirtualNodeClientToProxyActiveConnections();
 
         // When
@@ -954,6 +989,7 @@ class ProxyChannelStateMachineTest {
     void shouldDecrementActiveConnectionsOnServerException() {
         // Given - establish both client and server connections
         proxyChannelStateMachine.onClientActive(frontendHandler);
+        proxyChannelStateMachine.onClientActive(frontendGatewayHandler);
         stateMachineInConnecting();
         proxyChannelStateMachine.onServerActive();
 
@@ -974,6 +1010,7 @@ class ProxyChannelStateMachineTest {
     void shouldOnlyDecrementClientConnectionsWhenNotInForwardingState() {
         // Given - establish client connection but not server connection
         proxyChannelStateMachine.onClientActive(frontendHandler);
+        proxyChannelStateMachine.onClientActive(frontendGatewayHandler);
         int initialClientCount = getVirtualNodeClientToProxyActiveConnections();
         int initialServerCount = getVirtualNodeProxyToServerActiveConnections();
 
@@ -1023,6 +1060,7 @@ class ProxyChannelStateMachineTest {
     void onClientTlsHandshakeSuccessPassesExecutorToSubjectManager() {
         // Given
         proxyChannelStateMachine.onClientActive(frontendHandler);
+        proxyChannelStateMachine.onClientActive(frontendGatewayHandler);
         SSLSession sslSession = mock(SSLSession.class);
         AtomicBoolean executorUsed = new AtomicBoolean(false);
         when(frontendHandler.eventLoopExecutor()).thenReturn(command -> {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
@@ -265,7 +265,7 @@ class ProxyChannelStateMachineTest {
         // Then
         assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Closed.class);
         verify(backendHandler).inClosed();
-        verify(frontendHandler).inClosed(ArgumentMatchers.notNull(UnknownServerException.class));
+        verify(frontendGatewayHandler).inClosed(ArgumentMatchers.notNull(UnknownServerException.class));
     }
 
     private void useDownstreamSsl() {
@@ -286,7 +286,7 @@ class ProxyChannelStateMachineTest {
         // Then
         assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Closed.class);
         verify(backendHandler).inClosed();
-        verify(frontendHandler).inClosed(ArgumentMatchers.notNull(InvalidRequestException.class));
+        verify(frontendGatewayHandler).inClosed(ArgumentMatchers.notNull(InvalidRequestException.class));
     }
 
     @Test
@@ -301,7 +301,7 @@ class ProxyChannelStateMachineTest {
         // Then
         assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Closed.class);
         verify(backendHandler).inClosed();
-        verify(frontendHandler).inClosed(cause);
+        verify(frontendGatewayHandler).inClosed(cause);
     }
 
     @Test
@@ -370,13 +370,13 @@ class ProxyChannelStateMachineTest {
         var msg = metadataRequest();
 
         // When
-        proxyChannelStateMachine.onClientRequest(msg);
+        proxyChannelStateMachine.onClientRequestGateway(msg);
 
         // Then
         assertThat(proxyChannelStateMachine.state())
                 .isInstanceOf(ProxyChannelState.SelectingServer.class);
         verify(frontendHandler).inSelectingServer();
-        verify(frontendHandler).bufferMsg(msg);
+        verify(frontendGatewayHandler).bufferMsg(msg);
         verifyNoMoreInteractions(frontendHandler);
     }
 
@@ -387,13 +387,13 @@ class ProxyChannelStateMachineTest {
         var msg = apiVersionsRequest();
 
         // When
-        proxyChannelStateMachine.onClientRequest(msg);
+        proxyChannelStateMachine.onClientRequestGateway(msg);
 
         // Then
         assertThat(proxyChannelStateMachine.state())
                 .isInstanceOf(ProxyChannelState.SelectingServer.class);
         verify(frontendHandler).inSelectingServer();
-        verify(frontendHandler).bufferMsg(msg);
+        verify(frontendGatewayHandler).bufferMsg(msg);
         verifyNoMoreInteractions(frontendHandler);
     }
 
@@ -403,12 +403,12 @@ class ProxyChannelStateMachineTest {
         stateMachineInHaProxy();
 
         // When - an unexpected (non-Kafka) message arrives
-        proxyChannelStateMachine.onClientRequest(new Object());
+        proxyChannelStateMachine.onClientRequestTerminal(new Object());
 
         // Then
         assertThat(proxyChannelStateMachine.state())
                 .isInstanceOf(ProxyChannelState.Closed.class);
-        verify(frontendHandler).inClosed(null);
+        verify(frontendGatewayHandler).inClosed(null);
     }
 
     @Test
@@ -418,13 +418,13 @@ class ProxyChannelStateMachineTest {
         var msg = metadataRequest();
 
         // When
-        proxyChannelStateMachine.onClientRequest(msg);
+        proxyChannelStateMachine.onClientRequestGateway(msg);
 
         // Then
         assertThat(proxyChannelStateMachine.state())
                 .isInstanceOf(ProxyChannelState.SelectingServer.class);
         verify(frontendHandler).inSelectingServer();
-        verify(frontendHandler).bufferMsg(msg);
+        verify(frontendGatewayHandler).bufferMsg(msg);
         verifyNoMoreInteractions(frontendHandler);
     }
 
@@ -435,8 +435,7 @@ class ProxyChannelStateMachineTest {
         var msg = apiVersionsRequest();
 
         // When
-        proxyChannelStateMachine.onClientRequest(
-                msg);
+        proxyChannelStateMachine.onClientRequestGateway(msg);
 
         // Then
         var stateAssert = assertThat(proxyChannelStateMachine.state())
@@ -445,7 +444,7 @@ class ProxyChannelStateMachineTest {
                 .extracting(SelectingServer::clientSoftwareName).isEqualTo("mykafkalib");
         stateAssert
                 .extracting(SelectingServer::clientSoftwareVersion).isEqualTo("1.0.0");
-        verify(frontendHandler).bufferMsg(msg);
+        verify(frontendGatewayHandler).bufferMsg(msg);
     }
 
     @SuppressWarnings("DataFlowIssue")
@@ -480,7 +479,7 @@ class ProxyChannelStateMachineTest {
         // Then
         assertThat(proxyChannelStateMachine.state())
                 .isInstanceOf(ProxyChannelState.Closed.class);
-        verify(frontendHandler).inClosed(null);
+        verify(frontendGatewayHandler).inClosed(null);
         assertThat(proxyChannelStateMachine).extracting("backendHandler").isNull();
     }
 
@@ -495,7 +494,7 @@ class ProxyChannelStateMachineTest {
         // Then
         assertThat(proxyChannelStateMachine.state())
                 .isInstanceOf(ProxyChannelState.Closed.class);
-        verify(frontendHandler).inClosed(null);
+        verify(frontendGatewayHandler).inClosed(null);
         verify(backendHandler).inClosed();
     }
 
@@ -521,10 +520,10 @@ class ProxyChannelStateMachineTest {
 
         // When
         DecodedRequestFrame<MetadataRequestData> msg = metadataRequest();
-        proxyChannelStateMachine.onClientRequest(msg);
+        proxyChannelStateMachine.onClientRequestGateway(msg);
 
         // Then
-        verify(frontendHandler).bufferMsg(msg);
+        verify(frontendGatewayHandler).bufferMsg(msg);
         assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Connecting.class);
     }
 
@@ -539,7 +538,7 @@ class ProxyChannelStateMachineTest {
         // Then
         assertThat(proxyChannelStateMachine.state())
                 .isInstanceOf(ProxyChannelState.Closed.class);
-        verify(frontendHandler).inClosed(null);
+        verify(frontendGatewayHandler).inClosed(null);
     }
 
     @Test
@@ -550,7 +549,7 @@ class ProxyChannelStateMachineTest {
         var msg = metadataRequest();
 
         // When
-        proxyChannelStateMachine.onClientRequest(msg);
+        proxyChannelStateMachine.onClientRequestTerminal(msg);
 
         // Then
         assertThat(proxyChannelStateMachine.state()).isSameAs(forwarding);
@@ -580,7 +579,7 @@ class ProxyChannelStateMachineTest {
     void inForwardingShouldTransitionToClosedOnServerInactive() {
         // Given
         stateMachineInForwarding();
-        doAnswer(invocation -> assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Closed.class)).when(frontendHandler).inClosed(null);
+        doAnswer(invocation -> assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Closed.class)).when(frontendGatewayHandler).inClosed(null);
         doNothing().when(backendHandler).inClosed();
 
         // When
@@ -588,7 +587,7 @@ class ProxyChannelStateMachineTest {
 
         // Then
         assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Closed.class);
-        verify(frontendHandler).inClosed(null);
+        verify(frontendGatewayHandler).inClosed(null);
         verify(backendHandler).inClosed();
     }
 
@@ -596,14 +595,14 @@ class ProxyChannelStateMachineTest {
     void inForwardingShouldTransitionToClosedOnClientInactive() {
         // Given
         stateMachineInForwarding();
-        doAnswer(invocation -> assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Closed.class)).when(frontendHandler).inClosed(null);
+        doAnswer(invocation -> assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Closed.class)).when(frontendGatewayHandler).inClosed(null);
 
         // When
         proxyChannelStateMachine.onClientInactive();
 
         // Then
         assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Closed.class);
-        verify(frontendHandler).inClosed(null);
+        verify(frontendGatewayHandler).inClosed(null);
         verify(backendHandler).inClosed();
     }
 
@@ -611,7 +610,7 @@ class ProxyChannelStateMachineTest {
     void inForwardingShouldTransitionToClosedOnClientIdle() {
         // Given
         stateMachineInForwarding();
-        doAnswer(invocation -> assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Closed.class)).when(frontendHandler).inClosed(null);
+        doAnswer(invocation -> assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Closed.class)).when(frontendGatewayHandler).inClosed(null);
 
         // When
         proxyChannelStateMachine.onClientIdle();
@@ -619,7 +618,7 @@ class ProxyChannelStateMachineTest {
         // Then
         assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Closed.class);
         assertThat(proxyChannelStateMachine.kafkaSession().currentState()).isEqualTo(KafkaSessionState.TERMINATING);
-        verify(frontendHandler).inClosed(null);
+        verify(frontendGatewayHandler).inClosed(null);
         verify(backendHandler).inClosed();
     }
 
@@ -647,7 +646,7 @@ class ProxyChannelStateMachineTest {
 
         // Then
         assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Closed.class);
-        verify(frontendHandler).inClosed(illegalStateException);
+        verify(frontendGatewayHandler).inClosed(illegalStateException);
         verify(backendHandler).inClosed();
     }
 
@@ -658,7 +657,7 @@ class ProxyChannelStateMachineTest {
         stateMachineInForwarding();
         final ApiException expectedException = Errors.UNKNOWN_SERVER_ERROR.exception();
         final IllegalStateException illegalStateException = new IllegalStateException("She canny take it any more, captain");
-        doAnswer(invocation -> assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Closed.class)).when(frontendHandler)
+        doAnswer(invocation -> assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Closed.class)).when(frontendGatewayHandler)
                 .inClosed(expectedException);
         doNothing().when(backendHandler).inClosed();
         if (tlsEnabled) {
@@ -670,7 +669,7 @@ class ProxyChannelStateMachineTest {
 
         // Then
         assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Closed.class);
-        verify(frontendHandler).inClosed(expectedException);
+        verify(frontendGatewayHandler).inClosed(expectedException);
         verify(backendHandler).inClosed();
     }
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
@@ -1074,6 +1074,36 @@ class ProxyChannelStateMachineTest {
         assertThat(executorUsed).isTrue();
     }
 
+    @Test
+    void shouldCloseWhenFrontendHandlerActivatedInNonStartingState() {
+        // Given
+        stateMachineInClientActive();
+        KafkaProxyFrontendHandler newFrontendHandler = mock(KafkaProxyFrontendHandler.class);
+
+        // When
+        proxyChannelStateMachine.onClientActive(newFrontendHandler);
+
+        // Then
+        assertThat(proxyChannelStateMachine.state())
+                .isInstanceOf(ProxyChannelState.Closed.class);
+        verify(frontendGatewayHandler).inClosed(null);
+    }
+
+    @Test
+    void shouldCloseWhenGatewayHandlerActivatedInNonStartingState() {
+        // Given
+        stateMachineInClientActive();
+        KafkaProxyGatewayHandler newGatewayHandler = mock(KafkaProxyGatewayHandler.class);
+
+        // When
+        proxyChannelStateMachine.onClientActive(newGatewayHandler);
+
+        // Then
+        assertThat(proxyChannelStateMachine.state())
+                .isInstanceOf(ProxyChannelState.Closed.class);
+        verify(frontendGatewayHandler).inClosed(null);
+    }
+
     @org.junit.jupiter.api.Nested
     class DisconnectMetricsTest {
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes #3745

The problem is that we buffer messages after they have traversed the Filter chain. It is possible for messages to enter the filter chain while the Transport Subject is being created by some uncontrolled thread. We want to delay messages entering the Filter chain until after the Transport Subject has been built.

To do this we split a Gateway handler out of the frontend handler. The Gateway handler sits just after the Kafka message decoder and is responsible for:

1. registering with the ProxyChannelStateMachine (PCSM) (the PCSM now waits for both handlers to register before entering CLIENT_ACTIVE)
2. telling PCSM about messages entering the Gateway. PCSM decides whether they should be forwarded or buffered and tells Gateway what to do.
3. responding with an Error when the channel is closed if the state machine never got to Forwarding.
4. Feeding the SSL handshake details to the PCSM.

The corresponding behaviours have been stripped out of the Frontend handler (which we should probably rename so these form a pair like `GatewayFrontendHandler` and `TerminalFrontendHandler` for the handler at the end of the inbound chain, lets do it separately though as the rename would be noisy)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
