### PR TITLE
fix(test): flaky requiredModeShouldProxyKafkaRequestsAfterProxyHeader…

### DIFF
--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/KafkaClientHandler.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/client/KafkaClientHandler.java
@@ -5,6 +5,7 @@
  */
 package io.kroxylicious.test.client;
 
+import java.nio.channels.ClosedChannelException;
 import java.util.Deque;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -48,9 +49,23 @@ public class KafkaClientHandler extends ChannelInboundHandlerAdapter {
     }
 
     @Override
+    public void channelInactive(ChannelHandlerContext ctx) {
+        failQueuedRequests(new ClosedChannelException());
+        ctx.fireChannelInactive();
+    }
+
+    @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         LOGGER.warn("Kafka test client received unexpected exception, closing connection.", cause);
+        failQueuedRequests(cause);
         ctx.close();
+    }
+
+    private void failQueuedRequests(Throwable cause) {
+        RequestFrame pending;
+        while ((pending = queue.pollFirst()) != null) {
+            pending.getResponseFuture().completeExceptionally(cause);
+        }
     }
 
     /**

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/ProxyProtocolIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/ProxyProtocolIT.java
@@ -21,6 +21,7 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
 import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.SocketChannel;
@@ -93,21 +94,7 @@ class ProxyProtocolIT {
             var correlationManager = new CorrelationManager();
             var kafkaHandler = new KafkaClientHandler();
             try (var group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory())) {
-                var bootstrap = new Bootstrap()
-                        .group(group)
-                        .channel(NioSocketChannel.class)
-                        .option(ChannelOption.TCP_NODELAY, true)
-                        .handler(new ChannelInitializer<SocketChannel>() {
-                            @Override
-                            protected void initChannel(SocketChannel ch) {
-                                ch.pipeline().addLast(HAProxyMessageEncoder.INSTANCE);
-                                ch.pipeline().addLast(new KafkaRequestEncoder(correlationManager));
-                                ch.pipeline().addLast(new KafkaResponseDecoder(correlationManager));
-                                ch.pipeline().addLast(kafkaHandler);
-                            }
-                        });
-
-                Channel channel = bootstrap.connect(host, port).sync().channel();
+                Channel channel = connectClient(group, host, port, correlationManager, kafkaHandler);
 
                 // Send PROXY header first
                 channel.writeAndFlush(new HAProxyMessage(
@@ -184,21 +171,7 @@ class ProxyProtocolIT {
                     .build();
 
             try (var group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory())) {
-                var bootstrap = new Bootstrap()
-                        .group(group)
-                        .channel(NioSocketChannel.class)
-                        .option(ChannelOption.TCP_NODELAY, true)
-                        .handler(new ChannelInitializer<SocketChannel>() {
-                            @Override
-                            protected void initChannel(SocketChannel ch) {
-                                ch.pipeline().addLast(HAProxyMessageEncoder.INSTANCE);
-                                ch.pipeline().addLast(new KafkaRequestEncoder(correlationManager));
-                                ch.pipeline().addLast(new KafkaResponseDecoder(correlationManager));
-                                ch.pipeline().addLast(kafkaHandler);
-                            }
-                        });
-
-                Channel channel = bootstrap.connect(host, port).sync().channel();
+                Channel channel = connectClient(group, host, port, correlationManager, kafkaHandler);
 
                 // Send PROXY header first (before TLS handshake)
                 channel.writeAndFlush(new HAProxyMessage(
@@ -289,21 +262,7 @@ class ProxyProtocolIT {
                     .build();
 
             try (var group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory())) {
-                var bootstrap = new Bootstrap()
-                        .group(group)
-                        .channel(NioSocketChannel.class)
-                        .option(ChannelOption.TCP_NODELAY, true)
-                        .handler(new ChannelInitializer<SocketChannel>() {
-                            @Override
-                            protected void initChannel(SocketChannel ch) {
-                                ch.pipeline().addLast(HAProxyMessageEncoder.INSTANCE);
-                                ch.pipeline().addLast(new KafkaRequestEncoder(correlationManager));
-                                ch.pipeline().addLast(new KafkaResponseDecoder(correlationManager));
-                                ch.pipeline().addLast(kafkaHandler);
-                            }
-                        });
-
-                Channel channel = bootstrap.connect(host, port).sync().channel();
+                Channel channel = connectClient(group, host, port, correlationManager, kafkaHandler);
 
                 // Send PROXY header first (before TLS handshake)
                 channel.writeAndFlush(new HAProxyMessage(
@@ -349,21 +308,7 @@ class ProxyProtocolIT {
             var correlationManager = new CorrelationManager();
             var kafkaHandler = new KafkaClientHandler();
             try (var group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory())) {
-                var bootstrap = new Bootstrap()
-                        .group(group)
-                        .channel(NioSocketChannel.class)
-                        .option(ChannelOption.TCP_NODELAY, true)
-                        .handler(new ChannelInitializer<SocketChannel>() {
-                            @Override
-                            protected void initChannel(SocketChannel ch) {
-                                ch.pipeline().addLast(HAProxyMessageEncoder.INSTANCE);
-                                ch.pipeline().addLast(new KafkaRequestEncoder(correlationManager));
-                                ch.pipeline().addLast(new KafkaResponseDecoder(correlationManager));
-                                ch.pipeline().addLast(kafkaHandler);
-                            }
-                        });
-
-                Channel channel = bootstrap.connect(host, port).sync().channel();
+                Channel channel = connectClient(group, host, port, correlationManager, kafkaHandler);
 
                 // Send PROXY header — in DISABLED mode, proxy treats this as Kafka data
                 channel.writeAndFlush(new HAProxyMessage(
@@ -392,6 +337,33 @@ class ProxyProtocolIT {
     }
 
     // ---- Helpers ----
+
+    /**
+     * Build a {@link Bootstrap} with the standard test-client pipeline
+     * (PROXY encoder, Kafka codec, {@code kafkaHandler}) and wire channel-close
+     * to {@link CorrelationManager#onChannelClose()} so in-flight request futures
+     * are completed when the peer drops the connection.
+     */
+    private static Channel connectClient(EventLoopGroup group, String host, int port,
+                                         CorrelationManager correlationManager, KafkaClientHandler kafkaHandler)
+            throws InterruptedException {
+        var bootstrap = new Bootstrap()
+                .group(group)
+                .channel(NioSocketChannel.class)
+                .option(ChannelOption.TCP_NODELAY, true)
+                .handler(new ChannelInitializer<SocketChannel>() {
+                    @Override
+                    protected void initChannel(SocketChannel ch) {
+                        ch.pipeline().addLast(HAProxyMessageEncoder.INSTANCE);
+                        ch.pipeline().addLast(new KafkaRequestEncoder(correlationManager));
+                        ch.pipeline().addLast(new KafkaResponseDecoder(correlationManager));
+                        ch.pipeline().addLast(kafkaHandler);
+                    }
+                });
+        var channel = bootstrap.connect(host, port).sync().channel();
+        channel.closeFuture().addListener(f -> correlationManager.onChannelClose());
+        return channel;
+    }
 
     private static ConfigurationBuilder buildTlsProxyProtocolConfig(String mockBootstrap, CertificateGenerator.KeyStore keystore,
                                                                     ProxyProtocolMode mode) {


### PR DESCRIPTION
### Type of change
Bugfix

### Description

ProxyProtocolIT#requiredModeShouldProxyKafkaRequestsAfterProxyHeader flaked in CI with a 5s timeout because the test client never completed its request futures when the server closed the connection. Requests live in two places during their lifetime — KafkaClientHandler's pre-write queue and CorrelationManager's in-flight map — and neither was being drained on channelInactive for the raw-bootstrap path used in ProxyProtocolIT. The disabled-mode test was masking the same defect by coincidentally passing on failsWithin's TimeoutException fallback.

Make CorrelationManager a required constructor argument of KafkaClientHandler and drain both cleanup paths from channelInactive, so any future caller wires the full lifecycle by construction. Drain the queue on exceptionCaught so the real cause propagates rather than a follow-up ClosedChannelException. Remove the now-redundant closeFuture listener in KafkaClient.

### Additional Context

Relates to #3757

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
