### PR TITLE
fix: messages enter Filter chain before Transport Subject built

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#3769](https://github.com/kroxylicious/kroxylicious/pull/3769): fix(runtime): messages enter Filter chain before Transport Subject built
 * [#3757](https://github.com/kroxylicious/kroxylicious/issues/3757): fix(runtime): trigger read after HAProxy message to prevent deadlock when autoread disabled
 * [#1295](https://github.com/kroxylicious/kroxylicious/issues/1295): feat(aws-kms): add IRSA and EKS Pod Identity credential providers, and restructure AWS KMS credential configuration under a new `credentials` node (see [note](#note-021-aws-kms-credentials-restructure))
 * [#3745](https://github.com/kroxylicious/kroxylicious/issues/3745): fix(runtime): ensure async TransportSubjectBuilder callbacks execute on Netty event loop to prevent race conditions

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterChainCompletionHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterChainCompletionHandler.java
@@ -6,13 +6,14 @@
 
 package io.kroxylicious.proxy.internal;
 
-import java.util.Objects;
-
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 
+import static java.util.Objects.requireNonNull;
+
 /**
- * An inbound channel handler that informs a {@link ProxyChannelStateMachine} about messages read from the channel.
+ * An inbound channel handler that sits after the Filter Chain. It informs a {@link ProxyChannelStateMachine} about
+ * messages read from client channel, which have implicitly completed traversal of the Filter Chain.
  * <p>
  * The intent is to have this handler installed as the last handler in the pipeline (besides a catch-all error logger)
  * to inform the {@link ProxyChannelStateMachine} about messages that have traversed (or been sent from) the Filter chain
@@ -21,15 +22,15 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
  * {@link KafkaProxyFrontendHandler} and arrive at this handler until the state is {@link ProxyChannelState.Forwarding}.
  * </p>
  */
-class ForwardingHandler extends ChannelInboundHandlerAdapter {
+class FilterChainCompletionHandler extends ChannelInboundHandlerAdapter {
     private final ProxyChannelStateMachine proxyChannelStateMachine;
 
-    ForwardingHandler(ProxyChannelStateMachine proxyChannelStateMachine) {
-        this.proxyChannelStateMachine = Objects.requireNonNull(proxyChannelStateMachine, "proxyChannelStateMachine is null");
+    FilterChainCompletionHandler(ProxyChannelStateMachine proxyChannelStateMachine) {
+        this.proxyChannelStateMachine = requireNonNull(proxyChannelStateMachine);
     }
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-        proxyChannelStateMachine.messageFromClient(msg);
+        proxyChannelStateMachine.onClientFilterChainComplete(msg);
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -496,7 +496,6 @@ public class FilterHandler extends ChannelDuplexHandler {
                 .log("Filter forwarding request");
 
         ctx.fireChannelRead(decodedFrame);
-        ctx.fireChannelReadComplete();
     }
 
     /**

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ForwardingHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ForwardingHandler.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.internal;
+
+import java.util.Objects;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+/**
+ * An inbound channel handler that informs a {@link ProxyChannelStateMachine} about messages read from the channel.
+ * <p>
+ * The intent is to have this handler installed as the last handler in the pipeline (besides a catch-all error logger)
+ * to inform the {@link ProxyChannelStateMachine} about messages that have traversed (or been sent from) the Filter chain
+ * and should be forwarded to the {@link KafkaProxyBackendHandler}. We can infer that the state machine should be in
+ * {@link ProxyChannelState.Forwarding} or {@link ProxyChannelState.Closed} state, because messages should not flow through
+ * {@link KafkaProxyFrontendHandler} and arrive at this handler until the state is {@link ProxyChannelState.Forwarding}.
+ * </p>
+ */
+class ForwardingHandler extends ChannelInboundHandlerAdapter {
+    private final ProxyChannelStateMachine proxyChannelStateMachine;
+
+    ForwardingHandler(ProxyChannelStateMachine proxyChannelStateMachine) {
+        this.proxyChannelStateMachine = Objects.requireNonNull(proxyChannelStateMachine, "proxyChannelStateMachine is null");
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        proxyChannelStateMachine.messageFromClient(msg);
+    }
+}

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -74,7 +74,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 import static io.kroxylicious.proxy.internal.ProxyChannelState.Connecting;
-import static io.kroxylicious.proxy.internal.ProxyChannelState.Forwarding;
 import static io.kroxylicious.proxy.internal.ProxyChannelState.SelectingServer;
 
 public class KafkaProxyFrontendHandler
@@ -435,20 +434,6 @@ public class KafkaProxyFrontendHandler
     }
 
     /**
-     * Called by the {@link ProxyChannelStateMachine} on entry to the {@link Forwarding} state.
-     */
-    void inForwarding() {
-        // connection is complete, so first forward the buffered message
-        if (bufferedMsgs != null) {
-            for (Object bufferedMsg : bufferedMsgs) {
-                clientCtx().fireChannelRead(bufferedMsg);
-            }
-            bufferedMsgs = null;
-        }
-
-    }
-
-    /**
      * Called by the {@link ProxyChannelStateMachine} on entry to the {@link Closed} state.
      */
     void inClosed(@Nullable Throwable errorCodeEx) {
@@ -529,8 +514,19 @@ public class KafkaProxyFrontendHandler
 
     void unblockClient() {
         var inboundChannel = clientCtx().channel();
+        forwardBufferedMessages();
         inboundChannel.config().setAutoRead(true);
         proxyChannelStateMachine.onClientWritable();
+    }
+
+    private void forwardBufferedMessages() {
+        // connection is complete, so first forward the buffered message
+        if (bufferedMsgs != null) {
+            for (Object bufferedMsg : bufferedMsgs) {
+                clientCtx().fireChannelRead(bufferedMsg);
+            }
+            bufferedMsgs = null;
+        }
     }
 
     Executor eventLoopExecutor() {

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -105,11 +105,6 @@ public class KafkaProxyFrontendHandler
     private boolean pendingClientFlushes;
     private @Nullable String sniHostname;
 
-    // Flag if we receive a channelReadComplete() prior to outbound connection activation
-    // so we can perform the channelReadComplete()/outbound flush & auto_read
-    // once the outbound channel is active
-    private boolean pendingReadComplete = true;
-
     /**
      * @return the SSL session, or null if a session does not (currently) exist.
      */
@@ -157,7 +152,6 @@ public class KafkaProxyFrontendHandler
                 + ", number of bufferedMsgs=" + (bufferedMsgs == null ? 0 : bufferedMsgs.size())
                 + ", pendingClientFlushes=" + pendingClientFlushes
                 + ", sniHostname='" + sniHostname + '\''
-                + ", pendingReadComplete=" + pendingReadComplete
                 + '}';
     }
 
@@ -317,17 +311,6 @@ public class KafkaProxyFrontendHandler
     }
 
     /**
-     * <p>Invoked when the last message read by the current read operation
-     * has been consumed by {@link #channelRead(ChannelHandlerContext, Object)}.</p>
-     * This allows the proxy to batch requests.
-     * @param clientCtx The client context
-     */
-    @Override
-    public void channelReadComplete(ChannelHandlerContext clientCtx) {
-        proxyChannelStateMachine.clientReadComplete();
-    }
-
-    /**
      * Handles an exception in downstream/client pipeline by notifying {@link #proxyChannelStateMachine} of the issue.
      * @param ctx The downstream context
      * @param cause The downstream exception
@@ -458,14 +441,9 @@ public class KafkaProxyFrontendHandler
         // connection is complete, so first forward the buffered message
         if (bufferedMsgs != null) {
             for (Object bufferedMsg : bufferedMsgs) {
-                proxyChannelStateMachine.messageFromClient(bufferedMsg);
+                clientCtx().fireChannelRead(bufferedMsg);
             }
             bufferedMsgs = null;
-        }
-
-        if (pendingReadComplete) {
-            pendingReadComplete = false;
-            channelReadComplete(this.clientCtx());
         }
 
     }
@@ -535,14 +513,10 @@ public class KafkaProxyFrontendHandler
                                       List<FilterAndInvoker> filters,
                                       ChannelPipeline pipeline,
                                       Channel inboundChannel) {
-
-        int num = 0;
-
-        for (var protocolFilter : filters) {
-            // TODO configurable timeout
-            // Handler name must be unique, but filters are allowed to appear multiple times
-            String handlerName = "filter-" + ++num + "-" + protocolFilter.filterName();
-            pipeline.addBefore(clientCtx().name(),
+        for (int i = filters.size() - 1; i >= 0; i--) {
+            FilterAndInvoker protocolFilter = filters.get(i);
+            String handlerName = "filter-" + (i + 1) + "-" + protocolFilter.filterName();
+            pipeline.addAfter(clientCtx().name(),
                     handlerName,
                     new FilterHandler(
                             protocolFilter,
@@ -644,4 +618,7 @@ public class KafkaProxyFrontendHandler
         return nettySettings.flatMap(NettySettings::authenticatedIdleTimeout).map(Duration::toMillis).orElse(NO_TIMEOUT);
     }
 
+    public void forward(Object msg) {
+        clientCtx().fireChannelRead(msg);
+    }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -70,7 +70,6 @@ import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.CheckReturnValue;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 import static io.kroxylicious.proxy.internal.ProxyChannelState.Connecting;
@@ -288,7 +287,6 @@ public class KafkaProxyFrontendHandler
         initiateConnect(target);
     }
 
-    @NonNull
     private List<FilterAndInvoker> buildFilters() {
         List<FilterAndInvoker> apiVersionFilters = FilterAndInvoker.build("ApiVersionsIntersect (internal)", apiVersionsIntersectFilter);
         var filterAndInvokers = new ArrayList<>(apiVersionFilters);
@@ -494,14 +492,18 @@ public class KafkaProxyFrontendHandler
         bufferedMsgs.add(msg);
     }
 
+    /**
+     * Add Filters after this handler in the pipeline.
+     */
     private void addFiltersToPipeline(
                                       List<FilterAndInvoker> filters,
                                       ChannelPipeline pipeline,
                                       Channel inboundChannel) {
-        for (int i = filters.size() - 1; i >= 0; i--) {
-            FilterAndInvoker protocolFilter = filters.get(i);
-            String handlerName = "filter-" + (i + 1) + "-" + protocolFilter.filterName();
-            pipeline.addAfter(clientCtx().name(),
+        int i = 0;
+        String addNextFilterAfter = clientCtx().name();
+        for (FilterAndInvoker protocolFilter : filters) {
+            String handlerName = "filter-" + (++i) + "-" + protocolFilter.filterName();
+            pipeline.addAfter(addNextFilterAfter,
                     handlerName,
                     new FilterHandler(
                             protocolFilter,
@@ -509,6 +511,7 @@ public class KafkaProxyFrontendHandler
                             sniHostname,
                             inboundChannel,
                             proxyChannelStateMachine));
+            addNextFilterAfter = handlerName;
         }
     }
 
@@ -523,7 +526,7 @@ public class KafkaProxyFrontendHandler
         // connection is complete, so first forward the buffered message
         if (bufferedMsgs != null) {
             for (Object bufferedMsg : bufferedMsgs) {
-                clientCtx().fireChannelRead(bufferedMsg);
+                admitToFilterChain(bufferedMsg);
             }
             bufferedMsgs = null;
         }
@@ -614,7 +617,11 @@ public class KafkaProxyFrontendHandler
         return nettySettings.flatMap(NettySettings::authenticatedIdleTimeout).map(Duration::toMillis).orElse(NO_TIMEOUT);
     }
 
-    public void forward(Object msg) {
+    /**
+     * Forward a message towards the Filter Chain
+     * @param msg message
+     */
+    public void admitToFilterChain(Object msg) {
         clientCtx().fireChannelRead(msg);
     }
 }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -240,8 +240,9 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
                 proxyChannelStateMachine,
                 proxyNettySettings);
 
-        pipeline.addLast("netHandler", frontendHandler);
-        pipeline.addLast("forwardingHandler", new ForwardingHandler(proxyChannelStateMachine));
+        pipeline.addLast("frontendHandler", frontendHandler);
+        // Filter Handlers will be installed at this point in the pipeline by KafkaProxyFrontendHandler when the client channel fires channelActive()
+        pipeline.addLast("filterChainCompletionHandler", new FilterChainCompletionHandler(proxyChannelStateMachine));
         addLoggingErrorHandler(pipeline);
 
         LOGGER.atDebug()

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyInitializer.java
@@ -229,7 +229,6 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
         if (virtualCluster.isLogFrames()) {
             pipeline.addLast("frameLogger", new LoggingHandler("io.kroxylicious.proxy.internal.DownstreamFrameLogger", LogLevel.INFO));
         }
-
         var frontendHandler = new KafkaProxyFrontendHandler(
                 pfr,
                 filterChainFactory,
@@ -242,6 +241,7 @@ public class KafkaProxyInitializer extends ChannelInitializer<Channel> {
                 proxyNettySettings);
 
         pipeline.addLast("netHandler", frontendHandler);
+        pipeline.addLast("forwardingHandler", new ForwardingHandler(proxyChannelStateMachine));
         addLoggingErrorHandler(pipeline);
 
         LOGGER.atDebug()

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachine.java
@@ -411,10 +411,10 @@ public class ProxyChannelStateMachine {
     }
 
     /**
-     * A message has been received from the downstream client which should be passed to the upstream node
+     * A message has emerged from the Filter Chain and is ready to be forwarded to the upstream node
      * @param msg the RPC received from the upstream
      */
-    void messageFromClient(Object msg) {
+    void onClientFilterChainComplete(Object msg) {
         if (state() instanceof Forwarding) { // post-backend connection
             Objects.requireNonNull(backendHandler).forwardToServer(msg);
             backendHandler.flushToServer();
@@ -432,7 +432,7 @@ public class ProxyChannelStateMachine {
                          Object msg) {
         Objects.requireNonNull(frontendHandler);
         if (state() instanceof Forwarding) { // post-backend connection
-            frontendHandler.forward(msg);
+            frontendHandler.admitToFilterChain(msg);
         }
         else if (!onClientRequestBeforeForwarding(msg)) {
             illegalState("Unexpected message received: " + (msg == null ? "null" : "message class=" + msg.getClass()));
@@ -644,7 +644,7 @@ public class ProxyChannelStateMachine {
     private void toForwarding(Forwarding forwarding) {
         setState(forwarding);
         kafkaSession.transitionTo(KafkaSessionState.NOT_AUTHENTICATED);
-        // we must wait for the transport subject before forwarded buffered messages and then enanling autoread on the client
+        // we must wait for the transport subject to be built before forwarding the buffered messages and then enabling autoread on the client
         maybeUnblock();
         proxyToServerConnectionToken.acquire();
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachine.java
@@ -218,7 +218,11 @@ public class ProxyChannelStateMachine {
      * Sonar will complain if one uses this in prod code listen to it.
      */
     @VisibleForTesting
-    void forceState(ProxyChannelState state, KafkaProxyFrontendHandler frontendHandler, @Nullable KafkaProxyBackendHandler backendHandler, KafkaSession kafkaSession) {
+    void forceState(ProxyChannelState state,
+                    KafkaProxyFrontendHandler frontendHandler,
+                    @Nullable KafkaProxyBackendHandler backendHandler,
+                    KafkaSession kafkaSession,
+                    int transportAndBackendLatch) {
         LOGGER.atInfo()
                 .addKeyValue("state", state)
                 .addKeyValue("frontendHandler", frontendHandler)
@@ -228,6 +232,7 @@ public class ProxyChannelStateMachine {
         this.kafkaSession = kafkaSession;
         this.frontendHandler = frontendHandler;
         this.backendHandler = backendHandler;
+        this.progressionLatch = transportAndBackendLatch;
     }
 
     @Override
@@ -639,8 +644,7 @@ public class ProxyChannelStateMachine {
     private void toForwarding(Forwarding forwarding) {
         setState(forwarding);
         kafkaSession.transitionTo(KafkaSessionState.NOT_AUTHENTICATED);
-        Objects.requireNonNull(frontendHandler).inForwarding();
-        // once buffered message has been forwarded we enable auto-read to start accepting further messages
+        // we must wait for the transport subject before forwarded buffered messages and then enanling autoread on the client
         maybeUnblock();
         proxyToServerConnectionToken.acquire();
     }

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachine.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachine.java
@@ -410,15 +410,12 @@ public class ProxyChannelStateMachine {
      * @param msg the RPC received from the upstream
      */
     void messageFromClient(Object msg) {
-        Objects.requireNonNull(backendHandler).forwardToServer(msg);
-    }
-
-    /**
-     * Called to notify the state machine that reading the downstream the batch is complete.
-     */
-    void clientReadComplete() {
-        if (state instanceof Forwarding) {
-            Objects.requireNonNull(backendHandler).flushToServer();
+        if (state() instanceof Forwarding) { // post-backend connection
+            Objects.requireNonNull(backendHandler).forwardToServer(msg);
+            backendHandler.flushToServer();
+        }
+        else {
+            illegalState("Unexpected message received: " + (msg == null ? "null" : "message class=" + msg.getClass()));
         }
     }
 
@@ -430,7 +427,7 @@ public class ProxyChannelStateMachine {
                          Object msg) {
         Objects.requireNonNull(frontendHandler);
         if (state() instanceof Forwarding) { // post-backend connection
-            messageFromClient(msg);
+            frontendHandler.forward(msg);
         }
         else if (!onClientRequestBeforeForwarding(msg)) {
             illegalState("Unexpected message received: " + (msg == null ? "null" : "message class=" + msg.getClass()));

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
@@ -102,7 +102,8 @@ public abstract class FilterHarness {
                 forwarding,
                 mock(KafkaProxyFrontendHandler.class),
                 mock(KafkaProxyBackendHandler.class),
-                kafkaSession, -1);
+                kafkaSession,
+                -1);
         var filterHandlers = Arrays.stream(filters)
                 .collect(Collector.of(ArrayDeque<Filter>::new, ArrayDeque::addLast, (d1, d2) -> {
                     d2.addAll(d1);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/FilterHarness.java
@@ -102,7 +102,7 @@ public abstract class FilterHarness {
                 forwarding,
                 mock(KafkaProxyFrontendHandler.class),
                 mock(KafkaProxyBackendHandler.class),
-                kafkaSession);
+                kafkaSession, -1);
         var filterHandlers = Arrays.stream(filters)
                 .collect(Collector.of(ArrayDeque<Filter>::new, ArrayDeque::addLast, (d1, d2) -> {
                     d2.addAll(d1);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -480,7 +480,7 @@ class KafkaProxyFrontendHandlerTest {
             // and prevent it from reaching FilterHandlers (which only expect Kafka protocol messages)
             pipeline.addLast(new HaProxyMessageHandler(proxyChannelStateMachine.kafkaSession()));
             pipeline.addLast(handler);
-            pipeline.addLast(new ForwardingHandler(proxyChannelStateMachine));
+            pipeline.addLast(new FilterChainCompletionHandler(proxyChannelStateMachine));
         }
         assertThat(proxyChannelStateMachine.state()).isExactlyInstanceOf(ProxyChannelState.Startup.class);
         pipeline.fireChannelActive();

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandlerTest.java
@@ -480,6 +480,7 @@ class KafkaProxyFrontendHandlerTest {
             // and prevent it from reaching FilterHandlers (which only expect Kafka protocol messages)
             pipeline.addLast(new HaProxyMessageHandler(proxyChannelStateMachine.kafkaSession()));
             pipeline.addLast(handler);
+            pipeline.addLast(new ForwardingHandler(proxyChannelStateMachine));
         }
         assertThat(proxyChannelStateMachine.state()).isExactlyInstanceOf(ProxyChannelState.Startup.class);
         pipeline.fireChannelActive();

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -415,11 +415,11 @@ class KafkaProxyInitializerTest {
     }
 
     private void verifyFrontendHandlerAdded(InOrder orderedVerifyer) {
-        orderedVerifyer.verify(channelPipeline).addLast(eq("netHandler"), any(KafkaProxyFrontendHandler.class));
+        orderedVerifyer.verify(channelPipeline).addLast(eq("frontendHandler"), any(KafkaProxyFrontendHandler.class));
     }
 
     private void verifyForwardingHandlerAdded(InOrder orderedVerifyer) {
-        orderedVerifyer.verify(channelPipeline).addLast(eq("forwardingHandler"), any(ForwardingHandler.class));
+        orderedVerifyer.verify(channelPipeline).addLast(eq("filterChainCompletionHandler"), any(FilterChainCompletionHandler.class));
     }
 
     private void verifyErrorHandlerRemoved(InOrder orderedVerifyer) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/KafkaProxyInitializerTest.java
@@ -233,6 +233,7 @@ class KafkaProxyInitializerTest {
         verifyErrorHandlerRemoved(orderedVerifyer);
         verifyEncoderAndOrdererAdded(orderedVerifyer);
         verifyFrontendHandlerAdded(orderedVerifyer);
+        verifyForwardingHandlerAdded(orderedVerifyer);
         verifyErrorHandlerAdded(orderedVerifyer);
         Mockito.verifyNoMoreInteractions(channelPipeline);
     }
@@ -255,6 +256,7 @@ class KafkaProxyInitializerTest {
         verifyEncoderAndOrdererAdded(orderedVerifyer);
         verifyFrameLoggerAdded(orderedVerifyer);
         verifyFrontendHandlerAdded(orderedVerifyer);
+        verifyForwardingHandlerAdded(orderedVerifyer);
         verifyErrorHandlerAdded(orderedVerifyer);
         Mockito.verifyNoMoreInteractions(channelPipeline);
     }
@@ -277,6 +279,7 @@ class KafkaProxyInitializerTest {
         verifyNetworkLoggerAdded(orderedVerifyer);
         verifyEncoderAndOrdererAdded(orderedVerifyer);
         verifyFrontendHandlerAdded(orderedVerifyer);
+        verifyForwardingHandlerAdded(orderedVerifyer);
         verifyErrorHandlerAdded(orderedVerifyer);
         Mockito.verifyNoMoreInteractions(channelPipeline);
     }
@@ -413,6 +416,10 @@ class KafkaProxyInitializerTest {
 
     private void verifyFrontendHandlerAdded(InOrder orderedVerifyer) {
         orderedVerifyer.verify(channelPipeline).addLast(eq("netHandler"), any(KafkaProxyFrontendHandler.class));
+    }
+
+    private void verifyForwardingHandlerAdded(InOrder orderedVerifyer) {
+        orderedVerifyer.verify(channelPipeline).addLast(eq("forwardingHandler"), any(ForwardingHandler.class));
     }
 
     private void verifyErrorHandlerRemoved(InOrder orderedVerifyer) {

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineEndToEndTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineEndToEndTest.java
@@ -530,6 +530,7 @@ class ProxyChannelStateMachineEndToEndTest {
         final ChannelPipeline pipeline = inboundChannel.pipeline();
         if (pipeline.get(KafkaProxyFrontendHandler.class) == null) {
             pipeline.addLast(handler);
+            pipeline.addLast(new ForwardingHandler(proxyChannelStateMachine));
         }
         assertThat(proxyChannelStateMachine.state()).isExactlyInstanceOf(ProxyChannelState.Startup.class);
         pipeline.fireChannelActive();
@@ -804,9 +805,9 @@ class ProxyChannelStateMachineEndToEndTest {
 
         if (firstFilterIndex >= 0) {
             assertThat(firstFilterIndex)
-                    .as("First filter (at index %d) must come before KafkaProxyFrontendHandler (at index %d) in pipeline: %s",
+                    .as("First filter (at index %d) must come after KafkaProxyFrontendHandler (at index %d) in pipeline: %s",
                             firstFilterIndex, frontendHandlerIndex, handlerNames)
-                    .isLessThan(frontendHandlerIndex);
+                    .isGreaterThan(frontendHandlerIndex);
         }
 
         // Additional validation: frontend handler must be present

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineEndToEndTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineEndToEndTest.java
@@ -194,7 +194,7 @@ class ProxyChannelStateMachineEndToEndTest {
                     new ProxyChannelState.HaProxy(),
                     handler,
                     backendHandler,
-                    TEST_SESSION);
+                    TEST_SESSION, -1);
         }
 
         // When
@@ -701,13 +701,16 @@ class ProxyChannelStateMachineEndToEndTest {
         if (sni) {
             inboundChannel.pipeline().fireUserEventTriggered(new SniCompletionEvent(SNI_HOSTNAME));
         }
+        // the PCSM unblocks the client after the backend is active and transport subject is asynchronously created
+        // here we force it to wait for a single event before unblocking.
+        int waitingForOneEvent = 1;
         proxyChannelStateMachine.forceState(
                 new ProxyChannelState.SelectingServer(
                         firstMessage == ApiKeys.API_VERSIONS ? CLIENT_SOFTWARE_NAME : null,
                         firstMessage == ApiKeys.API_VERSIONS ? CLIENT_SOFTWARE_VERSION : null),
                 handler,
                 backendHandler,
-                TEST_SESSION);
+                TEST_SESSION, waitingForOneEvent);
 
         inboundChannel.config().setAutoRead(false);
 

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineEndToEndTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineEndToEndTest.java
@@ -530,7 +530,7 @@ class ProxyChannelStateMachineEndToEndTest {
         final ChannelPipeline pipeline = inboundChannel.pipeline();
         if (pipeline.get(KafkaProxyFrontendHandler.class) == null) {
             pipeline.addLast(handler);
-            pipeline.addLast(new ForwardingHandler(proxyChannelStateMachine));
+            pipeline.addLast(new FilterChainCompletionHandler(proxyChannelStateMachine));
         }
         assertThat(proxyChannelStateMachine.state()).isExactlyInstanceOf(ProxyChannelState.Startup.class);
         pipeline.fireChannelActive();

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
@@ -482,7 +482,8 @@ class ProxyChannelStateMachineTest {
                 new ProxyChannelState.Connecting(null, null, new HostPort("localhost", 9089)),
                 frontendHandler,
                 backendHandler,
-                TEST_KAFKA_SESSION, waitingForOneEvent);
+                TEST_KAFKA_SESSION,
+                waitingForOneEvent);
 
         // When
         proxyChannelStateMachine.onServerActive();
@@ -502,7 +503,8 @@ class ProxyChannelStateMachineTest {
                 new ProxyChannelState.Connecting(null, null, new HostPort("localhost", 9089)),
                 frontendHandler,
                 backendHandler,
-                TEST_KAFKA_SESSION, waitingForTwoEvents);
+                TEST_KAFKA_SESSION,
+                waitingForTwoEvents);
 
         // When
         proxyChannelStateMachine.onServerActive();
@@ -554,7 +556,7 @@ class ProxyChannelStateMachineTest {
 
         // Then
         assertThat(proxyChannelStateMachine.state()).isSameAs(forwarding);
-        verify(frontendHandler).forward(msg);
+        verify(frontendHandler).admitToFilterChain(msg);
         verifyNoInteractions(serverCtx);
     }
 
@@ -820,7 +822,8 @@ class ProxyChannelStateMachineTest {
                 new ProxyChannelState.ClientActive(),
                 frontendHandler,
                 null,
-                TEST_KAFKA_SESSION, -1);
+                TEST_KAFKA_SESSION,
+                -1);
     }
 
     private void stateMachineInHaProxy() {
@@ -828,7 +831,8 @@ class ProxyChannelStateMachineTest {
                 new ProxyChannelState.HaProxy(),
                 frontendHandler,
                 null,
-                TEST_KAFKA_SESSION, -1);
+                TEST_KAFKA_SESSION,
+                -1);
     }
 
     private void stateMachineInSelectingServer() {
@@ -836,7 +840,8 @@ class ProxyChannelStateMachineTest {
                 new ProxyChannelState.SelectingServer(null, null),
                 frontendHandler,
                 null,
-                TEST_KAFKA_SESSION, -1);
+                TEST_KAFKA_SESSION,
+                -1);
     }
 
     private void stateMachineInConnecting() {
@@ -844,7 +849,8 @@ class ProxyChannelStateMachineTest {
                 new ProxyChannelState.Connecting(null, null, new HostPort("localhost", 9089)),
                 frontendHandler,
                 backendHandler,
-                TEST_KAFKA_SESSION, -1);
+                TEST_KAFKA_SESSION,
+                -1);
     }
 
     private ProxyChannelState.Forwarding stateMachineInForwarding() {
@@ -853,7 +859,8 @@ class ProxyChannelStateMachineTest {
                 forwarding,
                 frontendHandler,
                 backendHandler,
-                TEST_KAFKA_SESSION, -1);
+                TEST_KAFKA_SESSION,
+                -1);
         return forwarding;
     }
 
@@ -862,7 +869,8 @@ class ProxyChannelStateMachineTest {
                 new ProxyChannelState.Closed(),
                 frontendHandler,
                 backendHandler,
-                TEST_KAFKA_SESSION, -1);
+                TEST_KAFKA_SESSION,
+                -1);
     }
 
     private static DecodedRequestFrame<ApiVersionsRequestData> apiVersionsRequest() {
@@ -1018,7 +1026,7 @@ class ProxyChannelStateMachineTest {
         Object msg = new Object();
 
         // When
-        proxyChannelStateMachine.messageFromClient(msg);
+        proxyChannelStateMachine.onClientFilterChainComplete(msg);
 
         // Then
         verify(backendHandler).forwardToServer(msg);
@@ -1026,13 +1034,13 @@ class ProxyChannelStateMachineTest {
     }
 
     @Test
-    void messageFromClientNotInForwarding() {
+    void onClientFilterChainCompleteNotInForwarding() {
         // Given
         stateMachineInClientActive();
         Object msg = new Object();
 
         // When
-        proxyChannelStateMachine.messageFromClient(msg);
+        proxyChannelStateMachine.onClientFilterChainComplete(msg);
 
         // Then
         assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Closed.class);

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
@@ -529,9 +529,8 @@ class ProxyChannelStateMachineTest {
 
         // Then
         assertThat(proxyChannelStateMachine.state()).isSameAs(forwarding);
-        verifyNoInteractions(frontendHandler);
+        verify(frontendHandler).forward(msg);
         verifyNoInteractions(serverCtx);
-        verify(backendHandler).forwardToServer(msg);
     }
 
     @Test
@@ -991,12 +990,28 @@ class ProxyChannelStateMachineTest {
     void shouldFlushToServerWhenClientReadCompletes() {
         // Given
         stateMachineInForwarding();
+        Object msg = new Object();
 
         // When
-        proxyChannelStateMachine.clientReadComplete();
+        proxyChannelStateMachine.messageFromClient(msg);
 
         // Then
+        verify(backendHandler).forwardToServer(msg);
         verify(backendHandler).flushToServer();
+    }
+
+    @Test
+    void messageFromClientNotInForwarding() {
+        // Given
+        stateMachineInClientActive();
+        Object msg = new Object();
+
+        // When
+        proxyChannelStateMachine.messageFromClient(msg);
+
+        // Then
+        assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Closed.class);
+        verify(frontendHandler).inClosed(null);
     }
 
     @Test

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/ProxyChannelStateMachineTest.java
@@ -477,7 +477,12 @@ class ProxyChannelStateMachineTest {
     @Test
     void inConnectingShouldTransitionWhenOnServerActiveCalled() {
         // Given
-        stateMachineInConnecting();
+        int waitingForOneEvent = 1;
+        proxyChannelStateMachine.forceState(
+                new ProxyChannelState.Connecting(null, null, new HostPort("localhost", 9089)),
+                frontendHandler,
+                backendHandler,
+                TEST_KAFKA_SESSION, waitingForOneEvent);
 
         // When
         proxyChannelStateMachine.onServerActive();
@@ -485,7 +490,27 @@ class ProxyChannelStateMachineTest {
         // Then
         assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Forwarding.class);
 
-        verify(frontendHandler).inForwarding();
+        verify(frontendHandler).unblockClient();
+        verifyNoInteractions(backendHandler);
+    }
+
+    @Test
+    void onServerActiveDoesNotUnblockClientIfWaitingForTransportSubject() {
+        // Given
+        int waitingForTwoEvents = 2;
+        proxyChannelStateMachine.forceState(
+                new ProxyChannelState.Connecting(null, null, new HostPort("localhost", 9089)),
+                frontendHandler,
+                backendHandler,
+                TEST_KAFKA_SESSION, waitingForTwoEvents);
+
+        // When
+        proxyChannelStateMachine.onServerActive();
+
+        // Then
+        assertThat(proxyChannelStateMachine.state()).isInstanceOf(ProxyChannelState.Forwarding.class);
+
+        verifyNoInteractions(frontendHandler);
         verifyNoInteractions(backendHandler);
     }
 
@@ -795,7 +820,7 @@ class ProxyChannelStateMachineTest {
                 new ProxyChannelState.ClientActive(),
                 frontendHandler,
                 null,
-                TEST_KAFKA_SESSION);
+                TEST_KAFKA_SESSION, -1);
     }
 
     private void stateMachineInHaProxy() {
@@ -803,7 +828,7 @@ class ProxyChannelStateMachineTest {
                 new ProxyChannelState.HaProxy(),
                 frontendHandler,
                 null,
-                TEST_KAFKA_SESSION);
+                TEST_KAFKA_SESSION, -1);
     }
 
     private void stateMachineInSelectingServer() {
@@ -811,7 +836,7 @@ class ProxyChannelStateMachineTest {
                 new ProxyChannelState.SelectingServer(null, null),
                 frontendHandler,
                 null,
-                TEST_KAFKA_SESSION);
+                TEST_KAFKA_SESSION, -1);
     }
 
     private void stateMachineInConnecting() {
@@ -819,7 +844,7 @@ class ProxyChannelStateMachineTest {
                 new ProxyChannelState.Connecting(null, null, new HostPort("localhost", 9089)),
                 frontendHandler,
                 backendHandler,
-                TEST_KAFKA_SESSION);
+                TEST_KAFKA_SESSION, -1);
     }
 
     private ProxyChannelState.Forwarding stateMachineInForwarding() {
@@ -828,7 +853,7 @@ class ProxyChannelStateMachineTest {
                 forwarding,
                 frontendHandler,
                 backendHandler,
-                TEST_KAFKA_SESSION);
+                TEST_KAFKA_SESSION, -1);
         return forwarding;
     }
 
@@ -837,7 +862,7 @@ class ProxyChannelStateMachineTest {
                 new ProxyChannelState.Closed(),
                 frontendHandler,
                 backendHandler,
-                TEST_KAFKA_SESSION);
+                TEST_KAFKA_SESSION, -1);
     }
 
     private static DecodedRequestFrame<ApiVersionsRequestData> apiVersionsRequest() {


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes #3745

One thing that must happen to resolve #3745 is we have to buffer the messages before the Filter chain. This prevents Filters being exposed to messages before the PCSM decides it is time.

To do this we change things so that Filters are installed AFTER the KafkaProxyFrontendHandler, so that it's buffering logic can prevent messages entering the Filters.

We also delay the forwarding of buffered messages until the client is unblocked. We had established logic that toggled autoread to true after both the backend server became active and the transport subject was created. With this change we additionally forward on all buffered messages at this point.

* Filters are moved from before the Frontend Handler to after the Frontend Handler. This allows the existing buffering in the Frontend Handler to prevent messages entering the Filter Chain.
* A FilterChainCompletionHandler is installed at the end of the pipeline, responsible for simply telling the PCSM about messages that have emerged from the Filter Chain.
* If the PCSM is told about a client message reaching the FilterChainCompletionHandler but the state is not Forward we transition to Closed due to illegal state.
* FilterHandlers no longer fire channelReadComplete. The PCSM flushes the server after every message is sent to the backend. This is no worse than before as prior we were firing from every FilterHandler forward, triggering redundant events that were eventually no-ops in the backend flushing logic.
* FrontendHandler no longer needs to be concerned with firing channelReadComplete
* Forwarding of Buffered messages is no longer done on entry into Forwarding, we wait for the client to unblock after we have both entered Forwarding and finished async creation of the Transport Subject

## Problematic Flow from Before

1. connection from client to proxy established
2. client channel becomes active
3. TLS handshake occurs and handshake event propagated to ProxyChannelStateMachine (PCSM)
4. PCSM starts async Subject build
5. message from client flows through Filter chain and is buffered by the PCSM/FrontendHandler <- **BAD, Subject not populated when Filter worked with the message**
6. backend connects, PCSM is moved into forwarding
7. buffered messages are forwarded to the backend channel
8. async Subject build completes, client unblocked (autoread = true)

## New Flow

1. connection from client to proxy established
2. client channel becomes active
3. TLS handshake occurs and handshake event propagated to ProxyChannelStateMachine (PCSM)
4. PCSM starts async Subject build
5. message is buffered by the PCSM/FrontendHandler (before the Filter chain) <- **GOOD, Filters haven't observed the message yet**
6. backend connects, PCSM is moved into forwarding <-**GOOD, buffered messages are not forwarded yet, Filters haven't observed the message yet**
8. async Subject build completes, buffered messages are forwarded into the Filter chain, client unblocked (autoread = true) <-**GOOD, Transport Subject is populated at this point**
9. message reaches FilterChainCompletionHandler, they are passed to the PCSM, which forwards it to the backend channel

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
