### PR TITLE
fix(runtime): trigger read after HAProxy message to prevent deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#3757](https://github.com/kroxylicious/kroxylicious/issues/3757): fix(runtime): trigger read after HAProxy message to prevent deadlock when autoread disabled
 * [#1295](https://github.com/kroxylicious/kroxylicious/issues/1295): feat(aws-kms): add IRSA and EKS Pod Identity credential providers, and restructure AWS KMS credential configuration under a new `credentials` node (see [note](#note-021-aws-kms-credentials-restructure))
 * [#3745](https://github.com/kroxylicious/kroxylicious/issues/3745): fix(runtime): ensure async TransportSubjectBuilder callbacks execute on Netty event loop to prevent race conditions
 * [#3620](https://github.com/kroxylicious/kroxylicious/issues/3620): Removed Deprecated clientSaslAuthenticationSuccess from FilterContext

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/HaProxyMessageHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/HaProxyMessageHandler.java
@@ -46,5 +46,7 @@ public class HaProxyMessageHandler extends SimpleChannelInboundHandler<HAProxyMe
                 .addKeyValue("destinationPort", haProxyMessage.destinationPort())
                 .log("Received HAProxy message");
         kafkaSession.setHaProxyContext(HaProxyContext.from(haProxyMessage));
+        // Trigger next read to consume subsequent Kafka messages when autoread is disabled
+        ctx.channel().read();
     }
 }

--- a/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/HaProxyMessageHandlerTest.java
+++ b/kroxylicious-runtime/src/test/java/io/kroxylicious/proxy/internal/HaProxyMessageHandlerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.haproxy.HAProxyCommand;
@@ -27,6 +28,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class HaProxyMessageHandlerTest {
@@ -48,6 +50,9 @@ class HaProxyMessageHandlerTest {
     @Mock
     private ChannelHandlerContext ctx;
 
+    @Mock
+    private Channel channel;
+
     private HaProxyMessageHandler handler;
 
     @BeforeEach
@@ -57,6 +62,9 @@ class HaProxyMessageHandlerTest {
 
     @Test
     void shouldStoreHaProxyContextInSession() throws Exception {
+        // Given
+        when(ctx.channel()).thenReturn(channel);
+
         // When
         handler.channelRead(ctx, newHAProxyMessage());
 
@@ -66,20 +74,32 @@ class HaProxyMessageHandlerTest {
     }
 
     @Test
+    void shouldTriggerReadAfterProcessingHaProxyMessage() throws Exception {
+        // Given
+        when(ctx.channel()).thenReturn(channel);
+
+        // When
+        handler.channelRead(ctx, newHAProxyMessage());
+
+        // Then - channel.read() should be called to consume next message when autoread is disabled
+        verify(channel).read();
+    }
+
+    @Test
     void shouldReleaseHaProxyMessageAfterProcessing() {
         // Given
         HAProxyMessage message = newHAProxyMessage();
         assertThat(message.refCnt()).isEqualTo(1);
-        EmbeddedChannel channel = new EmbeddedChannel(handler);
+        EmbeddedChannel embeddedChannel = new EmbeddedChannel(handler);
 
         // When
-        channel.writeInbound(message);
+        embeddedChannel.writeInbound(message);
 
         // Then - SimpleChannelInboundHandler must release the ref-counted message
         assertThat(message.refCnt()).isZero();
-        assertThat((Object) channel.readInbound()).isNull();
+        assertThat((Object) embeddedChannel.readInbound()).isNull();
         verify(kafkaSession).setHaProxyContext(any(HaProxyContext.class));
-        channel.finishAndReleaseAll();
+        embeddedChannel.finishAndReleaseAll();
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #3757 - HAProxy PROXY protocol deadlock when messages arrive in separate TCP reads

When HAProxy PROXY protocol messages and subsequent Kafka messages arrive in separate TCP read operations (timing-dependent), the proxy deadlocks due to read starvation:

- `HaProxyMessageHandler` extends `SimpleChannelInboundHandler<HAProxyMessage>`, which consumes matching messages without propagating them downstream
- After processing the HAProxy message, no `channel.read()` is triggered
- With autoread disabled in `ClientActive` state, the next Kafka message remains unread in the TCP buffer indefinitely
- The progression latch waits for backend connection, but backend connection requires the Kafka request to determine target server
- Result: deadlock → timeout after 5 seconds

## Solution

Add `ctx.channel().read()` call in `HaProxyMessageHandler.channelRead0()` to explicitly trigger the next read operation, ensuring subsequent Kafka messages are consumed even when autoread is disabled.

## Testing

- Added unit test verifying `channel.read()` is called after processing HAProxy message
- Updated existing test to properly mock channel
- All 8 `ProxyProtocolIT` tests pass
- Fix validated with `Thread.sleep(500)` reproducer that previously failed 100% reliably

## Changes

**Modified:**
- `HaProxyMessageHandler.java` - Added 2 lines (comment + `ctx.channel().read()` call)
- `HaProxyMessageHandlerTest.java` - Added 20 lines (new test + updated existing test)
- `CHANGELOG.md` - Added entry for #3757

## Credit

Root cause analysis and proposed solution by @robobario: https://github.com/kroxylicious/kroxylicious/issues/3757#issuecomment-4301865362

🤖 Generated with [Claude Code](https://claude.com/claude-code)