### PR TITLE
fix(test): await ACL and config visibility in EntityIsolationIT

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/entityisolation/EntityIsolationIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/entityisolation/EntityIsolationIT.java
@@ -462,10 +462,13 @@ class EntityIsolationIT {
                 assertThat(bobAdmin.incrementalAlterConfigs(Map.of(configResource, setConfig)).all())
                         .succeedsWithin(Duration.ofSeconds(5));
 
-                assertThat(bobAdmin.listConfigResources(Set.of(ConfigResource.Type.GROUP), new ListConfigResourcesOptions()).all())
-                        .succeedsWithin(Duration.ofSeconds(5))
-                        .asInstanceOf(InstanceOfAssertFactories.list(ConfigResource.class))
-                        .containsExactly(configResource);
+                await().atMost(Duration.ofSeconds(30))
+                        .untilAsserted(() -> {
+                            assertThat(bobAdmin.listConfigResources(Set.of(ConfigResource.Type.GROUP), new ListConfigResourcesOptions()).all())
+                                    .succeedsWithin(Duration.ofSeconds(5))
+                                    .asInstanceOf(InstanceOfAssertFactories.list(ConfigResource.class))
+                                    .containsExactly(configResource);
+                        });
             }
         }
     }
@@ -700,13 +703,16 @@ class EntityIsolationIT {
                 assertThat(bobAdmin.createAcls(List.of(aclBinding)).all())
                         .succeedsWithin(Duration.ofSeconds(5));
 
-                assertThat(bobAdmin.describeAcls(new AclBindingFilter(new ResourcePatternFilter(ResourceType.ANY, null, PatternType.ANY),
-                        AccessControlEntryFilter.ANY)).values())
-                        .succeedsWithin(Duration.ofSeconds(5))
-                        .asInstanceOf(collection(AclBinding.class))
-                        .extracting(AclBinding::pattern)
-                        .extracting(ResourcePattern::name)
-                        .containsExactlyInAnyOrderElementsOf(List.of(bobResourcePattern.name()));
+                await().atMost(Duration.ofSeconds(30))
+                        .untilAsserted(() -> {
+                            assertThat(bobAdmin.describeAcls(new AclBindingFilter(new ResourcePatternFilter(ResourceType.ANY, null, PatternType.ANY),
+                                    AccessControlEntryFilter.ANY)).values())
+                                    .succeedsWithin(Duration.ofSeconds(5))
+                                    .asInstanceOf(collection(AclBinding.class))
+                                    .extracting(AclBinding::pattern)
+                                    .extracting(ResourcePattern::name)
+                                    .containsExactlyInAnyOrderElementsOf(List.of(bobResourcePattern.name()));
+                        });
             }
         }
     }


### PR DESCRIPTION
## Summary
- Wraps describeAcls call with awaitility check after createAcls
- Wraps listConfigResources call with awaitility check after incrementalAlterConfigs
- Fixes flaky test failures caused by Kafka's eventual consistency

Fixes #3740 and a similar pattern in the same test class.

Claude also spotted a similar pattern in some of our Authz Tracing ITs but the pattern we would use is different there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)