### PR TITLE
Add sidecar injection webhook module (Phase 1)

### DIFF
--- a/kroxylicious-kubernetes-api/pom.xml
+++ b/kroxylicious-kubernetes-api/pom.xml
@@ -230,6 +230,12 @@
                         <io.kroxylicious.kubernetes.api.v1alpha1.kafkaprotocolfilterspec.ConfigTemplate>
                             java.lang.Object
                         </io.kroxylicious.kubernetes.api.v1alpha1.kafkaprotocolfilterspec.ConfigTemplate>
+                        <io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigstatus.Conditions>
+                            io.kroxylicious.kubernetes.api.common.Condition
+                        </io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigstatus.Conditions>
+                        <io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.Resources>
+                            io.fabric8.kubernetes.api.model.ResourceRequirements
+                        </io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.Resources>
                         <io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyingressspec.clusterip.Protocol>
                             io.kroxylicious.kubernetes.api.common.Protocol
                         </io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyingressspec.clusterip.Protocol>

--- a/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kroxylicioussidecarconfigs.kroxylicious.io-v1.yml
+++ b/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kroxylicioussidecarconfigs.kroxylicious.io-v1.yml
@@ -1,0 +1,168 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# Note the v1 in the filename refers to the version of the CustomResourceDefinition
+# not any of the versions of API being defined.
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: kroxylicioussidecarconfigs.kroxylicious.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: kroxylicious.io
+  scope: Namespaced
+  names:
+    plural: kroxylicioussidecarconfigs
+    singular: kroxylicioussidecarconfig
+    kind: KroxyliciousSidecarConfig
+    shortNames:
+      - ksc
+    categories:
+      - kroxylicious
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: Upstream
+          description: The bootstrap servers of the upstream Kafka cluster.
+          jsonPath: ".spec.upstreamBootstrapServers"
+          type: string
+          priority: 0
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            metadata:
+              type: object
+              properties:
+                name:
+                  type: string
+                  maxLength: 63
+                  pattern: "[a-z0-9]([a-z0-9-]*[a-z0-9])?"
+            spec:
+              type: object
+              required:
+                - upstreamBootstrapServers
+              properties:
+                upstreamBootstrapServers:
+                  description: |
+                    The bootstrap servers of the upstream Kafka cluster that the sidecar proxy
+                    will forward traffic to.
+                  type: string
+                proxyImage:
+                  description: |
+                    The container image to use for the sidecar proxy. If omitted, the webhook
+                    uses the image configured via the KROXYLICIOUS_IMAGE environment variable.
+                  type: string
+                bootstrapPort:
+                  description: |
+                    The port on localhost where the sidecar proxy listens for Kafka bootstrap
+                    connections. Broker ports are allocated sequentially starting from
+                    bootstrapPort + 1.
+                  type: integer
+                  default: 19092
+                  minimum: 1024
+                  maximum: 65535
+                nodeIdRange:
+                  description: |
+                    The range of Kafka broker node IDs that the sidecar proxy will allocate
+                    ports for. The number of broker ports is endInclusive - startInclusive + 1.
+                  type: object
+                  properties:
+                    startInclusive:
+                      description: The first node ID in the range (inclusive).
+                      type: integer
+                      default: 0
+                      minimum: 0
+                    endInclusive:
+                      description: The last node ID in the range (inclusive).
+                      type: integer
+                      default: 2
+                      minimum: 0
+                managementPort:
+                  description: |
+                    The port on which the sidecar proxy exposes its management endpoints
+                    (/livez, /metrics). Bound to all interfaces so that kubelet probes work.
+                  type: integer
+                  default: 9190
+                  minimum: 1024
+                  maximum: 65535
+                resources:
+                  description: |
+                    Resource requests and limits for the sidecar proxy container.
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                setBootstrapEnvVar:
+                  description: |
+                    Whether to set the KAFKA_BOOTSTRAP_SERVERS environment variable on
+                    application containers, pointing them to the sidecar proxy.
+                  type: boolean
+                  default: true
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  description: |
+                    The metadata.generation that was observed during the last reconciliation by the webhook.
+                  type: integer
+                conditions:
+                  # Mapped to Java type io.kroxylicious.kubernetes.api.common.Condition
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      lastTransitionTime:
+                        description: |
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.
+                          If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: |
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        type: string
+                        default: ""
+                        nullable: false
+                      observedGeneration:
+                        description: |
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the
+                          .status.conditions[x].observedGeneration is 9, the condition is out of date with
+                          respect to the current state of the instance.
+                        type: integer
+                        nullable: false
+                      reason:
+                        description: |
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        type: string
+                        nullable: false
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum: [ "True", "False", "Unknown" ]
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - observedGeneration
+                      - reason
+                      - message
+                      - type
+          required:
+            - spec

--- a/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kroxylicioussidecarconfigs.kroxylicious.io-v1.yml
+++ b/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kroxylicioussidecarconfigs.kroxylicious.io-v1.yml
@@ -4,6 +4,8 @@
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
+# TODO This should be factored into its own maven module so that the operator and sidecar are completely independent.
+
 # Note the v1 in the filename refers to the version of the CustomResourceDefinition
 # not any of the versions of API being defined.
 ---
@@ -33,6 +35,7 @@ spec:
         status: {}
       additionalPrinterColumns:
         - name: Upstream
+          # TODO All the "Upstream" in this API should be "Target", because that aligns with the terminology we use in non-Kube proxy configuration
           description: The bootstrap servers of the upstream Kafka cluster.
           jsonPath: ".spec.upstreamBootstrapServers"
           type: string
@@ -62,6 +65,7 @@ spec:
                   description: |
                     The container image to use for the sidecar proxy. If omitted, the webhook
                     uses the image configured via the KROXYLICIOUS_IMAGE environment variable.
+                  # TODO Can we reword this to avoid assuming the're a single consumer of this API which supports that env var?
                   type: string
                 bootstrapPort:
                   description: |
@@ -70,6 +74,7 @@ spec:
                     bootstrapPort + 1.
                   type: integer
                   default: 19092
+                  # TODO Change to 9092
                   minimum: 1024
                   maximum: 65535
                 nodeIdRange:
@@ -94,6 +99,7 @@ spec:
                     (/livez, /metrics). Bound to all interfaces so that kubelet probes work.
                   type: integer
                   default: 9190
+                  # TODO change to 9082
                   minimum: 1024
                   maximum: 65535
                 resources:

--- a/kroxylicious-kubernetes-web-hook/packaging/install/00.Namespace.kroxylicious-webhook.yaml
+++ b/kroxylicious-kubernetes-web-hook/packaging/install/00.Namespace.kroxylicious-webhook.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kroxylicious-webhook
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: webhook
+    # Enforce restricted pod security
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest

--- a/kroxylicious-kubernetes-web-hook/packaging/install/00.Namespace.kroxylicious-webhook.yaml
+++ b/kroxylicious-kubernetes-web-hook/packaging/install/00.Namespace.kroxylicious-webhook.yaml
@@ -3,6 +3,7 @@
 #
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
+
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/kroxylicious-kubernetes-web-hook/packaging/install/01.ClusterRole.kroxylicious-webhook.yaml
+++ b/kroxylicious-kubernetes-web-hook/packaging/install/01.ClusterRole.kroxylicious-webhook.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kroxylicious-webhook
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: webhook
+rules:
+  # Read sidecar configs across all namespaces
+  - apiGroups: ["kroxylicious.io"]
+    resources: ["kroxylicioussidecarconfigs"]
+    verbs: ["get", "list", "watch"]
+  # Update sidecar config status
+  - apiGroups: ["kroxylicious.io"]
+    resources: ["kroxylicioussidecarconfigs/status"]
+    verbs: ["get", "patch", "update"]

--- a/kroxylicious-kubernetes-web-hook/packaging/install/01.ClusterRole.kroxylicious-webhook.yaml
+++ b/kroxylicious-kubernetes-web-hook/packaging/install/01.ClusterRole.kroxylicious-webhook.yaml
@@ -3,6 +3,7 @@
 #
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/kroxylicious-kubernetes-web-hook/packaging/install/01.ServiceAccount.kroxylicious-webhook.yaml
+++ b/kroxylicious-kubernetes-web-hook/packaging/install/01.ServiceAccount.kroxylicious-webhook.yaml
@@ -1,0 +1,13 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kroxylicious-webhook
+  namespace: kroxylicious-webhook
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: webhook

--- a/kroxylicious-kubernetes-web-hook/packaging/install/01.ServiceAccount.kroxylicious-webhook.yaml
+++ b/kroxylicious-kubernetes-web-hook/packaging/install/01.ServiceAccount.kroxylicious-webhook.yaml
@@ -3,6 +3,7 @@
 #
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/kroxylicious-kubernetes-web-hook/packaging/install/02.ClusterRoleBinding.kroxylicious-webhook.yaml
+++ b/kroxylicious-kubernetes-web-hook/packaging/install/02.ClusterRoleBinding.kroxylicious-webhook.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kroxylicious-webhook
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kroxylicious-webhook
+subjects:
+  - kind: ServiceAccount
+    name: kroxylicious-webhook
+    namespace: kroxylicious-webhook

--- a/kroxylicious-kubernetes-web-hook/packaging/install/02.ClusterRoleBinding.kroxylicious-webhook.yaml
+++ b/kroxylicious-kubernetes-web-hook/packaging/install/02.ClusterRoleBinding.kroxylicious-webhook.yaml
@@ -3,6 +3,7 @@
 #
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/kroxylicious-kubernetes-web-hook/packaging/install/03.Deployment.kroxylicious-webhook.yaml
+++ b/kroxylicious-kubernetes-web-hook/packaging/install/03.Deployment.kroxylicious-webhook.yaml
@@ -1,0 +1,89 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kroxylicious-webhook
+  namespace: kroxylicious-webhook
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: webhook
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kroxylicious-webhook
+  template:
+    metadata:
+      labels:
+        app: kroxylicious-webhook
+        app.kubernetes.io/name: kroxylicious
+        app.kubernetes.io/component: webhook
+    spec:
+      serviceAccountName: kroxylicious-webhook
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: webhook
+          image: $[io.kroxylicious.webhook.image.name]
+          ports:
+            - containerPort: 8443
+              name: webhook
+              protocol: TCP
+          env:
+            - name: KROXYLICIOUS_IMAGE
+              value: $[io.kroxylicious.proxy.image.name]
+            - name: TLS_CERT_PATH
+              value: /etc/webhook/tls/tls.crt
+            - name: TLS_KEY_PATH
+              value: /etc/webhook/tls/tls.key
+          volumeMounts:
+            - name: tls
+              mountPath: /etc/webhook/tls
+              readOnly: true
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 500m
+            limits:
+              memory: 512Mi
+              cpu: "1"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          startupProbe:
+            httpGet:
+              path: /livez
+              port: webhook
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 2
+            failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: webhook
+              scheme: HTTPS
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /livez
+              port: webhook
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 3
+      volumes:
+        - name: tls
+          secret:
+            secretName: kroxylicious-webhook-cert

--- a/kroxylicious-kubernetes-web-hook/packaging/install/03.Deployment.kroxylicious-webhook.yaml
+++ b/kroxylicious-kubernetes-web-hook/packaging/install/03.Deployment.kroxylicious-webhook.yaml
@@ -3,6 +3,7 @@
 #
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/kroxylicious-kubernetes-web-hook/packaging/install/03.Deployment.kroxylicious-webhook.yaml
+++ b/kroxylicious-kubernetes-web-hook/packaging/install/03.Deployment.kroxylicious-webhook.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/component: webhook
 spec:
   replicas: 1
+  # TODO single replica, maybe okay for alpha, but better to have >1 and a PodDisruptionBudget to prevent them all being evicted simultaneously
   selector:
     matchLabels:
       app: kroxylicious-webhook
@@ -32,6 +33,7 @@ spec:
       containers:
         - name: webhook
           image: $[io.kroxylicious.webhook.image.name]
+          # TODO In phase 3 have maven-resources-plugin honour the implied interpolation
           ports:
             - containerPort: 8443
               name: webhook
@@ -51,6 +53,7 @@ spec:
             requests:
               memory: 256Mi
               cpu: 500m
+              # TODO do the work to find what a minimum realistic resources actually are
             limits:
               memory: 512Mi
               cpu: "1"

--- a/kroxylicious-kubernetes-web-hook/packaging/install/04.Service.kroxylicious-webhook.yaml
+++ b/kroxylicious-kubernetes-web-hook/packaging/install/04.Service.kroxylicious-webhook.yaml
@@ -3,6 +3,7 @@
 #
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
+
 apiVersion: v1
 kind: Service
 metadata:

--- a/kroxylicious-kubernetes-web-hook/packaging/install/04.Service.kroxylicious-webhook.yaml
+++ b/kroxylicious-kubernetes-web-hook/packaging/install/04.Service.kroxylicious-webhook.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+apiVersion: v1
+kind: Service
+metadata:
+  name: kroxylicious-webhook
+  namespace: kroxylicious-webhook
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: webhook
+spec:
+  ports:
+    - name: webhook
+      port: 443
+      targetPort: 8443
+      protocol: TCP
+  selector:
+    app: kroxylicious-webhook

--- a/kroxylicious-kubernetes-web-hook/packaging/install/05.MutatingWebhookConfiguration.yaml
+++ b/kroxylicious-kubernetes-web-hook/packaging/install/05.MutatingWebhookConfiguration.yaml
@@ -1,0 +1,51 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: kroxylicious-sidecar-injector
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: webhook
+  annotations:
+    # cert-manager injects the CA bundle from the Certificate resource
+    cert-manager.io/inject-ca-from: kroxylicious-webhook/kroxylicious-webhook-cert
+webhooks:
+  - name: sidecar-injector.kroxylicious.io
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    # Fail-open: if the webhook is unavailable, pods are created without sidecars
+    failurePolicy: Ignore
+    reinvocationPolicy: IfNeeded
+    timeoutSeconds: 10
+    clientConfig:
+      service:
+        name: kroxylicious-webhook
+        namespace: kroxylicious-webhook
+        path: /mutate
+        port: 443
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+    # Only intercept pods in namespaces that have opted in
+    namespaceSelector:
+      matchLabels:
+        kroxylicious.io/sidecar-injection: enabled
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kube-system
+            - kube-public
+            - kroxylicious-webhook
+    # Skip pods that have explicitly opted out
+    objectSelector:
+      matchExpressions:
+        - key: kroxylicious.io/inject-sidecar
+          operator: NotIn
+          values: ["false"]

--- a/kroxylicious-kubernetes-web-hook/packaging/install/05.MutatingWebhookConfiguration.yaml
+++ b/kroxylicious-kubernetes-web-hook/packaging/install/05.MutatingWebhookConfiguration.yaml
@@ -20,6 +20,7 @@ webhooks:
     sideEffects: None
     # Fail-open: if the webhook is unavailable, pods are created without sidecars
     failurePolicy: Ignore
+    # TODO fail closed by default
     reinvocationPolicy: IfNeeded
     timeoutSeconds: 10
     clientConfig:

--- a/kroxylicious-kubernetes-web-hook/packaging/install/05.MutatingWebhookConfiguration.yaml
+++ b/kroxylicious-kubernetes-web-hook/packaging/install/05.MutatingWebhookConfiguration.yaml
@@ -3,6 +3,7 @@
 #
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
+
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:

--- a/kroxylicious-kubernetes-web-hook/packaging/install/06.Certificate.kroxylicious-webhook.yaml
+++ b/kroxylicious-kubernetes-web-hook/packaging/install/06.Certificate.kroxylicious-webhook.yaml
@@ -3,8 +3,10 @@
 #
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
+
 # Requires cert-manager to be installed in the cluster.
 # See https://cert-manager.io/docs/installation/
+
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer

--- a/kroxylicious-kubernetes-web-hook/packaging/install/06.Certificate.kroxylicious-webhook.yaml
+++ b/kroxylicious-kubernetes-web-hook/packaging/install/06.Certificate.kroxylicious-webhook.yaml
@@ -1,0 +1,39 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Requires cert-manager to be installed in the cluster.
+# See https://cert-manager.io/docs/installation/
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: kroxylicious-webhook-selfsigned
+  namespace: kroxylicious-webhook
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: webhook
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kroxylicious-webhook-cert
+  namespace: kroxylicious-webhook
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: webhook
+spec:
+  secretName: kroxylicious-webhook-cert
+  issuerRef:
+    name: kroxylicious-webhook-selfsigned
+    kind: Issuer
+  dnsNames:
+    - kroxylicious-webhook
+    - kroxylicious-webhook.kroxylicious-webhook
+    - kroxylicious-webhook.kroxylicious-webhook.svc
+    - kroxylicious-webhook.kroxylicious-webhook.svc.cluster.local
+  duration: 8760h   # 1 year
+  renewBefore: 720h  # 30 days

--- a/kroxylicious-kubernetes-web-hook/pom.xml
+++ b/kroxylicious-kubernetes-web-hook/pom.xml
@@ -201,6 +201,10 @@
                                 <!-- Used in integration tests (not yet written) -->
                                 <ignoredUnusedDeclaredDependency>io.fabric8:kubernetes-server-mock
                                 </ignoredUnusedDeclaredDependency>
+                                <!-- dependency analyzer seems not to grok that a dependency on a
+                                @Retention(RetentionPolicy.SOURCE) annotation is still a dependency -->
+                                <ignoredUnusedDeclaredDependency>io.kroxylicious:kroxylicious-annotations
+                                </ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>

--- a/kroxylicious-kubernetes-web-hook/pom.xml
+++ b/kroxylicious-kubernetes-web-hook/pom.xml
@@ -43,6 +43,10 @@
         <!-- project dependencies -->
         <dependency>
             <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-kubernetes-api</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -139,6 +143,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit-pioneer</groupId>
+            <artifactId>junit-pioneer</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
@@ -151,6 +165,11 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-kms-test-support</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -203,6 +222,8 @@
                     <argLine>
                         @{jacoco.argline}
                         -javaagent:${org.mockito:mockito-core:jar}
+                        --add-opens java.base/java.util=ALL-UNNAMED
+                        --add-opens java.base/java.lang=ALL-UNNAMED
                     </argLine>
                 </configuration>
             </plugin>

--- a/kroxylicious-kubernetes-web-hook/pom.xml
+++ b/kroxylicious-kubernetes-web-hook/pom.xml
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.kroxylicious</groupId>
+        <artifactId>kroxylicious-parent</artifactId>
+        <version>0.21.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kroxylicious-kubernetes-web-hook</artifactId>
+    <name>Kubernetes Sidecar Injection Webhook</name>
+    <description>A mutating admission webhook that injects Kroxylicious proxy sidecars into Kafka application pods</description>
+
+    <properties>
+        <!-- Error Prone disabled - fabric8 builders not compatible with -XDcompilePolicy=simple -->
+        <errorprone.skip>true</errorprone.skip>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- note, we're inheriting the jackson & micrometer BOMs from our parent pom -->
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-client-bom</artifactId>
+                <version>${kubernetes-client.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <!-- project dependencies -->
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-kubernetes-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <!-- For the type-safe proxy Configuration model used to generate proxy config YAML.
+                 Same pattern as kroxylicious-operator. -->
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-runtime</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <!-- fabric8 kubernetes client -->
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client</artifactId>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-httpclient-vertx</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-jdk</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-admissionregistration</artifactId>
+        </dependency>
+
+        <!-- Jackson -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-layout-template-json</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Annotations -->
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-server-mock</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-httpclient-vertx</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>analyze</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <ignoredUnusedDeclaredDependencies>
+                                <!-- Used in integration tests (not yet written) -->
+                                <ignoredUnusedDeclaredDependency>io.fabric8:kubernetes-server-mock
+                                </ignoredUnusedDeclaredDependency>
+                            </ignoredUnusedDeclaredDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- Override parent's Error Prone compiler args (breaks fabric8 builders) -->
+                    <compilerArgs combine.self="override"/>
+                    <annotationProcessorPaths combine.self="override"/>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>
+                        @{jacoco.argline}
+                        -javaagent:${org.mockito:mockito-core:jar}
+                    </argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.admission.v1.AdmissionRequest;
+import io.fabric8.kubernetes.api.model.admission.v1.AdmissionResponse;
+import io.fabric8.kubernetes.api.model.admission.v1.AdmissionReview;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfig;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Handles admission review requests for sidecar injection.
+ */
+class AdmissionHandler implements HttpHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AdmissionHandler.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String JSON_PATCH_TYPE = "JSONPatch";
+
+    private final SidecarConfigResolver configResolver;
+    private final String proxyImage;
+
+    AdmissionHandler(
+                     @NonNull SidecarConfigResolver configResolver,
+                     @NonNull String proxyImage) {
+        this.configResolver = configResolver;
+        this.proxyImage = proxyImage;
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        try {
+            if (!"POST".equals(exchange.getRequestMethod())) {
+                exchange.sendResponseHeaders(405, -1);
+                return;
+            }
+
+            AdmissionReview review;
+            try (InputStream is = exchange.getRequestBody()) {
+                review = MAPPER.readValue(is, AdmissionReview.class);
+            }
+
+            AdmissionResponse response = processReview(review);
+            AdmissionReview responseReview = new AdmissionReview();
+            responseReview.setApiVersion("admission.k8s.io/v1");
+            responseReview.setKind("AdmissionReview");
+            responseReview.setResponse(response);
+
+            byte[] responseBytes = MAPPER.writeValueAsBytes(responseReview);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, responseBytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(responseBytes);
+            }
+        }
+        catch (Exception e) {
+            LOGGER.atError()
+                    .setCause(e)
+                    .log("Unexpected error handling admission request");
+            // Fail-open: always allow, even on error
+            sendAllowResponse(exchange, null);
+        }
+        finally {
+            exchange.close();
+        }
+    }
+
+    @NonNull
+    AdmissionResponse processReview(@NonNull AdmissionReview review) {
+        AdmissionRequest request = review.getRequest();
+        if (request == null) {
+            return allowResponse(null);
+        }
+
+        String uid = request.getUid();
+
+        try {
+            Pod pod = MAPPER.convertValue(request.getObject(), Pod.class);
+            if (pod == null) {
+                LOGGER.atWarn()
+                        .addKeyValue("uid", uid)
+                        .log("Admission request contained no pod object");
+                return allowResponse(uid);
+            }
+
+            String namespace = request.getNamespace();
+            String podName = pod.getMetadata() != null ? pod.getMetadata().getName() : null;
+            if (podName == null) {
+                podName = pod.getMetadata() != null ? pod.getMetadata().getGenerateName() : "<unknown>";
+            }
+
+            // Resolve sidecar config
+            Map<String, String> annotations = pod.getMetadata() != null ? pod.getMetadata().getAnnotations() : null;
+            String explicitConfigName = annotations != null ? annotations.get(Annotations.SIDECAR_CONFIG) : null;
+            Optional<KroxyliciousSidecarConfig> configOpt = configResolver.resolve(namespace, explicitConfigName);
+
+            // Evaluate injection decision
+            InjectionDecision.Decision decision = InjectionDecision.evaluate(pod, configOpt.isPresent());
+
+            LOGGER.atInfo()
+                    .addKeyValue("pod", podName)
+                    .addKeyValue("namespace", namespace)
+                    .addKeyValue("decision", decision.name())
+                    .addKeyValue("sidecarConfig", explicitConfigName)
+                    .log("Sidecar injection decision");
+
+            if (decision != InjectionDecision.Decision.INJECT) {
+                return allowResponse(uid);
+            }
+
+            // Generate the patch
+            KroxyliciousSidecarConfig sidecarConfig = configOpt.get();
+            String image = resolveImage(sidecarConfig);
+            String jsonPatch = PodMutator.createPatch(pod, sidecarConfig.getSpec(), image);
+
+            AdmissionResponse response = allowResponse(uid);
+            response.setPatchType(JSON_PATCH_TYPE);
+            response.setPatch(Base64.getEncoder().encodeToString(jsonPatch.getBytes(StandardCharsets.UTF_8)));
+            return response;
+        }
+        catch (Exception e) {
+            LOGGER.atError()
+                    .setCause(e)
+                    .addKeyValue("uid", uid)
+                    .log("Error processing admission request, allowing pod without sidecar");
+            return allowResponse(uid);
+        }
+    }
+
+    @NonNull
+    private String resolveImage(@NonNull KroxyliciousSidecarConfig config) {
+        String image = config.getSpec().getProxyImage();
+        return image != null ? image : proxyImage;
+    }
+
+    @NonNull
+    private static AdmissionResponse allowResponse(String uid) {
+        AdmissionResponse response = new AdmissionResponse();
+        response.setUid(uid != null ? uid : UUID.randomUUID().toString());
+        response.setAllowed(true);
+        return response;
+    }
+
+    private void sendAllowResponse(HttpExchange exchange, String uid) {
+        try {
+            AdmissionReview responseReview = new AdmissionReview();
+            responseReview.setApiVersion("admission.k8s.io/v1");
+            responseReview.setKind("AdmissionReview");
+            responseReview.setResponse(allowResponse(uid));
+            byte[] responseBytes = MAPPER.writeValueAsBytes(responseReview);
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, responseBytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(responseBytes);
+            }
+        }
+        catch (IOException e) {
+            LOGGER.atError()
+                    .setCause(e)
+                    .log("Failed to send error response");
+        }
+    }
+}

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
@@ -51,7 +51,7 @@ class AdmissionHandler implements HttpHandler {
     }
 
     @Override
-    public void handle(HttpExchange exchange) throws IOException {
+    public void handle(HttpExchange exchange) {
         try {
             if (!"POST".equals(exchange.getRequestMethod())) {
                 exchange.sendResponseHeaders(405, -1);
@@ -132,7 +132,7 @@ class AdmissionHandler implements HttpHandler {
             }
 
             // Generate the patch
-            KroxyliciousSidecarConfig sidecarConfig = configOpt.get();
+            KroxyliciousSidecarConfig sidecarConfig = configOpt.orElseThrow();
             String image = resolveImage(sidecarConfig);
             String jsonPatch = PodMutator.createPatch(pod, sidecarConfig.getSpec(), image);
 

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
@@ -63,6 +63,7 @@ class AdmissionHandler implements HttpHandler {
                 review = MAPPER.readValue(is, AdmissionReview.class);
             }
 
+            // TODO the below code share a lot of statements in common with sendAllowResponse()
             AdmissionResponse response = processReview(review);
             AdmissionReview responseReview = new AdmissionReview();
             responseReview.setApiVersion("admission.k8s.io/v1");
@@ -82,6 +83,7 @@ class AdmissionHandler implements HttpHandler {
                     .log("Unexpected error handling admission request");
             // Fail-open: always allow, even on error
             sendAllowResponse(exchange, null);
+            // TODO this will need to change when we default to fail closed.
         }
         finally {
             exchange.close();
@@ -152,6 +154,7 @@ class AdmissionHandler implements HttpHandler {
 
     @NonNull
     private String resolveImage(@NonNull KroxyliciousSidecarConfig config) {
+        // TODO rename to proxyImage()
         String image = config.getSpec().getProxyImage();
         return image != null ? image : proxyImage;
     }

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/Annotations.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/Annotations.java
@@ -11,6 +11,7 @@ package io.kroxylicious.kubernetes.webhook;
  */
 final class Annotations {
 
+    // TODO Javadoc these things, so we know what they're for
     static final String INJECT_SIDECAR = "kroxylicious.io/inject-sidecar";
     static final String SIDECAR_CONFIG = "kroxylicious.io/sidecar-config";
     static final String PROXY_CONFIG = "kroxylicious.io/proxy-config";

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/Annotations.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/Annotations.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+/**
+ * Annotation keys used by the sidecar injection webhook.
+ */
+final class Annotations {
+
+    static final String INJECT_SIDECAR = "kroxylicious.io/inject-sidecar";
+    static final String SIDECAR_CONFIG = "kroxylicious.io/sidecar-config";
+    static final String PROXY_CONFIG = "kroxylicious.io/proxy-config";
+    static final String SIDECAR_STATUS = "kroxylicious.io/sidecar-status";
+
+    private Annotations() {
+    }
+}

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/InjectionDecision.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/InjectionDecision.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.Pod;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Determines whether a sidecar should be injected into a pod.
+ */
+final class InjectionDecision {
+
+    static final String SIDECAR_CONTAINER_NAME = "kroxylicious-proxy";
+
+    enum Decision {
+        INJECT,
+        SKIP_ALREADY_INJECTED,
+        SKIP_OPT_OUT,
+        SKIP_NO_CONFIG
+    }
+
+    private InjectionDecision() {
+    }
+
+    /**
+     * Evaluates whether the given pod should have a sidecar injected.
+     *
+     * @param pod the pod being admitted
+     * @param hasConfig whether a {@code KroxyliciousSidecarConfig} was found for the pod's namespace
+     * @return the injection decision
+     */
+    @NonNull
+    static Decision evaluate(
+                             @NonNull Pod pod,
+                             boolean hasConfig) {
+
+        if (isOptedOut(pod)) {
+            return Decision.SKIP_OPT_OUT;
+        }
+
+        if (isAlreadyInjected(pod)) {
+            return Decision.SKIP_ALREADY_INJECTED;
+        }
+
+        if (!hasConfig) {
+            return Decision.SKIP_NO_CONFIG;
+        }
+
+        return Decision.INJECT;
+    }
+
+    private static boolean isOptedOut(@NonNull Pod pod) {
+        Map<String, String> annotations = annotations(pod);
+        String value = annotations.get(Annotations.INJECT_SIDECAR);
+        return "false".equals(value);
+    }
+
+    private static boolean isAlreadyInjected(@NonNull Pod pod) {
+        if (pod.getSpec() == null || pod.getSpec().getContainers() == null) {
+            return false;
+        }
+        return pod.getSpec().getContainers().stream()
+                .anyMatch(c -> SIDECAR_CONTAINER_NAME.equals(c.getName()));
+    }
+
+    @NonNull
+    private static Map<String, String> annotations(@NonNull Pod pod) {
+        @Nullable
+        Map<String, String> annotations = pod.getMetadata() != null ? pod.getMetadata().getAnnotations() : null;
+        return annotations != null ? annotations : Map.of();
+    }
+}

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/Labels.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/Labels.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+/**
+ * Label keys used by the sidecar injection webhook.
+ */
+final class Labels {
+
+    static final String SIDECAR_INJECTION = "kroxylicious.io/sidecar-injection";
+    static final String SIDECAR_INJECTION_ENABLED = "enabled";
+
+    private Labels() {
+    }
+}

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/Labels.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/Labels.java
@@ -11,6 +11,7 @@ package io.kroxylicious.kubernetes.webhook;
  */
 final class Labels {
 
+    // TODO Javadoc these things, so we know what they're for
     static final String SIDECAR_INJECTION = "kroxylicious.io/sidecar-injection";
     static final String SIDECAR_INJECTION_ENABLED = "enabled";
 

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
@@ -93,6 +93,7 @@ class PodMutator {
                 && pod.getSpec().getVolumes() != null
                 && !pod.getSpec().getVolumes().isEmpty();
 
+        // TODO Add a comment explaining what this is doing in Kube terms.
         ObjectNode volume = MAPPER.createObjectNode();
         volume.put("name", SIDECAR_VOLUME_NAME);
         ObjectNode downwardAPI = volume.putObject("downwardAPI");
@@ -256,6 +257,7 @@ class PodMutator {
         }
     }
 
+    // TODO add an import and avoid the fq name below
     private static int findEnvVarIndex(
                                        List<io.fabric8.kubernetes.api.model.EnvVar> env,
                                        String name) {

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
@@ -27,6 +27,7 @@ class PodMutator {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final String SIDECAR_VOLUME_NAME = "kroxylicious-config";
+    @SuppressWarnings("java:S1075") // there's nothing wrong with hard coding this path.
     private static final String CONFIG_MOUNT_PATH = "/opt/kroxylicious/config/proxy-config.yaml";
     private static final String CONFIG_FILE_NAME = "proxy-config.yaml";
     private static final String MANAGEMENT_PORT_NAME = "management";
@@ -142,9 +143,9 @@ class PodMutator {
         mgmtPort.put("protocol", "TCP");
 
         // Probes
-        addProbe(container, "startupProbe", managementPort, 5, 2, 30);
-        addProbe(container, "livenessProbe", managementPort, 30, 10, 3);
-        addProbe(container, "readinessProbe", managementPort, 5, 2, 5);
+        addProbe(container, "startupProbe", 5, 2, 30);
+        addProbe(container, "livenessProbe", 30, 10, 3);
+        addProbe(container, "readinessProbe", 5, 2, 5);
 
         // Volume mount
         ArrayNode volumeMounts = container.putArray("volumeMounts");
@@ -184,7 +185,6 @@ class PodMutator {
     private static void addProbe(
                                  ObjectNode container,
                                  String probeName,
-                                 int port,
                                  int initialDelay,
                                  int period,
                                  int failureThreshold) {
@@ -199,6 +199,9 @@ class PodMutator {
         probe.put("timeoutSeconds", 1);
     }
 
+    @SuppressWarnings("java:S1192") // dupe strings:
+    // "value": env var "value" here is not the same as json path op "value" later on
+    // "/spec/containers/": could use a constant, but it would make the code harder to understand
     private static void addBootstrapEnvVarOps(
                                               ArrayNode patch,
                                               Pod pod,
@@ -278,6 +281,7 @@ class PodMutator {
         }
     }
 
+    @SuppressWarnings("java:S1192") // dupe "value" strings, but env var "value" not the same as json path op "value"
     private static void addOp(ArrayNode patch, String op, String path, Object value) {
         ObjectNode opNode = MAPPER.createObjectNode();
         opNode.put("op", op);

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
@@ -1,0 +1,301 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.fabric8.kubernetes.api.model.Pod;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfigSpec;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Generates a JSON Patch (RFC 6902) to inject a Kroxylicious sidecar into a pod.
+ */
+class PodMutator {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String SIDECAR_VOLUME_NAME = "kroxylicious-config";
+    private static final String CONFIG_MOUNT_PATH = "/opt/kroxylicious/config/proxy-config.yaml";
+    private static final String CONFIG_FILE_NAME = "proxy-config.yaml";
+    private static final String MANAGEMENT_PORT_NAME = "management";
+    private static final String KAFKA_BOOTSTRAP_SERVERS_ENV = "KAFKA_BOOTSTRAP_SERVERS";
+
+    private PodMutator() {
+    }
+
+    /**
+     * Generates a JSON Patch to inject the sidecar into the pod.
+     *
+     * @param pod the original pod
+     * @param spec the sidecar configuration
+     * @param proxyImage the container image to use for the proxy
+     * @return JSON Patch string (RFC 6902)
+     */
+    @NonNull
+    static String createPatch(
+                              @NonNull Pod pod,
+                              @NonNull KroxyliciousSidecarConfigSpec spec,
+                              @NonNull String proxyImage) {
+        try {
+            ArrayNode patch = MAPPER.createArrayNode();
+
+            String proxyConfig = ProxyConfigGenerator.generateConfig(spec);
+            int bootstrapPort = ProxyConfigGenerator.resolveBootstrapPort(spec);
+            int managementPort = ProxyConfigGenerator.resolveManagementPort(spec);
+
+            addAnnotationOps(patch, pod, proxyConfig);
+            addVolumeOps(patch, pod);
+            addSidecarContainerOp(patch, pod, proxyImage, managementPort, spec);
+            addBootstrapEnvVarOps(patch, pod, spec, bootstrapPort);
+            addSecurityContextOps(patch, pod);
+
+            return MAPPER.writeValueAsString(patch);
+        }
+        catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialise JSON patch", e);
+        }
+    }
+
+    private static void addAnnotationOps(
+                                         ArrayNode patch,
+                                         Pod pod,
+                                         String proxyConfig) {
+
+        Map<String, String> existing = pod.getMetadata() != null ? pod.getMetadata().getAnnotations() : null;
+        if (existing == null) {
+            // annotations map doesn't exist yet — add it
+            ObjectNode annotations = MAPPER.createObjectNode();
+            annotations.put(Annotations.PROXY_CONFIG, proxyConfig);
+            annotations.put(Annotations.SIDECAR_STATUS, "injected");
+            addOp(patch, "add", "/metadata/annotations", annotations);
+        }
+        else {
+            addOp(patch, "add", "/metadata/annotations/" + escapeJsonPointer(Annotations.PROXY_CONFIG), proxyConfig);
+            addOp(patch, "add", "/metadata/annotations/" + escapeJsonPointer(Annotations.SIDECAR_STATUS), "injected");
+        }
+    }
+
+    private static void addVolumeOps(ArrayNode patch, Pod pod) {
+        boolean hasVolumes = pod.getSpec() != null
+                && pod.getSpec().getVolumes() != null
+                && !pod.getSpec().getVolumes().isEmpty();
+
+        ObjectNode volume = MAPPER.createObjectNode();
+        volume.put("name", SIDECAR_VOLUME_NAME);
+        ObjectNode downwardAPI = volume.putObject("downwardAPI");
+        ArrayNode items = downwardAPI.putArray("items");
+        ObjectNode item = items.addObject();
+        item.put("path", CONFIG_FILE_NAME);
+        ObjectNode fieldRef = item.putObject("fieldRef");
+        fieldRef.put("fieldPath", "metadata.annotations['" + Annotations.PROXY_CONFIG + "']");
+
+        if (hasVolumes) {
+            addOp(patch, "add", "/spec/volumes/-", volume);
+        }
+        else {
+            ArrayNode volumes = MAPPER.createArrayNode();
+            volumes.add(volume);
+            addOp(patch, "add", "/spec/volumes", volumes);
+        }
+    }
+
+    private static void addSidecarContainerOp(
+                                              ArrayNode patch,
+                                              Pod pod,
+                                              String proxyImage,
+                                              int managementPort,
+                                              KroxyliciousSidecarConfigSpec spec) {
+
+        ObjectNode container = MAPPER.createObjectNode();
+        container.put("name", InjectionDecision.SIDECAR_CONTAINER_NAME);
+        container.put("image", proxyImage);
+
+        ArrayNode args = container.putArray("args");
+        args.add("--config");
+        args.add(CONFIG_MOUNT_PATH);
+
+        // Security context
+        ObjectNode secCtx = container.putObject("securityContext");
+        secCtx.put("allowPrivilegeEscalation", false);
+        secCtx.put("readOnlyRootFilesystem", true);
+        ObjectNode capabilities = secCtx.putObject("capabilities");
+        ArrayNode drop = capabilities.putArray("drop");
+        drop.add("ALL");
+
+        // Ports
+        ArrayNode ports = container.putArray("ports");
+        ObjectNode mgmtPort = ports.addObject();
+        mgmtPort.put("containerPort", managementPort);
+        mgmtPort.put("name", MANAGEMENT_PORT_NAME);
+        mgmtPort.put("protocol", "TCP");
+
+        // Probes
+        addProbe(container, "startupProbe", managementPort, 5, 2, 30);
+        addProbe(container, "livenessProbe", managementPort, 30, 10, 3);
+        addProbe(container, "readinessProbe", managementPort, 5, 2, 5);
+
+        // Volume mount
+        ArrayNode volumeMounts = container.putArray("volumeMounts");
+        ObjectNode mount = volumeMounts.addObject();
+        mount.put("name", SIDECAR_VOLUME_NAME);
+        mount.put("mountPath", CONFIG_MOUNT_PATH);
+        mount.put("subPath", CONFIG_FILE_NAME);
+        mount.put("readOnly", true);
+
+        // Resources
+        if (spec.getResources() != null) {
+            try {
+                String resourcesJson = MAPPER.writeValueAsString(spec.getResources());
+                container.set("resources", MAPPER.readTree(resourcesJson));
+            }
+            catch (JsonProcessingException e) {
+                // Ignore resource serialization failures — sidecar will run without limits
+            }
+        }
+
+        container.put("terminationMessagePolicy", "FallbackToLogsOnError");
+
+        boolean hasContainers = pod.getSpec() != null
+                && pod.getSpec().getContainers() != null
+                && !pod.getSpec().getContainers().isEmpty();
+
+        if (hasContainers) {
+            addOp(patch, "add", "/spec/containers/-", container);
+        }
+        else {
+            ArrayNode containers = MAPPER.createArrayNode();
+            containers.add(container);
+            addOp(patch, "add", "/spec/containers", containers);
+        }
+    }
+
+    private static void addProbe(
+                                 ObjectNode container,
+                                 String probeName,
+                                 int port,
+                                 int initialDelay,
+                                 int period,
+                                 int failureThreshold) {
+
+        ObjectNode probe = container.putObject(probeName);
+        ObjectNode httpGet = probe.putObject("httpGet");
+        httpGet.put("path", "/livez");
+        httpGet.put("port", MANAGEMENT_PORT_NAME);
+        probe.put("initialDelaySeconds", initialDelay);
+        probe.put("periodSeconds", period);
+        probe.put("failureThreshold", failureThreshold);
+        probe.put("timeoutSeconds", 1);
+    }
+
+    private static void addBootstrapEnvVarOps(
+                                              ArrayNode patch,
+                                              Pod pod,
+                                              KroxyliciousSidecarConfigSpec spec,
+                                              int bootstrapPort) {
+
+        Boolean setEnvVar = spec.getSetBootstrapEnvVar();
+        if (setEnvVar != null && !setEnvVar) {
+            return;
+        }
+
+        if (pod.getSpec() == null || pod.getSpec().getContainers() == null) {
+            return;
+        }
+
+        String bootstrapValue = "localhost:" + bootstrapPort;
+        List<io.fabric8.kubernetes.api.model.Container> containers = pod.getSpec().getContainers();
+
+        for (int i = 0; i < containers.size(); i++) {
+            io.fabric8.kubernetes.api.model.Container c = containers.get(i);
+            // Don't set on the sidecar itself
+            if (InjectionDecision.SIDECAR_CONTAINER_NAME.equals(c.getName())) {
+                continue;
+            }
+
+            boolean hasEnv = c.getEnv() != null && !c.getEnv().isEmpty();
+            ObjectNode envVar = MAPPER.createObjectNode();
+            envVar.put("name", KAFKA_BOOTSTRAP_SERVERS_ENV);
+            envVar.put("value", bootstrapValue);
+
+            if (hasEnv) {
+                // Check if KAFKA_BOOTSTRAP_SERVERS is already set; if so, replace it
+                int existingIdx = findEnvVarIndex(c.getEnv(), KAFKA_BOOTSTRAP_SERVERS_ENV);
+                if (existingIdx >= 0) {
+                    addOp(patch, "replace",
+                            "/spec/containers/" + i + "/env/" + existingIdx + "/value",
+                            bootstrapValue);
+                }
+                else {
+                    addOp(patch, "add",
+                            "/spec/containers/" + i + "/env/-",
+                            envVar);
+                }
+            }
+            else {
+                ArrayNode envArray = MAPPER.createArrayNode();
+                envArray.add(envVar);
+                addOp(patch, "add",
+                        "/spec/containers/" + i + "/env",
+                        envArray);
+            }
+        }
+    }
+
+    private static int findEnvVarIndex(
+                                       List<io.fabric8.kubernetes.api.model.EnvVar> env,
+                                       String name) {
+        for (int i = 0; i < env.size(); i++) {
+            if (name.equals(env.get(i).getName())) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static void addSecurityContextOps(ArrayNode patch, Pod pod) {
+        if (pod.getSpec() == null) {
+            return;
+        }
+
+        if (pod.getSpec().getSecurityContext() == null) {
+            ObjectNode secCtx = MAPPER.createObjectNode();
+            secCtx.put("runAsNonRoot", true);
+            ObjectNode seccompProfile = secCtx.putObject("seccompProfile");
+            seccompProfile.put("type", "RuntimeDefault");
+            addOp(patch, "add", "/spec/securityContext", secCtx);
+        }
+    }
+
+    private static void addOp(ArrayNode patch, String op, String path, Object value) {
+        ObjectNode opNode = MAPPER.createObjectNode();
+        opNode.put("op", op);
+        opNode.put("path", path);
+        if (value instanceof String s) {
+            opNode.put("value", s);
+        }
+        else if (value instanceof com.fasterxml.jackson.databind.JsonNode jsonNode) {
+            opNode.set("value", jsonNode);
+        }
+        patch.add(opNode);
+    }
+
+    /**
+     * Escapes a string for use in a JSON Pointer (RFC 6901).
+     * {@code ~} is escaped as {@code ~0}, {@code /} is escaped as {@code ~1}.
+     */
+    static String escapeJsonPointer(String token) {
+        return token.replace("~", "~0").replace("/", "~1");
+    }
+}

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/ProxyConfigGenerator.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/ProxyConfigGenerator.java
@@ -99,6 +99,7 @@ class ProxyConfigGenerator {
                 null,
                 false,
                 Optional.empty(),
+                null,
                 null);
 
         return toYaml(configuration);

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/ProxyConfigGenerator.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/ProxyConfigGenerator.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Optional;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfigSpec;
+import io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.NodeIdRange;
+import io.kroxylicious.proxy.config.ConfigParser;
+import io.kroxylicious.proxy.config.Configuration;
+import io.kroxylicious.proxy.config.NamedRange;
+import io.kroxylicious.proxy.config.PortIdentifiesNodeIdentificationStrategy;
+import io.kroxylicious.proxy.config.TargetCluster;
+import io.kroxylicious.proxy.config.VirtualCluster;
+import io.kroxylicious.proxy.config.VirtualClusterGateway;
+import io.kroxylicious.proxy.config.admin.ManagementConfiguration;
+import io.kroxylicious.proxy.service.HostPort;
+
+/**
+ * Generates proxy configuration YAML for the sidecar container from a
+ * {@link KroxyliciousSidecarConfigSpec}.
+ */
+class ProxyConfigGenerator {
+
+    private static final String VIRTUAL_CLUSTER_NAME = "sidecar";
+    private static final String GATEWAY_NAME = "local";
+    private static final String LOCALHOST = "localhost";
+    private static final int DEFAULT_BOOTSTRAP_PORT = 19092;
+    private static final int DEFAULT_MANAGEMENT_PORT = 9190;
+    private static final int DEFAULT_NODE_ID_START = 0;
+    private static final int DEFAULT_NODE_ID_END = 2;
+
+    private ProxyConfigGenerator() {
+    }
+
+    /**
+     * Generates proxy configuration YAML for a sidecar.
+     *
+     * @param spec the sidecar config spec from the CRD
+     * @return YAML string suitable for passing to the proxy via {@code --config}
+     */
+    static String generateConfig(KroxyliciousSidecarConfigSpec spec) {
+        int bootstrapPort = resolveBootstrapPort(spec);
+        int managementPort = resolveManagementPort(spec);
+        int nodeIdStart = DEFAULT_NODE_ID_START;
+        int nodeIdEnd = DEFAULT_NODE_ID_END;
+
+        NodeIdRange nodeIdRange = spec.getNodeIdRange();
+        if (nodeIdRange != null) {
+            if (nodeIdRange.getStartInclusive() != null) {
+                nodeIdStart = nodeIdRange.getStartInclusive().intValue();
+            }
+            if (nodeIdRange.getEndInclusive() != null) {
+                nodeIdEnd = nodeIdRange.getEndInclusive().intValue();
+            }
+        }
+
+        var portStrategy = new PortIdentifiesNodeIdentificationStrategy(
+                new HostPort(LOCALHOST, bootstrapPort),
+                LOCALHOST,
+                bootstrapPort + 1,
+                List.of(new NamedRange("default", nodeIdStart, nodeIdEnd)));
+
+        var gateway = new VirtualClusterGateway(
+                GATEWAY_NAME,
+                portStrategy,
+                null,
+                Optional.empty());
+
+        var targetCluster = new TargetCluster(
+                spec.getUpstreamBootstrapServers(),
+                Optional.empty());
+
+        var virtualCluster = new VirtualCluster(
+                VIRTUAL_CLUSTER_NAME,
+                targetCluster,
+                List.of(gateway),
+                false,
+                false,
+                null);
+
+        var management = new ManagementConfiguration(
+                "0.0.0.0",
+                managementPort,
+                null);
+
+        var configuration = new Configuration(
+                management,
+                null,
+                null,
+                List.of(virtualCluster),
+                null,
+                false,
+                Optional.empty(),
+                null);
+
+        return toYaml(configuration);
+    }
+
+    static int resolveBootstrapPort(KroxyliciousSidecarConfigSpec spec) {
+        Long port = spec.getBootstrapPort();
+        return port != null ? port.intValue() : DEFAULT_BOOTSTRAP_PORT;
+    }
+
+    static int resolveManagementPort(KroxyliciousSidecarConfigSpec spec) {
+        Long port = spec.getManagementPort();
+        return port != null ? port.intValue() : DEFAULT_MANAGEMENT_PORT;
+    }
+
+    private static String toYaml(Configuration configuration) {
+        try {
+            return ConfigParser.createObjectMapper()
+                    .writeValueAsString(configuration)
+                    .stripTrailing();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/SidecarConfigResolver.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/SidecarConfigResolver.java
@@ -78,8 +78,8 @@ class SidecarConfigResolver implements Closeable {
             KroxyliciousSidecarConfig config = nsConfigs.get(configName);
             if (config == null) {
                 LOGGER.atWarn()
-                        .addKeyValue("namespace", namespace)
-                        .addKeyValue("name", configName)
+                        .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
+                        .addKeyValue(WebhookLoggingKeys.NAME, configName)
                         .log("KroxyliciousSidecarConfig not found");
             }
             return Optional.ofNullable(config);
@@ -91,12 +91,12 @@ class SidecarConfigResolver implements Closeable {
 
         if (nsConfigs.isEmpty()) {
             LOGGER.atDebug()
-                    .addKeyValue("namespace", namespace)
+                    .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
                     .log("No KroxyliciousSidecarConfig found in namespace");
         }
         else {
             LOGGER.atWarn()
-                    .addKeyValue("namespace", namespace)
+                    .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
                     .addKeyValue("count", nsConfigs.size())
                     .log("Multiple KroxyliciousSidecarConfig resources found, explicit annotation required");
         }
@@ -142,8 +142,8 @@ class SidecarConfigResolver implements Closeable {
         public void onAdd(KroxyliciousSidecarConfig obj) {
             put(obj);
             LOGGER.atInfo()
-                    .addKeyValue("namespace", obj.getMetadata().getNamespace())
-                    .addKeyValue("name", obj.getMetadata().getName())
+                    .addKeyValue(WebhookLoggingKeys.NAMESPACE, obj.getMetadata().getNamespace())
+                    .addKeyValue(WebhookLoggingKeys.NAME, obj.getMetadata().getName())
                     .log("KroxyliciousSidecarConfig added");
         }
 
@@ -153,8 +153,8 @@ class SidecarConfigResolver implements Closeable {
                              KroxyliciousSidecarConfig newObj) {
             put(newObj);
             LOGGER.atInfo()
-                    .addKeyValue("namespace", newObj.getMetadata().getNamespace())
-                    .addKeyValue("name", newObj.getMetadata().getName())
+                    .addKeyValue(WebhookLoggingKeys.NAMESPACE, newObj.getMetadata().getNamespace())
+                    .addKeyValue(WebhookLoggingKeys.NAME, newObj.getMetadata().getName())
                     .log("KroxyliciousSidecarConfig updated");
         }
 
@@ -164,8 +164,8 @@ class SidecarConfigResolver implements Closeable {
                              boolean deletedFinalStateUnknown) {
             remove(obj);
             LOGGER.atInfo()
-                    .addKeyValue("namespace", obj.getMetadata().getNamespace())
-                    .addKeyValue("name", obj.getMetadata().getName())
+                    .addKeyValue(WebhookLoggingKeys.NAMESPACE, obj.getMetadata().getNamespace())
+                    .addKeyValue(WebhookLoggingKeys.NAME, obj.getMetadata().getName())
                     .log("KroxyliciousSidecarConfig deleted");
         }
     }

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/SidecarConfigResolver.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/SidecarConfigResolver.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+import java.io.Closeable;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
+import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfig;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Watches {@link KroxyliciousSidecarConfig} resources and maintains an in-memory
+ * cache for resolving the config applicable to a given namespace.
+ */
+class SidecarConfigResolver implements Closeable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SidecarConfigResolver.class);
+
+    // namespace -> (name -> config)
+    private final Map<String, Map<String, KroxyliciousSidecarConfig>> cache = new ConcurrentHashMap<>();
+    @Nullable
+    private final SharedIndexInformer<KroxyliciousSidecarConfig> informer;
+
+    /**
+     * Creates a resolver that watches all namespaces using the given client.
+     */
+    SidecarConfigResolver(@NonNull KubernetesClient client) {
+        this.informer = client.resources(KroxyliciousSidecarConfig.class)
+                .inAnyNamespace()
+                .inform(new Handler());
+    }
+
+    /**
+     * Creates a resolver with no informer, for testing.
+     */
+    SidecarConfigResolver() {
+        this.informer = null;
+    }
+
+    /**
+     * Resolves the sidecar config for the given namespace.
+     *
+     * <p>Resolution strategy:
+     * <ol>
+     *   <li>If {@code configName} is non-null, look up by exact name.</li>
+     *   <li>If exactly one config exists in the namespace, use it.</li>
+     *   <li>Otherwise, return empty.</li>
+     * </ol>
+     *
+     * @param namespace the pod's namespace
+     * @param configName optional explicit config name from pod annotation
+     * @return the resolved config, or empty
+     */
+    @NonNull
+    Optional<KroxyliciousSidecarConfig> resolve(
+                                                @NonNull String namespace,
+                                                @Nullable String configName) {
+
+        Map<String, KroxyliciousSidecarConfig> nsConfigs = cache.getOrDefault(namespace, Map.of());
+
+        if (configName != null) {
+            KroxyliciousSidecarConfig config = nsConfigs.get(configName);
+            if (config == null) {
+                LOGGER.atWarn()
+                        .addKeyValue("namespace", namespace)
+                        .addKeyValue("name", configName)
+                        .log("KroxyliciousSidecarConfig not found");
+            }
+            return Optional.ofNullable(config);
+        }
+
+        if (nsConfigs.size() == 1) {
+            return Optional.of(nsConfigs.values().iterator().next());
+        }
+
+        if (nsConfigs.isEmpty()) {
+            LOGGER.atDebug()
+                    .addKeyValue("namespace", namespace)
+                    .log("No KroxyliciousSidecarConfig found in namespace");
+        }
+        else {
+            LOGGER.atWarn()
+                    .addKeyValue("namespace", namespace)
+                    .addKeyValue("count", nsConfigs.size())
+                    .log("Multiple KroxyliciousSidecarConfig resources found, explicit annotation required");
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Adds a config to the cache directly, for testing.
+     */
+    void put(@NonNull KroxyliciousSidecarConfig config) {
+        String ns = config.getMetadata().getNamespace();
+        String name = config.getMetadata().getName();
+        cache.computeIfAbsent(ns, k -> new ConcurrentHashMap<>()).put(name, config);
+    }
+
+    @Override
+    public void close() {
+        if (informer != null) {
+            informer.close();
+        }
+    }
+
+    private class Handler implements ResourceEventHandler<KroxyliciousSidecarConfig> {
+
+        @Override
+        public void onAdd(KroxyliciousSidecarConfig obj) {
+            put(obj);
+            LOGGER.atInfo()
+                    .addKeyValue("namespace", obj.getMetadata().getNamespace())
+                    .addKeyValue("name", obj.getMetadata().getName())
+                    .log("KroxyliciousSidecarConfig added");
+        }
+
+        @Override
+        public void onUpdate(
+                             KroxyliciousSidecarConfig oldObj,
+                             KroxyliciousSidecarConfig newObj) {
+            put(newObj);
+            LOGGER.atInfo()
+                    .addKeyValue("namespace", newObj.getMetadata().getNamespace())
+                    .addKeyValue("name", newObj.getMetadata().getName())
+                    .log("KroxyliciousSidecarConfig updated");
+        }
+
+        @Override
+        public void onDelete(
+                             KroxyliciousSidecarConfig obj,
+                             boolean deletedFinalStateUnknown) {
+            String ns = obj.getMetadata().getNamespace();
+            String name = obj.getMetadata().getName();
+            Map<String, KroxyliciousSidecarConfig> nsConfigs = cache.get(ns);
+            if (nsConfigs != null) {
+                nsConfigs.remove(name);
+                if (nsConfigs.isEmpty()) {
+                    cache.remove(ns);
+                }
+            }
+            LOGGER.atInfo()
+                    .addKeyValue("namespace", ns)
+                    .addKeyValue("name", name)
+                    .log("KroxyliciousSidecarConfig deleted");
+        }
+    }
+}

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/SidecarConfigResolver.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/SidecarConfigResolver.java
@@ -44,6 +44,7 @@ class SidecarConfigResolver implements Closeable {
         this.informer = client.resources(KroxyliciousSidecarConfig.class)
                 .inAnyNamespace()
                 .inform(new Handler());
+        // TODO comment that this blocks, because that's necessary to avoid a race condition during startup
     }
 
     /**

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/SidecarConfigResolver.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/SidecarConfigResolver.java
@@ -19,6 +19,7 @@ import io.fabric8.kubernetes.client.informers.ResourceEventHandler;
 import io.fabric8.kubernetes.client.informers.SharedIndexInformer;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfig;
+import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -105,10 +106,27 @@ class SidecarConfigResolver implements Closeable {
     /**
      * Adds a config to the cache directly, for testing.
      */
+    @VisibleForTesting
     void put(@NonNull KroxyliciousSidecarConfig config) {
         String ns = config.getMetadata().getNamespace();
         String name = config.getMetadata().getName();
         cache.computeIfAbsent(ns, k -> new ConcurrentHashMap<>()).put(name, config);
+    }
+
+    /**
+     * Removes a config from the cache, for testing.
+     */
+    @VisibleForTesting
+    void remove(@NonNull KroxyliciousSidecarConfig config) {
+        String ns = config.getMetadata().getNamespace();
+        String name = config.getMetadata().getName();
+        Map<String, KroxyliciousSidecarConfig> nsConfigs = cache.get(ns);
+        if (nsConfigs != null) {
+            nsConfigs.remove(name);
+            if (nsConfigs.isEmpty()) {
+                cache.remove(ns);
+            }
+        }
     }
 
     @Override
@@ -144,18 +162,10 @@ class SidecarConfigResolver implements Closeable {
         public void onDelete(
                              KroxyliciousSidecarConfig obj,
                              boolean deletedFinalStateUnknown) {
-            String ns = obj.getMetadata().getNamespace();
-            String name = obj.getMetadata().getName();
-            Map<String, KroxyliciousSidecarConfig> nsConfigs = cache.get(ns);
-            if (nsConfigs != null) {
-                nsConfigs.remove(name);
-                if (nsConfigs.isEmpty()) {
-                    cache.remove(ns);
-                }
-            }
+            remove(obj);
             LOGGER.atInfo()
-                    .addKeyValue("namespace", ns)
-                    .addKeyValue("name", name)
+                    .addKeyValue("namespace", obj.getMetadata().getNamespace())
+                    .addKeyValue("name", obj.getMetadata().getName())
                     .log("KroxyliciousSidecarConfig deleted");
         }
     }

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookLoggingKeys.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookLoggingKeys.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+public class WebhookLoggingKeys {
+
+    static final String NAMESPACE = "namespace";
+
+    static final String NAME = "name";
+
+    private WebhookLoggingKeys() {
+    }
+
+}

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
@@ -19,6 +19,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 
 import io.kroxylicious.proxy.service.HostPort;
+import io.kroxylicious.proxy.tag.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -117,17 +118,19 @@ public class WebhookMain {
         LOGGER.atInfo().log("Webhook stopped");
     }
 
+    @VisibleForTesting
     @NonNull
-    private static InetSocketAddress parseBindAddress(@NonNull Map<String, String> env) {
+    static InetSocketAddress parseBindAddress(@NonNull Map<String, String> env) {
         String bindAddress = env.getOrDefault(BIND_ADDRESS_VAR, DEFAULT_BIND_ADDRESS);
         HostPort hostPort = HostPort.parse(bindAddress);
         return new InetSocketAddress(hostPort.host(), hostPort.port());
     }
 
+    @VisibleForTesting
     @NonNull
-    private static String requiredEnv(
-                                      @NonNull Map<String, String> env,
-                                      @NonNull String name) {
+    static String requiredEnv(
+                              @NonNull Map<String, String> env,
+                              @NonNull String name) {
         String value = env.get(name);
         if (value == null || value.isBlank()) {
             throw new IllegalStateException("Required environment variable " + name + " is not set");

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+
+import io.kroxylicious.proxy.service.HostPort;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Entrypoint for the Kroxylicious sidecar injection webhook.
+ */
+public class WebhookMain {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WebhookMain.class);
+
+    private static final String BIND_ADDRESS_VAR = "BIND_ADDRESS";
+    private static final String TLS_CERT_PATH_VAR = "TLS_CERT_PATH";
+    private static final String TLS_KEY_PATH_VAR = "TLS_KEY_PATH";
+    private static final String KROXYLICIOUS_IMAGE_VAR = "KROXYLICIOUS_IMAGE";
+
+    private static final String DEFAULT_BIND_ADDRESS = "0.0.0.0:8443";
+    private static final String DEFAULT_CERT_PATH = "/etc/webhook/tls/tls.crt";
+    private static final String DEFAULT_KEY_PATH = "/etc/webhook/tls/tls.key";
+
+    private final WebhookServer server;
+    private final SidecarConfigResolver configResolver;
+    private final KubernetesClient kubeClient;
+
+    WebhookMain(
+                @NonNull WebhookServer server,
+                @NonNull SidecarConfigResolver configResolver,
+                @NonNull KubernetesClient kubeClient) {
+        this.server = server;
+        this.configResolver = configResolver;
+        this.kubeClient = kubeClient;
+    }
+
+    public static void main(String[] args) {
+        try {
+            WebhookMain webhook = create();
+            webhook.start();
+        }
+        catch (Exception e) {
+            LOGGER.atError()
+                    .setCause(e)
+                    .log("Webhook has thrown exception during startup, will now exit");
+            System.exit(1);
+        }
+    }
+
+    @NonNull
+    static WebhookMain create() throws IOException, GeneralSecurityException {
+        Map<String, String> env = System.getenv();
+
+        InetSocketAddress bindAddress = parseBindAddress(env);
+        Path certPath = Path.of(env.getOrDefault(TLS_CERT_PATH_VAR, DEFAULT_CERT_PATH));
+        Path keyPath = Path.of(env.getOrDefault(TLS_KEY_PATH_VAR, DEFAULT_KEY_PATH));
+        String proxyImage = requiredEnv(env, KROXYLICIOUS_IMAGE_VAR);
+
+        KubernetesClient kubeClient = new KubernetesClientBuilder().build();
+        SidecarConfigResolver configResolver = new SidecarConfigResolver(kubeClient);
+        AdmissionHandler admissionHandler = new AdmissionHandler(configResolver, proxyImage);
+        WebhookServer server = new WebhookServer(bindAddress, certPath, keyPath, admissionHandler);
+
+        return new WebhookMain(server, configResolver, kubeClient);
+    }
+
+    void start() {
+        Runtime.getRuntime().addShutdownHook(new Thread(this::stop, "webhook-shutdown"));
+        server.start();
+        LOGGER.atInfo()
+                .addKeyValue("javaVersion", Runtime::version)
+                .log("Webhook started");
+    }
+
+    void stop() {
+        try {
+            server.close();
+        }
+        catch (Exception e) {
+            LOGGER.atError()
+                    .setCause(e)
+                    .log("Error stopping webhook server");
+        }
+        try {
+            configResolver.close();
+        }
+        catch (Exception e) {
+            LOGGER.atError()
+                    .setCause(e)
+                    .log("Error closing config resolver");
+        }
+        try {
+            kubeClient.close();
+        }
+        catch (Exception e) {
+            LOGGER.atError()
+                    .setCause(e)
+                    .log("Error closing Kubernetes client");
+        }
+        LOGGER.atInfo().log("Webhook stopped");
+    }
+
+    @NonNull
+    private static InetSocketAddress parseBindAddress(@NonNull Map<String, String> env) {
+        String bindAddress = env.getOrDefault(BIND_ADDRESS_VAR, DEFAULT_BIND_ADDRESS);
+        HostPort hostPort = HostPort.parse(bindAddress);
+        return new InetSocketAddress(hostPort.host(), hostPort.port());
+    }
+
+    @NonNull
+    private static String requiredEnv(
+                                      @NonNull Map<String, String> env,
+                                      @NonNull String name) {
+        String value = env.get(name);
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException("Required environment variable " + name + " is not set");
+        }
+        return value;
+    }
+}

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookServer.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookServer.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.List;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sun.net.httpserver.HttpsConfigurator;
+import com.sun.net.httpserver.HttpsServer;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * An HTTPS server hosting the admission webhook endpoint.
+ */
+class WebhookServer implements Closeable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WebhookServer.class);
+
+    private final HttpsServer server;
+
+    WebhookServer(
+                  @NonNull InetSocketAddress bindAddress,
+                  @NonNull Path certPath,
+                  @NonNull Path keyPath,
+                  @NonNull AdmissionHandler admissionHandler)
+            throws IOException, GeneralSecurityException {
+
+        SSLContext sslContext = createSslContext(certPath, keyPath);
+        server = HttpsServer.create(bindAddress, 0);
+        server.setHttpsConfigurator(new HttpsConfigurator(sslContext));
+
+        server.createContext("/mutate", admissionHandler);
+        server.createContext("/livez", exchange -> {
+            try (exchange) {
+                exchange.sendResponseHeaders(200, -1);
+            }
+        });
+
+        LOGGER.atInfo()
+                .addKeyValue("interface", bindAddress.getHostString())
+                .addKeyValue("port", bindAddress.getPort())
+                .log("Webhook server configured");
+    }
+
+    void start() {
+        server.start();
+        LOGGER.atInfo().log("Webhook server started");
+    }
+
+    @Override
+    public void close() {
+        server.stop(5);
+        LOGGER.atInfo().log("Webhook server stopped");
+    }
+
+    @NonNull
+    static SSLContext createSslContext(
+                                       @NonNull Path certPath,
+                                       @NonNull Path keyPath)
+            throws GeneralSecurityException, IOException {
+
+        CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
+
+        // Load certificate chain
+        Collection<? extends Certificate> certs;
+        try (InputStream certStream = Files.newInputStream(certPath)) {
+            certs = certFactory.generateCertificates(certStream);
+        }
+
+        // Load private key
+        PrivateKey privateKey = loadPrivateKey(keyPath);
+
+        // Build keystore
+        KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        keyStore.load(null, null);
+        keyStore.setKeyEntry("webhook",
+                privateKey,
+                new char[0],
+                certs.toArray(new Certificate[0]));
+
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(keyStore, new char[0]);
+
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(kmf.getKeyManagers(), null, null);
+        return sslContext;
+    }
+
+    @NonNull
+    private static PrivateKey loadPrivateKey(@NonNull Path keyPath) throws IOException, GeneralSecurityException {
+        String keyPem = Files.readString(keyPath);
+        // Strip PEM headers/footers and whitespace
+        String keyBase64 = keyPem
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replace("-----END PRIVATE KEY-----", "")
+                .replace("-----BEGIN RSA PRIVATE KEY-----", "")
+                .replace("-----END RSA PRIVATE KEY-----", "")
+                .replace("-----BEGIN EC PRIVATE KEY-----", "")
+                .replace("-----END EC PRIVATE KEY-----", "")
+                .replaceAll("\\s", "");
+
+        byte[] keyBytes = Base64.getDecoder().decode(keyBase64);
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
+
+        // Try RSA first, then EC
+        for (String algorithm : List.of("RSA", "EC")) {
+            try {
+                return KeyFactory.getInstance(algorithm).generatePrivate(keySpec);
+            }
+            catch (GeneralSecurityException ignored) {
+                // Try next algorithm
+            }
+        }
+        throw new GeneralSecurityException("Unable to load private key from " + keyPath + " — unsupported key type");
+    }
+}

--- a/kroxylicious-kubernetes-web-hook/src/main/resources/log4j2.yaml
+++ b/kroxylicious-kubernetes-web-hook/src/main/resources/log4j2.yaml
@@ -1,0 +1,51 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+Configuration:
+  status: WARN
+  name: Config
+  Appenders:
+    Console:
+      - name: STDOUT-PATTERN
+        target: SYSTEM_OUT
+        PatternLayout:
+          pattern: "%d{yyyy-MM-dd HH:mm:ss} %-5p <%t> %c{2.}:%L - %m%replace{ %mdc}{' $'}{}%n"
+      - name: STDOUT-JSON
+        target: SYSTEM_OUT
+        JsonTemplateLayout:
+          eventTemplateUri: "classpath:LogstashJsonEventLayoutV1.json"
+    Routing:
+      name: STDOUT
+      Routes:
+        pattern: "${env:KROXYLICIOUS_LOG_FORMAT:-text}"
+        Route:
+          - key: json
+            ref: STDOUT-JSON
+          - key: text
+            ref: STDOUT-PATTERN
+  Loggers:
+    Root:
+      level: "${env:KROXYLICIOUS_ROOT_LOG_LEVEL:-WARN}"
+      additivity: false
+      AppenderRef:
+        - ref: STDOUT
+    Logger:
+      - name: io.kroxylicious
+        level: "${env:KROXYLICIOUS_APP_LOG_LEVEL:-${env:KROXYLICIOUS_ROOT_LOG_LEVEL:-INFO}}"
+        additivity: false
+        AppenderRef:
+          - ref: STDOUT
+      - name: io.fabric8
+        level: INFO
+        additivity: false
+        AppenderRef:
+          - ref: STDOUT
+      - name: io.fabric8.kubernetes.client.http
+        level: INFO
+        additivity: false
+        AppenderRef:
+          - ref: STDOUT

--- a/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AdmissionHandlerTest.java
+++ b/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AdmissionHandlerTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.admission.v1.AdmissionRequest;
+import io.fabric8.kubernetes.api.model.admission.v1.AdmissionResponse;
+import io.fabric8.kubernetes.api.model.admission.v1.AdmissionReview;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfig;
+import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfigSpec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdmissionHandlerTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String PROXY_IMAGE = "quay.io/kroxylicious/kroxylicious:latest";
+
+    @Mock
+    private SidecarConfigResolver configResolver;
+
+    private AdmissionHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new AdmissionHandler(configResolver, PROXY_IMAGE);
+    }
+
+    @Test
+    void allowsWhenRequestIsNull() {
+        AdmissionReview review = new AdmissionReview();
+        AdmissionResponse response = handler.processReview(review);
+
+        assertThat(response.getAllowed()).isTrue();
+        assertThat(response.getPatch()).isNull();
+    }
+
+    @Test
+    void allowsWhenPodObjectIsNull() {
+        AdmissionReview review = reviewWithPod(null, "test-ns");
+        AdmissionResponse response = handler.processReview(review);
+
+        assertThat(response.getAllowed()).isTrue();
+        assertThat(response.getPatch()).isNull();
+    }
+
+    @Test
+    void allowsAndPatchesWhenConfigExists() {
+        KroxyliciousSidecarConfig config = sidecarConfig("test-ns", "config");
+        when(configResolver.resolve("test-ns", null)).thenReturn(Optional.of(config));
+
+        AdmissionReview review = reviewWithPod(minimalPod(), "test-ns");
+        AdmissionResponse response = handler.processReview(review);
+
+        assertThat(response.getAllowed()).isTrue();
+        assertThat(response.getPatch()).isNotNull();
+        assertThat(response.getPatchType()).isEqualTo("JSONPatch");
+    }
+
+    @Test
+    void allowsWithoutPatchWhenNoConfig() {
+        when(configResolver.resolve(eq("test-ns"), isNull())).thenReturn(Optional.empty());
+
+        AdmissionReview review = reviewWithPod(minimalPod(), "test-ns");
+        AdmissionResponse response = handler.processReview(review);
+
+        assertThat(response.getAllowed()).isTrue();
+        assertThat(response.getPatch()).isNull();
+    }
+
+    @Test
+    void allowsWithoutPatchWhenOptedOut() {
+        Pod pod = minimalPod();
+        pod.getMetadata().setAnnotations(
+                new HashMap<>(Map.of(Annotations.INJECT_SIDECAR, "false")));
+
+        // Config resolver should still be called, but injection is skipped
+        when(configResolver.resolve(eq("test-ns"), isNull())).thenReturn(Optional.of(sidecarConfig("test-ns", "config")));
+
+        AdmissionReview review = reviewWithPod(pod, "test-ns");
+        AdmissionResponse response = handler.processReview(review);
+
+        assertThat(response.getAllowed()).isTrue();
+        assertThat(response.getPatch()).isNull();
+    }
+
+    @Test
+    void usesExplicitConfigName() {
+        KroxyliciousSidecarConfig config = sidecarConfig("test-ns", "my-config");
+        when(configResolver.resolve("test-ns", "my-config")).thenReturn(Optional.of(config));
+
+        Pod pod = minimalPod();
+        pod.getMetadata().setAnnotations(
+                new HashMap<>(Map.of(Annotations.SIDECAR_CONFIG, "my-config")));
+
+        AdmissionReview review = reviewWithPod(pod, "test-ns");
+        AdmissionResponse response = handler.processReview(review);
+
+        assertThat(response.getAllowed()).isTrue();
+        assertThat(response.getPatch()).isNotNull();
+    }
+
+    @Test
+    void preservesUidInResponse() {
+        when(configResolver.resolve(any(), isNull())).thenReturn(Optional.empty());
+
+        AdmissionReview review = reviewWithPod(minimalPod(), "test-ns");
+        review.getRequest().setUid("test-uid-123");
+
+        AdmissionResponse response = handler.processReview(review);
+        assertThat(response.getUid()).isEqualTo("test-uid-123");
+    }
+
+    @Test
+    void failsOpenOnException() {
+        when(configResolver.resolve(any(), isNull())).thenThrow(new RuntimeException("kaboom"));
+
+        AdmissionReview review = reviewWithPod(minimalPod(), "test-ns");
+        AdmissionResponse response = handler.processReview(review);
+
+        assertThat(response.getAllowed()).isTrue();
+        assertThat(response.getPatch()).isNull();
+    }
+
+    @Test
+    void usesProxyImageFromConfig() {
+        KroxyliciousSidecarConfig config = sidecarConfig("test-ns", "config");
+        config.getSpec().setProxyImage("custom-image:v1");
+        when(configResolver.resolve("test-ns", null)).thenReturn(Optional.of(config));
+
+        AdmissionReview review = reviewWithPod(minimalPod(), "test-ns");
+        AdmissionResponse response = handler.processReview(review);
+
+        assertThat(response.getAllowed()).isTrue();
+        assertThat(response.getPatch()).isNotNull();
+        // The patch should contain the custom image — decode and verify
+        String patchJson = new String(java.util.Base64.getDecoder().decode(response.getPatch()));
+        assertThat(patchJson).contains("custom-image:v1");
+    }
+
+    private static AdmissionReview reviewWithPod(Pod pod, String namespace) {
+        AdmissionReview review = new AdmissionReview();
+        AdmissionRequest request = new AdmissionRequest();
+        request.setUid("uid-" + System.nanoTime());
+        request.setNamespace(namespace);
+        if (pod != null) {
+            request.setObject(MAPPER.valueToTree(pod));
+        }
+        review.setRequest(request);
+        return review;
+    }
+
+    private static Pod minimalPod() {
+        Pod pod = new Pod();
+        ObjectMeta meta = new ObjectMeta();
+        meta.setName("test-pod");
+        pod.setMetadata(meta);
+        PodSpec spec = new PodSpec();
+        spec.setContainers(new java.util.ArrayList<>());
+        pod.setSpec(spec);
+        return pod;
+    }
+
+    private static KroxyliciousSidecarConfig sidecarConfig(
+                                                           String namespace,
+                                                           String name) {
+        KroxyliciousSidecarConfig config = new KroxyliciousSidecarConfig();
+        ObjectMeta meta = new ObjectMeta();
+        meta.setNamespace(namespace);
+        meta.setName(name);
+        config.setMetadata(meta);
+        KroxyliciousSidecarConfigSpec spec = new KroxyliciousSidecarConfigSpec();
+        spec.setUpstreamBootstrapServers("kafka.example.com:9092");
+        config.setSpec(spec);
+        return config;
+    }
+}

--- a/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AdmissionHandlerTest.java
+++ b/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AdmissionHandlerTest.java
@@ -6,6 +6,10 @@
 
 package io.kroxylicious.kubernetes.webhook;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -13,10 +17,15 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -32,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -49,6 +59,8 @@ class AdmissionHandlerTest {
     void setUp() {
         handler = new AdmissionHandler(configResolver, PROXY_IMAGE);
     }
+
+    // --- processReview() tests ---
 
     @Test
     void allowsWhenRequestIsNull() {
@@ -160,6 +172,109 @@ class AdmissionHandlerTest {
         // The patch should contain the custom image — decode and verify
         String patchJson = new String(java.util.Base64.getDecoder().decode(response.getPatch()));
         assertThat(patchJson).contains("custom-image:v1");
+    }
+
+    @Test
+    void processReviewHandlesPodWithGenerateNameButNoName() {
+        when(configResolver.resolve(eq("test-ns"), isNull())).thenReturn(Optional.empty());
+
+        Pod pod = new Pod();
+        ObjectMeta meta = new ObjectMeta();
+        meta.setGenerateName("my-deployment-");
+        pod.setMetadata(meta);
+        PodSpec spec = new PodSpec();
+        spec.setContainers(new java.util.ArrayList<>());
+        pod.setSpec(spec);
+
+        AdmissionReview review = reviewWithPod(pod, "test-ns");
+        AdmissionResponse response = handler.processReview(review);
+
+        assertThat(response.getAllowed()).isTrue();
+    }
+
+    @Test
+    void processReviewHandlesPodWithNullMetadata() {
+        Pod pod = new Pod();
+
+        AdmissionReview review = reviewWithPod(pod, "test-ns");
+        AdmissionResponse response = handler.processReview(review);
+
+        assertThat(response.getAllowed()).isTrue();
+    }
+
+    // --- handle(HttpExchange) tests ---
+
+    @ParameterizedTest
+    @ValueSource(strings = { "GET", "PUT", "DELETE", "PATCH" })
+    void handleRejectsNonPostMethods(String method) throws IOException {
+        HttpExchange exchange = createMockExchange(method, new byte[0]);
+
+        handler.handle(exchange);
+
+        verify(exchange).sendResponseHeaders(405, -1);
+    }
+
+    @Test
+    void handlePostReturnsAdmissionReviewResponse() throws IOException {
+        when(configResolver.resolve(eq("test-ns"), isNull())).thenReturn(Optional.empty());
+
+        AdmissionReview review = reviewWithPod(minimalPod(), "test-ns");
+        byte[] requestBody = MAPPER.writeValueAsBytes(review);
+        HttpExchange exchange = createMockExchange("POST", requestBody);
+
+        handler.handle(exchange);
+
+        ByteArrayOutputStream responseBody = (ByteArrayOutputStream) exchange.getResponseBody();
+        JsonNode responseJson = MAPPER.readTree(responseBody.toByteArray());
+
+        assertThat(responseJson.get("apiVersion").asText()).isEqualTo("admission.k8s.io/v1");
+        assertThat(responseJson.get("kind").asText()).isEqualTo("AdmissionReview");
+        assertThat(responseJson.get("response").get("allowed").asBoolean()).isTrue();
+        assertThat(exchange.getResponseHeaders().getFirst("Content-Type"))
+                .isEqualTo("application/json");
+    }
+
+    @Test
+    void handleFailsOpenOnDeserialisationError() throws IOException {
+        HttpExchange exchange = createMockExchange("POST", "not json".getBytes(StandardCharsets.UTF_8));
+
+        handler.handle(exchange);
+
+        ByteArrayOutputStream responseBody = (ByteArrayOutputStream) exchange.getResponseBody();
+        JsonNode responseJson = MAPPER.readTree(responseBody.toByteArray());
+
+        assertThat(responseJson.get("response").get("allowed").asBoolean()).isTrue();
+    }
+
+    @Test
+    void handleFailsOpenOnProcessReviewException() throws IOException {
+        when(configResolver.resolve(any(), isNull())).thenThrow(new RuntimeException("kaboom"));
+
+        AdmissionReview review = reviewWithPod(minimalPod(), "test-ns");
+        byte[] requestBody = MAPPER.writeValueAsBytes(review);
+        HttpExchange exchange = createMockExchange("POST", requestBody);
+
+        handler.handle(exchange);
+
+        ByteArrayOutputStream responseBody = (ByteArrayOutputStream) exchange.getResponseBody();
+        JsonNode responseJson = MAPPER.readTree(responseBody.toByteArray());
+
+        assertThat(responseJson.get("response").get("allowed").asBoolean()).isTrue();
+    }
+
+    // --- helpers ---
+
+    private static HttpExchange createMockExchange(
+                                                   String method,
+                                                   byte[] body) {
+        HttpExchange exchange = org.mockito.Mockito.mock(HttpExchange.class);
+        org.mockito.Mockito.lenient().when(exchange.getRequestMethod()).thenReturn(method);
+        org.mockito.Mockito.lenient().when(exchange.getRequestBody()).thenReturn(new ByteArrayInputStream(body));
+        ByteArrayOutputStream responseBody = new ByteArrayOutputStream();
+        org.mockito.Mockito.lenient().when(exchange.getResponseBody()).thenReturn(responseBody);
+        Headers headers = new Headers();
+        org.mockito.Mockito.lenient().when(exchange.getResponseHeaders()).thenReturn(headers);
+        return exchange;
     }
 
     private static AdmissionReview reviewWithPod(Pod pod, String namespace) {

--- a/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/InjectionDecisionTest.java
+++ b/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/InjectionDecisionTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InjectionDecisionTest {
+
+    @Test
+    void shouldInjectWhenConfigAvailableAndNotOptedOut() {
+        Pod pod = podWithAnnotations(Map.of());
+        assertThat(InjectionDecision.evaluate(pod, true)).isEqualTo(InjectionDecision.Decision.INJECT);
+    }
+
+    @Test
+    void shouldInjectWhenNoAnnotations() {
+        Pod pod = new Pod();
+        pod.setMetadata(new ObjectMeta());
+        pod.setSpec(new PodSpec());
+        assertThat(InjectionDecision.evaluate(pod, true)).isEqualTo(InjectionDecision.Decision.INJECT);
+    }
+
+    @Test
+    void shouldSkipWhenOptedOut() {
+        Pod pod = podWithAnnotations(Map.of(Annotations.INJECT_SIDECAR, "false"));
+        assertThat(InjectionDecision.evaluate(pod, true)).isEqualTo(InjectionDecision.Decision.SKIP_OPT_OUT);
+    }
+
+    @Test
+    void shouldInjectWhenAnnotationIsNotFalse() {
+        Pod pod = podWithAnnotations(Map.of(Annotations.INJECT_SIDECAR, "true"));
+        assertThat(InjectionDecision.evaluate(pod, true)).isEqualTo(InjectionDecision.Decision.INJECT);
+    }
+
+    @Test
+    void shouldSkipWhenAlreadyInjected() {
+        Pod pod = podWithAnnotations(Map.of());
+        Container sidecar = new Container();
+        sidecar.setName(InjectionDecision.SIDECAR_CONTAINER_NAME);
+        pod.getSpec().getContainers().add(sidecar);
+
+        assertThat(InjectionDecision.evaluate(pod, true)).isEqualTo(InjectionDecision.Decision.SKIP_ALREADY_INJECTED);
+    }
+
+    @Test
+    void shouldSkipWhenNoConfig() {
+        Pod pod = podWithAnnotations(Map.of());
+        assertThat(InjectionDecision.evaluate(pod, false)).isEqualTo(InjectionDecision.Decision.SKIP_NO_CONFIG);
+    }
+
+    @Test
+    void optOutTakesPriorityOverAlreadyInjected() {
+        Pod pod = podWithAnnotations(Map.of(Annotations.INJECT_SIDECAR, "false"));
+        Container sidecar = new Container();
+        sidecar.setName(InjectionDecision.SIDECAR_CONTAINER_NAME);
+        pod.getSpec().getContainers().add(sidecar);
+
+        assertThat(InjectionDecision.evaluate(pod, true)).isEqualTo(InjectionDecision.Decision.SKIP_OPT_OUT);
+    }
+
+    @Test
+    void alreadyInjectedTakesPriorityOverNoConfig() {
+        Pod pod = podWithAnnotations(Map.of());
+        Container sidecar = new Container();
+        sidecar.setName(InjectionDecision.SIDECAR_CONTAINER_NAME);
+        pod.getSpec().getContainers().add(sidecar);
+
+        assertThat(InjectionDecision.evaluate(pod, false)).isEqualTo(InjectionDecision.Decision.SKIP_ALREADY_INJECTED);
+    }
+
+    @Test
+    void shouldHandleNullSpec() {
+        Pod pod = new Pod();
+        pod.setMetadata(new ObjectMeta());
+        assertThat(InjectionDecision.evaluate(pod, true)).isEqualTo(InjectionDecision.Decision.INJECT);
+    }
+
+    private static Pod podWithAnnotations(Map<String, String> annotations) {
+        Pod pod = new Pod();
+        ObjectMeta meta = new ObjectMeta();
+        meta.setAnnotations(new java.util.HashMap<>(annotations));
+        pod.setMetadata(meta);
+        PodSpec spec = new PodSpec();
+        spec.setContainers(new java.util.ArrayList<>());
+        pod.setSpec(spec);
+        return pod;
+    }
+}

--- a/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/PodMutatorTest.java
+++ b/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/PodMutatorTest.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSecurityContext;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.Volume;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfigSpec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PodMutatorTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String PROXY_IMAGE = "quay.io/kroxylicious/kroxylicious:latest";
+
+    @Test
+    void patchSetsProxyConfigAnnotation() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        JsonNode patch = createPatchJson(pod);
+
+        // Whether annotations exist or not, proxy-config annotation must be set
+        String escapedKey = PodMutator.escapeJsonPointer(Annotations.PROXY_CONFIG);
+        boolean hasIndividualAnnotation = !patchOps(patch, "add",
+                "/metadata/annotations/" + escapedKey).isEmpty();
+        boolean hasAnnotationsMap = !patchOps(patch, "add", "/metadata/annotations").isEmpty();
+        assertThat(hasIndividualAnnotation || hasAnnotationsMap)
+                .as("patch should set proxy-config annotation")
+                .isTrue();
+    }
+
+    @Test
+    void patchAddsSidecarStatusAnnotation() throws Exception {
+        Pod pod = podWithAppContainer(Map.of("existing", "value"));
+        JsonNode patch = createPatchJson(pod);
+
+        String escapedKey = PodMutator.escapeJsonPointer(Annotations.SIDECAR_STATUS);
+        assertThat(patchOps(patch, "add", "/metadata/annotations/" + escapedKey))
+                .isNotEmpty();
+    }
+
+    @Test
+    void patchAddsVolumeWhenNoVolumesExist() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        JsonNode patch = createPatchJson(pod);
+
+        // With no existing volumes, the patch creates the volumes array
+        assertThat(patchOps(patch, "add", "/spec/volumes"))
+                .isNotEmpty();
+    }
+
+    @Test
+    void patchAppendsVolumeWhenVolumesExist() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        Volume existing = new Volume();
+        existing.setName("existing-volume");
+        pod.getSpec().setVolumes(new ArrayList<>(List.of(existing)));
+
+        JsonNode patch = createPatchJson(pod);
+
+        assertThat(patchOps(patch, "add", "/spec/volumes/-"))
+                .isNotEmpty();
+    }
+
+    @Test
+    void patchAppendsSidecarContainer() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        JsonNode patch = createPatchJson(pod);
+
+        // Pod already has an app container, so sidecar is appended
+        List<JsonNode> containerOps = patchOps(patch, "add", "/spec/containers/-");
+        assertThat(containerOps).hasSize(1);
+
+        JsonNode container = containerOps.get(0).path("value");
+        assertThat(container.path("name").asText()).isEqualTo(InjectionDecision.SIDECAR_CONTAINER_NAME);
+        assertThat(container.path("image").asText()).isEqualTo(PROXY_IMAGE);
+    }
+
+    @Test
+    void sidecarContainerHasSecurityContext() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        JsonNode patch = createPatchJson(pod);
+
+        List<JsonNode> containerOps = patchOps(patch, "add", "/spec/containers/-");
+        JsonNode secCtx = containerOps.get(0).path("value").path("securityContext");
+        assertThat(secCtx.path("allowPrivilegeEscalation").asBoolean()).isFalse();
+        assertThat(secCtx.path("readOnlyRootFilesystem").asBoolean()).isTrue();
+        assertThat(secCtx.path("capabilities").path("drop").get(0).asText()).isEqualTo("ALL");
+    }
+
+    @Test
+    void sidecarContainerHasProbes() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        JsonNode patch = createPatchJson(pod);
+
+        List<JsonNode> containerOps = patchOps(patch, "add", "/spec/containers/-");
+        JsonNode container = containerOps.get(0).path("value");
+        assertThat(container.has("startupProbe")).isTrue();
+        assertThat(container.has("livenessProbe")).isTrue();
+        assertThat(container.has("readinessProbe")).isTrue();
+        assertThat(container.path("startupProbe").path("httpGet").path("path").asText())
+                .isEqualTo("/livez");
+    }
+
+    @Test
+    void sidecarContainerHasVolumeMount() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        JsonNode patch = createPatchJson(pod);
+
+        List<JsonNode> containerOps = patchOps(patch, "add", "/spec/containers/-");
+        JsonNode mounts = containerOps.get(0).path("value").path("volumeMounts");
+        assertThat(mounts).hasSize(1);
+        assertThat(mounts.get(0).path("name").asText()).isEqualTo("kroxylicious-config");
+        assertThat(mounts.get(0).path("readOnly").asBoolean()).isTrue();
+    }
+
+    @Test
+    void patchSetsBootstrapEnvVar() throws Exception {
+        Pod pod = podWithAppContainer(null);
+
+        JsonNode patch = createPatchJson(pod);
+
+        // App container at index 0 should get env var
+        boolean hasEnvArray = !patchOps(patch, "add", "/spec/containers/0/env").isEmpty();
+        boolean hasEnvAppend = !patchOps(patch, "add", "/spec/containers/0/env/-").isEmpty();
+        assertThat(hasEnvArray || hasEnvAppend)
+                .as("patch should set KAFKA_BOOTSTRAP_SERVERS on app container")
+                .isTrue();
+    }
+
+    @Test
+    void patchAppendsBootstrapEnvVarWhenEnvExists() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        Container app = pod.getSpec().getContainers().get(0);
+        EnvVar existingEnv = new EnvVar();
+        existingEnv.setName("OTHER_VAR");
+        existingEnv.setValue("other");
+        app.setEnv(new ArrayList<>(List.of(existingEnv)));
+
+        JsonNode patch = createPatchJson(pod);
+
+        assertThat(patchOps(patch, "add", "/spec/containers/0/env/-"))
+                .isNotEmpty();
+    }
+
+    @Test
+    void patchReplacesExistingBootstrapEnvVar() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        Container app = pod.getSpec().getContainers().get(0);
+        EnvVar bootstrapEnv = new EnvVar();
+        bootstrapEnv.setName("KAFKA_BOOTSTRAP_SERVERS");
+        bootstrapEnv.setValue("old-kafka:9092");
+        app.setEnv(new ArrayList<>(List.of(bootstrapEnv)));
+
+        JsonNode patch = createPatchJson(pod);
+
+        List<JsonNode> replaceOps = patchOps(patch, "replace", "/spec/containers/0/env/0/value");
+        assertThat(replaceOps).hasSize(1);
+        assertThat(replaceOps.get(0).path("value").asText()).isEqualTo("localhost:19092");
+    }
+
+    @Test
+    void patchSkipsBootstrapEnvVarWhenDisabled() throws Exception {
+        Pod pod = podWithAppContainer(null);
+
+        KroxyliciousSidecarConfigSpec spec = defaultSpec();
+        spec.setSetBootstrapEnvVar(false);
+
+        String patchStr = PodMutator.createPatch(pod, spec, PROXY_IMAGE);
+        JsonNode patch = MAPPER.readTree(patchStr);
+
+        assertThat(patchOps(patch, "add", "/spec/containers/0/env")).isEmpty();
+        assertThat(patchOps(patch, "add", "/spec/containers/0/env/-")).isEmpty();
+    }
+
+    @Test
+    void patchAddsPodSecurityContextWhenAbsent() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        JsonNode patch = createPatchJson(pod);
+
+        List<JsonNode> secCtxOps = patchOps(patch, "add", "/spec/securityContext");
+        assertThat(secCtxOps).hasSize(1);
+        assertThat(secCtxOps.get(0).path("value").path("runAsNonRoot").asBoolean()).isTrue();
+    }
+
+    @Test
+    void patchPreservesExistingPodSecurityContext() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        PodSecurityContext secCtx = new PodSecurityContext();
+        secCtx.setRunAsNonRoot(true);
+        pod.getSpec().setSecurityContext(secCtx);
+
+        JsonNode patch = createPatchJson(pod);
+
+        assertThat(patchOps(patch, "add", "/spec/securityContext")).isEmpty();
+    }
+
+    @Test
+    void escapeJsonPointerHandsTildeAndSlash() {
+        assertThat(PodMutator.escapeJsonPointer("a~b/c")).isEqualTo("a~0b~1c");
+    }
+
+    @Test
+    void escapeJsonPointerHandlesPlainString() {
+        assertThat(PodMutator.escapeJsonPointer("simple.key")).isEqualTo("simple.key");
+    }
+
+    @Test
+    void patchIsValidJsonArray() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        String patchStr = PodMutator.createPatch(pod, defaultSpec(), PROXY_IMAGE);
+        JsonNode patch = MAPPER.readTree(patchStr);
+        assertThat(patch.isArray()).isTrue();
+        assertThat(patch).isNotEmpty();
+    }
+
+    /**
+     * Creates a pod with one application container already present.
+     * This ensures PodMutator uses the append ({@code /-}) path for adding the sidecar.
+     */
+    private static Pod podWithAppContainer(Map<String, String> annotations) {
+        Pod pod = new Pod();
+        ObjectMeta meta = new ObjectMeta();
+        meta.setName("test-pod");
+        meta.setNamespace("default");
+        if (annotations != null) {
+            meta.setAnnotations(new HashMap<>(annotations));
+        }
+        pod.setMetadata(meta);
+
+        PodSpec spec = new PodSpec();
+        Container app = new Container();
+        app.setName("my-app");
+        app.setImage("my-app:latest");
+        spec.setContainers(new ArrayList<>(List.of(app)));
+        pod.setSpec(spec);
+        return pod;
+    }
+
+    private static KroxyliciousSidecarConfigSpec defaultSpec() {
+        KroxyliciousSidecarConfigSpec spec = new KroxyliciousSidecarConfigSpec();
+        spec.setUpstreamBootstrapServers("kafka.example.com:9092");
+        return spec;
+    }
+
+    private JsonNode createPatchJson(Pod pod) throws Exception {
+        String patchStr = PodMutator.createPatch(pod, defaultSpec(), PROXY_IMAGE);
+        return MAPPER.readTree(patchStr);
+    }
+
+    private static List<JsonNode> patchOps(
+                                           JsonNode patch,
+                                           String op,
+                                           String path) {
+        List<JsonNode> result = new ArrayList<>();
+        for (JsonNode node : patch) {
+            if (op.equals(node.path("op").asText()) && path.equals(node.path("path").asText())) {
+                result.add(node);
+            }
+        }
+        return result;
+    }
+}

--- a/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/ProxyConfigGeneratorTest.java
+++ b/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/ProxyConfigGeneratorTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfigSpec;
+import io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.NodeIdRange;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProxyConfigGeneratorTest {
+
+    private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
+
+    @Test
+    void generatesValidYamlWithDefaults() throws Exception {
+        KroxyliciousSidecarConfigSpec spec = new KroxyliciousSidecarConfigSpec();
+        spec.setUpstreamBootstrapServers("kafka.example.com:9092");
+
+        String yaml = ProxyConfigGenerator.generateConfig(spec);
+        JsonNode root = YAML_MAPPER.readTree(yaml);
+
+        // Management
+        assertThat(root.path("management").path("port").asInt()).isEqualTo(9190);
+        assertThat(root.path("management").path("bindAddress").asText()).isEqualTo("0.0.0.0");
+
+        // Virtual cluster
+        JsonNode vc = root.path("virtualClusters").get(0);
+        assertThat(vc.path("name").asText()).isEqualTo("sidecar");
+        assertThat(vc.path("targetCluster").path("bootstrapServers").asText())
+                .isEqualTo("kafka.example.com:9092");
+
+        // Gateway
+        JsonNode gw = vc.path("gateways").get(0);
+        assertThat(gw.path("name").asText()).isEqualTo("local");
+        JsonNode portStrategy = gw.path("portIdentifiesNode");
+        assertThat(portStrategy.path("bootstrapAddress").asText()).isEqualTo("localhost:19092");
+        assertThat(portStrategy.path("advertisedBrokerAddressPattern").asText()).isEqualTo("localhost");
+    }
+
+    @Test
+    void usesCustomBootstrapPort() throws Exception {
+        KroxyliciousSidecarConfigSpec spec = new KroxyliciousSidecarConfigSpec();
+        spec.setUpstreamBootstrapServers("kafka:9092");
+        spec.setBootstrapPort(29092L);
+
+        String yaml = ProxyConfigGenerator.generateConfig(spec);
+        JsonNode root = YAML_MAPPER.readTree(yaml);
+
+        JsonNode portStrategy = root.path("virtualClusters").get(0)
+                .path("gateways").get(0)
+                .path("portIdentifiesNode");
+        assertThat(portStrategy.path("bootstrapAddress").asText()).isEqualTo("localhost:29092");
+        assertThat(portStrategy.path("nodeStartPort").asInt()).isEqualTo(29093);
+    }
+
+    @Test
+    void usesCustomManagementPort() throws Exception {
+        KroxyliciousSidecarConfigSpec spec = new KroxyliciousSidecarConfigSpec();
+        spec.setUpstreamBootstrapServers("kafka:9092");
+        spec.setManagementPort(8080L);
+
+        String yaml = ProxyConfigGenerator.generateConfig(spec);
+        JsonNode root = YAML_MAPPER.readTree(yaml);
+
+        assertThat(root.path("management").path("port").asInt()).isEqualTo(8080);
+    }
+
+    @Test
+    void usesCustomNodeIdRange() throws Exception {
+        KroxyliciousSidecarConfigSpec spec = new KroxyliciousSidecarConfigSpec();
+        spec.setUpstreamBootstrapServers("kafka:9092");
+        NodeIdRange nodeIdRange = new NodeIdRange();
+        nodeIdRange.setStartInclusive(0L);
+        nodeIdRange.setEndInclusive(9L);
+        spec.setNodeIdRange(nodeIdRange);
+
+        String yaml = ProxyConfigGenerator.generateConfig(spec);
+        JsonNode root = YAML_MAPPER.readTree(yaml);
+
+        JsonNode namedRange = root.path("virtualClusters").get(0)
+                .path("gateways").get(0)
+                .path("portIdentifiesNode")
+                .path("nodeIdRanges").get(0);
+        assertThat(namedRange.path("start").asInt()).isEqualTo(0);
+        assertThat(namedRange.path("end").asInt()).isEqualTo(9);
+    }
+
+    @Test
+    void resolveBootstrapPortUsesDefault() {
+        KroxyliciousSidecarConfigSpec spec = new KroxyliciousSidecarConfigSpec();
+        spec.setUpstreamBootstrapServers("kafka:9092");
+        assertThat(ProxyConfigGenerator.resolveBootstrapPort(spec)).isEqualTo(19092);
+    }
+
+    @Test
+    void resolveBootstrapPortUsesSpecified() {
+        KroxyliciousSidecarConfigSpec spec = new KroxyliciousSidecarConfigSpec();
+        spec.setUpstreamBootstrapServers("kafka:9092");
+        spec.setBootstrapPort(29092L);
+        assertThat(ProxyConfigGenerator.resolveBootstrapPort(spec)).isEqualTo(29092);
+    }
+
+    @Test
+    void resolveManagementPortUsesDefault() {
+        KroxyliciousSidecarConfigSpec spec = new KroxyliciousSidecarConfigSpec();
+        spec.setUpstreamBootstrapServers("kafka:9092");
+        assertThat(ProxyConfigGenerator.resolveManagementPort(spec)).isEqualTo(9190);
+    }
+
+    @Test
+    void resolveManagementPortUsesSpecified() {
+        KroxyliciousSidecarConfigSpec spec = new KroxyliciousSidecarConfigSpec();
+        spec.setUpstreamBootstrapServers("kafka:9092");
+        spec.setManagementPort(8080L);
+        assertThat(ProxyConfigGenerator.resolveManagementPort(spec)).isEqualTo(8080);
+    }
+
+    @Test
+    void generatedConfigIsParseable() throws Exception {
+        KroxyliciousSidecarConfigSpec spec = new KroxyliciousSidecarConfigSpec();
+        spec.setUpstreamBootstrapServers("my-kafka.ns.svc.cluster.local:9092");
+
+        String yaml = ProxyConfigGenerator.generateConfig(spec);
+
+        // Verify it's valid YAML with expected structure
+        JsonNode root = YAML_MAPPER.readTree(yaml);
+        assertThat(root.has("management")).isTrue();
+        assertThat(root.has("virtualClusters")).isTrue();
+        assertThat(root.path("virtualClusters").isArray()).isTrue();
+        assertThat(root.path("virtualClusters")).hasSize(1);
+    }
+}

--- a/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/SidecarConfigResolverTest.java
+++ b/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/SidecarConfigResolverTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfig;
+import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfigSpec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SidecarConfigResolverTest {
+
+    @Test
+    void resolveByExplicitName() {
+        SidecarConfigResolver resolver = new SidecarConfigResolver();
+        KroxyliciousSidecarConfig config = createConfig("ns1", "my-config");
+        resolver.put(config);
+
+        Optional<KroxyliciousSidecarConfig> result = resolver.resolve("ns1", "my-config");
+        assertThat(result).isPresent().get().isSameAs(config);
+    }
+
+    @Test
+    void resolveByExplicitNameReturnsEmptyWhenNotFound() {
+        SidecarConfigResolver resolver = new SidecarConfigResolver();
+        resolver.put(createConfig("ns1", "my-config"));
+
+        Optional<KroxyliciousSidecarConfig> result = resolver.resolve("ns1", "nonexistent");
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void resolvesSingleConfigInNamespace() {
+        SidecarConfigResolver resolver = new SidecarConfigResolver();
+        KroxyliciousSidecarConfig config = createConfig("ns1", "only-one");
+        resolver.put(config);
+
+        Optional<KroxyliciousSidecarConfig> result = resolver.resolve("ns1", null);
+        assertThat(result).isPresent().get().isSameAs(config);
+    }
+
+    @Test
+    void returnsEmptyWhenMultipleConfigsAndNoExplicitName() {
+        SidecarConfigResolver resolver = new SidecarConfigResolver();
+        resolver.put(createConfig("ns1", "config-a"));
+        resolver.put(createConfig("ns1", "config-b"));
+
+        Optional<KroxyliciousSidecarConfig> result = resolver.resolve("ns1", null);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void returnsEmptyWhenNoConfigsInNamespace() {
+        SidecarConfigResolver resolver = new SidecarConfigResolver();
+
+        Optional<KroxyliciousSidecarConfig> result = resolver.resolve("ns1", null);
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void resolvesFromCorrectNamespace() {
+        SidecarConfigResolver resolver = new SidecarConfigResolver();
+        KroxyliciousSidecarConfig ns1Config = createConfig("ns1", "config");
+        KroxyliciousSidecarConfig ns2Config = createConfig("ns2", "config");
+        resolver.put(ns1Config);
+        resolver.put(ns2Config);
+
+        assertThat(resolver.resolve("ns1", null)).isPresent().get().isSameAs(ns1Config);
+        assertThat(resolver.resolve("ns2", null)).isPresent().get().isSameAs(ns2Config);
+    }
+
+    @Test
+    void explicitNameIgnoresOtherNamespaces() {
+        SidecarConfigResolver resolver = new SidecarConfigResolver();
+        resolver.put(createConfig("ns1", "config"));
+
+        Optional<KroxyliciousSidecarConfig> result = resolver.resolve("ns2", "config");
+        assertThat(result).isEmpty();
+    }
+
+    private static KroxyliciousSidecarConfig createConfig(String namespace, String name) {
+        KroxyliciousSidecarConfig config = new KroxyliciousSidecarConfig();
+        ObjectMeta meta = new ObjectMeta();
+        meta.setNamespace(namespace);
+        meta.setName(name);
+        config.setMetadata(meta);
+        KroxyliciousSidecarConfigSpec spec = new KroxyliciousSidecarConfigSpec();
+        spec.setUpstreamBootstrapServers("kafka.example.com:9092");
+        config.setSpec(spec);
+        return config;
+    }
+}

--- a/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/SidecarConfigResolverTest.java
+++ b/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/SidecarConfigResolverTest.java
@@ -16,6 +16,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfig;
 import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfigSpec;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 class SidecarConfigResolverTest {
 
@@ -85,6 +86,65 @@ class SidecarConfigResolverTest {
 
         Optional<KroxyliciousSidecarConfig> result = resolver.resolve("ns2", "config");
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    void removeDeletesConfigFromCache() {
+        SidecarConfigResolver resolver = new SidecarConfigResolver();
+        KroxyliciousSidecarConfig config = createConfig("ns1", "my-config");
+        resolver.put(config);
+        resolver.remove(config);
+
+        assertThat(resolver.resolve("ns1", "my-config")).isEmpty();
+    }
+
+    @Test
+    void removeCleansUpEmptyNamespaceMap() {
+        SidecarConfigResolver resolver = new SidecarConfigResolver();
+        KroxyliciousSidecarConfig config = createConfig("ns1", "config-a");
+        resolver.put(config);
+        resolver.remove(config);
+
+        KroxyliciousSidecarConfig newConfig = createConfig("ns1", "config-b");
+        resolver.put(newConfig);
+        assertThat(resolver.resolve("ns1", "config-b")).isPresent().get().isSameAs(newConfig);
+    }
+
+    @Test
+    void removeNonexistentNamespaceDoesNotThrow() {
+        SidecarConfigResolver resolver = new SidecarConfigResolver();
+        KroxyliciousSidecarConfig config = createConfig("ns-unknown", "config");
+
+        assertThatCode(() -> resolver.remove(config)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void removeNonexistentConfigInExistingNamespace() {
+        SidecarConfigResolver resolver = new SidecarConfigResolver();
+        KroxyliciousSidecarConfig kept = createConfig("ns1", "config-a");
+        resolver.put(kept);
+
+        resolver.remove(createConfig("ns1", "config-b"));
+
+        assertThat(resolver.resolve("ns1", "config-a")).isPresent().get().isSameAs(kept);
+    }
+
+    @Test
+    void removeLastConfigThenAddNew() {
+        SidecarConfigResolver resolver = new SidecarConfigResolver();
+        resolver.put(createConfig("ns1", "old"));
+        resolver.remove(createConfig("ns1", "old"));
+
+        KroxyliciousSidecarConfig replacement = createConfig("ns1", "new");
+        resolver.put(replacement);
+
+        assertThat(resolver.resolve("ns1", null)).isPresent().get().isSameAs(replacement);
+    }
+
+    @Test
+    void closeWithNoInformerDoesNotThrow() {
+        SidecarConfigResolver resolver = new SidecarConfigResolver();
+        assertThatCode(resolver::close).doesNotThrowAnyException();
     }
 
     private static KroxyliciousSidecarConfig createConfig(String namespace, String name) {

--- a/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/WebhookMainTest.java
+++ b/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/WebhookMainTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+import java.net.InetSocketAddress;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junitpioneer.jupiter.ClearEnvironmentVariable;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class WebhookMainTest {
+
+    @Mock
+    private WebhookServer server;
+
+    @Mock
+    private SidecarConfigResolver configResolver;
+
+    @Mock
+    private KubernetesClient kubeClient;
+
+    // --- start/stop lifecycle tests ---
+
+    @Test
+    void startCallsServerStart() {
+        WebhookMain main = new WebhookMain(server, configResolver, kubeClient);
+        main.start();
+        verify(server).start();
+    }
+
+    @Test
+    void stopClosesAllComponents() {
+        WebhookMain main = new WebhookMain(server, configResolver, kubeClient);
+        main.stop();
+
+        InOrder order = inOrder(server, configResolver, kubeClient);
+        order.verify(server).close();
+        order.verify(configResolver).close();
+        order.verify(kubeClient).close();
+    }
+
+    @Test
+    void stopClosesRemainingWhenServerThrows() {
+        doThrow(new RuntimeException("server error")).when(server).close();
+
+        WebhookMain main = new WebhookMain(server, configResolver, kubeClient);
+        main.stop();
+
+        verify(configResolver).close();
+        verify(kubeClient).close();
+    }
+
+    @Test
+    void stopClosesRemainingWhenResolverThrows() {
+        doThrow(new RuntimeException("resolver error")).when(configResolver).close();
+
+        WebhookMain main = new WebhookMain(server, configResolver, kubeClient);
+        main.stop();
+
+        verify(server).close();
+        verify(kubeClient).close();
+    }
+
+    @Test
+    void stopClosesRemainingWhenAllThrow() {
+        doThrow(new RuntimeException("server error")).when(server).close();
+        doThrow(new RuntimeException("resolver error")).when(configResolver).close();
+        doThrow(new RuntimeException("client error")).when(kubeClient).close();
+
+        WebhookMain main = new WebhookMain(server, configResolver, kubeClient);
+        assertThatCode(main::stop).doesNotThrowAnyException();
+    }
+
+    // --- parseBindAddress tests ---
+
+    @Test
+    void parseBindAddressUsesDefault() {
+        InetSocketAddress addr = WebhookMain.parseBindAddress(Map.of());
+
+        assertThat(addr.getHostString()).isEqualTo("0.0.0.0");
+        assertThat(addr.getPort()).isEqualTo(8443);
+    }
+
+    @Test
+    void parseBindAddressUsesProvidedValue() {
+        InetSocketAddress addr = WebhookMain.parseBindAddress(
+                Map.of("BIND_ADDRESS", "127.0.0.1:9443"));
+
+        assertThat(addr.getHostString()).isEqualTo("127.0.0.1");
+        assertThat(addr.getPort()).isEqualTo(9443);
+    }
+
+    // --- requiredEnv tests ---
+
+    @Test
+    void requiredEnvThrowsWhenMissing() {
+        assertThatThrownBy(() -> WebhookMain.requiredEnv(Map.of(), "KROXYLICIOUS_IMAGE"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("KROXYLICIOUS_IMAGE");
+    }
+
+    @Test
+    void requiredEnvThrowsWhenBlank() {
+        assertThatThrownBy(() -> WebhookMain.requiredEnv(
+                Map.of("KROXYLICIOUS_IMAGE", "  "), "KROXYLICIOUS_IMAGE"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("KROXYLICIOUS_IMAGE");
+    }
+
+    @Test
+    void requiredEnvReturnsValue() {
+        String value = WebhookMain.requiredEnv(
+                Map.of("KROXYLICIOUS_IMAGE", "my-image:latest"), "KROXYLICIOUS_IMAGE");
+
+        assertThat(value).isEqualTo("my-image:latest");
+    }
+
+    // --- create() environment variable tests ---
+
+    @Test
+    @ClearEnvironmentVariable(key = "KROXYLICIOUS_IMAGE")
+    void createThrowsWhenKroxyliciousImageMissing() {
+        assertThatThrownBy(WebhookMain::create)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("KROXYLICIOUS_IMAGE");
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = "KROXYLICIOUS_IMAGE", value = "  ")
+    void createThrowsWhenKroxyliciousImageBlank() {
+        assertThatThrownBy(WebhookMain::create)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("KROXYLICIOUS_IMAGE");
+    }
+}

--- a/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/WebhookServerTest.java
+++ b/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/WebhookServerTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junitpioneer.jupiter.RestoreSystemProperties;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.fabric8.kubernetes.api.model.admission.v1.AdmissionRequest;
+import io.fabric8.kubernetes.api.model.admission.v1.AdmissionReview;
+
+import io.kroxylicious.proxy.tls.CertificateGenerator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for the HTTPS webhook server and its TLS configuration.
+ */
+@RestoreSystemProperties
+class WebhookServerTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static Path certPath;
+    private static Path keyPath;
+
+    private WebhookServer server;
+
+    @BeforeAll
+    static void generateCertificates() throws IOException {
+        KeyPair keyPair = CertificateGenerator.generateRsaKeyPair();
+        java.security.cert.X509Certificate cert = CertificateGenerator.generateSelfSignedX509Certificate(keyPair);
+        certPath = CertificateGenerator.generateCertPem(cert);
+        keyPath = writePkcs8Pem(keyPair);
+        System.setProperty(
+                "jdk.internal.httpclient.disableHostnameVerification", "true");
+    }
+
+    private static Path writePkcs8Pem(KeyPair keyPair) throws IOException {
+        byte[] encoded = keyPair.getPrivate().getEncoded();
+        String base64 = Base64.getMimeEncoder(64, "\n".getBytes()).encodeToString(encoded);
+        String pem = "-----BEGIN PRIVATE KEY-----\n" + base64 + "\n-----END PRIVATE KEY-----\n";
+        Path path = Files.createTempFile("pkcs8key", ".pem");
+        path.toFile().deleteOnExit();
+        Files.writeString(path, pem);
+        return path;
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.close();
+        }
+    }
+
+    // --- SSL context tests ---
+
+    @Test
+    void createSslContextWithRsaKey() throws Exception {
+        SSLContext ctx = WebhookServer.createSslContext(certPath, keyPath);
+
+        assertThat(ctx).isNotNull();
+        SSLEngine engine = ctx.createSSLEngine();
+        assertThat(engine).isNotNull();
+    }
+
+    @Test
+    void createSslContextThrowsForMissingCertFile() {
+        Path missing = Path.of("/nonexistent/cert.pem");
+
+        assertThatThrownBy(() -> WebhookServer.createSslContext(missing, keyPath))
+                .isInstanceOf(IOException.class);
+    }
+
+    @Test
+    void createSslContextThrowsForMissingKeyFile() {
+        Path missing = Path.of("/nonexistent/key.pem");
+
+        assertThatThrownBy(() -> WebhookServer.createSslContext(certPath, missing))
+                .isInstanceOf(IOException.class);
+    }
+
+    @Test
+    void createSslContextThrowsForUnsupportedKeyType(@TempDir Path tempDir) throws Exception {
+        Path badKey = tempDir.resolve("bad.pem");
+        byte[] randomBytes = new byte[64];
+        new SecureRandom().nextBytes(randomBytes);
+        String badPem = "-----BEGIN PRIVATE KEY-----\n"
+                + Base64.getEncoder().encodeToString(randomBytes)
+                + "\n-----END PRIVATE KEY-----\n";
+        Files.writeString(badKey, badPem);
+
+        assertThatThrownBy(() -> WebhookServer.createSslContext(certPath, badKey))
+                .isInstanceOf(GeneralSecurityException.class);
+    }
+
+    // --- Server lifecycle tests ---
+
+    @Test
+    void livezReturns200() throws Exception {
+        int port = findFreePort();
+        InetSocketAddress addr = new InetSocketAddress("127.0.0.1", port);
+        server = new WebhookServer(addr, certPath, keyPath, defaultHandler());
+        server.start();
+
+        HttpResponse<String> response = httpsGet(port, "/livez");
+
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    @Test
+    void mutateDelegatesToAdmissionHandler() throws Exception {
+        int port = findFreePort();
+        InetSocketAddress addr = new InetSocketAddress("127.0.0.1", port);
+
+        server = new WebhookServer(addr, certPath, keyPath, defaultHandler());
+        server.start();
+
+        AdmissionReview review = new AdmissionReview();
+        review.setApiVersion("admission.k8s.io/v1");
+        review.setKind("AdmissionReview");
+        AdmissionRequest request = new AdmissionRequest();
+        request.setUid("test-uid");
+        review.setRequest(request);
+
+        byte[] requestBody = MAPPER.writeValueAsBytes(review);
+        HttpResponse<String> response = httpsPost(port, "/mutate", requestBody);
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        JsonNode responseJson = MAPPER.readTree(response.body());
+        assertThat(responseJson.get("response").get("allowed").asBoolean()).isTrue();
+        assertThat(responseJson.get("response").get("uid").asText()).isEqualTo("test-uid");
+    }
+
+    @Test
+    void closeStopsServer() throws Exception {
+        int port = findFreePort();
+        InetSocketAddress addr = new InetSocketAddress("127.0.0.1", port);
+        server = new WebhookServer(addr, certPath, keyPath, defaultHandler());
+        server.start();
+
+        server.close();
+        server = null;
+
+        assertThatThrownBy(() -> httpsGet(port, "/livez"))
+                .hasCauseInstanceOf(ConnectException.class);
+    }
+
+    // --- helpers ---
+
+    private static int findFreePort() throws IOException {
+        try (ServerSocket ss = new ServerSocket(0)) {
+            return ss.getLocalPort();
+        }
+    }
+
+    private static AdmissionHandler defaultHandler() {
+        return new AdmissionHandler(new SidecarConfigResolver(), "image:latest");
+    }
+
+    private static HttpResponse<String> httpsGet(
+                                                 int port,
+                                                 String path)
+            throws Exception {
+        HttpClient client = trustAllClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://127.0.0.1:" + port + path))
+                .GET()
+                .build();
+        return client.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static HttpResponse<String> httpsPost(
+                                                  int port,
+                                                  String path,
+                                                  byte[] body)
+            throws Exception {
+        HttpClient client = trustAllClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://127.0.0.1:" + port + path))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+                .build();
+        return client.send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    @SuppressWarnings("java:S4830")
+    private static HttpClient trustAllClient() throws Exception {
+        TrustManager[] trustAll = new TrustManager[]{
+                new X509TrustManager() {
+                    @Override
+                    public void checkClientTrusted(X509Certificate[] chain, String authType) {
+                    }
+
+                    @Override
+                    public void checkServerTrusted(X509Certificate[] chain, String authType) {
+                    }
+
+                    @Override
+                    public X509Certificate[] getAcceptedIssuers() {
+                        return new X509Certificate[0];
+                    }
+                }
+        };
+        SSLContext ctx = SSLContext.getInstance("TLS");
+        ctx.init(null, trustAll, new SecureRandom());
+
+        return HttpClient.newBuilder()
+                .sslContext(ctx)
+                .build();
+    }
+}

--- a/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/WebhookServerTest.java
+++ b/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/WebhookServerTest.java
@@ -221,10 +221,12 @@ class WebhookServerTest {
                 new X509TrustManager() {
                     @Override
                     public void checkClientTrusted(X509Certificate[] chain, String authType) {
+                        // we trust everything, so just return
                     }
 
                     @Override
                     public void checkServerTrusted(X509Certificate[] chain, String authType) {
+                        // we trust everything, so just return
                     }
 
                     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -578,6 +578,7 @@
         <module>kroxylicious-operator-test-support</module>
         <module>kroxylicious-operator</module>
         <module>kroxylicious-operator-dist</module>
+        <module>kroxylicious-kubernetes-web-hook</module>
         <module>kroxylicious-docs</module>
         <module>kroxylicious-authorizer-api</module>
         <module>kroxylicious-authorizer-providers</module>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Implements a Kubernetes mutating admission webhook that injects Kroxylicious proxy sidecars into pods in labelled namespaces. Includes KroxyliciousSidecarConfig CRD, admission handler with fail-open semantics, JSON Patch generation, proxy config generation, and deployment artifacts with cert-manager TLS integration.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

Contributes towards #3890 

### Additional Context

This is phase 1 of several that would be needed for kroxylicious/design#100
