### PR TITLE
feat: protect user-declared Filter Chain from unexpected ApiVersions

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/ApiVersionsIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/ApiVersionsIT.java
@@ -18,6 +18,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.github.nettyplus.leakdetector.junit.NettyLeakDetectorExtension;
 
+import io.kroxylicious.it.testplugins.UnsafeApiVersionsCanary;
+import io.kroxylicious.proxy.config.ConfigurationBuilder;
+import io.kroxylicious.proxy.config.NamedFilterDefinition;
 import io.kroxylicious.proxy.internal.config.Feature;
 import io.kroxylicious.proxy.internal.config.Features;
 import io.kroxylicious.test.Request;
@@ -44,10 +47,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @ExtendWith(NettyLeakDetectorExtension.class)
 class ApiVersionsIT {
-
     @Test
     void shouldOfferTheMinimumHighestSupportedVersionWhenBrokerIsAheadOfKroxylicious() {
-        try (var tester = mockKafkaKroxyliciousTester(KroxyliciousConfigUtils::proxy);
+        try (var tester = mockKafkaKroxyliciousTester(ApiVersionsIT::proxyWithCanaryFilter);
                 var client = tester.simpleTestClient()) {
             givenMockRespondsWithApiVersionsForMetadataRequest(tester, ApiKeys.METADATA.oldestVersion(), (short) (ApiKeys.METADATA.latestVersion() + 1));
             Response response = whenGetApiVersionsFromKroxylicious(client);
@@ -71,7 +73,7 @@ class ApiVersionsIT {
 
     @Test
     void shouldOfferTheMinimumHighestSupportedVersionWhenKroxyliciousIsAheadOfBroker() {
-        try (var tester = mockKafkaKroxyliciousTester(KroxyliciousConfigUtils::proxy);
+        try (var tester = mockKafkaKroxyliciousTester(ApiVersionsIT::proxyWithCanaryFilter);
                 var client = tester.simpleTestClient()) {
             short expectedApiVersion = (short) (ApiKeys.METADATA.latestVersion() - 1);
             givenMockRespondsWithApiVersionsForMetadataRequest(tester, ApiKeys.METADATA.oldestVersion(), expectedApiVersion);
@@ -88,7 +90,7 @@ class ApiVersionsIT {
      */
     @Test
     void shouldHandleVersionZeroErrorResponseWhenKroxyliciousIsAheadOfBroker() {
-        try (var tester = mockKafkaKroxyliciousTester(KroxyliciousConfigUtils::proxy);
+        try (var tester = mockKafkaKroxyliciousTester(ApiVersionsIT::proxyWithCanaryFilter);
                 var client = tester.simpleTestClient()) {
             short brokerMaxVersion = (short) (ApiKeys.API_VERSIONS.latestVersion() - 1);
             givenMockRespondsWithDowngradedV0ApiVersionsResponse(tester, ApiKeys.API_VERSIONS.oldestVersion(), brokerMaxVersion);
@@ -101,7 +103,7 @@ class ApiVersionsIT {
 
     @Test
     void shouldOfferTheMaximumLowestSupportedVersionWhenBrokerIsAheadOfKroxylicious() {
-        try (var tester = mockKafkaKroxyliciousTester(KroxyliciousConfigUtils::proxy);
+        try (var tester = mockKafkaKroxyliciousTester(ApiVersionsIT::proxyWithCanaryFilter);
                 var client = tester.simpleTestClient()) {
             short brokerOldestVersion = (short) (ApiKeys.METADATA.oldestVersion() + 1);
             givenMockRespondsWithApiVersionsForMetadataRequest(tester, brokerOldestVersion, ApiKeys.METADATA.latestVersion());
@@ -112,7 +114,7 @@ class ApiVersionsIT {
 
     @Test
     void shouldOfferTheMaximumLowestSupportedVersionWhenKroxyliciousIsAheadOfBroker() {
-        try (var tester = mockKafkaKroxyliciousTester(KroxyliciousConfigUtils::proxy);
+        try (var tester = mockKafkaKroxyliciousTester(ApiVersionsIT::proxyWithCanaryFilter);
                 var client = tester.simpleTestClient()) {
             short brokerOldestVersion = (short) (ApiKeys.METADATA.oldestVersion() - 1);
             givenMockRespondsWithApiVersionsForMetadataRequest(tester, brokerOldestVersion, ApiKeys.METADATA.latestVersion());
@@ -124,7 +126,7 @@ class ApiVersionsIT {
 
     @Test
     void shouldNotOfferBrokerApisThatAreUnknownToKroxy() {
-        try (var tester = mockKafkaKroxyliciousTester(KroxyliciousConfigUtils::proxy);
+        try (var tester = mockKafkaKroxyliciousTester(ApiVersionsIT::proxyWithCanaryFilter);
                 var client = tester.simpleTestClient()) {
             ApiVersionsResponseData mockResponse = new ApiVersionsResponseData();
             ApiVersionsResponseData.ApiVersion version = new ApiVersionsResponseData.ApiVersion();
@@ -142,7 +144,7 @@ class ApiVersionsIT {
 
     @Test
     void shouldOfferBrokerApisThatAreKnownToKroxy() {
-        try (var tester = mockKafkaKroxyliciousTester(KroxyliciousConfigUtils::proxy);
+        try (var tester = mockKafkaKroxyliciousTester(ApiVersionsIT::proxyWithCanaryFilter);
                 var client = tester.simpleTestClient()) {
             ApiVersionsResponseData mockResponse = new ApiVersionsResponseData();
             for (ApiKeys knownValue : ApiKeys.values()) {
@@ -177,7 +179,7 @@ class ApiVersionsIT {
     @Test
     void shouldMarkProduceV0toV2AsSupportedVersions() {
         // Given
-        try (var tester = mockKafkaKroxyliciousTester(KroxyliciousConfigUtils::proxy);
+        try (var tester = mockKafkaKroxyliciousTester(ApiVersionsIT::proxyWithCanaryFilter);
                 var client = tester.simpleTestClient()) {
             ApiVersionsResponseData mockResponse = new ApiVersionsResponseData();
             ApiVersionsResponseData.ApiVersion version = new ApiVersionsResponseData.ApiVersion();
@@ -211,7 +213,7 @@ class ApiVersionsIT {
     @Test
     void shouldMarkProduceV0toV2AsSupportedVersionsEvenIfUpstreamDisagrees() {
         // Given
-        try (var tester = mockKafkaKroxyliciousTester(KroxyliciousConfigUtils::proxy);
+        try (var tester = mockKafkaKroxyliciousTester(ApiVersionsIT::proxyWithCanaryFilter);
                 var client = tester.simpleTestClient()) {
             ApiVersionsResponseData mockResponse = new ApiVersionsResponseData();
             ApiVersionsResponseData.ApiVersion version = new ApiVersionsResponseData.ApiVersion();
@@ -236,6 +238,13 @@ class ApiVersionsIT {
                                         assertThat(apiVersion.minVersion()).isEqualTo(ApiKeys.PRODUCE_API_VERSIONS_RESPONSE_MIN_VERSION);
                                     })));
         }
+    }
+
+    private static ConfigurationBuilder proxyWithCanaryFilter(String clusterBootstrapServers) {
+        NamedFilterDefinition unsafeFilterApiFilter = new NamedFilterDefinition("canary", UnsafeApiVersionsCanary.class.getName(), null);
+        return KroxyliciousConfigUtils.proxy(clusterBootstrapServers)
+                .addToFilterDefinitions(unsafeFilterApiFilter)
+                .addToDefaultFilters(unsafeFilterApiFilter.name());
     }
 
     private static void givenMockRespondsWithApiVersionsForMetadataRequest(MockServerKroxyliciousTester tester, short minVersion, short maxVersion) {

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/UnsafeApiVersionsCanary.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/testplugins/UnsafeApiVersionsCanary.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.it.testplugins;
+
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.ApiVersionsResponseData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+
+import io.kroxylicious.proxy.filter.ApiVersionsResponseFilter;
+import io.kroxylicious.proxy.filter.Filter;
+import io.kroxylicious.proxy.filter.FilterContext;
+import io.kroxylicious.proxy.filter.FilterFactory;
+import io.kroxylicious.proxy.filter.FilterFactoryContext;
+import io.kroxylicious.proxy.filter.ResponseFilterResult;
+import io.kroxylicious.proxy.plugin.Plugin;
+import io.kroxylicious.proxy.plugin.PluginConfigurationException;
+
+/**
+ * This Filter contains code that should fail explosively if it is exposed to an ApiVersionsResponse that contains
+ * APIs or versions that the proxy cannot decode. It should work without issue, unless the framework behaviour changes.
+ */
+@Plugin(configType = Void.class)
+public class UnsafeApiVersionsCanary implements FilterFactory<Void, Void> {
+    @Override
+    public Void initialize(FilterFactoryContext context, Void config) throws PluginConfigurationException {
+        return null;
+    }
+
+    @Override
+    public Filter createFilter(FilterFactoryContext context, Void initializationData) {
+        return new UnsafeApiVersionsCanaryFilter();
+    }
+
+    static class UnsafeApiVersionsCanaryFilter implements ApiVersionsResponseFilter {
+        @Override
+        public CompletionStage<ResponseFilterResult> onApiVersionsResponse(short apiVersion, ResponseHeaderData header, ApiVersionsResponseData response,
+                                                                           FilterContext context) {
+            for (ApiVersionsResponseData.ApiVersion apiKey : response.apiKeys()) {
+                // Unsafe if this Filter is exposed to api keys that are not known to the proxy.
+                // The Proxy should prevent this happening
+                ApiKeys apiKeys = ApiKeys.forId(apiKey.apiKey());
+                short minVersion = apiKey.minVersion();
+                short maxVersion = apiKey.maxVersion();
+                // Produce is allowed to offer v0-v2 despite the broker not really supporting it
+                if (apiKeys != ApiKeys.PRODUCE && minVersion < apiKeys.oldestVersion()) {
+                    throw new IllegalStateException(
+                            "received an ApiVersionsResponse with a min version " + minVersion + " for " + apiKeys + " below what the proxy supports "
+                                    + apiKeys.oldestVersion());
+                }
+                if (maxVersion > apiKeys.latestVersion(true)) {
+                    throw new IllegalStateException(
+                            "received an ApiVersionsResponse with a max version " + maxVersion + " for " + apiKeys + " above what the proxy supports "
+                                    + apiKeys.latestVersion(true));
+                }
+            }
+            return context.forwardResponse(header, response);
+        }
+
+    }
+}

--- a/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
+++ b/kroxylicious-integration-tests/src/test/resources/META-INF/services/io.kroxylicious.proxy.filter.FilterFactory
@@ -15,3 +15,4 @@ io.kroxylicious.it.testplugins.ClientAuthAwareLawyer
 io.kroxylicious.it.testplugins.ConstantSasl
 io.kroxylicious.it.testplugins.ProtocolCounter
 io.kroxylicious.it.testplugins.ShortCircuitErrorResponse
+io.kroxylicious.it.testplugins.UnsafeApiVersionsCanary

--- a/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
+++ b/kroxylicious-runtime/src/main/java/io/kroxylicious/proxy/internal/KafkaProxyFrontendHandler.java
@@ -288,9 +288,7 @@ public class KafkaProxyFrontendHandler
     }
 
     private List<FilterAndInvoker> buildFilters() {
-        List<FilterAndInvoker> apiVersionFilters = FilterAndInvoker.build("ApiVersionsIntersect (internal)", apiVersionsIntersectFilter);
-        var filterAndInvokers = new ArrayList<>(apiVersionFilters);
-        filterAndInvokers.addAll(FilterAndInvoker.build("ApiVersionsDowngrade (internal)", apiVersionsDowngradeFilter));
+        var filterAndInvokers = new ArrayList<>(FilterAndInvoker.build("ApiVersionsDowngrade (internal)", apiVersionsDowngradeFilter));
 
         NettyFilterContext filterContext = new NettyFilterContext(clientCtx().channel().eventLoop(), pfr);
         List<FilterAndInvoker> filterChain = filterChainFactory.createFilters(filterContext, this.namedFilterDefinitions);
@@ -304,6 +302,7 @@ public class KafkaProxyFrontendHandler
                 new BrokerAddressFilter(proxyChannelStateMachine.endpointGateway(), endpointReconciler));
         filterAndInvokers.addAll(brokerAddressFilters);
 
+        filterAndInvokers.addAll(FilterAndInvoker.build("ApiVersionsIntersect (internal)", apiVersionsIntersectFilter));
         return filterAndInvokers;
     }
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Moves ApiVersionsIntersectionFilter to after the Filter Chain, so that it is applied to Responses before they enter the Filter Chain.

Why:
In order to masquerade as a Kafka Broker, the Proxy must intersect the ApiVersions retrieved from the upstream broker with the versions we can decode at the proxy. We then tell the client about the supported versions and all is well.

However, this intersection was applied after the user-defined Filter Chain, meaning that those Filters were exposed to the raw ApiVersions Response from upstream, which can carry Api keys and versions that are unsupported by the Proxy. The Filter Author had to be vigilant and remember these special cases if they manipulate ApiVersions. It is easy to accidentally try to decode all the values into the ApiKeys enum and cause an Exception at runtime.

With this change we are now trusting Filters to not add unknown API versions or unsupported version ranges that the Proxy can't decode.

Contributes towards #3760

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
