### PR TITLE
docs: formalize AI disclosure requirement in commits

### DIFF
--- a/.claude/rules/commits.md
+++ b/.claude/rules/commits.md
@@ -1,0 +1,68 @@
+---
+paths:
+  - "**/*"
+---
+
+# Commit Message Conventions
+
+## Format
+
+Use Conventional Commits with AI disclosure.
+
+**Structure:**
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<trailers>
+```
+
+**Types:** feat, fix, docs, build, chore, refactor, perf, test, ci
+
+**Scope** (optional): Module or area (e.g., aws-kms, filters, runtime)
+
+**Subject:** Imperative mood, no period, <72 chars
+
+## AI Disclosure
+
+**Required:** When AI assists with code changes, add `Assisted-by:` trailer.
+
+**Format:** `Assisted-by: Claude <model-name> <noreply@anthropic.com>`
+
+**Placement:** After body, before Signed-off-by
+
+**Model names:**
+- Claude Sonnet 4.5
+- Claude Sonnet 4.6
+- Claude Opus 4.6
+- (Use actual model name from session)
+
+## Trailers Order
+
+1. Other trailers (Relates-to:, Fixes:, etc.)
+2. `Assisted-by:` (if applicable)
+3. `Signed-off-by:` (added automatically by git hook)
+
+## DCO Signoff
+
+The prepare-commit-msg hook automatically adds `Signed-off-by:` trailer. Do not add manually.
+
+## Complete Example
+
+```
+feat(record-encryption): add key rotation support
+
+Implements automatic KEK rotation with configurable intervals and
+zero-downtime key migration. Includes metrics for rotation events.
+
+Relates-to: #1234
+Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>
+Signed-off-by: Developer Name <dev@example.com>
+```
+
+## Important Notes
+
+- **Do NOT use** `Co-Authored-By:` for AI disclosure - use `Assisted-by:`
+- The git hook adds Signed-off-by automatically - you don't need to add it
+- When Claude Code creates commits, ensure it uses `Assisted-by:` format

--- a/.claude/rules/commits.md
+++ b/.claude/rules/commits.md
@@ -32,12 +32,6 @@ Use Conventional Commits with AI disclosure.
 
 **Placement:** After body, before Signed-off-by
 
-**Model names:**
-- Claude Sonnet 4.5
-- Claude Sonnet 4.6
-- Claude Opus 4.6
-- (Use actual model name from session)
-
 ## Trailers Order
 
 1. Other trailers (Relates-to:, Fixes:, etc.)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,5 +28,6 @@ _Please go through this checklist and make sure all applicable tasks have been d
 - [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
 - [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
 - [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
+- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
 
 > **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,46 @@ When writing code, follow these prescriptive rules:
 - [Logging](.claude/rules/logging.md) - Logging conventions
 - [Documentation](.claude/rules/documentation-requirements.md) - When to write docs
 
+## Commit Conventions
+
+When creating commits, follow these conventions:
+
+**Commit Message Format:**
+- Use Conventional Commits: `<type>(<scope>): <description>`
+- Types: `feat`, `fix`, `docs`, `build`, `chore`, `refactor`, `perf`, `test`, `ci`
+- Keep subject line under 72 characters
+
+**AI Disclosure Requirement:**
+When AI assists with code changes, add an `Assisted-by:` trailer:
+- Format: `Assisted-by: Claude <model-name> <noreply@anthropic.com>`
+- Placement: After commit body, before `Signed-off-by:` trailer
+- Model name examples: "Claude Sonnet 4.5", "Claude Opus 4.6"
+
+**DCO Signoff:**
+All commits require `Signed-off-by:` trailer (auto-added by git hook).
+
+**IMPORTANT for Claude Code:** Use `Assisted-by:` NOT `Co-Authored-By:`. Format:
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+Assisted-by: Claude <model-name> <noreply@anthropic.com>
+Signed-off-by: <name> <email>
+```
+
+**Example:**
+```
+feat(filters): add request throttling filter
+
+Implements configurable rate limiting at the filter level with
+per-client quotas and burst handling.
+
+Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>
+Signed-off-by: Jane Developer <jane@example.com>
+```
+
 ## Module-Specific Context
 
 See module README.md files for detailed context:

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -522,8 +522,54 @@ The workflow will push the container image to `${REGISTRY_DESTINATION}` so ensur
 The project requires that all commits are signed-off, indicating that _you_ certify the changes with the [Developer
 Certificate of Origin (DCO)](./DCO.txt).
 
-This can be done using `git commit -s` for each commit
-in your pull request. Alternatively, to signoff a bunch of commits you can use `git rebase --signoff _your-branch_`.
+### Automatic Signoff via Git Hook
+
+A prepare-commit-msg hook automatically adds the `Signed-off-by:` trailer to your commits. To set this up:
+
+1. Copy the hook template to your local git hooks directory:
+   ```shell
+   cp scripts/git-hooks/prepare-commit-msg .git/hooks/prepare-commit-msg
+   chmod +x .git/hooks/prepare-commit-msg
+   ```
+
+2. Verify the hook is working:
+   ```shell
+   git commit -m "test commit"
+   git log -1 --format=%B
+   ```
+   You should see `Signed-off-by: Your Name <your.email@example.com>` at the end.
+
+### Manual Signoff (Alternative)
+
+If you prefer not to use the hook, you can sign off commits manually:
+- Use `git commit -s` for each commit in your pull request
+- Or use `git rebase --signoff _your-branch_` to sign off multiple commits
+
+### AI Disclosure Requirement
+
+When AI tools (like Claude Code, GitHub Copilot, etc.) assist with your code changes, add an `Assisted-by:` trailer to document this:
+
+**Format:** `Assisted-by: <AI-name> <model> <email>`
+
+**Examples:**
+```
+Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>
+Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>
+```
+
+**Placement:** After the commit message body, before the `Signed-off-by:` trailer.
+
+**Complete example:**
+```
+feat(filters): add request throttling
+
+Implements configurable rate limiting with per-client quotas.
+
+Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>
+Signed-off-by: Jane Developer <jane@example.com>
+```
+
+This practice maintains transparency about AI assistance in our development process while preserving the human developer's accountability for the final code.
 
 # Development Guide for Kroxylicious Operator
 

--- a/kroxylicious-openmessaging-benchmarks/DEV_GUIDE.md
+++ b/kroxylicious-openmessaging-benchmarks/DEV_GUIDE.md
@@ -241,10 +241,4 @@ native memory growth in the coordinator JVM. The polling interval is controlled 
 - On-cluster sweep coordinator ([#3493](https://github.com/kroxylicious/kroxylicious/issues/3493))
   — run `measure-overhead.sh` as a Kubernetes Job so long sweeps don't require a laptop to stay awake
 
-## Contributing
 
-This project follows Kroxylicious contribution guidelines:
-
-- All commits must be signed off with DCO: `git commit -s`
-- Follow the conventional commit format for PR titles
-- Add `Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>` to commits assisted by Claude

--- a/scripts/git-hooks/prepare-commit-msg
+++ b/scripts/git-hooks/prepare-commit-msg
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# prepare-commit-msg hook for Kroxylicious
+#
+# Automatically adds DCO Signed-off-by trailer to commit messages.
+#
+# To install: cp scripts/git-hooks/prepare-commit-msg .git/hooks/prepare-commit-msg
+#             chmod +x .git/hooks/prepare-commit-msg
+
+NAME=$(git config user.name)
+EMAIL=$(git config user.email)
+
+if [ -z "$NAME" ]; then
+    echo "empty git config user.name"
+    exit 1
+fi
+
+if [ -z "$EMAIL" ]; then
+    echo "empty git config user.email"
+    exit 1
+fi
+
+git interpret-trailers --if-exists doNothing --trailer \
+    "Signed-off-by: $NAME <$EMAIL>" \
+    --in-place "$1"


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

This PR formalizes the existing practice of disclosing AI assistance in commits by documenting the requirement across multiple touchpoints:

- **CLAUDE.md**: Added commit conventions section with explicit instructions for Claude Code to use `Assisted-by:` trailer (not `Co-Authored-By:`)
- **.claude/rules/commits.md**: New rule file with detailed commit message format and AI disclosure requirements
- **DEV_GUIDE.md**: Expanded DCO Signoff section to include AI disclosure requirement, git hook setup instructions
- **scripts/git-hooks/prepare-commit-msg**: Version-controlled the DCO signoff hook template for discoverability
- **.github/PULL_REQUEST_TEMPLATE.md**: Added AI disclosure checklist item

The standardized format is: `Assisted-by: Claude <model> <noreply@anthropic.com>`

### Additional Context


We've documented the requirement in https://github.com/kroxylicious/.github/blob/main/CONTRIBUTING.md
but Claude wasn't discovering this automatically.

This creates two problems:

1. **Discoverability**: New contributors and Claude Code users cannot find this requirement
2. **Inconsistency**: Some recent commits use `Co-Authored-By:` instead, and Claude Code defaults to this format

By documenting the requirement:
- Claude Code will automatically use the correct format in future commits
- Human contributors will discover the requirement through DEV_GUIDE.md and the PR template
- The project maintains transparency about AI's role while preserving human accountability

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests
- [x] Update documentation
- [x] Make sure all unit/integration tests pass
- [x] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [x] If applicable to the change, make sure system tests pass.
- [x] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [x] Ensure the PR references relevant issue(s) so they are closed on merging.
- [x] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.