### PR TITLE
refactoring: Remove deprecated StatusFactory.newTrueConditionStatusPatch(R, Condition.Type) method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ### Changes, deprecations and removals
 
+* [#3786](https://github.com/kroxylicious/kroxylicious/issues/3786): The deprecated method `StatusFactory#newTrueConditionStatusPatch(CustomResource, Condition.Type)` (two-parameter form) is removed. Use `StatusFactory#newTrueConditionStatusPatch(CustomResource, Condition.Type, String)` instead, passing `MetadataChecksumGenerator.NO_CHECKSUM_SPECIFIED` if no checksum tracking is needed.
 * The deprecated method `FilterContext#clientSaslAuthenticationSuccess(String, String)` is removed. Filter authors must use `FilterContext#clientSaslAuthenticationSuccess(String, Subject)` to announce a successful SASL authentication to the other filters in the chain.
 * [#1295](https://github.com/kroxylicious/kroxylicious/issues/1295): The AWS KMS top-level `longTermCredentials` and `ec2MetadataCredentials` YAML keys are deprecated.  Use the new `credentials.longTerm` and `credentials.ec2Metadata` forms under the grouped `credentials` node instead.  The old keys continue to work for backward compatibility.
 

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/StatusFactory.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/StatusFactory.java
@@ -72,13 +72,4 @@ public abstract class StatusFactory<R extends CustomResource<?, ?>> {
     public abstract R newTrueConditionStatusPatch(R observedProxy,
                                                   Condition.Type type,
                                                   String checksum);
-
-    /**
-     * Deprecated in favour of {@link StatusFactory#newTrueConditionStatusPatch(CustomResource, Condition.Type, String)}
-     *
-     * @deprecated
-     */
-    @Deprecated(forRemoval = true)
-    public abstract R newTrueConditionStatusPatch(R observedProxy,
-                                                  Condition.Type type);
 }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterStatusFactory.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaprotocolfilter/KafkaProtocolFilterStatusFactory.java
@@ -71,12 +71,4 @@ public class KafkaProtocolFilterStatusFactory extends StatusFactory<KafkaProtoco
         Condition trueCondition = newTrueCondition(observedProxy, type);
         return filterStatusPatch(observedProxy, trueCondition, checksum);
     }
-
-    @SuppressWarnings("removal")
-    @Override
-    public KafkaProtocolFilter newTrueConditionStatusPatch(KafkaProtocolFilter observedProxy,
-                                                           Condition.Type type) {
-        return newTrueConditionStatusPatch(observedProxy, type, MetadataChecksumGenerator.NO_CHECKSUM_SPECIFIED);
-    }
-
 }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyStatusFactory.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyStatusFactory.java
@@ -17,7 +17,6 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxyStatus;
 import io.kroxylicious.kubernetes.operator.ResourceState;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.StatusFactory;
-import io.kroxylicious.kubernetes.operator.checksum.MetadataChecksumGenerator;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 
@@ -77,12 +76,5 @@ public class KafkaProxyStatusFactory extends StatusFactory<KafkaProxy> {
                                            @Nullable Integer replicaCount) {
         Condition trueCondition = newTrueCondition(observedProxy, type);
         return kafkaProxyStatusPatch(observedProxy, trueCondition, replicaCount);
-    }
-
-    @SuppressWarnings("removal")
-    @Override
-    public KafkaProxy newTrueConditionStatusPatch(KafkaProxy observedProxy,
-                                                  Condition.Type type) {
-        return newTrueConditionStatusPatch(observedProxy, type, MetadataChecksumGenerator.NO_CHECKSUM_SPECIFIED);
     }
 }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ProxyConfigStateDependentResource.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ProxyConfigStateDependentResource.java
@@ -21,6 +21,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaProxy;
 import io.kroxylicious.kubernetes.api.v1alpha1.VirtualKafkaCluster;
 import io.kroxylicious.kubernetes.operator.ProxyConfigStateData;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
+import io.kroxylicious.kubernetes.operator.checksum.MetadataChecksumGenerator;
 import io.kroxylicious.kubernetes.operator.model.ProxyModel;
 import io.kroxylicious.kubernetes.operator.model.networking.IngressConflictException;
 import io.kroxylicious.kubernetes.operator.model.networking.ProxyNetworkingModel;
@@ -87,7 +88,7 @@ public class ProxyConfigStateDependentResource
             }
             else {
                 patch = statusFactory.newTrueConditionStatusPatch(cluster,
-                        Condition.Type.Accepted);
+                        Condition.Type.Accepted, MetadataChecksumGenerator.NO_CHECKSUM_SPECIFIED);
             }
             if (!data.hasStatusPatchForCluster(ResourcesUtil.name(cluster))) {
                 data.addStatusPatchForCluster(ResourcesUtil.name(cluster), patch);

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressStatusFactory.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxyingress/KafkaProxyIngressStatusFactory.java
@@ -84,11 +84,4 @@ public class KafkaProxyIngressStatusFactory extends StatusFactory<KafkaProxyIngr
         Condition trueCondition = newTrueCondition(observedProxy, type);
         return ingressStatusPatch(observedProxy, trueCondition, checksum);
     }
-
-    @SuppressWarnings("removal")
-    @Override
-    public KafkaProxyIngress newTrueConditionStatusPatch(KafkaProxyIngress observedProxy,
-                                                         Condition.Type type) {
-        throw new IllegalStateException("Use newTrueConditionStatusPatch(KafkaProxyIngress, Condition.Type, String) instead");
-    }
 }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStatusFactory.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStatusFactory.java
@@ -86,11 +86,4 @@ public class KafkaServiceStatusFactory extends StatusFactory<KafkaService> {
         Condition trueCondition = newTrueCondition(observedProxy, type);
         return serviceStatusPatch(observedProxy, trueCondition, checksum, bootstrapServers);
     }
-
-    @Override
-    @SuppressWarnings("removal")
-    public KafkaService newTrueConditionStatusPatch(KafkaService observedProxy,
-                                                    Condition.Type type) {
-        throw new IllegalStateException("Use newTrueConditionStatusPatch(KafkaService, Condition.Type, String) instead");
-    }
 }

--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterStatusFactory.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/reconciler/virtualkafkacluster/VirtualKafkaClusterStatusFactory.java
@@ -18,7 +18,6 @@ import io.kroxylicious.kubernetes.api.v1alpha1.virtualkafkaclusterstatus.Ingress
 import io.kroxylicious.kubernetes.operator.ResourceState;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.StatusFactory;
-import io.kroxylicious.kubernetes.operator.checksum.MetadataChecksumGenerator;
 
 public class VirtualKafkaClusterStatusFactory extends StatusFactory<VirtualKafkaCluster> {
 
@@ -67,12 +66,5 @@ public class VirtualKafkaClusterStatusFactory extends StatusFactory<VirtualKafka
                                                            Condition.Type type, String checksum) {
         Condition trueCondition = newTrueCondition(observedProxy, type);
         return clusterStatusPatch(observedProxy, ResourceState.of(trueCondition), List.of());
-    }
-
-    @SuppressWarnings("removal")
-    @Override
-    public VirtualKafkaCluster newTrueConditionStatusPatch(VirtualKafkaCluster observedProxy,
-                                                           Condition.Type type) {
-        return newTrueConditionStatusPatch(observedProxy, type, MetadataChecksumGenerator.NO_CHECKSUM_SPECIFIED);
     }
 }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

_Please describe your pull request_

The two-parameter newTrueConditionStatusPatch(R, Condition.Type) method in io.kroxylicious.kubernetes.operator.StatusFactory was deprecated in version 0.12.0 and marked forRemoval = true.

_Why are you making this pull request?_

https://github.com/kroxylicious/kroxylicious/issues/3786

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
