### PR TITLE
fix(hashicorp-vault): add SKIP_SETCAP to TestVault

### DIFF
--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/TestVault.java
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-hashicorp-vault/src/test/java/io/kroxylicious/kms/provider/hashicorp/vault/TestVault.java
@@ -46,6 +46,7 @@ public class TestVault implements Closeable {
         }
         VaultContainer<?> vaultContainer = new VaultContainer<>(HASHICORP_VAULT)
                 .withVaultToken(VAULT_TOKEN)
+                .withEnv("SKIP_SETCAP", "true") // Workaround for Vault 2.x in rootless containers (SETFCAP capability unavailable). Acceptable for development/testing.
                 .withEnv("VAULT_FORMAT", "json")
                 .withInitCommand("secrets enable transit");
         if (serverKeys != null) {


### PR DESCRIPTION

### Description

Adds the missing `SKIP_SETCAP=true` environment variable to the `TestVault` container configuration.

### Additional Context

This change was inadvertently omitted from commit cc02737fc, which added the SKIP_SETCAP workaround to other Vault test configurations following PR #3716's upgrade to Vault 2.x.  The error slipped through owing to a CI issue (#3798)

Vault 2.x requires the SETFCAP capability for IPC_LOCK, which is unavailable in rootless containers. The SKIP_SETCAP workaround was applied to:
- `VaultTestKmsFacade` (integration tests)
- `helm_vault_overrides.yaml` (system tests) 
- `docker-compose.yaml` (performance tests)
- Record Encryption quickstart documentation

But was missed in `TestVault.java`, which is also used for testing with Vault 2.x containers.

**References:**
- PR #3716 (Vault upgrade to v2)
- Commit cc02737fc (SKIP_SETCAP workaround)
- https://github.com/hashicorp/vault/issues/31919

### Checklist

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests (no new tests needed - existing tests now work)
- [ ] Update documentation (no doc changes needed)
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, trigger the performance test suite. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).