### PR TITLE
test(operator): fix race condition in Route status update IT test

### DIFF
--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
@@ -984,7 +984,7 @@ public class KafkaProxyReconcilerIT {
 
         // The test is racing with the Ingress controller. We don't know if the ingress
         // controller will have updated the resource or not yet. We make an update to
-        // the Route that are certain will be different to that made by the controller
+        // the Route that we are certain will be different to that made by the controller
         // in order to be certain an update is made.
         testActor.resources(Route.class).resource(bootstrapRoute).editStatus(r -> new RouteBuilder(bootstrapRoute)
                 .withNewStatus()

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
@@ -976,24 +976,28 @@ public class KafkaProxyReconcilerIT {
         updateStatusObservedGeneration(testActor.create(cluster));
 
         String bootstrapRouteName = name(cluster) + "-bootstrap";
-        AWAIT.alias("bootstrap route created").untilAsserted(() -> assertThat(testActor.get(Route.class, bootstrapRouteName)).isNotNull());
+        Route bootstrapRoute = AWAIT.alias("bootstrap route created").until(() -> testActor.get(Route.class, bootstrapRouteName), Objects::nonNull);
 
-        String initialChecksum = deploymentPodTemplateChecksum(proxy);
+        var observedChecksum = deploymentPodTemplateChecksum(proxy);
 
-        // When - OpenShift assigns a host to the bootstrap route
-        Route bootstrapRoute = testActor.get(Route.class, bootstrapRouteName);
-        Route routeWithHost = new RouteBuilder(bootstrapRoute)
+        // When
+
+        // The test is racing with the Ingress controller. We don't know if the ingress
+        // controller will have updated the resource or not yet. We make an update to
+        // the Route that are certain will be different to that made by the controller
+        // in order to be certain an update is made.
+        testActor.resources(Route.class).resource(bootstrapRoute).editStatus(r -> new RouteBuilder(bootstrapRoute)
                 .withNewStatus()
-                .addNewIngress().withHost(bootstrapRouteName + ".apps-crc.testing").endIngress()
+                .addNewIngress().withHost("different.invalid").endIngress()
                 .endStatus()
-                .build();
-        testActor.patchStatus(routeWithHost);
+                .build());
 
         // Then - deployment pod template checksum should change so the proxy is restarted
         AWAIT.alias("deployment checksum updated after route host assignment")
-                .untilAsserted(() -> assertThat(deploymentPodTemplateChecksum(proxy)).isNotEqualTo(initialChecksum));
+                .untilAsserted(() -> assertThat(deploymentPodTemplateChecksum(proxy)).isNotEqualTo(observedChecksum));
     }
 
+    @Nullable
     private String deploymentPodTemplateChecksum(KafkaProxy proxy) {
         var deployment = testActor.get(Deployment.class, ProxyDeploymentDependentResource.deploymentName(proxy));
         assertThat(deployment).isNotNull();


### PR DESCRIPTION
### Type of change

- [x] Bugfix
- [ ] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

Fixes non-deterministic test failure in `KafkaProxyReconcilerIT.deploymentChecksumUpdatesWhenOpenshiftRouteHostAssigned` that was failing with 409 Conflict errors when racing with the OpenShift IngressController.

**Changes:**
- Changed from `patchStatus()` to `editStatus()` which automatically handles resource version conflicts through retries
- Use distinct host value `"another.invalid"` to ensure updates are never no-ops (even if IngressController has already set the expected host)
- Improved variable naming and code clarity

**Test validation:**
- Verified the fix works correctly against a local CRC cluster
- Test passes consistently without 409 errors

### Additional Context

The test was failing non-deterministically in CI (MicroShift) because both the test and the OpenShift IngressController were attempting to update the Route's status concurrently, causing resource version conflicts. The `editStatus()` method in Fabric8 Kubernetes client handles these conflicts automatically by retrying with updated resource versions, making the test reliable.

Fixes #3673

### Checklist

- [x] PR raised from a fork of this repository and made from a branch rather than main.
- [x] Write tests (this is a test fix - the test itself validates the change)
- [ ] Update documentation (not applicable - test-only change)
- [x] Make sure all unit/integration tests pass (verified locally on CRC)
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [x] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, trigger the performance test suite. Ensure that any degradations to performance numbers are understood and justified. (not applicable - test-only change)
- [x] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (not applicable - test-only change)
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.