### PR TITLE
ci(notifications): add workflow run link to Slack failure alerts

### DIFF
--- a/.github/actions/common/slack-notification/action.yml
+++ b/.github/actions/common/slack-notification/action.yml
@@ -34,6 +34,15 @@ inputs:
     description: "Message to be published on Slack"
     required: false
     default: 'The workflow ${{ job.status }} on branch ${{ github.ref_name }}.'
+  serverUrl:
+    description: "GitHub server URL"
+    required: true
+  repository:
+    description: "GitHub repository"
+    required: true
+  runId:
+    description: "GitHub run ID"
+    required: true
 
 runs:
   using: "composite"
@@ -44,4 +53,7 @@ runs:
         SLACK_WEBHOOK: ${{ inputs.slackWebhook }}
         SLACK_COLOR: ${{ inputs.slackColor }}
         SLACK_TITLE: ${{ inputs.slackTitle }}
-        SLACK_MESSAGE: ${{ inputs.slackMessage }}
+        SLACK_MESSAGE: |
+          ${{ inputs.slackMessage }}
+
+          <${{ inputs.serverUrl }}/${{ inputs.repository }}/actions/runs/${{ inputs.runId }}|:mag: View workflow run details>

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -123,3 +123,6 @@ jobs:
           slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
           slackTitle: 'Failure Alert: ${{ github.repository }}'
           slackMessage: 'The docker build workflow failed on branch ${{ github.ref_name }}.'
+          serverUrl: ${{ github.server_url }}
+          repository: ${{ github.repository }}
+          runId: ${{ github.run_id }}

--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -77,3 +77,6 @@ jobs:
           slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
           slackTitle: 'Failure Alert: ${{ github.repository }}'
           slackMessage: 'The documentation tests workflow failed on branch ${{ github.ref_name }}.'
+          serverUrl: ${{ github.server_url }}
+          repository: ${{ github.repository }}
+          runId: ${{ github.run_id }}

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -117,3 +117,6 @@ jobs:
           slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
           slackTitle: 'Failure Alert: ${{ github.repository }}'
           slackMessage: 'The maven workflow failed on branch ${{ github.ref_name }}.'
+          serverUrl: ${{ github.server_url }}
+          repository: ${{ github.repository }}
+          runId: ${{ github.run_id }}

--- a/.github/workflows/operator-maven.yaml
+++ b/.github/workflows/operator-maven.yaml
@@ -118,3 +118,6 @@ jobs:
           slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
           slackTitle: 'Failure Alert: ${{ github.repository }}'
           slackMessage: 'The operator maven workflow failed on branch ${{ github.ref_name }}.'
+          serverUrl: ${{ github.server_url }}
+          repository: ${{ github.repository }}
+          runId: ${{ github.run_id }}

--- a/.github/workflows/operator-tests-microshift.yaml
+++ b/.github/workflows/operator-tests-microshift.yaml
@@ -165,3 +165,6 @@ jobs:
           slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
           slackTitle: 'Failure Alert: ${{ github.repository }}'
           slackMessage: 'The operator maven workflow failed on branch ${{ github.ref_name }}.'
+          serverUrl: ${{ github.server_url }}
+          repository: ${{ github.repository }}
+          runId: ${{ github.run_id }}

--- a/.github/workflows/publish-snapshot-docs-to-website.yaml
+++ b/.github/workflows/publish-snapshot-docs-to-website.yaml
@@ -121,6 +121,9 @@ jobs:
           slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
           slackTitle: 'Failure Alert: ${{ github.repository }}'
           slackMessage: 'The snapshot documentation build workflow failed.'
+          serverUrl: ${{ github.server_url }}
+          repository: ${{ github.repository }}
+          runId: ${{ github.run_id }}
 
   # Deployment job
   deploy:
@@ -145,3 +148,6 @@ jobs:
           slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
           slackTitle: 'Failure Alert: ${{ github.repository }}'
           slackMessage: 'The snapshot documentation deployment workflow failed.'
+          serverUrl: ${{ github.server_url }}
+          repository: ${{ github.repository }}
+          runId: ${{ github.run_id }}

--- a/.github/workflows/system-tests-merge.yaml
+++ b/.github/workflows/system-tests-merge.yaml
@@ -108,3 +108,6 @@ jobs:
           slackWebhook: ${{ secrets.KROXYLICIOUS_SLACK_WEBHOOK }}
           slackTitle: 'Failure Alert: ${{ github.repository }}'
           slackMessage: 'The system tests workflow failed on branch ${{ github.ref_name }}.'
+          serverUrl: ${{ github.server_url }}
+          repository: ${{ github.repository }}
+          runId: ${{ github.run_id }}


### PR DESCRIPTION
## Summary

Enhances Slack notifications for GitHub Actions failures to include a prominent, clickable link to the workflow run details. This addresses #3675 by making the useful workflow run URL more visible instead of buried in the footer.

## Changes

- **Modified `.github/actions/common/slack-notification/action.yml`:**
  - Added three new required inputs: `serverUrl`, `repository`, and `runId`
  - Updated `SLACK_MESSAGE` to append a Slack-formatted link with magnifying glass emoji (🔍)
  
- **Updated 7 workflow files (8 total usages):**
  - `maven.yaml`
  - `documentation-tests.yml`
  - `docker.yaml`
  - `operator-maven.yaml`
  - `operator-tests-microshift.yaml`
  - `system-tests-merge.yaml`
  - `publish-snapshot-docs-to-website.yaml` (2 usages)
  
  Each now passes GitHub context variables to the slack-notification action.

## Before / After

**Before:**
```
Failure Alert: kroxylicious/kroxylicious
The maven workflow failed on branch main.

Powered By rtCamp's GitHub Actions Library | Triggered on this workflow run | ...
                                              ↑ workflow run link (buried in footer)
```

**After:**
```
Failure Alert: kroxylicious/kroxylicious
The maven workflow failed on branch main.

🔍 View workflow run details  ← prominent, clickable link
```

## Test Plan

- ✅ Tested on fork with intentional workflow failure
- ✅ Verified Slack notification includes clickable workflow run link
- ✅ Confirmed link navigates to correct workflow run page
- ✅ Verified formatting is clean and visually prominent

## Notes

- Uses Slack markdown link format: `<URL|link text>`
- The 🔍 (magnifying glass) emoji makes the link visually distinctive
- All workflows that use the slack-notification action automatically benefit from this improvement

Closes #3675

🤖 Generated with [Claude Code](https://claude.com/claude-code)