### PR TITLE
fix(operator): remove incorrect 'routes' resource from default API group ClusterRole (#3800)

### DIFF
--- a/kroxylicious-operator/packaging/install/01.ClusterRole.kroxylicious-operator-dependent.yaml
+++ b/kroxylicious-operator/packaging/install/01.ClusterRole.kroxylicious-operator-dependent.yaml
@@ -18,7 +18,6 @@ rules:
       - ""
     resources:
       - services
-      - routes
       - configmaps
     verbs:
       - get


### PR DESCRIPTION
Closes #3800.

The first rule block in \`kroxylicious-operator/packaging/install/01.ClusterRole.kroxylicious-operator-dependent.yaml\` lists \`routes\` under \`apiGroups: \"\"\` (the core Kubernetes API), but Routes are an OpenShift API (\`route.openshift.io\`) and have no equivalent in core Kubernetes. The rule never matched anything in practice; the second rule block already grants the correct permissions on the \`route.openshift.io\` group.

Drop the stray entry so the manifest accurately reflects the permissions the operator needs.