### PR TITLE
fix(ci): prevent Test Reporter from aggregating stale test results

### DIFF
--- a/.github/workflows/run-system-tests.yaml
+++ b/.github/workflows/run-system-tests.yaml
@@ -200,9 +200,8 @@ jobs:
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2
         if: ${{ !cancelled() }}
         with:
-          artifact: junit-results-${{ matrix.tests }}-${{ inputs.kafkaClient }}
           name: SystemTests-${{ matrix.tests }}-${{ inputs.kafkaClient }}
-          path: '*.xml'
+          path: 'kroxylicious-systemtests/target/surefire-reports/**/TEST-*.xml'
           reporter: java-junit
           fail-on-empty: 'false'
 


### PR DESCRIPTION
## Summary

Fixes a bug in the Test Reporter configuration that caused false positive test failures by aggregating results from multiple workflow runs instead of just the current run.

## Problem

The Test Reporter step was configured with the `artifact` parameter, which downloads artifacts by name from the repository. When artifact names are reused across workflow runs (as ours are), the action downloads **all** matching artifacts from the repository history and aggregates their results.

This caused the reporter to include stale test failures from previous runs, even when the current run's tests all passed.

Example from [run #24973221664](https://github.com/kroxylicious/kroxylicious/actions/runs/24973221664/job/73158115145?pr=3801):
- Actual test execution: ✅ All tests SUCCEEDED
- Test Reporter output: ❌ 2 tests FAILED (from old runs)

The logs showed Test Reporter downloading 3 different versions of the same artifact from different workflow runs.

## Solution

Changed Test Reporter to read test results directly from the local filesystem:
- **Before**: `artifact: junit-results-${{ matrix.tests }}-${{ inputs.kafkaClient }}` + `path: '*.xml'`
- **After**: `path: 'kroxylicious-systemtests/target/surefire-reports/**/TEST-*.xml'`

This ensures only the current run's test results are reported.

## Testing

The test results are already on disk from the `mvn verify` step, so Test Reporter can read them directly without downloading artifacts.

## Type of change

- [x] Bugfix
- [ ] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation