### PR TITLE
(fix) use DEFAULT_PROXY_BOOTSTRAP in ProxyProtocolIT

### DIFF
--- a/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousConfigUtils.java
+++ b/kroxylicious-integration-test-support/src/main/java/io/kroxylicious/test/tester/KroxyliciousConfigUtils.java
@@ -28,7 +28,7 @@ public class KroxyliciousConfigUtils {
     public static final String DEFAULT_VIRTUAL_CLUSTER = "demo";
     public static final String DEFAULT_GATEWAY_NAME = "default";
 
-    static final HostPort DEFAULT_PROXY_BOOTSTRAP = new HostPort("localhost", 9192);
+    public static final HostPort DEFAULT_PROXY_BOOTSTRAP = new HostPort("localhost", 9192);
 
     /**
      * Create a KroxyliciousConfigBuilder with a single virtual cluster configured to

--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/ProxyProtocolIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/ProxyProtocolIT.java
@@ -39,7 +39,6 @@ import io.kroxylicious.proxy.config.ConfigurationBuilder;
 import io.kroxylicious.proxy.config.ProxyProtocolConfig;
 import io.kroxylicious.proxy.config.ProxyProtocolMode;
 import io.kroxylicious.proxy.config.VirtualClusterBuilder;
-import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.proxy.tls.CertificateGenerator;
 import io.kroxylicious.test.Request;
 import io.kroxylicious.test.Response;
@@ -50,6 +49,7 @@ import io.kroxylicious.test.codec.KafkaRequestEncoder;
 import io.kroxylicious.test.codec.KafkaResponseDecoder;
 import io.kroxylicious.test.tester.KroxyliciousConfigUtils;
 
+import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.DEFAULT_PROXY_BOOTSTRAP;
 import static io.kroxylicious.test.tester.KroxyliciousConfigUtils.defaultPortIdentifiesNodeGatewayBuilder;
 import static io.kroxylicious.test.tester.KroxyliciousTesters.mockKafkaKroxyliciousTester;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -401,7 +401,7 @@ class ProxyProtocolIT {
                         .withNewTargetCluster()
                         .withBootstrapServers(mockBootstrap)
                         .endTargetCluster()
-                        .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(new HostPort("localhost", 49592))
+                        .addToGateways(defaultPortIdentifiesNodeGatewayBuilder(DEFAULT_PROXY_BOOTSTRAP)
                                 .withNewTls()
                                 .withNewKeyStoreKey()
                                 .withStoreFile(keystore.path().toString())


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The ProxyProtocolIT test is flaky and intermittently fails in CI with port binding errors.
This could be due to the hardcoded port being part of the ephemeral port range which could be assigned to an unknown process by the OS while this test is running.
(This is just a theory, but its better to replace the hardcoded HostPort with the DEFAULT)

Even after this PR, if the tests are still flaky, we will have to go back and re-analyse the potential root cause

### Additional Context

https://github.com/kroxylicious/kroxylicious/issues/3799

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
