### PR TITLE
test(operator): fix race condition in KafkaServiceStrimziKafkaRefReconcilerIT

### DIFF
--- a/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
+++ b/kroxylicious-operator/src/main/java/io/kroxylicious/kubernetes/operator/ResourcesUtil.java
@@ -610,10 +610,12 @@ public class ResourcesUtil {
                                                                           String eventSourceName) {
 
         Optional<Kafka> kafka = getKafka(context, eventSourceName);
-        return kafka.flatMap(value -> value.getStatus().getListeners().stream()
-                .filter(listenerStatus -> listenerStatus.getName()
-                        .equals(service.getSpec().getStrimziKafkaRef().getListenerName()))
-                .findFirst());
+        return kafka.flatMap(value -> Optional.ofNullable(value.getStatus())
+                .map(KafkaStatus::getListeners)
+                .flatMap(listeners -> listeners.stream()
+                        .filter(listenerStatus -> listenerStatus.getName()
+                                .equals(service.getSpec().getStrimziKafkaRef().getListenerName()))
+                        .findFirst()));
     }
 
     private static <T extends CustomResource<?, ?>> ResourceCheckResult<T> handleListener(T resource, StrimziKafkaRef strimziKafkaRef,

--- a/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
+++ b/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
@@ -266,12 +266,15 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
         AWAIT.untilAsserted(() -> {
             final KafkaService kafkaService = testActor.get(KafkaService.class, ResourcesUtil.name(cr));
             Assertions.assertThat(kafkaService).isNotNull();
-            Assertions.assertThat(kafkaService.getStatus().getBootstrapServers()).isEqualTo(expectedBootstrap);
             assertThat(kafkaService.getStatus())
                     .isNotNull()
-                    .conditionList()
-                    .singleElement()
-                    .isResolvedRefsTrue();
+                    .satisfies(status -> {
+                        Assertions.assertThat(status.getBootstrapServers()).isEqualTo(expectedBootstrap);
+                        assertThat(status)
+                                .conditionList()
+                                .singleElement()
+                                .isResolvedRefsTrue();
+                    });
             String checksum = getReferentChecksum(kafkaService);
             if (hasReferents) {
                 Assertions.assertThat(checksum).isNotEqualTo(NO_CHECKSUM_SPECIFIED);


### PR DESCRIPTION
## Summary

Fixes the flaky test reported in #3809 where `KafkaServiceStrimziKafkaRefReconcilerIT` fails intermittently with a NullPointerException when accessing the KafkaService status.

## Root Cause

The `assertResolvedRefsTrue` method was calling `kafkaService.getStatus().getBootstrapServers()` without null-checking `getStatus()` first. When the reconciler hadn't completed yet (or encountered errors), `getStatus()` returned `null`, causing an immediate NPE instead of allowing Awaitility to continue polling.

## Changes

1. **Test Fix (KafkaServiceStrimziKafkaRefReconcilerIT.java:269)**
   - Added null-check using AssertJ's `satisfies()` for clean chained assertions
   - Status is now verified to be non-null before accessing `getBootstrapServers()`
   - When status is null, Awaitility continues polling instead of throwing NPE
   - Follows the same pattern used in `KafkaServiceBootstrapReconcilerIT` (lines 298-299)

2. **Defensive Fix (ResourcesUtil.java:613)**
   - Added null-safety using `Optional.ofNullable()` and streams API
   - Gracefully handles cases where Kafka resource status or listeners are null
   - Returns empty Optional instead of throwing NPE

## Testing

- ✅ Code compiles successfully
- ✅ Checkstyle validation passed
- ✅ Integration tests will run in CI (require Kubernetes cluster)

Fixes #3809

🤖 Generated with [Claude Code](https://claude.com/claude-code)