### PR TITLE
chore: Update Kroxylicious version used in benchmarks as part of release process.

### DIFF
--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -89,8 +89,13 @@ ORIGINAL_WORKING_BRANCH=$(git branch --show-current)
 replaceInFile() {
   local EXPRESSION=$1
   local FILE=$2
-  ${SED} -i -e "${EXPRESSION}" "${FILE}"
+  ${SED} -E -i -e "${EXPRESSION}" "${FILE}"
   git add "${FILE}"
+}
+
+updateVersionInBenchmarks() {
+  replaceInFile "s|KROXYLICIOUS_VERSION:-[0-9]+\.[0-9]+\.[0-9]+|KROXYLICIOUS_VERSION:-${1}|g" \
+    kroxylicious-openmessaging-benchmarks/scripts/setup-cluster.sh
 }
 
 cleanup() {
@@ -147,6 +152,8 @@ replaceInFile "s_:KroxyliciousGitRef:.*_:KroxyliciousGitRef: v${RELEASE_VERSION}
 
 replaceInFile "s_image: 'quay.io/kroxylicious/proxy:.*'_image: 'quay.io/kroxylicious/proxy:${RELEASE_VERSION}'_g" compose/kafka-compose.yaml
 
+updateVersionInBenchmarks "${RELEASE_VERSION}"
+
 echo "Validating things still build"
 mvn -q -B clean install -Pquick
 
@@ -190,6 +197,8 @@ replaceInFile "s_:KroxyliciousVersion:.*_:KroxyliciousVersion: ${NEXT_VERSION}_g
 replaceInFile "s_:KroxyliciousGitRef:.*_:KroxyliciousGitRef: main_g" kroxylicious-docs/docs/_assets/attributes.adoc # this doesn't make a lot sense...
 
 replaceInFile "s_image: 'quay.io/kroxylicious/proxy:.*'_image: 'quay.io/kroxylicious/proxy:${NEXT_VERSION}'_g" compose/kafka-compose.yaml
+
+updateVersionInBenchmarks "${NEXT_VERSION}"
 
 # bump the reference version in kroxylicious-api
 mvn -q -B -pl :kroxylicious-api versions:set-property -Dproperty="ApiCompatability.ReferenceVersion" -DnewVersion="${RELEASE_VERSION}" -DgenerateBackupPoms=false


### PR DESCRIPTION

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

### Type of change

_Select the type of your PR_

- Bugfix

### Description

Updates the Kroxylicious version referenced in the open messaging benchmark scripts as part of the release process.

fixes: #3582


### Additional Context


### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
