### PR TITLE
fix(ci): run all integration tests across modules in PR workflow

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -25,7 +25,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  discover_integration_test_chunks:
+    runs-on: ubuntu-latest
+    outputs:
+      test_chunks: ${{ steps.discover.outputs.test_chunks }}
+      modules: ${{ steps.discover.outputs.modules }}
+    steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+      - name: 'Discover ITs'
+        id: discover
+        run: |
+          TESTS_PER_CHUNK=15
+          TEST_CHUNKS=$(./scripts/discover-integration-tests.sh ${TESTS_PER_CHUNK})
+
+          # Extract unique modules from the chunks JSON
+          # Parse "module:TestClass" format and get unique module artifact IDs (basename)
+          DISCOVERED_MODULES=$(echo "$TEST_CHUNKS" | jq -r '.[]' \
+            | tr ',' '\n' \
+            | cut -d: -f1 \
+            | xargs -n 1 basename \
+            | sort -u \
+            | sed 's|^|:|' \
+            | tr '\n' ',' \
+            | sed 's/,$//')
+
+          # Always include BOM as it's required for dependency management
+          MODULES=":kroxylicious-bom,${DISCOVERED_MODULES}"
+
+          echo "test_chunks=$TEST_CHUNKS" >> $GITHUB_OUTPUT
+          echo "modules=$MODULES" >> $GITHUB_OUTPUT
+          echo "Discovered modules: $MODULES"
+          echo "Discovered $(echo "$TEST_CHUNKS" | jq -r 'length') test chunks"
   build_artifacts:
+    needs: discover_integration_test_chunks
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out repository'
@@ -36,13 +71,14 @@ jobs:
         uses: ./.github/actions/common/setup-java
       - name: 'Cache Maven packages'
         uses: ./.github/actions/common/cache-maven-packages
-      - name: 'Build Kroxylicious proxy integration tests'
+      - name: 'Build Kroxylicious modules with integration tests'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          echo "Building modules: ${{ needs.discover_integration_test_chunks.outputs.modules }}"
           mvn --batch-mode \
             --activate-profiles '!qa' \
-            --projects :kroxylicious-bom,:kroxylicious-integration-tests,:kroxylicious-filter-archetype \
+            --projects ${{ needs.discover_integration_test_chunks.outputs.modules }} \
             --also-make \
             -DskipTests \
             -Dmaven.javadoc.skip=true \
@@ -60,22 +96,6 @@ jobs:
           name: kroxylicious-maven-artifacts
           path: /tmp/kroxylicious-artifacts/maven-repo.tar.gz
           retention-days: 1
-  discover_integration_test_chunks:
-    runs-on: ubuntu-latest
-    outputs:
-      test_chunks: ${{ steps.discover.outputs.test_chunks }}
-    steps:
-      - name: 'Check out repository'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          fetch-depth: 0
-      - name: 'Discover ITs'
-        working-directory: kroxylicious-integration-tests
-        id: discover
-        run: |
-          TESTS_PER_CHUNK=15
-          TEST_CHUNKS="[$(find . -type f -name "*IT.java" -exec basename {} .java \; | shuf | xargs -L ${TESTS_PER_CHUNK} | tr ' ' , | sed 's/.*/"&"/' | sed -z 's/\n/,/g;s/,$/\n/')]"
-          echo "test_chunks=$TEST_CHUNKS" >> $GITHUB_OUTPUT
   run_integration_tests:
     needs: [build_artifacts, discover_integration_test_chunks]
     runs-on: ubuntu-latest
@@ -84,8 +104,24 @@ jobs:
       matrix:
         tests: ${{ fromJson(needs.discover_integration_test_chunks.outputs.test_chunks) }}
     steps:
+      - name: Parse test specifications
+        id: parse
+        run: |
+          CHUNK="${{ matrix.tests }}"
+          echo "Processing chunk: $CHUNK"
+
+          # Extract module from first test (all tests in chunk are from same module)
+          FIRST_SPEC=$(echo "$CHUNK" | cut -d, -f1)
+          MODULE=$(echo "$FIRST_SPEC" | cut -d: -f1)
+
+          # Remove "module:" prefix from all tests
+          TEST_LIST=$(echo "$CHUNK" | sed "s|${MODULE}:||g")
+
+          echo "module=$MODULE" >> $GITHUB_OUTPUT
+          echo "tests=$TEST_LIST" >> $GITHUB_OUTPUT
+
       - name: Log tests to run
-        run: echo "Running tests on classes '${{ matrix.tests }}'"
+        run: echo "Running tests '${{ steps.parse.outputs.tests }}' in module '${{ steps.parse.outputs.module }}'"
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -104,7 +140,7 @@ jobs:
           mkdir -p "$HOME/.m2/repository"
           cd "$HOME/.m2/repository"
           tar xzf /tmp/kroxylicious-artifacts/maven-repo.tar.gz
-      - name: 'Run proxy Kroxylicious integration tests'
+      - name: 'Run integration tests'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # These variables/secrets support the Fortanix/KMS integration tests.   If the secrets are absent, the
@@ -112,13 +148,13 @@ jobs:
           KROXYLICIOUS_KMS_FORTANIX_API_ENDPOINT: ${{ vars.KROXYLICIOUS_KMS_FORTANIX_API_ENDPOINT }}
           KROXYLICIOUS_KMS_FORTANIX_ADMIN_API_KEY: ${{ secrets.KROXYLICIOUS_KMS_FORTANIX_ADMIN_API_KEY }}
           KROXYLICIOUS_KMS_FORTANIX_API_KEY: ${{ secrets.KROXYLICIOUS_KMS_FORTANIX_API_KEY }}
-        working-directory: kroxylicious-integration-tests
+        working-directory: ${{ steps.parse.outputs.module }}
         run: |
           mvn --batch-mode \
             --activate-profiles '!qa' \
             -DskipUTs \
             -Derrorprone.skip=true \
-            -Dit.test="${{ matrix.tests }}" \
+            -Dit.test="${{ steps.parse.outputs.tests }}" \
             verify
   integration_test_proxy:
     runs-on: ubuntu-latest
@@ -143,28 +179,3 @@ jobs:
         echo "$FAILED_JSON" | jq -r '"* [\(.name)](\(.url))"' >> $GITHUB_STEP_SUMMARY
         echo "$FAILED_JSON" | jq -r '"\(.name): \(.url)"'
         exit 1
-  integration_test_filter_archetype:
-    needs: build_artifacts
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Check out repository'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          fetch-depth: 0
-      - name: Setup Java
-        uses: ./.github/actions/common/setup-java
-      - name: 'Cache Maven packages'
-        uses: ./.github/actions/common/cache-maven-packages
-      - name: 'Download Kroxylicious Maven artifacts'
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: kroxylicious-maven-artifacts
-          path: /tmp/kroxylicious-artifacts
-      - name: 'Extract Kroxylicious Maven artifacts'
-        run: |
-          mkdir -p "$HOME/.m2/repository"
-          cd "$HOME/.m2/repository"
-          tar xzf /tmp/kroxylicious-artifacts/maven-repo.tar.gz
-      - name: 'run filter archetype integration tests'
-        working-directory: kroxylicious-filter-archetype
-        run: mvn -B verify

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -17,6 +17,8 @@
 name: "Run Kroxylicious Proxy Integration Tests"
 
 on:
+  push:
+    branches: [ main, 'release/**' ]
   pull_request:
     types: [ opened, synchronize, reopened ]
 
@@ -53,7 +55,8 @@ jobs:
             | sed 's/,$//')
 
           # Always include BOM as it's required for dependency management
-          MODULES=":kroxylicious-bom,${DISCOVERED_MODULES}"
+          # Also include filter-archetype as it has special IT requirements
+          MODULES=":kroxylicious-bom,:kroxylicious-filter-archetype,${DISCOVERED_MODULES}"
 
           echo "test_chunks=$TEST_CHUNKS" >> $GITHUB_OUTPUT
           echo "modules=$MODULES" >> $GITHUB_OUTPUT
@@ -156,9 +159,34 @@ jobs:
             -Derrorprone.skip=true \
             -Dit.test="${{ steps.parse.outputs.tests }}" \
             verify
+  integration_test_filter_archetype:
+    needs: build_artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+      - name: Setup Java
+        uses: ./.github/actions/common/setup-java
+      - name: 'Cache Maven packages'
+        uses: ./.github/actions/common/cache-maven-packages
+      - name: 'Download Kroxylicious Maven artifacts'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: kroxylicious-maven-artifacts
+          path: /tmp/kroxylicious-artifacts
+      - name: 'Extract Kroxylicious Maven artifacts'
+        run: |
+          mkdir -p "$HOME/.m2/repository"
+          cd "$HOME/.m2/repository"
+          tar xzf /tmp/kroxylicious-artifacts/maven-repo.tar.gz
+      - name: 'run filter archetype integration tests'
+        working-directory: kroxylicious-filter-archetype
+        run: mvn -B verify
   integration_test_proxy:
     runs-on: ubuntu-latest
-    needs: run_integration_tests
+    needs: [run_integration_tests, integration_test_filter_archetype]
     if: always()
     permissions:
       actions: read

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -99,14 +99,12 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          KROXYLICIOUS_KMS_FORTANIX_API_ENDPOINT: ${{ vars.KROXYLICIOUS_KMS_FORTANIX_API_ENDPOINT }}
-          KROXYLICIOUS_KMS_FORTANIX_ADMIN_API_KEY: ${{ secrets.KROXYLICIOUS_KMS_FORTANIX_ADMIN_API_KEY }}
-          KROXYLICIOUS_KMS_FORTANIX_API_KEY: ${{ secrets.KROXYLICIOUS_KMS_FORTANIX_API_KEY }}
         run: |
           mvn --batch-mode \
             --activate-profiles 'ci,!qa' \
             --projects ''!:kroxylicious-operator'' \
             -Derrorprone.skip=true \
+            -DskipITs=true \
             -Djapicmp.skip=${REFERENCE_RELEASE_UNPUBLISHED} \
             verify \
             org.sonarsource.scanner.maven:sonar-maven-plugin:5.5.0.6356:sonar

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/pom.xml
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms-test-support/pom.xml
@@ -125,10 +125,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
             </plugin>

--- a/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/pom.xml
+++ b/kroxylicious-kms-providers/kroxylicious-kms-provider-azure-key-vault-kms/pom.xml
@@ -120,10 +120,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.github.spotbugs</groupId>
-                <artifactId>spotbugs-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>

--- a/kroxylicious-kubernetes/kroxylicious-operator/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/pom.xml
@@ -328,6 +328,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
+                    <skipTests>${skipITs}</skipTests>
                     <runOrder>random</runOrder>
                     <argLine>
                         <!-- https://junit-pioneer.org/docs/environment-variables/#warnings-for-reflective-access -->

--- a/scripts/discover-integration-tests.sh
+++ b/scripts/discover-integration-tests.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+set -euo pipefail
+
+# Set up SED for platform compatibility (gsed on macOS, sed on Linux)
+OS=$(uname)
+if [ "$OS" = 'Darwin' ]; then
+  SED=$(command -v gsed || echo "sed")
+else
+  SED=$(command -v sed)
+fi
+
+# Default chunk size
+TESTS_PER_CHUNK=${1:-15}
+
+# Discover ITs from all modules, format as "module:TestClass"
+# Exclude target dirs and archetype template resources
+TEST_LIST=$(find . -type f -name "*IT.java" \
+  -not -path "*/target/*" \
+  -not -path "*/archetype-resources/*" \
+  | while read -r file; do
+      testname=$(basename "$file" .java)
+      # Extract module path: ./kroxylicious-operator/src/... -> kroxylicious-operator
+      module=$(echo "$file" | ${SED} 's|^\./||' | ${SED} 's|/src/.*||')
+      echo "${module}:${testname}"
+    done | sort)
+
+# Group tests by module, shuffle within each module, then chunk
+# Compatible with bash 3.2+ (no associative arrays)
+CHUNKS=()
+current_module=""
+module_tests=""
+
+while IFS= read -r spec; do
+    if [ -z "$spec" ]; then
+        continue
+    fi
+
+    module=$(echo "$spec" | cut -d: -f1)
+    test=$(echo "$spec" | cut -d: -f2)
+
+    # If we hit a new module, process the previous module's tests
+    if [ -n "$current_module" ] && [ "$module" != "$current_module" ]; then
+        # Shuffle and chunk the accumulated tests
+        shuffled=$(echo "$module_tests" | tr ' ' '\n' | grep -v '^$' | shuf)
+        while IFS= read -r chunk; do
+            if [ -n "$chunk" ]; then
+                # Prefix each test with module: and convert spaces to commas
+                prefixed=$(echo "$chunk" | ${SED} "s|\([^ ]*\)|${current_module}:\1|g" | tr ' ' ',')
+                CHUNKS+=("\"$prefixed\"")
+            fi
+        done <<< "$(echo "$shuffled" | xargs -L ${TESTS_PER_CHUNK})"
+
+        # Reset for new module
+        module_tests=""
+    fi
+
+    current_module="$module"
+    module_tests="${module_tests}${test} "
+done <<< "$TEST_LIST"
+
+# Process the last module
+if [ -n "$current_module" ] && [ -n "$module_tests" ]; then
+    shuffled=$(echo "$module_tests" | tr ' ' '\n' | grep -v '^$' | shuf)
+    while IFS= read -r chunk; do
+        if [ -n "$chunk" ]; then
+            # Prefix each test with module: and convert spaces to commas
+            prefixed=$(echo "$chunk" | ${SED} "s|\([^ ]*\)|${current_module}:\1|g" | tr ' ' ',')
+            CHUNKS+=("\"$prefixed\"")
+        fi
+    done <<< "$(echo "$shuffled" | xargs -L ${TESTS_PER_CHUNK})"
+fi
+
+# Output JSON array
+TEST_CHUNKS="[$(IFS=,; echo "${CHUNKS[*]}")]"
+echo "$TEST_CHUNKS"


### PR DESCRIPTION
> **Note**: This PR was updated after incorporating review feedback. Key changes:
> - ✅ **Archetype IT job restored** (not removed) - runs the special archetype integration test
> - ✅ **Workflow now runs on main/release branches** - ITs execute on both PRs and pushes to main/release

## Summary

Fixes #3798 

The integration test workflow had two major issues:

1. **Missing ITs from multiple modules** - Only discovered and ran ITs from `kroxylicious-integration-tests`, missing **17 ITs** in other modules:
   - 10 ITs in `kroxylicious-operator`
   - 5 ITs in `kroxylicious-kms-providers` submodules
   - 1 IT in `kroxylicious-app`
   - 1 IT in `kroxylicious-filter-archetype` (was in separate job, now properly restored)

2. **No integration tests on main branch** - Workflow only ran on PRs, providing no continuous validation on main/release branches

This created risk where PRs could be merged without running all ITs, and main branch had no IT coverage.

## Changes

### Workflow Changes
- **Created `scripts/discover-integration-tests.sh`** - Discovers ITs from all modules, groups by module, shuffles within module, and chunks for parallel execution
- **Updated `.github/workflows/integration-tests.yaml`**:
  - **Added `push` trigger for `main` and `release/**` branches** - ITs now run on both PRs and main/release pushes for continuous validation
  - Discovery job runs once and outputs both test chunks and module list
  - Build artifacts explicitly includes `:kroxylicious-filter-archetype` in addition to dynamically discovered modules
  - Tests run in their original module directories (preserving module-specific Maven configs)
  - **Restored `integration_test_filter_archetype` job** - Runs the archetype's special integration test (generates project from template and tests it)
  - `integration_test_proxy` waits for both dynamic ITs and archetype IT before reporting overall status
- **Updated `.github/workflows/maven.yaml`** - Added `-DskipITs=true` to sonar scan on main branch (ITs run separately in integration-tests workflow)

### POM Fixes
- **Fixed `kroxylicious-operator/pom.xml`** - Added `<skipTests>${skipITs}</skipTests>` to failsafe configuration to respect `-DskipITs` flag
- **Fixed Azure KMS modules** - Removed explicit `spotbugs-maven-plugin` declarations that were running outside the qa profile:
  - `kroxylicious-kms-provider-azure-key-vault-kms/pom.xml`
  - `kroxylicious-kms-provider-azure-key-vault-kms-test-support/pom.xml`

## How It Works

1. **Discovery**: Script finds all `*IT.java` files across modules (excluding archetype templates and target dirs)
2. **Grouping**: Groups tests by module and shuffles within each module
3. **Chunking**: Creates chunks of 15 tests per module for parallel execution
4. **Building**: Builds discovered modules plus BOM and archetype using `--projects` and `--also-make`
5. **Execution**: 
   - Dynamic ITs run in their original module directories, automatically inheriting module-specific configurations
   - Archetype IT runs separately with its special test harness (generates and tests a project from the archetype)

## Benefits

- ✅ All 108+ ITs now run on every PR **and** every push to main/release branches
- ✅ Continuous validation on main/release branches using the same workflow as PRs
- ✅ Module-specific configurations automatically applied (e.g., operator's `--add-opens` JVM args)
- ✅ Parallel execution maintained (~14 dynamic IT jobs + 1 archetype IT job)
- ✅ No hardcoded module lists - automatically adapts when new modules with ITs are added
- ✅ Single source of truth for IT discovery
- ✅ Archetype IT properly isolated with its special build/test requirements

## Testing

### Original Testing
Tested on fork PR: https://github.com/k-wall/kroxylicious/pull/160

### Testing After Review Feedback

**PR Trigger Test**: https://github.com/k-wall/kroxylicious/pull/161  
**PR Workflow Run**: https://github.com/k-wall/kroxylicious/actions/runs/25096833241  
✅ All 18 jobs passed (14 dynamic IT chunks + archetype IT + build + discover + proxy)

**Push to Main Test**:  
**Main Workflow Run**: https://github.com/k-wall/kroxylicious/actions/runs/25097419305  
✅ All 18 jobs passed

Verified:
- `integration_test_filter_archetype` job runs successfully
- Archetype explicitly included in build modules: `:kroxylicious-bom,:kroxylicious-filter-archetype,...`
- 14 dynamic IT test chunks discovered and executed across 8 modules
- `integration_test_proxy` waits for all IT jobs and reports comprehensive status
- Workflow triggers correctly on both PR events and pushes to main
- **Both PR and main branch workflows use identical IT execution logic**

All module ITs verified running:
- `kroxylicious-app` (1 IT)
- `kroxylicious-operator` (10 ITs)
- `kroxylicious-kms-providers/*` (5 ITs across submodules)
- `kroxylicious-integration-tests` (92 ITs)
- `kroxylicious-filter-archetype` (1 archetype IT)

## Verification

After merge, verify on next PR and main push:
```bash
# Check discovered modules (should include archetype)
gh run view <run-id> --log | grep "Discovered modules"

# Verify all test chunks
gh run view <run-id> --log | grep "Discovered.*test chunks"

# Verify archetype IT job ran
gh api repos/kroxylicious/kroxylicious/actions/runs/<run-id>/jobs | jq '.jobs[] | select(.name == "integration_test_filter_archetype")'

# Count total IT jobs (dynamic + archetype)
gh api repos/kroxylicious/kroxylicious/actions/runs/<run-id>/jobs | jq '[.jobs[] | select(.name | contains("integration_test"))] | length'
```

Expected: ~14 dynamic integration test jobs + 1 archetype IT job = 15 total