### PR TITLE
fix: remove unknown apis in Authorization & EntityIsolation Filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format `<github issue/pr number>: <short description>`.
 
 * [#2820](https://github.com/kroxylicious/kroxylicious/issues/2820): feat(operator): add automatic TLS trust discovery for Strimzi-managed Kafka clusters via `trustStrimziCaCertificate` field in KafkaService
 * [#3498](https://github.com/kroxylicious/kroxylicious/pull/3498): feat(record-validation): add Avro and Protobuf schema validation support
+* [#3760](https://github.com/kroxylicious/kroxylicious/issues/3760): fix: remove unknown apis in Authorization & EntityIsolation Filters
 * [#3769](https://github.com/kroxylicious/kroxylicious/pull/3769): fix(runtime): messages enter Filter chain before Transport Subject built
 * [#3757](https://github.com/kroxylicious/kroxylicious/issues/3757): fix(runtime): trigger read after HAProxy message to prevent deadlock when autoread disabled
 * [#1295](https://github.com/kroxylicious/kroxylicious/issues/1295): feat(aws-kms): add IRSA and EKS Pod Identity credential providers, and restructure AWS KMS credential configuration under a new `credentials` node (see [note](#note-021-aws-kms-credentials-restructure))

--- a/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/AuthorizationFilter.java
+++ b/kroxylicious-filters/kroxylicious-authorization/src/main/java/io/kroxylicious/filter/authorization/AuthorizationFilter.java
@@ -362,19 +362,24 @@ public class AuthorizationFilter implements RequestFilter, ResponseFilter {
         var toRemove = new ArrayList<ApiVersionsResponseData.ApiVersion>();
         ApiVersionsResponseData.ApiVersionCollection apiVersions = response.apiKeys();
         for (var version : apiVersions) {
-            ApiKeys key = ApiKeys.forId(version.apiKey());
-            var enforcement = apiEnforcement.get(key);
-            if (enforcement != null) {
-                // Kafka 4.0 presents itself as supporting v0-v2 of Produce despite it not really supporting
-                // those versions. This is to maintain support for older librdkafka versions.
-                // see https://issues.apache.org/jira/browse/KAFKA-18659
-                if (key != ApiKeys.PRODUCE) {
-                    version.setMinVersion(Passthrough.asShort(Math.max(enforcement.minSupportedVersion(), version.minVersion())));
-                }
-                version.setMaxVersion(Passthrough.asShort(Math.min(enforcement.maxSupportedVersion(), version.maxVersion())));
+            if (!ApiKeys.hasId(version.apiKey())) {
+                toRemove.add(version);
             }
             else {
-                toRemove.add(version);
+                ApiKeys key = ApiKeys.forId(version.apiKey());
+                var enforcement = apiEnforcement.get(key);
+                if (enforcement != null) {
+                    // Kafka 4.0 presents itself as supporting v0-v2 of Produce despite it not really supporting
+                    // those versions. This is to maintain support for older librdkafka versions.
+                    // see https://issues.apache.org/jira/browse/KAFKA-18659
+                    if (key != ApiKeys.PRODUCE) {
+                        version.setMinVersion(Passthrough.asShort(Math.max(enforcement.minSupportedVersion(), version.minVersion())));
+                    }
+                    version.setMaxVersion(Passthrough.asShort(Math.min(enforcement.maxSupportedVersion(), version.maxVersion())));
+                }
+                else {
+                    toRemove.add(version);
+                }
             }
         }
         apiVersions.removeAll(toRemove);

--- a/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/API_VERSIONS/4/unknown-api-version.yaml
+++ b/kroxylicious-filters/kroxylicious-authorization/src/test/resources/scenarios/API_VERSIONS/4/unknown-api-version.yaml
@@ -1,0 +1,62 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "API_VERSIONS"
+  apiVersion: 4
+  scenario: "baseline"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "API_VERSIONS"
+      expectedRequestVersion: 4
+      expectedRequestHeader:
+        requestApiKey: 18
+        requestApiVersion: 4
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        clientSoftwareName: "random-string-313"
+        clientSoftwareVersion: "random-string-234"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        errorCode: 45
+        apiKeys:
+          - apiKey: 3
+            minVersion: 0
+            maxVersion: 13
+          - apiKey: 10000 # hypothetical future apiKey not represented in the ApiKeys enum
+            minVersion: 0
+            maxVersion: 13
+        throttleTimeMs: 880
+  authorizerRules:
+    allowed:
+      - subject: "alice"
+        resourceName: "my-topic"
+        resourceClass: "TOPIC"
+        resourceType: "DESCRIBE"
+  topicNames: null
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 18
+    requestApiVersion: 4
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    clientSoftwareName: "random-string-313"
+    clientSoftwareVersion: "random-string-234"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    errorCode: 45
+    apiKeys:
+      - apiKey: 3
+        minVersion: 0
+        maxVersion: 13
+    throttleTimeMs: 880

--- a/kroxylicious-filters/kroxylicious-entity-isolation/src/main/java/io/kroxylicious/filter/entityisolation/EntityIsolationFilter.java
+++ b/kroxylicious-filters/kroxylicious-entity-isolation/src/main/java/io/kroxylicious/filter/entityisolation/EntityIsolationFilter.java
@@ -224,17 +224,22 @@ class EntityIsolationFilter implements RequestFilter, ResponseFilter {
             var toRemove = new ArrayList<ApiVersionsResponseData.ApiVersion>();
             ApiVersionsResponseData.ApiVersionCollection apiVersions = response.apiKeys();
             for (var version : apiVersions) {
-                var key = ApiKeys.forId(version.apiKey());
-                var processor = processorMap.get(key);
-                if (processor != null) {
-                    // Produce is special-cased owing to https://github.com/kroxylicious/kroxylicious/pull/2851 / KAFKA-18659
-                    var min = asShort(key == ApiKeys.PRODUCE ? 0 : Math.max(processor.minSupportedVersion(), version.minVersion()));
-                    var max = asShort(Math.min(processor.maxSupportedVersion(), version.maxVersion()));
-                    version.setMinVersion(min);
-                    version.setMaxVersion(max);
+                if (!ApiKeys.hasId(version.apiKey())) {
+                    toRemove.add(version);
                 }
                 else {
-                    toRemove.add(version);
+                    var key = ApiKeys.forId(version.apiKey());
+                    var processor = processorMap.get(key);
+                    if (processor != null) {
+                        // Produce is special-cased owing to https://github.com/kroxylicious/kroxylicious/pull/2851 / KAFKA-18659
+                        var min = asShort(key == ApiKeys.PRODUCE ? 0 : Math.max(processor.minSupportedVersion(), version.minVersion()));
+                        var max = asShort(Math.min(processor.maxSupportedVersion(), version.maxVersion()));
+                        version.setMinVersion(min);
+                        version.setMaxVersion(max);
+                    }
+                    else {
+                        toRemove.add(version);
+                    }
                 }
             }
             apiVersions.removeAll(toRemove);

--- a/kroxylicious-filters/kroxylicious-entity-isolation/src/test/resources/io/kroxylicious/filter/entityisolation/API_VERSIONS/4/remove-unknown-api-keys.yaml
+++ b/kroxylicious-filters/kroxylicious-entity-isolation/src/test/resources/io/kroxylicious/filter/entityisolation/API_VERSIONS/4/remove-unknown-api-keys.yaml
@@ -1,0 +1,57 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+metadata:
+  apiKeys: "API_VERSIONS"
+  apiVersion: 4
+  scenario: "ensures that filters remove unknown api keys"
+given:
+  mockedUpstreamResponses:
+    - expectedRequestKey: "API_VERSIONS"
+      expectedRequestVersion: 4
+      expectedRequestHeader:
+        requestApiKey: 18
+        requestApiVersion: 4
+        correlationId: 1
+        clientId: "clientId"
+      expectedRequest:
+        clientSoftwareName: "random-string-313"
+        clientSoftwareVersion: "random-string-234"
+      upstreamResponseHeader:
+        correlationId: 1
+      upstreamResponse:
+        errorCode: 45
+        apiKeys:
+          - apiKey: 17
+            minVersion: 0
+            maxVersion: 1
+          - apiKey: 10000 # unknown API key, is removed by filter
+            minVersion: 0
+            maxVersion: 32767
+        throttleTimeMs: 880
+  topicNames: null
+  entityTypes: ["GROUP_ID"]
+when:
+  subject: "alice"
+  requestHeader:
+    requestApiKey: 18
+    requestApiVersion: 4
+    correlationId: 1
+    clientId: "clientId"
+  request:
+    clientSoftwareName: "random-string-313"
+    clientSoftwareVersion: "random-string-234"
+then:
+  expectedResponseHeader:
+    correlationId: 1
+  expectedResponse:
+    errorCode: 45
+    apiKeys:
+      - apiKey: 17
+        minVersion: 0
+        maxVersion: 1
+    throttleTimeMs: 880


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

- Remove unknown API versions from ApiVersionsResponseData in AuthorizationFilter.
- Remove unknown API versions from ApiVersionsResponseData in EntityIsolationFilter.

A user hit an issue with the authorization filter in front of a
Confluent Cloud Kafka. The Confluent Kafka advertises some proprietary
RPCs that aren't present in apache kafka using high ids of 10000+. The Proxy
aims to only present the intersection of versions that can be decoded by
the Proxy and the upstream. However the logic to do this is downstream
of the user Filter Chain. So user filters have to cope with unknown
API ids if they intercept ApiVersionResponseData.

Note that in future we could consider building safeties into the runtime
to prevent Filters being exposed to these unknown api keys. However that
is also a kind of secret knowledge that is equally hard to communicate
to Filter Authors, and logically we would need to apply an intersection
in between each user user Filter to give the same guarantee to all Filters.
Any filter could introduce unknown ids if it wanted to by manipulating
the ApiVersions response.

Fixes #3760

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
