### PR TITLE
Webhook Phase 2: filters, upstream TLS, delegated annotations, native…

### DIFF
--- a/kroxylicious-kubernetes-api/pom.xml
+++ b/kroxylicious-kubernetes-api/pom.xml
@@ -236,6 +236,9 @@
                         <io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.Resources>
                             io.fabric8.kubernetes.api.model.ResourceRequirements
                         </io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.Resources>
+                        <io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.filterdefinitions.Config>
+                            java.lang.Object
+                        </io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.filterdefinitions.Config>
                         <io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyingressspec.clusterip.Protocol>
                             io.kroxylicious.kubernetes.api.common.Protocol
                         </io.kroxylicious.kubernetes.api.v1alpha1.kafkaproxyingressspec.clusterip.Protocol>

--- a/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kroxylicioussidecarconfigs.kroxylicious.io-v1.yml
+++ b/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kroxylicioussidecarconfigs.kroxylicious.io-v1.yml
@@ -113,6 +113,59 @@ spec:
                     application containers, pointing them to the sidecar proxy.
                   type: boolean
                   default: true
+                filterDefinitions:
+                  description: |
+                    Filter definitions applied to traffic passing through the sidecar proxy.
+                    Each filter has a unique name, a type identifying the FilterFactory plugin,
+                    and optional plugin-specific configuration.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - type
+                    properties:
+                      name:
+                        description: A unique name for this filter instance.
+                        type: string
+                        pattern: "[a-z0-9A-Z]([a-z0-9A-Z_.\\-]{0,251}[a-z0-9A-Z])?"
+                      type:
+                        description: The fully qualified type name of the FilterFactory plugin.
+                        type: string
+                      config:
+                        description: Plugin-specific configuration for this filter.
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                upstreamTls:
+                  description: |
+                    TLS configuration for the connection from the sidecar proxy to the upstream
+                    Kafka cluster. If omitted, the proxy connects to Kafka without TLS.
+                  type: object
+                  properties:
+                    trustAnchorSecretRef:
+                      description: |
+                        A reference to a Secret containing the trusted CA certificate(s) for
+                        validation of the upstream Kafka broker's TLS server certificate.
+                        The referenced key should contain a PEM-encoded certificate bundle.
+                      type: object
+                      required:
+                        - name
+                        - key
+                      properties:
+                        name:
+                          description: The name of the Secret in the pod's namespace.
+                          type: string
+                        key:
+                          description: The key within the Secret data identifying the CA certificate bundle.
+                          type: string
+                delegatedAnnotations:
+                  description: |
+                    Annotations that the application pod owner is permitted to set to override
+                    sidecar configuration. Any annotation in the kroxylicious.io/ namespace
+                    that is not in this list will be ignored with a warning.
+                  type: array
+                  items:
+                    type: string
             status:
               type: object
               properties:

--- a/kroxylicious-kubernetes-web-hook/pom.xml
+++ b/kroxylicious-kubernetes-web-hook/pom.xml
@@ -43,6 +43,10 @@
         <!-- project dependencies -->
         <dependency>
             <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
             <artifactId>kroxylicious-annotations</artifactId>
         </dependency>
         <dependency>

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
@@ -44,18 +44,6 @@ class AdmissionHandler implements HttpHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(AdmissionHandler.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final String JSON_PATCH_TYPE = "JSONPatch";
-    private static final String KROXYLICIOUS_ANNOTATION_PREFIX = "kroxylicious.io/";
-
-    /** Annotation keys that app owners can use to override sidecar config when delegated. */
-    static final String DELEGATED_BOOTSTRAP_PORT = "kroxylicious.io/sidecar-bootstrap-port";
-    static final String DELEGATED_NODE_ID_RANGE = "kroxylicious.io/sidecar-node-id-range";
-
-    /** Annotations managed by the webhook itself — never treated as undelegated. */
-    private static final Set<String> WEBHOOK_MANAGED_ANNOTATIONS = Set.of(
-            Annotations.INJECT_SIDECAR,
-            Annotations.SIDECAR_CONFIG,
-            Annotations.PROXY_CONFIG,
-            Annotations.SIDECAR_STATUS);
 
     private final SidecarConfigResolver configResolver;
     private final String proxyImage;
@@ -198,7 +186,6 @@ class AdmissionHandler implements HttpHandler {
         List<String> delegated = adminSpec.getDelegatedAnnotations();
         Set<String> delegatedSet = delegated != null ? Set.copyOf(delegated) : Set.of();
 
-        // Warn about undelegated kroxylicious.io/ annotations
         warnAboutUndelegatedAnnotations(namespace, podName, podAnnotations, delegatedSet);
 
         if (delegatedSet.isEmpty()) {
@@ -208,10 +195,8 @@ class AdmissionHandler implements HttpHandler {
         // Copy the spec so we don't mutate the cached admin config
         KroxyliciousSidecarConfigSpec effective = copySpec(adminSpec);
 
-        // Apply bootstrap port override
         applyBootstrapPortOverride(podAnnotations, podName, namespace, delegatedSet, effective);
 
-        // Apply node ID range override (format: "start-end")
         applyNodeIdRangeOverride(podAnnotations, podName, namespace, delegatedSet, effective);
 
         return effective;
@@ -222,8 +207,8 @@ class AdmissionHandler implements HttpHandler {
                                                  String namespace,
                                                  Set<String> delegatedSet,
                                                  KroxyliciousSidecarConfigSpec effective) {
-        if (delegatedSet.contains(DELEGATED_NODE_ID_RANGE)) {
-            String rangeStr = podAnnotations.get(DELEGATED_NODE_ID_RANGE);
+        if (delegatedSet.contains(Annotations.DELEGATED_NODE_ID_RANGE)) {
+            String rangeStr = podAnnotations.get(Annotations.DELEGATED_NODE_ID_RANGE);
             if (rangeStr != null) {
                 String[] parts = rangeStr.split("-", 2);
                 if (parts.length == 2) {
@@ -237,7 +222,7 @@ class AdmissionHandler implements HttpHandler {
                         LOGGER.atWarn()
                                 .addKeyValue(WebhookLoggingKeys.POD, podName)
                                 .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
-                                .addKeyValue(WebhookLoggingKeys.ANNOTATION, DELEGATED_NODE_ID_RANGE)
+                                .addKeyValue(WebhookLoggingKeys.ANNOTATION, Annotations.DELEGATED_NODE_ID_RANGE)
                                 .addKeyValue(WebhookLoggingKeys.ANNOTATION_VALUE, rangeStr)
                                 .log("Invalid node ID range in delegated annotation, using admin default");
                     }
@@ -246,7 +231,7 @@ class AdmissionHandler implements HttpHandler {
                     LOGGER.atWarn()
                             .addKeyValue(WebhookLoggingKeys.POD, podName)
                             .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
-                            .addKeyValue(WebhookLoggingKeys.ANNOTATION, DELEGATED_NODE_ID_RANGE)
+                            .addKeyValue(WebhookLoggingKeys.ANNOTATION, Annotations.DELEGATED_NODE_ID_RANGE)
                             .addKeyValue(WebhookLoggingKeys.ANNOTATION_VALUE, rangeStr)
                             .log("Invalid node ID range format in delegated annotation (expected start-end), using admin default");
                 }
@@ -259,8 +244,8 @@ class AdmissionHandler implements HttpHandler {
                                                    String namespace,
                                                    Set<String> delegatedSet,
                                                    KroxyliciousSidecarConfigSpec effective) {
-        if (delegatedSet.contains(DELEGATED_BOOTSTRAP_PORT)) {
-            String portStr = podAnnotations.get(DELEGATED_BOOTSTRAP_PORT);
+        if (delegatedSet.contains(Annotations.DELEGATED_BOOTSTRAP_PORT)) {
+            String portStr = podAnnotations.get(Annotations.DELEGATED_BOOTSTRAP_PORT);
             if (portStr != null) {
                 try {
                     effective.setBootstrapPort(Long.parseLong(portStr));
@@ -269,7 +254,7 @@ class AdmissionHandler implements HttpHandler {
                     LOGGER.atWarn()
                             .addKeyValue(WebhookLoggingKeys.POD, podName)
                             .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
-                            .addKeyValue(WebhookLoggingKeys.ANNOTATION, DELEGATED_NODE_ID_RANGE)
+                            .addKeyValue(WebhookLoggingKeys.ANNOTATION, Annotations.DELEGATED_NODE_ID_RANGE)
                             .addKeyValue(WebhookLoggingKeys.ANNOTATION_VALUE, portStr)
                             .log("Invalid bootstrap port in delegated annotation, using admin default");
                 }
@@ -282,8 +267,8 @@ class AdmissionHandler implements HttpHandler {
                                                         Map<String, String> podAnnotations,
                                                         Set<String> delegatedSet) {
         for (String key : podAnnotations.keySet()) {
-            if (key.startsWith(KROXYLICIOUS_ANNOTATION_PREFIX)
-                    && !WEBHOOK_MANAGED_ANNOTATIONS.contains(key)
+            if (Annotations.isKroxyliciousAnnotation(key)
+                    && !Annotations.isWebhookManagedAnnotation(key)
                     && !delegatedSet.contains(key)) {
                 LOGGER.atWarn()
                         .addKeyValue(WebhookLoggingKeys.POD, podName)

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
@@ -31,6 +31,7 @@ import io.fabric8.kubernetes.api.model.admission.v1.AdmissionReview;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfig;
 import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfigSpec;
+import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfigSpecBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.NodeIdRange;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -147,8 +148,8 @@ class AdmissionHandler implements HttpHandler {
             InjectionDecision.Decision decision = InjectionDecision.evaluate(pod, configOpt.isPresent());
 
             LOGGER.atInfo()
-                    .addKeyValue("pod", podName)
-                    .addKeyValue("namespace", namespace)
+                    .addKeyValue(WebhookLoggingKeys.POD, podName)
+                    .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
                     .addKeyValue("decision", decision.name())
                     .addKeyValue("sidecarConfig", explicitConfigName)
                     .log("Sidecar injection decision");
@@ -198,17 +199,7 @@ class AdmissionHandler implements HttpHandler {
         Set<String> delegatedSet = delegated != null ? Set.copyOf(delegated) : Set.of();
 
         // Warn about undelegated kroxylicious.io/ annotations
-        for (String key : podAnnotations.keySet()) {
-            if (key.startsWith(KROXYLICIOUS_ANNOTATION_PREFIX)
-                    && !WEBHOOK_MANAGED_ANNOTATIONS.contains(key)
-                    && !delegatedSet.contains(key)) {
-                LOGGER.atWarn()
-                        .addKeyValue("pod", podName)
-                        .addKeyValue("namespace", namespace)
-                        .addKeyValue("annotation", key)
-                        .log("Pod has undelegated kroxylicious.io annotation, ignoring");
-            }
-        }
+        warnAboutUndelegatedAnnotations(namespace, podName, podAnnotations, delegatedSet);
 
         if (delegatedSet.isEmpty()) {
             return adminSpec;
@@ -218,23 +209,19 @@ class AdmissionHandler implements HttpHandler {
         KroxyliciousSidecarConfigSpec effective = copySpec(adminSpec);
 
         // Apply bootstrap port override
-        if (delegatedSet.contains(DELEGATED_BOOTSTRAP_PORT)) {
-            String portStr = podAnnotations.get(DELEGATED_BOOTSTRAP_PORT);
-            if (portStr != null) {
-                try {
-                    effective.setBootstrapPort(Long.parseLong(portStr));
-                }
-                catch (NumberFormatException e) {
-                    LOGGER.atWarn()
-                            .addKeyValue("pod", podName)
-                            .addKeyValue("namespace", namespace)
-                            .addKeyValue("value", portStr)
-                            .log("Invalid bootstrap port in delegated annotation, using admin default");
-                }
-            }
-        }
+        applyBootstrapPortOverride(podAnnotations, podName, namespace, delegatedSet, effective);
 
         // Apply node ID range override (format: "start-end")
+        applyNodeIdRangeOverride(podAnnotations, podName, namespace, delegatedSet, effective);
+
+        return effective;
+    }
+
+    private static void applyNodeIdRangeOverride(Map<String, String> podAnnotations,
+                                                 String podName,
+                                                 String namespace,
+                                                 Set<String> delegatedSet,
+                                                 KroxyliciousSidecarConfigSpec effective) {
         if (delegatedSet.contains(DELEGATED_NODE_ID_RANGE)) {
             String rangeStr = podAnnotations.get(DELEGATED_NODE_ID_RANGE);
             if (rangeStr != null) {
@@ -248,39 +235,69 @@ class AdmissionHandler implements HttpHandler {
                     }
                     catch (NumberFormatException e) {
                         LOGGER.atWarn()
-                                .addKeyValue("pod", podName)
-                                .addKeyValue("namespace", namespace)
-                                .addKeyValue("value", rangeStr)
+                                .addKeyValue(WebhookLoggingKeys.POD, podName)
+                                .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
+                                .addKeyValue(WebhookLoggingKeys.ANNOTATION, DELEGATED_NODE_ID_RANGE)
+                                .addKeyValue(WebhookLoggingKeys.ANNOTATION_VALUE, rangeStr)
                                 .log("Invalid node ID range in delegated annotation, using admin default");
                     }
                 }
                 else {
                     LOGGER.atWarn()
-                            .addKeyValue("pod", podName)
-                            .addKeyValue("namespace", namespace)
-                            .addKeyValue("value", rangeStr)
-                            .log("Invalid node ID range format (expected start-end), using admin default");
+                            .addKeyValue(WebhookLoggingKeys.POD, podName)
+                            .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
+                            .addKeyValue(WebhookLoggingKeys.ANNOTATION, DELEGATED_NODE_ID_RANGE)
+                            .addKeyValue(WebhookLoggingKeys.ANNOTATION_VALUE, rangeStr)
+                            .log("Invalid node ID range format in delegated annotation (expected start-end), using admin default");
                 }
             }
         }
+    }
 
-        return effective;
+    private static void applyBootstrapPortOverride(Map<String, String> podAnnotations,
+                                                   String podName,
+                                                   String namespace,
+                                                   Set<String> delegatedSet,
+                                                   KroxyliciousSidecarConfigSpec effective) {
+        if (delegatedSet.contains(DELEGATED_BOOTSTRAP_PORT)) {
+            String portStr = podAnnotations.get(DELEGATED_BOOTSTRAP_PORT);
+            if (portStr != null) {
+                try {
+                    effective.setBootstrapPort(Long.parseLong(portStr));
+                }
+                catch (NumberFormatException e) {
+                    LOGGER.atWarn()
+                            .addKeyValue(WebhookLoggingKeys.POD, podName)
+                            .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
+                            .addKeyValue(WebhookLoggingKeys.ANNOTATION, DELEGATED_NODE_ID_RANGE)
+                            .addKeyValue(WebhookLoggingKeys.ANNOTATION_VALUE, portStr)
+                            .log("Invalid bootstrap port in delegated annotation, using admin default");
+                }
+            }
+        }
+    }
+
+    private static void warnAboutUndelegatedAnnotations(String namespace,
+                                                        String podName,
+                                                        Map<String, String> podAnnotations,
+                                                        Set<String> delegatedSet) {
+        for (String key : podAnnotations.keySet()) {
+            if (key.startsWith(KROXYLICIOUS_ANNOTATION_PREFIX)
+                    && !WEBHOOK_MANAGED_ANNOTATIONS.contains(key)
+                    && !delegatedSet.contains(key)) {
+                LOGGER.atWarn()
+                        .addKeyValue(WebhookLoggingKeys.POD, podName)
+                        .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
+                        .addKeyValue("annotation", key)
+                        .log("Pod has undelegated kroxylicious.io annotation, ignoring");
+            }
+        }
     }
 
     @NonNull
     private static KroxyliciousSidecarConfigSpec copySpec(@NonNull KroxyliciousSidecarConfigSpec src) {
-        KroxyliciousSidecarConfigSpec copy = new KroxyliciousSidecarConfigSpec();
-        copy.setUpstreamBootstrapServers(src.getUpstreamBootstrapServers());
-        copy.setProxyImage(src.getProxyImage());
-        copy.setBootstrapPort(src.getBootstrapPort());
-        copy.setNodeIdRange(src.getNodeIdRange());
-        copy.setManagementPort(src.getManagementPort());
-        copy.setResources(src.getResources());
-        copy.setSetBootstrapEnvVar(src.getSetBootstrapEnvVar());
-        copy.setFilterDefinitions(src.getFilterDefinitions());
-        copy.setUpstreamTls(src.getUpstreamTls());
-        copy.setDelegatedAnnotations(src.getDelegatedAnnotations());
-        return copy;
+        KroxyliciousSidecarConfigSpecBuilder builder = new KroxyliciousSidecarConfigSpecBuilder(src);
+        return builder.build();
     }
 
     @NonNull

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
@@ -202,6 +202,7 @@ class AdmissionHandler implements HttpHandler {
         return effective;
     }
 
+    // TODO: Do we really want to support this for the initial feature?
     private static void applyNodeIdRangeOverride(Map<String, String> podAnnotations,
                                                  String podName,
                                                  String namespace,

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
@@ -11,8 +11,10 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import org.slf4j.Logger;
@@ -28,6 +30,8 @@ import io.fabric8.kubernetes.api.model.admission.v1.AdmissionResponse;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionReview;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfig;
+import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfigSpec;
+import io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.NodeIdRange;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -39,15 +43,36 @@ class AdmissionHandler implements HttpHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(AdmissionHandler.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final String JSON_PATCH_TYPE = "JSONPatch";
+    private static final String KROXYLICIOUS_ANNOTATION_PREFIX = "kroxylicious.io/";
+
+    /** Annotation keys that app owners can use to override sidecar config when delegated. */
+    static final String DELEGATED_BOOTSTRAP_PORT = "kroxylicious.io/sidecar-bootstrap-port";
+    static final String DELEGATED_NODE_ID_RANGE = "kroxylicious.io/sidecar-node-id-range";
+
+    /** Annotations managed by the webhook itself — never treated as undelegated. */
+    private static final Set<String> WEBHOOK_MANAGED_ANNOTATIONS = Set.of(
+            Annotations.INJECT_SIDECAR,
+            Annotations.SIDECAR_CONFIG,
+            Annotations.PROXY_CONFIG,
+            Annotations.SIDECAR_STATUS);
 
     private final SidecarConfigResolver configResolver;
     private final String proxyImage;
+    private final boolean useNativeSidecar;
+
+    AdmissionHandler(
+                     @NonNull SidecarConfigResolver configResolver,
+                     @NonNull String proxyImage,
+                     boolean useNativeSidecar) {
+        this.configResolver = configResolver;
+        this.proxyImage = proxyImage;
+        this.useNativeSidecar = useNativeSidecar;
+    }
 
     AdmissionHandler(
                      @NonNull SidecarConfigResolver configResolver,
                      @NonNull String proxyImage) {
-        this.configResolver = configResolver;
-        this.proxyImage = proxyImage;
+        this(configResolver, proxyImage, false);
     }
 
     @Override
@@ -81,7 +106,6 @@ class AdmissionHandler implements HttpHandler {
             LOGGER.atError()
                     .setCause(e)
                     .log("Unexpected error handling admission request");
-            // Fail-open: always allow, even on error
             sendAllowResponse(exchange, null);
             // TODO this will need to change when we default to fail closed.
         }
@@ -133,10 +157,13 @@ class AdmissionHandler implements HttpHandler {
                 return allowResponse(uid);
             }
 
-            // Generate the patch
+            // Apply delegated annotation overrides
             KroxyliciousSidecarConfig sidecarConfig = configOpt.orElseThrow();
+            KroxyliciousSidecarConfigSpec effectiveSpec = applyDelegatedOverrides(
+                    sidecarConfig.getSpec(), annotations, podName, namespace);
+
             String image = resolveImage(sidecarConfig);
-            String jsonPatch = PodMutator.createPatch(pod, sidecarConfig.getSpec(), image);
+            String jsonPatch = PodMutator.createPatch(pod, effectiveSpec, image, useNativeSidecar);
 
             AdmissionResponse response = allowResponse(uid);
             response.setPatchType(JSON_PATCH_TYPE);
@@ -150,6 +177,110 @@ class AdmissionHandler implements HttpHandler {
                     .log("Error processing admission request, allowing pod without sidecar");
             return allowResponse(uid);
         }
+    }
+
+    /**
+     * Applies delegated annotation overrides from the pod to the sidecar config spec.
+     * Logs warnings for undelegated annotations in the {@code kroxylicious.io/} namespace.
+     */
+    @NonNull
+    KroxyliciousSidecarConfigSpec applyDelegatedOverrides(
+                                                          @NonNull KroxyliciousSidecarConfigSpec adminSpec,
+                                                          Map<String, String> podAnnotations,
+                                                          String podName,
+                                                          String namespace) {
+
+        if (podAnnotations == null || podAnnotations.isEmpty()) {
+            return adminSpec;
+        }
+
+        List<String> delegated = adminSpec.getDelegatedAnnotations();
+        Set<String> delegatedSet = delegated != null ? Set.copyOf(delegated) : Set.of();
+
+        // Warn about undelegated kroxylicious.io/ annotations
+        for (String key : podAnnotations.keySet()) {
+            if (key.startsWith(KROXYLICIOUS_ANNOTATION_PREFIX)
+                    && !WEBHOOK_MANAGED_ANNOTATIONS.contains(key)
+                    && !delegatedSet.contains(key)) {
+                LOGGER.atWarn()
+                        .addKeyValue("pod", podName)
+                        .addKeyValue("namespace", namespace)
+                        .addKeyValue("annotation", key)
+                        .log("Pod has undelegated kroxylicious.io annotation, ignoring");
+            }
+        }
+
+        if (delegatedSet.isEmpty()) {
+            return adminSpec;
+        }
+
+        // Copy the spec so we don't mutate the cached admin config
+        KroxyliciousSidecarConfigSpec effective = copySpec(adminSpec);
+
+        // Apply bootstrap port override
+        if (delegatedSet.contains(DELEGATED_BOOTSTRAP_PORT)) {
+            String portStr = podAnnotations.get(DELEGATED_BOOTSTRAP_PORT);
+            if (portStr != null) {
+                try {
+                    effective.setBootstrapPort(Long.parseLong(portStr));
+                }
+                catch (NumberFormatException e) {
+                    LOGGER.atWarn()
+                            .addKeyValue("pod", podName)
+                            .addKeyValue("namespace", namespace)
+                            .addKeyValue("value", portStr)
+                            .log("Invalid bootstrap port in delegated annotation, using admin default");
+                }
+            }
+        }
+
+        // Apply node ID range override (format: "start-end")
+        if (delegatedSet.contains(DELEGATED_NODE_ID_RANGE)) {
+            String rangeStr = podAnnotations.get(DELEGATED_NODE_ID_RANGE);
+            if (rangeStr != null) {
+                String[] parts = rangeStr.split("-", 2);
+                if (parts.length == 2) {
+                    try {
+                        NodeIdRange range = new NodeIdRange();
+                        range.setStartInclusive(Long.parseLong(parts[0]));
+                        range.setEndInclusive(Long.parseLong(parts[1]));
+                        effective.setNodeIdRange(range);
+                    }
+                    catch (NumberFormatException e) {
+                        LOGGER.atWarn()
+                                .addKeyValue("pod", podName)
+                                .addKeyValue("namespace", namespace)
+                                .addKeyValue("value", rangeStr)
+                                .log("Invalid node ID range in delegated annotation, using admin default");
+                    }
+                }
+                else {
+                    LOGGER.atWarn()
+                            .addKeyValue("pod", podName)
+                            .addKeyValue("namespace", namespace)
+                            .addKeyValue("value", rangeStr)
+                            .log("Invalid node ID range format (expected start-end), using admin default");
+                }
+            }
+        }
+
+        return effective;
+    }
+
+    @NonNull
+    private static KroxyliciousSidecarConfigSpec copySpec(@NonNull KroxyliciousSidecarConfigSpec src) {
+        KroxyliciousSidecarConfigSpec copy = new KroxyliciousSidecarConfigSpec();
+        copy.setUpstreamBootstrapServers(src.getUpstreamBootstrapServers());
+        copy.setProxyImage(src.getProxyImage());
+        copy.setBootstrapPort(src.getBootstrapPort());
+        copy.setNodeIdRange(src.getNodeIdRange());
+        copy.setManagementPort(src.getManagementPort());
+        copy.setResources(src.getResources());
+        copy.setSetBootstrapEnvVar(src.getSetBootstrapEnvVar());
+        copy.setFilterDefinitions(src.getFilterDefinitions());
+        copy.setUpstreamTls(src.getUpstreamTls());
+        copy.setDelegatedAnnotations(src.getDelegatedAnnotations());
+        return copy;
     }
 
     @NonNull

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/Annotations.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/Annotations.java
@@ -6,16 +6,81 @@
 
 package io.kroxylicious.kubernetes.webhook;
 
+import java.util.Set;
+
 /**
  * Annotation keys used by the sidecar injection webhook.
  */
 final class Annotations {
 
+    private static final String KROXYLICIOUS_ANNOTATION_PREFIX = "kroxylicious.io/";
+
     // TODO Javadoc these things, so we know what they're for
+    /**
+     * Annotation on the target Pod, when the value is false the sidecar will not be injected into the Pod
+     */
     static final String INJECT_SIDECAR = "kroxylicious.io/inject-sidecar";
+
+    /**
+     * Annotation on the target Pod used to name the {@code KroxyliciousSidecarConfig}
+     * resource which should apply to that Pod.
+     */
     static final String SIDECAR_CONFIG = "kroxylicious.io/sidecar-config";
+
+    /**
+     * Annotation on the target Pod used to store the proxy configuration, consumed
+     * by the sidecar container via a downwardAPI volume mount.
+     */
     static final String PROXY_CONFIG = "kroxylicious.io/proxy-config";
+
+    /**
+     * Annotation on the target Pod which takes the value {@code "injected"} when
+     * the webhook has mutated the pod spec (used because the
+     * {@ocde MutatingWebhookConfiguration} is configured with
+     * {@code reinvocationPolicy: IfNeeded}).
+     */
     static final String SIDECAR_STATUS = "kroxylicious.io/sidecar-status";
+
+    /**
+     * <p>Annotation that app owners may set on the {@code Pod}
+     * to configure the port used in the value of the
+     * {@code KAFKA_BOOTSTRAP_SERVERS} which is set on the all the containers
+     * in the target {@code Pod} except the proxy sidecar container.</p>
+     *
+     * <p>The ability of the app owner to use this annotation
+     * depends on whether this annotation has been delegatated to them in the
+     * {@ocde MutatingWebhookConfiguration}</p>
+     */
+    static final String DELEGATED_BOOTSTRAP_PORT = "kroxylicious.io/sidecar-bootstrap-port";
+
+    /**
+     * <p>Annotation that app owners may set on the target {@code Pod} to configure
+     * node id range which will be used in the proxy configuration
+     * consumed by the proxy sidecar.</p>
+     *
+     * <p>The ability of the app owner to use this annotation
+     * depends on whether this annotation has been delegatated to them in the
+     * {@ocde MutatingWebhookConfiguration}</p>
+     */
+    static final String DELEGATED_NODE_ID_RANGE = "kroxylicious.io/sidecar-node-id-range";
+
+    /** The set of annotations managed by the webhook itself — never treated as undelegated. */
+    static final Set<String> WEBHOOK_MANAGED_ANNOTATIONS = Set.of(
+            INJECT_SIDECAR,
+            SIDECAR_CONFIG,
+            PROXY_CONFIG,
+            SIDECAR_STATUS);
+
+    /**
+     * Determines whether the given annotation is one that's managed by the webhook itself
+     */
+    static boolean isWebhookManagedAnnotation(String key) {
+        return WEBHOOK_MANAGED_ANNOTATIONS.contains(key);
+    }
+
+    static boolean isKroxyliciousAnnotation(String key) {
+        return key.startsWith(KROXYLICIOUS_ANNOTATION_PREFIX);
+    }
 
     private Annotations() {
     }

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/Labels.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/Labels.java
@@ -11,8 +11,17 @@ package io.kroxylicious.kubernetes.webhook;
  */
 final class Labels {
 
-    // TODO Javadoc these things, so we know what they're for
+    /**
+     * Label applied to Kubernetes {@code Namespace} resources controlling whether
+     * {@code Pods} created in that {@code Namespace} will be intercepted by the webhook.
+     * Interception is enabled when this label has the value {@code enabled}.
+     */
     static final String SIDECAR_INJECTION = "kroxylicious.io/sidecar-injection";
+    
+    /**
+     * The value of the {@code kroxylicious.io/sidecar-injection} label which enables
+     * interception by the webhook.
+     */
     static final String SIDECAR_INJECTION_ENABLED = "enabled";
 
     private Labels() {

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/Labels.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/Labels.java
@@ -17,7 +17,7 @@ final class Labels {
      * Interception is enabled when this label has the value {@code enabled}.
      */
     static final String SIDECAR_INJECTION = "kroxylicious.io/sidecar-injection";
-    
+
     /**
      * The value of the {@code kroxylicious.io/sidecar-injection} label which enables
      * interception by the webhook.

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
@@ -17,8 +17,11 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.fabric8.kubernetes.api.model.Pod;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfigSpec;
+import io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.UpstreamTls;
+import io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.upstreamtls.TrustAnchorSecretRef;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Generates a JSON Patch (RFC 6902) to inject a Kroxylicious sidecar into a pod.
@@ -27,6 +30,9 @@ class PodMutator {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final String SIDECAR_VOLUME_NAME = "kroxylicious-config";
+    private static final String UPSTREAM_TLS_VOLUME_NAME = "upstream-tls";
+    @SuppressWarnings("java:S1075") // there's nothing wrong with hard coding this path.
+    private static final String UPSTREAM_TLS_MOUNT_PATH = "/opt/kroxylicious/tls/upstream";
     @SuppressWarnings("java:S1075") // there's nothing wrong with hard coding this path.
     private static final String CONFIG_MOUNT_PATH = "/opt/kroxylicious/config/proxy-config.yaml";
     private static final String CONFIG_FILE_NAME = "proxy-config.yaml";
@@ -42,23 +48,26 @@ class PodMutator {
      * @param pod the original pod
      * @param spec the sidecar configuration
      * @param proxyImage the container image to use for the proxy
+     * @param useNativeSidecar if true, inject as an init container with restartPolicy: Always (K8s 1.28+)
      * @return JSON Patch string (RFC 6902)
      */
     @NonNull
     static String createPatch(
                               @NonNull Pod pod,
                               @NonNull KroxyliciousSidecarConfigSpec spec,
-                              @NonNull String proxyImage) {
+                              @NonNull String proxyImage,
+                              boolean useNativeSidecar) {
         try {
             ArrayNode patch = MAPPER.createArrayNode();
 
-            String proxyConfig = ProxyConfigGenerator.generateConfig(spec);
+            String upstreamTrustStorePath = resolveUpstreamTrustStorePath(spec);
+            String proxyConfig = ProxyConfigGenerator.generateConfig(spec, upstreamTrustStorePath);
             int bootstrapPort = ProxyConfigGenerator.resolveBootstrapPort(spec);
             int managementPort = ProxyConfigGenerator.resolveManagementPort(spec);
 
             addAnnotationOps(patch, pod, proxyConfig);
-            addVolumeOps(patch, pod);
-            addSidecarContainerOp(patch, pod, proxyImage, managementPort, spec);
+            addVolumeOps(patch, pod, spec);
+            addSidecarContainerOp(patch, pod, proxyImage, managementPort, spec, useNativeSidecar);
             addBootstrapEnvVarOps(patch, pod, spec, bootstrapPort);
             addSecurityContextOps(patch, pod);
 
@@ -69,6 +78,30 @@ class PodMutator {
         }
     }
 
+    /**
+     * Overload for backwards compatibility (no native sidecar).
+     */
+    @NonNull
+    static String createPatch(
+                              @NonNull Pod pod,
+                              @NonNull KroxyliciousSidecarConfigSpec spec,
+                              @NonNull String proxyImage) {
+        return createPatch(pod, spec, proxyImage, false);
+    }
+
+    /**
+     * Computes the path where the upstream CA cert will be mounted inside the sidecar,
+     * or null if upstream TLS is not configured.
+     */
+    @Nullable
+    static String resolveUpstreamTrustStorePath(KroxyliciousSidecarConfigSpec spec) {
+        UpstreamTls tls = spec.getUpstreamTls();
+        if (tls == null || tls.getTrustAnchorSecretRef() == null) {
+            return null;
+        }
+        return UPSTREAM_TLS_MOUNT_PATH + "/" + tls.getTrustAnchorSecretRef().getKey();
+    }
+
     private static void addAnnotationOps(
                                          ArrayNode patch,
                                          Pod pod,
@@ -76,7 +109,6 @@ class PodMutator {
 
         Map<String, String> existing = pod.getMetadata() != null ? pod.getMetadata().getAnnotations() : null;
         if (existing == null) {
-            // annotations map doesn't exist yet — add it
             ObjectNode annotations = MAPPER.createObjectNode();
             annotations.put(Annotations.PROXY_CONFIG, proxyConfig);
             annotations.put(Annotations.SIDECAR_STATUS, "injected");
@@ -88,15 +120,19 @@ class PodMutator {
         }
     }
 
-    private static void addVolumeOps(ArrayNode patch, Pod pod) {
+    private static void addVolumeOps(
+                                     ArrayNode patch,
+                                     Pod pod,
+                                     KroxyliciousSidecarConfigSpec spec) {
         boolean hasVolumes = pod.getSpec() != null
                 && pod.getSpec().getVolumes() != null
                 && !pod.getSpec().getVolumes().isEmpty();
 
         // TODO Add a comment explaining what this is doing in Kube terms.
-        ObjectNode volume = MAPPER.createObjectNode();
-        volume.put("name", SIDECAR_VOLUME_NAME);
-        ObjectNode downwardAPI = volume.putObject("downwardAPI");
+        // Config volume (downwardAPI)
+        ObjectNode configVolume = MAPPER.createObjectNode();
+        configVolume.put("name", SIDECAR_VOLUME_NAME);
+        ObjectNode downwardAPI = configVolume.putObject("downwardAPI");
         ArrayNode items = downwardAPI.putArray("items");
         ObjectNode item = items.addObject();
         item.put("path", CONFIG_FILE_NAME);
@@ -104,12 +140,32 @@ class PodMutator {
         fieldRef.put("fieldPath", "metadata.annotations['" + Annotations.PROXY_CONFIG + "']");
 
         if (hasVolumes) {
-            addOp(patch, "add", "/spec/volumes/-", volume);
+            addOp(patch, "add", "/spec/volumes/-", configVolume);
         }
         else {
             ArrayNode volumes = MAPPER.createArrayNode();
-            volumes.add(volume);
+            volumes.add(configVolume);
             addOp(patch, "add", "/spec/volumes", volumes);
+            hasVolumes = true;
+        }
+
+        // Upstream TLS volume (Secret)
+        UpstreamTls tls = spec.getUpstreamTls();
+        if (tls != null && tls.getTrustAnchorSecretRef() != null) {
+            TrustAnchorSecretRef secretRef = tls.getTrustAnchorSecretRef();
+            ObjectNode tlsVolume = MAPPER.createObjectNode();
+            tlsVolume.put("name", UPSTREAM_TLS_VOLUME_NAME);
+            ObjectNode secret = tlsVolume.putObject("secret");
+            secret.put("secretName", secretRef.getName());
+
+            if (hasVolumes) {
+                addOp(patch, "add", "/spec/volumes/-", tlsVolume);
+            }
+            else {
+                ArrayNode volumes = MAPPER.createArrayNode();
+                volumes.add(tlsVolume);
+                addOp(patch, "add", "/spec/volumes", volumes);
+            }
         }
     }
 
@@ -118,11 +174,16 @@ class PodMutator {
                                               Pod pod,
                                               String proxyImage,
                                               int managementPort,
-                                              KroxyliciousSidecarConfigSpec spec) {
+                                              KroxyliciousSidecarConfigSpec spec,
+                                              boolean useNativeSidecar) {
 
         ObjectNode container = MAPPER.createObjectNode();
         container.put("name", InjectionDecision.SIDECAR_CONTAINER_NAME);
         container.put("image", proxyImage);
+
+        if (useNativeSidecar) {
+            container.put("restartPolicy", "Always");
+        }
 
         ArrayNode args = container.putArray("args");
         args.add("--config");
@@ -148,13 +209,21 @@ class PodMutator {
         addProbe(container, "livenessProbe", 30, 10, 3);
         addProbe(container, "readinessProbe", 5, 2, 5);
 
-        // Volume mount
+        // Volume mounts
         ArrayNode volumeMounts = container.putArray("volumeMounts");
-        ObjectNode mount = volumeMounts.addObject();
-        mount.put("name", SIDECAR_VOLUME_NAME);
-        mount.put("mountPath", CONFIG_MOUNT_PATH);
-        mount.put("subPath", CONFIG_FILE_NAME);
-        mount.put("readOnly", true);
+        ObjectNode configMount = volumeMounts.addObject();
+        configMount.put("name", SIDECAR_VOLUME_NAME);
+        configMount.put("mountPath", CONFIG_MOUNT_PATH);
+        configMount.put("subPath", CONFIG_FILE_NAME);
+        configMount.put("readOnly", true);
+
+        // Upstream TLS volume mount
+        if (spec.getUpstreamTls() != null && spec.getUpstreamTls().getTrustAnchorSecretRef() != null) {
+            ObjectNode tlsMount = volumeMounts.addObject();
+            tlsMount.put("name", UPSTREAM_TLS_VOLUME_NAME);
+            tlsMount.put("mountPath", UPSTREAM_TLS_MOUNT_PATH);
+            tlsMount.put("readOnly", true);
+        }
 
         // Resources
         if (spec.getResources() != null) {
@@ -169,6 +238,15 @@ class PodMutator {
 
         container.put("terminationMessagePolicy", "FallbackToLogsOnError");
 
+        if (useNativeSidecar) {
+            addInitContainer(patch, pod, container);
+        }
+        else {
+            addRegularContainer(patch, pod, container);
+        }
+    }
+
+    private static void addRegularContainer(ArrayNode patch, Pod pod, ObjectNode container) {
         boolean hasContainers = pod.getSpec() != null
                 && pod.getSpec().getContainers() != null
                 && !pod.getSpec().getContainers().isEmpty();
@@ -180,6 +258,21 @@ class PodMutator {
             ArrayNode containers = MAPPER.createArrayNode();
             containers.add(container);
             addOp(patch, "add", "/spec/containers", containers);
+        }
+    }
+
+    private static void addInitContainer(ArrayNode patch, Pod pod, ObjectNode container) {
+        boolean hasInitContainers = pod.getSpec() != null
+                && pod.getSpec().getInitContainers() != null
+                && !pod.getSpec().getInitContainers().isEmpty();
+
+        if (hasInitContainers) {
+            addOp(patch, "add", "/spec/initContainers/-", container);
+        }
+        else {
+            ArrayNode initContainers = MAPPER.createArrayNode();
+            initContainers.add(container);
+            addOp(patch, "add", "/spec/initContainers", initContainers);
         }
     }
 
@@ -223,7 +316,6 @@ class PodMutator {
 
         for (int i = 0; i < containers.size(); i++) {
             io.fabric8.kubernetes.api.model.Container c = containers.get(i);
-            // Don't set on the sidecar itself
             if (InjectionDecision.SIDECAR_CONTAINER_NAME.equals(c.getName())) {
                 continue;
             }
@@ -234,7 +326,6 @@ class PodMutator {
             envVar.put("value", bootstrapValue);
 
             if (hasEnv) {
-                // Check if KAFKA_BOOTSTRAP_SERVERS is already set; if so, replace it
                 int existingIdx = findEnvVarIndex(c.getEnv(), KAFKA_BOOTSTRAP_SERVERS_ENV);
                 if (existingIdx >= 0) {
                     addOp(patch, "replace",

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
@@ -128,8 +128,8 @@ class PodMutator {
                 && pod.getSpec().getVolumes() != null
                 && !pod.getSpec().getVolumes().isEmpty();
 
-        // TODO Add a comment explaining what this is doing in Kube terms.
-        // Config volume (downwardAPI)
+        // Use downwardAPI to mount a volume such that the container's proxy-config.yaml has the content of the
+        // kroxylicious.io/proxy-config annotation's value.
         ObjectNode configVolume = MAPPER.createObjectNode();
         configVolume.put("name", SIDECAR_VOLUME_NAME);
         ObjectNode downwardAPI = configVolume.putObject("downwardAPI");

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/ProxyConfigGenerator.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/ProxyConfigGenerator.java
@@ -17,6 +17,7 @@ import io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.Nod
 import io.kroxylicious.proxy.config.ConfigParser;
 import io.kroxylicious.proxy.config.Configuration;
 import io.kroxylicious.proxy.config.NamedFilterDefinition;
+import io.kroxylicious.proxy.config.NamedRange;
 import io.kroxylicious.proxy.config.PortIdentifiesNodeIdentificationStrategy;
 import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.config.VirtualCluster;
@@ -74,7 +75,7 @@ class ProxyConfigGenerator {
                 new HostPort(LOCALHOST, bootstrapPort),
                 LOCALHOST,
                 bootstrapPort + 1,
-                List.of(new io.kroxylicious.proxy.config.NamedRange("default", nodeIdStart, nodeIdEnd)));
+                List.of(new NamedRange("default", nodeIdStart, nodeIdEnd)));
 
         var gateway = new VirtualClusterGateway(
                 GATEWAY_NAME,

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/ProxyConfigGenerator.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/ProxyConfigGenerator.java
@@ -12,16 +12,21 @@ import java.util.List;
 import java.util.Optional;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfigSpec;
+import io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.FilterDefinitions;
 import io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.NodeIdRange;
 import io.kroxylicious.proxy.config.ConfigParser;
 import io.kroxylicious.proxy.config.Configuration;
-import io.kroxylicious.proxy.config.NamedRange;
+import io.kroxylicious.proxy.config.NamedFilterDefinition;
 import io.kroxylicious.proxy.config.PortIdentifiesNodeIdentificationStrategy;
 import io.kroxylicious.proxy.config.TargetCluster;
 import io.kroxylicious.proxy.config.VirtualCluster;
 import io.kroxylicious.proxy.config.VirtualClusterGateway;
 import io.kroxylicious.proxy.config.admin.ManagementConfiguration;
+import io.kroxylicious.proxy.config.tls.Tls;
+import io.kroxylicious.proxy.config.tls.TrustStore;
 import io.kroxylicious.proxy.service.HostPort;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Generates proxy configuration YAML for the sidecar container from a
@@ -44,9 +49,12 @@ class ProxyConfigGenerator {
      * Generates proxy configuration YAML for a sidecar.
      *
      * @param spec the sidecar config spec from the CRD
+     * @param upstreamTrustStorePath path to the mounted CA cert file for upstream TLS, or null if no TLS
      * @return YAML string suitable for passing to the proxy via {@code --config}
      */
-    static String generateConfig(KroxyliciousSidecarConfigSpec spec) {
+    static String generateConfig(
+                                 KroxyliciousSidecarConfigSpec spec,
+                                 @Nullable String upstreamTrustStorePath) {
         int bootstrapPort = resolveBootstrapPort(spec);
         int managementPort = resolveManagementPort(spec);
         int nodeIdStart = DEFAULT_NODE_ID_START;
@@ -66,7 +74,7 @@ class ProxyConfigGenerator {
                 new HostPort(LOCALHOST, bootstrapPort),
                 LOCALHOST,
                 bootstrapPort + 1,
-                List.of(new NamedRange("default", nodeIdStart, nodeIdEnd)));
+                List.of(new io.kroxylicious.proxy.config.NamedRange("default", nodeIdStart, nodeIdEnd)));
 
         var gateway = new VirtualClusterGateway(
                 GATEWAY_NAME,
@@ -74,9 +82,18 @@ class ProxyConfigGenerator {
                 null,
                 Optional.empty());
 
+        Optional<Tls> upstreamTls = Optional.empty();
+        if (upstreamTrustStorePath != null) {
+            upstreamTls = Optional.of(new Tls(
+                    null,
+                    new TrustStore(upstreamTrustStorePath, null, "PEM"),
+                    null,
+                    null));
+        }
+
         var targetCluster = new TargetCluster(
                 spec.getUpstreamBootstrapServers(),
-                Optional.empty());
+                upstreamTls);
 
         var virtualCluster = new VirtualCluster(
                 VIRTUAL_CLUSTER_NAME,
@@ -91,10 +108,16 @@ class ProxyConfigGenerator {
                 managementPort,
                 null);
 
+        // Convert CRD filter definitions to proxy config model
+        List<NamedFilterDefinition> filterDefs = toNamedFilterDefinitions(spec);
+        List<String> defaultFilters = filterDefs != null
+                ? filterDefs.stream().map(NamedFilterDefinition::name).toList()
+                : null;
+
         var configuration = new Configuration(
                 management,
-                null,
-                null,
+                filterDefs,
+                defaultFilters,
                 List.of(virtualCluster),
                 null,
                 false,
@@ -103,6 +126,24 @@ class ProxyConfigGenerator {
                 null);
 
         return toYaml(configuration);
+    }
+
+    /**
+     * Overload for backwards compatibility (no upstream TLS).
+     */
+    static String generateConfig(KroxyliciousSidecarConfigSpec spec) {
+        return generateConfig(spec, null);
+    }
+
+    @Nullable
+    private static List<NamedFilterDefinition> toNamedFilterDefinitions(KroxyliciousSidecarConfigSpec spec) {
+        List<FilterDefinitions> crdFilters = spec.getFilterDefinitions();
+        if (crdFilters == null || crdFilters.isEmpty()) {
+            return null;
+        }
+        return crdFilters.stream()
+                .map(f -> new NamedFilterDefinition(f.getName(), f.getType(), f.getConfig()))
+                .toList();
     }
 
     static int resolveBootstrapPort(KroxyliciousSidecarConfigSpec spec) {

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookLoggingKeys.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookLoggingKeys.java
@@ -12,6 +12,12 @@ public class WebhookLoggingKeys {
 
     static final String NAME = "name";
 
+    static final String POD = "pod";
+
+    static final String ANNOTATION = "annotation";
+
+    static final String ANNOTATION_VALUE = "annotationValue";
+
     private WebhookLoggingKeys() {
     }
 

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
@@ -127,13 +127,14 @@ public class WebhookMain {
     static boolean detectNativeSidecarSupport(@NonNull KubernetesClient client) {
         try {
             VersionInfo version = client.getKubernetesVersion();
+            int major = Integer.parseInt(version.getMajor().replaceAll("\\D", ""));
             int minor = Integer.parseInt(version.getMinor().replaceAll("\\D", ""));
-            boolean supported = minor >= 28;
+            boolean nativeSidecarSupported = major > 1 || (major == 1 && minor >= 28);
             LOGGER.atInfo()
                     .addKeyValue("kubernetesVersion", version.getGitVersion())
-                    .addKeyValue("nativeSidecar", supported)
+                    .addKeyValue("nativeSidecar", nativeSidecarSupported)
                     .log("Detected Kubernetes version");
-            return supported;
+            return nativeSidecarSupported;
         }
         catch (Exception e) {
             LOGGER.atWarn()

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
@@ -120,7 +120,6 @@ public class WebhookMain {
         LOGGER.atInfo().log("Webhook stopped");
     }
 
-
     /**
      * Detects whether the cluster supports native sidecar containers (Kubernetes 1.28+).
      */

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
@@ -120,10 +120,11 @@ public class WebhookMain {
         LOGGER.atInfo().log("Webhook stopped");
     }
 
-    @VisibleForTesting
+
     /**
      * Detects whether the cluster supports native sidecar containers (Kubernetes 1.28+).
      */
+    @VisibleForTesting
     static boolean detectNativeSidecarSupport(@NonNull KubernetesClient client) {
         try {
             VersionInfo version = client.getKubernetesVersion();

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
@@ -127,7 +127,7 @@ public class WebhookMain {
     static boolean detectNativeSidecarSupport(@NonNull KubernetesClient client) {
         try {
             VersionInfo version = client.getKubernetesVersion();
-            int minor = Integer.parseInt(version.getMinor().replaceAll("[^0-9]", ""));
+            int minor = Integer.parseInt(version.getMinor().replaceAll("\\D", ""));
             boolean supported = minor >= 28;
             LOGGER.atInfo()
                     .addKeyValue("kubernetesVersion", version.getGitVersion())

--- a/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
+++ b/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.VersionInfo;
 
 import io.kroxylicious.proxy.service.HostPort;
 import io.kroxylicious.proxy.tag.VisibleForTesting;
@@ -75,8 +76,9 @@ public class WebhookMain {
         String proxyImage = requiredEnv(env, KROXYLICIOUS_IMAGE_VAR);
 
         KubernetesClient kubeClient = new KubernetesClientBuilder().build();
+        boolean useNativeSidecar = detectNativeSidecarSupport(kubeClient);
         SidecarConfigResolver configResolver = new SidecarConfigResolver(kubeClient);
-        AdmissionHandler admissionHandler = new AdmissionHandler(configResolver, proxyImage);
+        AdmissionHandler admissionHandler = new AdmissionHandler(configResolver, proxyImage, useNativeSidecar);
         WebhookServer server = new WebhookServer(bindAddress, certPath, keyPath, admissionHandler);
 
         return new WebhookMain(server, configResolver, kubeClient);
@@ -119,6 +121,28 @@ public class WebhookMain {
     }
 
     @VisibleForTesting
+    /**
+     * Detects whether the cluster supports native sidecar containers (Kubernetes 1.28+).
+     */
+    static boolean detectNativeSidecarSupport(@NonNull KubernetesClient client) {
+        try {
+            VersionInfo version = client.getKubernetesVersion();
+            int minor = Integer.parseInt(version.getMinor().replaceAll("[^0-9]", ""));
+            boolean supported = minor >= 28;
+            LOGGER.atInfo()
+                    .addKeyValue("kubernetesVersion", version.getGitVersion())
+                    .addKeyValue("nativeSidecar", supported)
+                    .log("Detected Kubernetes version");
+            return supported;
+        }
+        catch (Exception e) {
+            LOGGER.atWarn()
+                    .setCause(e)
+                    .log("Could not detect Kubernetes version, defaulting to regular sidecar containers");
+            return false;
+        }
+    }
+
     @NonNull
     static InetSocketAddress parseBindAddress(@NonNull Map<String, String> env) {
         String bindAddress = env.getOrDefault(BIND_ADDRESS_VAR, DEFAULT_BIND_ADDRESS);

--- a/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AdmissionHandlerTest.java
+++ b/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AdmissionHandlerTest.java
@@ -294,7 +294,7 @@ class AdmissionHandlerTest {
                 adminSpec, annotations, "test-pod", "test-ns");
 
         assertThat(effective.getNodeIdRange()).isNotNull();
-        assertThat(effective.getNodeIdRange().getStartInclusive()).isEqualTo(0L);
+        assertThat(effective.getNodeIdRange().getStartInclusive()).isZero();
         assertThat(effective.getNodeIdRange().getEndInclusive()).isEqualTo(9L);
     }
 

--- a/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AdmissionHandlerTest.java
+++ b/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AdmissionHandlerTest.java
@@ -270,9 +270,9 @@ class AdmissionHandlerTest {
         KroxyliciousSidecarConfigSpec adminSpec = new KroxyliciousSidecarConfigSpec();
         adminSpec.setUpstreamBootstrapServers("kafka:9092");
         adminSpec.setBootstrapPort(19092L);
-        adminSpec.setDelegatedAnnotations(List.of(AdmissionHandler.DELEGATED_BOOTSTRAP_PORT));
+        adminSpec.setDelegatedAnnotations(List.of(Annotations.DELEGATED_BOOTSTRAP_PORT));
 
-        Map<String, String> annotations = Map.of(AdmissionHandler.DELEGATED_BOOTSTRAP_PORT, "29092");
+        Map<String, String> annotations = Map.of(Annotations.DELEGATED_BOOTSTRAP_PORT, "29092");
 
         KroxyliciousSidecarConfigSpec effective = handler.applyDelegatedOverrides(
                 adminSpec, annotations, "test-pod", "test-ns");
@@ -286,9 +286,9 @@ class AdmissionHandlerTest {
     void appliesDelegatedNodeIdRange() {
         KroxyliciousSidecarConfigSpec adminSpec = new KroxyliciousSidecarConfigSpec();
         adminSpec.setUpstreamBootstrapServers("kafka:9092");
-        adminSpec.setDelegatedAnnotations(List.of(AdmissionHandler.DELEGATED_NODE_ID_RANGE));
+        adminSpec.setDelegatedAnnotations(List.of(Annotations.DELEGATED_NODE_ID_RANGE));
 
-        Map<String, String> annotations = Map.of(AdmissionHandler.DELEGATED_NODE_ID_RANGE, "0-9");
+        Map<String, String> annotations = Map.of(Annotations.DELEGATED_NODE_ID_RANGE, "0-9");
 
         KroxyliciousSidecarConfigSpec effective = handler.applyDelegatedOverrides(
                 adminSpec, annotations, "test-pod", "test-ns");
@@ -305,7 +305,7 @@ class AdmissionHandlerTest {
         adminSpec.setBootstrapPort(19092L);
         // No delegatedAnnotations set
 
-        Map<String, String> annotations = Map.of(AdmissionHandler.DELEGATED_BOOTSTRAP_PORT, "29092");
+        Map<String, String> annotations = Map.of(Annotations.DELEGATED_BOOTSTRAP_PORT, "29092");
 
         KroxyliciousSidecarConfigSpec effective = handler.applyDelegatedOverrides(
                 adminSpec, annotations, "test-pod", "test-ns");
@@ -319,9 +319,9 @@ class AdmissionHandlerTest {
         KroxyliciousSidecarConfigSpec adminSpec = new KroxyliciousSidecarConfigSpec();
         adminSpec.setUpstreamBootstrapServers("kafka:9092");
         adminSpec.setBootstrapPort(19092L);
-        adminSpec.setDelegatedAnnotations(List.of(AdmissionHandler.DELEGATED_BOOTSTRAP_PORT));
+        adminSpec.setDelegatedAnnotations(List.of(Annotations.DELEGATED_BOOTSTRAP_PORT));
 
-        Map<String, String> annotations = Map.of(AdmissionHandler.DELEGATED_BOOTSTRAP_PORT, "not-a-number");
+        Map<String, String> annotations = Map.of(Annotations.DELEGATED_BOOTSTRAP_PORT, "not-a-number");
 
         KroxyliciousSidecarConfigSpec effective = handler.applyDelegatedOverrides(
                 adminSpec, annotations, "test-pod", "test-ns");
@@ -333,9 +333,9 @@ class AdmissionHandlerTest {
     void ignoresInvalidNodeIdRangeFormat() {
         KroxyliciousSidecarConfigSpec adminSpec = new KroxyliciousSidecarConfigSpec();
         adminSpec.setUpstreamBootstrapServers("kafka:9092");
-        adminSpec.setDelegatedAnnotations(List.of(AdmissionHandler.DELEGATED_NODE_ID_RANGE));
+        adminSpec.setDelegatedAnnotations(List.of(Annotations.DELEGATED_NODE_ID_RANGE));
 
-        Map<String, String> annotations = Map.of(AdmissionHandler.DELEGATED_NODE_ID_RANGE, "invalid");
+        Map<String, String> annotations = Map.of(Annotations.DELEGATED_NODE_ID_RANGE, "invalid");
 
         KroxyliciousSidecarConfigSpec effective = handler.applyDelegatedOverrides(
                 adminSpec, annotations, "test-pod", "test-ns");

--- a/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AdmissionHandlerTest.java
+++ b/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AdmissionHandlerTest.java
@@ -11,6 +11,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -260,6 +261,97 @@ class AdmissionHandlerTest {
         JsonNode responseJson = MAPPER.readTree(responseBody.toByteArray());
 
         assertThat(responseJson.get("response").get("allowed").asBoolean()).isTrue();
+    }
+
+    // --- Phase 2: Delegated annotations ---
+
+    @Test
+    void appliesDelegatedBootstrapPort() {
+        KroxyliciousSidecarConfigSpec adminSpec = new KroxyliciousSidecarConfigSpec();
+        adminSpec.setUpstreamBootstrapServers("kafka:9092");
+        adminSpec.setBootstrapPort(19092L);
+        adminSpec.setDelegatedAnnotations(List.of(AdmissionHandler.DELEGATED_BOOTSTRAP_PORT));
+
+        Map<String, String> annotations = Map.of(AdmissionHandler.DELEGATED_BOOTSTRAP_PORT, "29092");
+
+        KroxyliciousSidecarConfigSpec effective = handler.applyDelegatedOverrides(
+                adminSpec, annotations, "test-pod", "test-ns");
+
+        assertThat(effective.getBootstrapPort()).isEqualTo(29092L);
+        // Original should be unchanged
+        assertThat(adminSpec.getBootstrapPort()).isEqualTo(19092L);
+    }
+
+    @Test
+    void appliesDelegatedNodeIdRange() {
+        KroxyliciousSidecarConfigSpec adminSpec = new KroxyliciousSidecarConfigSpec();
+        adminSpec.setUpstreamBootstrapServers("kafka:9092");
+        adminSpec.setDelegatedAnnotations(List.of(AdmissionHandler.DELEGATED_NODE_ID_RANGE));
+
+        Map<String, String> annotations = Map.of(AdmissionHandler.DELEGATED_NODE_ID_RANGE, "0-9");
+
+        KroxyliciousSidecarConfigSpec effective = handler.applyDelegatedOverrides(
+                adminSpec, annotations, "test-pod", "test-ns");
+
+        assertThat(effective.getNodeIdRange()).isNotNull();
+        assertThat(effective.getNodeIdRange().getStartInclusive()).isEqualTo(0L);
+        assertThat(effective.getNodeIdRange().getEndInclusive()).isEqualTo(9L);
+    }
+
+    @Test
+    void ignoresUndelegatedAnnotation() {
+        KroxyliciousSidecarConfigSpec adminSpec = new KroxyliciousSidecarConfigSpec();
+        adminSpec.setUpstreamBootstrapServers("kafka:9092");
+        adminSpec.setBootstrapPort(19092L);
+        // No delegatedAnnotations set
+
+        Map<String, String> annotations = Map.of(AdmissionHandler.DELEGATED_BOOTSTRAP_PORT, "29092");
+
+        KroxyliciousSidecarConfigSpec effective = handler.applyDelegatedOverrides(
+                adminSpec, annotations, "test-pod", "test-ns");
+
+        // Port should remain at admin default since annotation is not delegated
+        assertThat(effective.getBootstrapPort()).isEqualTo(19092L);
+    }
+
+    @Test
+    void ignoresInvalidBootstrapPort() {
+        KroxyliciousSidecarConfigSpec adminSpec = new KroxyliciousSidecarConfigSpec();
+        adminSpec.setUpstreamBootstrapServers("kafka:9092");
+        adminSpec.setBootstrapPort(19092L);
+        adminSpec.setDelegatedAnnotations(List.of(AdmissionHandler.DELEGATED_BOOTSTRAP_PORT));
+
+        Map<String, String> annotations = Map.of(AdmissionHandler.DELEGATED_BOOTSTRAP_PORT, "not-a-number");
+
+        KroxyliciousSidecarConfigSpec effective = handler.applyDelegatedOverrides(
+                adminSpec, annotations, "test-pod", "test-ns");
+
+        assertThat(effective.getBootstrapPort()).isEqualTo(19092L);
+    }
+
+    @Test
+    void ignoresInvalidNodeIdRangeFormat() {
+        KroxyliciousSidecarConfigSpec adminSpec = new KroxyliciousSidecarConfigSpec();
+        adminSpec.setUpstreamBootstrapServers("kafka:9092");
+        adminSpec.setDelegatedAnnotations(List.of(AdmissionHandler.DELEGATED_NODE_ID_RANGE));
+
+        Map<String, String> annotations = Map.of(AdmissionHandler.DELEGATED_NODE_ID_RANGE, "invalid");
+
+        KroxyliciousSidecarConfigSpec effective = handler.applyDelegatedOverrides(
+                adminSpec, annotations, "test-pod", "test-ns");
+
+        assertThat(effective.getNodeIdRange()).isNull();
+    }
+
+    @Test
+    void returnsOriginalSpecWhenNoAnnotations() {
+        KroxyliciousSidecarConfigSpec adminSpec = new KroxyliciousSidecarConfigSpec();
+        adminSpec.setUpstreamBootstrapServers("kafka:9092");
+
+        KroxyliciousSidecarConfigSpec effective = handler.applyDelegatedOverrides(
+                adminSpec, null, "test-pod", "test-ns");
+
+        assertThat(effective).isSameAs(adminSpec);
     }
 
     // --- helpers ---

--- a/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/PodMutatorTest.java
+++ b/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/PodMutatorTest.java
@@ -25,6 +25,8 @@ import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Volume;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfigSpec;
+import io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.UpstreamTls;
+import io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.upstreamtls.TrustAnchorSecretRef;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -233,6 +235,111 @@ class PodMutatorTest {
         assertThat(patch).isNotEmpty();
     }
 
+    // --- Phase 2: Upstream TLS ---
+
+    @Test
+    void patchAddsUpstreamTlsVolume() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        // Give the pod existing volumes so both config and TLS use the append path
+        pod.getSpec().setVolumes(new ArrayList<>(List.of(new Volume())));
+        KroxyliciousSidecarConfigSpec spec = specWithUpstreamTls();
+
+        String patchStr = PodMutator.createPatch(pod, spec, PROXY_IMAGE);
+        JsonNode patch = MAPPER.readTree(patchStr);
+
+        List<JsonNode> volumeOps = patchOps(patch, "add", "/spec/volumes/-");
+        assertThat(volumeOps).hasSizeGreaterThanOrEqualTo(2);
+
+        boolean hasTlsVolume = volumeOps.stream()
+                .anyMatch(op -> "upstream-tls".equals(op.path("value").path("name").asText()));
+        assertThat(hasTlsVolume).as("patch should add upstream-tls volume").isTrue();
+    }
+
+    @Test
+    void patchAddsUpstreamTlsVolumeMount() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        KroxyliciousSidecarConfigSpec spec = specWithUpstreamTls();
+
+        String patchStr = PodMutator.createPatch(pod, spec, PROXY_IMAGE);
+        JsonNode patch = MAPPER.readTree(patchStr);
+
+        List<JsonNode> containerOps = patchOps(patch, "add", "/spec/containers/-");
+        JsonNode mounts = containerOps.get(0).path("value").path("volumeMounts");
+        assertThat(mounts).hasSize(2);
+
+        JsonNode tlsMount = mounts.get(1);
+        assertThat(tlsMount.path("name").asText()).isEqualTo("upstream-tls");
+        assertThat(tlsMount.path("mountPath").asText()).isEqualTo("/opt/kroxylicious/tls/upstream");
+        assertThat(tlsMount.path("readOnly").asBoolean()).isTrue();
+    }
+
+    @Test
+    void noTlsVolumeWhenNotConfigured() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        JsonNode patch = createPatchJson(pod);
+
+        // Only config volume, not TLS
+        boolean hasTlsVolume = false;
+        for (JsonNode op : patch) {
+            if ("add".equals(op.path("op").asText())) {
+                JsonNode value = op.path("value");
+                if (value.isObject() && "upstream-tls".equals(value.path("name").asText())) {
+                    hasTlsVolume = true;
+                }
+                if (value.isArray()) {
+                    for (JsonNode item : value) {
+                        if ("upstream-tls".equals(item.path("name").asText())) {
+                            hasTlsVolume = true;
+                        }
+                    }
+                }
+            }
+        }
+        assertThat(hasTlsVolume).as("no TLS volume expected without upstream TLS config").isFalse();
+    }
+
+    @Test
+    void resolveUpstreamTrustStorePathWithTls() {
+        KroxyliciousSidecarConfigSpec spec = specWithUpstreamTls();
+        String path = PodMutator.resolveUpstreamTrustStorePath(spec);
+        assertThat(path).isEqualTo("/opt/kroxylicious/tls/upstream/ca.crt");
+    }
+
+    @Test
+    void resolveUpstreamTrustStorePathWithoutTls() {
+        KroxyliciousSidecarConfigSpec spec = defaultSpec();
+        String path = PodMutator.resolveUpstreamTrustStorePath(spec);
+        assertThat(path).isNull();
+    }
+
+    // --- Phase 2: Native sidecar ---
+
+    @Test
+    void nativeSidecarInjectsAsInitContainer() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        String patchStr = PodMutator.createPatch(pod, defaultSpec(), PROXY_IMAGE, true);
+        JsonNode patch = MAPPER.readTree(patchStr);
+
+        // Should add to initContainers, not containers
+        List<JsonNode> initOps = patchOps(patch, "add", "/spec/initContainers");
+        assertThat(initOps).isNotEmpty();
+
+        JsonNode container = initOps.get(0).path("value").get(0);
+        assertThat(container.path("name").asText()).isEqualTo(InjectionDecision.SIDECAR_CONTAINER_NAME);
+        assertThat(container.path("restartPolicy").asText()).isEqualTo("Always");
+    }
+
+    @Test
+    void regularSidecarDoesNotSetRestartPolicy() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        String patchStr = PodMutator.createPatch(pod, defaultSpec(), PROXY_IMAGE, false);
+        JsonNode patch = MAPPER.readTree(patchStr);
+
+        List<JsonNode> containerOps = patchOps(patch, "add", "/spec/containers/-");
+        assertThat(containerOps).isNotEmpty();
+        assertThat(containerOps.get(0).path("value").has("restartPolicy")).isFalse();
+    }
+
     /**
      * Creates a pod with one application container already present.
      * This ensures PodMutator uses the append ({@code /-}) path for adding the sidecar.
@@ -259,6 +366,17 @@ class PodMutatorTest {
     private static KroxyliciousSidecarConfigSpec defaultSpec() {
         KroxyliciousSidecarConfigSpec spec = new KroxyliciousSidecarConfigSpec();
         spec.setUpstreamBootstrapServers("kafka.example.com:9092");
+        return spec;
+    }
+
+    private static KroxyliciousSidecarConfigSpec specWithUpstreamTls() {
+        KroxyliciousSidecarConfigSpec spec = defaultSpec();
+        UpstreamTls tls = new UpstreamTls();
+        TrustAnchorSecretRef ref = new TrustAnchorSecretRef();
+        ref.setName("kafka-ca");
+        ref.setKey("ca.crt");
+        tls.setTrustAnchorSecretRef(ref);
+        spec.setUpstreamTls(tls);
         return spec;
     }
 

--- a/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/ProxyConfigGeneratorTest.java
+++ b/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/ProxyConfigGeneratorTest.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.kubernetes.webhook;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -13,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfigSpec;
+import io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.FilterDefinitions;
 import io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.NodeIdRange;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -138,5 +141,95 @@ class ProxyConfigGeneratorTest {
         assertThat(root.has("virtualClusters")).isTrue();
         assertThat(root.path("virtualClusters").isArray()).isTrue();
         assertThat(root.path("virtualClusters")).hasSize(1);
+    }
+
+    @Test
+    void includesFilterDefinitions() throws Exception {
+        KroxyliciousSidecarConfigSpec spec = new KroxyliciousSidecarConfigSpec();
+        spec.setUpstreamBootstrapServers("kafka:9092");
+
+        FilterDefinitions filter = new FilterDefinitions();
+        filter.setName("my-filter");
+        filter.setType("com.example.MyFilterFactory");
+        spec.setFilterDefinitions(List.of(filter));
+
+        String yaml = ProxyConfigGenerator.generateConfig(spec);
+        JsonNode root = YAML_MAPPER.readTree(yaml);
+
+        JsonNode filterDefs = root.path("filterDefinitions");
+        assertThat(filterDefs.isArray()).isTrue();
+        assertThat(filterDefs).hasSize(1);
+        assertThat(filterDefs.get(0).path("name").asText()).isEqualTo("my-filter");
+        assertThat(filterDefs.get(0).path("type").asText()).isEqualTo("com.example.MyFilterFactory");
+
+        JsonNode defaultFilters = root.path("defaultFilters");
+        assertThat(defaultFilters.isArray()).isTrue();
+        assertThat(defaultFilters.get(0).asText()).isEqualTo("my-filter");
+    }
+
+    @Test
+    void includesMultipleFilterDefinitions() throws Exception {
+        KroxyliciousSidecarConfigSpec spec = new KroxyliciousSidecarConfigSpec();
+        spec.setUpstreamBootstrapServers("kafka:9092");
+
+        FilterDefinitions f1 = new FilterDefinitions();
+        f1.setName("filter-a");
+        f1.setType("com.example.FilterA");
+        FilterDefinitions f2 = new FilterDefinitions();
+        f2.setName("filter-b");
+        f2.setType("com.example.FilterB");
+        spec.setFilterDefinitions(List.of(f1, f2));
+
+        String yaml = ProxyConfigGenerator.generateConfig(spec);
+        JsonNode root = YAML_MAPPER.readTree(yaml);
+
+        assertThat(root.path("filterDefinitions")).hasSize(2);
+        assertThat(root.path("defaultFilters")).hasSize(2);
+        assertThat(root.path("defaultFilters").get(0).asText()).isEqualTo("filter-a");
+        assertThat(root.path("defaultFilters").get(1).asText()).isEqualTo("filter-b");
+    }
+
+    @Test
+    void omitsFiltersWhenNoneConfigured() throws Exception {
+        KroxyliciousSidecarConfigSpec spec = new KroxyliciousSidecarConfigSpec();
+        spec.setUpstreamBootstrapServers("kafka:9092");
+
+        String yaml = ProxyConfigGenerator.generateConfig(spec);
+        JsonNode root = YAML_MAPPER.readTree(yaml);
+
+        assertThat(root.path("filterDefinitions").isMissingNode() || root.path("filterDefinitions").isNull())
+                .as("filterDefinitions should be absent when none configured")
+                .isTrue();
+    }
+
+    @Test
+    void includesUpstreamTlsConfig() throws Exception {
+        KroxyliciousSidecarConfigSpec spec = new KroxyliciousSidecarConfigSpec();
+        spec.setUpstreamBootstrapServers("kafka:9093");
+
+        String trustStorePath = "/opt/kroxylicious/tls/upstream/ca.crt";
+        String yaml = ProxyConfigGenerator.generateConfig(spec, trustStorePath);
+        JsonNode root = YAML_MAPPER.readTree(yaml);
+
+        JsonNode tls = root.path("virtualClusters").get(0)
+                .path("targetCluster").path("tls");
+        assertThat(tls.isMissingNode()).isFalse();
+        assertThat(tls.path("trust").path("storeFile").asText()).isEqualTo(trustStorePath);
+        assertThat(tls.path("trust").path("storeType").asText()).isEqualTo("PEM");
+    }
+
+    @Test
+    void omitsUpstreamTlsWhenPathIsNull() throws Exception {
+        KroxyliciousSidecarConfigSpec spec = new KroxyliciousSidecarConfigSpec();
+        spec.setUpstreamBootstrapServers("kafka:9092");
+
+        String yaml = ProxyConfigGenerator.generateConfig(spec, null);
+        JsonNode root = YAML_MAPPER.readTree(yaml);
+
+        JsonNode tls = root.path("virtualClusters").get(0)
+                .path("targetCluster").path("tls");
+        assertThat(tls.isMissingNode() || tls.isNull())
+                .as("TLS should be absent when no trust store path")
+                .isTrue();
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This is phase 2 of the pod admission webhook (see https://github.com/kroxylicious/design/pull/100).

Extend the sidecar injection webhook with:
- Filter definitions in KroxyliciousSidecarConfig CRD and proxy config generation
- Upstream TLS support with Secret volume mounts for CA trust anchors
- Delegated annotation overrides (bootstrap port, node ID range) with validation
- Native sidecar container injection (initContainers with restartPolicy: Always) for K8s 1.28+
- Kubernetes version detection in WebhookMain to auto-select sidecar strategy

Contributes towards #3890 

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>
Signed-off-by: Tom Bentley <tbentley@redhat.com>