### PR TITLE
fix(cicd): include new parent module in operator main build

### DIFF
--- a/.github/workflows/operator-maven.yaml
+++ b/.github/workflows/operator-maven.yaml
@@ -95,7 +95,7 @@ jobs:
         run: |
           mvn --batch-mode \
             --activate-profiles 'ci,!qa' \
-            --projects ':kroxylicious-operator,:kroxylicious-parent' \
+            --projects ':kroxylicious-operator,:kroxylicious-kubernetes-parent,:kroxylicious-parent' \
             -Derrorprone.skip=true \
             -Djapicmp.skip=true \
             -Dsonar.projectName='Kroxylicious Operator' \


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

https://github.com/kroxylicious/kroxylicious/actions/runs/25090163506/job/73514385303

The sonarcloud operator scan needs to know about the new parent module

```
 Failed to execute goal org.sonarsource.scanner.maven:sonar-maven-plugin:5.5.0.6356:sonar (default-cli) on project kroxylicious-parent: Unable to determine structure of project. Probably you use Maven Advanced Reactor Options with a broken tree of modules. "Kubernetes Operator" is orphan -> [Help 1]
 ```

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
