### PR TITLE
Webhook Phase 3: container image build, integration tests, module docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,8 +80,9 @@ See module README.md files for detailed context:
 - [kroxylicious-filters/README.md](kroxylicious-filters/README.md) - End-user filters
 - [kroxylicious-kms/README.md](kroxylicious-kms/README.md) - KMS API
 - [kroxylicious-authorizer-api/README.md](kroxylicious-authorizer-api/README.md) - Authoriser API
+- [kroxylicious-kubernetes/kroxylicious-kubernetes-api/README.md](kroxylicious-kubernetes/kroxylicious-kubernetes-api/README.md) - Kubernetes CRDs documentation)
 - [kroxylicious-kubernetes/kroxylicious-operator/README.md](kroxylicious-kubernetes/kroxylicious-operator/README.md) - Kubernetes operator
-- [kroxylicious-kubernetes/kroxylicious-kubernetes-api/README.md](kroxylicious-kubernetes/kroxylicious-kubernetes-api/README.md) - Kubernetes CRDs
+- [kroxylicious-kubernetes-web-hook/README.md](kroxylicious-kubernetes-web-hook/README.md) - Sidecar injection webhook
 - [kroxylicious-docs/README.md](kroxylicious-docs/README.md) - Documentation
 
 ## Kubernetes

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/CLAUDE.md
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/CLAUDE.md
@@ -1,0 +1,32 @@
+# Kroxylicious Sidecar Webhook - Claude Context
+
+This module implements a Kubernetes mutating admission webhook for sidecar injection.
+
+## Primary Documentation
+
+See [README.md](README.md) for comprehensive webhook documentation including:
+- Trust model (admin vs app owner)
+- Injection decision logic
+- Delegated annotations
+- Native sidecar support (K8s 1.28+)
+- Fail-open semantics
+- Key classes and configuration
+
+## Critical Constraints
+
+**Fail-open**: The webhook must always return `allowed: true`. Never reject a pod admission request, even on internal errors.
+
+**Trust model**: The webhook administrator does not trust the application pod owner. The webhook always overwrites the proxy config annotation. Non-delegated annotations in the `kroxylicious.io/` namespace are ignored.
+
+**Security context**: The sidecar security context is never weakened. The proxy runs as non-root with read-only root filesystem and all capabilities dropped.
+
+## For Claude
+
+When working with this module:
+- Follow fail-open semantics in error handling
+- Never allow app owners to control the proxy image, security context, or upstream address
+- Delegated annotations must be explicitly listed in `KroxyliciousSidecarConfig`
+- The proxy config YAML is generated using the same `Configuration` model from `kroxylicious-runtime`
+- Use structured logging with `addKeyValue()` per the [logging rules](../.claude/rules/logging.md)
+
+See [README.md](README.md) for detailed guidance.

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/README.md
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/README.md
@@ -1,0 +1,136 @@
+# kroxylicious-kubernetes-web-hook Module
+
+This module implements a Kubernetes mutating admission webhook that injects Kroxylicious proxy sidecars into Kafka application pods. See also [`../README.md`](../README.md) for project-wide context.
+
+## Purpose
+
+The webhook automates the "sidecar injection" pattern (as used by Istio/Linkerd) for Kroxylicious. When a pod is created in an enabled namespace, the webhook mutates it to add a Kroxylicious sidecar container that proxies Kafka traffic via `localhost`.
+
+## Trust Model
+
+The webhook operates under a strict trust boundary between two roles:
+
+- **Webhook administrator**: Controls what gets injected (proxy image, filters, upstream cluster, security context). Creates `KroxyliciousSidecarConfig` resources.
+- **Application pod owner**: Can only influence injection through explicitly delegated annotations. Cannot tamper with the proxy config, image, or security context.
+
+The webhook always overwrites the `kroxylicious.io/proxy-config` annotation, preventing app owners from pre-setting malicious config.
+
+## How Injection Works
+
+1. The `MutatingWebhookConfiguration` uses `namespaceSelector` to intercept pod CREATE requests in namespaces labelled `kroxylicious.io/sidecar-injection: enabled`.
+2. The webhook resolves a `KroxyliciousSidecarConfig` for the pod's namespace.
+3. If injection should proceed, the webhook generates a JSON Patch (RFC 6902) that:
+   - Adds a sidecar container running the Kroxylicious proxy
+   - Adds a downwardAPI volume projecting the proxy config from a pod annotation
+   - Sets `KAFKA_BOOTSTRAP_SERVERS=localhost:<port>` on existing app containers
+   - Sets pod-level security context if not already present
+   - Adds upstream TLS trust anchor volumes if configured
+
+## Custom Resource: `KroxyliciousSidecarConfig`
+
+A namespaced CRD (group `kroxylicious.io`, version `v1alpha1`) that defines sidecar configuration per namespace. Key fields:
+
+| Field | Description |
+|-------|-------------|
+| `upstreamBootstrapServers` | Bootstrap servers of the upstream Kafka cluster (required) |
+| `proxyImage` | Override the proxy container image |
+| `bootstrapPort` | Proxy bootstrap port on localhost (default: 19092) |
+| `nodeIdRange` | Broker node ID range (default: 0-2) |
+| `managementPort` | Management endpoint port (default: 9190) |
+| `filterDefinitions` | Filters applied to proxied traffic |
+| `upstreamTls` | TLS configuration for the upstream Kafka connection |
+| `delegatedAnnotations` | Annotations app owners may set to override config |
+| `setBootstrapEnvVar` | Whether to set `KAFKA_BOOTSTRAP_SERVERS` on app containers (default: true) |
+| `resources` | Resource requests/limits for the sidecar container |
+
+## Annotations
+
+| Annotation | Purpose | Controlled by |
+|------------|---------|---------------|
+| `kroxylicious.io/sidecar-injection` | Namespace-level opt-in (label) | Admin |
+| `kroxylicious.io/inject-sidecar` | Pod-level opt-out (`"false"`) | App owner |
+| `kroxylicious.io/sidecar-config` | Select specific config by name | App owner |
+| `kroxylicious.io/proxy-config` | Generated proxy YAML (set by webhook) | Webhook |
+| `kroxylicious.io/sidecar-status` | Injection status (set by webhook) | Webhook |
+| `kroxylicious.io/sidecar-bootstrap-port` | Override bootstrap port (if delegated) | App owner |
+| `kroxylicious.io/sidecar-node-id-range` | Override node ID range (if delegated) | App owner |
+
+## Injection Decision Logic
+
+The injection decision follows this order:
+
+1. **Opt-out**: Pod has annotation `kroxylicious.io/inject-sidecar: "false"` &rarr; skip
+2. **Already injected**: Pod has a container named `kroxylicious-proxy` &rarr; skip
+3. **No config**: No `KroxyliciousSidecarConfig` found for the namespace &rarr; skip
+4. Otherwise &rarr; inject
+
+## Delegated Annotations
+
+The admin can list annotation keys in `delegatedAnnotations` to allow app owners to override specific settings. If an app owner sets a `kroxylicious.io/` annotation that is not delegated, it is ignored and a warning is logged.
+
+## Native Sidecar Support
+
+On Kubernetes 1.28+, the webhook injects the sidecar as an init container with `restartPolicy: Always` (native sidecar). This ensures proper startup ordering (sidecar starts before app containers) and shutdown ordering (sidecar stops after). On older clusters, the sidecar is injected as a regular container. The webhook auto-detects the cluster version at startup.
+
+## Fail-Open Semantics
+
+The webhook always returns `allowed: true`, even on internal errors. If the webhook is unavailable, the `MutatingWebhookConfiguration` uses `failurePolicy: Ignore` so pods are created without sidecars. This is the standard approach for sidecar injection webhooks.
+
+## Key Classes
+
+| Class | Purpose |
+|-------|---------|
+| `WebhookMain` | Entrypoint; creates HTTPS server, fabric8 client, config resolver |
+| `WebhookServer` | `HttpsServer` lifecycle, TLS from PEM cert/key files |
+| `AdmissionHandler` | `POST /mutate` handler; deserialises admission review, delegates to mutator |
+| `InjectionDecision` | Pure function determining whether to inject |
+| `PodMutator` | Generates JSON Patch operations for pod mutation |
+| `ProxyConfigGenerator` | Generates proxy configuration YAML from `KroxyliciousSidecarConfigSpec` |
+| `SidecarConfigResolver` | Fabric8 informer-based cache of `KroxyliciousSidecarConfig` resources |
+
+## Configuration
+
+The webhook is configured via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BIND_ADDRESS` | `0.0.0.0:8443` | HTTPS bind address |
+| `TLS_CERT_PATH` | `/etc/webhook/tls/tls.crt` | PEM certificate file |
+| `TLS_KEY_PATH` | `/etc/webhook/tls/tls.key` | PEM private key file |
+| `KROXYLICIOUS_IMAGE` | (required) | Default proxy container image |
+
+## Deployment
+
+Install manifests are in `packaging/install/`. They include namespace, RBAC, deployment, service, `MutatingWebhookConfiguration`, and cert-manager resources.
+
+**With cert-manager:**
+```bash
+kubectl apply -f packaging/install/
+```
+
+**Without cert-manager:** Skip `06.Certificate.kroxylicious-webhook.yaml`, create the TLS Secret manually, and patch the `MutatingWebhookConfiguration` `caBundle` field.
+
+## Building
+
+```bash
+# Build the module
+mvn clean install -pl kroxylicious-kubernetes-web-hook -am
+
+# Build container image (requires dist profile)
+mvn clean install -pl kroxylicious-kubernetes-web-hook -am -Pdist
+
+# Run integration tests on Kind
+mvn verify -pl kroxylicious-kubernetes-web-hook -Pdist
+```
+
+## Testing
+
+- **Unit tests** (`*Test.java`): Test individual classes in isolation. Run with `mvn test`.
+- **KT tests** (`*KT.java`): Kubernetes integration tests requiring a real cluster and the `dist` Maven profile. Gated by `@EnabledIf` annotations that check for cluster availability.
+
+## Cross-References
+
+- **CRD definition**: See `../kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kroxylicioussidecarconfigs.kroxylicious.io-v1.yml`
+- **Proxy configuration model**: See `../kroxylicious-runtime/`
+- **Operator (standalone proxy deployment)**: See [`../kroxylicious-operator/README.md`](../kroxylicious-operator/README.md)
+- **Security patterns**: See [`../.claude/rules/security-patterns.md`](../.claude/rules/security-patterns.md)

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/packaging/install/03.Deployment.kroxylicious-webhook.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/packaging/install/03.Deployment.kroxylicious-webhook.yaml
@@ -33,7 +33,6 @@ spec:
       containers:
         - name: webhook
           image: $[io.kroxylicious.webhook.image.name]
-          # TODO In phase 3 have maven-resources-plugin honour the implied interpolation
           ports:
             - containerPort: 8443
               name: webhook

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/pom.xml
@@ -182,6 +182,11 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-apps</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-server-mock</artifactId>
             <scope>test</scope>
             <exclusions>

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/pom.xml
@@ -23,6 +23,10 @@
     <properties>
         <!-- Error Prone disabled - fabric8 builders not compatible with -XDcompilePolicy=simple -->
         <errorprone.skip>true</errorprone.skip>
+        <io.kroxylicious.webhook.image.name>quay.io/kroxylicious/webhook:${project.version}</io.kroxylicious.webhook.image.name>
+        <io.kroxylicious.webhook.image.archive>target/kroxylicious-webhook.img.tar.gz</io.kroxylicious.webhook.image.archive>
+        <!-- Used in packaging/install/03.Deployment manifest for the KROXYLICIOUS_IMAGE env var -->
+        <io.kroxylicious.proxy.image.name>quay.io/kroxylicious/proxy:${project.version}</io.kroxylicious.proxy.image.name>
     </properties>
 
     <dependencyManagement>
@@ -187,9 +191,29 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-integration-test-support</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+            </testResource>
+            <testResource>
+                <directory>src/test/resources-filtered</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -202,12 +226,14 @@
                         </goals>
                         <configuration>
                             <ignoredUnusedDeclaredDependencies>
-                                <!-- Used in integration tests (not yet written) -->
                                 <ignoredUnusedDeclaredDependency>io.fabric8:kubernetes-server-mock
                                 </ignoredUnusedDeclaredDependency>
                                 <!-- dependency analyzer seems not to grok that a dependency on a
                                 @Retention(RetentionPolicy.SOURCE) annotation is still a dependency -->
                                 <ignoredUnusedDeclaredDependency>io.kroxylicious:kroxylicious-annotations
+                                </ignoredUnusedDeclaredDependency>
+                                <!-- Used in KT integration tests, only compiled with dist profile -->
+                                <ignoredUnusedDeclaredDependency>io.kroxylicious:kroxylicious-integration-test-support
                                 </ignoredUnusedDeclaredDependency>
                             </ignoredUnusedDeclaredDependencies>
                         </configuration>
@@ -237,4 +263,127 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>dist</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>app</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <descriptors>
+                                        <descriptor>src/assembly/app.xml</descriptor>
+                                    </descriptors>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                    <goal>save</goal>
+                                </goals>
+                                <configuration>
+                                    <!--suppress MavenModelInspection -->
+                                    <skip>${skipContainerImageBuild}</skip>
+                                    <images>
+                                        <image>
+                                            <name>${io.kroxylicious.webhook.image.name}</name>
+                                            <alias>webhook</alias>
+                                            <build>
+                                                <dockerFile>src/main/docker/webhook.dockerfile</dockerFile>
+                                                <contextDir>${project.basedir}</contextDir>
+                                                <args>
+                                                    <KROXYLICIOUS_VERSION>${project.version}</KROXYLICIOUS_VERSION>
+                                                </args>
+                                            </build>
+                                        </image>
+                                    </images>
+                                    <saveFile>${io.kroxylicious.webhook.image.archive}</saveFile>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-webhook-install</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <delimiters>
+                                        <delimiter>$[*]</delimiter>
+                                    </delimiters>
+                                    <resources>
+                                        <resource>
+                                            <directory>packaging</directory>
+                                            <filtering>true</filtering>
+                                        </resource>
+                                    </resources>
+                                    <outputDirectory>target/packaged</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>kube-integration-test</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                </goals>
+                                <configuration>
+                                    <includes>
+                                        <include>**/KT*.java</include>
+                                        <include>**/*KT.java</include>
+                                        <include>**/*KTCase.java</include>
+                                    </includes>
+                                    <!--suppress MavenModelInspection -->
+                                    <skipITs>${skipKTs}</skipITs>
+                                    <!--suppress MavenModelInspection -->
+                                    <skip>${skipKTs}</skip>
+                                    <!--suppress MavenModelInspection -->
+                                    <skipTests>${skipKTs}</skipTests>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>kube-verify</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <!--suppress MavenModelInspection -->
+                                    <skipITs>${skipKTs}</skipITs>
+                                    <!--suppress MavenModelInspection -->
+                                    <skip>${skipKTs}</skip>
+                                    <!--suppress MavenModelInspection -->
+                                    <skipTests>${skipKTs}</skipTests>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/assembly/app.xml
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/assembly/app.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 https://maven.apache.org/xsd/assembly-2.2.0.xsd">
+    <id>app</id>
+    <formats>
+        <format>dir</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}/src/assembly</directory>
+            <outputDirectory>/bin/</outputDirectory>
+            <includes>
+                <include>run-java.sh</include>
+                <include>webhook-start.sh</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/..</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>LICENSE</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/src/main/resources/</directory>
+            <outputDirectory>/config/</outputDirectory>
+            <includes>
+                <include>log4j2.yaml</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/libs/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>false</unpack>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/assembly/run-java.sh
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/assembly/run-java.sh
@@ -1,0 +1,619 @@
+#!/bin/bash
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# shellcheck disable=SC2039,SC2002
+# Disable SC2039 something is undefined in posix script wide as we run in
+# Disable SC2002 useless use of cat.
+
+# ===================================================================================
+# Generic startup script for running arbitrary Java applications with
+# being optimized for running in containers
+#
+# Usage:
+#    # Execute a Java app:
+#    ./run-java.sh <args given to Java code>
+#
+#    # Get options which can be used for invoking Java apps like Maven or Tomcat
+#    ./run-java.sh options [....]
+#
+#
+# This script will pick up either a 'fat' jar which can be run with "-jar"
+# or you can specify a JAVA_MAIN_CLASS.
+#
+# Source and Documentation can be found
+# at https://github.com/fabric8io-images/run-java-sh
+#
+# Env-variables evaluated in this script:
+#
+# JAVA_OPTIONS: Checked for already set options
+# JAVA_MAX_MEM_RATIO: Ratio use to calculate a default maximum Memory, in percent.
+#                     E.g. the "50" value implies that 50% of the Memory
+#                     given to the container is used as the maximum heap memory with
+#                     '-Xmx'.
+#                     It defaults to "25" when the maximum amount of memory available
+#                     to the container is below 300M, otherwise defaults to "50".
+#                     It is a heuristic and should be better backed up with real
+#                     experiments and measurements.
+#                     For a good overviews what tuning options are available -->
+#                             https://youtu.be/Vt4G-pHXfs4
+#                             https://www.youtube.com/watch?v=w1rZOY5gbvk
+#                             https://vimeo.com/album/4133413/video/181900266
+# Also note that heap is only a small portion of the memory used by a JVM. There are lot
+# of other memory areas (metadata, thread, code cache, ...) which adds to the overall
+# size. When your container gets killed because of an OOM, then you should tune
+# the absolute values.
+# JAVA_INIT_MEM_RATIO: Ratio use to calculate a default initial heap memory, in percent.
+#                      By default this value is not set.
+#
+# The following variables are exposed to your Java application:
+#
+# CONTAINER_MAX_MEMORY: Max memory for the container (if running within a container)
+# MAX_CORE_LIMIT: Number of cores available for the container (if running within a container)
+
+
+# ==========================================================
+
+# Fail on a single failed command in a pipeline (if supported)
+(set -o | grep -q pipefail) && set -o pipefail
+
+# Fail on error and undefined vars
+set -eu
+
+# Save global script args
+ARGS="$@"
+
+# ksh is different for defining local vars
+if [ -n "${KSH_VERSION:-}" ]; then
+  alias local=typeset
+fi
+
+# Error is indicated with a prefix in the return value
+check_error() {
+  local error_msg="$1"
+  if echo "${error_msg}" | grep -q "^ERROR:"; then
+    echo "${error_msg}"
+    exit 1
+  fi
+}
+
+# The full qualified directory where this script is located in
+script_dir() {
+  # Default is current directory
+  local dir full_dir
+  dir=$(dirname "$0")
+  full_dir=$(cd "${dir}" && pwd)
+  echo "${full_dir}"
+}
+
+# Try hard to find a sane default jar-file
+auto_detect_jar_file() {
+  local dir="$1"
+
+  # Filter out temporary jars from the shade plugin which start with 'original-'
+  local old_dir
+  old_dir="$(pwd)"
+  if cd "${dir}"; then
+    # NB: Find both (single) JAR *or* WAR <https://github.com/fabric8io-images/run-java-sh/issues/79>
+    local nr_jars
+    nr_jars="$(ls 2>/dev/null | grep -e '.*\.jar$' -e '.*\.war$' | grep -c -v '^original-' | awk '{print $1}')"
+    if [ "${nr_jars}" = 1 ]; then
+      ls 2>/dev/null | grep -e '.*\.jar$' -e '.*\.war$' | grep -v '^original-'
+      exit 0
+    fi
+    cd "${old_dir}"
+    echo "ERROR: Neither JAVA_MAIN_CLASS nor JAVA_APP_JAR is set and ${nr_jars} found in ${dir} (1 expected)"
+  else
+    echo "ERROR: No directory ${dir} found for auto detection"
+  fi
+}
+
+# Check directories (arg 2...n) for a jar file (arg 1)
+find_jar_file() {
+  local jar="$1"
+  shift;
+
+  # Absolute path check if jar specifies an absolute path
+  if [ "${jar}" != ${jar#/} ]; then
+    if [ -f "${jar}" ]; then
+      echo "${jar}"
+    else
+      echo "ERROR: No such file ${jar}"
+    fi
+  else
+    for dir in $*; do
+      if [ -f "${dir}/$jar" ]; then
+        echo "${dir}/$jar"
+        return
+      fi
+    done
+    echo "ERROR: No ${jar} found in $*"
+  fi
+}
+
+# Generic formula evaluation based on awk
+calc() {
+  local formula="$1"
+  shift
+  echo "$@" | awk '
+    function ceil(x) {
+      return x % 1 ? int(x) + 1 : x
+    }
+    function log2(x) {
+      return log(x)/log(2)
+    }
+    function max2(x, y) {
+      return x > y ? x : y
+    }
+    function round(x) {
+      return int(x + 0.5)
+    }
+    {print '"int(${formula})"'}
+  '
+}
+
+# kroxy customization: use code from https://github.com/fabric8io-images/run-java-sh/pull/113 to support cgroups v2 locations
+# Based on the cgroup limits, figure out the max number of core we should utilize
+core_limit() {
+  if [ -r "/sys/fs/cgroup/cgroup.controllers" ]; then
+    # cgroup v2
+    local cpu_file="/sys/fs/cgroup/cpu.max"
+    if [ -r "${cpu_file}" ]; then
+      local cpu_quota cpu_period
+      cpu_quota="$(cat ${cpu_file} | awk '{ print $1 }')"
+      cpu_period="$(cat ${cpu_file} | awk '{ print $2 }')"
+
+      # cfs_quota_us == max --> no restrictions
+      if [ "${cpu_quota:-0}" != "max" ]; then
+        calc 'ceil($1/$2)' "${cpu_quota}" "${cpu_period}"
+      fi
+    fi
+  else
+    # cgroup v1
+    local cpu_period_file="/sys/fs/cgroup/cpu/cpu.cfs_period_us"
+    local cpu_quota_file="/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+    if [ -r "${cpu_period_file}" ]; then
+      local cpu_period
+      cpu_period="$(cat ${cpu_period_file})"
+
+      if [ -r "${cpu_quota_file}" ]; then
+        local cpu_quota
+        cpu_quota="$(cat ${cpu_quota_file})"
+        # cfs_quota_us == -1 --> no restrictions
+        if [ ${cpu_quota:-0} -ne -1 ]; then
+          calc 'ceil($1/$2)' "${cpu_quota}" "${cpu_period}"
+        fi
+      fi
+    fi
+  fi
+}
+
+# kroxy customization: use code from https://github.com/fabric8io-images/run-java-sh/pull/113 to support cgroups v2 locations
+max_memory() {
+  # High number which is the max limit until which memory is supposed to be
+  # unbounded.
+
+  local mem_file=""
+  if [ -r "/sys/fs/cgroup/cgroup.controllers" ]; then
+    # cgroup v2
+    mem_file="/sys/fs/cgroup/memory.max"
+  else
+    # cgroup v1
+    mem_file="/sys/fs/cgroup/memory/memory.limit_in_bytes"
+  fi
+
+  if [ -r "${mem_file}" ]; then
+    local max_mem_cgroup max_mem_meminfo_kb max_mem_meminfo
+    max_mem_cgroup="$(cat ${mem_file})"
+    max_mem_meminfo_kb="$(cat /proc/meminfo | awk '/MemTotal/ {print $2}')"
+    max_mem_meminfo="$((max_mem_meminfo_kb * 1024))"
+    if [ ${max_mem_cgroup:-0} != -1 ] && [ "${max_mem_cgroup:-max}" != "max" ] && [ ${max_mem_cgroup:-0} -lt ${max_mem_meminfo:-0} ]
+    then
+      echo "${max_mem_cgroup}"
+    fi
+  fi
+}
+
+init_limit_env_vars() {
+  # Read in container limits and export the as environment variables
+  local core_limit mem_limit
+  core_limit="$(core_limit)"
+  if [ -n "${core_limit}" ]; then
+    export CONTAINER_CORE_LIMIT="${core_limit}"
+  fi
+
+  mem_limit="$(max_memory)"
+  if [ -n "${mem_limit}" ]; then
+    export CONTAINER_MAX_MEMORY="${mem_limit}"
+  fi
+}
+
+load_env() {
+  local script_dir="$1"
+
+  # Configuration stuff is read from this file
+  local run_env_sh="run-env.sh"
+
+  # Load default default config
+  if [ -f "${script_dir}/${run_env_sh}" ]; then
+    . "${script_dir}/${run_env_sh}"
+  fi
+
+  # Check also $JAVA_APP_DIR. Overrides other defaults
+  # It's valid to set the app dir in the default script
+  JAVA_APP_DIR="${JAVA_APP_DIR:-${script_dir}}"
+  if [ -f "${JAVA_APP_DIR}/${run_env_sh}" ]; then
+    . "${JAVA_APP_DIR}/${run_env_sh}"
+  fi
+  export JAVA_APP_DIR
+
+  # JAVA_LIB_DIR defaults to JAVA_APP_DIR/lib
+  export JAVA_LIB_DIR="${JAVA_LIB_DIR:-${JAVA_APP_DIR}}"
+  if [ -z "${JAVA_MAIN_CLASS:-}" ] && [ -z "${JAVA_APP_JAR:-}" ]; then
+    JAVA_APP_JAR="$(auto_detect_jar_file ${JAVA_APP_DIR})"
+    check_error "${JAVA_APP_JAR}"
+  fi
+
+  if [ -n "${JAVA_APP_JAR:-}" ]; then
+    local jar
+    jar="$(find_jar_file ${JAVA_APP_JAR} ${JAVA_APP_DIR} ${JAVA_LIB_DIR})"
+    check_error "${jar}"
+    export JAVA_APP_JAR="${jar}"
+  else
+    export JAVA_MAIN_CLASS
+  fi
+}
+
+# Check for standard /opt/run-java-options first, fallback to run-java-options in the path if not existing
+run_java_options() {
+  if [ -f "/opt/run-java-options" ]; then
+    . /opt/run-java-options
+  else
+    if which run-java-options >/dev/null 2>&1; then
+      run-java-options
+    fi
+  fi
+}
+
+debug_options() {
+  if [ -n "${JAVA_ENABLE_DEBUG:-}" ] || [ -n "${JAVA_DEBUG_ENABLE:-}" ] ||  [ -n "${JAVA_DEBUG:-}" ]; then
+	  local debug_port="${JAVA_DEBUG_PORT:-5005}"
+    local suspend_mode="n"
+    if [ -n "${JAVA_DEBUG_SUSPEND:-}" ]; then
+      if ! echo "${JAVA_DEBUG_SUSPEND}" | grep -q -e '^\(false\|n\|no\|0\)$'; then
+        suspend_mode="y"
+      fi
+    fi
+
+	  echo "-agentlib:jdwp=transport=dt_socket,server=y,suspend=${suspend_mode},address=*:${debug_port}"
+  fi
+}
+
+# Read in a classpath either from a file with a single line, colon separated
+# or given line-by-line in separate lines
+# Arg 1: path to classpath (must exist), optional arg2: application jar, which is stripped from the classpath in
+# multi line arrangements
+format_classpath() {
+  local cp_file="$1"
+  local app_jar="${2:-}"
+
+  local wc_out
+  if wc_out=$(wc -l "${cp_file}" 2>&1); then
+    echo "Cannot read lines in ${cp_file}: $wc_out"
+    exit 1
+  fi
+
+  local nr_lines
+  nr_lines=$(echo $wc_out | awk '{ print $1 }')
+  if [ ${nr_lines} -gt 1 ]; then
+    local sep=""
+    local classpath=""
+    while read file; do
+      local full_path="${JAVA_LIB_DIR}/${file}"
+      # Don't include app jar if include in list
+      if [ "${app_jar}" != "${full_path}" ]; then
+        classpath="${classpath}${sep}${full_path}"
+      fi
+      sep=":"
+    done < "${cp_file}"
+    echo "${classpath}"
+  else
+    # Supposed to be a single line, colon separated classpath file
+    cat "${cp_file}"
+  fi
+}
+
+# ==========================================================================
+
+memory_options() {
+  echo "$(calc_init_memory) $(calc_max_memory)"
+  return
+}
+
+# Check for memory options and set max heap size if needed
+calc_max_memory() {
+  # Check whether -Xmx is already given in JAVA_OPTIONS
+  if echo "${JAVA_OPTIONS:-}" | grep -q -- "-Xmx"; then
+    return
+  fi
+
+  if [ -z "${CONTAINER_MAX_MEMORY:-}" ]; then
+    return
+  fi
+
+  # Check for the 'real memory size' and calculate Xmx from the ratio
+  if [ -n "${JAVA_MAX_MEM_RATIO:-}" ]; then
+    if [ "${JAVA_MAX_MEM_RATIO}" -eq 0 ]; then
+      # Explicitly switched off
+      return
+    fi
+    calc_mem_opt "${CONTAINER_MAX_MEMORY}" "${JAVA_MAX_MEM_RATIO}" "mx"
+  fi
+}
+
+# Check for memory options and set initial heap size if requested
+calc_init_memory() {
+  # Check whether -Xms is already given in JAVA_OPTIONS.
+  if echo "${JAVA_OPTIONS:-}" | grep -q -- "-Xms"; then
+    return
+  fi
+
+  # Check if value set
+  if [ -z "${JAVA_INIT_MEM_RATIO:-}" ] || [ -z "${CONTAINER_MAX_MEMORY:-}" ] || [ "${JAVA_INIT_MEM_RATIO}" -eq 0 ]; then
+    return
+  fi
+
+  # Calculate Xms from the ratio given
+  calc_mem_opt "${CONTAINER_MAX_MEMORY}" "${JAVA_INIT_MEM_RATIO}" "ms"
+}
+
+calc_mem_opt() {
+  local max_mem="$1"
+  local fraction="$2"
+  local mem_opt="$3"
+
+  local val
+  val=$(calc 'round($1*$2/100/1048576)' "${max_mem}" "${fraction}")
+  echo "-X${mem_opt}${val}m"
+}
+
+c2_disabled() {
+  if [ -n "${CONTAINER_MAX_MEMORY:-}" ]; then
+    # Disable C2 compiler when container memory <=300MB
+    if [ "${CONTAINER_MAX_MEMORY}" -le 314572800 ]; then
+      echo true
+      return
+    fi
+  fi
+  echo false
+}
+
+# Switch on diagnostics except when switched off
+diagnostics_options() {
+  if [ -n "${JAVA_DIAGNOSTICS:-}" ]; then
+    echo "-XX:NativeMemoryTracking=summary -Xlog:gc*:stdout:time -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints"
+  fi
+}
+
+# Replicate thread ergonomics for tiered compilation.
+# This could ideally be skipped when tiered compilation is disabled.
+# The algorithm is taken from:
+# OpenJDK / jdk8u / jdk8u / hotspot
+# src/share/vm/runtime/advancedThresholdPolicy.cpp
+ci_compiler_count() {
+  local core_limit="$1"
+  local log_cpu loglog_cpu count c1_count c2_count
+  log_cpu=$(calc 'log2($1)' "$core_limit")
+  loglog_cpu=$(calc 'log2(max2($1,1))' "$log_cpu")
+  count=$(calc 'max2($1*$2,1)*3/2' "$log_cpu" "$loglog_cpu")
+  c1_count=$(calc 'max2($1/3,1)' "$count")
+  c2_count=$(calc 'max2($1-$2,1)' "$count" "$c1_count")
+  [ $(c2_disabled) = true ] && echo "$c1_count" || calc '$1+$2' "$c1_count" "$c2_count"
+}
+
+#-XX:MinHeapFreeRatio=20  These parameters tell the heap to shrink aggressively and to grow conservatively.
+#-XX:MaxHeapFreeRatio=40  Thereby optimizing the amount of memory available to the operating system.
+heap_ratio() {
+  echo "-XX:MinHeapFreeRatio=20 -XX:MaxHeapFreeRatio=40"
+}
+
+# These parameters are necessary when running parallel GC if you want to use the Min and Max Heap Free ratios.
+# Skip setting gc_options if any other GC is set in JAVA_OPTIONS.
+# -XX:GCTimeRatio=4
+# -XX:AdaptiveSizePolicyWeight=90
+gc_options() {
+  if echo "${JAVA_OPTIONS:-}" | grep -q -- "-XX:.*Use.*GC"; then
+    return
+  fi
+  echo " -XX:+ExitOnOutOfMemoryError"
+}
+
+java_default_options() {
+  # Echo options, trimming trailing and multiple spaces
+  echo "$(memory_options) $(diagnostics_options) $(gc_options)" | awk '$1=$1'
+
+}
+
+# ==============================================================================
+
+# parse the URL
+parse_url() {
+  #[scheme://][user[:password]@]host[:port][/path][?params]
+  # shellcheck disable=SC2001
+  # This is not a simple search and replace of a single value. The usage of sed is justified
+  echo "$1" | sed -e "s+^\(\([^:]*\)://\)\?\(\([^:@]*\)\(:\([^@]*\)\)\?@\)\?\([^:/?]*\)\(:\([^/?]*\)\)\?.*$+ local scheme='\2' username='\4' password='\6' hostname='\7' port='\9'+"
+}
+
+java_proxy_options() {
+  local url="$1"
+  local transport="$2"
+  local ret=""
+
+  if [ -n "$url" ] ; then
+    eval $(parse_url "$url")
+    if [ -n "$hostname" ] ; then
+      ret="-D${transport}.proxyHost=${hostname}"
+    fi
+    if [ -n "$port" ] ; then
+      ret="$ret -D${transport}.proxyPort=${port}"
+    fi
+    if [ -n "$username" ] || [ -n "$password" ] ; then
+      echo "WARNING: Proxy URL for ${transport} contains authentication credentials, these are not supported by java" >&2
+    fi
+  fi
+  echo "$ret"
+}
+
+# Check for proxy options and echo if enabled.
+proxy_options() {
+  local ret=""
+  ret="$(java_proxy_options "${https_proxy:-${HTTPS_PROXY:-}}" https)"
+  ret="$ret $(java_proxy_options "${http_proxy:-${HTTP_PROXY:-}}" http)"
+
+  local noProxy="${no_proxy:-${NO_PROXY:-}}"
+  if [ -n "$noProxy" ] ; then
+    ret="$ret -Dhttp.nonProxyHosts=$(echo "|$noProxy" | sed -e 's/,[[:space:]]*/|/g' | sed -e 's/[[:space:]]//g' | sed -e 's/|\./|\*\./g' | cut -c 2-)"
+  fi
+  echo "$ret"
+}
+
+# ==============================================================================
+
+# Set process name if possible
+exec_args() {
+  if [ -n "${JAVA_APP_NAME:-}" ]; then
+    # Not all shells support the 'exec -a newname' syntax..
+    # shellcheck disable=SC2046
+    # disable SC2046 as there is no word splitting to happen
+    if eval $(exec -a test true 2>/dev/null); then
+      echo "-a '${JAVA_APP_NAME}'"
+    fi
+  fi
+}
+
+# Combine all java options
+java_options() {
+  # Normalize spaces with awk (i.e. trim and eliminate double spaces)
+  # See e.g. https://www.physicsforums.com/threads/awk-1-1-1-file-txt.658865/ for an explanation
+  # of this awk idiom
+  echo "${JAVA_OPTIONS:-} $(run_java_options) $(debug_options) $(proxy_options) $(java_default_options)" | awk '$1=$1'
+}
+
+# Fetch classpath from env or from a local "run-classpath" file
+classpath() {
+  local cp_path="."
+  if [ "${JAVA_LIB_DIR}" != "${JAVA_APP_DIR}" ]; then
+    cp_path="${cp_path}:${JAVA_LIB_DIR}"
+  fi
+  if [ -z "${JAVA_CLASSPATH:-}" ] && [ -n "${JAVA_MAIN_CLASS:-}" ]; then
+    if [ -n "${JAVA_APP_JAR:-}" ]; then
+      cp_path="${cp_path}:${JAVA_APP_JAR}"
+    fi
+    if [ -f "${JAVA_LIB_DIR}/classpath" ]; then
+      # Classpath is pre-created and stored in a 'run-classpath' file
+      cp_path="${cp_path}:$(format_classpath ${JAVA_LIB_DIR}/classpath ${JAVA_APP_JAR:-})"
+    else
+      # No order implied
+      cp_path="${cp_path}:${JAVA_APP_DIR}/*"
+    fi
+  elif [ -n "${JAVA_CLASSPATH:-}" ]; then
+    # Given from the outside
+    cp_path="${JAVA_CLASSPATH}"
+  fi
+  echo "${cp_path}"
+}
+
+# Checks if a flag is present in the arguments.
+hasflag() {
+    local filters="$@"
+    for var in $ARGS; do
+        for filter in $filters; do
+          if [ "$var" = "$filter" ]; then
+              echo 'true'
+              return
+          fi
+        done
+    done
+}
+
+# ==============================================================================
+
+options() {
+    if [ -z ${1:-} ]; then
+      java_options
+      return
+    fi
+
+    local ret=""
+    if [ $(hasflag --debug) ]; then
+      ret="$ret $(debug_options)"
+    fi
+    if [ $(hasflag --proxy) ]; then
+      ret="$ret $(proxy_options)"
+    fi
+    if [ $(hasflag --java-default) ]; then
+      ret="$ret $(java_default_options)"
+    fi
+    if [ $(hasflag --memory) ]; then
+      ret="$ret $(memory_options)"
+    fi
+    if [ $(hasflag --diagnostics) ]; then
+      ret="$ret $(diagnostics_options)"
+    fi
+    if [ $(hasflag --gc) ]; then
+      ret="$ret $(gc_options)"
+    fi
+
+    echo $ret | awk '$1=$1'
+}
+
+# Start JVM
+run() {
+  # Initialize environment
+  load_env $(script_dir)
+
+  local args
+  pushd ${JAVA_APP_DIR}
+  if [ -n "${JAVA_MAIN_CLASS:-}" ] ; then
+     args="${JAVA_MAIN_CLASS}"
+  elif [ -n "${JAVA_APP_JAR:-}" ]; then
+     args="-jar ${JAVA_APP_JAR}"
+  else
+     echo "Either JAVA_MAIN_CLASS or JAVA_APP_JAR needs to be given"
+     exit 1
+  fi
+
+  if [ "${HIDE_CMD_LINE:-}" != 1 ] && [ "${HIDE_CMD_LINE:-}" != true ]; then
+    echo exec $(exec_args) java $(java_options) -cp "$(classpath)" ${args} "$@"
+  fi
+
+  # Don't put ${args} in quotes, otherwise it would be interpreted as a single arg.
+  # However it could be two args (see above). zsh doesn't like this btw, but zsh is not
+  # supported anyway.
+
+  # kroxy customization: return to user dir so configuration path can be relative
+  popd
+  exec $(exec_args) java $(java_options) -cp "$(classpath)" ${args} "$@"
+}
+
+# =============================================================================
+# Fire up
+
+# Set env vars reflecting limits
+init_limit_env_vars
+
+first_arg=${1:-}
+if [ "${first_arg}" = "options" ]; then
+  # Print out options only
+  shift
+  options "$@"
+  exit 0
+elif [ "${first_arg}" = "run" ]; then
+  # Run is the default command, but can be given to allow "options"
+  # as first argument to your
+  shift
+fi
+run "$@"

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/assembly/webhook-start.sh
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/assembly/webhook-start.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+# Disable warnings about `local` variables
+# shellcheck disable=SC3043
+script_dir() {
+  # Default is current directory
+  local dir
+  dir=$(dirname "$0")
+  local full_dir
+  full_dir=$(cd "${dir}" && pwd)
+  echo ${full_dir}
+}
+
+classpath() {
+  local class_path
+  class_path="$(script_dir)/../libs/*"
+  if [ -n "${KROXYLICIOUS_CLASSPATH:-}" ]; then
+    class_path="$class_path:${KROXYLICIOUS_CLASSPATH}"
+  fi
+  echo "${class_path}"
+}
+
+if [ "${JAVA_MAX_MEM_RATIO+set}" != set ]; then
+  export JAVA_MAX_MEM_RATIO="50"
+fi
+
+if [ "${KROXYLICIOUS_LOGGING_OPTIONS+set}" != set ]; then
+  KROXYLICIOUS_LOGGING_OPTIONS="-Dlog4j2.configurationFile=$(script_dir)/../config/log4j2.yaml"
+fi
+export JAVA_OPTIONS="${KROXYLICIOUS_LOGGING_OPTIONS} ${JAVA_OPTIONS:-}"
+JAVA_CLASSPATH="$(classpath)"
+export JAVA_CLASSPATH
+export JAVA_MAIN_CLASS=io.kroxylicious.kubernetes.webhook.WebhookMain
+exec "$(script_dir)"/run-java.sh "$@"

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/docker/webhook.dockerfile
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/docker/webhook.dockerfile
@@ -1,0 +1,62 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1775623882@sha256:d91be7cea9f03a757d69ad7fcdfcd7849dba820110e7980d5e2a1f46ed06ea3b
+
+ARG TARGETOS=linux
+ARG TARGETARCH
+ARG JAVA_VERSION=21
+ARG KROXYLICIOUS_VERSION
+ARG CONTAINER_USER=kroxylicious
+ARG CONTAINER_USER_UID=185
+
+USER root
+WORKDIR /opt/kroxylicious-webhook
+
+# Download Tini
+ARG TINI_VERSION=v0.19.0
+ARG TINI_SHA256_AMD64=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c
+ARG TINI_SHA256_ARM64=07952557df20bfd2a95f9bef198b445e006171969499a1d361bd9e6f8e5e0e81
+ARG TINI_SHA256_PPC64LE=3f658420974768e40810001a038c29d003728c5fe86da211cff5059e48cfdfde
+ARG TINI_SHA256_S390X=931b70a182af879ca249ae9de87ef68423121b38d235c78997fafc680ceab32d
+ARG TINI_DEST=/usr/bin/tini
+
+RUN set -ex; \
+    mkdir -p /opt/tini/bin/; \
+    if [[ "${TARGETOS}/${TARGETARCH}" = "linux/ppc64le" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-ppc64le -o ${TINI_DEST}; \
+        echo "${TINI_SHA256_PPC64LE} *${TINI_DEST}" | sha256sum -c; \
+    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/arm64" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-arm64 -o ${TINI_DEST}; \
+        echo "${TINI_SHA256_ARM64} *${TINI_DEST}" | sha256sum -c; \
+    elif [[ "${TARGETOS}/${TARGETARCH}" = "linux/s390x" ]]; then \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-s390x -o ${TINI_DEST}; \
+        echo "${TINI_SHA256_S390X} *${TINI_DEST}" | sha256sum -c; \
+    else \
+        curl -s -L https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini -o ${TINI_DEST}; \
+        echo "${TINI_SHA256_AMD64} *${TINI_DEST}" | sha256sum -c; \
+    fi; \
+    chmod +x ${TINI_DEST}
+
+RUN microdnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
+                java-${JAVA_VERSION}-openjdk-headless \
+                openssl \
+                shadow-utils \
+    && if [[ -n "${CONTAINER_USER}" && "${CONTAINER_USER}" != "root" ]] ; then groupadd -r -g "${CONTAINER_USER_UID}" "${CONTAINER_USER}" && useradd -m -r -u "${CONTAINER_USER_UID}" -g "${CONTAINER_USER}" "${CONTAINER_USER}"; fi \
+    && microdnf remove -y shadow-utils \
+    && microdnf clean all
+
+ENV JAVA_HOME=/usr/lib/jvm/jre-${JAVA_VERSION}
+
+COPY target/kroxylicious-kubernetes-web-hook-${KROXYLICIOUS_VERSION}-app/kroxylicious-kubernetes-web-hook-${KROXYLICIOUS_VERSION}/ .
+
+USER ${CONTAINER_USER_UID}
+
+ENTRYPOINT ["/usr/bin/tini", "--", "/opt/kroxylicious-webhook/bin/webhook-start.sh" ]
+
+LABEL url="https://kroxylicious.io/"
+LABEL vendor="The Kroxylicious Project"
+LABEL maintainer="Kroxylicious Maintainers"

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/InjectionDecision.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/InjectionDecision.java
@@ -64,11 +64,18 @@ final class InjectionDecision {
     }
 
     private static boolean isAlreadyInjected(@NonNull Pod pod) {
-        if (pod.getSpec() == null || pod.getSpec().getContainers() == null) {
+        if (pod.getSpec() == null) {
             return false;
         }
-        return pod.getSpec().getContainers().stream()
-                .anyMatch(c -> SIDECAR_CONTAINER_NAME.equals(c.getName()));
+        if (pod.getSpec().getContainers() != null
+                && pod.getSpec().getContainers().stream()
+                        .anyMatch(c -> SIDECAR_CONTAINER_NAME.equals(c.getName()))) {
+            return true;
+        }
+        // Also check initContainers for native sidecar mode (K8s 1.28+)
+        return pod.getSpec().getInitContainers() != null
+                && pod.getSpec().getInitContainers().stream()
+                        .anyMatch(c -> SIDECAR_CONTAINER_NAME.equals(c.getName()));
     }
 
     @NonNull

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
@@ -108,7 +108,7 @@ class PodMutator {
                                          String proxyConfig) {
 
         Map<String, String> existing = pod.getMetadata() != null ? pod.getMetadata().getAnnotations() : null;
-        if (existing == null) {
+        if (existing == null || existing.isEmpty()) {
             ObjectNode annotations = MAPPER.createObjectNode();
             annotations.put(Annotations.PROXY_CONFIG, proxyConfig);
             annotations.put(Annotations.SIDECAR_STATUS, "injected");

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractWebhookInstallKT.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractWebhookInstallKT.java
@@ -184,7 +184,7 @@ abstract class AbstractWebhookInstallKT {
         LOGGER.info("Waiting for webhook to observe sidecar config");
         try {
             // TODO replace this sleep with watching for a Ready condition in the
-            //  status of the KroxyliciousSidecarConfig
+            // status of the KroxyliciousSidecarConfig
             Thread.sleep(5000);
         }
         catch (InterruptedException e) {

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractWebhookInstallKT.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractWebhookInstallKT.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.kroxylicious.test.ShellUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+/**
+ * Tests that the webhook can be installed from YAML manifests and that sidecar
+ * injection works. Abstract because it does not define how a cluster is provided
+ * or how images are loaded — subclasses handle that.
+ */
+abstract class AbstractWebhookInstallKT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractWebhookInstallKT.class);
+    static final Predicate<Stream<String>> ALWAYS_VALID = lines -> true;
+
+    private static final String INSTALL_DIR = "target/packaged/install";
+    private static final String WEBHOOK_NS = "kroxylicious-webhook";
+    private static final String TEST_NS = "webhook-test";
+
+    static boolean testImageAvailable() {
+        String imageArchive = WebhookInfo.fromResource().imageArchive();
+        assumeThat(Path.of(imageArchive))
+                .describedAs("Container image archive %s must exist", imageArchive)
+                .withFailMessage("Container image archive %s did not exist", imageArchive)
+                .exists();
+        return true;
+    }
+
+    @Test
+    void shouldInstallAndInjectSidecar() {
+        try {
+            installWebhook();
+            waitForWebhookReady();
+            createTestNamespaceAndConfig();
+            verifyInjection();
+            verifyOptOut();
+        }
+        finally {
+            cleanup();
+        }
+    }
+
+    private void installWebhook() {
+        // Apply everything except the cert-manager Certificate (06.Certificate.*)
+        // Instead we generate a self-signed cert and create the Secret directly
+        LOGGER.info("Installing CRDs");
+        applyCrds();
+
+        // Apply namespace, service account, RBAC (00-02)
+        LOGGER.info("Applying namespace and RBAC manifests (00-02)");
+        for (int i = 0; i <= 2; i++) {
+            String prefix = String.format("%02d.", i);
+            applyManifestsWithPrefix(prefix);
+        }
+
+        // Create TLS secret before the Deployment tries to mount it
+        LOGGER.info("Creating self-signed TLS certificate for webhook");
+        createWebhookTlsSecret();
+
+        // Apply deployment, service, webhook config (03-05)
+        LOGGER.info("Applying deployment and webhook manifests (03-05)");
+        for (int i = 3; i <= 5; i++) {
+            String prefix = String.format("%02d.", i);
+            applyManifestsWithPrefix(prefix);
+        }
+
+        // Patch the MutatingWebhookConfiguration with the CA bundle
+        // (normally cert-manager does this via the inject-ca-from annotation)
+        LOGGER.info("Patching MutatingWebhookConfiguration with CA bundle");
+        patchWebhookCaBundle();
+    }
+
+    private void applyCrds() {
+        // The KroxyliciousSidecarConfig CRD is in kroxylicious-kubernetes-api
+        assertThat(ShellUtils.execValidate(ALWAYS_VALID, ALWAYS_VALID,
+                "kubectl", "apply", "-f",
+                "../kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kroxylicioussidecarconfigs.kroxylicious.io-v1.yml"))
+                .isTrue();
+    }
+
+    private void applyManifestsWithPrefix(String prefix) {
+        Path installDir = Path.of(INSTALL_DIR);
+        try (var files = java.nio.file.Files.list(installDir)) {
+            files.filter(p -> p.getFileName().toString().startsWith(prefix))
+                    .sorted()
+                    .forEach(p -> {
+                        LOGGER.info("Applying {}", p.getFileName());
+                        assertThat(ShellUtils.execValidate(ALWAYS_VALID, ALWAYS_VALID,
+                                "kubectl", "apply", "-f", p.toString()))
+                                .isTrue();
+                    });
+        }
+        catch (java.io.IOException e) {
+            throw new java.io.UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Generates a self-signed certificate and creates the TLS Secret that the
+     * webhook deployment expects.
+     */
+    private void createWebhookTlsSecret() {
+        // Generate self-signed cert with openssl
+        ShellUtils.exec(
+                "openssl", "req", "-x509", "-newkey", "rsa:2048",
+                "-keyout", "target/webhook-tls.key",
+                "-out", "target/webhook-tls.crt",
+                "-days", "1",
+                "-nodes",
+                "-subj", "/CN=kroxylicious-webhook.kroxylicious-webhook.svc",
+                "-addext", """
+                        subjectAltName=\
+                        DNS:kroxylicious-webhook,\
+                        DNS:kroxylicious-webhook.kroxylicious-webhook,\
+                        DNS:kroxylicious-webhook.kroxylicious-webhook.svc,\
+                        DNS:kroxylicious-webhook.kroxylicious-webhook.svc.cluster.local""");
+
+        // Create the Secret
+        ShellUtils.exec(
+                "kubectl", "create", "secret", "tls", "kroxylicious-webhook-cert",
+                "-n", WEBHOOK_NS,
+                "--cert=target/webhook-tls.crt",
+                "--key=target/webhook-tls.key");
+    }
+
+    /**
+     * Patches the MutatingWebhookConfiguration with the CA bundle so the API
+     * server trusts the webhook. Must be called after the webhook configuration
+     * manifest (05) has been applied.
+     */
+    private void patchWebhookCaBundle() {
+        ShellUtils.exec("bash", "-c", """
+                kubectl patch mutatingwebhookconfiguration kroxylicious-sidecar-injector \
+                --type=json -p='[{"op":"add","path":"/webhooks/0/clientConfig/caBundle",\
+                "value":"'$(base64 -w0 target/webhook-tls.crt)'"}]'""");
+    }
+
+    private void waitForWebhookReady() {
+        LOGGER.info("Waiting for webhook deployment to become ready");
+        assertThat(ShellUtils.execValidate(ALWAYS_VALID, ALWAYS_VALID,
+                "kubectl", "wait", "-n", WEBHOOK_NS,
+                "--for=jsonpath={.status.readyReplicas}=1",
+                "--timeout=300s",
+                "deployment", "kroxylicious-webhook"))
+                .isTrue();
+        LOGGER.info("Webhook deployment is ready");
+    }
+
+    private void createTestNamespaceAndConfig() {
+        LOGGER.info("Creating test namespace with injection label");
+        ShellUtils.exec("kubectl", "create", "namespace", TEST_NS);
+        ShellUtils.exec("kubectl", "label", "namespace", TEST_NS,
+                "kroxylicious.io/sidecar-injection=enabled");
+
+        LOGGER.info("Creating KroxyliciousSidecarConfig");
+        ShellUtils.exec("bash", "-c", """
+                cat <<'EOF' | kubectl apply -n %s -f -
+                apiVersion: kroxylicious.io/v1alpha1
+                kind: KroxyliciousSidecarConfig
+                metadata:
+                  name: test-config
+                spec:
+                  upstreamBootstrapServers: kafka-bootstrap.kafka.svc.cluster.local:9092
+                EOF""".formatted(TEST_NS));
+
+        // Wait for the webhook's informer to sync the config
+        LOGGER.info("Waiting for webhook to observe sidecar config");
+        try {
+            Thread.sleep(5000);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void verifyInjection() {
+        LOGGER.info("Creating test pod to verify sidecar injection");
+        ShellUtils.exec("bash", "-c", """
+                cat <<'EOF' | kubectl apply -n %s -f -
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: test-app
+                spec:
+                  terminationGracePeriodSeconds: 0
+                  containers:
+                    - name: app
+                      image: busybox:latest
+                      command: ["sleep", "3600"]
+                EOF""".formatted(TEST_NS));
+
+        // Verify sidecar container was injected
+        LOGGER.info("Verifying sidecar container was injected");
+        assertThat(ShellUtils.execValidate(
+                lines -> lines.anyMatch(line -> line.contains("kroxylicious-proxy")),
+                ALWAYS_VALID,
+                "kubectl", "get", "pod", "test-app", "-n", TEST_NS,
+                "-o", "jsonpath={.spec.containers[*].name}{.spec.initContainers[*].name}"))
+                .as("Pod should have kroxylicious-proxy sidecar container")
+                .isTrue();
+
+        // Verify the proxy config annotation was set
+        assertThat(ShellUtils.execValidate(
+                lines -> lines.anyMatch(line -> line.contains("injected")),
+                ALWAYS_VALID,
+                "kubectl", "get", "pod", "test-app", "-n", TEST_NS,
+                "-o", "jsonpath={.metadata.annotations.kroxylicious\\.io/sidecar-status}"))
+                .as("Pod should have sidecar-status annotation set to 'injected'")
+                .isTrue();
+
+        // Verify KAFKA_BOOTSTRAP_SERVERS env var was set on the app container
+        assertThat(ShellUtils.execValidate(
+                lines -> lines.anyMatch(line -> line.contains("localhost:")),
+                ALWAYS_VALID,
+                "kubectl", "get", "pod", "test-app", "-n", TEST_NS,
+                "-o", "jsonpath={.spec.containers[?(@.name=='app')].env[?(@.name=='KAFKA_BOOTSTRAP_SERVERS')].value}"))
+                .as("App container should have KAFKA_BOOTSTRAP_SERVERS pointing to localhost")
+                .isTrue();
+
+        LOGGER.info("Sidecar injection verified successfully");
+    }
+
+    private void verifyOptOut() {
+        LOGGER.info("Creating opted-out pod to verify opt-out works");
+        ShellUtils.exec("bash", "-c", """
+                cat <<'EOF' | kubectl apply -n %s -f -
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: test-app-no-sidecar
+                  labels:
+                    kroxylicious.io/inject-sidecar: "false"
+                spec:
+                  terminationGracePeriodSeconds: 0
+                  containers:
+                    - name: app
+                      image: busybox:latest
+                      command: ["sleep", "3600"]
+                EOF""".formatted(TEST_NS));
+
+        // Verify sidecar was NOT injected
+        assertThat(ShellUtils.execValidate(
+                lines -> lines.noneMatch(line -> line.contains("kroxylicious-proxy")),
+                ALWAYS_VALID,
+                "kubectl", "get", "pod", "test-app-no-sidecar", "-n", TEST_NS,
+                "-o", "jsonpath={.spec.containers[*].name}"))
+                .as("Opted-out pod should not have sidecar")
+                .isTrue();
+
+        LOGGER.info("Opt-out verified successfully");
+    }
+
+    private void cleanup() {
+        LOGGER.info("Cleaning up test resources");
+        ShellUtils.execValidate(ALWAYS_VALID, ALWAYS_VALID,
+                "kubectl", "delete", "namespace", TEST_NS, "--ignore-not-found");
+        // Delete install manifests (00-05)
+        for (int i = 5; i >= 0; i--) {
+            String prefix = String.format("%02d.", i);
+            deleteManifestsWithPrefix(prefix);
+        }
+        ShellUtils.execValidate(ALWAYS_VALID, ALWAYS_VALID,
+                "kubectl", "delete", "-f",
+                "../kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kroxylicioussidecarconfigs.kroxylicious.io-v1.yml",
+                "--ignore-not-found");
+    }
+
+    private void deleteManifestsWithPrefix(String prefix) {
+        Path installDir = Path.of(INSTALL_DIR);
+        try (var files = java.nio.file.Files.list(installDir)) {
+            files.filter(p -> p.getFileName().toString().startsWith(prefix))
+                    .sorted()
+                    .forEach(p -> ShellUtils.execValidate(ALWAYS_VALID, ALWAYS_VALID,
+                            "kubectl", "delete", "-f", p.toString(), "--ignore-not-found"));
+        }
+        catch (java.io.IOException e) {
+            throw new java.io.UncheckedIOException(e);
+        }
+    }
+
+    static boolean validateKubeContext(String expectedContext) {
+        return ShellUtils.execValidate(
+                lines -> lines.anyMatch(line -> line.contains(expectedContext)),
+                ALWAYS_VALID,
+                "kubectl", "config", "current-context");
+    }
+}

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractWebhookInstallKT.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractWebhookInstallKT.java
@@ -13,7 +13,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Base64;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -254,7 +253,6 @@ abstract class AbstractWebhookInstallKT {
                 .withNewMetadata()
                 .withName("test-app")
                 .withNamespace(TEST_NS)
-                .withAnnotations(Map.of("app.kubernetes.io/name", "test-app"))
                 .endMetadata()
                 .withNewSpec()
                 .withTerminationGracePeriodSeconds(0L)
@@ -305,7 +303,6 @@ abstract class AbstractWebhookInstallKT {
                 .withNewMetadata()
                 .withName("test-app-no-sidecar")
                 .withNamespace(TEST_NS)
-                .withAnnotations(Map.of("app.kubernetes.io/name", "test-app-no-sidecar"))
                 .addToLabels("kroxylicious.io/inject-sidecar", "false")
                 .endMetadata()
                 .withNewSpec()

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractWebhookInstallKT.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractWebhookInstallKT.java
@@ -180,8 +180,11 @@ abstract class AbstractWebhookInstallKT {
                 EOF""".formatted(TEST_NS));
 
         // Wait for the webhook's informer to sync the config
+
         LOGGER.info("Waiting for webhook to observe sidecar config");
         try {
+            // TODO replace this sleep with watching for a Ready condition in the
+            //  status of the KroxyliciousSidecarConfig
             Thread.sleep(5000);
         }
         catch (InterruptedException e) {

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractWebhookInstallKT.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractWebhookInstallKT.java
@@ -81,31 +81,15 @@ abstract class AbstractWebhookInstallKT {
     }
 
     private void installWebhook() {
-        // Apply everything except the cert-manager Certificate (06.Certificate.*)
-        // Instead we generate a self-signed cert and create the Secret directly
         LOGGER.info("Installing CRDs");
         applyCrds();
 
-        // Apply namespace, service account, RBAC (00-02)
-        LOGGER.info("Applying namespace and RBAC manifests (00-02)");
-        for (int i = 0; i <= 2; i++) {
-            String prefix = String.format("%02d.", i);
-            applyManifestsWithPrefix(prefix);
-        }
+        LOGGER.info("Applying install manifests");
+        applyAllManifests();
 
-        // Create TLS secret before the Deployment tries to mount it
         LOGGER.info("Creating self-signed TLS certificate for webhook");
         createWebhookTlsSecret();
 
-        // Apply deployment, service, webhook config (03-05)
-        LOGGER.info("Applying deployment and webhook manifests (03-05)");
-        for (int i = 3; i <= 5; i++) {
-            String prefix = String.format("%02d.", i);
-            applyManifestsWithPrefix(prefix);
-        }
-
-        // Patch the MutatingWebhookConfiguration with the CA bundle
-        // (normally cert-manager does this via the inject-ca-from annotation)
         LOGGER.info("Patching MutatingWebhookConfiguration with CA bundle");
         patchWebhookCaBundle();
     }
@@ -119,11 +103,10 @@ abstract class AbstractWebhookInstallKT {
         }
     }
 
-    private void applyManifestsWithPrefix(String prefix) {
+    private void applyAllManifests() {
         Path installDir = Path.of(INSTALL_DIR);
         try (var files = Files.list(installDir)) {
-            files.filter(p -> p.getFileName().toString().startsWith(prefix))
-                    .sorted()
+            files.sorted()
                     .forEach(p -> {
                         LOGGER.info("Applying {}", p.getFileName());
                         try (InputStream is = Files.newInputStream(p)) {
@@ -332,11 +315,7 @@ abstract class AbstractWebhookInstallKT {
         }
         ignoreCleanupErrors("test namespace",
                 () -> client.namespaces().withName(TEST_NS).delete());
-        // Delete install manifests (00-05)
-        for (int i = 5; i >= 0; i--) {
-            String prefix = String.format("%02d.", i);
-            deleteManifestsWithPrefix(prefix);
-        }
+        deleteAllManifests();
         ignoreCleanupErrors("CRD",
                 () -> {
                     try (InputStream is = Files.newInputStream(CRD_PATH)) {
@@ -346,11 +325,10 @@ abstract class AbstractWebhookInstallKT {
         ignoreCleanupErrors("Kubernetes client", client::close);
     }
 
-    private void deleteManifestsWithPrefix(String prefix) {
+    private void deleteAllManifests() {
         Path installDir = Path.of(INSTALL_DIR);
         try (var files = Files.list(installDir)) {
-            files.filter(p -> p.getFileName().toString().startsWith(prefix))
-                    .sorted()
+            files.sorted()
                     .forEach(p -> ignoreCleanupErrors(p.getFileName().toString(),
                             () -> {
                                 try (InputStream is = Files.newInputStream(p)) {

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractWebhookInstallKT.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractWebhookInstallKT.java
@@ -6,7 +6,15 @@
 
 package io.kroxylicious.kubernetes.webhook;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -14,6 +22,17 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+
+import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfigBuilder;
 import io.kroxylicious.test.ShellUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,6 +52,11 @@ abstract class AbstractWebhookInstallKT {
     private static final String WEBHOOK_NS = "kroxylicious-webhook";
     private static final String TEST_NS = "webhook-test";
 
+    private static final Path CRD_PATH = Path.of(
+            "../kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kroxylicioussidecarconfigs.kroxylicious.io-v1.yml");
+
+    private KubernetesClient client;
+
     static boolean testImageAvailable() {
         String imageArchive = WebhookInfo.fromResource().imageArchive();
         assumeThat(Path.of(imageArchive))
@@ -44,6 +68,7 @@ abstract class AbstractWebhookInstallKT {
 
     @Test
     void shouldInstallAndInjectSidecar() {
+        client = new KubernetesClientBuilder().build();
         try {
             installWebhook();
             waitForWebhookReady();
@@ -87,27 +112,31 @@ abstract class AbstractWebhookInstallKT {
     }
 
     private void applyCrds() {
-        // The KroxyliciousSidecarConfig CRD is in kroxylicious-kubernetes-api
-        assertThat(ShellUtils.execValidate(ALWAYS_VALID, ALWAYS_VALID,
-                "kubectl", "apply", "-f",
-                "../kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kroxylicioussidecarconfigs.kroxylicious.io-v1.yml"))
-                .isTrue();
+        try (InputStream is = Files.newInputStream(CRD_PATH)) {
+            client.load(is).createOrReplace();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     private void applyManifestsWithPrefix(String prefix) {
         Path installDir = Path.of(INSTALL_DIR);
-        try (var files = java.nio.file.Files.list(installDir)) {
+        try (var files = Files.list(installDir)) {
             files.filter(p -> p.getFileName().toString().startsWith(prefix))
                     .sorted()
                     .forEach(p -> {
                         LOGGER.info("Applying {}", p.getFileName());
-                        assertThat(ShellUtils.execValidate(ALWAYS_VALID, ALWAYS_VALID,
-                                "kubectl", "apply", "-f", p.toString()))
-                                .isTrue();
+                        try (InputStream is = Files.newInputStream(p)) {
+                            client.load(is).createOrReplace();
+                        }
+                        catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
                     });
         }
-        catch (java.io.IOException e) {
-            throw new java.io.UncheckedIOException(e);
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 
@@ -131,12 +160,21 @@ abstract class AbstractWebhookInstallKT {
                         DNS:kroxylicious-webhook.kroxylicious-webhook.svc,\
                         DNS:kroxylicious-webhook.kroxylicious-webhook.svc.cluster.local""");
 
-        // Create the Secret
-        ShellUtils.exec(
-                "kubectl", "create", "secret", "tls", "kroxylicious-webhook-cert",
-                "-n", WEBHOOK_NS,
-                "--cert=target/webhook-tls.crt",
-                "--key=target/webhook-tls.key");
+        try {
+            var secret = new SecretBuilder()
+                    .withNewMetadata()
+                    .withName("kroxylicious-webhook-cert")
+                    .withNamespace(WEBHOOK_NS)
+                    .endMetadata()
+                    .withType("kubernetes.io/tls")
+                    .addToStringData("tls.crt", Files.readString(Path.of("target/webhook-tls.crt")))
+                    .addToStringData("tls.key", Files.readString(Path.of("target/webhook-tls.key")))
+                    .build();
+            client.resource(secret).create();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     /**
@@ -145,39 +183,57 @@ abstract class AbstractWebhookInstallKT {
      * manifest (05) has been applied.
      */
     private void patchWebhookCaBundle() {
-        ShellUtils.exec("bash", "-c", """
-                kubectl patch mutatingwebhookconfiguration kroxylicious-sidecar-injector \
-                --type=json -p='[{"op":"add","path":"/webhooks/0/clientConfig/caBundle",\
-                "value":"'$(base64 -w0 target/webhook-tls.crt)'"}]'""");
+        try {
+            byte[] certBytes = Files.readAllBytes(Path.of("target/webhook-tls.crt"));
+            String caBundle = Base64.getEncoder().encodeToString(certBytes);
+            client.admissionRegistration().v1()
+                    .mutatingWebhookConfigurations()
+                    .withName("kroxylicious-sidecar-injector")
+                    .edit(mwc -> {
+                        mwc.getWebhooks().get(0).getClientConfig().setCaBundle(caBundle);
+                        return mwc;
+                    });
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     private void waitForWebhookReady() {
         LOGGER.info("Waiting for webhook deployment to become ready");
-        assertThat(ShellUtils.execValidate(ALWAYS_VALID, ALWAYS_VALID,
-                "kubectl", "wait", "-n", WEBHOOK_NS,
-                "--for=jsonpath={.status.readyReplicas}=1",
-                "--timeout=300s",
-                "deployment", "kroxylicious-webhook"))
-                .isTrue();
+        client.apps().deployments()
+                .inNamespace(WEBHOOK_NS)
+                .withName("kroxylicious-webhook")
+                .waitUntilCondition(
+                        d -> d != null
+                                && d.getStatus() != null
+                                && d.getStatus().getReadyReplicas() != null
+                                && d.getStatus().getReadyReplicas() >= 1,
+                        300, TimeUnit.SECONDS);
         LOGGER.info("Webhook deployment is ready");
     }
 
     private void createTestNamespaceAndConfig() {
         LOGGER.info("Creating test namespace with injection label");
-        ShellUtils.exec("kubectl", "create", "namespace", TEST_NS);
-        ShellUtils.exec("kubectl", "label", "namespace", TEST_NS,
-                "kroxylicious.io/sidecar-injection=enabled");
+        var ns = new NamespaceBuilder()
+                .withNewMetadata()
+                .withName(TEST_NS)
+                .addToLabels("kroxylicious.io/sidecar-injection", "enabled")
+                .endMetadata()
+                .build();
+        client.namespaces().resource(ns).create();
 
         LOGGER.info("Creating KroxyliciousSidecarConfig");
-        ShellUtils.exec("bash", "-c", """
-                cat <<'EOF' | kubectl apply -n %s -f -
-                apiVersion: kroxylicious.io/v1alpha1
-                kind: KroxyliciousSidecarConfig
-                metadata:
-                  name: test-config
-                spec:
-                  upstreamBootstrapServers: kafka-bootstrap.kafka.svc.cluster.local:9092
-                EOF""".formatted(TEST_NS));
+        var sidecarConfig = new KroxyliciousSidecarConfigBuilder()
+                .withNewMetadata()
+                .withName("test-config")
+                .withNamespace(TEST_NS)
+                .endMetadata()
+                .withNewSpec()
+                .withUpstreamBootstrapServers("kafka-bootstrap.kafka.svc.cluster.local:9092")
+                .endSpec()
+                .build();
+        client.resource(sidecarConfig).create();
 
         // Wait for the webhook's informer to sync the config
 
@@ -194,113 +250,147 @@ abstract class AbstractWebhookInstallKT {
 
     private void verifyInjection() {
         LOGGER.info("Creating test pod to verify sidecar injection");
-        ShellUtils.exec("bash", "-c", """
-                cat <<'EOF' | kubectl apply -n %s -f -
-                apiVersion: v1
-                kind: Pod
-                metadata:
-                  name: test-app
-                spec:
-                  terminationGracePeriodSeconds: 0
-                  containers:
-                    - name: app
-                      image: busybox:latest
-                      command: ["sleep", "3600"]
-                EOF""".formatted(TEST_NS));
+        var testPod = new PodBuilder()
+                .withNewMetadata()
+                .withName("test-app")
+                .withNamespace(TEST_NS)
+                .withAnnotations(Map.of("app.kubernetes.io/name", "test-app"))
+                .endMetadata()
+                .withNewSpec()
+                .withTerminationGracePeriodSeconds(0L)
+                .addNewContainer()
+                .withName("app")
+                .withImage("busybox:latest")
+                .withCommand("sleep", "3600")
+                .endContainer()
+                .endSpec()
+                .build();
+        Pod created = client.resource(testPod).create();
 
         // Verify sidecar container was injected
         LOGGER.info("Verifying sidecar container was injected");
-        assertThat(ShellUtils.execValidate(
-                lines -> lines.anyMatch(line -> line.contains("kroxylicious-proxy")),
-                ALWAYS_VALID,
-                "kubectl", "get", "pod", "test-app", "-n", TEST_NS,
-                "-o", "jsonpath={.spec.containers[*].name}{.spec.initContainers[*].name}"))
+        var allContainerNames = new ArrayList<String>();
+        created.getSpec().getContainers().forEach(c -> allContainerNames.add(c.getName()));
+        if (created.getSpec().getInitContainers() != null) {
+            created.getSpec().getInitContainers().forEach(c -> allContainerNames.add(c.getName()));
+        }
+        assertThat(allContainerNames)
                 .as("Pod should have kroxylicious-proxy sidecar container")
-                .isTrue();
+                .contains("kroxylicious-proxy");
 
         // Verify the proxy config annotation was set
-        assertThat(ShellUtils.execValidate(
-                lines -> lines.anyMatch(line -> line.contains("injected")),
-                ALWAYS_VALID,
-                "kubectl", "get", "pod", "test-app", "-n", TEST_NS,
-                "-o", "jsonpath={.metadata.annotations.kroxylicious\\.io/sidecar-status}"))
+        assertThat(created.getMetadata().getAnnotations())
                 .as("Pod should have sidecar-status annotation set to 'injected'")
-                .isTrue();
+                .containsEntry("kroxylicious.io/sidecar-status", "injected");
 
         // Verify KAFKA_BOOTSTRAP_SERVERS env var was set on the app container
-        assertThat(ShellUtils.execValidate(
-                lines -> lines.anyMatch(line -> line.contains("localhost:")),
-                ALWAYS_VALID,
-                "kubectl", "get", "pod", "test-app", "-n", TEST_NS,
-                "-o", "jsonpath={.spec.containers[?(@.name=='app')].env[?(@.name=='KAFKA_BOOTSTRAP_SERVERS')].value}"))
+        Container appContainer = created.getSpec().getContainers().stream()
+                .filter(c -> "app".equals(c.getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("app container not found in pod"));
+        assertThat(appContainer.getEnv())
                 .as("App container should have KAFKA_BOOTSTRAP_SERVERS pointing to localhost")
-                .isTrue();
+                .filteredOn(env -> "KAFKA_BOOTSTRAP_SERVERS".equals(env.getName()))
+                .singleElement()
+                .extracting(EnvVar::getValue)
+                .asString()
+                .contains("localhost:");
 
         LOGGER.info("Sidecar injection verified successfully");
     }
 
     private void verifyOptOut() {
         LOGGER.info("Creating opted-out pod to verify opt-out works");
-        ShellUtils.exec("bash", "-c", """
-                cat <<'EOF' | kubectl apply -n %s -f -
-                apiVersion: v1
-                kind: Pod
-                metadata:
-                  name: test-app-no-sidecar
-                  labels:
-                    kroxylicious.io/inject-sidecar: "false"
-                spec:
-                  terminationGracePeriodSeconds: 0
-                  containers:
-                    - name: app
-                      image: busybox:latest
-                      command: ["sleep", "3600"]
-                EOF""".formatted(TEST_NS));
+        var optedOutPod = new PodBuilder()
+                .withNewMetadata()
+                .withName("test-app-no-sidecar")
+                .withNamespace(TEST_NS)
+                .withAnnotations(Map.of("app.kubernetes.io/name", "test-app-no-sidecar"))
+                .addToLabels("kroxylicious.io/inject-sidecar", "false")
+                .endMetadata()
+                .withNewSpec()
+                .withTerminationGracePeriodSeconds(0L)
+                .addNewContainer()
+                .withName("app")
+                .withImage("busybox:latest")
+                .withCommand("sleep", "3600")
+                .endContainer()
+                .endSpec()
+                .build();
+        Pod created = client.resource(optedOutPod).create();
 
         // Verify sidecar was NOT injected
-        assertThat(ShellUtils.execValidate(
-                lines -> lines.noneMatch(line -> line.contains("kroxylicious-proxy")),
-                ALWAYS_VALID,
-                "kubectl", "get", "pod", "test-app-no-sidecar", "-n", TEST_NS,
-                "-o", "jsonpath={.spec.containers[*].name}"))
+        assertThat(created.getSpec().getContainers())
                 .as("Opted-out pod should not have sidecar")
-                .isTrue();
+                .extracting(Container::getName)
+                .doesNotContain("kroxylicious-proxy");
 
         LOGGER.info("Opt-out verified successfully");
     }
 
     private void cleanup() {
         LOGGER.info("Cleaning up test resources");
-        ShellUtils.execValidate(ALWAYS_VALID, ALWAYS_VALID,
-                "kubectl", "delete", "namespace", TEST_NS, "--ignore-not-found");
+        if (client == null) {
+            return;
+        }
+        ignoreCleanupErrors("test namespace",
+                () -> client.namespaces().withName(TEST_NS).delete());
         // Delete install manifests (00-05)
         for (int i = 5; i >= 0; i--) {
             String prefix = String.format("%02d.", i);
             deleteManifestsWithPrefix(prefix);
         }
-        ShellUtils.execValidate(ALWAYS_VALID, ALWAYS_VALID,
-                "kubectl", "delete", "-f",
-                "../kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kroxylicioussidecarconfigs.kroxylicious.io-v1.yml",
-                "--ignore-not-found");
+        ignoreCleanupErrors("CRD",
+                () -> {
+                    try (InputStream is = Files.newInputStream(CRD_PATH)) {
+                        client.load(is).delete();
+                    }
+                });
+        ignoreCleanupErrors("Kubernetes client", client::close);
     }
 
     private void deleteManifestsWithPrefix(String prefix) {
         Path installDir = Path.of(INSTALL_DIR);
-        try (var files = java.nio.file.Files.list(installDir)) {
+        try (var files = Files.list(installDir)) {
             files.filter(p -> p.getFileName().toString().startsWith(prefix))
                     .sorted()
-                    .forEach(p -> ShellUtils.execValidate(ALWAYS_VALID, ALWAYS_VALID,
-                            "kubectl", "delete", "-f", p.toString(), "--ignore-not-found"));
+                    .forEach(p -> ignoreCleanupErrors(p.getFileName().toString(),
+                            () -> {
+                                try (InputStream is = Files.newInputStream(p)) {
+                                    client.load(is).delete();
+                                }
+                            }));
         }
-        catch (java.io.IOException e) {
-            throw new java.io.UncheckedIOException(e);
+        catch (IOException e) {
+            LOGGER.atWarn().setCause(e).log("failed to list install directory during cleanup");
         }
     }
 
+    private static void ignoreCleanupErrors(String description, CleanupAction action) {
+        try {
+            action.run();
+        }
+        catch (Exception e) {
+            LOGGER.atWarn()
+                    .addKeyValue("resource", description)
+                    .setCause(e)
+                    .log("cleanup failed");
+        }
+    }
+
+    @FunctionalInterface
+    interface CleanupAction {
+        void run() throws Exception;
+    }
+
     static boolean validateKubeContext(String expectedContext) {
-        return ShellUtils.execValidate(
-                lines -> lines.anyMatch(line -> line.contains(expectedContext)),
-                ALWAYS_VALID,
-                "kubectl", "config", "current-context");
+        try {
+            Config config = Config.autoConfigure(null);
+            var context = config.getCurrentContext();
+            return context != null && expectedContext.equals(context.getName());
+        }
+        catch (Exception e) {
+            return false;
+        }
     }
 }

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractWebhookInstallKT.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractWebhookInstallKT.java
@@ -96,7 +96,7 @@ abstract class AbstractWebhookInstallKT {
 
     private void applyCrds() {
         try (InputStream is = Files.newInputStream(CRD_PATH)) {
-            client.load(is).createOrReplace();
+            client.load(is).serverSideApply();
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -110,7 +110,7 @@ abstract class AbstractWebhookInstallKT {
                     .forEach(p -> {
                         LOGGER.info("Applying {}", p.getFileName());
                         try (InputStream is = Files.newInputStream(p)) {
-                            client.load(is).createOrReplace();
+                            client.load(is).serverSideApply();
                         }
                         catch (IOException e) {
                             throw new UncheckedIOException(e);
@@ -301,8 +301,10 @@ abstract class AbstractWebhookInstallKT {
 
         // Verify sidecar was NOT injected
         assertThat(created.getSpec().getContainers())
-                .as("Opted-out pod should not have sidecar")
+                .as("Pod's containers should not be empty")
+                .isNotEmpty()
                 .extracting(Container::getName)
+                .as("Opted-out pod should not have sidecar")
                 .doesNotContain("kroxylicious-proxy");
 
         LOGGER.info("Opt-out verified successfully");

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/InjectionDecisionTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/InjectionDecisionTest.java
@@ -82,6 +82,16 @@ class InjectionDecisionTest {
     }
 
     @Test
+    void shouldSkipWhenAlreadyInjectedAsInitContainer() {
+        Pod pod = podWithAnnotations(Map.of());
+        Container sidecar = new Container();
+        sidecar.setName(InjectionDecision.SIDECAR_CONTAINER_NAME);
+        pod.getSpec().setInitContainers(new java.util.ArrayList<>(java.util.List.of(sidecar)));
+
+        assertThat(InjectionDecision.evaluate(pod, true)).isEqualTo(InjectionDecision.Decision.SKIP_ALREADY_INJECTED);
+    }
+
+    @Test
     void shouldHandleNullSpec() {
         Pod pod = new Pod();
         pod.setMetadata(new ObjectMeta());

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/KindWebhookInstallKT.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/KindWebhookInstallKT.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.kroxylicious.test.ShellUtils;
+
+/**
+ * Webhook installation and sidecar injection test on a Kind cluster.
+ * Requires a running Kind cluster and the webhook container image archive
+ * (built by the {@code dist} Maven profile).
+ */
+@EnabledIf("io.kroxylicious.kubernetes.webhook.KindWebhookInstallKT#isEnvironmentValid")
+class KindWebhookInstallKT extends AbstractWebhookInstallKT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KindWebhookInstallKT.class);
+
+    private static final String IMAGE_NAME = WebhookInfo.fromResource().imageName();
+    private static final String IMAGE_ARCHIVE = WebhookInfo.fromResource().imageArchive();
+
+    @BeforeAll
+    static void beforeAll() {
+        LOGGER.info("Importing {} into kind", IMAGE_NAME);
+        ShellUtils.execValidate(ALWAYS_VALID, ALWAYS_VALID,
+                "kind", "load", "image-archive", IMAGE_ARCHIVE);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        // Kind does not provide a clean way to remove images
+    }
+
+    public static boolean isEnvironmentValid() {
+        return ShellUtils.validateToolsOnPath("kind", "openssl")
+                && validateKubeContext("kind-kind")
+                && testImageAvailable();
+    }
+}

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/MinikubeWebhookInstallKT.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/MinikubeWebhookInstallKT.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.kroxylicious.test.ShellUtils;
+
+/**
+ * Webhook installation and sidecar injection test on a Minikube cluster.
+ * Requires a running Minikube cluster and the webhook container image archive
+ * (built by the {@code dist} Maven profile).
+ */
+@EnabledIf("io.kroxylicious.kubernetes.webhook.MinikubeWebhookInstallKT#isEnvironmentValid")
+class MinikubeWebhookInstallKT extends AbstractWebhookInstallKT {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MinikubeWebhookInstallKT.class);
+
+    private static final String IMAGE_NAME = WebhookInfo.fromResource().imageName();
+    private static final String IMAGE_ARCHIVE = WebhookInfo.fromResource().imageArchive();
+
+    private static boolean loaded = false;
+
+    @BeforeAll
+    static void beforeAll() {
+        LOGGER.info("Loading {} into minikube registry", IMAGE_ARCHIVE);
+        ShellUtils.execValidate(ALWAYS_VALID, ALWAYS_VALID,
+                "minikube", "image", "load", IMAGE_ARCHIVE);
+        loaded = true;
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (loaded) {
+            LOGGER.info("Removing {} from minikube registry", IMAGE_NAME);
+            ShellUtils.execValidate(ALWAYS_VALID, ALWAYS_VALID,
+                    "minikube", "image", "rm", IMAGE_NAME);
+        }
+    }
+
+    public static boolean isEnvironmentValid() {
+        return ShellUtils.validateToolsOnPath("minikube", "openssl")
+                && validateKubeContext("minikube")
+                && testImageAvailable();
+    }
+}

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/PodMutatorTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/PodMutatorTest.java
@@ -51,6 +51,16 @@ class PodMutatorTest {
     }
 
     @Test
+    void patchSetsAnnotationsAsObjectWhenAnnotationsEmpty() throws Exception {
+        Pod pod = podWithAppContainer(Map.of());
+        JsonNode patch = createPatchJson(pod);
+
+        assertThat(patchOps(patch, "add", "/metadata/annotations"))
+                .as("patch should add the whole annotations object when annotations map is empty")
+                .isNotEmpty();
+    }
+
+    @Test
     void patchAddsSidecarStatusAnnotation() throws Exception {
         Pod pod = podWithAppContainer(Map.of("existing", "value"));
         JsonNode patch = createPatchJson(pod);

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/WebhookInfo.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/WebhookInfo.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Properties;
+
+/**
+ * Provides webhook image metadata, read from a filtered properties file.
+ */
+record WebhookInfo(String imageName,
+                   String imageArchive) {
+
+    static WebhookInfo fromResource() {
+        try (var is = WebhookInfo.class.getResourceAsStream("/webhook-info.properties")) {
+            var properties = new Properties();
+            properties.load(is);
+            String imageName = properties.getProperty("webhook.image.name");
+            String imageArchive = properties.getProperty("webhook.image.archive");
+            return new WebhookInfo(imageName, imageArchive);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/resources-filtered/webhook-info.properties
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/resources-filtered/webhook-info.properties
@@ -1,0 +1,8 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+webhook.image.name: ${io.kroxylicious.webhook.image.name}
+webhook.image.archive: ${io.kroxylicious.webhook.image.archive}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

- Assembly descriptor, start script, Dockerfile for webhook container image
- Maven dist profile: image build, manifest interpolation, failsafe KT tests
- KindWebhookInstallKT: installs webhook on Kind, verifies sidecar injection and opt-out, using self-signed TLS (no cert-manager dependency)
- Add MinikubeWebhookInstallKT for running the webhook integration test on Minikube clusters too.
- Fix InjectionDecision to check initContainers for native sidecar idempotency
- Add README.md and CLAUDE.md for the webhook module

Contributes towards #3890
Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>