### PR TITLE
(fix) Call LogManager.shutdown() in kroxylicious-app

### DIFF
--- a/kroxylicious-app/pom.xml
+++ b/kroxylicious-app/pom.xml
@@ -73,7 +73,6 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/kroxylicious-app/src/main/java/io/kroxylicious/app/Kroxylicious.java
+++ b/kroxylicious-app/src/main/java/io/kroxylicious/app/Kroxylicious.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 
+import org.apache.logging.log4j.LogManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,6 +83,13 @@ public class Kroxylicious implements Callable<Integer> {
                     }
                     catch (Exception e) {
                         LOGGER.atWarn().setCause(e).log("Error during shutdown hook");
+                    }
+                    finally {
+                        // Log4j2's own shutdown hook is disabled in log4j2.yaml so it doesn't
+                        // race with the proxy's drain logging. However for AsyncAppender, RollingFileAppender
+                        // the logs might still be buffered, we call the shutdown() method explicitly to flush
+                        // the remaining logs
+                        LogManager.shutdown();
                     }
                 }, "proxy-shutdown-hook"));
                 kafkaProxy.block();


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

I had disabled the auto-shutdown hook for log4j2 in this [PR](https://github.com/kroxylicious/kroxylicious/pull/3738), for the draining logs to be visible.
However this created a new problem that incase of certain appenders, the logs are usually buffered in-memory to improve performance. 
So if the JVM kills before this logs have a chance to flush, we might lose logs which are appearing last.
This PR fixes this issue by explicitly calling the `shutdown()` method to trigger the flush before killing the JVM. 

### Additional Context

https://github.com/kroxylicious/kroxylicious/pull/3738#discussion_r3164773250

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
