### PR TITLE
fix(operator-tests): handle 409 Conflict in deploymentChecksumUpdatesWhenOpenshiftRouteHostAssigned test (yes again)

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/KafkaProxyReconcilerIT.java
@@ -986,11 +986,23 @@ public class KafkaProxyReconcilerIT {
         // controller will have updated the resource or not yet. We make an update to
         // the Route that we are certain will be different to that made by the controller
         // in order to be certain an update is made.
-        testActor.resources(Route.class).resource(bootstrapRoute).editStatus(r -> new RouteBuilder(r)
-                .editOrNewStatus()
-                .addNewIngress().withHost("different.invalid").endIngress()
-                .endStatus()
-                .build());
+        //
+        // editStatus() is a non-locking operation that does not retry on 409 Conflict.
+        // See fabric8 kubernetes-client CHANGELOG v5.4.0:
+        // "Added editStatus... to support non-locking status updates"
+        // https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md
+        // We must retry manually when concurrent modifications are expected.
+        AWAIT.alias("update route status")
+                .ignoreExceptionsMatching(e -> e instanceof io.fabric8.kubernetes.client.KubernetesClientException kce && kce.getCode() == 409)
+                .until(() -> {
+                    Route currentRoute = testActor.get(Route.class, bootstrapRouteName);
+                    testActor.resources(Route.class).resource(currentRoute).editStatus(r -> new RouteBuilder(r)
+                            .editOrNewStatus()
+                            .addNewIngress().withHost("different.invalid").endIngress()
+                            .endStatus()
+                            .build());
+                    return true;
+                });
 
         // Then - deployment pod template checksum should change so the proxy is restarted
         AWAIT.alias("deployment checksum updated after route host assignment")


### PR DESCRIPTION
## Previous Fix Attempts

⚠️ **Previous attempts to fix this issue were flawed**

1. **PR #3801** - Switched from `patchStatus()` to `editStatus()`, incorrectly claiming that `editStatus()` "automatically handles resource version conflicts through retries"
2. **PR #3817** - Fixed lambda parameter usage, still incorrectly claiming there was a "built-in retry mechanism"

**Both PRs were based on the incorrect assumption that `editStatus()` automatically retries 409 Conflict errors.** This assumption was wrong. The fabric8 kubernetes-client does **not** retry 409 errors - only HTTP 429 and 5xx errors are retried.

This PR provides the complete fix by adding the explicit retry logic that was missing from both previous attempts.

---

## Problem

The `deploymentChecksumUpdatesWhenOpenshiftRouteHostAssigned` integration test was failing intermittently with HTTP 409 Conflict errors:

**Test failure:** https://github.com/kroxylicious/kroxylicious/actions/runs/25166752253/job/73774889983

```
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: PATCH at: 
https://api.crc.testing:6443/apis/route.openshift.io/v1/namespaces/.../routes/bar-bootstrap/status. 
Message: Operation cannot be fulfilled on routes.route.openshift.io "bar-bootstrap": 
the object has been modified; please apply your changes to the latest version and try again.
Received status: Status(apiVersion=v1, code=409, ...)
```

## Root Cause

The test was racing with the OpenShift ingress controller. Both the test and the controller attempt to update the Route's status, leading to optimistic locking conflicts:

1. Test calls `editStatus()` which reads the Route
2. Ingress controller modifies the Route (changing its `resourceVersion`)
3. Test attempts PATCH with stale `resourceVersion`
4. Kubernetes API returns 409 Conflict

**The fabric8 kubernetes-client's `editStatus()` method does not automatically retry on 409 Conflict errors.** This is documented behavior - `editStatus()` is a "non-locking operation" (kubernetes-client CHANGELOG v5.4.0).

### How the Retry Mechanism Works (and Why 409 Isn't Retried)

The client **does** have retry logic in `StandardHttpClient.retryWithExponentialBackoff()`, but it explicitly excludes 409 errors.

**Stack trace from the failure:**
```
io.fabric8.kubernetes.client.KubernetesClientException: ...code=409...
	at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.requestFailure(OperationSupport.java:642)
	at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.requestFailure(OperationSupport.java:622)
	at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.assertResponseCode(OperationSupport.java:582)  ← Throws on non-2xx
	at io.fabric8.kubernetes.client.dsl.internal.OperationSupport.lambda$handleResponse$0(OperationSupport.java:549)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:646)
	...
	at io.fabric8.kubernetes.client.http.StandardHttpClient.lambda$completeOrCancel$10(StandardHttpClient.java:141)  ← HTTP client layer
	...
	at io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperation.editStatus(HasMetadataOperation.java:76)
	at io.kroxylicious.kubernetes.operator.reconciler.kafkaproxy.KafkaProxyReconcilerIT.deploymentChecksumUpdatesWhenOpenshiftRouteHostAssigned(KafkaProxyReconcilerIT.java:989)  ← Our test
```

**Call flow:**
1. `editStatus()` → sends PATCH request via HTTP client
2. HTTP client receives 409 response
3. **`StandardHttpClient.shouldRetry()`** examines the response code ([source](https://github.com/fabric8io/kubernetes-client/blob/v7.6.1/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpClient.java#L169-L193)):
   ```java
   if (code == 429 || code >= 500) {  // Line 175
       return retryInterval;  // Retry
   }
   return -1;  // Don't retry - 409 falls through here
   ```
4. 409 doesn't match the retry criteria → returns -1 (don't retry)
5. `OperationSupport.assertResponseCode()` throws `KubernetesClientException`
6. Exception propagates to test → test fails

**The retry logic IS invoked, but it explicitly decides NOT to retry 409 Conflict errors.** They're treated as non-retryable client errors (4xx), not server errors.

## Solution

Wrap the `editStatus()` call in an `AWAIT` retry loop that specifically handles 409 Conflict errors:

```java
AWAIT.alias("update route status")
    .ignoreExceptionsMatching(e -> e instanceof KubernetesClientException kce && kce.getCode() == 409)
    .until(() -> {
        Route currentRoute = testActor.get(Route.class, bootstrapRouteName);
        testActor.resources(Route.class).resource(currentRoute).editStatus(...);
        return true;
    });
```

This approach:
- ✅ Re-fetches the latest Route on each retry attempt
- ✅ Only retries on 409 Conflict (other errors fail the test immediately)
- ✅ Handles the expected race condition with the ingress controller

## References

- [fabric8 kubernetes-client CHANGELOG v5.4.0](https://github.com/fabric8io/kubernetes-client/blob/main/CHANGELOG.md): "Added editStatus... to support non-locking status updates"
- [fabric8 kubernetes-client FAQ - Optimistic Locking Behavior](https://github.com/fabric8io/kubernetes-client/blob/main/doc/FAQ.md): "When the resourceVersion is null for a patch the server will always attempt to perform the patch - but of course there may be conflicts to deal with if there has been an intervening modification."
- [Issue #3066](https://github.com/fabric8io/kubernetes-client/issues/3066): Original request for non-locking status update methods
- [PR #3070](https://github.com/fabric8io/kubernetes-client/pull/3070): Implementation that explicitly removed retry logic from patch operations
- [`StandardHttpClient.shouldRetry()`](https://github.com/fabric8io/kubernetes-client/blob/v7.6.1/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/http/StandardHttpClient.java#L169-L193): Retry logic implementation showing only 429 and 5xx are retried

## Testing

This fix allows the test to complete successfully even when the ingress controller races to update the Route status.