### PR TITLE
Webhook Phase 4: 3rd party plugin support via OCI image volumes; init…

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kroxylicioussidecarconfigs.kroxylicious.io-v1.yml
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kroxylicioussidecarconfigs.kroxylicious.io-v1.yml
@@ -158,6 +158,54 @@ spec:
                         key:
                           description: The key within the Secret data identifying the CA certificate bundle.
                           type: string
+                plugins:
+                  description: |
+                    Third-party plugin images to mount in the sidecar container. Each plugin's
+                    JARs are mounted at /opt/kroxylicious/classpath-plugins/[name]/ and added to the
+                    proxy classpath automatically.
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - name
+                      - image
+                    properties:
+                      name:
+                        description: |
+                          A unique name for this plugin, used as the mount subdirectory under
+                          /opt/kroxylicious/plugins/. Must be a valid DNS label.
+                        type: string
+                        pattern: "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$"
+                        maxLength: 63
+                      image:
+                        description: |
+                          The OCI image containing the plugin JARs. The image should be built
+                          FROM scratch with JARs at the image root.
+                        type: object
+                        required:
+                          - reference
+                        properties:
+                          reference:
+                            description: |
+                              OCI image reference. For delegated plugin images, this must include
+                              a @sha256: digest.
+                            type: string
+                          pullPolicy:
+                            description: Image pull policy for the plugin image.
+                            type: string
+                            enum:
+                              - Always
+                              - IfNotPresent
+                              - Never
+                            default: IfNotPresent
+                allowedPluginRegistries:
+                  description: |
+                    Registry prefixes allowed for delegated plugin images. When plugin image
+                    selection is delegated to app owners, only images matching one of these
+                    prefixes are accepted.
+                  type: array
+                  items:
+                    type: string
                 delegatedAnnotations:
                   description: |
                     Annotations that the application pod owner is permitted to set to override

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
@@ -333,8 +333,8 @@ class AdmissionHandler implements HttpHandler {
             com.fasterxml.jackson.databind.JsonNode array = MAPPER.readTree(pluginsJson);
             if (!array.isArray()) {
                 LOGGER.atWarn()
-                        .addKeyValue("pod", podName)
-                        .addKeyValue("namespace", namespace)
+                        .addKeyValue(WebhookLoggingKeys.POD, podName)
+                        .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
                         .log("Delegated plugin images annotation is not a JSON array, ignoring");
                 return result;
             }
@@ -344,8 +344,8 @@ class AdmissionHandler implements HttpHandler {
                 String reference = entry.path("reference").asText(null);
                 if (name == null || reference == null) {
                     LOGGER.atWarn()
-                            .addKeyValue("pod", podName)
-                            .addKeyValue("namespace", namespace)
+                            .addKeyValue(WebhookLoggingKeys.POD, podName)
+                            .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
                             .log("Delegated plugin entry missing name or reference, skipping");
                     continue;
                 }
@@ -353,9 +353,9 @@ class AdmissionHandler implements HttpHandler {
                 // Require @sha256: digest
                 if (!reference.contains("@sha256:")) {
                     LOGGER.atWarn()
-                            .addKeyValue("pod", podName)
-                            .addKeyValue("namespace", namespace)
-                            .addKeyValue("reference", reference)
+                            .addKeyValue(WebhookLoggingKeys.POD, podName)
+                            .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
+                            .addKeyValue(WebhookLoggingKeys.IMG_REF, reference)
                             .log("Delegated plugin image rejected: must include @sha256: digest");
                     continue;
                 }
@@ -364,18 +364,18 @@ class AdmissionHandler implements HttpHandler {
                 if (!allowedSet.isEmpty()
                         && allowedSet.stream().noneMatch(reference::startsWith)) {
                     LOGGER.atWarn()
-                            .addKeyValue("pod", podName)
-                            .addKeyValue("namespace", namespace)
-                            .addKeyValue("reference", reference)
+                            .addKeyValue(WebhookLoggingKeys.POD, podName)
+                            .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
+                            .addKeyValue(WebhookLoggingKeys.IMG_REF, reference)
                             .log("Delegated plugin image rejected: registry not in allowedPluginRegistries");
                     continue;
                 }
 
                 LOGGER.atInfo()
-                        .addKeyValue("pod", podName)
-                        .addKeyValue("namespace", namespace)
+                        .addKeyValue(WebhookLoggingKeys.POD, podName)
+                        .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
                         .addKeyValue("plugin", name)
-                        .addKeyValue("reference", reference)
+                        .addKeyValue(WebhookLoggingKeys.IMG_REF, reference)
                         .log("Accepting delegated plugin image");
 
                 Plugins plugin = new Plugins();
@@ -388,9 +388,9 @@ class AdmissionHandler implements HttpHandler {
         }
         catch (com.fasterxml.jackson.core.JsonProcessingException e) {
             LOGGER.atWarn()
-                    .addKeyValue("pod", podName)
-                    .addKeyValue("namespace", namespace)
-                    .addKeyValue("error", e.getMessage())
+                    .addKeyValue(WebhookLoggingKeys.POD, podName)
+                    .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
+                    .addKeyValue(WebhookLoggingKeys.ERROR, e.getMessage())
                     .log("Failed to parse delegated plugin images JSON, ignoring");
         }
 

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
@@ -33,6 +33,8 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfig;
 import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfigSpec;
 import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfigSpecBuilder;
 import io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.NodeIdRange;
+import io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.Plugins;
+import io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.plugins.Image;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -48,20 +50,22 @@ class AdmissionHandler implements HttpHandler {
     private final SidecarConfigResolver configResolver;
     private final String proxyImage;
     private final boolean useNativeSidecar;
+    private final boolean useOciImageVolumes;
 
     AdmissionHandler(
                      @NonNull SidecarConfigResolver configResolver,
                      @NonNull String proxyImage,
-                     boolean useNativeSidecar) {
+                     KubernetesVersion kubernetesVersion) {
         this.configResolver = configResolver;
         this.proxyImage = proxyImage;
-        this.useNativeSidecar = useNativeSidecar;
+        this.useNativeSidecar = kubernetesVersion.supportedNativeSidecar();
+        this.useOciImageVolumes = kubernetesVersion.supportsOciImageVolumes();
     }
 
     AdmissionHandler(
                      @NonNull SidecarConfigResolver configResolver,
                      @NonNull String proxyImage) {
-        this(configResolver, proxyImage, false);
+        this(configResolver, proxyImage, new KubernetesVersion(1, 0));
     }
 
     @Override
@@ -152,7 +156,8 @@ class AdmissionHandler implements HttpHandler {
                     sidecarConfig.getSpec(), annotations, podName, namespace);
 
             String image = resolveImage(sidecarConfig);
-            String jsonPatch = PodMutator.createPatch(pod, effectiveSpec, image, useNativeSidecar);
+            String jsonPatch = PodMutator.createPatch(
+                    pod, effectiveSpec, image, useNativeSidecar, useOciImageVolumes);
 
             AdmissionResponse response = allowResponse(uid);
             response.setPatchType(JSON_PATCH_TYPE);
@@ -199,7 +204,29 @@ class AdmissionHandler implements HttpHandler {
 
         applyNodeIdRangeOverride(podAnnotations, podName, namespace, delegatedSet, effective);
 
+        // Apply delegated plugin images (JSON array of {name, reference} objects)
+        applyDelegatedPluginImages(adminSpec, podAnnotations, podName, namespace, delegatedSet, effective);
+
         return effective;
+    }
+
+    private void applyDelegatedPluginImages(@NonNull KroxyliciousSidecarConfigSpec adminSpec, Map<String, String> podAnnotations, String podName, String namespace,
+                                            Set<String> delegatedSet, KroxyliciousSidecarConfigSpec effective) {
+        if (delegatedSet.contains(Annotations.DELEGATED_PLUGIN_IMAGES)) {
+            String pluginsJson = podAnnotations.get(Annotations.DELEGATED_PLUGIN_IMAGES);
+            if (pluginsJson != null) {
+                List<Plugins> delegatedPlugins = parseDelegatedPlugins(
+                        pluginsJson, adminSpec, podName, namespace);
+                if (!delegatedPlugins.isEmpty()) {
+                    List<Plugins> merged = new java.util.ArrayList<>();
+                    if (effective.getPlugins() != null) {
+                        merged.addAll(effective.getPlugins());
+                    }
+                    merged.addAll(delegatedPlugins);
+                    effective.setPlugins(merged);
+                }
+            }
+        }
     }
 
     // TODO: Do we really want to support this for the initial feature?
@@ -284,6 +311,90 @@ class AdmissionHandler implements HttpHandler {
     private static KroxyliciousSidecarConfigSpec copySpec(@NonNull KroxyliciousSidecarConfigSpec src) {
         KroxyliciousSidecarConfigSpecBuilder builder = new KroxyliciousSidecarConfigSpecBuilder(src);
         return builder.build();
+    }
+
+    /**
+     * Parses and validates delegated plugin images from a pod annotation.
+     * Rejects images that do not include a {@code @sha256:} digest or that do not match
+     * one of the allowed registry prefixes.
+     */
+    @NonNull
+    List<Plugins> parseDelegatedPlugins(
+                                        @NonNull String pluginsJson,
+                                        @NonNull KroxyliciousSidecarConfigSpec adminSpec,
+                                        String podName,
+                                        String namespace) {
+
+        List<Plugins> result = new java.util.ArrayList<>();
+        List<String> allowed = adminSpec.getAllowedPluginRegistries();
+        Set<String> allowedSet = allowed != null ? Set.copyOf(allowed) : Set.of();
+
+        try {
+            com.fasterxml.jackson.databind.JsonNode array = MAPPER.readTree(pluginsJson);
+            if (!array.isArray()) {
+                LOGGER.atWarn()
+                        .addKeyValue("pod", podName)
+                        .addKeyValue("namespace", namespace)
+                        .log("Delegated plugin images annotation is not a JSON array, ignoring");
+                return result;
+            }
+
+            for (com.fasterxml.jackson.databind.JsonNode entry : array) {
+                String name = entry.path("name").asText(null);
+                String reference = entry.path("reference").asText(null);
+                if (name == null || reference == null) {
+                    LOGGER.atWarn()
+                            .addKeyValue("pod", podName)
+                            .addKeyValue("namespace", namespace)
+                            .log("Delegated plugin entry missing name or reference, skipping");
+                    continue;
+                }
+
+                // Require @sha256: digest
+                if (!reference.contains("@sha256:")) {
+                    LOGGER.atWarn()
+                            .addKeyValue("pod", podName)
+                            .addKeyValue("namespace", namespace)
+                            .addKeyValue("reference", reference)
+                            .log("Delegated plugin image rejected: must include @sha256: digest");
+                    continue;
+                }
+
+                // Validate against allowed registries
+                if (!allowedSet.isEmpty()
+                        && allowedSet.stream().noneMatch(reference::startsWith)) {
+                    LOGGER.atWarn()
+                            .addKeyValue("pod", podName)
+                            .addKeyValue("namespace", namespace)
+                            .addKeyValue("reference", reference)
+                            .log("Delegated plugin image rejected: registry not in allowedPluginRegistries");
+                    continue;
+                }
+
+                LOGGER.atInfo()
+                        .addKeyValue("pod", podName)
+                        .addKeyValue("namespace", namespace)
+                        .addKeyValue("plugin", name)
+                        .addKeyValue("reference", reference)
+                        .log("Accepting delegated plugin image");
+
+                Plugins plugin = new Plugins();
+                plugin.setName(name);
+                Image image = new Image();
+                image.setReference(reference);
+                plugin.setImage(image);
+                result.add(plugin);
+            }
+        }
+        catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            LOGGER.atWarn()
+                    .addKeyValue("pod", podName)
+                    .addKeyValue("namespace", namespace)
+                    .addKeyValue("error", e.getMessage())
+                    .log("Failed to parse delegated plugin images JSON, ignoring");
+        }
+
+        return result;
     }
 
     @NonNull

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
@@ -318,6 +319,7 @@ class AdmissionHandler implements HttpHandler {
      * Rejects images that do not include a {@code @sha256:} digest or that do not match
      * one of the allowed registry prefixes.
      */
+    @SuppressWarnings("S135") // for loop with > 1 continue, but refactoring would be header to understand
     @NonNull
     List<Plugins> parseDelegatedPlugins(
                                         @NonNull String pluginsJson,
@@ -330,7 +332,7 @@ class AdmissionHandler implements HttpHandler {
         Set<String> allowedSet = allowed != null ? Set.copyOf(allowed) : Set.of();
 
         try {
-            com.fasterxml.jackson.databind.JsonNode array = MAPPER.readTree(pluginsJson);
+            JsonNode array = MAPPER.readTree(pluginsJson);
             if (!array.isArray()) {
                 LOGGER.atWarn()
                         .addKeyValue(WebhookLoggingKeys.POD, podName)
@@ -339,7 +341,7 @@ class AdmissionHandler implements HttpHandler {
                 return result;
             }
 
-            for (com.fasterxml.jackson.databind.JsonNode entry : array) {
+            for (JsonNode entry : array) {
                 String name = entry.path("name").asText(null);
                 String reference = entry.path("reference").asText(null);
                 if (name == null || reference == null) {

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/Annotations.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/Annotations.java
@@ -64,6 +64,8 @@ final class Annotations {
      */
     static final String DELEGATED_NODE_ID_RANGE = "kroxylicious.io/sidecar-node-id-range";
 
+    static final String DELEGATED_PLUGIN_IMAGES = "kroxylicious.io/sidecar-plugin-images";
+
     /** The set of annotations managed by the webhook itself — never treated as undelegated. */
     static final Set<String> WEBHOOK_MANAGED_ANNOTATIONS = Set.of(
             INJECT_SIDECAR,

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/KubernetesVersion.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/KubernetesVersion.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+import io.kroxylicious.proxy.tag.VisibleForTesting;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+record KubernetesVersion(int major, int minor) implements Comparable<KubernetesVersion> {
+    KubernetesVersion {
+        if (major < 1) {
+            throw new IllegalArgumentException("Major must be at least 1");
+        }
+        else if (minor < 0) {
+            throw new IllegalArgumentException("Minor must be at least 0");
+        }
+    }
+
+    @Override
+    public int compareTo(@NonNull KubernetesVersion o) {
+        int cmp = Integer.compare(major, o.major);
+        if (cmp == 0) {
+            cmp = Integer.compare(minor, o.minor);
+        }
+        return cmp;
+    }
+
+    /**
+     * Detects whether the cluster supports native sidecar containers (Kubernetes 1.28+).
+     */
+    @VisibleForTesting
+    boolean supportedNativeSidecar() {
+        return this.compareTo(new KubernetesVersion(1, 28)) >= 0;
+    }
+
+    /**
+     * Detects whether the cluster supports OCI image volumes (Kubernetes 1.31+).
+     * Note that the {@code ImageVolume} feature gate must also be enabled on the cluster.
+     */
+    boolean supportsOciImageVolumes() {
+        return this.compareTo(new KubernetesVersion(1, 31)) >= 0;
+    }
+}

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
@@ -28,6 +28,8 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * Generates a JSON Patch (RFC 6902) to inject a Kroxylicious sidecar into a pod.
  */
 class PodMutator {
+    // TODO we should try to use the Fabric8 API to construct pojos which we then serialize to JSON
+    // rather than building the objects "my hand" (and which causes sonar to complain about the string literal keys)
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final String SIDECAR_VOLUME_NAME = "kroxylicious-config";

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.fabric8.kubernetes.api.model.Pod;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfigSpec;
+import io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.Plugins;
 import io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.UpstreamTls;
 import io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.upstreamtls.TrustAnchorSecretRef;
 
@@ -34,6 +35,9 @@ class PodMutator {
     @SuppressWarnings("java:S1075") // there's nothing wrong with hard coding this path.
     private static final String UPSTREAM_TLS_MOUNT_PATH = "/opt/kroxylicious/tls/upstream";
     @SuppressWarnings("java:S1075") // there's nothing wrong with hard coding this path.
+    private static final String PLUGINS_BASE_PATH = "/opt/kroxylicious/classpath-plugins";
+    private static final String PLUGIN_VOLUME_PREFIX = "plugin-";
+    @SuppressWarnings("java:S1075") // there's nothing wrong with hard coding this path.
     private static final String CONFIG_MOUNT_PATH = "/opt/kroxylicious/config/proxy-config.yaml";
     private static final String CONFIG_FILE_NAME = "proxy-config.yaml";
     private static final String MANAGEMENT_PORT_NAME = "management";
@@ -49,6 +53,8 @@ class PodMutator {
      * @param spec the sidecar configuration
      * @param proxyImage the container image to use for the proxy
      * @param useNativeSidecar if true, inject as an init container with restartPolicy: Always (K8s 1.28+)
+     * @param useOciImageVolumes if true, mount plugin images as OCI image volumes (K8s 1.31+);
+     *                          otherwise use init-container + emptyDir fallback
      * @return JSON Patch string (RFC 6902)
      */
     @NonNull
@@ -56,7 +62,8 @@ class PodMutator {
                               @NonNull Pod pod,
                               @NonNull KroxyliciousSidecarConfigSpec spec,
                               @NonNull String proxyImage,
-                              boolean useNativeSidecar) {
+                              boolean useNativeSidecar,
+                              boolean useOciImageVolumes) {
         try {
             ArrayNode patch = MAPPER.createArrayNode();
 
@@ -66,8 +73,10 @@ class PodMutator {
             int managementPort = ProxyConfigGenerator.resolveManagementPort(spec);
 
             addAnnotationOps(patch, pod, proxyConfig);
-            addVolumeOps(patch, pod, spec);
-            addSidecarContainerOp(patch, pod, proxyImage, managementPort, spec, useNativeSidecar);
+            addVolumeOps(patch, pod, spec, useOciImageVolumes);
+            addPluginCopyInitContainers(patch, pod, spec, useOciImageVolumes);
+            addSidecarContainerOp(patch, pod, proxyImage, managementPort, spec,
+                    useNativeSidecar, useOciImageVolumes);
             addBootstrapEnvVarOps(patch, pod, spec, bootstrapPort);
             addSecurityContextOps(patch, pod);
 
@@ -79,14 +88,14 @@ class PodMutator {
     }
 
     /**
-     * Overload for backwards compatibility (no native sidecar).
+     * Overload for backwards compatibility (no plugins).
      */
     @NonNull
     static String createPatch(
                               @NonNull Pod pod,
                               @NonNull KroxyliciousSidecarConfigSpec spec,
                               @NonNull String proxyImage) {
-        return createPatch(pod, spec, proxyImage, false);
+        return createPatch(pod, spec, proxyImage, false, false);
     }
 
     /**
@@ -123,7 +132,8 @@ class PodMutator {
     private static void addVolumeOps(
                                      ArrayNode patch,
                                      Pod pod,
-                                     KroxyliciousSidecarConfigSpec spec) {
+                                     KroxyliciousSidecarConfigSpec spec,
+                                     boolean useOciImageVolumes) {
         boolean hasVolumes = pod.getSpec() != null
                 && pod.getSpec().getVolumes() != null
                 && !pod.getSpec().getVolumes().isEmpty();
@@ -146,8 +156,9 @@ class PodMutator {
             ArrayNode volumes = MAPPER.createArrayNode();
             volumes.add(configVolume);
             addOp(patch, "add", "/spec/volumes", volumes);
-            hasVolumes = true;
         }
+        // From this point, volumes array exists
+        hasVolumes = true;
 
         // Upstream TLS volume (Secret)
         UpstreamTls tls = spec.getUpstreamTls();
@@ -157,15 +168,71 @@ class PodMutator {
             tlsVolume.put("name", UPSTREAM_TLS_VOLUME_NAME);
             ObjectNode secret = tlsVolume.putObject("secret");
             secret.put("secretName", secretRef.getName());
+            addOp(patch, "add", "/spec/volumes/-", tlsVolume);
+        }
 
-            if (hasVolumes) {
-                addOp(patch, "add", "/spec/volumes/-", tlsVolume);
+        // Plugin volumes
+        List<Plugins> plugins = spec.getPlugins();
+        if (plugins != null) {
+            for (Plugins plugin : plugins) {
+                ObjectNode pluginVolume = MAPPER.createObjectNode();
+                pluginVolume.put("name", PLUGIN_VOLUME_PREFIX + plugin.getName());
+
+                if (useOciImageVolumes) {
+                    ObjectNode image = pluginVolume.putObject("image");
+                    image.put("reference", plugin.getImage().getReference());
+                    if (plugin.getImage().getPullPolicy() != null) {
+                        image.put("pullPolicy", plugin.getImage().getPullPolicy().getValue());
+                    }
+                }
+                else {
+                    // Fallback: emptyDir volume, populated by an init container
+                    pluginVolume.putObject("emptyDir");
+                }
+
+                addOp(patch, "add", "/spec/volumes/-", pluginVolume);
             }
-            else {
-                ArrayNode volumes = MAPPER.createArrayNode();
-                volumes.add(tlsVolume);
-                addOp(patch, "add", "/spec/volumes", volumes);
-            }
+        }
+    }
+
+    /**
+     * Adds init containers that copy plugin JARs from OCI images to emptyDir volumes.
+     * Only used when OCI image volumes are not available.
+     */
+    private static void addPluginCopyInitContainers(
+                                                    ArrayNode patch,
+                                                    Pod pod,
+                                                    KroxyliciousSidecarConfigSpec spec,
+                                                    boolean useOciImageVolumes) {
+
+        List<Plugins> plugins = spec.getPlugins();
+        if (plugins == null || plugins.isEmpty() || useOciImageVolumes) {
+            return;
+        }
+
+        for (Plugins plugin : plugins) {
+            ObjectNode initContainer = MAPPER.createObjectNode();
+            initContainer.put("name", PLUGIN_VOLUME_PREFIX + plugin.getName() + "-copy");
+            initContainer.put("image", plugin.getImage().getReference());
+
+            ArrayNode command = initContainer.putArray("command");
+            command.add("sh");
+            command.add("-c");
+            command.add("cp -r /. /plugins/");
+
+            ArrayNode mounts = initContainer.putArray("volumeMounts");
+            ObjectNode mount = mounts.addObject();
+            mount.put("name", PLUGIN_VOLUME_PREFIX + plugin.getName());
+            mount.put("mountPath", "/plugins");
+
+            // Security context for init container
+            ObjectNode secCtx = initContainer.putObject("securityContext");
+            secCtx.put("allowPrivilegeEscalation", false);
+            secCtx.put("readOnlyRootFilesystem", true);
+            ObjectNode capabilities = secCtx.putObject("capabilities");
+            capabilities.putArray("drop").add("ALL");
+
+            addInitContainer(patch, pod, initContainer);
         }
     }
 
@@ -175,7 +242,8 @@ class PodMutator {
                                               String proxyImage,
                                               int managementPort,
                                               KroxyliciousSidecarConfigSpec spec,
-                                              boolean useNativeSidecar) {
+                                              boolean useNativeSidecar,
+                                              boolean useOciImageVolumes) {
 
         ObjectNode container = MAPPER.createObjectNode();
         container.put("name", InjectionDecision.SIDECAR_CONTAINER_NAME);
@@ -223,6 +291,17 @@ class PodMutator {
             tlsMount.put("name", UPSTREAM_TLS_VOLUME_NAME);
             tlsMount.put("mountPath", UPSTREAM_TLS_MOUNT_PATH);
             tlsMount.put("readOnly", true);
+        }
+
+        // Plugin volume mounts
+        List<Plugins> plugins = spec.getPlugins();
+        if (plugins != null) {
+            for (Plugins plugin : plugins) {
+                ObjectNode pluginMount = volumeMounts.addObject();
+                pluginMount.put("name", PLUGIN_VOLUME_PREFIX + plugin.getName());
+                pluginMount.put("mountPath", PLUGINS_BASE_PATH + "/" + plugin.getName());
+                pluginMount.put("readOnly", true);
+            }
         }
 
         // Resources

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
@@ -42,6 +42,8 @@ class PodMutator {
     private static final String CONFIG_FILE_NAME = "proxy-config.yaml";
     private static final String MANAGEMENT_PORT_NAME = "management";
     private static final String KAFKA_BOOTSTRAP_SERVERS_ENV = "KAFKA_BOOTSTRAP_SERVERS";
+    public static final String OP_ADD = "add";
+    public static final String OP_REPLACE = "replace";
 
     private PodMutator() {
     }
@@ -121,11 +123,11 @@ class PodMutator {
             ObjectNode annotations = MAPPER.createObjectNode();
             annotations.put(Annotations.PROXY_CONFIG, proxyConfig);
             annotations.put(Annotations.SIDECAR_STATUS, "injected");
-            addOp(patch, "add", "/metadata/annotations", annotations);
+            addOp(patch, OP_ADD, "/metadata/annotations", annotations);
         }
         else {
-            addOp(patch, "add", "/metadata/annotations/" + escapeJsonPointer(Annotations.PROXY_CONFIG), proxyConfig);
-            addOp(patch, "add", "/metadata/annotations/" + escapeJsonPointer(Annotations.SIDECAR_STATUS), "injected");
+            addOp(patch, OP_ADD, "/metadata/annotations/" + escapeJsonPointer(Annotations.PROXY_CONFIG), proxyConfig);
+            addOp(patch, OP_ADD, "/metadata/annotations/" + escapeJsonPointer(Annotations.SIDECAR_STATUS), "injected");
         }
     }
 
@@ -138,6 +140,57 @@ class PodMutator {
                 && pod.getSpec().getVolumes() != null
                 && !pod.getSpec().getVolumes().isEmpty();
 
+        ObjectNode configVolume = buildProxyConfigVolume();
+        if (hasVolumes) {
+            addOp(patch, OP_ADD, "/spec/volumes/-", configVolume);
+        }
+        else {
+            ArrayNode volumes = MAPPER.createArrayNode();
+            volumes.add(configVolume);
+            addOp(patch, OP_ADD, "/spec/volumes", volumes);
+        }
+
+        // Upstream TLS volume (Secret)
+        UpstreamTls tls = spec.getUpstreamTls();
+        if (tls != null && tls.getTrustAnchorSecretRef() != null) {
+            TrustAnchorSecretRef secretRef = tls.getTrustAnchorSecretRef();
+            ObjectNode tlsVolume = MAPPER.createObjectNode();
+            tlsVolume.put("name", UPSTREAM_TLS_VOLUME_NAME);
+            ObjectNode secret = tlsVolume.putObject("secret");
+            secret.put("secretName", secretRef.getName());
+            addOp(patch, OP_ADD, "/spec/volumes/-", tlsVolume);
+        }
+
+        // Plugin volumes
+        List<Plugins> plugins = spec.getPlugins();
+        if (plugins != null) {
+            for (Plugins plugin : plugins) {
+                addOp(patch, OP_ADD, "/spec/volumes/-", buildPluginVolume(useOciImageVolumes, plugin));
+            }
+        }
+    }
+
+    @NonNull
+    private static ObjectNode buildPluginVolume(boolean useOciImageVolumes, Plugins plugin) {
+        ObjectNode pluginVolume = MAPPER.createObjectNode();
+        pluginVolume.put("name", PLUGIN_VOLUME_PREFIX + plugin.getName());
+
+        if (useOciImageVolumes) {
+            ObjectNode image = pluginVolume.putObject("image");
+            image.put("reference", plugin.getImage().getReference());
+            if (plugin.getImage().getPullPolicy() != null) {
+                image.put("pullPolicy", plugin.getImage().getPullPolicy().getValue());
+            }
+        }
+        else {
+            // Fallback: emptyDir volume, populated by an init container
+            pluginVolume.putObject("emptyDir");
+        }
+        return pluginVolume;
+    }
+
+    @NonNull
+    private static ObjectNode buildProxyConfigVolume() {
         // Use downwardAPI to mount a volume such that the container's proxy-config.yaml has the content of the
         // kroxylicious.io/proxy-config annotation's value.
         ObjectNode configVolume = MAPPER.createObjectNode();
@@ -148,51 +201,7 @@ class PodMutator {
         item.put("path", CONFIG_FILE_NAME);
         ObjectNode fieldRef = item.putObject("fieldRef");
         fieldRef.put("fieldPath", "metadata.annotations['" + Annotations.PROXY_CONFIG + "']");
-
-        if (hasVolumes) {
-            addOp(patch, "add", "/spec/volumes/-", configVolume);
-        }
-        else {
-            ArrayNode volumes = MAPPER.createArrayNode();
-            volumes.add(configVolume);
-            addOp(patch, "add", "/spec/volumes", volumes);
-        }
-        // From this point, volumes array exists
-        hasVolumes = true;
-
-        // Upstream TLS volume (Secret)
-        UpstreamTls tls = spec.getUpstreamTls();
-        if (tls != null && tls.getTrustAnchorSecretRef() != null) {
-            TrustAnchorSecretRef secretRef = tls.getTrustAnchorSecretRef();
-            ObjectNode tlsVolume = MAPPER.createObjectNode();
-            tlsVolume.put("name", UPSTREAM_TLS_VOLUME_NAME);
-            ObjectNode secret = tlsVolume.putObject("secret");
-            secret.put("secretName", secretRef.getName());
-            addOp(patch, "add", "/spec/volumes/-", tlsVolume);
-        }
-
-        // Plugin volumes
-        List<Plugins> plugins = spec.getPlugins();
-        if (plugins != null) {
-            for (Plugins plugin : plugins) {
-                ObjectNode pluginVolume = MAPPER.createObjectNode();
-                pluginVolume.put("name", PLUGIN_VOLUME_PREFIX + plugin.getName());
-
-                if (useOciImageVolumes) {
-                    ObjectNode image = pluginVolume.putObject("image");
-                    image.put("reference", plugin.getImage().getReference());
-                    if (plugin.getImage().getPullPolicy() != null) {
-                        image.put("pullPolicy", plugin.getImage().getPullPolicy().getValue());
-                    }
-                }
-                else {
-                    // Fallback: emptyDir volume, populated by an init container
-                    pluginVolume.putObject("emptyDir");
-                }
-
-                addOp(patch, "add", "/spec/volumes/-", pluginVolume);
-            }
-        }
+        return configVolume;
     }
 
     /**
@@ -331,12 +340,12 @@ class PodMutator {
                 && !pod.getSpec().getContainers().isEmpty();
 
         if (hasContainers) {
-            addOp(patch, "add", "/spec/containers/-", container);
+            addOp(patch, OP_ADD, "/spec/containers/-", container);
         }
         else {
             ArrayNode containers = MAPPER.createArrayNode();
             containers.add(container);
-            addOp(patch, "add", "/spec/containers", containers);
+            addOp(patch, OP_ADD, "/spec/containers", containers);
         }
     }
 
@@ -346,12 +355,12 @@ class PodMutator {
                 && !pod.getSpec().getInitContainers().isEmpty();
 
         if (hasInitContainers) {
-            addOp(patch, "add", "/spec/initContainers/-", container);
+            addOp(patch, OP_ADD, "/spec/initContainers/-", container);
         }
         else {
             ArrayNode initContainers = MAPPER.createArrayNode();
             initContainers.add(container);
-            addOp(patch, "add", "/spec/initContainers", initContainers);
+            addOp(patch, OP_ADD, "/spec/initContainers", initContainers);
         }
     }
 
@@ -407,12 +416,12 @@ class PodMutator {
             if (hasEnv) {
                 int existingIdx = findEnvVarIndex(c.getEnv(), KAFKA_BOOTSTRAP_SERVERS_ENV);
                 if (existingIdx >= 0) {
-                    addOp(patch, "replace",
+                    addOp(patch, OP_REPLACE,
                             "/spec/containers/" + i + "/env/" + existingIdx + "/value",
                             bootstrapValue);
                 }
                 else {
-                    addOp(patch, "add",
+                    addOp(patch, OP_ADD,
                             "/spec/containers/" + i + "/env/-",
                             envVar);
                 }
@@ -420,7 +429,7 @@ class PodMutator {
             else {
                 ArrayNode envArray = MAPPER.createArrayNode();
                 envArray.add(envVar);
-                addOp(patch, "add",
+                addOp(patch, OP_ADD,
                         "/spec/containers/" + i + "/env",
                         envArray);
             }
@@ -449,7 +458,7 @@ class PodMutator {
             secCtx.put("runAsNonRoot", true);
             ObjectNode seccompProfile = secCtx.putObject("seccompProfile");
             seccompProfile.put("type", "RuntimeDefault");
-            addOp(patch, "add", "/spec/securityContext", secCtx);
+            addOp(patch, OP_ADD, "/spec/securityContext", secCtx);
         }
     }
 

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookLoggingKeys.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookLoggingKeys.java
@@ -6,6 +6,9 @@
 
 package io.kroxylicious.kubernetes.webhook;
 
+/**
+ * Constants used for logging
+ */
 public class WebhookLoggingKeys {
 
     static final String NAMESPACE = "namespace";

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookLoggingKeys.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookLoggingKeys.java
@@ -21,6 +21,10 @@ public class WebhookLoggingKeys {
 
     static final String ANNOTATION_VALUE = "annotationValue";
 
+    static final String IMG_REF = "imageReference";
+
+    static final String ERROR = "error";
+
     private WebhookLoggingKeys() {
     }
 

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
@@ -53,6 +53,12 @@ public class WebhookMain {
         this.kubeClient = kubeClient;
     }
 
+    /**
+     * The webhook main method.
+     * Note: this method does JVM global things like installing a shutdown hook
+     * and calling {@link System#exit(int)}.
+     * @param args The command line arguments.
+     */
     public static void main(String[] args) {
         try {
             WebhookMain webhook = create();
@@ -76,9 +82,10 @@ public class WebhookMain {
         String proxyImage = requiredEnv(env, KROXYLICIOUS_IMAGE_VAR);
 
         KubernetesClient kubeClient = new KubernetesClientBuilder().build();
-        boolean useNativeSidecar = detectNativeSidecarSupport(kubeClient);
+        var kubernetesVersion = detectVersion(kubeClient);
         SidecarConfigResolver configResolver = new SidecarConfigResolver(kubeClient);
-        AdmissionHandler admissionHandler = new AdmissionHandler(configResolver, proxyImage, useNativeSidecar);
+        AdmissionHandler admissionHandler = new AdmissionHandler(
+                configResolver, proxyImage, kubernetesVersion);
         WebhookServer server = new WebhookServer(bindAddress, certPath, keyPath, admissionHandler);
 
         return new WebhookMain(server, configResolver, kubeClient);
@@ -120,27 +127,24 @@ public class WebhookMain {
         LOGGER.atInfo().log("Webhook stopped");
     }
 
-    /**
-     * Detects whether the cluster supports native sidecar containers (Kubernetes 1.28+).
-     */
-    @VisibleForTesting
-    static boolean detectNativeSidecarSupport(@NonNull KubernetesClient client) {
+    private static KubernetesVersion detectVersion(@NonNull KubernetesClient client) {
         try {
             VersionInfo version = client.getKubernetesVersion();
             int major = Integer.parseInt(version.getMajor().replaceAll("\\D", ""));
             int minor = Integer.parseInt(version.getMinor().replaceAll("\\D", ""));
-            boolean nativeSidecarSupported = major > 1 || (major == 1 && minor >= 28);
+
             LOGGER.atInfo()
-                    .addKeyValue("kubernetesVersion", version.getGitVersion())
-                    .addKeyValue("nativeSidecar", nativeSidecarSupported)
+                    .addKeyValue("gitVersion", version.getGitVersion())
+                    .addKeyValue("major", major)
+                    .addKeyValue("minor", minor)
                     .log("Detected Kubernetes version");
-            return nativeSidecarSupported;
+            return new KubernetesVersion(major, minor);
         }
         catch (Exception e) {
             LOGGER.atWarn()
                     .setCause(e)
-                    .log("Could not detect Kubernetes version, defaulting to regular sidecar containers");
-            return false;
+                    .log("Could not detect Kubernetes version, defaulting to conservative feature set");
+            return new KubernetesVersion(1, 0);
         }
     }
 

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AdmissionHandlerTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/AdmissionHandlerTest.java
@@ -343,6 +343,143 @@ class AdmissionHandlerTest {
         assertThat(effective.getNodeIdRange()).isNull();
     }
 
+    // --- Phase 4: Delegated plugin images ---
+
+    @Test
+    void parsesValidDelegatedPlugins() {
+        KroxyliciousSidecarConfigSpec adminSpec = new KroxyliciousSidecarConfigSpec();
+        adminSpec.setUpstreamBootstrapServers("kafka:9092");
+        adminSpec.setAllowedPluginRegistries(List.of("reg.io/"));
+
+        String json = """
+                [{"name":"my-filter","reference":"reg.io/filter@sha256:abc123def"}]""";
+
+        List<io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.Plugins> result = handler.parseDelegatedPlugins(json, adminSpec, "pod", "ns");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getName()).isEqualTo("my-filter");
+        assertThat(result.get(0).getImage().getReference()).isEqualTo("reg.io/filter@sha256:abc123def");
+    }
+
+    @Test
+    void rejectsDelegatedPluginWithoutDigest() {
+        KroxyliciousSidecarConfigSpec adminSpec = new KroxyliciousSidecarConfigSpec();
+        adminSpec.setUpstreamBootstrapServers("kafka:9092");
+
+        String json = """
+                [{"name":"my-filter","reference":"reg.io/filter:latest"}]""";
+
+        List<io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.Plugins> result = handler.parseDelegatedPlugins(json, adminSpec, "pod", "ns");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void rejectsDelegatedPluginFromDisallowedRegistry() {
+        KroxyliciousSidecarConfigSpec adminSpec = new KroxyliciousSidecarConfigSpec();
+        adminSpec.setUpstreamBootstrapServers("kafka:9092");
+        adminSpec.setAllowedPluginRegistries(List.of("trusted.io/"));
+
+        String json = """
+                [{"name":"my-filter","reference":"evil.io/filter@sha256:abc123"}]""";
+
+        List<io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.Plugins> result = handler.parseDelegatedPlugins(json, adminSpec, "pod", "ns");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void acceptsDelegatedPluginWhenNoRegistryRestrictions() {
+        KroxyliciousSidecarConfigSpec adminSpec = new KroxyliciousSidecarConfigSpec();
+        adminSpec.setUpstreamBootstrapServers("kafka:9092");
+        // No allowedPluginRegistries set — all registries allowed
+
+        String json = """
+                [{"name":"my-filter","reference":"any.io/filter@sha256:abc123"}]""";
+
+        List<io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.Plugins> result = handler.parseDelegatedPlugins(json, adminSpec, "pod", "ns");
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void skipsDelegatedPluginEntryMissingName() {
+        KroxyliciousSidecarConfigSpec adminSpec = new KroxyliciousSidecarConfigSpec();
+        adminSpec.setUpstreamBootstrapServers("kafka:9092");
+
+        String json = """
+                [{"reference":"reg.io/filter@sha256:abc123"}]""";
+
+        List<io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.Plugins> result = handler.parseDelegatedPlugins(json, adminSpec, "pod", "ns");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void ignoresNonArrayDelegatedPluginsJson() {
+        KroxyliciousSidecarConfigSpec adminSpec = new KroxyliciousSidecarConfigSpec();
+        adminSpec.setUpstreamBootstrapServers("kafka:9092");
+
+        List<io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.Plugins> result = handler.parseDelegatedPlugins("{\"not\":\"array\"}", adminSpec,
+                "pod", "ns");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void ignoresMalformedDelegatedPluginsJson() {
+        KroxyliciousSidecarConfigSpec adminSpec = new KroxyliciousSidecarConfigSpec();
+        adminSpec.setUpstreamBootstrapServers("kafka:9092");
+
+        List<io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.Plugins> result = handler.parseDelegatedPlugins("not json at all", adminSpec, "pod",
+                "ns");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void appliesDelegatedPluginImages() {
+        KroxyliciousSidecarConfigSpec adminSpec = new KroxyliciousSidecarConfigSpec();
+        adminSpec.setUpstreamBootstrapServers("kafka:9092");
+        adminSpec.setDelegatedAnnotations(List.of(Annotations.DELEGATED_PLUGIN_IMAGES));
+        adminSpec.setAllowedPluginRegistries(List.of("reg.io/"));
+
+        String pluginsJson = """
+                [{"name":"my-filter","reference":"reg.io/filter@sha256:abc123"}]""";
+        Map<String, String> annotations = Map.of(Annotations.DELEGATED_PLUGIN_IMAGES, pluginsJson);
+
+        KroxyliciousSidecarConfigSpec effective = handler.applyDelegatedOverrides(
+                adminSpec, annotations, "test-pod", "test-ns");
+
+        assertThat(effective.getPlugins()).hasSize(1);
+        assertThat(effective.getPlugins().get(0).getName()).isEqualTo("my-filter");
+    }
+
+    @Test
+    void mergesDelegatedPluginsWithAdminPlugins() {
+        KroxyliciousSidecarConfigSpec adminSpec = new KroxyliciousSidecarConfigSpec();
+        adminSpec.setUpstreamBootstrapServers("kafka:9092");
+        adminSpec.setDelegatedAnnotations(List.of(Annotations.DELEGATED_PLUGIN_IMAGES));
+
+        io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.Plugins adminPlugin = new io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.Plugins();
+        adminPlugin.setName("admin-plugin");
+        io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.plugins.Image adminImage = new io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.plugins.Image();
+        adminImage.setReference("reg.io/admin@sha256:aaa");
+        adminPlugin.setImage(adminImage);
+        adminSpec.setPlugins(List.of(adminPlugin));
+
+        String pluginsJson = """
+                [{"name":"user-plugin","reference":"any.io/user@sha256:bbb"}]""";
+        Map<String, String> annotations = Map.of(Annotations.DELEGATED_PLUGIN_IMAGES, pluginsJson);
+
+        KroxyliciousSidecarConfigSpec effective = handler.applyDelegatedOverrides(
+                adminSpec, annotations, "test-pod", "test-ns");
+
+        assertThat(effective.getPlugins()).hasSize(2);
+        assertThat(effective.getPlugins().get(0).getName()).isEqualTo("admin-plugin");
+        assertThat(effective.getPlugins().get(1).getName()).isEqualTo("user-plugin");
+    }
+
     @Test
     void returnsOriginalSpecWhenNoAnnotations() {
         KroxyliciousSidecarConfigSpec adminSpec = new KroxyliciousSidecarConfigSpec();

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/PodMutatorTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/src/test/java/io/kroxylicious/kubernetes/webhook/PodMutatorTest.java
@@ -25,7 +25,9 @@ import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Volume;
 
 import io.kroxylicious.kubernetes.api.v1alpha1.KroxyliciousSidecarConfigSpec;
+import io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.Plugins;
 import io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.UpstreamTls;
+import io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.plugins.Image;
 import io.kroxylicious.kubernetes.api.v1alpha1.kroxylicioussidecarconfigspec.upstreamtls.TrustAnchorSecretRef;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -327,7 +329,7 @@ class PodMutatorTest {
     @Test
     void nativeSidecarInjectsAsInitContainer() throws Exception {
         Pod pod = podWithAppContainer(null);
-        String patchStr = PodMutator.createPatch(pod, defaultSpec(), PROXY_IMAGE, true);
+        String patchStr = PodMutator.createPatch(pod, defaultSpec(), PROXY_IMAGE, true, false);
         JsonNode patch = MAPPER.readTree(patchStr);
 
         // Should add to initContainers, not containers
@@ -342,12 +344,142 @@ class PodMutatorTest {
     @Test
     void regularSidecarDoesNotSetRestartPolicy() throws Exception {
         Pod pod = podWithAppContainer(null);
-        String patchStr = PodMutator.createPatch(pod, defaultSpec(), PROXY_IMAGE, false);
+        String patchStr = PodMutator.createPatch(pod, defaultSpec(), PROXY_IMAGE, false, false);
         JsonNode patch = MAPPER.readTree(patchStr);
 
         List<JsonNode> containerOps = patchOps(patch, "add", "/spec/containers/-");
         assertThat(containerOps).isNotEmpty();
         assertThat(containerOps.get(0).path("value").has("restartPolicy")).isFalse();
+    }
+
+    // --- Phase 4: Plugin volumes ---
+
+    @Test
+    void patchAddsOciImageVolumeForPlugin() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        KroxyliciousSidecarConfigSpec spec = specWithPlugin("my-filter", "reg.io/filter:v1@sha256:abc123");
+
+        String patchStr = PodMutator.createPatch(pod, spec, PROXY_IMAGE, false, true);
+        JsonNode patch = MAPPER.readTree(patchStr);
+
+        boolean hasPluginVolume = false;
+        for (JsonNode op : patch) {
+            if ("add".equals(op.path("op").asText())) {
+                JsonNode value = op.path("value");
+                if (value.isObject() && "plugin-my-filter".equals(value.path("name").asText())) {
+                    assertThat(value.has("image")).isTrue();
+                    assertThat(value.path("image").path("reference").asText())
+                            .isEqualTo("reg.io/filter:v1@sha256:abc123");
+                    hasPluginVolume = true;
+                }
+            }
+        }
+        assertThat(hasPluginVolume).as("patch should add OCI image volume for plugin").isTrue();
+    }
+
+    @Test
+    void patchAddsEmptyDirVolumeForPluginWithoutOciSupport() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        KroxyliciousSidecarConfigSpec spec = specWithPlugin("my-filter", "reg.io/filter:v1@sha256:abc123");
+
+        String patchStr = PodMutator.createPatch(pod, spec, PROXY_IMAGE, false, false);
+        JsonNode patch = MAPPER.readTree(patchStr);
+
+        boolean hasPluginVolume = false;
+        for (JsonNode op : patch) {
+            if ("add".equals(op.path("op").asText())) {
+                JsonNode value = op.path("value");
+                if (value.isObject() && "plugin-my-filter".equals(value.path("name").asText())) {
+                    assertThat(value.has("emptyDir")).isTrue();
+                    assertThat(value.has("image")).isFalse();
+                    hasPluginVolume = true;
+                }
+            }
+        }
+        assertThat(hasPluginVolume).as("patch should add emptyDir volume for plugin").isTrue();
+    }
+
+    @Test
+    void patchAddsInitContainerForPluginWithoutOciSupport() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        KroxyliciousSidecarConfigSpec spec = specWithPlugin("my-filter", "reg.io/filter:v1@sha256:abc123");
+
+        String patchStr = PodMutator.createPatch(pod, spec, PROXY_IMAGE, false, false);
+        JsonNode patch = MAPPER.readTree(patchStr);
+
+        List<JsonNode> initOps = patchOps(patch, "add", "/spec/initContainers");
+        assertThat(initOps).isNotEmpty();
+
+        JsonNode initContainer = initOps.get(0).path("value").get(0);
+        assertThat(initContainer.path("name").asText()).isEqualTo("plugin-my-filter-copy");
+        assertThat(initContainer.path("image").asText()).isEqualTo("reg.io/filter:v1@sha256:abc123");
+        assertThat(initContainer.path("securityContext").path("allowPrivilegeEscalation").asBoolean()).isFalse();
+    }
+
+    @Test
+    void patchDoesNotAddInitContainerForPluginWithOciSupport() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        KroxyliciousSidecarConfigSpec spec = specWithPlugin("my-filter", "reg.io/filter:v1@sha256:abc123");
+
+        String patchStr = PodMutator.createPatch(pod, spec, PROXY_IMAGE, false, true);
+        JsonNode patch = MAPPER.readTree(patchStr);
+
+        List<JsonNode> initOps = patchOps(patch, "add", "/spec/initContainers");
+        assertThat(initOps).isEmpty();
+    }
+
+    @Test
+    void patchAddsPluginVolumeMountOnSidecar() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        KroxyliciousSidecarConfigSpec spec = specWithPlugin("my-filter", "reg.io/filter:v1@sha256:abc123");
+
+        String patchStr = PodMutator.createPatch(pod, spec, PROXY_IMAGE, false, true);
+        JsonNode patch = MAPPER.readTree(patchStr);
+
+        List<JsonNode> containerOps = patchOps(patch, "add", "/spec/containers/-");
+        JsonNode mounts = containerOps.get(0).path("value").path("volumeMounts");
+
+        boolean hasPluginMount = false;
+        for (JsonNode mount : mounts) {
+            if ("plugin-my-filter".equals(mount.path("name").asText())) {
+                assertThat(mount.path("mountPath").asText()).isEqualTo("/opt/kroxylicious/classpath-plugins/my-filter");
+                assertThat(mount.path("readOnly").asBoolean()).isTrue();
+                hasPluginMount = true;
+            }
+        }
+        assertThat(hasPluginMount).as("sidecar should have plugin volume mount").isTrue();
+    }
+
+    @Test
+    void patchSupportsMultiplePlugins() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        KroxyliciousSidecarConfigSpec spec = defaultSpec();
+        List<Plugins> plugins = new ArrayList<>();
+        plugins.add(createPlugin("filter-a", "reg.io/a@sha256:aaa"));
+        plugins.add(createPlugin("filter-b", "reg.io/b@sha256:bbb"));
+        spec.setPlugins(plugins);
+
+        String patchStr = PodMutator.createPatch(pod, spec, PROXY_IMAGE, false, true);
+        JsonNode patch = MAPPER.readTree(patchStr);
+
+        int pluginVolumeCount = 0;
+        for (JsonNode op : patch) {
+            if ("add".equals(op.path("op").asText())) {
+                JsonNode value = op.path("value");
+                if (value.isObject() && value.path("name").asText().startsWith("plugin-")) {
+                    pluginVolumeCount++;
+                }
+            }
+        }
+        assertThat(pluginVolumeCount).isEqualTo(2);
+
+        List<JsonNode> containerOps = patchOps(patch, "add", "/spec/containers/-");
+        JsonNode mounts = containerOps.get(0).path("value").path("volumeMounts");
+        List<String> mountNames = new ArrayList<>();
+        for (JsonNode mount : mounts) {
+            mountNames.add(mount.path("name").asText());
+        }
+        assertThat(mountNames).contains("plugin-filter-a", "plugin-filter-b");
     }
 
     /**
@@ -393,6 +525,25 @@ class PodMutatorTest {
     private JsonNode createPatchJson(Pod pod) throws Exception {
         String patchStr = PodMutator.createPatch(pod, defaultSpec(), PROXY_IMAGE);
         return MAPPER.readTree(patchStr);
+    }
+
+    private static KroxyliciousSidecarConfigSpec specWithPlugin(
+                                                                String name,
+                                                                String reference) {
+        KroxyliciousSidecarConfigSpec spec = defaultSpec();
+        spec.setPlugins(new ArrayList<>(List.of(createPlugin(name, reference))));
+        return spec;
+    }
+
+    private static Plugins createPlugin(
+                                        String name,
+                                        String reference) {
+        Plugins plugin = new Plugins();
+        plugin.setName(name);
+        Image image = new Image();
+        image.setReference(reference);
+        plugin.setImage(image);
+        return plugin;
     }
 
     private static List<JsonNode> patchOps(


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds 3rd party plugins via OCI image mounting.

### Additional Context

See https://github.com/kroxylicious/design/pull/100

Contributes towards #3890
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
