### PR TITLE
feat(benchmarks): workload improvements and profiling fixes

### DIFF
--- a/kroxylicious-openmessaging-benchmarks/QUICKSTART.md
+++ b/kroxylicious-openmessaging-benchmarks/QUICKSTART.md
@@ -79,7 +79,7 @@ To run one scenario and workload manually:
 
 Available scenarios: `baseline`, `proxy-no-filters`, `encryption`
 
-Available workloads: `1topic-1kb`, `10topics-1kb`, `100topics-1kb`
+Available workloads: `1topic-1kb`, `10topics-1kb`, `100topics-1kb`, `1topic-10kb`, `1topic-100kb`
 
 ### Cluster-specific settings
 

--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/configmaps/workload-100topics-1kb.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/configmaps/workload-100topics-1kb.yaml
@@ -27,10 +27,10 @@ data:
 
     # Subscription configuration
     subscriptionsPerTopic: 1
-    consumerPerSubscription: 1
+    consumerPerSubscription: {{ .Values.benchmark.consumerPerSubscription }}
 
     # Producer configuration
-    producersPerTopic: 1
+    producersPerTopic: {{ .Values.benchmark.producersPerTopic }}
     producerRate: {{ div .Values.benchmark.producerRate 100 }}
 
     # Test duration

--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/configmaps/workload-10topics-1kb.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/configmaps/workload-10topics-1kb.yaml
@@ -27,10 +27,10 @@ data:
 
     # Subscription configuration
     subscriptionsPerTopic: 1
-    consumerPerSubscription: 1
+    consumerPerSubscription: {{ .Values.benchmark.consumerPerSubscription }}
 
     # Producer configuration
-    producersPerTopic: 1
+    producersPerTopic: {{ .Values.benchmark.producersPerTopic }}
     producerRate: {{ div .Values.benchmark.producerRate 10 }}
 
     # Test duration

--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/configmaps/workload-1topic-100kb.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/configmaps/workload-1topic-100kb.yaml
@@ -1,0 +1,37 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: omb-workload-1topic-100kb
+  labels:
+    app: omb-benchmark
+data:
+  workload.yaml: |
+    # OpenMessaging Benchmark Workload Definition
+    # Single topic with 100KB messages
+
+    name: 1topic-1partition-100kb
+
+    # Topic configuration
+    topics: 1
+    partitionsPerTopic: 1
+
+    # Message configuration
+    messageSize: 102400
+
+    # Subscription configuration
+    subscriptionsPerTopic: 1
+    consumerPerSubscription: 1
+
+    # Producer configuration
+    producersPerTopic: 1
+    producerRate: {{ .Values.benchmark.producerRate }}
+
+    # Test duration
+    testDurationMinutes: {{ .Values.benchmark.testDurationMinutes }}
+    warmupDurationMinutes: {{ .Values.benchmark.warmupDurationMinutes }}

--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/configmaps/workload-1topic-100kb.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/configmaps/workload-1topic-100kb.yaml
@@ -26,10 +26,10 @@ data:
 
     # Subscription configuration
     subscriptionsPerTopic: 1
-    consumerPerSubscription: 1
+    consumerPerSubscription: {{ .Values.benchmark.consumerPerSubscription }}
 
     # Producer configuration
-    producersPerTopic: 1
+    producersPerTopic: {{ .Values.benchmark.producersPerTopic }}
     producerRate: {{ .Values.benchmark.producerRate }}
 
     # Test duration

--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/configmaps/workload-1topic-10kb.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/configmaps/workload-1topic-10kb.yaml
@@ -1,0 +1,37 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: omb-workload-1topic-10kb
+  labels:
+    app: omb-benchmark
+data:
+  workload.yaml: |
+    # OpenMessaging Benchmark Workload Definition
+    # Single topic with 10KB messages
+
+    name: 1topic-1partition-10kb
+
+    # Topic configuration
+    topics: 1
+    partitionsPerTopic: 1
+
+    # Message configuration
+    messageSize: 10240
+
+    # Subscription configuration
+    subscriptionsPerTopic: 1
+    consumerPerSubscription: 1
+
+    # Producer configuration
+    producersPerTopic: 1
+    producerRate: {{ .Values.benchmark.producerRate }}
+
+    # Test duration
+    testDurationMinutes: {{ .Values.benchmark.testDurationMinutes }}
+    warmupDurationMinutes: {{ .Values.benchmark.warmupDurationMinutes }}

--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/configmaps/workload-1topic-10kb.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/configmaps/workload-1topic-10kb.yaml
@@ -26,10 +26,10 @@ data:
 
     # Subscription configuration
     subscriptionsPerTopic: 1
-    consumerPerSubscription: 1
+    consumerPerSubscription: {{ .Values.benchmark.consumerPerSubscription }}
 
     # Producer configuration
-    producersPerTopic: 1
+    producersPerTopic: {{ .Values.benchmark.producersPerTopic }}
     producerRate: {{ .Values.benchmark.producerRate }}
 
     # Test duration

--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/configmaps/workload-1topic-1kb.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/templates/configmaps/workload-1topic-1kb.yaml
@@ -27,10 +27,10 @@ data:
 
     # Subscription configuration
     subscriptionsPerTopic: 1
-    consumerPerSubscription: 1
+    consumerPerSubscription: {{ .Values.benchmark.consumerPerSubscription }}
 
     # Producer configuration
-    producersPerTopic: 1
+    producersPerTopic: {{ .Values.benchmark.producersPerTopic }}
     producerRate: {{ .Values.benchmark.producerRate }}
 
     # Test duration

--- a/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/values.yaml
+++ b/kroxylicious-openmessaging-benchmarks/helm/kroxylicious-benchmark/values.yaml
@@ -112,3 +112,5 @@ benchmark:
   testDurationMinutes: 15
   warmupDurationMinutes: 5
   producerRate: 50000
+  producersPerTopic: 1
+  consumerPerSubscription: 1

--- a/kroxylicious-openmessaging-benchmarks/scripts/run-benchmark.sh
+++ b/kroxylicious-openmessaging-benchmarks/scripts/run-benchmark.sh
@@ -706,12 +706,19 @@ if [[ -n "${PROXY_POD}" ]]; then
                 sh -c "JAVA_TOOL_OPTIONS='' jcmd ${JVM_PID} JFR.start name=benchmark settings=profile maxsize=${JFR_MAX_SIZE}" \
                 >/dev/null 2>&1
             echo "JFR recording restarted for next probe."
+            # Only restart async-profiler if the deployment patch was applied on probe 0.
+            # The patch sets ASYNC_PROFILER_FLAGS in the container env; if absent, the
+            # cluster rejected the Unconfined seccomp patch and profiling was skipped.
             if [[ -n "${AGENT_LIB}" ]]; then
-                kubectl exec -n "${NAMESPACE}" "${PROXY_POD}" -- \
-                    sh -c "JAVA_TOOL_OPTIONS='' jcmd ${JVM_PID} JVMTI.agent_load ${AGENT_LIB} \
-                           '\"start,event=cpu,flamegraph,file=/tmp/flamegraph.html\"'" \
-                    >/dev/null 2>&1
-                echo "async-profiler restarted for next probe."
+                PROFILER_FLAGS=$(kubectl exec -n "${NAMESPACE}" "${PROXY_POD}" -- \
+                    sh -c "tr '\0' '\n' < /proc/${JVM_PID}/environ | grep '^ASYNC_PROFILER_FLAGS=' | cut -d= -f2-") || true
+                if [[ -n "${PROFILER_FLAGS}" ]]; then
+                    kubectl exec -n "${NAMESPACE}" "${PROXY_POD}" -- \
+                        sh -c "JAVA_TOOL_OPTIONS='' jcmd ${JVM_PID} JVMTI.agent_load ${AGENT_LIB} \
+                               '\"start,event=cpu,flamegraph,file=/tmp/flamegraph.html\"'" \
+                        >/dev/null 2>&1
+                    echo "async-profiler restarted for next probe."
+                fi
             fi
         fi
     fi

--- a/kroxylicious-openmessaging-benchmarks/scripts/run-benchmark.sh
+++ b/kroxylicious-openmessaging-benchmarks/scripts/run-benchmark.sh
@@ -700,12 +700,19 @@ if [[ -n "${PROXY_POD}" ]]; then
             fi
         fi
 
-        # If more probes follow, restart a fresh recording for the next rate.
+        # If more probes follow, restart fresh recordings for the next rate.
         if [[ "${SKIP_TEARDOWN}" == "true" ]]; then
             kubectl exec -n "${NAMESPACE}" "${PROXY_POD}" -- \
-                sh -c "JAVA_TOOL_OPTIONS='' jcmd ${JVM_PID} JFR.start name=benchmark settings=default maxsize=${JFR_MAX_SIZE}" \
+                sh -c "JAVA_TOOL_OPTIONS='' jcmd ${JVM_PID} JFR.start name=benchmark settings=profile maxsize=${JFR_MAX_SIZE}" \
                 >/dev/null 2>&1
             echo "JFR recording restarted for next probe."
+            if [[ -n "${AGENT_LIB}" ]]; then
+                kubectl exec -n "${NAMESPACE}" "${PROXY_POD}" -- \
+                    sh -c "JAVA_TOOL_OPTIONS='' jcmd ${JVM_PID} JVMTI.agent_load ${AGENT_LIB} \
+                           '\"start,event=cpu,flamegraph,file=/tmp/flamegraph.html\"'" \
+                    >/dev/null 2>&1
+                echo "async-profiler restarted for next probe."
+            fi
         fi
     fi
     echo "Dump complete."

--- a/kroxylicious-openmessaging-benchmarks/scripts/run-benchmark.sh
+++ b/kroxylicious-openmessaging-benchmarks/scripts/run-benchmark.sh
@@ -598,6 +598,10 @@ echo "  OMB log: ${OUTPUT_DIR}/omb.log"
 
 # Stream Job logs to file in the background (best-effort; survives brief disconnects).
 # The benchmark process runs as the Job entrypoint and is NOT killed if the stream drops.
+# Wait for the benchmark pod to be created before starting the log stream — without this,
+# kubectl logs finds no matching pods and exits immediately with no output.
+kubectl wait pod -n "${NAMESPACE}" -l app=omb-benchmark \
+    --for=create --timeout=120s >/dev/null 2>&1
 kubectl logs -f -n "${NAMESPACE}" -l app=omb-benchmark \
     >> "${OUTPUT_DIR}/omb.log" 2>/dev/null &
 LOGS_PID=$!

--- a/kroxylicious-openmessaging-benchmarks/src/main/java/io/kroxylicious/benchmarks/results/RunMetadata.java
+++ b/kroxylicious-openmessaging-benchmarks/src/main/java/io/kroxylicious/benchmarks/results/RunMetadata.java
@@ -34,7 +34,7 @@ public class RunMetadata {
     private static final DateTimeFormatter ISO_UTC = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
             .withZone(ZoneOffset.UTC);
     private static final String DEFAULT_UNKNOWN_VALUE = "unknown";
-    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(RunMetadata.class);
+    private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(RunMetadata.class);
 
     /**
      * Probe-specific context written alongside the standard git/system metadata.
@@ -170,11 +170,54 @@ public class RunMetadata {
                 long memGb = Long.parseLong(memKi.substring(0, memKi.length() - 2)) / (1024 * 1024);
                 info.put("memoryPerNodeGb", memGb);
             }
+            String workerNode = firstWorkerNodeName(items);
+            if (workerNode != null) {
+                Long nicSpeedMbps = tryGetNicSpeedMbps(runner, workerNode);
+                if (nicSpeedMbps != null) {
+                    info.put("nicSpeedMbps", nicSpeedMbps);
+                }
+            }
         }
         catch (Exception e) {
-            log.debug("kubectl not available or not pointed at a cluster — cluster node info will be omitted", e);
+            LOGGER.debug("kubectl not available or not pointed at a cluster — cluster node info will be omitted", e);
         }
         return info;
+    }
+
+    static String firstWorkerNodeName(JsonNode items) {
+        for (JsonNode node : items) {
+            JsonNode labels = node.path("metadata").path("labels");
+            if (!labels.has("node-role.kubernetes.io/master") &&
+                    !labels.has("node-role.kubernetes.io/control-plane")) {
+                return node.path("metadata").path("name").asText(null);
+            }
+        }
+        return null;
+    }
+
+    static Long tryGetNicSpeedMbps(CommandRunner runner, String workerNodeName) {
+        // On OpenShift, MachineConfigDaemon pods mount the host filesystem at /rootfs,
+        // giving us access to the host's /sys/class/net/<iface>/speed without needing
+        // a privileged pod or kubectl debug node.
+        try {
+            String mcdPod = runner.run("kubectl", "get", "pods",
+                    "-n", "openshift-machine-config-operator",
+                    "-l", "k8s-app=machine-config-daemon",
+                    "--field-selector", "spec.nodeName=" + workerNodeName,
+                    "-o", "jsonpath={.items[0].metadata.name}");
+            if (mcdPod.isBlank() || DEFAULT_UNKNOWN_VALUE.equals(mcdPod)) {
+                return null;
+            }
+            String speed = runner.run("kubectl", "exec",
+                    "-n", "openshift-machine-config-operator", mcdPod.trim(),
+                    "--", "chroot", "/rootfs", "sh", "-c",
+                    "cat /sys/class/net/$(ip route show default | awk '/default/{print $5; exit}')/speed");
+            return Long.parseLong(speed.trim());
+        }
+        catch (Exception e) {
+            LOGGER.atDebug().addKeyValue("workerNode", workerNodeName).setCause(e).log("Could not read NIC speed from node via MachineConfigDaemon");
+            return null;
+        }
     }
 
     private static Map<String, Object> orchestratorSystemInfo() {
@@ -196,7 +239,7 @@ public class RunMetadata {
             info.putAll(parseProcMemInfo(memInfoPath));
         }
         catch (Exception e) {
-            log.error("Failed to parse proc entries", e);
+            LOGGER.error("Failed to parse proc entries", e);
         }
         return info;
     }

--- a/kroxylicious-openmessaging-benchmarks/src/test/java/io/kroxylicious/benchmarks/results/RunMetadataTest.java
+++ b/kroxylicious-openmessaging-benchmarks/src/test/java/io/kroxylicious/benchmarks/results/RunMetadataTest.java
@@ -242,6 +242,130 @@ class RunMetadataTest {
         assertThat(info).isEmpty();
     }
 
+    // --- firstWorkerNodeName tests ---
+
+    @Test
+    void firstWorkerNodeNameReturnsFirstNodeWhenNoRoleLabels() throws Exception {
+        JsonNode items = MAPPER.readTree("""
+                [
+                  {"metadata":{"name":"node-0","labels":{}},"status":{}},
+                  {"metadata":{"name":"node-1","labels":{}},"status":{}}
+                ]
+                """);
+        assertThat(RunMetadata.firstWorkerNodeName(items)).isEqualTo("node-0");
+    }
+
+    @Test
+    void firstWorkerNodeNameSkipsMasterLabelledNodes() throws Exception {
+        JsonNode items = MAPPER.readTree("""
+                [
+                  {"metadata":{"name":"master-0","labels":{"node-role.kubernetes.io/master":""}},"status":{}},
+                  {"metadata":{"name":"worker-0","labels":{}},"status":{}}
+                ]
+                """);
+        assertThat(RunMetadata.firstWorkerNodeName(items)).isEqualTo("worker-0");
+    }
+
+    @Test
+    void firstWorkerNodeNameSkipsControlPlaneLabelledNodes() throws Exception {
+        JsonNode items = MAPPER.readTree("""
+                [
+                  {"metadata":{"name":"cp-0","labels":{"node-role.kubernetes.io/control-plane":""}},"status":{}},
+                  {"metadata":{"name":"worker-0","labels":{}},"status":{}}
+                ]
+                """);
+        assertThat(RunMetadata.firstWorkerNodeName(items)).isEqualTo("worker-0");
+    }
+
+    @Test
+    void firstWorkerNodeNameReturnsNullWhenAllNodesAreControlPlane() throws Exception {
+        JsonNode items = MAPPER.readTree("""
+                [
+                  {"metadata":{"name":"cp-0","labels":{"node-role.kubernetes.io/control-plane":""}},"status":{}},
+                  {"metadata":{"name":"cp-1","labels":{"node-role.kubernetes.io/master":""}},"status":{}}
+                ]
+                """);
+        assertThat(RunMetadata.firstWorkerNodeName(items)).isNull();
+    }
+
+    // --- tryGetNicSpeedMbps tests ---
+
+    @Test
+    void tryGetNicSpeedMbpsReturnsParsedSpeed() throws Exception {
+        RunMetadata.CommandRunner runner = mock(RunMetadata.CommandRunner.class);
+        // First call returns the MCD pod name, second call returns the NIC speed
+        when(runner.run(eq("kubectl"), any(String[].class)))
+                .thenReturn("machine-config-daemon-abc12", "10000");
+
+        assertThat(RunMetadata.tryGetNicSpeedMbps(runner, "worker-0")).isEqualTo(10000L);
+    }
+
+    @Test
+    void tryGetNicSpeedMbpsReturnsNullWhenMcdPodIsBlank() throws Exception {
+        RunMetadata.CommandRunner runner = mock(RunMetadata.CommandRunner.class);
+        when(runner.run(eq("kubectl"), any(String[].class))).thenReturn("");
+
+        assertThat(RunMetadata.tryGetNicSpeedMbps(runner, "worker-0")).isNull();
+    }
+
+    @Test
+    void tryGetNicSpeedMbpsReturnsNullWhenMcdPodIsUnknown() throws Exception {
+        RunMetadata.CommandRunner runner = mock(RunMetadata.CommandRunner.class);
+        when(runner.run(eq("kubectl"), any(String[].class))).thenReturn("unknown");
+
+        assertThat(RunMetadata.tryGetNicSpeedMbps(runner, "worker-0")).isNull();
+    }
+
+    @Test
+    void tryGetNicSpeedMbpsReturnsNullWhenRunnerThrows() throws Exception {
+        RunMetadata.CommandRunner runner = mock(RunMetadata.CommandRunner.class);
+        when(runner.run(eq("kubectl"), any(String[].class))).thenThrow(new java.io.IOException("kubectl not found"));
+
+        assertThat(RunMetadata.tryGetNicSpeedMbps(runner, "worker-0")).isNull();
+    }
+
+    @Test
+    void tryGetNicSpeedMbpsReturnsNullWhenSpeedIsNotNumeric() throws Exception {
+        RunMetadata.CommandRunner runner = mock(RunMetadata.CommandRunner.class);
+        // Speed command returns a non-numeric string (e.g., file not found message)
+        when(runner.run(eq("kubectl"), any(String[].class)))
+                .thenReturn("machine-config-daemon-abc12", "N/A");
+
+        assertThat(RunMetadata.tryGetNicSpeedMbps(runner, "worker-0")).isNull();
+    }
+
+    @Test
+    void nicSpeedPopulatedInClusterNodesWhenMcdAvailable(@TempDir Path tempDir) throws Exception {
+        RunMetadata.CommandRunner runner = mock(RunMetadata.CommandRunner.class);
+        when(runner.run(eq("git"), any(String[].class))).thenReturn("unknown");
+        when(runner.run(eq("minikube"), any(String[].class))).thenReturn("{}");
+        // kubectl calls in order: get nodes, get pods (MCD pod), exec (NIC speed)
+        when(runner.run(eq("kubectl"), any(String[].class)))
+                .thenReturn(kubectlGetNodesJson, "machine-config-daemon-abc12", "10000");
+
+        RunMetadata.generate(tempDir, runner);
+
+        JsonNode clusterNodes = MAPPER.readTree(Files.readString(tempDir.resolve("run-metadata.json"))).get("clusterNodes");
+        assertThat(clusterNodes).isNotNull();
+        assertThat(clusterNodes.get("nicSpeedMbps").asLong()).isEqualTo(10000L);
+    }
+
+    @Test
+    void nicSpeedAbsentFromClusterNodesWhenMcdUnavailable(@TempDir Path tempDir) throws Exception {
+        RunMetadata.CommandRunner runner = mock(RunMetadata.CommandRunner.class);
+        when(runner.run(eq("git"), any(String[].class))).thenReturn("unknown");
+        when(runner.run(eq("minikube"), any(String[].class))).thenReturn("{}");
+        // MCD pod lookup returns blank — NIC speed is skipped
+        when(runner.run(eq("kubectl"), any(String[].class)))
+                .thenReturn(kubectlGetNodesJson, "");
+
+        RunMetadata.generate(tempDir, runner);
+
+        JsonNode clusterNodes = MAPPER.readTree(Files.readString(tempDir.resolve("run-metadata.json"))).get("clusterNodes");
+        assertThat(clusterNodes).isNotNull();
+        assertThat(clusterNodes.has("nicSpeedMbps")).isFalse();
+    }
+
     private static Path fixture(String name) throws URISyntaxException {
         URL fixtureUrl = RunMetadataTest.class.getResource("/fixtures/" + name);
         Assumptions.assumeTrue(fixtureUrl != null);


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Bugfix

### Description

A collection of improvements to the OpenMessaging Benchmark infrastructure accumulated during a performance benchmarking campaign on Fyre/OpenShift.

**New workload definitions:**
- `1topic-10kb` and `1topic-100kb` — single-topic workloads for larger message sizes, useful for isolating network I/O behaviour from crypto overhead

**Parameterised producer/consumer counts:**
- `producersPerTopic` and `consumerPerSubscription` are now Helm values (`benchmark.producersPerTopic`, `benchmark.consumerPerSubscription`) rather than hardcoded in each workload
- Enables multi-producer experiments without editing workload YAML directly

**Benchmark pod readiness fix:**
- `run-benchmark.sh` now waits for the OMB benchmark pod to exist before streaming logs, preventing a race where log streaming started before the pod was scheduled

**JFR and async-profiler fixes (rate sweep probes):**
- Fixed: subsequent rate-sweep probes restarted JFR with `settings=default`, which omits `jdk.NetworkUtilization` events. Now uses `settings=profile` consistently.
- Fixed: async-profiler was stopped between probes but never restarted, causing all probes after the first to capture stale flamegraph data from probe 0
- Fixed: async-profiler restart was guarded on `ASYNC_PROFILER_LIB` (always set when the native library exists) rather than `ASYNC_PROFILER_FLAGS` (only set when `seccompProfile: Unconfined` was successfully applied). The wrong guard caused profiling restarts to be attempted on clusters where profiling was intentionally skipped.

**NIC speed in run-metadata.json:**
- On OpenShift clusters, reads NIC speed (Mbps) from the host via the MachineConfigDaemon pod (which mounts the host filesystem at `/rootfs`), avoiding the need for privileged pods
- Falls back gracefully on non-OCP clusters (field omitted)
- Covered by unit tests

### Additional Context

These changes were made during an active benchmarking campaign measuring Kroxylicious proxy and record encryption overhead. The profiling bugs meant that rate-sweep flamegraphs beyond the first probe were silently capturing stale data — fixing them is necessary for meaningful per-probe CPU profiling.

### Checklist

- [x] PR raised from a fork of this repository and made from a branch rather than main.
- [x] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, trigger the performance test suite.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer.