### PR TITLE
build: remove duplicate kiota-http-jdk dependency declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,11 +379,6 @@
                 <version>${apicurio-registry.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.kiota</groupId>
-                <artifactId>kiota-http-jdk</artifactId>
-                <version>${kiota.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.bitbucket.b_c</groupId>
                 <artifactId>jose4j</artifactId>
                 <version>${jose4j.version}</version>


### PR DESCRIPTION
## Summary

Removes duplicate declaration of `io.kiota:kiota-http-jdk` in the parent pom's `dependencyManagement` section.

## Problem

The dependency was declared twice (lines 363 and 383), causing Maven warnings:

```
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: io.kiota:kiota-http-jdk:jar -> duplicate declaration of version ${kiota.version}
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
```

## Changes

- Removed the second (duplicate) declaration at line 381-385
- Kept the first declaration at line 361-365

## Verification

- `mvn validate` no longer produces duplicate dependency warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)