### PR TITLE
Fix jbang download failures by pinning to a specific jbang release from  GitHub releases

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -281,6 +281,17 @@
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "regex:^omb-[a-f0-9]+-krox-[a-f0-9]+-(?<major>\\d+)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/pom.xml/"
+      ],
+      "matchStrings": [
+        "<jbangVersion>(?<currentValue>\\d+\\.\\d+\\.\\d+)</jbangVersion>"
+      ],
+      "depNameTemplate": "jbangdev/jbang",
+      "datasourceTemplate": "github-releases"
     }
   ],
   "managerFilePatterns": [

--- a/pom.xml
+++ b/pom.xml
@@ -845,6 +845,9 @@
                     <groupId>dev.jbang</groupId>
                     <artifactId>jbang-maven-plugin</artifactId>
                     <version>0.0.8</version>
+                    <configuration>
+                        <jbangVersion>0.138.0</jbangVersion>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Problem

CI builds are experiencing intermittent failures with the error:
```
Archive is not a ZIP archive
```

The root cause is that `https://www.jbang.dev/releases/latest/download/jbang.zip` returns **HTTP 200 OK with an HTML error page** instead of either the ZIP file or a proper 404 status code. This causes:

1. maven-download-plugin sees 200 status → considers download successful
2. Saves HTML content as `jbang.zip` 
3. No checksum validation configured → doesn't detect corruption
4. Unpack step tries to extract HTML as ZIP
5. Build fails with misleading "Archive is not a ZIP archive" error

Upstream issue filed: https://github.com/jbangdev/jbang/issues/2454

## Solution

This PR makes two changes:

1. **Pin jbang version to 0.138.0** - Configures `jbangVersion` in jbang-maven-plugin, which makes it download from GitHub at `https://github.com/jbangdev/jbang/releases/download/v0.138.0/jbang-0.138.0.zip` instead of the broken jbang.dev URL

2. **Add Renovate rule** - Automatically updates the jbang version when new releases are published

## Benefits

- ✅ Fixes CI build failures caused by broken jbang.dev download URL
- ✅ Improves build repeatability by pinning to a specific jbang version
- ✅ Enables automatic updates via Renovate
- ✅ Uses GitHub releases which return proper HTTP status codes

## Verification

Tested locally with clean build - jbang downloads successfully from GitHub and build completes without errors.