### PR TITLE
build(deps)!: upgrade Strimzi from 0.51.0 to 1.0.0 (and the Strimzi kube api from v1beta2 to v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ## SNAPSHOT
 
+* [#3236](https://github.com/kroxylicious/kroxylicious/issues/3236): build(deps): bump strimzi.version from 0.51.0 to 1.0.0
 * [#3824](https://github.com/kroxylicious/kroxylicious/pull/3824): refactor(archetype): reuse record batch transform module
 * [#3842](https://github.com/kroxylicious/kroxylicious/pull/3842): fix(operator): use precise Kafka CRD detection for Strimzi support (prerequisite for Strimzi v1 upgrade)
 * [#2820](https://github.com/kroxylicious/kroxylicious/issues/2820): feat(operator): add automatic TLS trust discovery for Strimzi-managed Kafka clusters via `trustStrimziCaCertificate` field in KafkaService
@@ -24,6 +25,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ### Changes, deprecations and removals
 
+* [#3236](https://github.com/kroxylicious/kroxylicious/issues/3236): **BREAKING CHANGE** - If making use of the Strimzi integration feature in the KafkaService CR (`spec.strimziKafkaRef`), Strimzi 0.49.0 or later is now **required**. The Kroxylicious Operator now uses the Strimzi Kafka CR v1 API exclusively; v1beta2 API support has been dropped. Users running Strimzi versions prior to 0.49.0 must upgrade Strimzi.
 * [#3786](https://github.com/kroxylicious/kroxylicious/issues/3786): The deprecated method `StatusFactory#newTrueConditionStatusPatch(CustomResource, Condition.Type)` (two-parameter form) is removed. Use `StatusFactory#newTrueConditionStatusPatch(CustomResource, Condition.Type, String)` instead, passing `MetadataChecksumGenerator.NO_CHECKSUM_SPECIFIED` if no checksum tracking is needed.
 * The deprecated method `FilterContext#clientSaslAuthenticationSuccess(String, String)` is removed. Filter authors must use `FilterContext#clientSaslAuthenticationSuccess(String, Subject)` to announce a successful SASL authentication to the other filters in the chain.
 * [#1295](https://github.com/kroxylicious/kroxylicious/issues/1295): The AWS KMS top-level `longTermCredentials` and `ec2MetadataCredentials` YAML keys are deprecated.  Use the new `credentials.longTerm` and `credentials.ec2Metadata` forms under the grouped `credentials` node instead.  The old keys continue to work for backward compatibility.

--- a/kroxylicious-kubernetes/kroxylicious-operator/packaging/examples/authorization/01.Kafka.my-cluster.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/packaging/examples/authorization/01.Kafka.my-cluster.yaml
@@ -5,7 +5,7 @@
 #
 
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: dual-role
@@ -27,7 +27,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: my-cluster

--- a/kroxylicious-kubernetes/kroxylicious-operator/packaging/examples/authorization/02.KafkaUser.alice.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/packaging/examples/authorization/02.KafkaUser.alice.yaml
@@ -5,7 +5,7 @@
 #
 
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
 metadata:
   name: alice

--- a/kroxylicious-kubernetes/kroxylicious-operator/packaging/examples/authorization/02.KafkaUser.bob.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/packaging/examples/authorization/02.KafkaUser.bob.yaml
@@ -5,7 +5,7 @@
 #
 
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
 metadata:
   name: bob

--- a/kroxylicious-kubernetes/kroxylicious-operator/packaging/examples/entity-isolation/01.Kafka.my-cluster.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/packaging/examples/entity-isolation/01.Kafka.my-cluster.yaml
@@ -5,7 +5,7 @@
 #
 
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: dual-role
@@ -27,7 +27,7 @@ spec:
         kraftMetadata: shared
 ---
 
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: my-cluster

--- a/kroxylicious-kubernetes/kroxylicious-operator/packaging/examples/entity-isolation/02.KafkaUser.alice.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/packaging/examples/entity-isolation/02.KafkaUser.alice.yaml
@@ -5,7 +5,7 @@
 #
 
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
 metadata:
   name: alice

--- a/kroxylicious-kubernetes/kroxylicious-operator/packaging/examples/entity-isolation/02.KafkaUser.bob.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/packaging/examples/entity-isolation/02.KafkaUser.bob.yaml
@@ -5,7 +5,7 @@
 #
 
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaUser
 metadata:
   name: bob

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
@@ -51,7 +51,7 @@ public final class Constants {
     /**
      * API versions of Strimzi CustomResources
      */
-    public static final String KAFKA_API_VERSION_V1BETA2 = "kafka.strimzi.io/v1beta2";
+    public static final String KAFKA_API_VERSION_V1 = "kafka.strimzi.io/v1";
 
     /**
      * Listener names for Kafka cluster

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/strimzi/KafkaTemplates.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/templates/strimzi/KafkaTemplates.java
@@ -93,7 +93,7 @@ public class KafkaTemplates {
     public static KafkaBuilder defaultKafka(String namespaceName, String clusterName, int kafkaReplicas) {
         // @formatter:off
         return new KafkaBuilder()
-                .withApiVersion(Constants.KAFKA_API_VERSION_V1BETA2)
+                .withApiVersion(Constants.KAFKA_API_VERSION_V1)
                 .withKind(Constants.STRIMZI_KAFKA_KIND)
                 .withNewMetadata()
                     .withName(clusterName)

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <jose4j.version>0.9.6</jose4j.version>
 
         <!-- Test dependencies -->
-        <strimzi.version>0.51.0</strimzi.version>  <!-- when bumping strimzi, be sure to comment out the kafka.version override in the systemtest module's pom -->
+        <strimzi.version>1.0.0</strimzi.version>  <!-- when bumping strimzi, be sure to comment out the kafka.version override in the systemtest module's pom -->
         <kubernetes-client.version>7.6.1</kubernetes-client.version>
         <maven.core.version>3.9.15</maven.core.version>
         <awaitility.version>4.3.0</awaitility.version>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Migrates the Kroxylicious Operator to use the Strimzi Kafka CR v1 API, upgrading the Strimzi dependency from 0.51.0 to 1.0.0.

**Changes:**
- Updated `strimzi.version` from 0.51.0 to 1.0.0 in root pom.xml
- Changed all example YAML files to use `apiVersion: kafka.strimzi.io/v1` (6 files in entity-isolation and authorization examples)
- Renamed system test constant `KAFKA_API_VERSION_V1BETA2` to `KAFKA_API_VERSION_V1` and updated usages in `KafkaTemplates.java`
- Added CHANGELOG entry with breaking change notice

**Breaking Change:** ⚠️ The operator now requires Strimzi 0.49.0 or later (any version supporting the v1 Kafka CR API). Users running Strimzi versions prior to 0.49.0 must upgrade Strimzi and migrate their Kafka custom resources to v1 before upgrading the Kroxylicious Operator.

**No Java code changes required** - the Fabric8 Kubernetes client automatically uses the correct API version based on the Strimzi Kafka class annotations, and listener field structures are unchanged between v1beta2 and v1.

### Additional Context

This change is required because Strimzi 1.0.0 has completely removed v1beta2 API support. The operator would fail to start with Strimzi 1.0.0 without this migration.

Following the approved proposal in kroxylicious/design#92, this PR migrates directly to v1 API only, avoiding the complexity of supporting both versions simultaneously (which would have required GenericKubernetesResource and loss of type safety).

### Checklist

- [x] PR raised from a fork of this repository and made from a branch rather than main.
- [x] Write tests - no new tests needed; existing tests pass with v1 API
- [x] Update documentation - CHANGELOG.md updated with breaking change notice
- [x] Make sure all unit/integration tests pass - operator unit tests passed
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, trigger the performance test suite. Ensure that any degradations to performance numbers are understood and justified.
- [x] Ensure the PR references relevant issue(s) so they are closed on merging - Closes #3236, Closes #3237
- [x] For user facing changes, update CHANGELOG.md
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.