### PR TITLE
Make use of the `withAdditionalCustomResourceDefinition` from JOSDK

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
@@ -21,7 +21,6 @@ import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -88,6 +87,7 @@ class AllReconcilersIT {
     private static final String CLUSTER_FOO_CLUSTER_IP_INGRESS = "foo-cluster-ip";
     private static final String CLUSTER_FOO_SERVICE = "foo-service";
     private static final String CLUSTER_FOO_FILTER = "foo-filter";
+    private static final String STRIMZI_TLS_LISTENER = "tls";
     private static final ConditionFactory AWAIT = await().timeout(Duration.ofSeconds(60));
 
     // the initial operator image pull can take a long time and interfere with the tests
@@ -417,94 +417,85 @@ class AllReconcilersIT {
         assertResourcesAttainCondition(AllReconcilersIT::refsResolved, myCluster, myIngress, myService);
     }
 
-    /**
-     * Nested class for tests that require Strimzi CRD
-     */
-    @Nested
-    class StrimziKafkaIntegrationTests {
-
-        private static final String STRIMZI_TLS_LISTENER = "tls";
-
-        @Test
-        void upstreamTlsFromStrimziKafkaRef() {
-            // Given
-            String kafkaName = "my-cluster";
-            // @formatter:off
-            var kafka = testActor.create(new KafkaBuilder()
-                    .withNewMetadata()
-                        .withName(kafkaName)
-                    .endMetadata()
-                    .withNewSpec()
-                        .withNewKafka()
-                            .addNewListener()
-                                .withName(STRIMZI_TLS_LISTENER)
-                                .withTls(true)
-                            .endListener()
-                        .endKafka()
-                    .endSpec()
-                    .build());
-
-            // Patch the Kafka status to simulate what the Strimzi operator would do.
-            // The Strimzi operator manages the status subresource of Kafka CRs, populating
-            // listener addresses and other runtime state. In tests, we must manually set
-            // this status since the Strimzi operator is not running.
-            testActor.patchStatus(new KafkaBuilder(kafka)
-                    .withNewStatus()
+    @Test
+    void upstreamTlsFromStrimziKafkaRef() {
+        // Given
+        String kafkaName = "my-cluster";
+        // @formatter:off
+        var kafka = testActor.create(new KafkaBuilder()
+                .withNewMetadata()
+                    .withName(kafkaName)
+                .endMetadata()
+                .withNewSpec()
+                    .withNewKafka()
                         .addNewListener()
                             .withName(STRIMZI_TLS_LISTENER)
-                            .addNewAddress()
-                                    .withHost("kafka.example.com")
-                                    .withPort(9093)
-                            .endAddress()
+                            .withTls(true)
                         .endListener()
-                    .endStatus()
-                    .build());
+                    .endKafka()
+                .endSpec()
+                .build());
 
-            testActor.create(new SecretBuilder()
-                    .withNewMetadata()
-                        .withName(kafkaName + ResourcesUtil.STRIMZI_CLUSTER_CA_CERT_SECRET_SUFFIX)
-                    .endMetadata()
-                    .addToData(ResourcesUtil.STRIMZI_CLUSTER_CA_BUNDLE, "dGVzdC1jYQ==")
-                    .build());
+        // Patch the Kafka status to simulate what the Strimzi operator would do.
+        // The Strimzi operator manages the status subresource of Kafka CRs, populating
+        // listener addresses and other runtime state. In tests, we must manually set
+        // this status since the Strimzi operator is not running.
+        testActor.patchStatus(new KafkaBuilder(kafka)
+                .withNewStatus()
+                    .addNewListener()
+                        .withName(STRIMZI_TLS_LISTENER)
+                        .addNewAddress()
+                                .withHost("kafka.example.com")
+                                .withPort(9093)
+                        .endAddress()
+                    .endListener()
+                .endStatus()
+                .build());
 
-            var myService = editableStrimziService(CLUSTER_FOO_SERVICE, kafkaName, STRIMZI_TLS_LISTENER).build();
-            var myProxy = editableProxy(PROXY_A).build();
-            var myIngress = editableIngress(CLUSTER_FOO_CLUSTER_IP_INGRESS, myProxy)
-                    .editOrNewSpec()
-                        .withNewClusterIP()
-                            .withProtocol(Protocol.TCP)
-                        .endClusterIP()
-                    .endSpec()
-                    .build();
-            // @formatter:on
+        testActor.create(new SecretBuilder()
+                .withNewMetadata()
+                    .withName(kafkaName + ResourcesUtil.STRIMZI_CLUSTER_CA_CERT_SECRET_SUFFIX)
+                .endMetadata()
+                .addToData(ResourcesUtil.STRIMZI_CLUSTER_CA_BUNDLE, "dGVzdC1jYQ==")
+                .build());
 
-            var myCluster = editableVirtualCluster(CLUSTER_FOO, myProxy, myService, List.of(myIngress), List.of()).build();
+        var myService = editableStrimziService(CLUSTER_FOO_SERVICE, kafkaName, STRIMZI_TLS_LISTENER).build();
+        var myProxy = editableProxy(PROXY_A).build();
+        var myIngress = editableIngress(CLUSTER_FOO_CLUSTER_IP_INGRESS, myProxy)
+                .editOrNewSpec()
+                    .withNewClusterIP()
+                        .withProtocol(Protocol.TCP)
+                    .endClusterIP()
+                .endSpec()
+                .build();
+        // @formatter:on
 
-            // When
-            createAll(myProxy, myCluster, myIngress, myService);
+        var myCluster = editableVirtualCluster(CLUSTER_FOO, myProxy, myService, List.of(myIngress), List.of()).build();
 
-            // Then
-            assertResourcesAttainCondition(AllReconcilersIT::resourceReady, myProxy);
-            assertResourcesAttainCondition(AllReconcilersIT::refsResolved, myCluster, myIngress, myService);
-        }
+        // When
+        createAll(myProxy, myCluster, myIngress, myService);
 
-        private static KafkaServiceBuilder editableStrimziService(String name, String kafkaName, String listenerName) {
-            // @formatter:off
-            return new KafkaServiceBuilder()
-                    .withNewMetadata()
-                        .withName(name)
-                    .endMetadata()
-                    .withNewSpec()
-                        .withNewStrimziKafkaRef()
-                            .withListenerName(listenerName)
-                            .withTrustStrimziCaCertificate(true)
-                            .withNewRef()
-                                .withName(kafkaName)
-                            .endRef()
-                        .endStrimziKafkaRef()
-                    .endSpec();
-            // @formatter:on
-        }
+        // Then
+        assertResourcesAttainCondition(AllReconcilersIT::resourceReady, myProxy);
+        assertResourcesAttainCondition(AllReconcilersIT::refsResolved, myCluster, myIngress, myService);
+    }
+
+    private static KafkaServiceBuilder editableStrimziService(String name, String kafkaName, String listenerName) {
+        // @formatter:off
+        return new KafkaServiceBuilder()
+                .withNewMetadata()
+                    .withName(name)
+                .endMetadata()
+                .withNewSpec()
+                    .withNewStrimziKafkaRef()
+                        .withListenerName(listenerName)
+                        .withTrustStrimziCaCertificate(true)
+                        .withNewRef()
+                            .withName(kafkaName)
+                        .endRef()
+                    .endStrimziKafkaRef()
+                .endSpec();
+        // @formatter:on
     }
 
     private void createAll(HasMetadata... resources) {

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/AllReconcilersIT.java
@@ -19,7 +19,6 @@ import java.util.stream.Stream;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.core.ConditionFactory;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
@@ -36,8 +35,6 @@ import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.client.CustomResource;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.dsl.Updatable;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.kafka.KafkaBuilder;
@@ -113,6 +110,7 @@ class AllReconcilersIT {
             .withKubernetesClient(rbacHandler.operatorClient())
             .waitForNamespaceDeletion(false)
             .withConfigurationService(x -> x.withCloseClientOnStop(false))
+            .withAdditionalCustomResourceDefinition(Crds.kafka())
             .build();
     private final TestActor testActor = rbacHandler.testActor(extension);
 
@@ -426,26 +424,6 @@ class AllReconcilersIT {
     class StrimziKafkaIntegrationTests {
 
         private static final String STRIMZI_TLS_LISTENER = "tls";
-
-        @BeforeAll
-        static void setUpStrimziCrd() {
-            try (KubernetesClient client = OperatorTestUtils.kubeClient()) {
-                client.apiextensions().v1().customResourceDefinitions().resource(Crds.kafka()).createOr(Updatable::update);
-            }
-            catch (Exception e) {
-                throw new RuntimeException("Failed to set up Strimzi CRD", e);
-            }
-        }
-
-        @AfterAll
-        static void tearDownStrimziCrd() {
-            try (KubernetesClient client = OperatorTestUtils.kubeClient()) {
-                client.apiextensions().v1().customResourceDefinitions().resource(Crds.kafka()).delete();
-            }
-            catch (Exception e) {
-                LOGGER.atWarn().setCause(e).log("Failed to clean up Strimzi CRD");
-            }
-        }
 
         @Test
         void upstreamTlsFromStrimziKafkaRef() {

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaservice/KafkaServiceStrimziKafkaRefReconcilerIT.java
@@ -11,9 +11,7 @@ import java.time.Duration;
 
 import org.assertj.core.api.Assertions;
 import org.awaitility.core.ConditionFactory;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -24,8 +22,6 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.dsl.Updatable;
 import io.javaoperatorsdk.operator.junit.LocallyRunOperatorExtension;
 import io.strimzi.api.kafka.Crds;
 import io.strimzi.api.kafka.model.kafka.Kafka;
@@ -42,7 +38,6 @@ import io.kroxylicious.kubernetes.api.v1alpha1.KafkaServiceStatus;
 import io.kroxylicious.kubernetes.api.v1alpha1.kafkaservicestatus.Tls;
 import io.kroxylicious.kubernetes.operator.Annotations;
 import io.kroxylicious.kubernetes.operator.LocallyRunningOperatorRbacHandler;
-import io.kroxylicious.kubernetes.operator.OperatorTestUtils;
 import io.kroxylicious.kubernetes.operator.ResourcesUtil;
 import io.kroxylicious.kubernetes.operator.TestFiles;
 import io.kroxylicious.kubernetes.operator.assertj.OperatorAssertions;
@@ -77,29 +72,8 @@ class KafkaServiceStrimziKafkaRefReconcilerIT {
             .withKubernetesClient(rbacHandler.operatorClient())
             .waitForNamespaceDeletion(false)
             .withConfigurationService(x -> x.withCloseClientOnStop(false))
+            .withAdditionalCustomResourceDefinition(Crds.kafka())
             .build();
-
-    @BeforeAll
-    static void beforeAll() {
-        // note that we could not find a nice way to do this via the LocallyRunOperatorExtension. I tried serializing the CRD to
-        // a temp file and using `withAdditionalCRD(path)` but it didn't load those CRDs before initializing the reconciler.
-        try (KubernetesClient client = OperatorTestUtils.kubeClient()) {
-            client.apiextensions().v1().customResourceDefinitions().resource(Crds.kafka()).createOr(Updatable::update);
-        }
-        catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @AfterAll
-    static void afterAll() {
-        try (KubernetesClient client = OperatorTestUtils.kubeClient()) {
-            client.apiextensions().v1().customResourceDefinitions().resource(Crds.kafka()).delete();
-        }
-        catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
 
     private final LocallyRunningOperatorRbacHandler.TestActor testActor = rbacHandler.testActor(extension);
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

_Please describe your pull request_

During the previous Strimzi Integration work, it was not possible to use `withAdditionalCustomResourceDefinition` and also when we tried serialising the CRD to a temp file and using `withAdditionalCRD(path)`, it didn't load those CRDs before initialising the reconciler. This issue https://github.com/operator-framework/java-operator-sdk/issues/3004 contains more context for the same. The issue is now fixed in JOSDK and therefore we can now use `withAdditionalCustomResourceDefinition` method for the same.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [x] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
