### PR TITLE
test: fix TopicTracingIT flaky test

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/TopicTracingIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/TopicTracingIT.java
@@ -155,6 +155,7 @@ class TopicTracingIT extends AbstractTracingIT {
                     admin.describeConfigs(ConfigResource.Type.TOPIC, topicA);
                     admin.alterConfigs(ConfigResource.Type.TOPIC, topicA, new ConfigEntry(TopicConfig.COMPRESSION_TYPE_CONFIG, "zstd"));
                     var topicBId = setup.createTopic(topicB).value();
+                    Awaitility.waitAtMost(10, TimeUnit.SECONDS).until(() -> ClusterPrepUtils.allTopicPartitionsHaveALeader(setup.admin(), List.of(TOPIC_B)));
 
                     admin.deleteTopic(topicBId);
                 }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Fixes intermittent `UnknownTopicIdException` failure in `TopicTracingIT.shouldEnforceAccessToTopics` by adding a wait for topicB metadata propagation before deletion.

The test was creating topicB using the `setup` admin client, then immediately trying to delete it using a different `admin` client without waiting for the topic metadata to propagate between clients. This caused the `admin` client to not know about topicB, resulting in `UnknownTopicIdException`.

**Fix**: Added single line to wait for topicB to have a leader before attempting deletion with the other admin client.

### Additional Context

This addresses issue #3858 which reported the flaky test failure observed in CI:
https://github.com/kroxylicious/kroxylicious/actions/runs/25213624406/job/73929754196

The root cause was identified as a race condition between topic creation (by one admin client) and topic deletion (by a different admin client) without proper synchronization.

### Checklist

- [x] PR raised from a fork of this repository and made from a branch rather than main. 
- [x] Write tests (existing test now works reliably)
- [ ] Update documentation (not applicable - test-only change)
- [x] Make sure all unit/integration tests pass (TopicTracingIT now passes consistently)
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [x] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too). (not user-facing)
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).