### PR TITLE
fix: example generates certificate and privatekey consumable by webhook

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -244,6 +244,7 @@ Alternatively, to test locally made changes, push the built operator and proxy i
 ```
 minikube image load kroxylicious-kubernetes/kroxylicious-operator/target/kroxylicious-operator.img.tar.gz --alsologtostderr=true 2>&1 | tail -n1
 minikube image load kroxylicious-app/target/kroxylicious-proxy.img.tar.gz --alsologtostderr=true 2>&1 | tail -n1
+minikube image load kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/target/kroxylicious-webhook.img.tar.gz --alsologtostderr=true 2>&1 | tail -n1
 ```
 
 > :warning: Some minikube container runtimes may not be able to load a gzipped tar (https://github.com/kubernetes/minikube/issues/21678), if the above commands report a failure 
@@ -251,6 +252,7 @@ minikube image load kroxylicious-app/target/kroxylicious-proxy.img.tar.gz --also
 > ```
 > gunzip --to-stdout kroxylicious-kubernetes/kroxylicious-operator/target/kroxylicious-operator.img.tar.gz | minikube image load - --alsologtostderr=true 2>&1 | tail -n1
 > gunzip --to-stdout kroxylicious-app/target/kroxylicious-proxy.img.tar.gz | minikube image load - --alsologtostderr=true 2>&1 | tail -n1
+> gunzip --to-stdout kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/target/kroxylicious-webhook.img.tar.gz | minikube image load - --alsologtostderr=true 2>&1 | tail -n1
 > ```
 
 ## IDE setup

--- a/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/packaging/install/06.Certificate.kroxylicious-webhook.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-kubernetes-web-hook/packaging/install/06.Certificate.kroxylicious-webhook.yaml
@@ -32,10 +32,13 @@ spec:
   issuerRef:
     name: kroxylicious-webhook-selfsigned
     kind: Issuer
+  commonName: kroxylicious-webhook.kroxylicious-webhook.svc.cluster.local
   dnsNames:
     - kroxylicious-webhook
     - kroxylicious-webhook.kroxylicious-webhook
     - kroxylicious-webhook.kroxylicious-webhook.svc
     - kroxylicious-webhook.kroxylicious-webhook.svc.cluster.local
+  privateKey:
+    encoding: PKCS8
   duration: 8760h   # 1 year
   renewBefore: 720h  # 30 days


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The example certificate was not consumable, complaining about "Empty issuer DN not allowed in X509Certificates" in the Webhook. This is resolved by specifying a common name in the Certificate

Then, the default tls.key failed to parse. By default it is emitted as PKCS#1 (starts with -----BEGIN RSA PRIVATE KEY-----). We attempt to parse it as a PKCS8 spec and fail. Java does not have native support for PKCS#1 so we change the Certificate to emit PCKS8

We should follow up with fail-fast on PKCS#1 keys so it's more obvious.

Contributes towards #3890

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
