### PR TITLE
Remove delegated nodeId override on the pod

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-admission/README.md
+++ b/kroxylicious-kubernetes/kroxylicious-admission/README.md
@@ -53,7 +53,6 @@ A namespaced CRD (group `kroxylicious.io`, version `v1alpha1`) that defines side
 | `kroxylicious.io/proxy-config` | Generated proxy YAML (set by webhook) | Webhook |
 | `kroxylicious.io/sidecar-status` | Injection status (set by webhook) | Webhook |
 | `kroxylicious.io/sidecar-bootstrap-port` | Override bootstrap port (if delegated) | App owner |
-| `kroxylicious.io/sidecar-node-id-range` | Override node ID range (if delegated) | App owner |
 
 ## Injection Decision Logic
 

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
@@ -33,7 +33,6 @@ import io.fabric8.kubernetes.api.model.admission.v1.AdmissionReview;
 import io.kroxylicious.kubernetes.api.admission.v1alpha1.KroxyliciousSidecarConfig;
 import io.kroxylicious.kubernetes.api.admission.v1alpha1.KroxyliciousSidecarConfigSpec;
 import io.kroxylicious.kubernetes.api.admission.v1alpha1.KroxyliciousSidecarConfigSpecBuilder;
-import io.kroxylicious.kubernetes.api.admission.v1alpha1.kroxylicioussidecarconfigspec.NodeIdRange;
 import io.kroxylicious.kubernetes.api.admission.v1alpha1.kroxylicioussidecarconfigspec.Plugins;
 import io.kroxylicious.kubernetes.api.admission.v1alpha1.kroxylicioussidecarconfigspec.plugins.Image;
 
@@ -203,8 +202,6 @@ class AdmissionHandler implements HttpHandler {
 
         applyBootstrapPortOverride(podAnnotations, podName, namespace, delegatedSet, effective);
 
-        applyNodeIdRangeOverride(podAnnotations, podName, namespace, delegatedSet, effective);
-
         // Apply delegated plugin images (JSON array of {name, reference} objects)
         applyDelegatedPluginImages(adminSpec, podAnnotations, podName, namespace, delegatedSet, effective);
 
@@ -230,44 +227,6 @@ class AdmissionHandler implements HttpHandler {
         }
     }
 
-    // TODO: Do we really want to support this for the initial feature?
-    private static void applyNodeIdRangeOverride(Map<String, String> podAnnotations,
-                                                 String podName,
-                                                 String namespace,
-                                                 Set<String> delegatedSet,
-                                                 KroxyliciousSidecarConfigSpec effective) {
-        if (delegatedSet.contains(Annotations.DELEGATED_NODE_ID_RANGE)) {
-            String rangeStr = podAnnotations.get(Annotations.DELEGATED_NODE_ID_RANGE);
-            if (rangeStr != null) {
-                String[] parts = rangeStr.split("-", 2);
-                if (parts.length == 2) {
-                    try {
-                        NodeIdRange range = new NodeIdRange();
-                        range.setStartInclusive(Long.parseLong(parts[0]));
-                        range.setEndInclusive(Long.parseLong(parts[1]));
-                        effective.setNodeIdRange(range);
-                    }
-                    catch (NumberFormatException e) {
-                        LOGGER.atWarn()
-                                .addKeyValue(WebhookLoggingKeys.POD, podName)
-                                .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
-                                .addKeyValue(WebhookLoggingKeys.ANNOTATION, Annotations.DELEGATED_NODE_ID_RANGE)
-                                .addKeyValue(WebhookLoggingKeys.ANNOTATION_VALUE, rangeStr)
-                                .log("Invalid node ID range in delegated annotation, using admin default");
-                    }
-                }
-                else {
-                    LOGGER.atWarn()
-                            .addKeyValue(WebhookLoggingKeys.POD, podName)
-                            .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
-                            .addKeyValue(WebhookLoggingKeys.ANNOTATION, Annotations.DELEGATED_NODE_ID_RANGE)
-                            .addKeyValue(WebhookLoggingKeys.ANNOTATION_VALUE, rangeStr)
-                            .log("Invalid node ID range format in delegated annotation (expected start-end), using admin default");
-                }
-            }
-        }
-    }
-
     private static void applyBootstrapPortOverride(Map<String, String> podAnnotations,
                                                    String podName,
                                                    String namespace,
@@ -283,7 +242,7 @@ class AdmissionHandler implements HttpHandler {
                     LOGGER.atWarn()
                             .addKeyValue(WebhookLoggingKeys.POD, podName)
                             .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
-                            .addKeyValue(WebhookLoggingKeys.ANNOTATION, Annotations.DELEGATED_NODE_ID_RANGE)
+                            .addKeyValue(WebhookLoggingKeys.ANNOTATION, Annotations.DELEGATED_BOOTSTRAP_PORT)
                             .addKeyValue(WebhookLoggingKeys.ANNOTATION_VALUE, portStr)
                             .log("Invalid bootstrap port in delegated annotation, using admin default");
                 }

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/Annotations.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/Annotations.java
@@ -52,17 +52,6 @@ final class Annotations {
      */
     static final String DELEGATED_BOOTSTRAP_PORT = "kroxylicious.io/sidecar-bootstrap-port";
 
-    /**
-     * <p>Annotation that app owners may set on the target {@code Pod} to configure
-     * node id range which will be used in the proxy configuration
-     * consumed by the proxy sidecar.</p>
-     *
-     * <p>The ability of the app owner to use this annotation
-     * depends on whether this annotation has been delegatated to them in the
-     * {@ocde MutatingWebhookConfiguration}</p>
-     */
-    static final String DELEGATED_NODE_ID_RANGE = "kroxylicious.io/sidecar-node-id-range";
-
     static final String DELEGATED_PLUGIN_IMAGES = "kroxylicious.io/sidecar-plugin-images";
 
     /** The set of annotations managed by the webhook itself — never treated as undelegated. */

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AdmissionHandlerTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AdmissionHandlerTest.java
@@ -285,22 +285,6 @@ class AdmissionHandlerTest {
     }
 
     @Test
-    void appliesDelegatedNodeIdRange() {
-        KroxyliciousSidecarConfigSpec adminSpec = new KroxyliciousSidecarConfigSpec();
-        adminSpec.setTargetBootstrapServers("kafka:9092");
-        adminSpec.setDelegatedAnnotations(List.of(Annotations.DELEGATED_NODE_ID_RANGE));
-
-        Map<String, String> annotations = Map.of(Annotations.DELEGATED_NODE_ID_RANGE, "0-9");
-
-        KroxyliciousSidecarConfigSpec effective = handler.applyDelegatedOverrides(
-                adminSpec, annotations, "test-pod", "test-ns");
-
-        assertThat(effective.getNodeIdRange()).isNotNull();
-        assertThat(effective.getNodeIdRange().getStartInclusive()).isZero();
-        assertThat(effective.getNodeIdRange().getEndInclusive()).isEqualTo(9L);
-    }
-
-    @Test
     void ignoresUndelegatedAnnotation() {
         KroxyliciousSidecarConfigSpec adminSpec = new KroxyliciousSidecarConfigSpec();
         adminSpec.setTargetBootstrapServers("kafka:9092");
@@ -329,20 +313,6 @@ class AdmissionHandlerTest {
                 adminSpec, annotations, "test-pod", "test-ns");
 
         assertThat(effective.getBootstrapPort()).isEqualTo(19092L);
-    }
-
-    @Test
-    void ignoresInvalidNodeIdRangeFormat() {
-        KroxyliciousSidecarConfigSpec adminSpec = new KroxyliciousSidecarConfigSpec();
-        adminSpec.setTargetBootstrapServers("kafka:9092");
-        adminSpec.setDelegatedAnnotations(List.of(Annotations.DELEGATED_NODE_ID_RANGE));
-
-        Map<String, String> annotations = Map.of(Annotations.DELEGATED_NODE_ID_RANGE, "invalid");
-
-        KroxyliciousSidecarConfigSpec effective = handler.applyDelegatedOverrides(
-                adminSpec, annotations, "test-pod", "test-ns");
-
-        assertThat(effective.getNodeIdRange()).isNull();
     }
 
     // --- Phase 4: Delegated plugin images ---


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

The target topology is a concern of the admission webhook admin, not the application owner. Unclear why they would want to override it at the pod level.

Contributes towards #3890

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
