### PR TITLE
fix(webhook): fail fast when TLS key is PKCS1 format

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookServer.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookServer.java
@@ -114,14 +114,18 @@ class WebhookServer implements Closeable {
     @NonNull
     private static PrivateKey loadPrivateKey(@NonNull Path keyPath) throws IOException, GeneralSecurityException {
         String keyPem = Files.readString(keyPath);
+
+        // Detect PKCS1 format and fail fast
+        if (keyPem.contains("-----BEGIN RSA PRIVATE KEY-----") || keyPem.contains("-----BEGIN EC PRIVATE KEY-----")) {
+            throw new GeneralSecurityException("Private key at " + keyPath + " is in PKCS1 format, which is not supported." +
+                    "The only supported format is PKCS8. (if you are using cert-manager, you can set 'spec.privateKey.encoding' "
+                    + "on your Certificate to 'PKCS8')");
+        }
+
         // Strip PEM headers/footers and whitespace
         String keyBase64 = keyPem
                 .replace("-----BEGIN PRIVATE KEY-----", "")
                 .replace("-----END PRIVATE KEY-----", "")
-                .replace("-----BEGIN RSA PRIVATE KEY-----", "")
-                .replace("-----END RSA PRIVATE KEY-----", "")
-                .replace("-----BEGIN EC PRIVATE KEY-----", "")
-                .replace("-----END EC PRIVATE KEY-----", "")
                 .replaceAll("\\s", "");
 
         byte[] keyBytes = Base64.getDecoder().decode(keyBase64);

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/WebhookServerTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/WebhookServerTest.java
@@ -116,13 +116,45 @@ class WebhookServerTest {
         Path badKey = tempDir.resolve("bad.pem");
         byte[] randomBytes = new byte[64];
         new SecureRandom().nextBytes(randomBytes);
-        String badPem = "-----BEGIN PRIVATE KEY-----\n"
-                + Base64.getEncoder().encodeToString(randomBytes)
-                + "\n-----END PRIVATE KEY-----\n";
+        String badPem = """
+                -----BEGIN PRIVATE KEY-----
+                %s
+                -----END PRIVATE KEY-----
+                """.formatted(Base64.getEncoder().encodeToString(randomBytes));
         Files.writeString(badKey, badPem);
 
         assertThatThrownBy(() -> WebhookServer.createSslContext(certPath, badKey))
                 .isInstanceOf(GeneralSecurityException.class);
+    }
+
+    @Test
+    void createSslContextThrowsForPkcs1RsaKey(@TempDir Path tempDir) throws Exception {
+        Path pkcs1Key = tempDir.resolve("pkcs1-rsa.pem");
+        String pkcs1Pem = """
+                -----BEGIN RSA PRIVATE KEY-----
+                MIIEpAIBAAKCAQEA...
+                -----END RSA PRIVATE KEY-----
+                """;
+        Files.writeString(pkcs1Key, pkcs1Pem);
+
+        assertThatThrownBy(() -> WebhookServer.createSslContext(certPath, pkcs1Key))
+                .isInstanceOf(GeneralSecurityException.class)
+                .hasMessageContaining("is in PKCS1 format, which is not supported");
+    }
+
+    @Test
+    void createSslContextThrowsForPkcs1EcKey(@TempDir Path tempDir) throws Exception {
+        Path pkcs1Key = tempDir.resolve("pkcs1-ec.pem");
+        String pkcs1Pem = """
+                -----BEGIN EC PRIVATE KEY-----
+                MHcCAQEEIIGlRDpz...
+                -----END EC PRIVATE KEY-----
+                """;
+        Files.writeString(pkcs1Key, pkcs1Pem);
+
+        assertThatThrownBy(() -> WebhookServer.createSslContext(certPath, pkcs1Key))
+                .isInstanceOf(GeneralSecurityException.class)
+                .hasMessageContaining("is in PKCS1 format, which is not supported");
     }
 
     // --- Server lifecycle tests ---


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Java's KeyFactory cannot parse PKCS1-encoded private keys (those with BEGIN RSA PRIVATE KEY or BEGIN EC PRIVATE KEY headers). Previously, the webhook would strip these headers and attempt PKCS8 parsing, leading to cryptic errors at runtime.

Now the webhook detects PKCS1 format during startup and fails with a clear error message.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>

Contributes towards #3890

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
