### PR TITLE
feat(admission): default to fail-closed with configurable failure policy

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-admission/CLAUDE.md
+++ b/kroxylicious-kubernetes/kroxylicious-admission/CLAUDE.md
@@ -9,12 +9,12 @@ See [README.md](README.md) for comprehensive webhook documentation including:
 - Injection decision logic
 - Delegated annotations
 - Native sidecar support (K8s 1.28+)
-- Fail-open semantics
+- Failure policy (fail-closed by default, configurable)
 - Key classes and configuration
 
 ## Critical Constraints
 
-**Fail-open**: The webhook must always return `allowed: true`. Never reject a pod admission request, even on internal errors.
+**Fail-closed by default**: On internal errors, the webhook denies the admission request. This is configurable via the `FAILURE_POLICY` environment variable (`Fail` or `Ignore`). Non-error paths (null request, null pod, opt-out, no config, already injected) always return `allowed: true` regardless of the failure policy.
 
 **Trust model**: The webhook administrator does not trust the application pod owner. The webhook always overwrites the proxy config annotation. Non-delegated annotations in the `kroxylicious.io/` namespace are ignored.
 
@@ -23,7 +23,7 @@ See [README.md](README.md) for comprehensive webhook documentation including:
 ## For Claude
 
 When working with this module:
-- Follow fail-open semantics in error handling
+- Error paths use `errorResponse()` which delegates to `denyResponse()` or `allowResponse()` based on `failClosed`
 - Never allow app owners to control the proxy image, security context, or target cluster address
 - Delegated annotations must be explicitly listed in `KroxyliciousSidecarConfig`
 - The proxy config YAML is generated using the same `Configuration` model from `kroxylicious-runtime`

--- a/kroxylicious-kubernetes/kroxylicious-admission/README.md
+++ b/kroxylicious-kubernetes/kroxylicious-admission/README.md
@@ -72,9 +72,13 @@ The admin can list annotation keys in `delegatedAnnotations` to allow app owners
 
 On Kubernetes 1.28+, the webhook injects the sidecar as an init container with `restartPolicy: Always` (native sidecar). This ensures proper startup ordering (sidecar starts before app containers) and shutdown ordering (sidecar stops after). On older clusters, the sidecar is injected as a regular container. The webhook auto-detects the cluster version at startup.
 
-## Fail-Open Semantics
+## Failure Policy
 
-The webhook always returns `allowed: true`, even on internal errors. If the webhook is unavailable, the `MutatingWebhookConfiguration` uses `failurePolicy: Ignore` so pods are created without sidecars. This is the standard approach for sidecar injection webhooks.
+By default, the webhook is **fail-closed**: on internal errors, it denies the admission request, and if the webhook is unreachable, the `MutatingWebhookConfiguration` uses `failurePolicy: Fail` to block pod creation. This is the standard approach for sidecar injection webhooks (consistent with Istio and Linkerd).
+
+Non-error paths (null request, null pod, opt-out, no config found, already injected) always allow the pod regardless of failure policy.
+
+The failure policy is configurable via the `FAILURE_POLICY` environment variable on the webhook `Deployment`. To opt into fail-open behaviour, set `FAILURE_POLICY=Ignore` in the `Deployment` **and** change `failurePolicy: Ignore` in the `MutatingWebhookConfiguration`. The environment variable controls the webhook's response to internal errors; the `MutatingWebhookConfiguration` `failurePolicy` controls the API server's behaviour when the webhook is unreachable.
 
 ## Key Classes
 
@@ -98,10 +102,11 @@ The webhook is configured via environment variables:
 | `TLS_CERT_PATH` | `/etc/webhook/tls/tls.crt` | PEM certificate file |
 | `TLS_KEY_PATH` | `/etc/webhook/tls/tls.key` | PEM private key file |
 | `KROXYLICIOUS_IMAGE` | (required) | Default proxy container image |
+| `FAILURE_POLICY` | `Fail` | Error handling policy: `Fail` (deny on error) or `Ignore` (allow on error) |
 
 ## Deployment
 
-Install manifests are in `packaging/install/`. They include namespace, RBAC, deployment, service, `MutatingWebhookConfiguration`, and cert-manager resources.
+Install manifests are in `packaging/install/`. They include namespace, RBAC, deployment, service, `MutatingWebhookConfiguration`, `PodDisruptionBudget`, and cert-manager resources. The deployment runs 2 replicas with pod anti-affinity and a PDB to ensure availability during voluntary disruptions.
 
 **With cert-manager:**
 ```bash

--- a/kroxylicious-kubernetes/kroxylicious-admission/packaging/install/03.Deployment.kroxylicious-webhook.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/packaging/install/03.Deployment.kroxylicious-webhook.yaml
@@ -13,8 +13,7 @@ metadata:
     app.kubernetes.io/name: kroxylicious
     app.kubernetes.io/component: webhook
 spec:
-  replicas: 1
-  # TODO single replica, maybe okay for alpha, but better to have >1 and a PodDisruptionBudget to prevent them all being evicted simultaneously
+  replicas: 2
   selector:
     matchLabels:
       app: kroxylicious-webhook
@@ -26,6 +25,15 @@ spec:
         app.kubernetes.io/component: webhook
     spec:
       serviceAccountName: kroxylicious-webhook
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: kroxylicious-webhook
+                topologyKey: kubernetes.io/hostname
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -44,6 +52,8 @@ spec:
               value: /etc/webhook/tls/tls.crt
             - name: TLS_KEY_PATH
               value: /etc/webhook/tls/tls.key
+            - name: FAILURE_POLICY
+              value: "Fail"
           volumeMounts:
             - name: tls
               mountPath: /etc/webhook/tls

--- a/kroxylicious-kubernetes/kroxylicious-admission/packaging/install/03.PodDisruptionBudget.kroxylicious-webhook.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/packaging/install/03.PodDisruptionBudget.kroxylicious-webhook.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: kroxylicious-webhook
+  namespace: kroxylicious-webhook
+  labels:
+    app.kubernetes.io/name: kroxylicious
+    app.kubernetes.io/component: webhook
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: kroxylicious-webhook

--- a/kroxylicious-kubernetes/kroxylicious-admission/packaging/install/05.MutatingWebhookConfiguration.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/packaging/install/05.MutatingWebhookConfiguration.yaml
@@ -18,9 +18,8 @@ webhooks:
   - name: sidecar-injector.kroxylicious.io
     admissionReviewVersions: ["v1"]
     sideEffects: None
-    # Fail-open: if the webhook is unavailable, pods are created without sidecars
-    failurePolicy: Ignore
-    # TODO fail closed by default
+    # Fail-closed: if the webhook is unavailable, pod creation is blocked
+    failurePolicy: Fail
     reinvocationPolicy: IfNeeded
     timeoutSeconds: 10
     clientConfig:

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
@@ -26,6 +26,7 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionRequest;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionResponse;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionReview;
@@ -52,21 +53,24 @@ class AdmissionHandler implements HttpHandler {
     private final String proxyImage;
     private final boolean useNativeSidecar;
     private final boolean useOciImageVolumes;
+    private final boolean failClosed;
 
     AdmissionHandler(
                      @NonNull SidecarConfigResolver configResolver,
                      @NonNull String proxyImage,
-                     KubernetesVersion kubernetesVersion) {
+                     KubernetesVersion kubernetesVersion,
+                     boolean failClosed) {
         this.configResolver = configResolver;
         this.proxyImage = proxyImage;
         this.useNativeSidecar = kubernetesVersion.supportedNativeSidecar();
         this.useOciImageVolumes = kubernetesVersion.supportsOciImageVolumes();
+        this.failClosed = failClosed;
     }
 
     AdmissionHandler(
                      @NonNull SidecarConfigResolver configResolver,
                      @NonNull String proxyImage) {
-        this(configResolver, proxyImage, new KubernetesVersion(1, 0));
+        this(configResolver, proxyImage, new KubernetesVersion(1, 0), true);
     }
 
     @Override
@@ -82,7 +86,6 @@ class AdmissionHandler implements HttpHandler {
                 review = MAPPER.readValue(is, AdmissionReview.class);
             }
 
-            // TODO the below code share a lot of statements in common with sendAllowResponse()
             AdmissionResponse response = processReview(review);
             AdmissionReview responseReview = new AdmissionReview();
             responseReview.setApiVersion("admission.k8s.io/v1");
@@ -100,8 +103,7 @@ class AdmissionHandler implements HttpHandler {
             LOGGER.atError()
                     .setCause(e)
                     .log("Unexpected error handling admission request");
-            sendAllowResponse(exchange, null);
-            // TODO this will need to change when we default to fail closed.
+            sendErrorResponse(exchange, null, "Failed to process admission request");
         }
         finally {
             exchange.close();
@@ -169,8 +171,8 @@ class AdmissionHandler implements HttpHandler {
             LOGGER.atError()
                     .setCause(e)
                     .addKeyValue("uid", uid)
-                    .log("Error processing admission request, allowing pod without sidecar");
-            return allowResponse(uid);
+                    .log("Error processing admission request");
+            return errorResponse(uid, "Error processing admission request: " + e.getMessage());
         }
     }
 
@@ -413,12 +415,34 @@ class AdmissionHandler implements HttpHandler {
         return response;
     }
 
-    private void sendAllowResponse(HttpExchange exchange, String uid) {
+    @NonNull
+    private static AdmissionResponse denyResponse(String uid, String reason) {
+        AdmissionResponse response = new AdmissionResponse();
+        response.setUid(uid != null ? uid : UUID.randomUUID().toString());
+        response.setAllowed(false);
+        Status status = new Status();
+        status.setCode(403);
+        status.setMessage(reason);
+        status.setReason("Forbidden");
+        status.setStatus("Failure");
+        response.setStatus(status);
+        return response;
+    }
+
+    @NonNull
+    private AdmissionResponse errorResponse(String uid, String reason) {
+        if (failClosed) {
+            return denyResponse(uid, reason);
+        }
+        return allowResponse(uid);
+    }
+
+    private void sendErrorResponse(HttpExchange exchange, String uid, String reason) {
         try {
             AdmissionReview responseReview = new AdmissionReview();
             responseReview.setApiVersion("admission.k8s.io/v1");
             responseReview.setKind("AdmissionReview");
-            responseReview.setResponse(allowResponse(uid));
+            responseReview.setResponse(errorResponse(uid, reason));
             byte[] responseBytes = MAPPER.writeValueAsBytes(responseReview);
             exchange.getResponseHeaders().set("Content-Type", "application/json");
             exchange.sendResponseHeaders(200, responseBytes.length);

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
@@ -36,6 +36,7 @@ public class WebhookMain {
     private static final String TLS_CERT_PATH_VAR = "TLS_CERT_PATH";
     private static final String TLS_KEY_PATH_VAR = "TLS_KEY_PATH";
     private static final String KROXYLICIOUS_IMAGE_VAR = "KROXYLICIOUS_IMAGE";
+    private static final String FAILURE_POLICY_VAR = "FAILURE_POLICY";
 
     private static final String DEFAULT_BIND_ADDRESS = "0.0.0.0:8443";
     @SuppressWarnings("java:S1075") // there's nothing wrong with hard coding this path.
@@ -83,13 +84,17 @@ public class WebhookMain {
         Path certPath = Path.of(env.getOrDefault(TLS_CERT_PATH_VAR, DEFAULT_CERT_PATH));
         Path keyPath = Path.of(env.getOrDefault(TLS_KEY_PATH_VAR, DEFAULT_KEY_PATH));
         String proxyImage = requiredEnv(env, KROXYLICIOUS_IMAGE_VAR);
+        boolean failClosed = parseFailClosed(env);
+        LOGGER.atInfo()
+                .addKeyValue("failurePolicy", failClosed ? "Fail" : "Ignore")
+                .log("Webhook failure policy configured");
 
         KubernetesClient kubeClient = new KubernetesClientBuilder().build();
         var kubernetesVersion = detectVersion(kubeClient);
         SidecarConfigStatusUpdater statusUpdater = new SidecarConfigStatusUpdater(kubeClient, Clock.systemUTC());
         SidecarConfigResolver configResolver = new SidecarConfigResolver(kubeClient, statusUpdater);
         AdmissionHandler admissionHandler = new AdmissionHandler(
-                configResolver, proxyImage, kubernetesVersion);
+                configResolver, proxyImage, kubernetesVersion, failClosed);
         WebhookServer server = new WebhookServer(bindAddress, certPath, keyPath, admissionHandler);
 
         return new WebhookMain(server, configResolver, kubeClient);
@@ -169,5 +174,17 @@ public class WebhookMain {
             throw new IllegalStateException("Required environment variable " + name + " is not set");
         }
         return value;
+    }
+
+    @VisibleForTesting
+    static boolean parseFailClosed(@NonNull Map<String, String> env) {
+        String value = env.getOrDefault(FAILURE_POLICY_VAR, "Fail");
+        return switch (value) {
+            case "Fail" -> true;
+            case "Ignore" -> false;
+            default -> throw new IllegalStateException(
+                    "Invalid " + FAILURE_POLICY_VAR + " value '" + value
+                            + "': must be 'Fail' or 'Ignore'");
+        };
     }
 }

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractWebhookInstallKT.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractWebhookInstallKT.java
@@ -30,6 +30,7 @@ import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 
 import io.kroxylicious.kubernetes.api.admission.common.Condition;
 import io.kroxylicious.kubernetes.api.admission.v1alpha1.KroxyliciousSidecarConfig;
@@ -37,6 +38,7 @@ import io.kroxylicious.kubernetes.api.admission.v1alpha1.KroxyliciousSidecarConf
 import io.kroxylicious.test.ShellUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
@@ -76,6 +78,7 @@ abstract class AbstractWebhookInstallKT {
             createTestNamespaceAndConfig();
             verifyInjection();
             verifyOptOut();
+            verifyFailClosed();
         }
         finally {
             cleanup();
@@ -311,6 +314,67 @@ abstract class AbstractWebhookInstallKT {
                 .doesNotContain("kroxylicious-proxy");
 
         LOGGER.info("Opt-out verified successfully");
+    }
+
+    private void verifyFailClosed() {
+        LOGGER.info("Scaling webhook deployment to 0 replicas to verify fail-closed behaviour");
+        client.apps().deployments()
+                .inNamespace(WEBHOOK_NS)
+                .withName("kroxylicious-webhook")
+                .scale(0);
+
+        client.apps().deployments()
+                .inNamespace(WEBHOOK_NS)
+                .withName("kroxylicious-webhook")
+                .waitUntilCondition(
+                        d -> d != null
+                                && d.getStatus() != null
+                                && (d.getStatus().getReadyReplicas() == null
+                                        || d.getStatus().getReadyReplicas() == 0),
+                        60, TimeUnit.SECONDS);
+
+        // Wait for the Service endpoints to be drained so the API server
+        // considers the webhook unreachable
+        client.endpoints()
+                .inNamespace(WEBHOOK_NS)
+                .withName("kroxylicious-webhook")
+                .waitUntilCondition(
+                        ep -> ep == null
+                                || ep.getSubsets() == null
+                                || ep.getSubsets().isEmpty()
+                                || ep.getSubsets().stream()
+                                        .allMatch(s -> s.getAddresses() == null
+                                                || s.getAddresses().isEmpty()),
+                        60, TimeUnit.SECONDS);
+
+        LOGGER.info("Webhook scaled to 0, attempting pod creation (expecting rejection)");
+        var pod = new PodBuilder()
+                .withNewMetadata()
+                .withName("test-app-fail-closed")
+                .withNamespace(TEST_NS)
+                .endMetadata()
+                .withNewSpec()
+                .withTerminationGracePeriodSeconds(0L)
+                .addNewContainer()
+                .withName("app")
+                .withImage("busybox:latest")
+                .withCommand("sleep", "3600")
+                .endContainer()
+                .endSpec()
+                .build();
+
+        assertThatThrownBy(() -> client.resource(pod).create())
+                .isInstanceOf(KubernetesClientException.class)
+                .hasMessageContaining("sidecar-injector.kroxylicious.io");
+
+        LOGGER.info("Fail-closed verified: pod creation rejected when webhook unavailable");
+
+        LOGGER.info("Scaling webhook back to 2 replicas");
+        client.apps().deployments()
+                .inNamespace(WEBHOOK_NS)
+                .withName("kroxylicious-webhook")
+                .scale(2);
+        waitForWebhookReady();
     }
 
     private void cleanup() {

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AdmissionHandlerTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AdmissionHandlerTest.java
@@ -57,10 +57,13 @@ class AdmissionHandlerTest {
     private SidecarConfigResolver configResolver;
 
     private AdmissionHandler handler;
+    private AdmissionHandler failOpenHandler;
 
     @BeforeEach
     void setUp() {
         handler = new AdmissionHandler(configResolver, PROXY_IMAGE);
+        failOpenHandler = new AdmissionHandler(configResolver, PROXY_IMAGE,
+                new KubernetesVersion(1, 0), false);
     }
 
     // --- processReview() tests ---
@@ -151,14 +154,41 @@ class AdmissionHandlerTest {
     }
 
     @Test
-    void failsOpenOnException() {
+    void failsClosedOnExceptionByDefault() {
         when(configResolver.resolve(any(), isNull())).thenThrow(new RuntimeException("kaboom"));
 
         AdmissionReview review = reviewWithPod(minimalPod(), "test-ns");
         AdmissionResponse response = handler.processReview(review);
 
+        assertThat(response.getAllowed()).isFalse();
+        assertThat(response.getStatus()).isNotNull();
+        assertThat(response.getStatus().getMessage()).contains("kaboom");
+        assertThat(response.getPatch()).isNull();
+    }
+
+    @Test
+    void failsOpenOnExceptionWhenConfigured() {
+        when(configResolver.resolve(any(), isNull())).thenThrow(new RuntimeException("kaboom"));
+
+        AdmissionReview review = reviewWithPod(minimalPod(), "test-ns");
+        AdmissionResponse response = failOpenHandler.processReview(review);
+
         assertThat(response.getAllowed()).isTrue();
         assertThat(response.getPatch()).isNull();
+    }
+
+    @Test
+    void denyResponseIncludesStatusDetails() {
+        when(configResolver.resolve(any(), isNull())).thenThrow(new RuntimeException("test error"));
+
+        AdmissionReview review = reviewWithPod(minimalPod(), "test-ns");
+        AdmissionResponse response = handler.processReview(review);
+
+        assertThat(response.getAllowed()).isFalse();
+        assertThat(response.getStatus()).isNotNull();
+        assertThat(response.getStatus().getCode()).isEqualTo(403);
+        assertThat(response.getStatus().getReason()).isEqualTo("Forbidden");
+        assertThat(response.getStatus().getMessage()).contains("test error");
     }
 
     @Test
@@ -238,10 +268,39 @@ class AdmissionHandlerTest {
     }
 
     @Test
-    void handleFailsOpenOnDeserialisationError() throws IOException {
+    void handleFailsClosedOnDeserialisationError() throws IOException {
         HttpExchange exchange = createMockExchange("POST", "not json".getBytes(StandardCharsets.UTF_8));
 
         handler.handle(exchange);
+
+        ByteArrayOutputStream responseBody = (ByteArrayOutputStream) exchange.getResponseBody();
+        JsonNode responseJson = MAPPER.readTree(responseBody.toByteArray());
+
+        assertThat(responseJson.get("response").get("allowed").asBoolean()).isFalse();
+        assertThat(responseJson.get("response").get("status").get("message").asText()).isNotEmpty();
+    }
+
+    @Test
+    void handleFailsClosedOnProcessReviewException() throws IOException {
+        when(configResolver.resolve(any(), isNull())).thenThrow(new RuntimeException("kaboom"));
+
+        AdmissionReview review = reviewWithPod(minimalPod(), "test-ns");
+        byte[] requestBody = MAPPER.writeValueAsBytes(review);
+        HttpExchange exchange = createMockExchange("POST", requestBody);
+
+        handler.handle(exchange);
+
+        ByteArrayOutputStream responseBody = (ByteArrayOutputStream) exchange.getResponseBody();
+        JsonNode responseJson = MAPPER.readTree(responseBody.toByteArray());
+
+        assertThat(responseJson.get("response").get("allowed").asBoolean()).isFalse();
+    }
+
+    @Test
+    void handleFailsOpenOnDeserialisationErrorWhenConfigured() throws IOException {
+        HttpExchange exchange = createMockExchange("POST", "not json".getBytes(StandardCharsets.UTF_8));
+
+        failOpenHandler.handle(exchange);
 
         ByteArrayOutputStream responseBody = (ByteArrayOutputStream) exchange.getResponseBody();
         JsonNode responseJson = MAPPER.readTree(responseBody.toByteArray());
@@ -250,14 +309,14 @@ class AdmissionHandlerTest {
     }
 
     @Test
-    void handleFailsOpenOnProcessReviewException() throws IOException {
+    void handleFailsOpenOnProcessReviewExceptionWhenConfigured() throws IOException {
         when(configResolver.resolve(any(), isNull())).thenThrow(new RuntimeException("kaboom"));
 
         AdmissionReview review = reviewWithPod(minimalPod(), "test-ns");
         byte[] requestBody = MAPPER.writeValueAsBytes(review);
         HttpExchange exchange = createMockExchange("POST", requestBody);
 
-        handler.handle(exchange);
+        failOpenHandler.handle(exchange);
 
         ByteArrayOutputStream responseBody = (ByteArrayOutputStream) exchange.getResponseBody();
         JsonNode responseJson = MAPPER.readTree(responseBody.toByteArray());

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/WebhookMainTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/WebhookMainTest.java
@@ -134,6 +134,42 @@ class WebhookMainTest {
         assertThat(value).isEqualTo("my-image:latest");
     }
 
+    // --- parseFailClosed tests ---
+
+    @Test
+    void parseFailClosedDefaultsToTrue() {
+        boolean result = WebhookMain.parseFailClosed(Map.of());
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void parseFailClosedReturnsTrueForFail() {
+        boolean result = WebhookMain.parseFailClosed(Map.of("FAILURE_POLICY", "Fail"));
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void parseFailClosedReturnsFalseForIgnore() {
+        boolean result = WebhookMain.parseFailClosed(Map.of("FAILURE_POLICY", "Ignore"));
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void parseFailClosedThrowsForInvalidValue() {
+        assertThatThrownBy(() -> WebhookMain.parseFailClosed(
+                Map.of("FAILURE_POLICY", "invalid")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("FAILURE_POLICY")
+                .hasMessageContaining("invalid");
+    }
+
+    @Test
+    void parseFailClosedIsCaseSensitive() {
+        assertThatThrownBy(() -> WebhookMain.parseFailClosed(
+                Map.of("FAILURE_POLICY", "fail")))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
     // --- create() environment variable tests ---
 
     @Test


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

The webhook now denies admission requests on internal errors by default (fail-closed), matching the convention used by Istio and Linkerd. Administrators can opt back into fail-open by setting FAILURE_POLICY=Ignore on the Deployment and failurePolicy: Ignore on the MutatingWebhookConfiguration.

The Deployment now runs 2 replicas with pod anti-affinity and a PodDisruptionBudget (maxUnavailable: 1) to maintain availability during voluntary disruptions.

Includes a KT integration test that verifies pod creation is rejected when the webhook is unreachable.

Contributes towards #3890

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>