### PR TITLE
ci(docker): build admission webhook image in docker workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,9 +1,11 @@
-# docker.yaml - builds and pushes a kroxylicious container image.
+# docker.yaml - builds and pushes kroxylicious container images.
 #
 # Requires repository variables:
 # - REGISTRY_SERVER - the server of the container registry service e.g. `quay.io` or `docker.io`
 # - REGISTRY_USERNAME - your username on the service (or username of your robot account)
-# - REGISTRY_DESTINATION - the push destination (without tag portion) e.g. `quay.io/<my org>/kroxylicious`
+# - PROXY_IMAGE_NAME - the proxy image name (without tag)
+# - OPERATOR_IMAGE_NAME - the operator image name (without tag)
+# - ADMISSION_IMAGE_NAME - the admission webhook image name (without tag)
 # and a repository secret
 # - REGISTRY_TOKEN - the access token that corresponds to `REGISTRY_USERNAME`
 #
@@ -58,13 +60,16 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" || "${{ vars.REGISTRY_SERVER }}" == "" ]]; then
             echo "proxy_tags=kroxylicious-proxy:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
             echo "operator_tags=kroxylicious-operator:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+            echo "admission_tags=kroxylicious-admission:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
             echo "push_images=false" >> $GITHUB_OUTPUT
             echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
           else
             PROXY_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.PROXY_IMAGE_NAME }}"
             OPERATOR_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.OPERATOR_IMAGE_NAME }}"
+            ADMISSION_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.ADMISSION_IMAGE_NAME }}"
             echo "proxy_tags=${PROXY_IMAGE}:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
             echo "operator_tags=${OPERATOR_IMAGE}:${RELEASE_VERSION},${OPERATOR_IMAGE}:latest" >> $GITHUB_OUTPUT
+            echo "admission_tags=${ADMISSION_IMAGE}:${RELEASE_VERSION},${ADMISSION_IMAGE}:latest" >> $GITHUB_OUTPUT
             echo "push_images=true" >> $GITHUB_OUTPUT
             echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
           fi
@@ -75,7 +80,7 @@ jobs:
             --batch-mode \
             --activate-profiles 'dist,!qa' \
             --also-make \
-            --projects :kroxylicious-app,:kroxylicious-operator,:kroxylicious-operator-dist \
+            --projects :kroxylicious-app,:kroxylicious-operator,:kroxylicious-operator-dist,:kroxylicious-admission \
             -Derrorprone.skip=true \
             -DskipTests \
             -Dmaven.javadoc.skip=true \
@@ -116,6 +121,20 @@ jobs:
           tags: ${{ steps.build_configuration.outputs.operator_tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max,compression=zstd
+
+      - name: Build and maybe push Admission webhook image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
+        with:
+          context: ./kroxylicious-kubernetes/kroxylicious-admission
+          file: ./kroxylicious-kubernetes/kroxylicious-admission/src/main/docker/webhook.dockerfile
+          platforms: ${{ steps.build_configuration.outputs.platforms }}
+          push: ${{ steps.build_configuration.outputs.push_images == 'true' }}
+          build-args: |
+            KROXYLICIOUS_VERSION=${{ steps.build_configuration.outputs.release_version }}
+          tags: ${{ steps.build_configuration.outputs.admission_tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max,compression=zstd
+
       - name: Slack Notification on Failure
         if: failure() && env.SLACK_WEBHOOK_SET == 'true' && github.event_name == 'push'
         uses: ./.github/actions/common/slack-notification


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds admission webhook Docker image building to the docker.yaml workflow, following the same pattern used for the operator image. The workflow now:
- Builds kroxylicious-admission Maven artifacts
- Configures admission_tags for both PR and push builds
- Builds and optionally pushes the webhook image to the registry

This requires the ADMISSION_IMAGE_NAME repository variable to be configured for pushing to registries.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>

Contributes towards #3890
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
