### PR TITLE
build(admission): add distribution module for release artifacts

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-admission-dist/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-admission-dist/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.kroxylicious</groupId>
+        <artifactId>kroxylicious-kubernetes-parent</artifactId>
+        <version>0.21.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kroxylicious-admission-dist</artifactId>
+    <name>Kubernetes Admission Webhook distribution</name>
+    <description>Assembles the admission webhook assets for release</description>
+    <packaging>pom</packaging>
+
+    <properties>
+        <errorprone.skip>true</errorprone.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.kroxylicious</groupId>
+            <artifactId>kroxylicious-admission</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>dist</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>admission-asset</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <appendAssemblyId>false</appendAssemblyId>
+                                    <finalName>kroxylicious-admission-${project.version}</finalName>
+                                    <descriptors>
+                                        <!-- Custom assembly descriptor -->
+                                        <descriptor>src/assembly/asset.xml</descriptor>
+                                    </descriptors>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/kroxylicious-kubernetes/kroxylicious-admission-dist/src/assembly/asset.xml
+++ b/kroxylicious-kubernetes/kroxylicious-admission-dist/src/assembly/asset.xml
@@ -17,7 +17,7 @@
     <includeBaseDirectory>false</includeBaseDirectory>
     <fileSets>
         <fileSet>
-            <directory>${project.basedir}/..</directory>
+            <directory>${project.basedir}/../..</directory>
             <outputDirectory>/</outputDirectory>
             <includes>
                 <include>LICENSE</include>

--- a/kroxylicious-kubernetes/kroxylicious-admission-dist/src/assembly/asset.xml
+++ b/kroxylicious-kubernetes/kroxylicious-admission-dist/src/assembly/asset.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 https://maven.apache.org/xsd/assembly-2.2.0.xsd">
+    <id>asset</id>
+    <formats>
+        <format>zip</format>
+        <format>tar.gz</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}/..</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>LICENSE</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/../kroxylicious-admission/target/packaged</directory>
+            <outputDirectory>/</outputDirectory>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/kroxylicious-kubernetes/kroxylicious-admission/package_crds.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/package_crds.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS org.yaml:snakeyaml:2.2
+
+import java.io.*;
+import java.nio.file.*;
+import java.util.*;
+import org.yaml.snakeyaml.Yaml;
+
+public class package_crds {
+    public static void main(String[] args) throws IOException {
+        if (args.length != 2) {
+            System.out.println("Usage: jbang package_crds.java SOURCEDIR TARGETDIR");
+            System.exit(1);
+        }
+
+        var sourceDir = Path.of(args[0]);
+        if (!Files.exists(sourceDir)) {
+            System.out.println("[package_crds.java] SOURCEDIR '" + sourceDir + "' does not exist");
+            System.exit(1);
+        }
+        var targetDir = Path.of(args[1]);
+
+        Files.createDirectories(targetDir);
+        var yaml = new Yaml();
+
+        try (var stream = Files.list(sourceDir)) {
+            stream.filter(path -> path.toString().endsWith(".yaml") || path.toString().endsWith(".yml"))
+                    .forEach(path -> {
+                        try (var reader = Files.newBufferedReader(path)) {
+                            String singular;
+                            String kind;
+                            if (yaml.load(reader) instanceof Map<?, ?> data) {
+                                kind = kind(data);
+                                singular = singular(data);
+                            } else {
+                                throw new IOException("YAML was not an object");
+                            }
+                            var target = targetDir.resolve("00." + kind + "." + singular + ".yaml");
+                            Files.copy(path, target, StandardCopyOption.REPLACE_EXISTING);
+                            System.out.println("Copied to " + target);
+                        } catch (IOException e) {
+                            throw new UncheckedIOException("With file " + path, e);
+                        }
+                    });
+        }
+    }
+
+    private static String kind(Map<?, ?> data) throws IOException {
+        if (data.get("kind") instanceof String kind) {
+            return kind;
+        }
+        throw new IOException("YAML lacks .kind, or it is not an string");
+    }
+
+    private static String singular(Map<?, ?> data) throws IOException {
+        if (data.get("spec") instanceof Map<?, ?> spec) {
+            if (spec.get("names") instanceof Map<?, ?> names) {
+                if (names.get("singular") instanceof String singular) {
+                    return singular;
+                }
+                throw new IOException("YAML lacks .spec.names.singular, or it is not a string");
+            }
+            throw new IOException("YAML lacks .spec.names, or it is not an object");
+        }
+        throw new IOException("YAML lacks .spec, or it is not an object");
+    }
+}

--- a/kroxylicious-kubernetes/kroxylicious-admission/pom.xml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/pom.xml
@@ -402,6 +402,31 @@
                         </executions>
                     </plugin>
                     <plugin>
+                        <groupId>dev.jbang</groupId>
+                        <artifactId>jbang-maven-plugin</artifactId>
+                        <executions>
+                            <!-- Add the crds to target/packaged/install, renaming the files to match the other YAMLs -->
+                            <execution>
+                                <id>rename-crds</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <!-- jbang plugin has a somewhat funky handling of cwd, https://github.com/jbangdev/jbang/issues/2062 -->
+                                    <!--suppress UnresolvedMavenProperty -->
+                                    <script>${rootdir}/kroxylicious-kubernetes/kroxylicious-admission/package_crds.java</script>
+                                    <args>
+                                        <!--suppress UnresolvedMavenProperty -->
+                                        <arg>${rootdir}/kroxylicious-kubernetes/kroxylicious-admission-api/src/main/resources/META-INF/fabric8</arg>
+                                        <!--suppress UnresolvedMavenProperty -->
+                                        <arg>${rootdir}/kroxylicious-kubernetes/kroxylicious-admission/target/packaged/install</arg>
+                                    </args>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <executions>
                             <execution>

--- a/kroxylicious-kubernetes/kroxylicious-operator-dist/src/assembly/asset.xml
+++ b/kroxylicious-kubernetes/kroxylicious-operator-dist/src/assembly/asset.xml
@@ -17,7 +17,7 @@
     <includeBaseDirectory>false</includeBaseDirectory>
     <fileSets>
         <fileSet>
-            <directory>${project.basedir}/..</directory>
+            <directory>${project.basedir}/../..</directory>
             <outputDirectory>/</outputDirectory>
             <includes>
                 <include>LICENSE</include>

--- a/kroxylicious-kubernetes/pom.xml
+++ b/kroxylicious-kubernetes/pom.xml
@@ -28,6 +28,7 @@
         <module>kroxylicious-operator-test-support</module>
         <module>kroxylicious-admission-api</module>
         <module>kroxylicious-admission</module>
+        <module>kroxylicious-admission-dist</module>
     </modules>
 
     <build>
@@ -52,6 +53,7 @@
                                         <include>io.kroxylicious:kroxylicious-runtime</include>
                                         <include>io.kroxylicious:kroxylicious-annotations</include>
                                         <include>io.kroxylicious:kroxylicious-operator</include>
+                                        <include>io.kroxylicious:kroxylicious-admission</include>
                                         <include>io.kroxylicious:kroxylicious-docs</include>
                                         <include>io.kroxylicious:kroxylicious-kubernetes-api</include>
                                         <include>io.kroxylicious:kroxylicious-admission-api</include>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

We need an artefact to distribute to users to install the webhook. This PR follows the approach we use for the operator:

1. Adds `kroxylicious-kubernetes/kroxylicious-admission-dist` to build a tarball/zip
2. `kroxylicious-admission-dist` assembles:
  i. the CRD and deployment manifests
  ii. the cert-manager example
  ii. license file
  
The CRDs are renamed so that they will be applied before files like the webhook deployment, same approach as the operator.

In future we will also include documentation in the dist.

Contributes towards #3890

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
