### PR TITLE
test(admission): add CRD validation integration test

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-admission-api/src/main/resources/META-INF/fabric8/kroxylicioussidecarconfigs.sidecar.kroxylicious.io-v1.yml
+++ b/kroxylicious-kubernetes/kroxylicious-admission-api/src/main/resources/META-INF/fabric8/kroxylicioussidecarconfigs.sidecar.kroxylicious.io-v1.yml
@@ -166,7 +166,7 @@ spec:
                       name:
                         description: A unique name for this filter instance.
                         type: string
-                        pattern: "[a-z0-9A-Z]([a-z0-9A-Z_.\\-]{0,251}[a-z0-9A-Z])?"
+                        pattern: "^[a-z0-9A-Z]([a-z0-9A-Z_.\\-]{0,251}[a-z0-9A-Z])?$"
                       type:
                         description: The fully qualified type name of the FilterFactory plugin.
                         type: string

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AdmissionTestUtils.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AdmissionTestUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AdmissionTestUtils {
+
+    /**
+     * The timeouts of this client build are tuned to handle the case where Kubernetes isn't present,
+     * as might be the case on a developer's machine where minikube isn't running.
+     */
+    private static final KubernetesClientBuilder PRESENCE_PROBING_KUBE_CLIENT_BUILD = new KubernetesClientBuilder()
+            .editOrNewConfig()
+            .withRequestRetryBackoffLimit(2)
+            .withConnectionTimeout(1000)
+            .endConfig();
+
+    public static @NonNull KubernetesClient kubeClient() {
+        return kubeClient(new KubernetesClientBuilder());
+    }
+
+    public static @NonNull KubernetesClient kubeClient(KubernetesClientBuilder kubernetesClientBuilder) {
+        KubernetesClient kubernetesClient = kubernetesClientBuilder.build();
+        assertThat(kubernetesClient).isNotNull();
+        return kubernetesClient;
+    }
+
+    public static boolean isKubeClientAvailable() {
+        var client = PRESENCE_PROBING_KUBE_CLIENT_BUILD.build();
+        try {
+            client.namespaces().list();
+            return true;
+        }
+        catch (KubernetesClientException e) {
+            client.close();
+            return false;
+        }
+    }
+}

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/CustomResourceValidationIT.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/CustomResourceValidationIT.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.Status;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.NamespaceableResource;
+import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@EnabledIf(value = "io.kroxylicious.kubernetes.webhook.AdmissionTestUtils#isKubeClientAvailable", disabledReason = "no viable kube client available")
+class CustomResourceValidationIT {
+
+    public static final Namespace NAMESPACE = new NamespaceBuilder().withNewMetadata().withName("webhook-validation-test").endMetadata().build();
+    public static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
+    private static final Path CRD_PATH = Path.of(
+            "../kroxylicious-admission-api/src/main/resources/META-INF/fabric8/kroxylicioussidecarconfigs.sidecar.kroxylicious.io-v1.yml");
+
+    @BeforeAll
+    static void beforeAll() {
+        KubernetesClient client = AdmissionTestUtils.kubeClient();
+        applyCrd(client);
+        waitForCrdEstablished(client);
+        client.namespaces().resource(NAMESPACE).createOr(NonDeletingOperation::update);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        try (KubernetesClient kubernetesClient = AdmissionTestUtils.kubeClient()) {
+            kubernetesClient.namespaces().resource(NAMESPACE).delete();
+            deleteCrd(kubernetesClient);
+        }
+    }
+
+    private static void applyCrd(KubernetesClient client) {
+        try (InputStream is = Files.newInputStream(CRD_PATH)) {
+            client.load(is).serverSideApply();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static void waitForCrdEstablished(KubernetesClient client) {
+        client.apiextensions().v1().customResourceDefinitions()
+                .withName("kroxylicioussidecarconfigs.sidecar.kroxylicious.io")
+                .waitUntilCondition(
+                        crd -> crd != null
+                                && crd.getStatus() != null
+                                && crd.getStatus().getConditions() != null
+                                && crd.getStatus().getConditions().stream()
+                                        .anyMatch(c -> "Established".equals(c.getType())
+                                                && "True".equals(c.getStatus())),
+                        60, TimeUnit.SECONDS);
+    }
+
+    private static void deleteCrd(KubernetesClient client) {
+        try (InputStream is = Files.newInputStream(CRD_PATH)) {
+            client.load(is).delete();
+        }
+        catch (IOException e) {
+            // Swallow exceptions during cleanup
+        }
+    }
+
+    public static Stream<Path> testResourceValid() {
+        return TestFiles.recursiveFilesInDirectoryForTest(CustomResourceValidationIT.class, "valid-*.yaml").stream();
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void testResourceValid(Path validYaml) {
+        testValid(validYaml);
+    }
+
+    private static void testValid(Path validYaml) {
+        try (InputStream is = Files.newInputStream(validYaml)) {
+            NamespaceableResource<HasMetadata> resource = AdmissionTestUtils.kubeClient().resource(is);
+            assertThatCode(resource::create).doesNotThrowAnyException();
+            assertThatCode(resource::delete).doesNotThrowAnyException();
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    record InvalidResource(String expectFailureMessageToContain, Object resource) {
+        String resourceAsString() {
+            try {
+                return YAML_MAPPER.writeValueAsString(resource);
+            }
+            catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public static Stream<Arguments> testResourceInvalid() {
+        return TestFiles.recursiveFilesInDirectoryForTest(CustomResourceValidationIT.class, "invalid-*.yaml").stream().map(p -> {
+            try {
+                return Arguments.argumentSet(p.toString(), YAML_MAPPER.readValue(p.toFile(), InvalidResource.class));
+            }
+            catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void testResourceInvalid(InvalidResource invalidYaml) {
+        NamespaceableResource<HasMetadata> resource = AdmissionTestUtils.kubeClient().resource(invalidYaml.resourceAsString());
+        try {
+            assertThatThrownBy(resource::create).isInstanceOfSatisfying(KubernetesClientException.class, e -> {
+                Status status = e.getStatus();
+                assertThat(status).isNotNull();
+                assertThat(status.getCode()).isEqualTo(422);
+                assertThat(status.getMessage()).contains(invalidYaml.expectFailureMessageToContain);
+            });
+        }
+        finally {
+            try {
+                resource.delete();
+            }
+            catch (KubernetesClientException e) {
+                // ignored, redundantly deleting in case the resource was accidentally valid
+            }
+        }
+    }
+
+    public static Stream<Path> testResourceValidStatus() {
+        return TestFiles.recursiveFilesInDirectoryForTest(CustomResourceValidationIT.class, "validStatus-*.yaml").stream();
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void testResourceValidStatus(Path validYaml) {
+        try (InputStream is = Files.newInputStream(validYaml)) {
+            NamespaceableResource<HasMetadata> resource = AdmissionTestUtils.kubeClient().resource(is);
+            assertThatCode(resource::create).doesNotThrowAnyException();
+            assertThatCode(resource::patchStatus).doesNotThrowAnyException();
+            assertThatCode(resource::delete).doesNotThrowAnyException();
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static Stream<Arguments> testResourceInvalidStatus() {
+        return TestFiles.recursiveFilesInDirectoryForTest(CustomResourceValidationIT.class, "invalidStatus-*.yaml").stream().map(p -> {
+            try {
+                return Arguments.argumentSet(p.toString(), YAML_MAPPER.readValue(p.toFile(), InvalidResource.class));
+            }
+            catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void testResourceInvalidStatus(InvalidResource invalidYaml) {
+        NamespaceableResource<HasMetadata> resource = AdmissionTestUtils.kubeClient().resource(invalidYaml.resourceAsString());
+        try {
+            assertThatCode(resource::create).doesNotThrowAnyException();
+            assertThatThrownBy(resource::patchStatus).isInstanceOfSatisfying(KubernetesClientException.class, e -> {
+                Status status = e.getStatus();
+                assertThat(status).isNotNull();
+                assertThat(status.getCode()).isEqualTo(422);
+                assertThat(status.getMessage()).contains(invalidYaml.expectFailureMessageToContain);
+            });
+        }
+        finally {
+            try {
+                resource.delete();
+            }
+            catch (KubernetesClientException e) {
+                // ignored, redundantly deleting in case the resource was accidentally valid
+            }
+        }
+    }
+}

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/TestFiles.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/TestFiles.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.kubernetes.webhook;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import io.kroxylicious.proxy.tag.VisibleForTesting;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+public class TestFiles {
+
+    public static final String INSTALL_MANIFESTS_DIR = "packaging/install";
+
+    @NonNull
+    static HashSet<Path> childFilesMatching(
+                                            Path testDir,
+                                            String glob)
+            throws IOException {
+        return StreamSupport.stream(Files.newDirectoryStream(testDir, glob).spliterator(), false)
+                .filter(Files::isRegularFile)
+                .collect(Collectors.toCollection(HashSet::new));
+    }
+
+    static List<Path> subDirectoriesForTest(Class<?> testClazz) {
+        var dir = testDir(testClazz);
+        return subDirectories(dir);
+    }
+
+    private static @NonNull Path testDir(Class<?> testClazz) {
+        return Path.of("target", "test-classes", testClazz.getSimpleName());
+    }
+
+    @NonNull
+    static List<Path> subDirectories(Path dir) {
+        var directories = new ArrayList<Path>();
+        try (var expected = Files.newDirectoryStream(dir, Files::isDirectory)) {
+            for (Path f : expected) {
+                directories.add(f);
+            }
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return directories;
+    }
+
+    static List<Path> recursiveFilesInDirectoryForTest(Class<?> testClazz, String filenameGlob) {
+        Path path = testDir(testClazz);
+        return recursiveFilesInDirectory(filenameGlob, path);
+    }
+
+    @VisibleForTesting
+    static @NonNull List<Path> recursiveFilesInDirectory(String filenameGlob, Path path) {
+        PathMatcher globMatcher = FileSystems.getDefault().getPathMatcher("glob:**/" + filenameGlob);
+        List<Path> files = new ArrayList<>();
+        try {
+            Files.walkFileTree(path, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (globMatcher.matches(file)) {
+                        files.add(file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return files;
+    }
+}

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-bootstrapPort-above-maximum.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-bootstrapPort-above-maximum.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: invalid-bootstrap-port-max
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+        bootstrapPort: 65536
+expectFailureMessageToContain: "spec.virtualClusters[0].bootstrapPort"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-bootstrapPort-below-minimum.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-bootstrapPort-below-minimum.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: invalid-bootstrap-port
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+        bootstrapPort: 1023
+expectFailureMessageToContain: "spec.virtualClusters[0].bootstrapPort"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-filterDefinition-name-invalid-pattern.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-filterDefinition-name-invalid-pattern.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: invalid-filter-name-pattern
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+    filterDefinitions:
+      - name: "-invalid-start"
+        type: io.kroxylicious.filter.Example
+        config: {}
+expectFailureMessageToContain: "spec.filterDefinitions"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-filterDefinition-name-missing.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-filterDefinition-name-missing.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: invalid-filter-no-name
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+    filterDefinitions:
+      - type: io.kroxylicious.filter.Example
+        config: {}
+expectFailureMessageToContain: "spec.filterDefinitions"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-filterDefinition-type-missing.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-filterDefinition-type-missing.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: invalid-filter-no-type
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+    filterDefinitions:
+      - name: myFilter
+        config: {}
+expectFailureMessageToContain: "spec.filterDefinitions"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-managementPort-above-maximum.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-managementPort-above-maximum.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: invalid-mgmt-port-max
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+    managementPort: 65536
+expectFailureMessageToContain: "spec.managementPort"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-managementPort-below-minimum.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-managementPort-below-minimum.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: invalid-mgmt-port
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+    managementPort: 1023
+expectFailureMessageToContain: "spec.managementPort"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-metadata-name-invalid-pattern.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-metadata-name-invalid-pattern.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: "Invalid_Name"
+    namespace: webhook-validation-test
+  spec:
+    targetBootstrapServers: kafka.example.com:9092
+expectFailureMessageToContain: "metadata.name"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-metadata-name-too-long.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-metadata-name-too-long.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: "this-is-a-very-long-name-that-exceeds-the-sixty-three-character-maximum-length-allowed-by-the-crd"
+    namespace: webhook-validation-test
+  spec:
+    targetBootstrapServers: kafka.example.com:9092
+expectFailureMessageToContain: "metadata.name"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-nodeIdRange-endInclusive-negative.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-nodeIdRange-endInclusive-negative.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: invalid-node-id-end
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+        nodeIdRange:
+          startInclusive: 0
+          endInclusive: -1
+expectFailureMessageToContain: "spec.virtualClusters[0].nodeIdRange.endInclusive"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-nodeIdRange-startInclusive-negative.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-nodeIdRange-startInclusive-negative.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: invalid-node-id-start
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+        nodeIdRange:
+          startInclusive: -1
+          endInclusive: 2
+expectFailureMessageToContain: "spec.virtualClusters[0].nodeIdRange.startInclusive"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-plugin-image-missing.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-plugin-image-missing.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: invalid-plugin-no-image
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+    plugins:
+      - name: example-plugin
+expectFailureMessageToContain: "spec.plugins"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-plugin-image-reference-missing.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-plugin-image-reference-missing.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: missing-plugin-reference
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+    plugins:
+      - name: example-plugin
+        image:
+          pullPolicy: IfNotPresent
+expectFailureMessageToContain: "spec.plugins"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-plugin-name-invalid-pattern.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-plugin-name-invalid-pattern.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: invalid-plugin-name-pattern
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+    plugins:
+      - name: "Invalid_Name"
+        image:
+          reference: quay.io/kroxylicious/example@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+expectFailureMessageToContain: "spec.plugins"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-plugin-name-missing.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-plugin-name-missing.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: invalid-plugin-no-name
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+    plugins:
+      - image:
+          reference: quay.io/kroxylicious/example@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+expectFailureMessageToContain: "spec.plugins"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-plugin-name-too-long.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-plugin-name-too-long.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: invalid-plugin-name-length
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+    plugins:
+      - name: "this-plugin-name-is-way-too-long-and-exceeds-the-sixty-three-character-limit-imposed-by-the-crd"
+        image:
+          reference: quay.io/kroxylicious/example@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+expectFailureMessageToContain: "spec.plugins"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-plugin-pullPolicy-invalid-enum.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-plugin-pullPolicy-invalid-enum.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: invalid-plugin-pull-policy
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+    plugins:
+      - name: example-plugin
+        image:
+          reference: quay.io/kroxylicious/example@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+          pullPolicy: InvalidValue
+expectFailureMessageToContain: "spec.plugins"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-secretMount-name-invalid-pattern.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-secretMount-name-invalid-pattern.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: invalid-secretmount-name-pattern
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+    secretMounts:
+      - name: "Invalid_Name"
+        secretName: my-secret
+expectFailureMessageToContain: "spec.secretMounts"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-secretMount-name-missing.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-secretMount-name-missing.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: missing-secretmount-name
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+    secretMounts:
+      - secretName: my-secret
+expectFailureMessageToContain: "spec.secretMounts"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-secretMount-name-too-long.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-secretMount-name-too-long.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: too-long-secretmount-name
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+    secretMounts:
+      - name: "this-is-a-very-long-secret-mount-name-that-exceeds-sixty-three-characters"
+        secretName: my-secret
+expectFailureMessageToContain: "spec.secretMounts"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-secretMount-secretName-missing.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-secretMount-secretName-missing.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: missing-secretname
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+    secretMounts:
+      - name: my-mount
+expectFailureMessageToContain: "spec.secretMounts"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-spec-missing.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-spec-missing.yaml
@@ -1,0 +1,14 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: missing-spec
+    namespace: webhook-validation-test
+expectFailureMessageToContain: "spec: Required value"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-targetBootstrapServers-missing.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-targetBootstrapServers-missing.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: missing-target
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+expectFailureMessageToContain: "spec.virtualClusters[0].targetBootstrapServers"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-targetClusterTls-trustAnchorSecretRef-key-missing.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-targetClusterTls-trustAnchorSecretRef-key-missing.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: missing-tls-secret-key
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+        targetClusterTls:
+          trustAnchorSecretRef:
+            name: kafka-ca-cert
+expectFailureMessageToContain: "spec.virtualClusters[0].targetClusterTls.trustAnchorSecretRef.key"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-targetClusterTls-trustAnchorSecretRef-name-missing.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-targetClusterTls-trustAnchorSecretRef-name-missing.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: missing-tls-secret-name
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+        targetClusterTls:
+          trustAnchorSecretRef:
+            key: ca.crt
+expectFailureMessageToContain: "spec.virtualClusters[0].targetClusterTls.trustAnchorSecretRef.name"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-virtualCluster-name-invalid-pattern.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-virtualCluster-name-invalid-pattern.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: invalid-vc-name-pattern
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: "Invalid_Name"
+        targetBootstrapServers: kafka.example.com:9092
+expectFailureMessageToContain: "spec.virtualClusters[0].name"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-virtualCluster-name-missing.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-virtualCluster-name-missing.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: missing-vc-name
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - targetBootstrapServers: kafka.example.com:9092
+expectFailureMessageToContain: "spec.virtualClusters[0].name"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-virtualCluster-name-too-long.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-virtualCluster-name-too-long.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: too-long-vc-name
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: "this-is-a-very-long-virtual-cluster-name-that-exceeds-sixty-three-characters"
+        targetBootstrapServers: kafka.example.com:9092
+expectFailureMessageToContain: "spec.virtualClusters[0].name"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-virtualClusters-empty.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-virtualClusters-empty.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: empty-virtualclusters
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters: []
+expectFailureMessageToContain: "spec.virtualClusters"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-virtualClusters-missing.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-virtualClusters-missing.yaml
@@ -1,0 +1,15 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: missing-virtualclusters
+    namespace: webhook-validation-test
+  spec: {}
+expectFailureMessageToContain: "spec.virtualClusters"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-virtualClusters-multiple-items.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalid-virtualClusters-multiple-items.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: multiple-virtualclusters
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: cluster1
+        targetBootstrapServers: kafka1.example.com:9092
+      - name: cluster2
+        targetBootstrapServers: kafka2.example.com:9092
+expectFailureMessageToContain: "spec.virtualClusters"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalidStatus-invalid-status-enum.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalidStatus-invalid-status-enum.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: invalid-status-enum
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+  status:
+    observedGeneration: 1
+    conditions:
+      - type: Ready
+        status: "Invalid"
+        reason: ConfigurationValid
+        message: Configuration is valid
+        lastTransitionTime: "2026-05-05T10:00:00Z"
+        observedGeneration: 1
+expectFailureMessageToContain: "status.conditions"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalidStatus-missing-required-reason.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalidStatus-missing-required-reason.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: invalid-status-no-reason
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+  status:
+    observedGeneration: 1
+    conditions:
+      - type: Ready
+        status: "True"
+        message: Configuration is valid
+        lastTransitionTime: "2026-05-05T10:00:00Z"
+        observedGeneration: 1
+expectFailureMessageToContain: "status.conditions"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalidStatus-missing-required-type.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/invalidStatus-missing-required-type.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+resource:
+  kind: KroxyliciousSidecarConfig
+  apiVersion: sidecar.kroxylicious.io/v1alpha1
+  metadata:
+    name: invalid-status-no-type
+    namespace: webhook-validation-test
+  spec:
+    virtualClusters:
+      - name: demo
+        targetBootstrapServers: kafka.example.com:9092
+  status:
+    observedGeneration: 1
+    conditions:
+      - status: "True"
+        reason: ConfigurationValid
+        message: Configuration is valid
+        lastTransitionTime: "2026-05-05T10:00:00Z"
+        observedGeneration: 1
+expectFailureMessageToContain: "status.conditions"

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/valid-all-fields.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/valid-all-fields.yaml
@@ -1,0 +1,47 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KroxyliciousSidecarConfig
+apiVersion: sidecar.kroxylicious.io/v1alpha1
+metadata:
+  name: all-fields-config
+  namespace: webhook-validation-test
+spec:
+  virtualClusters:
+    - name: demo
+      targetBootstrapServers: kafka.example.com:9092
+      bootstrapPort: 9092
+      nodeIdRange:
+        startInclusive: 0
+        endInclusive: 2
+      targetClusterTls:
+        trustAnchorSecretRef:
+          name: kafka-ca-cert
+          key: ca.crt
+  proxyImage: quay.io/kroxylicious/kroxylicious:latest
+  managementPort: 9082
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+  setBootstrapEnvVar: true
+  filterDefinitions:
+    - name: myFilter
+      type: io.kroxylicious.filter.Example
+      config:
+        key: value
+  secretMounts:
+    - name: my-secret
+      secretName: app-secrets
+  plugins:
+    - name: example-plugin
+      image:
+        reference: quay.io/kroxylicious/example@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+        pullPolicy: IfNotPresent

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/valid-minimal.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/valid-minimal.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KroxyliciousSidecarConfig
+apiVersion: sidecar.kroxylicious.io/v1alpha1
+metadata:
+  name: minimal-config
+  namespace: webhook-validation-test
+spec:
+  virtualClusters:
+    - name: demo
+      targetBootstrapServers: kafka.example.com:9092

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/valid-with-custom-ports.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/valid-with-custom-ports.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KroxyliciousSidecarConfig
+apiVersion: sidecar.kroxylicious.io/v1alpha1
+metadata:
+  name: custom-ports-config
+  namespace: webhook-validation-test
+spec:
+  virtualClusters:
+    - name: demo
+      targetBootstrapServers: kafka.example.com:9092
+      bootstrapPort: 19092
+      nodeIdRange:
+        startInclusive: 0
+        endInclusive: 5
+  managementPort: 19082

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/valid-with-filters.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/valid-with-filters.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KroxyliciousSidecarConfig
+apiVersion: sidecar.kroxylicious.io/v1alpha1
+metadata:
+  name: filters-config
+  namespace: webhook-validation-test
+spec:
+  virtualClusters:
+    - name: demo
+      targetBootstrapServers: kafka.example.com:9092
+  filterDefinitions:
+    - name: filter1
+      type: io.kroxylicious.filter.FirstFilter
+    - name: filter_2.with-dots
+      type: io.kroxylicious.filter.SecondFilter
+      config:
+        enabled: true

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/valid-with-plugins.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/valid-with-plugins.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KroxyliciousSidecarConfig
+apiVersion: sidecar.kroxylicious.io/v1alpha1
+metadata:
+  name: plugins-config
+  namespace: webhook-validation-test
+spec:
+  virtualClusters:
+    - name: demo
+      targetBootstrapServers: kafka.example.com:9092
+  plugins:
+    - name: plugin1
+      image:
+        reference: quay.io/kroxylicious/plugin1@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+        pullPolicy: Always
+    - name: plugin-2
+      image:
+        reference: quay.io/kroxylicious/plugin2:latest
+        pullPolicy: Never

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/valid-with-secretMounts.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/valid-with-secretMounts.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KroxyliciousSidecarConfig
+apiVersion: sidecar.kroxylicious.io/v1alpha1
+metadata:
+  name: secretmounts-config
+  namespace: webhook-validation-test
+spec:
+  virtualClusters:
+    - name: demo
+      targetBootstrapServers: kafka.example.com:9092
+  secretMounts:
+    - name: credentials
+      secretName: app-credentials
+    - name: certificates
+      secretName: app-certs

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/valid-with-targetClusterTls.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/valid-with-targetClusterTls.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KroxyliciousSidecarConfig
+apiVersion: sidecar.kroxylicious.io/v1alpha1
+metadata:
+  name: tls-config
+  namespace: webhook-validation-test
+spec:
+  virtualClusters:
+    - name: secure-cluster
+      targetBootstrapServers: kafka-secure.example.com:9093
+      targetClusterTls:
+        trustAnchorSecretRef:
+          name: kafka-ca-bundle
+          key: ca.crt

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/validStatus-ready-condition.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/resources/CustomResourceValidationIT/validStatus-ready-condition.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+kind: KroxyliciousSidecarConfig
+apiVersion: sidecar.kroxylicious.io/v1alpha1
+metadata:
+  name: valid-status-config
+  namespace: webhook-validation-test
+spec:
+  virtualClusters:
+    - name: demo
+      targetBootstrapServers: kafka.example.com:9092
+status:
+  observedGeneration: 1
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: ConfigurationValid
+      message: Configuration is valid
+      lastTransitionTime: "2026-05-05T10:00:00Z"
+      observedGeneration: 1


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Adds CustomResourceValidationIT following the same pattern as the operator's validation test. The test validates KroxyliciousSidecarConfig CRD schema enforcement by applying YAML scenarios against a live Kubernetes cluster.

Test coverage:
- Required fields (spec.targetBootstrapServers)
- Pattern validations (metadata.name, filterDefinitions, plugins)
- Numeric constraints (port ranges, nodeIdRange minimums)
- Enum validations (pullPolicy)
- Length constraints (maxLength on names)
- Status subresource schema (Kubernetes condition structure)

Infrastructure:
- AdmissionTestUtils: Kubernetes client utilities
- TestFiles: YAML scenario file discovery (duplicated from operator)

Test uses direct Fabric8 client calls (serverSideApply) rather than JOSDK, consistent with existing admission module patterns.

Also fixes CRD schema issues:
- Anchors filter name pattern to prevent partial matches
- Adds missing "status" to required fields in conditions

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>

Contributes towards #3890

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
