### PR TITLE
docs(admission): add sidecar injection demo with message uppercasing

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-admission/packaging/examples/sidecar-injection-demo/01-namespace.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/packaging/examples/sidecar-injection-demo/01-namespace.yaml
@@ -1,0 +1,13 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo-app
+  labels:
+    sidecar.kroxylicious.io/injection: enabled

--- a/kroxylicious-kubernetes/kroxylicious-admission/packaging/examples/sidecar-injection-demo/02-kafka.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/packaging/examples/sidecar-injection-demo/02-kafka.yaml
@@ -1,0 +1,54 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaNodePool
+metadata:
+  name: dual-role
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  replicas: 1
+  roles:
+    - controller
+    - broker
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: ephemeral
+        kraftMetadata: shared
+---
+
+apiVersion: kafka.strimzi.io/v1
+kind: Kafka
+metadata:
+  name: my-cluster
+  namespace: kafka
+spec:
+  kafka:
+    version: 4.2.0
+    metadataVersion: 4.2-IV1
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+    config:
+      offsets.topic.replication.factor: 1
+      transaction.state.log.replication.factor: 1
+      transaction.state.log.min.isr: 1
+      default.replication.factor: 1
+      min.insync.replicas: 1
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}

--- a/kroxylicious-kubernetes/kroxylicious-admission/packaging/examples/sidecar-injection-demo/03-sidecar-config.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/packaging/examples/sidecar-injection-demo/03-sidecar-config.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: sidecar.kroxylicious.io/v1alpha1
+kind: KroxyliciousSidecarConfig
+metadata:
+  name: demo-config
+  namespace: demo-app
+spec:
+  virtualClusters:
+    - name: my-cluster
+      targetBootstrapServers: my-cluster-kafka-bootstrap.kafka.svc:9092
+  filterDefinitions:
+    - name: produce-uppercase
+      type: ProduceRequestTransformation
+      config:
+        transformation: UpperCasing
+        transformationConfig:
+          charset: UTF-8
+    - name: fetch-replace
+      type: FetchResponseTransformation
+      config:
+        transformation: Replacing
+        transformationConfig:
+          charset: UTF-8
+          targetPattern: "O"
+          replacementValue: "❤️"

--- a/kroxylicious-kubernetes/kroxylicious-admission/packaging/examples/sidecar-injection-demo/04-app.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-admission/packaging/examples/sidecar-injection-demo/04-app.yaml
@@ -1,0 +1,51 @@
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: message-producer
+  namespace: demo-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: message-producer
+  template:
+    metadata:
+      labels:
+        app: message-producer
+    spec:
+      containers:
+        - name: producer
+          image: quay.io/strimzi/kafka:1.0.0-kafka-4.2.0
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -e
+
+              # Wait for Kafka to be ready (via the sidecar proxy on localhost)
+              echo "Waiting for Kafka to be ready..."
+              while ! echo "test" | /opt/kafka/bin/kafka-console-producer.sh \
+                --bootstrap-server ${KAFKA_BOOTSTRAP_SERVERS} \
+                --topic test 2>/dev/null; do
+                echo "Kafka not ready, retrying in 5s..."
+                sleep 5
+              done
+
+              echo "Kafka is ready. Starting message producer..."
+              echo "Sending lowercase messages to topic 'demo-topic' via ${KAFKA_BOOTSTRAP_SERVERS}"
+
+              # Produce lowercase messages in a loop
+              while true; do
+                echo "hello world from kubernetes at $(date)" | \
+                  /opt/kafka/bin/kafka-console-producer.sh \
+                    --bootstrap-server ${KAFKA_BOOTSTRAP_SERVERS} \
+                    --topic demo-topic
+                sleep 5
+              done

--- a/kroxylicious-kubernetes/kroxylicious-admission/packaging/examples/sidecar-injection-demo/README.md
+++ b/kroxylicious-kubernetes/kroxylicious-admission/packaging/examples/sidecar-injection-demo/README.md
@@ -1,0 +1,148 @@
+# Sidecar Injection Demo: Message Uppercasing
+
+This example demonstrates the Kroxylicious admission webhook by injecting a sidecar proxy that transforms Kafka messages to uppercase.
+
+## Prerequisites
+
+- Kubernetes cluster (1.28+ for native sidecar support)
+- `kubectl` configured to access your cluster
+- Kroxylicious admission webhook installed (see [../install/](../../install/))
+
+## Architecture
+
+The example creates:
+
+1. A namespace (`demo-app`) with sidecar injection enabled
+2. A single-node Strimzi Kafka cluster
+3. A `KroxyliciousSidecarConfig` that configures message uppercasing
+4. An application that sends lowercase messages to Kafka
+
+The admission webhook intercepts pod creation in the `demo-app` namespace and injects a Kroxylicious sidecar container. The sidecar applies two filters:
+
+- `ProduceRequestTransformation` with `UpperCasing` - transforms produced messages to uppercase
+- `FetchResponseTransformation` with `Replacing` - transforms fetched messages by replacing 'O' with '❤️'
+
+Application containers automatically have `KAFKA_BOOTSTRAP_SERVERS` set to `localhost:9092`, pointing to the sidecar proxy.
+
+## Installation
+
+### 1. Install Strimzi Operator
+
+```bash
+kubectl create namespace kafka
+kubectl apply -f https://strimzi.io/install/latest?namespace=kafka -n kafka
+```
+
+Wait for the operator to be ready:
+
+```bash
+kubectl wait --for=condition=ready pod -l name=strimzi-cluster-operator -n kafka --timeout=300s
+```
+
+### 2. Apply the Demo Manifests
+
+```bash
+kubectl apply -f 01-namespace.yaml
+kubectl apply -f 02-kafka.yaml
+kubectl apply -f 03-sidecar-config.yaml
+kubectl apply -f 04-app.yaml
+```
+
+### 3. Wait for Resources to be Ready
+
+Wait for Kafka cluster:
+
+```bash
+kubectl wait kafka/my-cluster --for=condition=Ready --timeout=300s -n kafka
+```
+
+Wait for the application pod:
+
+```bash
+kubectl wait --for=condition=ready pod -l app=message-producer -n demo-app --timeout=300s
+```
+
+## Verification
+
+### Verify Sidecar Injection
+
+Check that the application pod has a `kroxylicious-proxy` sidecar container injected:
+
+```bash
+kubectl get pod -l app=message-producer -n demo-app -o jsonpath='{.items[0].spec.containers[*].name}'
+kubectl get pod -l app=message-producer -n demo-app -o jsonpath='{.items[0].spec.initContainers[*].name}'
+```
+
+Expected output: `producer kroxylicious-proxy`
+
+### Verify Environment Variable Injection
+
+Check that `KAFKA_BOOTSTRAP_SERVERS` was set by the webhook:
+
+```bash
+kubectl exec -n demo-app deployment/message-producer -c producer -- env | grep KAFKA_BOOTSTRAP_SERVERS
+```
+
+Expected output: `KAFKA_BOOTSTRAP_SERVERS=localhost:9092`
+
+### View Producer Logs
+
+The producer application sends lowercase messages like `hello world from kubernetes at <timestamp>`:
+
+```bash
+kubectl logs -n demo-app deployment/message-producer -c producer --tail=20
+```
+
+### Consume Messages and See Uppercase Transformation
+
+Run a consumer inside the Kafka cluster (bypassing the proxy) to see messages as stored in Kafka:
+
+```bash
+kubectl exec -n kafka my-cluster-dual-role-0 -- \
+  /opt/kafka/bin/kafka-console-consumer.sh \
+    --bootstrap-server localhost:9092 \
+    --topic demo-topic \
+    --from-beginning \
+    --max-messages 5
+```
+
+Expected output shows **uppercase** messages:
+
+```
+HELLO WORLD FROM KUBERNETES AT MON MAY  5 12:34:56 UTC 2026
+HELLO WORLD FROM KUBERNETES AT MON MAY  5 12:35:01 UTC 2026
+...
+```
+
+The producer sent lowercase messages, but the `ProduceRequestTransformation` filter uppercased them before they reached Kafka.
+
+### Consume via the Proxy
+
+Consume messages from the application pod (via the sidecar proxy):
+
+```bash
+kubectl exec -n demo-app deployment/message-producer -c producer -- \
+  bash -c '/opt/kafka/bin/kafka-console-consumer.sh \
+    --bootstrap-server ${KAFKA_BOOTSTRAP_SERVERS} \
+    --topic demo-topic \
+    --from-beginning \
+    --max-messages 5'
+```
+
+You should see the uppercase content sent to the target cluster, but with 'O's replaced with '❤️ 's.
+
+```
+HELL❤️ W❤️RLD FR❤️M KUBERNETES AT WED MAY  6 23:43:10 UTC 2026
+HELL❤️ W❤️RLD FR❤️M KUBERNETES AT WED MAY  6 23:43:16 UTC 2026
+HELL❤️ W❤️RLD FR❤️M KUBERNETES AT WED MAY  6 23:43:22 UTC 2026
+HELL❤️ W❤️RLD FR❤️M KUBERNETES AT WED MAY  6 23:43:28 UTC 2026
+HELL❤️ W❤️RLD FR❤️M KUBERNETES AT WED MAY  6 23:43:34 UTC 2026
+```
+
+The target cluster contains uppercase messages, but the `FetchResponseTransformation` filter replaced the 'O's with '❤️ 's before they are forwarded to the client.
+
+## Cleanup
+
+```bash
+kubectl delete namespace demo-app
+```

--- a/scripts/run-webhook.sh
+++ b/scripts/run-webhook.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Copyright Kroxylicious Authors.
+#
+# Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+#
+
+set -euo pipefail
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+. "${SCRIPT_DIR}/common.sh"
+cd "${SCRIPT_DIR}/.."
+
+info "Deleting existing minikube cluster"
+${MINIKUBE} delete || true
+
+info "Starting minikube with 4GB memory"
+${MINIKUBE} start --memory=4096
+
+info "Building distribution with Maven"
+mvn clean install -Pdist -Dquick -pl :kroxylicious-admission-dist -am
+
+info "Extracting distribution tarball"
+DIST_DIR=$(mktemp -d)
+tar -xzf kroxylicious-kubernetes/kroxylicious-admission-dist/target/kroxylicious-admission-*.tar.gz -C "${DIST_DIR}"
+
+info "Loading webhook image into minikube"
+gunzip --to-stdout kroxylicious-kubernetes/kroxylicious-admission/target/kroxylicious-webhook.img.tar.gz \
+  | ${MINIKUBE} image load - --alsologtostderr=true 2>&1 | tee /dev/tty | tail -n1 | grep -q 'succeeded pushing to: minikube'
+
+info "Loading proxy image into minikube"
+gunzip --to-stdout kroxylicious-app/target/kroxylicious-proxy.img.tar.gz \
+  | ${MINIKUBE} image load - --alsologtostderr=true 2>&1 | tee /dev/tty | tail -n1 | grep -q 'succeeded pushing to: minikube'
+
+info "Installing cert-manager"
+${KUBECTL} apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.20.2/cert-manager.yaml
+${KUBECTL} wait deployment/cert-manager-webhook --for=condition=Available=True --timeout=300s -n cert-manager
+
+info "Applying webhook installation manifests"
+${KUBECTL} apply -f "${DIST_DIR}/install/"
+${KUBECTL} apply -f "${DIST_DIR}/examples/cert-manager/"
+${KUBECTL} wait deployment/kroxylicious-webhook --for=condition=Available=True --timeout=300s -n kroxylicious-webhook
+
+info "Installing Strimzi operator"
+${KUBECTL} create namespace kafka
+${KUBECTL} apply -f https://strimzi.io/install/latest?namespace=kafka -n kafka
+${KUBECTL} wait --for=condition=ready pod -l name=strimzi-cluster-operator -n kafka --timeout=300s
+
+info "Applying sidecar injection demo manifests"
+${KUBECTL} apply -f "${DIST_DIR}/examples/sidecar-injection-demo/01-namespace.yaml"
+${KUBECTL} apply -f "${DIST_DIR}/examples/sidecar-injection-demo/02-kafka.yaml"
+${KUBECTL} apply -f "${DIST_DIR}/examples/sidecar-injection-demo/03-sidecar-config.yaml"
+${KUBECTL} apply -f "${DIST_DIR}/examples/sidecar-injection-demo/04-app.yaml"
+
+info "Waiting for Kafka cluster to be ready"
+${KUBECTL} wait kafka/my-cluster --for=condition=Ready --timeout=300s -n kafka
+
+info "Waiting for message-producer pod to be ready"
+${KUBECTL} wait --for=condition=ready pod -l app=message-producer -n demo-app --timeout=300s
+
+echo -e "${GREEN}Installation complete!${NO_COLOUR}"
+echo ""
+cat << EOF
+Verify sidecar injection:
+  kubectl get pod -l app=message-producer -n demo-app -o jsonpath='{.items[0].spec.containers[*].name}'
+  kubectl get pod -l app=message-producer -n demo-app -o jsonpath='{.items[0].spec.initContainers[*].name}'
+Expected: producer, kroxylicious-proxy
+Consume messages (should be UPPERCASE):
+  kubectl exec -n kafka my-cluster-dual-role-0 -- \\
+    /opt/kafka/bin/kafka-console-consumer.sh \\
+    --bootstrap-server localhost:9092 \\
+    --topic demo-topic \\
+    --from-beginning \\
+    --max-messages 5
+EOF


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Includes a demonstration where users can inject an uppercasing sidecar with just a few commands

Contributes towards #3890
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
