### PR TITLE
build(image): rename proxy container image to quay.io/kroxylicious/proxy

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -62,8 +62,9 @@ jobs:
             echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
           else
             PROXY_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.PROXY_IMAGE_NAME }}"
+            LEGACY_PROXY_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/kroxylicious"
             OPERATOR_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.OPERATOR_IMAGE_NAME }}"
-            echo "proxy_tags=${PROXY_IMAGE}:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+            echo "proxy_tags=${PROXY_IMAGE}:${RELEASE_VERSION},${LEGACY_PROXY_IMAGE}:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
             echo "operator_tags=${OPERATOR_IMAGE}:${RELEASE_VERSION},${OPERATOR_IMAGE}:latest" >> $GITHUB_OUTPUT
             echo "push_images=true" >> $GITHUB_OUTPUT
             echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT

--- a/.github/workflows/documentation-tests.yml
+++ b/.github/workflows/documentation-tests.yml
@@ -64,8 +64,7 @@ jobs:
           KROXYLICIOUS_PROXY_IMAGE="$(mvn --quiet --projects :kroxylicious-app --activate-profiles dist org.apache.maven.plugins:maven-help-plugin:3.4.0:evaluate -Dexpression=io.kroxylicious.proxy.image.name -DforceStdout)"
           KROXYLICIOUS_OPERATOR_IMAGE="$(mvn --quiet --projects :kroxylicious-operator --activate-profiles dist org.apache.maven.plugins:maven-help-plugin:3.4.0:evaluate -Dexpression=io.kroxylicious.operator.image.name -DforceStdout)"
           KROXYLICIOUS_VERSION="$(mvn --quiet org.apache.maven.plugins:maven-help-plugin:3.5.1:evaluate -Dexpression=project.version -DforceStdout)"
-          minikube image tag ${KROXYLICIOUS_PROXY_IMAGE} quay.io/kroxylicious/kroxylicious:${KROXYLICIOUS_VERSION}
-          minikube image ls | grep --fixed-strings quay.io/kroxylicious/kroxylicious:${KROXYLICIOUS_VERSION}
+          minikube image ls | grep --fixed-strings ${KROXYLICIOUS_PROXY_IMAGE}
           minikube image ls | grep --fixed-strings ${KROXYLICIOUS_OPERATOR_IMAGE}
       - name: 'Run documentation tests'
         run: |

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -75,7 +75,7 @@ jobs:
           GIT_HASH="$(git rev-parse HEAD)"
           IMAGE_TAG="dev-git-${GIT_HASH}"
           KROXYLICIOUS_VERSION="$(mvn org.apache.maven.plugins:maven-help-plugin:3.4.0:evaluate -Dexpression=project.version -q -DforceStdout)"
-          KROXYLICIOUS_IMAGE="quay.io/kroxylicious/kroxylicious:${IMAGE_TAG}"
+          KROXYLICIOUS_IMAGE="quay.io/kroxylicious/proxy:${IMAGE_TAG}"
           echo "KROXYLICIOUS_VERSION=${KROXYLICIOUS_VERSION}" >> "$GITHUB_ENV"
           # KROXYLICIOUS_IMAGE env var is used by the Operator ITs
           echo "KROXYLICIOUS_IMAGE=${KROXYLICIOUS_IMAGE}" >> "$GITHUB_ENV"

--- a/.github/workflows/run-system-tests.yaml
+++ b/.github/workflows/run-system-tests.yaml
@@ -152,8 +152,7 @@ jobs:
           KROXYLICIOUS_PROXY_IMAGE="$(mvn --quiet --projects :kroxylicious-app --activate-profiles dist org.apache.maven.plugins:maven-help-plugin:3.5.1:evaluate -Dexpression=io.kroxylicious.proxy.image.name -DforceStdout)"
           KROXYLICIOUS_OPERATOR_IMAGE="$(mvn --quiet --projects :kroxylicious-operator --activate-profiles dist org.apache.maven.plugins:maven-help-plugin:3.5.1:evaluate -Dexpression=io.kroxylicious.operator.image.name -DforceStdout)"
           KROXYLICIOUS_VERSION="$(mvn --quiet org.apache.maven.plugins:maven-help-plugin:3.5.1:evaluate -Dexpression=project.version -DforceStdout)"
-          minikube image tag ${KROXYLICIOUS_PROXY_IMAGE} quay.io/kroxylicious/kroxylicious:${KROXYLICIOUS_VERSION}          
-          minikube image ls | grep --fixed-strings quay.io/kroxylicious/kroxylicious:${KROXYLICIOUS_VERSION}
+          minikube image ls | grep --fixed-strings ${KROXYLICIOUS_PROXY_IMAGE}
           minikube image ls | grep --fixed-strings ${KROXYLICIOUS_OPERATOR_IMAGE}
 
       - name: 'Run system tests'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format `<github issue/pr number>: <short description>`.
 ## SNAPSHOT
 
 * [#3861](https://github.com/kroxylicious/kroxylicious/pull/3861): refactor: move test-support modules to `io.kroxylicious.testing`
+* [#3882](https://github.com/kroxylicious/kroxylicious/pull/3882): build(image): proxy container image renamed from `quay.io/kroxylicious/kroxylicious` to `quay.io/kroxylicious/proxy`
 * [#3236](https://github.com/kroxylicious/kroxylicious/issues/3236): build(deps): bump strimzi.version from 0.51.0 to 1.0.0
 * [#3824](https://github.com/kroxylicious/kroxylicious/pull/3824): refactor(archetype): reuse record batch transform module
 * [#3842](https://github.com/kroxylicious/kroxylicious/pull/3842): fix(operator): use precise Kafka CRD detection for Strimzi support (prerequisite for Strimzi v1 upgrade)
@@ -26,6 +27,7 @@ Format `<github issue/pr number>: <short description>`.
 
 ### Changes, deprecations and removals
 
+* [#3882](https://github.com/kroxylicious/kroxylicious/pull/3882): The primary proxy container image is now `quay.io/kroxylicious/proxy`. `quay.io/kroxylicious/kroxylicious` is deprecated and subject to removal following our deprecation policy. Users deploying the proxy image directly (without the operator) should update their deployment configurations to use the new image name. The operator will automatically use the new image name.
 * [#3861](https://github.com/kroxylicious/kroxylicious/pull/3861): The `kroxylicious-*-test-support` modules now consistently use the package prefix `io.kroxylicious.testing`. Many of these modules modules are effectively internal, but 3rd party filters may have a dependency on `kroxylicious-filter-test-support` and 3rd party KMSes may have a dependency on `kroxylicious-kms-test-support`. When upgrading you will need to use the new package name in your tests.
 * [#3236](https://github.com/kroxylicious/kroxylicious/issues/3236): **BREAKING CHANGE** - If making use of the Strimzi integration feature in the KafkaService CR (`spec.strimziKafkaRef`), Strimzi 0.49.0 or later is now **required**. The Kroxylicious Operator now uses the Strimzi Kafka CR v1 API exclusively; v1beta2 API support has been dropped. Users running Strimzi versions prior to 0.49.0 must upgrade Strimzi.
 * [#3786](https://github.com/kroxylicious/kroxylicious/issues/3786): The deprecated method `StatusFactory#newTrueConditionStatusPatch(CustomResource, Condition.Type)` (two-parameter form) is removed. Use `StatusFactory#newTrueConditionStatusPatch(CustomResource, Condition.Type, String)` instead, passing `MetadataChecksumGenerator.NO_CHECKSUM_SPECIFIED` if no checksum tracking is needed.

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -426,7 +426,7 @@ example config entry:
 * `ARCHITECTURE`: architecture of the cluster where the test clients are deployed. Default value: `System.getProperty("os.arch")`
 * `KROXYLICIOUS_OPERATOR_VERSION`: version of kroxylicious operator to be used. Default value: `${project.version}` in pom file
 * `KROXYLICIOUS_OPERATOR_INSTALL_DIR`: directory of the operator install files. Used for operator yaml installation. Default value: `System.getProperty("user.dir") + "/target/kroxylicious-operator-dist/install/"`
-* `KROXYLICIOUS_IMAGE`: image location of the kroxylicious (proxy) image. Defaults to `quay.io/kroxylicious/kroxylicious:${project.version}`
+* `KROXYLICIOUS_IMAGE`: image location of the kroxylicious (proxy) image. Defaults to `quay.io/kroxylicious/proxy:${project.version}`
 * `KAFKA_VERSION`: kafka version to be used. Default value: `${kafka.version}` in pom file
 * `STRIMZI_VERSION`: strimzi version to be used. Default value: `${strimzi.version}` in pom file
 * `STRIMZI_NAMESPACE`: namespace used for strimzi cluster operator installation. Useful when strimzi is previously installed. Default value: `kafka`
@@ -452,7 +452,7 @@ First of all, start Minikube:
 minikube start --cpus 4
 ```
 
-By default, the system tests will pull the Operator from `quay.io/kroxylicious/operator:${project.version}` and the Proxy from `quay.io/kroxylicious/kroxylicious:${project.version}`.
+By default, the system tests will pull the Operator from `quay.io/kroxylicious/operator:${project.version}` and the Proxy from `quay.io/kroxylicious/proxy:${project.version}`.
 These will be the latest images built by CI.  You can change this behaviour by setting the environment variables shown in the table above.
 
 Alternatively, to run system tests against locally made changes, push the built operator and proxy images into your Minikube. Refer to section [Building and pushing Kroxylicious Container Images](#building-and-pushing-kroxylicious-container-images).

--- a/kroxylicious-docs/release-manifest.yaml
+++ b/kroxylicious-docs/release-manifest.yaml
@@ -23,8 +23,8 @@ assets:
         path: kroxylicious-operator-$(VERSION).tar.gz
 images:
   - name: Proxy
-    url: https://quay.io/repository/kroxylicious/kroxylicious?tab=tags
-    registry: quay.io/kroxylicious/kroxylicious
+    url: https://quay.io/repository/kroxylicious/proxy?tab=tags
+    registry: quay.io/kroxylicious/proxy
     tag: $(VERSION)
     digest: sha256:REPLACE_WITH_SHA_AFTER_IMAGE_RELEASE
   - name: Operator

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/main/resources-filtered/kroxylicious-image.properties
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/main/resources-filtered/kroxylicious-image.properties
@@ -4,4 +4,4 @@
 # Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 #
 
-kroxylicious-image=quay.io/kroxylicious/kroxylicious:${project.version}
+kroxylicious-image=quay.io/kroxylicious/proxy:${project.version}

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/DerivedResourcesTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/DerivedResourcesTest.java
@@ -177,7 +177,7 @@ class DerivedResourcesTest {
     }
 
     @TestFactory
-    @SetEnvironmentVariable(key = KROXYLICIOUS_IMAGE_ENV_VAR, value = "quay.io/kroxylicious/kroxylicious:test")
+    @SetEnvironmentVariable(key = KROXYLICIOUS_IMAGE_ENV_VAR, value = "quay.io/kroxylicious/proxy:test")
     Stream<DynamicContainer> dependentResourcesShouldEqual() {
         // Note that the order in this list should reflect the dependency order declared in the ProxyReconciler's
         // @ControllerConfiguration annotation, because the statefulness of Context<KafkaProxy> means that

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ProxyDeploymentTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/java/io/kroxylicious/kubernetes/operator/reconciler/kafkaproxy/ProxyDeploymentTest.java
@@ -70,7 +70,7 @@ class ProxyDeploymentTest {
     @ClearEnvironmentVariable(key = KROXYLICIOUS_IMAGE_ENV_VAR)
     void operandImageDefault() {
         assertThat(ProxyDeploymentDependentResource.getOperandImage())
-                .matches("^quay.io/kroxylicious/kroxylicious:.*");
+                .matches("^quay.io/kroxylicious/proxy:.*");
     }
 
     @Test

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-Deployment-example.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/clusterref-resource-not-found/out-Deployment-example.yaml
@@ -41,7 +41,7 @@ spec:
         - args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Deployment-example.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/colliding-secret-interpolation/out-Deployment-example.yaml
@@ -41,7 +41,7 @@ spec:
         - args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Deployment-example.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/filter-resource-not-found/out-Deployment-example.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Deployment-minimal.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-and-clusterip-ingress/out-Deployment-minimal.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress-with-no-downstream-tls-on-cluster/out-Deployment-twocluster.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress-with-no-downstream-tls-on-cluster/out-Deployment-twocluster.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress/out-Deployment-minimal.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/loadbalancer-ingress/out-Deployment-minimal.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Deployment-minimal.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/minimal/out-Deployment-minimal.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress-hosts-ready/out-Deployment-minimal.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress-hosts-ready/out-Deployment-minimal.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress/out-Deployment-minimal.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/route-ingress/out-Deployment-minimal.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-Deployment-twocluster.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-one-with-unresolved-ingress/out-Deployment-twocluster.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-Deployment-twocluster.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-clusterip-ingress/out-Deployment-twocluster.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/out-Deployment-twocluster.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-colliding-ingress-and-unresolved-filter/out-Deployment-twocluster.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-shared-loadbalancer-ingress/out-Deployment-twocluster.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-clusters-with-shared-loadbalancer-ingress/out-Deployment-twocluster.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Deployment-example.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/two-filters/out-Deployment-example.yaml
@@ -41,7 +41,7 @@ spec:
         - args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           name: "proxy"
           livenessProbe:
             failureThreshold: 3

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/user-supplies-proxy-container-resource-config-without-limits/out-Deployment-minimal.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/user-supplies-proxy-container-resource-config-without-limits/out-Deployment-minimal.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/user-supplies-proxy-container-resource-config/out-Deployment-minimal.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/user-supplies-proxy-container-resource-config/out-Deployment-minimal.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-downstream-tls-controls/out-Deployment-minimal.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-downstream-tls-controls/out-Deployment-minimal.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-downstream-tls-with-client-auth-none-mode/out-Deployment-minimal.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-downstream-tls-with-client-auth-none-mode/out-Deployment-minimal.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-downstream-tls-with-client-auth-requested-mode/out-Deployment-minimal.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-downstream-tls-with-client-auth-requested-mode/out-Deployment-minimal.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-downstream-tls-with-client-auth-required-mode/out-Deployment-minimal.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-downstream-tls-with-client-auth-required-mode/out-Deployment-minimal.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-downstream-tls-with-client-auth-trust-from-configmap-with-storeType/out-Deployment-minimal.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-downstream-tls-with-client-auth-trust-from-configmap-with-storeType/out-Deployment-minimal.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-downstream-tls-with-client-auth-trust-from-configmap/out-Deployment-minimal.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-downstream-tls-with-client-auth-trust-from-configmap/out-Deployment-minimal.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-downstream-tls-with-client-auth-trust-from-secret-with-storeType/out-Deployment-minimal.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-downstream-tls-with-client-auth-trust-from-secret-with-storeType/out-Deployment-minimal.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-downstream-tls-with-client-auth-trust-from-secret/out-Deployment-minimal.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-downstream-tls-with-client-auth-trust-from-secret/out-Deployment-minimal.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-downstream-tls/out-Deployment-minimal.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-downstream-tls/out-Deployment-minimal.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-upstream-tls-trust-from-configmap-with-storetype/out-Deployment-minimal.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-upstream-tls-trust-from-configmap-with-storetype/out-Deployment-minimal.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-upstream-tls-trust-from-configmap/out-Deployment-minimal.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-upstream-tls-trust-from-configmap/out-Deployment-minimal.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-upstream-tls-trust-from-secret-with-storetype/out-Deployment-minimal.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-upstream-tls-trust-from-secret-with-storetype/out-Deployment-minimal.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-upstream-tls-trust-from-secret/out-Deployment-minimal.yaml
+++ b/kroxylicious-kubernetes/kroxylicious-operator/src/test/resources/DerivedResourcesTest/virtualcluster-with-upstream-tls-trust-from-secret/out-Deployment-minimal.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: "proxy"
-          image: "quay.io/kroxylicious/kroxylicious:test"
+          image: "quay.io/kroxylicious/proxy:test"
           args:
             - "--config"
             - "/opt/kroxylicious/config/proxy-config.yaml"

--- a/performance-tests/perf-tests.sh
+++ b/performance-tests/perf-tests.sh
@@ -34,7 +34,7 @@ STRIMZI_VERSION=${STRIMZI_VERSION:-$(mvn -f "${KROXYLICIOUS_CHECKOUT}"/pom.xml o
 KROXYLICIOUS_VERSION=${KROXYLICIOUS_VERSION:-$(mvn -f "${KROXYLICIOUS_CHECKOUT}"/pom.xml org.apache.maven.plugins:maven-help-plugin:3.4.0:evaluate -Dexpression=project.version -q -DforceStdout)}
 KAFKA_TOOL_IMAGE=${KAFKA_TOOL_IMAGE:-quay.io/strimzi/kafka:${STRIMZI_VERSION}-kafka-${KAFKA_VERSION}}
 KAFKA_IMAGE=${KAFKA_IMAGE:-"${DOCKER_REGISTRY}/apache/kafka-native:${KAFKA_VERSION}"}
-KROXYLICIOUS_IMAGE=${KROXYLICIOUS_IMAGE:-"quay.io/kroxylicious/kroxylicious:${KROXYLICIOUS_VERSION}"}
+KROXYLICIOUS_IMAGE=${KROXYLICIOUS_IMAGE:-"quay.io/kroxylicious/proxy:${KROXYLICIOUS_VERSION}"}
 VAULT_IMAGE=${VAULT_IMAGE:-"${DOCKER_REGISTRY}/hashicorp/vault:2.0.0@sha256:e40c741ed95bb271425e3e6ca6c222d620cf8682f6f7a1b1e7c9d49d0aba484b"}
 PERF_NETWORK=performance-tests_perf_network
 CONTAINER_ENGINE=${CONTAINER_ENGINE:-"docker"}

--- a/scripts/run-example.sh
+++ b/scripts/run-example.sh
@@ -6,7 +6,7 @@
 #
 
 set -euo pipefail
-DEFAULT_KROXYLICIOUS_IMAGE='quay.io/kroxylicious/kroxylicious'
+DEFAULT_KROXYLICIOUS_IMAGE='quay.io/kroxylicious/proxy'
 KROXYLICIOUS_IMAGE=${KROXYLICIOUS_IMAGE:-${DEFAULT_KROXYLICIOUS_IMAGE}}
 STRIMZI_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.4.0:evaluate -Dexpression=strimzi.version -q -DforceStdout)
 


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Standardize on the new proxy image name `quay.io/kroxylicious/proxy` across all code, configuration, tests, and documentation. This progresses the migration from the original `quay.io/kroxylicious/kroxylicious` naming. The only usage of the old image is to publish it, we will remove it in some releases time following our deprecation cycle.

Changes:
- Update operator properties file to use new image name
- Update GitHub workflows (maven.yaml, run-system-tests.yaml, documentation-tests.yml)
- Remove backward-compatibility retagging in Minikube workflows
- Add backwards-compatible tagging to docker deploy workflow
- Update all operator test fixtures and assertions
- Update user-facing scripts (run-example.sh, perf-tests.sh)
- Update documentation (DEV_GUIDE.md, release-manifest.yaml)
- Add CHANGELOG entry documenting the change

Note: GitHub org variable PROXY_IMAGE_NAME must be manually updated from 'kroxylicious' to 'proxy' after this change is merged.

Closes #3878 

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] PR raised from a fork of this repository and made from a branch rather than main. 
- [ ] Write tests
- [ ] Update documentation
- [ ] Make sure all unit/integration tests pass
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] If applicable to the change, make sure system tests pass.
- [ ] If applicable to the change, [trigger the performance test suite](../blob/main/PERFORMANCE.md#jenkins-pipeline-for-performance). Ensure that any degradations to performance numbers are understood and justified.
- [ ] Ensure the PR references relevant issue(s) so they are closed on merging.
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).

> **_NOTE:_**  You must be a member of `@kroxylicious/developers` to trigger the system test and performance test suites.  If you are not part of this group, comment on the PR requesting a trigger, tagging `@kroxylicious/developers`.
