### PR TITLE
fix(integration-tests): fix flaky JoinGroupAuthzIT.shouldEnforceAccessToTopics

### DIFF
--- a/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/JoinGroupAuthzIT.java
+++ b/kroxylicious-integration-tests/src/test/java/io/kroxylicious/it/filter/authorization/JoinGroupAuthzIT.java
@@ -21,8 +21,6 @@ import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.acl.AclPermissionType;
-import org.apache.kafka.common.message.ConsumerGroupHeartbeatRequestData;
-import org.apache.kafka.common.message.ConsumerGroupHeartbeatResponseData;
 import org.apache.kafka.common.message.JoinGroupRequestData;
 import org.apache.kafka.common.message.JoinGroupResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
@@ -157,6 +155,11 @@ public class JoinGroupAuthzIT extends AuthzIT {
         }
 
         @Override
+        public boolean needsRetry(JoinGroupResponseData response) {
+            return Errors.forCode(response.errorCode()) == Errors.NOT_COORDINATOR;
+        }
+
+        @Override
         public void prepareCluster(BaseClusterFixture cluster) {
             KafkaDriver driver = new KafkaDriver(cluster, cluster.authenticatedClient(AuthzIT.SUPER, SUPER_PASSWORD), AuthzIT.SUPER);
             driver.findCoordinator(FindCoordinatorRequest.CoordinatorType.GROUP, group);
@@ -211,7 +214,7 @@ public class JoinGroupAuthzIT extends AuthzIT {
 
     @ParameterizedTest
     @MethodSource
-    void shouldEnforceAccessToTopics(VersionSpecificVerification<ConsumerGroupHeartbeatRequestData, ConsumerGroupHeartbeatResponseData> test) {
+    void shouldEnforceAccessToTopics(VersionSpecificVerification<JoinGroupRequestData, JoinGroupResponseData> test) {
         try (var referenceCluster = new ReferenceCluster(kafkaClusterWithAuthz, this.topicIdsInUnproxiedCluster);
                 var proxiedCluster = new ProxiedCluster(kafkaClusterNoAuthz, this.topicIdsInProxiedCluster, rulesFile)) {
             test.verifyBehaviour(referenceCluster, proxiedCluster);


### PR DESCRIPTION


### Type of change

- Bugfix

### Description

Add needsRetry() override to retry on NOT_COORDINATOR, which handles the race between findCoordinator() in prepareCluster() and the actual JoinGroup request being sent on a different connection. Also fix incorrect type parameters on the test method signature.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>


### Additional Context

Fixes #3739

