### PR TITLE
ci(docker): fix aarch64 proxy image missing native Netty transport JARs

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -168,7 +168,7 @@ jobs:
           mvn --quiet \
             --batch-mode \
             --activate-profiles 'dist,aarch64,!qa' \
-            --projects :kroxylicious-app \
+            --projects :kroxylicious-runtime,:kroxylicious-app \
             -Derrorprone.skip=true \
             -DskipTests \
             -Dmaven.javadoc.skip=true \

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -9,6 +9,17 @@
 #
 # If the required repository variables aren't set the workflow will be skipped. This means the workflow won't fail
 # on the forks of developers who haven't configured the variables/secrets.
+#
+# Multi-arch proxy images are built as a 4-phase process:
+#   1. mvn install  — compile and install all module JARs into ~/.m2 once
+#   2. mvn + docker — dist packaging and image build for linux/amd64
+#   3. mvn + docker — dist packaging (with -Paarch64) and image build for linux/arm64
+#   4. manifest     — merge per-arch images into a multi-arch manifest list
+#
+# The operator has no architecture-specific native JARs, so a single multi-arch
+# Docker Buildx build covers both platforms without a paired Maven run.
+#
+# PR builds validate only linux/amd64 for speed.
 
 name: Docker Build
 
@@ -56,25 +67,38 @@ jobs:
           echo "release_version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
 
           if [[ "${{ github.event_name }}" == "pull_request" || "${{ vars.REGISTRY_SERVER }}" == "" ]]; then
-            echo "proxy_tags=kroxylicious-proxy:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
-            echo "operator_tags=kroxylicious-operator:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+            # PR / no-registry builds: amd64 only for speed, no push, no manifest needed.
             echo "push_images=false" >> $GITHUB_OUTPUT
-            echo "platforms=linux/amd64" >> $GITHUB_OUTPUT
+            echo "multi_arch=false" >> $GITHUB_OUTPUT
+            echo "proxy_amd64_tag=kroxylicious-proxy:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+            echo "proxy_arm64_tag=" >> $GITHUB_OUTPUT
+            echo "proxy_final_tags=" >> $GITHUB_OUTPUT
+            echo "operator_platforms=linux/amd64" >> $GITHUB_OUTPUT
+            echo "operator_tags=kroxylicious-operator:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
           else
             PROXY_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.PROXY_IMAGE_NAME }}"
             LEGACY_PROXY_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/kroxylicious"
             OPERATOR_IMAGE="${{ vars.REGISTRY_SERVER }}/${{ vars.REGISTRY_ORGANISATION }}/${{ vars.OPERATOR_IMAGE_NAME }}"
-            echo "proxy_tags=${PROXY_IMAGE}:${RELEASE_VERSION},${LEGACY_PROXY_IMAGE}:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
-            echo "operator_tags=${OPERATOR_IMAGE}:${RELEASE_VERSION},${OPERATOR_IMAGE}:latest" >> $GITHUB_OUTPUT
+            # Per-arch intermediate tags are pushed individually then merged into the
+            # final manifest list (which also covers the legacy kroxylicious image name).
             echo "push_images=true" >> $GITHUB_OUTPUT
-            echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
+            echo "multi_arch=true" >> $GITHUB_OUTPUT
+            echo "proxy_amd64_tag=${PROXY_IMAGE}:${RELEASE_VERSION}-amd64" >> $GITHUB_OUTPUT
+            echo "proxy_arm64_tag=${PROXY_IMAGE}:${RELEASE_VERSION}-arm64" >> $GITHUB_OUTPUT
+            echo "proxy_final_tags=${PROXY_IMAGE}:${RELEASE_VERSION},${LEGACY_PROXY_IMAGE}:${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+            echo "operator_platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
+            echo "operator_tags=${OPERATOR_IMAGE}:${RELEASE_VERSION},${OPERATOR_IMAGE}:latest" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build Kroxylicious distribution artifacts
+      # ── Phase 1: compile and install ─────────────────────────────────────────
+      # Install (not just package) so the per-arch dist steps can resolve local
+      # module JARs from ~/.m2 without needing --also-make.
+
+      - name: Compile and install all modules
         run: |
           mvn --quiet \
             --batch-mode \
-            --activate-profiles 'dist,!qa' \
+            --activate-profiles '!qa' \
             --also-make \
             --projects :kroxylicious-app,:kroxylicious-operator,:kroxylicious-operator-dist \
             -Derrorprone.skip=true \
@@ -82,7 +106,7 @@ jobs:
             -Dmaven.javadoc.skip=true \
             -DskipDocs=true \
             -DskipContainerImageBuild=true \
-            package
+            install
 
       - name: Login to container registry
         if: steps.build_configuration.outputs.push_images == 'true'
@@ -92,31 +116,93 @@ jobs:
           username: ${{ vars.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_TOKEN }}
 
-      - name: Build and maybe push Proxy image
+      # ── Phase 2: amd64 dist + images ─────────────────────────────────────────
+
+      - name: Build amd64 distribution artifacts
+        run: |
+          mvn --quiet \
+            --batch-mode \
+            --activate-profiles 'dist,!qa' \
+            --projects :kroxylicious-app,:kroxylicious-operator,:kroxylicious-operator-dist \
+            -Derrorprone.skip=true \
+            -DskipTests \
+            -Dmaven.javadoc.skip=true \
+            -DskipDocs=true \
+            -DskipContainerImageBuild=true \
+            package
+
+      - name: Build and maybe push amd64 proxy image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: ./kroxylicious-app
           file: ./kroxylicious-app/src/main/docker/proxy.dockerfile
-          platforms: ${{ steps.build_configuration.outputs.platforms }}
+          platforms: linux/amd64
           push: ${{ steps.build_configuration.outputs.push_images == 'true' }}
           build-args: |
             KROXYLICIOUS_VERSION=${{ steps.build_configuration.outputs.release_version }}
-          tags: ${{ steps.build_configuration.outputs.proxy_tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,compression=zstd
+          tags: ${{ steps.build_configuration.outputs.proxy_amd64_tag }}
+          cache-from: type=gha,scope=proxy-amd64
+          cache-to: type=gha,mode=max,compression=zstd,scope=proxy-amd64
 
-      - name: Build and maybe push Operator image
+      - name: Build and maybe push operator image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: ./kroxylicious-kubernetes/kroxylicious-operator
           file: ./kroxylicious-kubernetes/kroxylicious-operator/src/main/docker/operator.dockerfile
-          platforms: ${{ steps.build_configuration.outputs.platforms }}
+          platforms: ${{ steps.build_configuration.outputs.operator_platforms }}
           push: ${{ steps.build_configuration.outputs.push_images == 'true' }}
           build-args: |
             KROXYLICIOUS_VERSION=${{ steps.build_configuration.outputs.release_version }}
           tags: ${{ steps.build_configuration.outputs.operator_tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,compression=zstd
+          cache-from: type=gha,scope=operator
+          cache-to: type=gha,mode=max,compression=zstd,scope=operator
+
+      # ── Phase 3: arm64 dist + image ──────────────────────────────────────────
+      # `clean package` on kroxylicious-app alone wipes its target/ directory so
+      # the aarch64 assembly contains only linux-aarch_64 Netty native binaries
+      # (no leftovers from the amd64 run above).
+
+      - name: Build arm64 distribution artifacts
+        if: steps.build_configuration.outputs.multi_arch == 'true'
+        run: |
+          mvn --quiet \
+            --batch-mode \
+            --activate-profiles 'dist,aarch64,!qa' \
+            --projects :kroxylicious-app \
+            -Derrorprone.skip=true \
+            -DskipTests \
+            -Dmaven.javadoc.skip=true \
+            -DskipDocs=true \
+            -DskipContainerImageBuild=true \
+            clean package
+
+      - name: Build and push arm64 proxy image
+        if: steps.build_configuration.outputs.multi_arch == 'true'
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
+        with:
+          context: ./kroxylicious-app
+          file: ./kroxylicious-app/src/main/docker/proxy.dockerfile
+          platforms: linux/arm64
+          push: true
+          build-args: |
+            KROXYLICIOUS_VERSION=${{ steps.build_configuration.outputs.release_version }}
+          tags: ${{ steps.build_configuration.outputs.proxy_arm64_tag }}
+          cache-from: type=gha,scope=proxy-arm64
+          cache-to: type=gha,mode=max,compression=zstd,scope=proxy-arm64
+
+      # ── Phase 4: multi-arch manifest ─────────────────────────────────────────
+      # Assemble the canonical proxy tag and the legacy kroxylicious alias as
+      # manifest lists pointing at the per-arch images pushed above.
+
+      - name: Create and push proxy multi-arch manifest
+        if: steps.build_configuration.outputs.multi_arch == 'true'
+        run: |
+          for TAG in $(echo "${{ steps.build_configuration.outputs.proxy_final_tags }}" | tr ',' ' '); do
+            docker buildx imagetools create -t "${TAG}" \
+              "${{ steps.build_configuration.outputs.proxy_amd64_tag }}" \
+              "${{ steps.build_configuration.outputs.proxy_arm64_tag }}"
+          done
+
       - name: Slack Notification on Failure
         if: failure() && env.SLACK_WEBHOOK_SET == 'true' && github.event_name == 'push'
         uses: ./.github/actions/common/slack-notification

--- a/scripts/stage-release.sh
+++ b/scripts/stage-release.sh
@@ -17,7 +17,8 @@ BRANCH_FROM="main"
 WORK_BRANCH_NAME="release-work-$(openssl rand -hex 12)"
 SKIP_VALIDATION="false"
 RELEASE_NOTES_DIR=${RELEASE_NOTES_DIR:-.releaseNotes}
-while getopts ":l:v:b:k:r:n:w:sh" opt; do
+PROXY_IMAGE_REPO="quay.io/kroxylicious/proxy"
+while getopts ":i:l:v:b:k:r:n:w:sh" opt; do
   case $opt in
     v) RELEASE_VERSION="${OPTARG}"
     ;;
@@ -29,6 +30,8 @@ while getopts ":l:v:b:k:r:n:w:sh" opt; do
     ;;
     k) GPG_KEY="${OPTARG}"
     ;;
+    i) PROXY_IMAGE_REPO="${OPTARG}"
+    ;;
     l) RELCAND_ID_LABEL="${OPTARG}"
     ;;
     w) WORK_BRANCH_NAME="${OPTARG}"
@@ -37,13 +40,14 @@ while getopts ":l:v:b:k:r:n:w:sh" opt; do
     ;;
     h)
       1>&2 cat << EOF
-usage: $0 -k keyid -v version -l relcand-label [-b branch] [-r repository] [-s] [-d] [-h]
+usage: $0 -k keyid -v version -l relcand-label [-b branch] [-r repository] [-i proxy-image-repo] [-s] [-d] [-h]
  -k short key id used to sign the release
  -v version number e.g. 0.3.0
  -b branch to release from (defaults to 'main')
  -n development version e.g. 0.4.0-SNAPSHOT
  -l Release candidate label to be applied to the PR.
  -r the remote name of the kroxylicious repository (defaults to 'origin')
+ -i proxy image repo override for arm64 verification (default: quay.io/kroxylicious/proxy)
  -w release work branch
  -s skips validation
  -h this help message
@@ -246,4 +250,54 @@ gh pr create --head "${PREPARE_DEVELOPMENT_BRANCH}" \
              --body "${BODY}" \
              --repo "$(gh repo set-default -v)" \
              --label "${RELCAND_ID_LABEL}"
+
+# ── Verification: arm64 proxy image contains correct native libs ──────────────
+# The docker.yaml workflow was triggered by the tag push earlier in this script.
+# By the time we reach here (after mvn deploy + release prep), the workflow has
+# had significant time to run.  We poll for the run, wait for completion, then
+# spot-check that the linux/arm64 image layer contains aarch_64 Netty native
+# libraries and NO x86_64 ones.
+#
+# Defaults to quay.io/kroxylicious/proxy; override with -i for fork testing.
+if [[ -n "${PROXY_IMAGE_REPO}" ]]; then
+  echo "Waiting for docker workflow triggered by ${RELEASE_TAG} to appear..."
+  DOCKER_RUN_ID=""
+  for _attempt in 1 2 3 4 5 6 7 8 9 10; do
+    DOCKER_RUN_ID=$(gh run list \
+      --workflow docker.yaml \
+      --branch "${RELEASE_TAG}" \
+      --json databaseId \
+      --jq '.[0].databaseId // empty' 2>/dev/null || true)
+    [[ -n "${DOCKER_RUN_ID}" ]] && break
+    echo "  Run not yet visible (attempt ${_attempt}/10); retrying in 15s..."
+    sleep 15
+  done
+
+  if [[ -z "${DOCKER_RUN_ID}" ]]; then
+    echo "ERROR: Could not find docker workflow run for tag ${RELEASE_TAG}." >&2
+    echo "       Check the Actions tab and verify the arm64 image manually." >&2
+    exit 1
+  fi
+
+  echo "Found docker workflow run ${DOCKER_RUN_ID}; waiting for completion..."
+  gh run watch "${DOCKER_RUN_ID}" --exit-status
+
+  echo "Verifying arm64 proxy image native libraries in ${PROXY_IMAGE_REPO}:${RELEASE_VERSION}..."
+  _CONTAINER_ID=$(docker create --platform linux/arm64 "${PROXY_IMAGE_REPO}:${RELEASE_VERSION}")
+  _NATIVE_DIR=$(mktemp -d)
+  docker cp "${_CONTAINER_ID}:/opt/kroxylicious/libs/native/netty/." "${_NATIVE_DIR}/"
+  docker rm "${_CONTAINER_ID}" > /dev/null
+
+  _AARCH64_COUNT=$(find "${_NATIVE_DIR}" -name '*aarch_64*' | wc -l | tr -d ' ')
+  _X86_64_COUNT=$(find "${_NATIVE_DIR}" -name '*x86_64*' | wc -l | tr -d ' ')
+  rm -rf "${_NATIVE_DIR}"
+
+  if [[ "${_AARCH64_COUNT}" -gt 0 && "${_X86_64_COUNT}" -eq 0 ]]; then
+    echo "arm64 proxy image OK: ${_AARCH64_COUNT} aarch_64 native lib(s), no x86_64 libs."
+  else
+    echo "ERROR: arm64 native lib check failed (aarch_64=${_AARCH64_COUNT}, x86_64=${_X86_64_COUNT})." >&2
+    echo "       Use drop-release to clean up, then investigate the docker workflow." >&2
+    exit 1
+  fi
+fi
 


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `docker.yaml` workflow was building the proxy container image using a single multi-arch `docker buildx` build. This meant the Maven `dist` profile (which uses `unpack-dependencies` to extract architecture-specific Netty native `.so` files) only ran once on the x86_64 CI runner. Both the `linux/amd64` and `linux/arm64` image layers therefore contained only `linux-x86_64` Netty native transport libraries — the arm64 image was silently broken.

**Fix:** Restructure the workflow into a 4-phase process:

1. `mvn install` — compile and install all module JARs into `~/.m2` once
2. `mvn -Pdist package` + Docker build — amd64 dist and `linux/amd64` image
3. `mvn -Pdist,aarch64 clean package` + Docker build — arm64 dist (with `-Paarch64` to switch Netty classifier to `linux-aarch_64`) and `linux/arm64` image
4. `docker buildx imagetools create` — merge per-arch images into a multi-arch manifest list

The operator image has no arch-specific native JARs so it continues to use a single multi-arch Buildx build.

PR builds (and forks without registry variables) continue to build amd64-only with no push.

Also adds a post-tag verification step to `scripts/stage-release.sh` that waits for the `docker.yaml` workflow triggered by the release tag, then uses `docker create --platform linux/arm64` + `docker cp` to confirm the arm64 image contains `aarch_64` Netty native libs and no `x86_64` ones.

### Additional Context

Closes #2382

### Checklist

- [ ] New tests written (where applicable).
- [ ] User facing documentation written/updated (where applicable).
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [x] PR references related GitHub issue(s) so they are closed on merging.
- [x] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).