### PR TITLE
test(admission): Add test covering `SidecarContainers=false,ImageVolume=false`

### DIFF
--- a/kroxylicious-kubernetes/kroxylicious-admission-api/src/main/resources/META-INF/fabric8/kroxylicioussidecarconfigs.sidecar.kroxylicious.io-v1.yml
+++ b/kroxylicious-kubernetes/kroxylicious-admission-api/src/main/resources/META-INF/fabric8/kroxylicioussidecarconfigs.sidecar.kroxylicious.io-v1.yml
@@ -218,8 +218,9 @@ spec:
                         maxLength: 63
                       image:
                         description: |
-                          The OCI image containing the plugin JARs. The image should be built
-                          FROM scratch with JARs at the image root.
+                          The OCI image containing the plugin JARs. JARs must be placed in
+                          the /plugins directory within the image. If OCI image volumes are
+                          not available the image must also include a shell (e.g. busybox).
                         type: object
                         required:
                           - reference

--- a/kroxylicious-kubernetes/kroxylicious-admission/README.md
+++ b/kroxylicious-kubernetes/kroxylicious-admission/README.md
@@ -28,21 +28,7 @@ The webhook always overwrites the `kroxylicious.io/proxy-config` annotation, pre
 
 ## Custom Resource: `KroxyliciousSidecarConfig`
 
-A namespaced CRD (group `kroxylicious.io`, version `v1alpha1`) that defines sidecar configuration per namespace. Key fields:
-
-| Field                    | Description |
-|--------------------------|-------------|
-| `targetBootstrapServers` | Bootstrap servers of the target Kafka cluster (required) |
-| `proxyImage`             | Override the proxy container image |
-| `bootstrapPort`          | Proxy bootstrap port on localhost (default: 19092) |
-| `nodeIdRange`            | Broker node ID range (default: 0-2) |
-| `managementPort`         | Management endpoint port (default: 9190) |
-| `filterDefinitions`      | Filters applied to proxied traffic |
-| `targetClusterTls`       | TLS configuration for the target Kafka connection |
-| `plugins`                | Third-party plugin images providing additional filter JARs |
-| `delegatedAnnotations`   | Annotations app owners may set to override config |
-| `setBootstrapEnvVar`     | Whether to set `KAFKA_BOOTSTRAP_SERVERS` on app containers (default: true) |
-| `resources`              | Resource requests/limits for the sidecar container |
+A namespaced CRD that defines sidecar configuration per namespace. See the [CRD definition](../kroxylicious-admission-api/src/main/resources/META-INF/fabric8/kroxylicioussidecarconfigs.sidecar.kroxylicious.io-v1.yml) for the full field reference.
 
 ### Plugin Images
 
@@ -212,7 +198,7 @@ mvn test -pl kroxylicious-kubernetes/kroxylicious-kubernetes-admission \
 
 ## Cross-References
 
-- **CRD definition**: See `../kroxylicious-kubernetes-api/src/main/resources/META-INF/fabric8/kroxylicioussidecarconfigs.kroxylicious.io-v1.yml`
+- **CRD definition**: See `../kroxylicious-admission-api/src/main/resources/META-INF/fabric8/kroxylicioussidecarconfigs.sidecar.kroxylicious.io-v1.yml`
 - **Proxy configuration model**: See `../kroxylicious-runtime/`
 - **Operator (standalone proxy deployment)**: See [`../kroxylicious-operator/README.md`](../kroxylicious-operator/README.md)
 - **Security patterns**: See [`../.claude/rules/security-patterns.md`](../.claude/rules/security-patterns.md)

--- a/kroxylicious-kubernetes/kroxylicious-admission/README.md
+++ b/kroxylicious-kubernetes/kroxylicious-admission/README.md
@@ -39,9 +39,33 @@ A namespaced CRD (group `kroxylicious.io`, version `v1alpha1`) that defines side
 | `managementPort`         | Management endpoint port (default: 9190) |
 | `filterDefinitions`      | Filters applied to proxied traffic |
 | `targetClusterTls`       | TLS configuration for the target Kafka connection |
+| `plugins`                | Third-party plugin images providing additional filter JARs |
 | `delegatedAnnotations`   | Annotations app owners may set to override config |
 | `setBootstrapEnvVar`     | Whether to set `KAFKA_BOOTSTRAP_SERVERS` on app containers (default: true) |
 | `resources`              | Resource requests/limits for the sidecar container |
+
+### Plugin Images
+
+Third-party filter plugins are packaged as OCI images. JARs must be placed in the `/plugins` directory within the image.
+
+How the webhook mounts plugin JARs depends on the Kubernetes cluster version:
+
+- **OCI image volumes (Kubernetes 1.35+):** The image is mounted directly as a read-only volume. The image can be built `FROM scratch` since no executable is needed — the container runtime handles the mount.
+- **EmptyDir fallback (older clusters):** The webhook creates an init container that runs the plugin image and executes `cp /plugins/*.jar /dest/` to copy JARs into an emptyDir volume. This requires the image to include at least `sh` and `cp` (e.g. a busybox base image).
+
+If your plugin image needs to work on clusters both with and without OCI image volume support, use a base image that provides a shell:
+
+```dockerfile
+FROM quay.io/quay/busybox
+COPY my-filter.jar /plugins/
+```
+
+If you know your target cluster supports OCI image volumes, a scratch-based image is sufficient:
+
+```dockerfile
+FROM scratch
+COPY my-filter.jar /plugins/
+```
 
 ## Labels
 
@@ -107,6 +131,7 @@ The webhook is configured via environment variables:
 | `TLS_KEY_PATH` | `/etc/webhook/tls/tls.key` | PEM private key file |
 | `KROXYLICIOUS_IMAGE` | (required) | Default proxy container image |
 | `FAILURE_POLICY` | `Fail` | Error handling policy: `Fail` (deny on error) or `Ignore` (allow on error) |
+| `FEATURE_GATES` | (auto-detect) | Comma-separated feature gate overrides, e.g. `SidecarContainers=false,ImageVolume=false` |
 
 ## Deployment
 
@@ -146,7 +171,7 @@ KT tests require:
    ```bash
    mvn package -pl kroxylicious-kubernetes/kroxylicious-kubernetes-admission -Pdist -am -DskipTests
    ```
-3. **A Kubernetes cluster whose container runtime supports OCI image volumes.** The plugin end-to-end test (`*PluginEndToEndKT`) mounts third-party plugin JARs as image volumes (Kubernetes `ImageVolume` feature gate, beta since 1.33). This requires **containerd 2.0+** or **CRI-O**; the Docker runtime does not support image volumes.
+3. **A Kubernetes cluster.** The plugin end-to-end tests (`*PluginEndToEndKT`) cover both OCI image volume mounting (Kubernetes 1.35+, `ImageVolume` feature gate) and the emptyDir fallback path. The Kind variant creates a cluster with `ImageVolume` enabled; the Minikube variant requires Kubernetes 1.35+ (the test will be skipped with an `assumeTrue` message if the version is too old).
 
 #### Minikube
 

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
@@ -163,9 +163,7 @@ class AdmissionHandler implements HttpHandler {
             LOGGER.atDebug()
                     .addKeyValue(WebhookLoggingKeys.POD, podName)
                     .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
-                    .addKeyValue("pluginCount",
-                            spec.getPlugins() != null ? spec.getPlugins().size() : 0)
-                    .addKeyValue("pluginsNull", spec.getPlugins() == null)
+                    .addKeyValue("plugins", spec.getPlugins())
                     .addKeyValue("useNativeSidecar", useNativeSidecar)
                     .addKeyValue("useOciImageVolumes", useOciImageVolumes)
                     .log("Resolved sidecar config for patch generation");

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/AdmissionHandler.java
@@ -158,9 +158,27 @@ class AdmissionHandler implements HttpHandler {
             String image = proxyImage(sidecarConfig);
             Long gen = sidecarConfig.getMetadata().getGeneration();
             long configGeneration = gen != null ? gen : 0L;
+
+            var spec = sidecarConfig.getSpec();
+            LOGGER.atDebug()
+                    .addKeyValue(WebhookLoggingKeys.POD, podName)
+                    .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
+                    .addKeyValue("pluginCount",
+                            spec.getPlugins() != null ? spec.getPlugins().size() : 0)
+                    .addKeyValue("pluginsNull", spec.getPlugins() == null)
+                    .addKeyValue("useNativeSidecar", useNativeSidecar)
+                    .addKeyValue("useOciImageVolumes", useOciImageVolumes)
+                    .log("Resolved sidecar config for patch generation");
+
             String jsonPatch = PodMutator.createPatch(
-                    pod, sidecarConfig.getSpec(), image, configGeneration,
+                    pod, spec, image, configGeneration,
                     useNativeSidecar, useOciImageVolumes);
+
+            LOGGER.atDebug()
+                    .addKeyValue(WebhookLoggingKeys.POD, podName)
+                    .addKeyValue(WebhookLoggingKeys.NAMESPACE, namespace)
+                    .addKeyValue("jsonPatch", jsonPatch)
+                    .log("Generated admission response patch");
 
             AdmissionResponse response = allowResponse(uid);
             response.setPatchType(JSON_PATCH_TYPE);

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/KubernetesVersion.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/KubernetesVersion.java
@@ -61,15 +61,15 @@ record KubernetesVersion(int major, int minor, Map<String, Boolean> featureGates
 
     /**
      * Detects whether the cluster supports OCI image volumes.
-     * Enabled by default since Kubernetes 1.33 (beta). On 1.31-1.32 (alpha),
-     * requires the {@code ImageVolume} feature gate to be explicitly enabled.
+     * Enabled by default since Kubernetes 1.35. On 1.31-1.34 the
+     * {@code ImageVolume} feature gate must be explicitly enabled.
      */
     boolean supportsOciImageVolumes() {
         Boolean gate = featureGates.get(IMAGE_VOLUME_GATE);
         if (gate != null) {
             return gate;
         }
-        return isAtLeast(1, 33);
+        return isAtLeast(1, 35);
     }
 
     private boolean isAtLeast(int reqMajor, int reqMinor) {

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
@@ -264,7 +264,7 @@ class PodMutator {
             ContainerBuilder cb = new ContainerBuilder()
                     .withName(PLUGIN_VOLUME_PREFIX + plugin.getName() + "-copy")
                     .withImage(plugin.getImage().getReference())
-                    .withCommand("sh", "-c", "find / -maxdepth 1 -not -type d -exec cp {} /plugins/ \\;");
+                    .withCommand("sh", "-c", "cp /*.jar /plugins/");
             if (plugin.getImage().getPullPolicy() != null) {
                 cb.withImagePullPolicy(plugin.getImage().getPullPolicy().getValue());
             }

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
@@ -261,10 +261,14 @@ class PodMutator {
         }
 
         for (Plugins plugin : plugins) {
-            Container initContainer = new ContainerBuilder()
+            ContainerBuilder cb = new ContainerBuilder()
                     .withName(PLUGIN_VOLUME_PREFIX + plugin.getName() + "-copy")
                     .withImage(plugin.getImage().getReference())
-                    .withCommand("sh", "-c", "cp -r /. /plugins/")
+                    .withCommand("sh", "-c", "find / -maxdepth 1 -not -type d -exec cp {} /plugins/ \\;");
+            if (plugin.getImage().getPullPolicy() != null) {
+                cb.withImagePullPolicy(plugin.getImage().getPullPolicy().getValue());
+            }
+            Container initContainer = cb
                     .addNewVolumeMount()
                     .withName(PLUGIN_VOLUME_PREFIX + plugin.getName())
                     .withMountPath("/plugins")

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
@@ -51,7 +51,9 @@ class PodMutator {
     @SuppressWarnings("java:S1075") // there's nothing wrong with hard coding this path.
     private static final String PLUGINS_BASE_PATH = "/opt/kroxylicious/classpath-plugins";
     private static final String PLUGIN_VOLUME_PREFIX = "plugin-";
+    /** Path within plugin OCI images where JARs must be placed. */
     private static final String PLUGIN_IMAGE_JAR_PATH = "/plugins";
+    /** Mount path for the emptyDir volume inside plugin-copy init containers. */
     private static final String PLUGIN_COPY_DEST_PATH = "/dest";
     private static final String SECRET_VOLUME_PREFIX = "secret-";
     @SuppressWarnings("java:S1075")

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/PodMutator.java
@@ -51,6 +51,8 @@ class PodMutator {
     @SuppressWarnings("java:S1075") // there's nothing wrong with hard coding this path.
     private static final String PLUGINS_BASE_PATH = "/opt/kroxylicious/classpath-plugins";
     private static final String PLUGIN_VOLUME_PREFIX = "plugin-";
+    private static final String PLUGIN_IMAGE_JAR_PATH = "/plugins";
+    private static final String PLUGIN_COPY_DEST_PATH = "/dest";
     private static final String SECRET_VOLUME_PREFIX = "secret-";
     @SuppressWarnings("java:S1075")
     private static final String SECRETS_BASE_PATH = "/opt/kroxylicious/secrets";
@@ -264,14 +266,16 @@ class PodMutator {
             ContainerBuilder cb = new ContainerBuilder()
                     .withName(PLUGIN_VOLUME_PREFIX + plugin.getName() + "-copy")
                     .withImage(plugin.getImage().getReference())
-                    .withCommand("sh", "-c", "cp /*.jar /plugins/");
+                    .withCommand("sh", "-c",
+                            "cp " + PLUGIN_IMAGE_JAR_PATH + "/*.jar "
+                                    + PLUGIN_COPY_DEST_PATH + "/");
             if (plugin.getImage().getPullPolicy() != null) {
                 cb.withImagePullPolicy(plugin.getImage().getPullPolicy().getValue());
             }
             Container initContainer = cb
                     .addNewVolumeMount()
                     .withName(PLUGIN_VOLUME_PREFIX + plugin.getName())
-                    .withMountPath("/plugins")
+                    .withMountPath(PLUGIN_COPY_DEST_PATH)
                     .endVolumeMount()
                     .withNewSecurityContext()
                     .withAllowPrivilegeEscalation(false)
@@ -350,11 +354,14 @@ class PodMutator {
         List<Plugins> plugins = spec.getPlugins();
         if (plugins != null) {
             for (Plugins plugin : plugins) {
-                builder.addNewVolumeMount()
+                var mount = builder.addNewVolumeMount()
                         .withName(PLUGIN_VOLUME_PREFIX + plugin.getName())
                         .withMountPath(PLUGINS_BASE_PATH + "/" + plugin.getName())
-                        .withReadOnly(true)
-                        .endVolumeMount();
+                        .withReadOnly(true);
+                if (useOciImageVolumes) {
+                    mount.withSubPath(PLUGIN_IMAGE_JAR_PATH.substring(1));
+                }
+                mount.endVolumeMount();
             }
         }
 

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/main/java/io/kroxylicious/kubernetes/webhook/WebhookMain.java
@@ -37,7 +37,7 @@ public class WebhookMain {
     private static final String TLS_KEY_PATH_VAR = "TLS_KEY_PATH";
     private static final String KROXYLICIOUS_IMAGE_VAR = "KROXYLICIOUS_IMAGE";
     private static final String FAILURE_POLICY_VAR = "FAILURE_POLICY";
-    private static final String FEATURE_GATES_VAR = "FEATURE_GATES";
+    static final String FEATURE_GATES_VAR = "FEATURE_GATES";
 
     private static final String DEFAULT_BIND_ADDRESS = "0.0.0.0:8443";
     @SuppressWarnings("java:S1075") // there's nothing wrong with hard coding this path.

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/docker/test-plugin.dockerfile
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/docker/test-plugin.dockerfile
@@ -5,9 +5,9 @@
 #
 
 # Test plugin OCI image for integration tests.
-# Contains the simple-transform filter JARs at the image root.
-# Used to verify OCI image volume plugin mounting in the sidecar.
+# Plugin JARs go in /plugins/ — the webhook mounts this subdirectory
+# (via subPath for OCI, or copies from it for emptyDir fallback).
 # Uses busybox (not scratch) so the emptyDir fallback init container
 # can run "sh -c cp" when OCI image volumes are unavailable.
 FROM quay.io/quay/busybox
-COPY target/test-plugin-jars/*.jar /
+COPY target/test-plugin-jars/*.jar /plugins/

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/docker/test-plugin.dockerfile
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/docker/test-plugin.dockerfile
@@ -7,5 +7,7 @@
 # Test plugin OCI image for integration tests.
 # Contains the simple-transform filter JARs at the image root.
 # Used to verify OCI image volume plugin mounting in the sidecar.
-FROM scratch
+# Uses busybox (not scratch) so the emptyDir fallback init container
+# can run "sh -c cp" when OCI image volumes are unavailable.
+FROM quay.io/quay/busybox
 COPY target/test-plugin-jars/*.jar /

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractPluginEndToEndKT.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractPluginEndToEndKT.java
@@ -80,8 +80,6 @@ abstract class AbstractPluginEndToEndKT {
 
     abstract String kubeContext();
 
-    // --- Shared lifecycle (called by subclass @BeforeAll) ---
-
     protected void initClientAndInstallStrimzi() {
         Config config = Config.autoConfigure(kubeContext());
         client = new KubernetesClientBuilder().withConfig(config).build();
@@ -104,8 +102,6 @@ abstract class AbstractPluginEndToEndKT {
                 () -> client.namespaces().withName(KAFKA_NS).delete());
         ignoreCleanupErrors("Kubernetes client", client::close);
     }
-
-    // --- Test methods ---
 
     @Test
     void pluginFilterTransformsTrafficThroughSidecar() {
@@ -161,8 +157,6 @@ abstract class AbstractPluginEndToEndKT {
         });
     }
 
-    // --- Common test flow ---
-
     private void testWithFeatureGates(
                                       String featureGates,
                                       Consumer<Pod> podStructureAssertions) {
@@ -175,8 +169,6 @@ abstract class AbstractPluginEndToEndKT {
             perTestCleanup();
         }
     }
-
-    // --- Strimzi + Kafka ---
 
     private void installStrimzi() {
         LOGGER.info("Installing Strimzi operator");
@@ -263,8 +255,6 @@ abstract class AbstractPluginEndToEndKT {
                         kafka -> hasCondition(kafka, "Ready", "True"),
                         280, TimeUnit.SECONDS);
     }
-
-    // --- Webhook installation ---
 
     private void installWebhook(String featureGates) {
         LOGGER.info("Installing CRDs");
@@ -385,8 +375,6 @@ abstract class AbstractPluginEndToEndKT {
         }
     }
 
-    // --- Test namespace with plugin config ---
-
     private void createTestNamespaceAndConfig() {
         LOGGER.info("Creating test namespace with injection label");
         var ns = new NamespaceBuilder()
@@ -445,8 +433,6 @@ abstract class AbstractPluginEndToEndKT {
                         30, TimeUnit.SECONDS);
 
     }
-
-    // --- Producer + verification ---
 
     private void runProducerAndVerify(Consumer<Pod> podStructureAssertions) {
         String kafkaImage = discoverKafkaImage();
@@ -677,8 +663,6 @@ abstract class AbstractPluginEndToEndKT {
         LOGGER.info("Plugin end-to-end test passed");
     }
 
-    // --- Per-test cleanup ---
-
     private void perTestCleanup() {
         LOGGER.info("Cleaning up per-test resources");
         if (client == null) {
@@ -723,8 +707,6 @@ abstract class AbstractPluginEndToEndKT {
                     .log("failed to list install directory during cleanup");
         }
     }
-
-    // --- Helpers ---
 
     private void waitForDeploymentRollout(
                                           String name,

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractPluginEndToEndKT.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractPluginEndToEndKT.java
@@ -21,7 +21,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterAll;
@@ -42,7 +41,6 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
-import io.fabric8.kubernetes.client.KubernetesClientException;
 
 import io.kroxylicious.kubernetes.api.admission.common.Condition;
 import io.kroxylicious.sidecar.v1alpha1.KroxyliciousSidecarConfig;
@@ -126,7 +124,7 @@ abstract class AbstractPluginEndToEndKT {
             assertThat(pod.getSpec().getInitContainers())
                     .as("Sidecar should be a native sidecar (in initContainers)")
                     .extracting(Container::getName)
-                    .contains("kroxylicious-proxy");
+                    .contains(InjectionDecision.SIDECAR_CONTAINER_NAME);
         });
     }
 
@@ -151,11 +149,11 @@ abstract class AbstractPluginEndToEndKT {
                     : List.of();
             assertThat(initContainerNames)
                     .as("Sidecar should NOT be in initContainers")
-                    .doesNotContain("kroxylicious-proxy");
+                    .doesNotContain(InjectionDecision.SIDECAR_CONTAINER_NAME);
             assertThat(pod.getSpec().getContainers())
                     .as("Sidecar should be a regular container")
                     .extracting(Container::getName)
-                    .contains("kroxylicious-proxy");
+                    .contains(InjectionDecision.SIDECAR_CONTAINER_NAME);
 
             assertThat(initContainerNames)
                     .as("Plugin copy init container should exist")
@@ -287,20 +285,23 @@ abstract class AbstractPluginEndToEndKT {
             LOGGER.atInfo()
                     .addKeyValue("featureGates", featureGates)
                     .log("Patching webhook deployment with feature gates");
-            editDeploymentWithRetry("kroxylicious-webhook", d -> {
-                var envList = d.getSpec().getTemplate().getSpec()
-                        .getContainers().get(0).getEnv();
-                if (envList == null) {
-                    envList = new ArrayList<>();
-                    d.getSpec().getTemplate().getSpec()
-                            .getContainers().get(0).setEnv(envList);
-                }
-                envList.add(new EnvVarBuilder()
-                        .withName("FEATURE_GATES")
-                        .withValue(featureGates)
-                        .build());
-                return d;
-            });
+            client.apps().deployments()
+                    .inNamespace(WEBHOOK_NS)
+                    .withName("kroxylicious-webhook")
+                    .edit(d -> {
+                        var envList = d.getSpec().getTemplate().getSpec()
+                                .getContainers().get(0).getEnv();
+                        if (envList == null) {
+                            envList = new ArrayList<>();
+                            d.getSpec().getTemplate().getSpec()
+                                    .getContainers().get(0).setEnv(envList);
+                        }
+                        envList.add(new EnvVarBuilder()
+                                .withName(WebhookMain.FEATURE_GATES_VAR)
+                                .withValue(featureGates)
+                                .build());
+                        return d;
+                    });
         }
 
         LOGGER.info("Creating self-signed TLS certificate for webhook");
@@ -506,7 +507,7 @@ abstract class AbstractPluginEndToEndKT {
 
         assertThat(allContainerNames)
                 .as("Pod should have kroxylicious-proxy sidecar container")
-                .contains("kroxylicious-proxy");
+                .contains(InjectionDecision.SIDECAR_CONTAINER_NAME);
 
         assertThat(pod.getSpec().getVolumes())
                 .as("Pod should have plugin-simple-transform volume")
@@ -540,7 +541,7 @@ abstract class AbstractPluginEndToEndKT {
                 pod.getStatus().getContainerStatuses())
                 .filter(list -> list != null)
                 .flatMap(List::stream)
-                .anyMatch(s -> "kroxylicious-proxy".equals(s.getName())
+                .anyMatch(s -> InjectionDecision.SIDECAR_CONTAINER_NAME.equals(s.getName())
                         && Boolean.TRUE.equals(s.getReady()));
     }
 
@@ -559,7 +560,7 @@ abstract class AbstractPluginEndToEndKT {
             String proxyLogs = client.pods()
                     .inNamespace(TEST_NS)
                     .withName("test-producer")
-                    .inContainer("kroxylicious-proxy")
+                    .inContainer(InjectionDecision.SIDECAR_CONTAINER_NAME)
                     .getLog();
             LOGGER.atError()
                     .addKeyValue("logs", proxyLogs)
@@ -742,45 +743,26 @@ abstract class AbstractPluginEndToEndKT {
                 .inNamespace(WEBHOOK_NS)
                 .withName(name)
                 .waitUntilCondition(
-                        d -> d != null
-                                && d.getStatus() != null
-                                && d.getStatus().getObservedGeneration() != null
-                                && d.getStatus().getObservedGeneration() >= expectedGeneration
-                                && d.getStatus().getReadyReplicas() != null
-                                && d.getStatus().getReadyReplicas()
-                                        .equals(d.getSpec().getReplicas())
-                                && d.getStatus().getUpdatedReplicas() != null
-                                && d.getStatus().getUpdatedReplicas()
-                                        .equals(d.getSpec().getReplicas())
-                                && d.getStatus().getReplicas() != null
-                                && d.getStatus().getReplicas()
-                                        .equals(d.getSpec().getReplicas()),
+                        d -> isRolloutComplete(d, expectedGeneration),
                         timeoutSeconds, TimeUnit.SECONDS);
         LOGGER.info("Deployment rollout complete");
     }
 
-    private void editDeploymentWithRetry(
-                                         String name,
-                                         UnaryOperator<Deployment> editor) {
-        int maxRetries = 5;
-        for (int attempt = 1; attempt <= maxRetries; attempt++) {
-            try {
-                client.apps().deployments()
-                        .inNamespace(WEBHOOK_NS)
-                        .withName(name)
-                        .edit(editor);
-                return;
-            }
-            catch (KubernetesClientException e) {
-                if (e.getCode() == 409 && attempt < maxRetries) {
-                    LOGGER.atInfo()
-                            .addKeyValue("attempt", attempt)
-                            .log("Retrying deployment edit after conflict");
-                    continue;
-                }
-                throw e;
-            }
+    private static boolean isRolloutComplete(
+                                             Deployment d,
+                                             long expectedGeneration) {
+        if (d == null || d.getStatus() == null) {
+            return false;
         }
+        var status = d.getStatus();
+        return status.getObservedGeneration() != null
+                && status.getObservedGeneration() >= expectedGeneration
+                && status.getReadyReplicas() != null
+                && status.getReadyReplicas().equals(d.getSpec().getReplicas())
+                && status.getUpdatedReplicas() != null
+                && status.getUpdatedReplicas().equals(d.getSpec().getReplicas())
+                && status.getReplicas() != null
+                && status.getReplicas().equals(d.getSpec().getReplicas());
     }
 
     private String strimziInstallUrl() {

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractPluginEndToEndKT.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/AbstractPluginEndToEndKT.java
@@ -19,22 +19,30 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 
 import io.kroxylicious.kubernetes.api.admission.common.Condition;
 import io.kroxylicious.sidecar.v1alpha1.KroxyliciousSidecarConfig;
@@ -45,15 +53,14 @@ import io.kroxylicious.test.ShellUtils;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * End-to-end integration test for 3rd party plugin support via OCI image volumes.
- * Deploys Strimzi + a single-node Kafka cluster, installs the webhook, and verifies
- * that a plugin filter loaded from an OCI image volume transforms Kafka traffic.
- * Subclasses provide cluster lifecycle and image loading.
+ * End-to-end integration test for sidecar injection across feature gate configurations.
+ * Deploys Strimzi and a single-node Kafka cluster once per class, then runs each test
+ * with a fresh webhook configuration. Subclasses provide cluster lifecycle and image loading.
  */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractPluginEndToEndKT {
 
     // TODO switch away from using the exec openssl pattern and use the kroxylicious-certificate-test-support module.
-    // TODO The the scenario where the kubernetes does not have the OCI volume mounting feature gate enabled.
     // TODO have a test that covers indirectly creates pods, e.g. pods which are part of the deployment, sts, job.
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractPluginEndToEndKT.class);
@@ -75,18 +82,99 @@ abstract class AbstractPluginEndToEndKT {
 
     abstract String kubeContext();
 
-    @Test
-    void pluginFilterTransformsTrafficThroughSidecar() {
+    // --- Shared lifecycle (called by subclass @BeforeAll) ---
+
+    protected void initClientAndInstallStrimzi() {
         Config config = Config.autoConfigure(kubeContext());
         client = new KubernetesClientBuilder().withConfig(config).build();
+        installStrimzi();
+    }
+
+    @AfterAll
+    void tearDownSharedInfrastructure() {
+        if (client == null) {
+            return;
+        }
+        ignoreCleanupErrors("Strimzi operator",
+                () -> {
+                    try (InputStream is = URI.create(strimziInstallUrl())
+                            .toURL().openStream()) {
+                        client.load(is).delete();
+                    }
+                });
+        ignoreCleanupErrors("kafka namespace",
+                () -> client.namespaces().withName(KAFKA_NS).delete());
+        ignoreCleanupErrors("Kubernetes client", client::close);
+    }
+
+    // --- Test methods ---
+
+    @Test
+    void pluginFilterTransformsTrafficThroughSidecar() {
+        testWithFeatureGates("", pod -> {
+            var pluginVolume = pod.getSpec().getVolumes().stream()
+                    .filter(v -> "plugin-simple-transform".equals(v.getName()))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(pluginVolume.getImage())
+                    .as("Plugin volume should be an OCI image volume")
+                    .isNotNull();
+            assertThat(pluginVolume.getImage().getReference())
+                    .as("Plugin volume should reference the test plugin image")
+                    .contains(INFO.testPluginImageName());
+
+            assertThat(pod.getSpec().getInitContainers())
+                    .as("Sidecar should be a native sidecar (in initContainers)")
+                    .extracting(Container::getName)
+                    .contains("kroxylicious-proxy");
+        });
+    }
+
+    @Test
+    void pluginFilterWorksWithoutNativeSidecarOrImageVolume() {
+        testWithFeatureGates("SidecarContainers=false,ImageVolume=false", pod -> {
+            var pluginVolume = pod.getSpec().getVolumes().stream()
+                    .filter(v -> "plugin-simple-transform".equals(v.getName()))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(pluginVolume.getEmptyDir())
+                    .as("Plugin volume should be emptyDir (no OCI image volumes)")
+                    .isNotNull();
+            assertThat(pluginVolume.getImage())
+                    .as("Plugin volume should NOT be an OCI image volume")
+                    .isNull();
+
+            List<String> initContainerNames = pod.getSpec().getInitContainers() != null
+                    ? pod.getSpec().getInitContainers().stream()
+                            .map(Container::getName)
+                            .toList()
+                    : List.of();
+            assertThat(initContainerNames)
+                    .as("Sidecar should NOT be in initContainers")
+                    .doesNotContain("kroxylicious-proxy");
+            assertThat(pod.getSpec().getContainers())
+                    .as("Sidecar should be a regular container")
+                    .extracting(Container::getName)
+                    .contains("kroxylicious-proxy");
+
+            assertThat(initContainerNames)
+                    .as("Plugin copy init container should exist")
+                    .contains("plugin-simple-transform-copy");
+        });
+    }
+
+    // --- Common test flow ---
+
+    private void testWithFeatureGates(
+                                      String featureGates,
+                                      Consumer<Pod> podStructureAssertions) {
         try {
-            installStrimzi();
-            installWebhook();
+            installWebhook(featureGates);
             createTestNamespaceAndConfig();
-            runProducerAndVerify();
+            runProducerAndVerify(podStructureAssertions);
         }
         finally {
-            cleanup();
+            perTestCleanup();
         }
     }
 
@@ -180,7 +268,7 @@ abstract class AbstractPluginEndToEndKT {
 
     // --- Webhook installation ---
 
-    private void installWebhook() {
+    private void installWebhook(String featureGates) {
         LOGGER.info("Installing CRDs");
         try (InputStream is = Files.newInputStream(CRD_PATH)) {
             client.load(is).serverSideApply();
@@ -195,23 +283,34 @@ abstract class AbstractPluginEndToEndKT {
         LOGGER.info("Applying install manifests");
         applyAllManifests();
 
+        if (featureGates != null && !featureGates.isEmpty()) {
+            LOGGER.atInfo()
+                    .addKeyValue("featureGates", featureGates)
+                    .log("Patching webhook deployment with feature gates");
+            editDeploymentWithRetry("kroxylicious-webhook", d -> {
+                var envList = d.getSpec().getTemplate().getSpec()
+                        .getContainers().get(0).getEnv();
+                if (envList == null) {
+                    envList = new ArrayList<>();
+                    d.getSpec().getTemplate().getSpec()
+                            .getContainers().get(0).setEnv(envList);
+                }
+                envList.add(new EnvVarBuilder()
+                        .withName("FEATURE_GATES")
+                        .withValue(featureGates)
+                        .build());
+                return d;
+            });
+        }
+
         LOGGER.info("Creating self-signed TLS certificate for webhook");
         createWebhookTlsSecret();
 
         LOGGER.info("Patching MutatingWebhookConfiguration with CA bundle");
         patchWebhookCaBundle();
 
-        LOGGER.info("Waiting for webhook deployment to become ready");
-        client.apps().deployments()
-                .inNamespace(WEBHOOK_NS)
-                .withName("kroxylicious-webhook")
-                .waitUntilCondition(
-                        d -> d != null
-                                && d.getStatus() != null
-                                && d.getStatus().getReadyReplicas() != null
-                                && d.getStatus().getReadyReplicas() >= 1,
-                        300, TimeUnit.SECONDS);
-        LOGGER.info("Webhook deployment is ready");
+        LOGGER.info("Waiting for webhook deployment rollout to complete");
+        waitForDeploymentRollout("kroxylicious-webhook", 300);
     }
 
     private void applyAllManifests() {
@@ -343,11 +442,12 @@ abstract class AbstractPluginEndToEndKT {
                                                 && Condition.Status.TRUE
                                                         .equals(cond.getStatus())),
                         30, TimeUnit.SECONDS);
+
     }
 
     // --- Producer + verification ---
 
-    private void runProducerAndVerify() {
+    private void runProducerAndVerify(Consumer<Pod> podStructureAssertions) {
         String kafkaImage = discoverKafkaImage();
         LOGGER.atInfo()
                 .addKeyValue("kafkaImage", kafkaImage)
@@ -381,6 +481,7 @@ abstract class AbstractPluginEndToEndKT {
         Pod created = client.resource(producerPod).create();
 
         verifyPodStructure(created);
+        podStructureAssertions.accept(created);
         waitForProxyReady();
         verifyProducerCompletes();
         verifyConsumedMessagesUpperCased();
@@ -395,27 +496,22 @@ abstract class AbstractPluginEndToEndKT {
             pod.getSpec().getInitContainers()
                     .forEach(c -> allContainerNames.add(c.getName()));
         }
+
+        LOGGER.atInfo()
+                .addKeyValue("containers", allContainerNames)
+                .addKeyValue("volumes", pod.getSpec().getVolumes().stream()
+                        .map(Volume::getName)
+                        .toList())
+                .log("Pod structure after admission");
+
         assertThat(allContainerNames)
                 .as("Pod should have kroxylicious-proxy sidecar container")
                 .contains("kroxylicious-proxy");
 
-        LOGGER.info("Verifying plugin volume was mounted");
         assertThat(pod.getSpec().getVolumes())
                 .as("Pod should have plugin-simple-transform volume")
                 .extracting(Volume::getName)
                 .contains("plugin-simple-transform");
-
-        LOGGER.info("Verifying OCI image volume (not emptyDir)");
-        var pluginVolume = pod.getSpec().getVolumes().stream()
-                .filter(v -> "plugin-simple-transform".equals(v.getName()))
-                .findFirst()
-                .orElseThrow();
-        assertThat(pluginVolume.getImage())
-                .as("Plugin volume should be an OCI image volume")
-                .isNotNull();
-        assertThat(pluginVolume.getImage().getReference())
-                .as("Plugin volume should reference the test plugin image")
-                .contains(INFO.testPluginImageName());
     }
 
     private void waitForProxyReady() {
@@ -425,16 +521,7 @@ abstract class AbstractPluginEndToEndKT {
                     .inNamespace(TEST_NS)
                     .withName("test-producer")
                     .waitUntilCondition(
-                            pod -> pod != null
-                                    && pod.getStatus() != null
-                                    && pod.getStatus()
-                                            .getInitContainerStatuses() != null
-                                    && pod.getStatus()
-                                            .getInitContainerStatuses().stream()
-                                            .anyMatch(s -> "kroxylicious-proxy"
-                                                    .equals(s.getName())
-                                                    && Boolean.TRUE
-                                                            .equals(s.getReady())),
+                            AbstractPluginEndToEndKT::isProxyReady,
                             120, TimeUnit.SECONDS);
         }
         catch (Exception e) {
@@ -442,6 +529,19 @@ abstract class AbstractPluginEndToEndKT {
             throw new AssertionError("Sidecar proxy did not become ready", e);
         }
         LOGGER.info("Sidecar proxy is ready");
+    }
+
+    private static boolean isProxyReady(Pod pod) {
+        if (pod == null || pod.getStatus() == null) {
+            return false;
+        }
+        return Stream.of(
+                pod.getStatus().getInitContainerStatuses(),
+                pod.getStatus().getContainerStatuses())
+                .filter(list -> list != null)
+                .flatMap(List::stream)
+                .anyMatch(s -> "kroxylicious-proxy".equals(s.getName())
+                        && Boolean.TRUE.equals(s.getReady()));
     }
 
     private void dumpPodDiagnostics() {
@@ -576,10 +676,10 @@ abstract class AbstractPluginEndToEndKT {
         LOGGER.info("Plugin end-to-end test passed");
     }
 
-    // --- Cleanup ---
+    // --- Per-test cleanup ---
 
-    private void cleanup() {
-        LOGGER.info("Cleaning up test resources");
+    private void perTestCleanup() {
+        LOGGER.info("Cleaning up per-test resources");
         if (client == null) {
             return;
         }
@@ -597,16 +697,11 @@ abstract class AbstractPluginEndToEndKT {
                         client.load(is).delete();
                     }
                 });
-        ignoreCleanupErrors("Strimzi operator",
-                () -> {
-                    try (InputStream is = URI.create(strimziInstallUrl())
-                            .toURL().openStream()) {
-                        client.load(is).delete();
-                    }
-                });
-        ignoreCleanupErrors("kafka namespace",
-                () -> client.namespaces().withName(KAFKA_NS).delete());
-        ignoreCleanupErrors("Kubernetes client", client::close);
+        ignoreCleanupErrors("webhook namespace deletion wait",
+                () -> client.namespaces().withName(WEBHOOK_NS)
+                        .waitUntilCondition(
+                                ns -> ns == null,
+                                60, TimeUnit.SECONDS));
     }
 
     private void deleteAllManifests() {
@@ -629,6 +724,64 @@ abstract class AbstractPluginEndToEndKT {
     }
 
     // --- Helpers ---
+
+    private void waitForDeploymentRollout(
+                                          String name,
+                                          int timeoutSeconds) {
+        var dep = client.apps().deployments()
+                .inNamespace(WEBHOOK_NS)
+                .withName(name)
+                .get();
+        long expectedGeneration = dep.getMetadata().getGeneration();
+        LOGGER.atInfo()
+                .addKeyValue("deployment", name)
+                .addKeyValue("expectedGeneration", expectedGeneration)
+                .log("Waiting for deployment rollout");
+
+        client.apps().deployments()
+                .inNamespace(WEBHOOK_NS)
+                .withName(name)
+                .waitUntilCondition(
+                        d -> d != null
+                                && d.getStatus() != null
+                                && d.getStatus().getObservedGeneration() != null
+                                && d.getStatus().getObservedGeneration() >= expectedGeneration
+                                && d.getStatus().getReadyReplicas() != null
+                                && d.getStatus().getReadyReplicas()
+                                        .equals(d.getSpec().getReplicas())
+                                && d.getStatus().getUpdatedReplicas() != null
+                                && d.getStatus().getUpdatedReplicas()
+                                        .equals(d.getSpec().getReplicas())
+                                && d.getStatus().getReplicas() != null
+                                && d.getStatus().getReplicas()
+                                        .equals(d.getSpec().getReplicas()),
+                        timeoutSeconds, TimeUnit.SECONDS);
+        LOGGER.info("Deployment rollout complete");
+    }
+
+    private void editDeploymentWithRetry(
+                                         String name,
+                                         UnaryOperator<Deployment> editor) {
+        int maxRetries = 5;
+        for (int attempt = 1; attempt <= maxRetries; attempt++) {
+            try {
+                client.apps().deployments()
+                        .inNamespace(WEBHOOK_NS)
+                        .withName(name)
+                        .edit(editor);
+                return;
+            }
+            catch (KubernetesClientException e) {
+                if (e.getCode() == 409 && attempt < maxRetries) {
+                    LOGGER.atInfo()
+                            .addKeyValue("attempt", attempt)
+                            .log("Retrying deployment edit after conflict");
+                    continue;
+                }
+                throw e;
+            }
+        }
+    }
 
     private String strimziInstallUrl() {
         return "https://strimzi.io/install/latest?namespace=" + KAFKA_NS;

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/KindPluginEndToEndKT.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/KindPluginEndToEndKT.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 import io.kroxylicious.test.ShellUtils;
 
 /**
- * Runs the plugin end-to-end test on a dedicated Kind cluster with the
+ * Runs the plugin end-to-end tests on a dedicated Kind cluster with the
  * {@code ImageVolume} feature gate enabled.
  */
 @EnabledIf("io.kroxylicious.kubernetes.webhook.KindPluginEndToEndKT#isEnvironmentValid")
@@ -32,7 +32,7 @@ class KindPluginEndToEndKT extends AbstractPluginEndToEndKT {
     }
 
     @BeforeAll
-    static void createKindCluster() {
+    void setUp() {
         LOGGER.info("Creating Kind cluster '{}' with ImageVolume feature gate", KIND_CLUSTER_NAME);
         ShellUtils.exec("bash", "-c", """
                 cat <<'EOF' | kind create cluster --name %s --config=-
@@ -51,10 +51,12 @@ class KindPluginEndToEndKT extends AbstractPluginEndToEndKT {
                 "--name", KIND_CLUSTER_NAME);
         ShellUtils.exec("kind", "load", "image-archive", INFO.testPluginImageArchive(),
                 "--name", KIND_CLUSTER_NAME);
+
+        initClientAndInstallStrimzi();
     }
 
     @AfterAll
-    static void deleteKindCluster() {
+    void tearDown() {
         LOGGER.info("Deleting Kind cluster '{}'", KIND_CLUSTER_NAME);
         ShellUtils.execValidate(ALWAYS_VALID, ALWAYS_VALID,
                 "kind", "delete", "cluster", "--name", KIND_CLUSTER_NAME);

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/MinikubePluginEndToEndKT.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/MinikubePluginEndToEndKT.java
@@ -12,19 +12,26 @@ import org.junit.jupiter.api.condition.EnabledIf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+
 import io.kroxylicious.test.ShellUtils;
 
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 /**
- * Runs the plugin end-to-end test on an existing Minikube cluster.
- * Requires a running Minikube cluster and the webhook, proxy, and test-plugin
- * container image archives (built by the {@code dist} Maven profile).
+ * Runs the plugin end-to-end tests on an existing Minikube cluster.
+ * Requires a running Minikube cluster (K8s >= 1.35 for ImageVolume support)
+ * and the webhook, proxy, and test-plugin container image archives
+ * (built by the {@code dist} Maven profile).
  */
 @EnabledIf("io.kroxylicious.kubernetes.webhook.MinikubePluginEndToEndKT#isEnvironmentValid")
 class MinikubePluginEndToEndKT extends AbstractPluginEndToEndKT {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MinikubePluginEndToEndKT.class);
 
-    private static boolean loaded = false;
+    private boolean loaded = false;
 
     @Override
     String kubeContext() {
@@ -32,7 +39,9 @@ class MinikubePluginEndToEndKT extends AbstractPluginEndToEndKT {
     }
 
     @BeforeAll
-    static void loadImages() {
+    void setUp() {
+        checkMinikubeKubernetesVersion();
+
         LOGGER.info("Loading images into minikube registry");
         ShellUtils.execValidate(ALWAYS_VALID, ALWAYS_VALID,
                 "minikube", "image", "load", INFO.imageArchive());
@@ -41,10 +50,12 @@ class MinikubePluginEndToEndKT extends AbstractPluginEndToEndKT {
         ShellUtils.execValidate(ALWAYS_VALID, ALWAYS_VALID,
                 "minikube", "image", "load", INFO.testPluginImageArchive());
         loaded = true;
+
+        initClientAndInstallStrimzi();
     }
 
     @AfterAll
-    static void removeImages() {
+    void tearDown() {
         if (loaded) {
             LOGGER.info("Removing images from minikube registry");
             ShellUtils.execValidate(ALWAYS_VALID, ALWAYS_VALID,
@@ -53,6 +64,20 @@ class MinikubePluginEndToEndKT extends AbstractPluginEndToEndKT {
                     "minikube", "image", "rm", INFO.proxyImageName());
             ShellUtils.execValidate(ALWAYS_VALID, ALWAYS_VALID,
                     "minikube", "image", "rm", INFO.testPluginImageName());
+        }
+    }
+
+    private static void checkMinikubeKubernetesVersion() {
+        Config config = Config.autoConfigure("minikube");
+        try (KubernetesClient c = new KubernetesClientBuilder()
+                .withConfig(config).build()) {
+            var info = c.getKubernetesVersion();
+            int minor = Integer.parseInt(info.getMinor().replaceAll("[^0-9]", ""));
+            assumeTrue(minor >= 35,
+                    "Minikube Kubernetes version is 1." + minor
+                            + " but >= 1.35 is required (ImageVolume enabled by default)."
+                            + " Restart minikube with a newer version:"
+                            + " minikube start --kubernetes-version=v1.35.0");
         }
     }
 

--- a/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/PodMutatorTest.java
+++ b/kroxylicious-kubernetes/kroxylicious-admission/src/test/java/io/kroxylicious/kubernetes/webhook/PodMutatorTest.java
@@ -408,7 +408,7 @@ class PodMutatorTest {
     }
 
     @Test
-    void patchAddsPluginVolumeMountOnSidecar() throws Exception {
+    void patchAddsPluginVolumeMountWithSubPathForOci() throws Exception {
         Pod pod = podWithAppContainer(null);
         KroxyliciousSidecarConfigSpec spec = specWithPlugin("my-filter", "reg.io/filter:v1@sha256:abc123");
 
@@ -423,6 +423,30 @@ class PodMutatorTest {
             if ("plugin-my-filter".equals(mount.path("name").asText())) {
                 assertThat(mount.path("mountPath").asText()).isEqualTo("/opt/kroxylicious/classpath-plugins/my-filter");
                 assertThat(mount.path("readOnly").asBoolean()).isTrue();
+                assertThat(mount.path("subPath").asText()).isEqualTo("plugins");
+                hasPluginMount = true;
+            }
+        }
+        assertThat(hasPluginMount).as("sidecar should have plugin volume mount").isTrue();
+    }
+
+    @Test
+    void patchAddsPluginVolumeMountWithoutSubPathForEmptyDir() throws Exception {
+        Pod pod = podWithAppContainer(null);
+        KroxyliciousSidecarConfigSpec spec = specWithPlugin("my-filter", "reg.io/filter:v1@sha256:abc123");
+
+        String patchStr = PodMutator.createPatch(pod, spec, PROXY_IMAGE, 0L, false, false);
+        JsonNode patch = MAPPER.readTree(patchStr);
+
+        List<JsonNode> containerOps = patchOps(patch, "add", "/spec/containers/-");
+        JsonNode mounts = containerOps.get(0).path("value").path("volumeMounts");
+
+        boolean hasPluginMount = false;
+        for (JsonNode mount : mounts) {
+            if ("plugin-my-filter".equals(mount.path("name").asText())) {
+                assertThat(mount.path("mountPath").asText()).isEqualTo("/opt/kroxylicious/classpath-plugins/my-filter");
+                assertThat(mount.path("readOnly").asBoolean()).isTrue();
+                assertThat(mount.has("subPath")).isFalse();
                 hasPluginMount = true;
             }
         }


### PR DESCRIPTION
### Type of change

- Bugfix
- Test

### Description

- Add E2E test exercising the webhook with `SidecarContainers=false,ImageVolume=false` to verify correct behaviour on older Kubernetes clusters (emptyDir plugin volumes, plugin-copy init containers, regular sidecars)
- Mandate a `/plugins` directory convention for plugin image JARs, to avoid needing fragile copying commands like `find / -maxdepth 1` approach that needed to skip `/proc`, `/sys`, `/dev` on non-scratch images
- OCI image volumes now use `subPath: "plugins"`; emptyDir init containers copy from `/plugins/*.jar` to `/dest/`
- Restructure E2E test lifecycle: Strimzi/Kafka installed once per class, webhook installed per test with appropriate `FEATURE_GATES`
- Fix OCI image volume version threshold (1.33 → 1.35)
- Use constants (`SIDECAR_CONTAINER_NAME`, `FEATURE_GATES_VAR`) instead of hardcoded strings
- Update CRD description, admission README, and javadoc for plugin path constants   

Contributes towards #3890 