### PR TITLE
test(admission): add system test for admission webhook installation

### DIFF
--- a/.github/workflows/build-kroxylicious-container-images.yaml
+++ b/.github/workflows/build-kroxylicious-container-images.yaml
@@ -40,7 +40,7 @@ jobs:
             --batch-mode \
             --activate-profiles 'dist,!qa' \
             --also-make \
-            --projects :kroxylicious-app,:kroxylicious-operator,:kroxylicious-operator-dist \
+            --projects :kroxylicious-app,:kroxylicious-operator,:kroxylicious-operator-dist,:kroxylicious-admission \
             -Derrorprone.skip=true \
             -DskipTests \
             -Dmaven.javadoc.skip=true \
@@ -56,3 +56,8 @@ jobs:
         with:
           name: kroxylicious-operator
           path: kroxylicious-kubernetes/kroxylicious-operator/target/kroxylicious-operator.img.tar.gz
+      - name: 'Archive kroxylicious admission webhook image'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: kroxylicious-admission-webhook
+          path: kroxylicious-kubernetes/kroxylicious-admission/target/kroxylicious-webhook.img.tar.gz

--- a/.github/workflows/run-system-tests.yaml
+++ b/.github/workflows/run-system-tests.yaml
@@ -138,6 +138,12 @@ jobs:
           workflow: build_kroxylicious_images
           name: kroxylicious-operator
           run_id: ${{github.run_id}}
+      - name: Download kroxylicious admission-webhook container artifact
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151
+        with:
+          workflow: build_kroxylicious_images
+          name: kroxylicious-admission-webhook
+          run_id: ${{github.run_id}}
       - name: 'Extract Kroxylicious Maven artifacts'
         run: |
           mkdir -p "$HOME/.m2/repository"
@@ -147,6 +153,7 @@ jobs:
         run: |
           minikube image load kroxylicious-proxy.img.tar.gz
           minikube image load kroxylicious-operator.img.tar.gz
+          minikube image load kroxylicious-webhook.img.tar.gz
           
           # https://github.com/kubernetes/minikube/issues/21393 - minikube image load doesn't fail if the load fails.
           KROXYLICIOUS_PROXY_IMAGE="$(mvn --quiet --projects :kroxylicious-app --activate-profiles dist org.apache.maven.plugins:maven-help-plugin:3.5.1:evaluate -Dexpression=io.kroxylicious.proxy.image.name -DforceStdout)"

--- a/kroxylicious-systemtests/pom.xml
+++ b/kroxylicious-systemtests/pom.xml
@@ -336,6 +336,13 @@
                     <type>zip</type>
                     <scope>runtime</scope>
                 </dependency>
+                <dependency>
+                    <groupId>io.kroxylicious</groupId>
+                    <artifactId>kroxylicious-admission-dist</artifactId>
+                    <version>${project.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
             </dependencies>
 
             <build>
@@ -366,6 +373,27 @@
                                 </configuration>
                             </execution>
                             <execution>
+                                <id>copy-kroxylicious-admission-zip</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>io.kroxylicious</groupId>
+                                            <artifactId>kroxylicious-admission-dist</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>zip</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>${project.build.directory}/kroxylicious-admission-dist
+                                            </outputDirectory>
+                                            <destFileName>kroxylicious-admission.zip</destFileName>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                            <execution>
                                 <id>unpack</id>
                                 <phase>pre-integration-test</phase>
                                 <goals>
@@ -379,6 +407,24 @@
                                             <version>${project.version}</version>
                                             <type>zip</type>
                                             <outputDirectory>${project.build.directory}/kroxylicious-operator-dist/</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>unpack-admission</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>io.kroxylicious</groupId>
+                                            <artifactId>kroxylicious-admission-dist</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>zip</type>
+                                            <outputDirectory>${project.build.directory}/kroxylicious-admission-dist/</outputDirectory>
                                         </artifactItem>
                                     </artifactItems>
                                 </configuration>

--- a/kroxylicious-systemtests/pom.xml
+++ b/kroxylicious-systemtests/pom.xml
@@ -62,6 +62,11 @@
         </dependency>
         <dependency>
             <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model-admissionregistration</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
             <artifactId>certmanager-model</artifactId>
             <scope>compile</scope>
         </dependency>

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
@@ -107,8 +107,11 @@ public final class Constants {
     /**
      * Webhook related constants
      */
+    public static final String WEBHOOK_NAMESPACE = "kroxylicious-webhook";
     public static final String WEBHOOK_DEPLOYMENT_NAME = "kroxylicious-webhook";
     public static final String WEBHOOK_CONFIG_NAME = "kroxylicious-sidecar-injector";
+    public static final String WEBHOOK_ISSUER_NAME = "kroxylicious-webhook-selfsigned";
+    public static final String WEBHOOK_CERT_NAME = "kroxylicious-webhook-cert";
 
     /**
      * Service type names.

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
@@ -105,13 +105,14 @@ public final class Constants {
     public static final String KROXYLICIOUS_VIRTUAL_KAFKA_CLUSTER_KIND = "VirtualKafkaCluster";
 
     /**
-     * Webhook related constants
+     * Admission webhook related constants
      */
-    public static final String WEBHOOK_NAMESPACE = "kroxylicious-webhook";
-    public static final String WEBHOOK_DEPLOYMENT_NAME = "kroxylicious-webhook";
-    public static final String WEBHOOK_CONFIG_NAME = "kroxylicious-sidecar-injector";
-    public static final String WEBHOOK_ISSUER_NAME = "kroxylicious-webhook-selfsigned";
-    public static final String WEBHOOK_CERT_NAME = "kroxylicious-webhook-cert";
+    public static final String ADMISSION_NAMESPACE = "kroxylicious-webhook";
+    public static final String ADMISSION_DEPLOYMENT_NAME = "kroxylicious-webhook";
+    public static final String ADMISSION_SERVICE_NAME = "kroxylicious-webhook";
+    public static final String ADMISSION_REGISTRATION_NAME = "kroxylicious-sidecar-injector";
+    public static final String ADMISSION_TLS_ISSUER_NAME = "kroxylicious-webhook-selfsigned";
+    public static final String ADMISSION_TLS_CERT_NAME = "kroxylicious-webhook-cert";
 
     /**
      * Service type names.

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Constants.java
@@ -105,6 +105,12 @@ public final class Constants {
     public static final String KROXYLICIOUS_VIRTUAL_KAFKA_CLUSTER_KIND = "VirtualKafkaCluster";
 
     /**
+     * Webhook related constants
+     */
+    public static final String WEBHOOK_DEPLOYMENT_NAME = "kroxylicious-webhook";
+    public static final String WEBHOOK_CONFIG_NAME = "kroxylicious-sidecar-injector";
+
+    /**
      * Service type names.
      */
     public static final String LOAD_BALANCER_TYPE = "LoadBalancer";

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
@@ -61,6 +61,7 @@ public class Environment {
     private static final String TEST_CLIENTS_PULL_SECRET_ENV = "TEST_CLIENTS_PULL_SECRET";
     private static final String ARCHITECTURE_ENV = "ARCHITECTURE";
     private static final String KROXYLICIOUS_OPERATOR_INSTALL_DIR_ENV = "KROXYLICIOUS_OPERATOR_INSTALL_DIR";
+    private static final String KROXYLICIOUS_ADMISSION_WEBHOOK_INSTALL_DIR_ENV = "KROXYLICIOUS_ADMISSION_WEBHOOK_INSTALL_DIR";
     private static final String CURL_IMAGE_ENV = "CURL_IMAGE";
 
     /**
@@ -112,6 +113,7 @@ public class Environment {
     private static final boolean SYNC_RESOURCES_DELETION_DEFAULT = false;
     private static final String ARCHITECTURE_DEFAULT = System.getProperty("os.arch");
     private static final String KROXYLICIOUS_OPERATOR_INSTALL_DIR_DEFAULT = System.getProperty("user.dir") + "/target/kroxylicious-operator-dist/install/";
+    private static final String KROXYLICIOUS_ADMISSION_WEBHOOK_INSTALL_DIR_DEFAULT = System.getProperty("user.dir") + "/target/kroxylicious-admission-dist/install/";
     public static final String CURL_IMAGE_DEFAULT = Constants.DOCKER_REGISTRY_GCR_MIRROR
             + "/curlimages/curl:8.20.0@sha256:b3f1fb2a51d923260350d21b8654bbc607164a987e2f7c84a0ac199a67df812a";
 
@@ -175,6 +177,8 @@ public class Environment {
     public static final String ARCHITECTURE = ENVIRONMENT_VARIABLES.getOrDefault(ARCHITECTURE_ENV, ARCHITECTURE_DEFAULT);
     public static final String KROXYLICIOUS_OPERATOR_INSTALL_DIR = ENVIRONMENT_VARIABLES.getOrDefault(KROXYLICIOUS_OPERATOR_INSTALL_DIR_ENV,
             KROXYLICIOUS_OPERATOR_INSTALL_DIR_DEFAULT);
+    public static final String KROXYLICIOUS_ADMISSION_WEBHOOK_INSTALL_DIR = ENVIRONMENT_VARIABLES.getOrDefault(KROXYLICIOUS_ADMISSION_WEBHOOK_INSTALL_DIR_ENV,
+            KROXYLICIOUS_ADMISSION_WEBHOOK_INSTALL_DIR_DEFAULT);
     public static final String CURL_IMAGE = ENVIRONMENT_VARIABLES.getOrDefault(CURL_IMAGE_ENV, CURL_IMAGE_DEFAULT);
 
     private static String readMetadataProperty(String property) {

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/Environment.java
@@ -98,7 +98,8 @@ public class Environment {
     private static final String CONTAINER_CONFIG_PATH_DEFAULT = System.getProperty("user.home") + "/.docker/config.json";
     private static final boolean SKIP_STRIMZI_INSTALL_DEFAULT = false;
     private static final String KAFKA_CLIENT_DEFAULT = "strimzi_test_client";
-    private static final String CLUSTER_DUMP_DIR_DEFAULT = System.getProperty("user.dir") + "/target/logs/";
+    private static final String USER_DIR = System.getProperty("user.dir");
+    private static final String CLUSTER_DUMP_DIR_DEFAULT = USER_DIR + "/target/logs/";
     public static final String AWS_ACCESS_KEY_ID_DEFAULT = "test";
     private static final String AWS_SECRET_ACCESS_KEY_DEFAULT = "test";
     private static final String USE_CLOUD_KMS_DEFAULT = "false";
@@ -112,8 +113,8 @@ public class Environment {
     private static final String CATALOG_NAMESPACE_DEFAULT = "openshift-marketplace";
     private static final boolean SYNC_RESOURCES_DELETION_DEFAULT = false;
     private static final String ARCHITECTURE_DEFAULT = System.getProperty("os.arch");
-    private static final String KROXYLICIOUS_OPERATOR_INSTALL_DIR_DEFAULT = System.getProperty("user.dir") + "/target/kroxylicious-operator-dist/install/";
-    private static final String KROXYLICIOUS_ADMISSION_WEBHOOK_INSTALL_DIR_DEFAULT = System.getProperty("user.dir") + "/target/kroxylicious-admission-dist/install/";
+    private static final String KROXYLICIOUS_OPERATOR_INSTALL_DIR_DEFAULT = USER_DIR + "/target/kroxylicious-operator-dist/install/";
+    private static final String KROXYLICIOUS_ADMISSION_WEBHOOK_INSTALL_DIR_DEFAULT = USER_DIR + "/target/kroxylicious-admission-dist/install/";
     public static final String CURL_IMAGE_DEFAULT = Constants.DOCKER_REGISTRY_GCR_MIRROR
             + "/curlimages/curl:8.20.0@sha256:b3f1fb2a51d923260350d21b8654bbc607164a987e2f7c84a0ac199a67df812a";
 

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/TestTags.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/TestTags.java
@@ -20,4 +20,9 @@ public final class TestTags {
      * Tag for test suites that run operator only related tests (no kafka involved).
      */
     public static final String OPERATOR = "operator";
+
+    /**
+     * Tag for test suites that run admission webhook related tests.
+     */
+    public static final String ADMISSION_WEBHOOK = "admissionWebhook";
 }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/admission/AdmissionWebhook.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/admission/AdmissionWebhook.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.systemtests.installation.admission;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.fabric8.certmanager.api.model.v1.CertificateBuilder;
+import io.fabric8.certmanager.api.model.v1.IssuerBuilder;
+
+import io.kroxylicious.systemtests.installation.kroxylicious.CertManager;
+import io.kroxylicious.systemtests.resources.manager.ResourceManager;
+import io.kroxylicious.systemtests.utils.DeploymentUtils;
+
+import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
+
+/**
+ * Installer for the Kroxylicious admission webhook from distribution manifests.
+ */
+public class AdmissionWebhook {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AdmissionWebhook.class);
+    private static final String DISTRIBUTION_DIR = "target/kroxylicious-admission-dist";
+    private static final String INSTALL_DIR = DISTRIBUTION_DIR + "/install";
+    private static final String WEBHOOK_DEPLOYMENT_NAME = "kroxylicious-webhook";
+    private static final String WEBHOOK_CONFIG_NAME = "kroxylicious-sidecar-injector";
+    private static final String ISSUER_NAME = "kroxylicious-webhook-selfsigned";
+    private static final String CERT_NAME = "kroxylicious-webhook-cert";
+
+    private final String deploymentNamespace;
+    private boolean deleteWebhook = true;
+
+    /**
+     * Creates a new AdmissionWebhook installer.
+     *
+     * @param deploymentNamespace the namespace to deploy the webhook into
+     */
+    public AdmissionWebhook(String deploymentNamespace) {
+        this.deploymentNamespace = deploymentNamespace;
+    }
+
+    /**
+     * Deploys the admission webhook from distribution manifests.
+     *
+     * @param certManager the cert-manager instance to use for certificate creation
+     */
+    public void deploy(CertManager certManager) {
+        if (isDeployed()) {
+            LOGGER.warn("Skipping admission webhook deployment. It is already deployed!");
+            deleteWebhook = false;
+            return;
+        }
+
+        LOGGER.info("Deploying admission webhook in {} namespace", deploymentNamespace);
+
+        validateDistribution();
+        applyCrd();
+        applyInstallManifests();
+        createCertificateResources(certManager);
+        waitForWebhookReady();
+
+        LOGGER.info("Admission webhook deployment complete");
+    }
+
+    /**
+     * Deletes the admission webhook and associated resources.
+     */
+    public void delete() {
+        if (!deleteWebhook) {
+            LOGGER.warn("Skipping admission webhook deletion. It was previously installed");
+            return;
+        }
+
+        LOGGER.info("Deleting admission webhook in {} namespace", deploymentNamespace);
+
+        deleteInstallManifests();
+        deleteCrd();
+
+        LOGGER.info("Admission webhook deletion complete");
+    }
+
+    private boolean isDeployed() {
+        return kubeClient().getClient().apps().deployments()
+                .inNamespace(deploymentNamespace)
+                .withName(WEBHOOK_DEPLOYMENT_NAME)
+                .get() != null;
+    }
+
+    private void validateDistribution() {
+        Path installPath = Path.of(INSTALL_DIR);
+        if (!Files.exists(installPath) || !Files.isDirectory(installPath)) {
+            throw new IllegalStateException(
+                    "Distribution directory not found at " + installPath.toAbsolutePath() +
+                            ". Please build the distribution first with: " +
+                            "mvn clean install -DskipTests -pl kroxylicious-kubernetes/kroxylicious-admission-dist -am");
+        }
+    }
+
+    private void applyCrd() {
+        LOGGER.info("Applying CRD");
+        Path crdPath = Path.of(INSTALL_DIR, "00.CustomResourceDefinition.kroxylicioussidecarconfig.yaml");
+        applyManifest(crdPath);
+    }
+
+    private void applyInstallManifests() {
+        LOGGER.info("Applying install manifests from {}", INSTALL_DIR);
+        try (var files = Files.list(Path.of(INSTALL_DIR))) {
+            files.filter(p -> !p.getFileName().toString().startsWith("00.CustomResourceDefinition"))
+                    .sorted()
+                    .forEach(this::applyManifest);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException("Failed to list install manifests", e);
+        }
+    }
+
+    private void applyManifest(Path manifestPath) {
+        LOGGER.info("Applying manifest: {}", manifestPath.getFileName());
+        try (InputStream is = Files.newInputStream(manifestPath)) {
+            kubeClient().getClient().load(is).serverSideApply();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException("Failed to apply manifest: " + manifestPath, e);
+        }
+    }
+
+    private void createCertificateResources(CertManager certManager) {
+        LOGGER.info("Creating cert-manager Issuer and Certificate for webhook TLS");
+
+        var issuer = new IssuerBuilder()
+                .withNewMetadata()
+                .withName(ISSUER_NAME)
+                .withNamespace(deploymentNamespace)
+                .addToLabels("app.kubernetes.io/name", "kroxylicious")
+                .addToLabels("app.kubernetes.io/component", "webhook")
+                .endMetadata()
+                .withNewSpec()
+                .withNewSelfSigned()
+                .endSelfSigned()
+                .endSpec()
+                .build();
+
+        ResourceManager.getInstance().createResourceFromBuilderWithWait(
+                new IssuerBuilder(issuer));
+
+        var certificate = new CertificateBuilder()
+                .withNewMetadata()
+                .withName(CERT_NAME)
+                .withNamespace(deploymentNamespace)
+                .addToLabels("app.kubernetes.io/name", "kroxylicious")
+                .addToLabels("app.kubernetes.io/component", "webhook")
+                .endMetadata()
+                .withNewSpec()
+                .withSecretName(CERT_NAME)
+                .withNewIssuerRef()
+                .withName(ISSUER_NAME)
+                .withKind("Issuer")
+                .endIssuerRef()
+                .withCommonName(WEBHOOK_DEPLOYMENT_NAME + "." + deploymentNamespace + ".svc.cluster.local")
+                .withDnsNames(
+                        WEBHOOK_DEPLOYMENT_NAME,
+                        WEBHOOK_DEPLOYMENT_NAME + "." + deploymentNamespace,
+                        WEBHOOK_DEPLOYMENT_NAME + "." + deploymentNamespace + ".svc",
+                        WEBHOOK_DEPLOYMENT_NAME + "." + deploymentNamespace + ".svc.cluster.local")
+                .withNewPrivateKey()
+                .withEncoding("PKCS8")
+                .endPrivateKey()
+                .endSpec()
+                .build();
+
+        ResourceManager.getInstance().createResourceFromBuilderWithWait(
+                new CertificateBuilder(certificate));
+
+        waitForCertificateReady();
+    }
+
+    private void waitForCertificateReady() {
+        LOGGER.info("Waiting for Certificate to be ready");
+        kubeClient().getClient().resources(io.fabric8.certmanager.api.model.v1.Certificate.class)
+                .inNamespace(deploymentNamespace)
+                .withName(CERT_NAME)
+                .waitUntilCondition(
+                        cert -> cert != null
+                                && cert.getStatus() != null
+                                && cert.getStatus().getConditions() != null
+                                && cert.getStatus().getConditions().stream()
+                                        .anyMatch(c -> "Ready".equals(c.getType())
+                                                && "True".equals(c.getStatus())),
+                        120, TimeUnit.SECONDS);
+    }
+
+    private void waitForWebhookReady() {
+        LOGGER.info("Waiting for webhook deployment to become ready");
+        DeploymentUtils.waitForDeploymentReady(deploymentNamespace, WEBHOOK_DEPLOYMENT_NAME);
+
+        waitForCaBundleInjected();
+    }
+
+    private void waitForCaBundleInjected() {
+        LOGGER.info("Waiting for CA bundle to be injected into MutatingWebhookConfiguration");
+        kubeClient().getClient().admissionRegistration().v1()
+                .mutatingWebhookConfigurations()
+                .withName(WEBHOOK_CONFIG_NAME)
+                .waitUntilCondition(
+                        mwc -> mwc != null
+                                && !mwc.getWebhooks().isEmpty()
+                                && mwc.getWebhooks().get(0).getClientConfig() != null
+                                && mwc.getWebhooks().get(0).getClientConfig().getCaBundle() != null
+                                && !mwc.getWebhooks().get(0).getClientConfig().getCaBundle().isBlank(),
+                        120, TimeUnit.SECONDS);
+    }
+
+    private void deleteInstallManifests() {
+        LOGGER.info("Deleting install manifests");
+        try (var files = Files.list(Path.of(INSTALL_DIR))) {
+            files.filter(p -> !p.getFileName().toString().startsWith("00.CustomResourceDefinition"))
+                    .sorted()
+                    .forEach(this::deleteManifest);
+        }
+        catch (IOException e) {
+            LOGGER.atWarn()
+                    .addKeyValue("error", e.getMessage())
+                    .log("Failed to list install manifests during deletion");
+        }
+    }
+
+    private void deleteCrd() {
+        LOGGER.info("Deleting CRD");
+        Path crdPath = Path.of(INSTALL_DIR, "00.CustomResourceDefinition.kroxylicioussidecarconfig.yaml");
+        deleteManifest(crdPath);
+    }
+
+    private void deleteManifest(Path manifestPath) {
+        try (InputStream is = Files.newInputStream(manifestPath)) {
+            kubeClient().getClient().load(is).delete();
+        }
+        catch (Exception e) {
+            LOGGER.atWarn()
+                    .addKeyValue("manifest", manifestPath.getFileName())
+                    .addKeyValue("error", e.getMessage())
+                    .log("Failed to delete manifest");
+        }
+    }
+}

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/admission/AdmissionWebhook.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/admission/AdmissionWebhook.java
@@ -23,6 +23,8 @@ import io.kroxylicious.systemtests.installation.kroxylicious.CertManager;
 import io.kroxylicious.systemtests.resources.manager.ResourceManager;
 import io.kroxylicious.systemtests.utils.DeploymentUtils;
 
+import static io.kroxylicious.systemtests.Constants.WEBHOOK_CONFIG_NAME;
+import static io.kroxylicious.systemtests.Constants.WEBHOOK_DEPLOYMENT_NAME;
 import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
 
 /**
@@ -32,8 +34,6 @@ public class AdmissionWebhook {
     private static final Logger LOGGER = LoggerFactory.getLogger(AdmissionWebhook.class);
     private static final String DISTRIBUTION_DIR = "target/kroxylicious-admission-dist";
     private static final String INSTALL_DIR = DISTRIBUTION_DIR + "/install";
-    private static final String WEBHOOK_DEPLOYMENT_NAME = "kroxylicious-webhook";
-    private static final String WEBHOOK_CONFIG_NAME = "kroxylicious-sidecar-injector";
     private static final String ISSUER_NAME = "kroxylicious-webhook-selfsigned";
     private static final String CERT_NAME = "kroxylicious-webhook-cert";
 
@@ -115,7 +115,10 @@ public class AdmissionWebhook {
     private void applyInstallManifests() {
         LOGGER.info("Applying install manifests from {}", INSTALL_DIR);
         try (var files = Files.list(Path.of(INSTALL_DIR))) {
-            files.filter(p -> !p.getFileName().toString().startsWith("00.CustomResourceDefinition"))
+            files.filter(p -> {
+                Path fileName = p.getFileName();
+                return fileName != null && !fileName.toString().startsWith("00.CustomResourceDefinition");
+            })
                     .sorted()
                     .forEach(this::applyManifest);
         }
@@ -223,7 +226,10 @@ public class AdmissionWebhook {
     private void deleteInstallManifests() {
         LOGGER.info("Deleting install manifests");
         try (var files = Files.list(Path.of(INSTALL_DIR))) {
-            files.filter(p -> !p.getFileName().toString().startsWith("00.CustomResourceDefinition"))
+            files.filter(p -> {
+                Path fileName = p.getFileName();
+                return fileName != null && !fileName.toString().startsWith("00.CustomResourceDefinition");
+            })
                     .sorted()
                     .forEach(this::deleteManifest);
         }

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/admission/AdmissionWebhook.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/admission/AdmissionWebhook.java
@@ -11,6 +11,8 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
@@ -23,11 +25,12 @@ import io.kroxylicious.systemtests.installation.kroxylicious.CertManager;
 import io.kroxylicious.systemtests.resources.manager.ResourceManager;
 import io.kroxylicious.systemtests.utils.DeploymentUtils;
 
-import static io.kroxylicious.systemtests.Constants.WEBHOOK_CERT_NAME;
-import static io.kroxylicious.systemtests.Constants.WEBHOOK_CONFIG_NAME;
-import static io.kroxylicious.systemtests.Constants.WEBHOOK_DEPLOYMENT_NAME;
-import static io.kroxylicious.systemtests.Constants.WEBHOOK_ISSUER_NAME;
-import static io.kroxylicious.systemtests.Constants.WEBHOOK_NAMESPACE;
+import static io.kroxylicious.systemtests.Constants.ADMISSION_DEPLOYMENT_NAME;
+import static io.kroxylicious.systemtests.Constants.ADMISSION_NAMESPACE;
+import static io.kroxylicious.systemtests.Constants.ADMISSION_REGISTRATION_NAME;
+import static io.kroxylicious.systemtests.Constants.ADMISSION_SERVICE_NAME;
+import static io.kroxylicious.systemtests.Constants.ADMISSION_TLS_CERT_NAME;
+import static io.kroxylicious.systemtests.Constants.ADMISSION_TLS_ISSUER_NAME;
 import static io.kroxylicious.systemtests.Environment.KROXYLICIOUS_ADMISSION_WEBHOOK_INSTALL_DIR;
 import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
 
@@ -38,12 +41,6 @@ public class AdmissionWebhook {
     private static final Logger LOGGER = LoggerFactory.getLogger(AdmissionWebhook.class);
 
     private boolean deleteWebhook = true;
-
-    /**
-     * Creates a new AdmissionWebhook installer.
-     */
-    public AdmissionWebhook() {
-    }
 
     /**
      * Deploys the admission webhook from distribution manifests.
@@ -57,7 +54,7 @@ public class AdmissionWebhook {
             return;
         }
 
-        LOGGER.info("Deploying admission webhook in {} namespace", WEBHOOK_NAMESPACE);
+        LOGGER.info("Deploying admission webhook in {} namespace", ADMISSION_NAMESPACE);
 
         validateDistribution();
         applyCrd();
@@ -77,7 +74,7 @@ public class AdmissionWebhook {
             return;
         }
 
-        LOGGER.info("Deleting admission webhook in {} namespace", WEBHOOK_NAMESPACE);
+        LOGGER.info("Deleting admission webhook in {} namespace", ADMISSION_NAMESPACE);
 
         deleteInstallManifests();
         deleteCrd();
@@ -87,8 +84,8 @@ public class AdmissionWebhook {
 
     private boolean isDeployed() {
         return kubeClient().getClient().apps().deployments()
-                .inNamespace(WEBHOOK_NAMESPACE)
-                .withName(WEBHOOK_DEPLOYMENT_NAME)
+                .inNamespace(ADMISSION_NAMESPACE)
+                .withName(ADMISSION_DEPLOYMENT_NAME)
                 .get() != null;
     }
 
@@ -138,8 +135,8 @@ public class AdmissionWebhook {
 
         var issuer = new IssuerBuilder()
                 .withNewMetadata()
-                .withName(WEBHOOK_ISSUER_NAME)
-                .withNamespace(WEBHOOK_NAMESPACE)
+                .withName(ADMISSION_TLS_ISSUER_NAME)
+                .withNamespace(ADMISSION_NAMESPACE)
                 .addToLabels("app.kubernetes.io/name", "kroxylicious")
                 .addToLabels("app.kubernetes.io/component", "webhook")
                 .endMetadata()
@@ -154,23 +151,23 @@ public class AdmissionWebhook {
 
         var certificate = new CertificateBuilder()
                 .withNewMetadata()
-                .withName(WEBHOOK_CERT_NAME)
-                .withNamespace(WEBHOOK_NAMESPACE)
+                .withName(ADMISSION_TLS_CERT_NAME)
+                .withNamespace(ADMISSION_NAMESPACE)
                 .addToLabels("app.kubernetes.io/name", "kroxylicious")
                 .addToLabels("app.kubernetes.io/component", "webhook")
                 .endMetadata()
                 .withNewSpec()
-                .withSecretName(WEBHOOK_CERT_NAME)
+                .withSecretName(ADMISSION_TLS_CERT_NAME)
                 .withNewIssuerRef()
-                .withName(WEBHOOK_ISSUER_NAME)
+                .withName(ADMISSION_TLS_ISSUER_NAME)
                 .withKind("Issuer")
                 .endIssuerRef()
-                .withCommonName(WEBHOOK_DEPLOYMENT_NAME + "." + WEBHOOK_NAMESPACE + ".svc.cluster.local")
+                .withCommonName(ADMISSION_DEPLOYMENT_NAME + "." + ADMISSION_NAMESPACE + ".svc.cluster.local")
                 .withDnsNames(
-                        WEBHOOK_DEPLOYMENT_NAME,
-                        WEBHOOK_DEPLOYMENT_NAME + "." + WEBHOOK_NAMESPACE,
-                        WEBHOOK_DEPLOYMENT_NAME + "." + WEBHOOK_NAMESPACE + ".svc",
-                        WEBHOOK_DEPLOYMENT_NAME + "." + WEBHOOK_NAMESPACE + ".svc.cluster.local")
+                        ADMISSION_DEPLOYMENT_NAME,
+                        ADMISSION_DEPLOYMENT_NAME + "." + ADMISSION_NAMESPACE,
+                        ADMISSION_DEPLOYMENT_NAME + "." + ADMISSION_NAMESPACE + ".svc",
+                        ADMISSION_DEPLOYMENT_NAME + "." + ADMISSION_NAMESPACE + ".svc.cluster.local")
                 .withNewPrivateKey()
                 .withEncoding("PKCS8")
                 .endPrivateKey()
@@ -186,8 +183,8 @@ public class AdmissionWebhook {
     private void waitForCertificateReady() {
         LOGGER.info("Waiting for Certificate to be ready");
         kubeClient().getClient().resources(io.fabric8.certmanager.api.model.v1.Certificate.class)
-                .inNamespace(WEBHOOK_NAMESPACE)
-                .withName(WEBHOOK_CERT_NAME)
+                .inNamespace(ADMISSION_NAMESPACE)
+                .withName(ADMISSION_TLS_CERT_NAME)
                 .waitUntilCondition(
                         cert -> cert != null
                                 && cert.getStatus() != null
@@ -199,9 +196,10 @@ public class AdmissionWebhook {
     }
 
     private void waitForWebhookReady() {
-        LOGGER.info("Waiting for webhook deployment to become ready");
-        DeploymentUtils.waitForDeploymentReady(WEBHOOK_NAMESPACE, WEBHOOK_DEPLOYMENT_NAME);
-
+        LOGGER.info("Waiting for admission webhook deployment to become ready");
+        DeploymentUtils.waitForDeploymentReady(ADMISSION_NAMESPACE, ADMISSION_DEPLOYMENT_NAME);
+        LOGGER.info("Waiting for admission webhook service to become ready");
+        DeploymentUtils.waitForServiceReady(ADMISSION_NAMESPACE, ADMISSION_SERVICE_NAME, Duration.of(1, ChronoUnit.MINUTES));
         waitForCaBundleInjected();
     }
 
@@ -209,7 +207,7 @@ public class AdmissionWebhook {
         LOGGER.info("Waiting for CA bundle to be injected into MutatingWebhookConfiguration");
         kubeClient().getClient().admissionRegistration().v1()
                 .mutatingWebhookConfigurations()
-                .withName(WEBHOOK_CONFIG_NAME)
+                .withName(ADMISSION_REGISTRATION_NAME)
                 .waitUntilCondition(
                         mwc -> mwc != null
                                 && !mwc.getWebhooks().isEmpty()

--- a/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/admission/AdmissionWebhook.java
+++ b/kroxylicious-systemtests/src/main/java/io/kroxylicious/systemtests/installation/admission/AdmissionWebhook.java
@@ -23,8 +23,12 @@ import io.kroxylicious.systemtests.installation.kroxylicious.CertManager;
 import io.kroxylicious.systemtests.resources.manager.ResourceManager;
 import io.kroxylicious.systemtests.utils.DeploymentUtils;
 
+import static io.kroxylicious.systemtests.Constants.WEBHOOK_CERT_NAME;
 import static io.kroxylicious.systemtests.Constants.WEBHOOK_CONFIG_NAME;
 import static io.kroxylicious.systemtests.Constants.WEBHOOK_DEPLOYMENT_NAME;
+import static io.kroxylicious.systemtests.Constants.WEBHOOK_ISSUER_NAME;
+import static io.kroxylicious.systemtests.Constants.WEBHOOK_NAMESPACE;
+import static io.kroxylicious.systemtests.Environment.KROXYLICIOUS_ADMISSION_WEBHOOK_INSTALL_DIR;
 import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
 
 /**
@@ -32,21 +36,13 @@ import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
  */
 public class AdmissionWebhook {
     private static final Logger LOGGER = LoggerFactory.getLogger(AdmissionWebhook.class);
-    private static final String DISTRIBUTION_DIR = "target/kroxylicious-admission-dist";
-    private static final String INSTALL_DIR = DISTRIBUTION_DIR + "/install";
-    private static final String ISSUER_NAME = "kroxylicious-webhook-selfsigned";
-    private static final String CERT_NAME = "kroxylicious-webhook-cert";
 
-    private final String deploymentNamespace;
     private boolean deleteWebhook = true;
 
     /**
      * Creates a new AdmissionWebhook installer.
-     *
-     * @param deploymentNamespace the namespace to deploy the webhook into
      */
-    public AdmissionWebhook(String deploymentNamespace) {
-        this.deploymentNamespace = deploymentNamespace;
+    public AdmissionWebhook() {
     }
 
     /**
@@ -61,7 +57,7 @@ public class AdmissionWebhook {
             return;
         }
 
-        LOGGER.info("Deploying admission webhook in {} namespace", deploymentNamespace);
+        LOGGER.info("Deploying admission webhook in {} namespace", WEBHOOK_NAMESPACE);
 
         validateDistribution();
         applyCrd();
@@ -81,7 +77,7 @@ public class AdmissionWebhook {
             return;
         }
 
-        LOGGER.info("Deleting admission webhook in {} namespace", deploymentNamespace);
+        LOGGER.info("Deleting admission webhook in {} namespace", WEBHOOK_NAMESPACE);
 
         deleteInstallManifests();
         deleteCrd();
@@ -91,13 +87,13 @@ public class AdmissionWebhook {
 
     private boolean isDeployed() {
         return kubeClient().getClient().apps().deployments()
-                .inNamespace(deploymentNamespace)
+                .inNamespace(WEBHOOK_NAMESPACE)
                 .withName(WEBHOOK_DEPLOYMENT_NAME)
                 .get() != null;
     }
 
     private void validateDistribution() {
-        Path installPath = Path.of(INSTALL_DIR);
+        Path installPath = Path.of(KROXYLICIOUS_ADMISSION_WEBHOOK_INSTALL_DIR);
         if (!Files.exists(installPath) || !Files.isDirectory(installPath)) {
             throw new IllegalStateException(
                     "Distribution directory not found at " + installPath.toAbsolutePath() +
@@ -108,13 +104,13 @@ public class AdmissionWebhook {
 
     private void applyCrd() {
         LOGGER.info("Applying CRD");
-        Path crdPath = Path.of(INSTALL_DIR, "00.CustomResourceDefinition.kroxylicioussidecarconfig.yaml");
+        Path crdPath = Path.of(KROXYLICIOUS_ADMISSION_WEBHOOK_INSTALL_DIR, "00.CustomResourceDefinition.kroxylicioussidecarconfig.yaml");
         applyManifest(crdPath);
     }
 
     private void applyInstallManifests() {
-        LOGGER.info("Applying install manifests from {}", INSTALL_DIR);
-        try (var files = Files.list(Path.of(INSTALL_DIR))) {
+        LOGGER.info("Applying install manifests from {}", KROXYLICIOUS_ADMISSION_WEBHOOK_INSTALL_DIR);
+        try (var files = Files.list(Path.of(KROXYLICIOUS_ADMISSION_WEBHOOK_INSTALL_DIR))) {
             files.filter(p -> {
                 Path fileName = p.getFileName();
                 return fileName != null && !fileName.toString().startsWith("00.CustomResourceDefinition");
@@ -142,8 +138,8 @@ public class AdmissionWebhook {
 
         var issuer = new IssuerBuilder()
                 .withNewMetadata()
-                .withName(ISSUER_NAME)
-                .withNamespace(deploymentNamespace)
+                .withName(WEBHOOK_ISSUER_NAME)
+                .withNamespace(WEBHOOK_NAMESPACE)
                 .addToLabels("app.kubernetes.io/name", "kroxylicious")
                 .addToLabels("app.kubernetes.io/component", "webhook")
                 .endMetadata()
@@ -158,23 +154,23 @@ public class AdmissionWebhook {
 
         var certificate = new CertificateBuilder()
                 .withNewMetadata()
-                .withName(CERT_NAME)
-                .withNamespace(deploymentNamespace)
+                .withName(WEBHOOK_CERT_NAME)
+                .withNamespace(WEBHOOK_NAMESPACE)
                 .addToLabels("app.kubernetes.io/name", "kroxylicious")
                 .addToLabels("app.kubernetes.io/component", "webhook")
                 .endMetadata()
                 .withNewSpec()
-                .withSecretName(CERT_NAME)
+                .withSecretName(WEBHOOK_CERT_NAME)
                 .withNewIssuerRef()
-                .withName(ISSUER_NAME)
+                .withName(WEBHOOK_ISSUER_NAME)
                 .withKind("Issuer")
                 .endIssuerRef()
-                .withCommonName(WEBHOOK_DEPLOYMENT_NAME + "." + deploymentNamespace + ".svc.cluster.local")
+                .withCommonName(WEBHOOK_DEPLOYMENT_NAME + "." + WEBHOOK_NAMESPACE + ".svc.cluster.local")
                 .withDnsNames(
                         WEBHOOK_DEPLOYMENT_NAME,
-                        WEBHOOK_DEPLOYMENT_NAME + "." + deploymentNamespace,
-                        WEBHOOK_DEPLOYMENT_NAME + "." + deploymentNamespace + ".svc",
-                        WEBHOOK_DEPLOYMENT_NAME + "." + deploymentNamespace + ".svc.cluster.local")
+                        WEBHOOK_DEPLOYMENT_NAME + "." + WEBHOOK_NAMESPACE,
+                        WEBHOOK_DEPLOYMENT_NAME + "." + WEBHOOK_NAMESPACE + ".svc",
+                        WEBHOOK_DEPLOYMENT_NAME + "." + WEBHOOK_NAMESPACE + ".svc.cluster.local")
                 .withNewPrivateKey()
                 .withEncoding("PKCS8")
                 .endPrivateKey()
@@ -190,8 +186,8 @@ public class AdmissionWebhook {
     private void waitForCertificateReady() {
         LOGGER.info("Waiting for Certificate to be ready");
         kubeClient().getClient().resources(io.fabric8.certmanager.api.model.v1.Certificate.class)
-                .inNamespace(deploymentNamespace)
-                .withName(CERT_NAME)
+                .inNamespace(WEBHOOK_NAMESPACE)
+                .withName(WEBHOOK_CERT_NAME)
                 .waitUntilCondition(
                         cert -> cert != null
                                 && cert.getStatus() != null
@@ -204,7 +200,7 @@ public class AdmissionWebhook {
 
     private void waitForWebhookReady() {
         LOGGER.info("Waiting for webhook deployment to become ready");
-        DeploymentUtils.waitForDeploymentReady(deploymentNamespace, WEBHOOK_DEPLOYMENT_NAME);
+        DeploymentUtils.waitForDeploymentReady(WEBHOOK_NAMESPACE, WEBHOOK_DEPLOYMENT_NAME);
 
         waitForCaBundleInjected();
     }
@@ -225,7 +221,7 @@ public class AdmissionWebhook {
 
     private void deleteInstallManifests() {
         LOGGER.info("Deleting install manifests");
-        try (var files = Files.list(Path.of(INSTALL_DIR))) {
+        try (var files = Files.list(Path.of(KROXYLICIOUS_ADMISSION_WEBHOOK_INSTALL_DIR))) {
             files.filter(p -> {
                 Path fileName = p.getFileName();
                 return fileName != null && !fileName.toString().startsWith("00.CustomResourceDefinition");
@@ -242,7 +238,7 @@ public class AdmissionWebhook {
 
     private void deleteCrd() {
         LOGGER.info("Deleting CRD");
-        Path crdPath = Path.of(INSTALL_DIR, "00.CustomResourceDefinition.kroxylicioussidecarconfig.yaml");
+        Path crdPath = Path.of(KROXYLICIOUS_ADMISSION_WEBHOOK_INSTALL_DIR, "00.CustomResourceDefinition.kroxylicioussidecarconfig.yaml");
         deleteManifest(crdPath);
     }
 

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/admission/AdmissionWebhookST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/admission/AdmissionWebhookST.java
@@ -8,6 +8,7 @@ package io.kroxylicious.systemtests.admission;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,6 +21,7 @@ import io.kroxylicious.systemtests.installation.kroxylicious.CertManager;
 import static io.kroxylicious.systemtests.Constants.ADMISSION_DEPLOYMENT_NAME;
 import static io.kroxylicious.systemtests.Constants.ADMISSION_NAMESPACE;
 import static io.kroxylicious.systemtests.Constants.ADMISSION_REGISTRATION_NAME;
+import static io.kroxylicious.systemtests.TestTags.ADMISSION_WEBHOOK;
 import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Phase 1: Validates that the admission webhook can be deployed from distribution
  * manifests and becomes ready. Future phases will test actual sidecar injection.
  */
+@Tag(ADMISSION_WEBHOOK)
 class AdmissionWebhookST extends AbstractSystemTests {
     private static final Logger LOGGER = LoggerFactory.getLogger(AdmissionWebhookST.class);
 

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/admission/AdmissionWebhookST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/admission/AdmissionWebhookST.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.systemtests.admission;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.skodjob.testframe.listeners.TestVisualSeparatorExtension;
+
+import io.kroxylicious.systemtests.AbstractSystemTests;
+import io.kroxylicious.systemtests.Environment;
+import io.kroxylicious.systemtests.installation.admission.AdmissionWebhook;
+import io.kroxylicious.systemtests.installation.kroxylicious.CertManager;
+
+import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * System test for the Kroxylicious admission webhook.
+ * <p>
+ * Phase 1: Validates that the admission webhook can be deployed from distribution
+ * manifests and becomes ready. Future phases will test actual sidecar injection.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(TestVisualSeparatorExtension.class)
+class AdmissionWebhookST extends AbstractSystemTests {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AdmissionWebhookST.class);
+    private static final String WEBHOOK_NAMESPACE = "kroxylicious-webhook";
+    private static final String WEBHOOK_DEPLOYMENT_NAME = "kroxylicious-webhook";
+    private static final String WEBHOOK_CONFIG_NAME = "kroxylicious-sidecar-injector";
+
+    private static CertManager certManager;
+    private static AdmissionWebhook admissionWebhook;
+
+    @BeforeAll
+    void setupWebhook() {
+        LOGGER.info("Setting up admission webhook system test");
+
+        LOGGER.info("Deploying cert-manager");
+        certManager = new CertManager();
+        certManager.deploy();
+
+        LOGGER.info("Deploying admission webhook from distribution");
+        admissionWebhook = new AdmissionWebhook(WEBHOOK_NAMESPACE);
+        admissionWebhook.deploy(certManager);
+
+        LOGGER.info("Admission webhook setup complete");
+    }
+
+    @Test
+    void shouldDeployWebhookSuccessfully() {
+        LOGGER.info("Verifying webhook deployment is ready");
+
+        var deployment = kubeClient().getClient().apps().deployments()
+                .inNamespace(WEBHOOK_NAMESPACE)
+                .withName(WEBHOOK_DEPLOYMENT_NAME)
+                .get();
+
+        assertThat(deployment)
+                .withFailMessage("Webhook deployment should exist")
+                .isNotNull();
+
+        assertThat(deployment.getSpec().getReplicas())
+                .withFailMessage("Webhook should have 2 replicas configured")
+                .isEqualTo(2);
+
+        assertThat(deployment.getStatus().getReadyReplicas())
+                .withFailMessage("Webhook should have 2 ready replicas")
+                .isEqualTo(2);
+
+        LOGGER.info("Verifying MutatingWebhookConfiguration exists");
+
+        var webhookConfig = kubeClient().getClient().admissionRegistration().v1()
+                .mutatingWebhookConfigurations()
+                .withName(WEBHOOK_CONFIG_NAME)
+                .get();
+
+        assertThat(webhookConfig)
+                .withFailMessage("MutatingWebhookConfiguration should exist")
+                .isNotNull();
+
+        assertThat(webhookConfig.getWebhooks())
+                .withFailMessage("MutatingWebhookConfiguration should have exactly one webhook")
+                .hasSize(1);
+
+        LOGGER.info("Verifying CA bundle was injected by cert-manager");
+
+        var caBundle = webhookConfig.getWebhooks().get(0).getClientConfig().getCaBundle();
+
+        assertThat(caBundle)
+                .withFailMessage("CA bundle should be injected by cert-manager")
+                .isNotNull()
+                .isNotBlank();
+
+        LOGGER.info("Webhook deployment verified successfully");
+    }
+
+    @AfterAll
+    void cleanupWebhook() {
+        if (!Environment.SKIP_TEARDOWN) {
+            if (admissionWebhook != null) {
+                LOGGER.info("Deleting admission webhook");
+                admissionWebhook.delete();
+            }
+            if (certManager != null) {
+                LOGGER.info("Deleting cert-manager");
+                certManager.delete();
+            }
+        }
+        else {
+            LOGGER.info("Skipping webhook cleanup due to SKIP_TEARDOWN");
+        }
+    }
+}

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/admission/AdmissionWebhookST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/admission/AdmissionWebhookST.java
@@ -19,6 +19,7 @@ import io.kroxylicious.systemtests.installation.kroxylicious.CertManager;
 
 import static io.kroxylicious.systemtests.Constants.WEBHOOK_CONFIG_NAME;
 import static io.kroxylicious.systemtests.Constants.WEBHOOK_DEPLOYMENT_NAME;
+import static io.kroxylicious.systemtests.Constants.WEBHOOK_NAMESPACE;
 import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,7 +31,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class AdmissionWebhookST extends AbstractSystemTests {
     private static final Logger LOGGER = LoggerFactory.getLogger(AdmissionWebhookST.class);
-    private static final String WEBHOOK_NAMESPACE = "kroxylicious-webhook";
 
     private static CertManager certManager;
     private static AdmissionWebhook admissionWebhook;
@@ -44,7 +44,7 @@ class AdmissionWebhookST extends AbstractSystemTests {
         certManager.deploy();
 
         LOGGER.info("Deploying admission webhook from distribution");
-        admissionWebhook = new AdmissionWebhook(WEBHOOK_NAMESPACE);
+        admissionWebhook = new AdmissionWebhook();
         admissionWebhook.deploy(certManager);
 
         LOGGER.info("Admission webhook setup complete");

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/admission/AdmissionWebhookST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/admission/AdmissionWebhookST.java
@@ -9,18 +9,16 @@ package io.kroxylicious.systemtests.admission;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import io.skodjob.testframe.listeners.TestVisualSeparatorExtension;
 
 import io.kroxylicious.systemtests.AbstractSystemTests;
 import io.kroxylicious.systemtests.Environment;
 import io.kroxylicious.systemtests.installation.admission.AdmissionWebhook;
 import io.kroxylicious.systemtests.installation.kroxylicious.CertManager;
 
+import static io.kroxylicious.systemtests.Constants.WEBHOOK_CONFIG_NAME;
+import static io.kroxylicious.systemtests.Constants.WEBHOOK_DEPLOYMENT_NAME;
 import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,13 +28,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Phase 1: Validates that the admission webhook can be deployed from distribution
  * manifests and becomes ready. Future phases will test actual sidecar injection.
  */
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@ExtendWith(TestVisualSeparatorExtension.class)
 class AdmissionWebhookST extends AbstractSystemTests {
     private static final Logger LOGGER = LoggerFactory.getLogger(AdmissionWebhookST.class);
     private static final String WEBHOOK_NAMESPACE = "kroxylicious-webhook";
-    private static final String WEBHOOK_DEPLOYMENT_NAME = "kroxylicious-webhook";
-    private static final String WEBHOOK_CONFIG_NAME = "kroxylicious-sidecar-injector";
 
     private static CertManager certManager;
     private static AdmissionWebhook admissionWebhook;

--- a/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/admission/AdmissionWebhookST.java
+++ b/kroxylicious-systemtests/src/test/java/io/kroxylicious/systemtests/admission/AdmissionWebhookST.java
@@ -17,9 +17,9 @@ import io.kroxylicious.systemtests.Environment;
 import io.kroxylicious.systemtests.installation.admission.AdmissionWebhook;
 import io.kroxylicious.systemtests.installation.kroxylicious.CertManager;
 
-import static io.kroxylicious.systemtests.Constants.WEBHOOK_CONFIG_NAME;
-import static io.kroxylicious.systemtests.Constants.WEBHOOK_DEPLOYMENT_NAME;
-import static io.kroxylicious.systemtests.Constants.WEBHOOK_NAMESPACE;
+import static io.kroxylicious.systemtests.Constants.ADMISSION_DEPLOYMENT_NAME;
+import static io.kroxylicious.systemtests.Constants.ADMISSION_NAMESPACE;
+import static io.kroxylicious.systemtests.Constants.ADMISSION_REGISTRATION_NAME;
 import static io.kroxylicious.systemtests.k8s.KubeClusterResource.kubeClient;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -55,8 +55,8 @@ class AdmissionWebhookST extends AbstractSystemTests {
         LOGGER.info("Verifying webhook deployment is ready");
 
         var deployment = kubeClient().getClient().apps().deployments()
-                .inNamespace(WEBHOOK_NAMESPACE)
-                .withName(WEBHOOK_DEPLOYMENT_NAME)
+                .inNamespace(ADMISSION_NAMESPACE)
+                .withName(ADMISSION_DEPLOYMENT_NAME)
                 .get();
 
         assertThat(deployment)
@@ -75,7 +75,7 @@ class AdmissionWebhookST extends AbstractSystemTests {
 
         var webhookConfig = kubeClient().getClient().admissionRegistration().v1()
                 .mutatingWebhookConfigurations()
-                .withName(WEBHOOK_CONFIG_NAME)
+                .withName(ADMISSION_REGISTRATION_NAME)
                 .get();
 
         assertThat(webhookConfig)


### PR DESCRIPTION

### Type of change

- Enhancement / new feature

### Description

Adds initial system test that validates the admission webhook can be deployed from distribution manifests. The test:

- Creates AdmissionWebhook installer class that applies CRD and install manifests, creates cert-manager Issuer and Certificate for TLS, and waits for webhook deployment to be ready
- Adds AdmissionWebhookST test that deploys cert-manager and webhook, then verifies deployment has 2 ready replicas and MutatingWebhookConfiguration has CA bundle injected
- Configures Maven to unpack admission-dist artifact for test use

Still to come in future is making it inject a sidecar into a pod.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>

Contributes towards #3890 

### Checklist

The checklist is used to help Committers judge a PR's readiness for merge.
Contributors: please check off items you consider done.

- [ ] New tests written (where applicable).
- [ ] User facing documentation written/updated (where applicable).
- [ ] Existing unit/integration/system tests passing.
- [ ] Any Sonarcloud warnings are addressed (or suppressed with `@SuppressWarnings` and a justifying comment).
- [ ] PR references related GitHub issue(s) so they are closed on merging.
- [ ] If AI tools assisted with code changes, ensure commit messages include `Assisted-by:` trailer (see [DEV_GUIDE.md](../blob/main/DEV_GUIDE.md#ai-disclosure-requirement)).
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
